### PR TITLE
Allow setting model attributes before training

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -133,6 +133,7 @@ class BaseTrainer:
         """
         Builds dataloaders and optimizer on correct rank process
         """
+        self.set_model_attributes()
         self.optimizer = build_optimizer(model=self.model,
                                          name=self.args.optimizer,
                                          lr=self.args.lr0,
@@ -145,19 +146,6 @@ class BaseTrainer:
             self.validator = self.get_validator()
             print("created testloader :", rank)
             self.console.info(self.progress_string())
-
-    def _set_model_attributes(self):
-        # TODO: fix and use after self.data_dict is available
-        '''
-        head = utils.torch_utils.de_parallel(self.model).model[-1]
-        self.args.box *= 3 / head.nl  # scale to layers
-        self.args.cls *= head.nc / 80 * 3 / head.nl  # scale to classes and layers
-        self.args.obj *= (self.args.img_size / 640) ** 2 * 3 / nl  # scale to image size and layers
-        model.nc = nc  # attach number of classes to model
-        model.hyp = hyp  # attach hyperparameters to model
-        model.class_weights = labels_to_class_weights(dataset.labels, nc).to(device) * nc  # attach class weights
-        model.names = names
-        '''
 
     def _do_train(self, rank, world_size):
         if world_size > 1:
@@ -301,6 +289,12 @@ class BaseTrainer:
         self.fitness = self.metrics.get("fitness") or (-self.loss)  # use loss as fitness measure if not found
         if not self.best_fitness or self.best_fitness < self.fitness:
             self.best_fitness = self.fitness
+
+    def set_model_attributes(self):
+        """
+        To set or update model parameters before training.
+        """
+        pass
 
     def build_targets(self, preds, targets):
         pass

--- a/ultralytics/yolo/v8/segment/train.py
+++ b/ultralytics/yolo/v8/segment/train.py
@@ -54,6 +54,16 @@ class SegmentationTrainer(BaseTrainer):
             model.load(weights)
         return model
 
+    def set_model_attributes(self):
+        nl = de_parallel(self.model).model[-1].nl  # number of detection layers (to scale hyps)
+        self.args.box *= 3 / nl  # scale to layers
+        self.args.cls *= self.data["nc"] / 80 * 3 / nl  # scale to classes and layers
+        self.args.obj *= (self.args.img_size / 640) ** 2 * 3 / nl  # scale to image size and layers
+        self.model.nc = self.data["nc"]  # attach number of classes to model
+        self.model.args = self.args  # attach hyperparameters to model
+        # TODO: self.model.class_weights = labels_to_class_weights(dataset.labels, nc).to(device) * nc
+        self.model.names = self.data["names"]
+
     def get_validator(self):
         return v8.segment.SegmentationValidator(self.test_loader, self.device, logger=self.console)
 


### PR DESCRIPTION
@glenn-jocher @Laughing-q 
Now that the datasets and models interface is standard across all tasks, we can access attributes the same way.

 Do you think class_weights assignment is important? Currently its commented out because we're not saving dataset instance as class variable. So it can only access the dataloader.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring model attribute setting in the training process.

### 📊 Key Changes
- Extracted repetitive code into `set_model_attributes` method.
- Removed a placeholder `_set_model_attributes` method.
- Integrated hyperparameter scaling and attribute assignment into the new `set_model_attributes`.

### 🎯 Purpose & Impact
- **Code Cleanup:** Removing unused and commented code improves readability and maintainability.
- **Scalability:** Harmonizing the process for setting model attributes facilitates easier adjustments and scaling of hyperparameters for different model layers and classes.
- **Simplicity:** The changes centralize model setup, reducing complexity for future development and debugging. Users will benefit from a potentially smoother training experience due to cleaner and more maintainable underlying code. 🧹🔧

🚢 These improvements ultimately aim to streamline the training process, making it more robust and adaptable to changes in model configurations or training data.