### PR TITLE
Revert augment_hyps

### DIFF
--- a/ultralytics/yolo/data/build.py
+++ b/ultralytics/yolo/data/build.py
@@ -65,7 +65,7 @@ def build_dataloader(cfg, batch_size, img_path, stride=32, label_path=None, rank
             img_size=cfg.img_size,
             batch_size=batch_size,
             augment=True if mode == "train" else False,  # augmentation
-            hyp=cfg.get("augment_hyp", None),
+            hyp=cfg,  # TODO: probably add a get_hyps_from_cfg function
             rect=cfg.rect if mode == "train" else True,  # rectangular batches
             cache=None if cfg.noval else cfg.get("cache", None),
             single_cls=cfg.get("single_cls", False),

--- a/ultralytics/yolo/utils/configs/default.yaml
+++ b/ultralytics/yolo/utils/configs/default.yaml
@@ -83,20 +83,19 @@ fl_gamma: 0.0  # focal loss gamma (efficientDet default gamma=1.5)
 label_smoothing: 0.0
 nbs: 64 # nominal batch size
 # anchors: 3
-augment_hyp:
-  hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
-  hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
-  hsv_v: 0.4  # image HSV-Value augmentation (fraction)
-  degrees: 0.0  # image rotation (+/- deg)
-  translate: 0.1  # image translation (+/- fraction)
-  scale: 0.5  # image scale (+/- gain)
-  shear: 0.0  # image shear (+/- deg)
-  perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
-  flipud: 0.0  # image flip up-down (probability)
-  fliplr: 0.5  # image flip left-right (probability)
-  mosaic: 1.0  # image mosaic (probability)
-  mixup: 0.0  # image mixup (probability)
-  copy_paste: 0.0  # segment copy-paste (probability)
+hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
+hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
+hsv_v: 0.4  # image HSV-Value augmentation (fraction)
+degrees: 0.0  # image rotation (+/- deg)
+translate: 0.1  # image translation (+/- fraction)
+scale: 0.5  # image scale (+/- gain)
+shear: 0.0  # image shear (+/- deg)
+perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+flipud: 0.0  # image flip up-down (probability)
+fliplr: 0.5  # image flip left-right (probability)
+mosaic: 1.0  # image mosaic (probability)
+mixup: 0.0  # image mixup (probability)
+copy_paste: 0.0  # segment copy-paste (probability)
 
 # Hydra configs --------------------------------------------------------------------------------------------------------
 hydra:


### PR DESCRIPTION
@AyushExel 
- revert augment_hyps in default.yaml
- clean up val a little bit

this PR is ready if you think so. :)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring and simplification of augmentation parameters and validation code in Ultralytics' YOLO project.

### 📊 Key Changes
- Simplified the augmentation hyperparameter structure in the configuration file by removing the nested `augment_hyp` dictionary.
- Updated the `build_dataloader` function to directly use the cfg object for hyperparameters instead of `augment_hyp`.
- Removed unnecessary checks for package requirements and redundant code in validation modules for both detection and segmentation.
- Streamlined metric initialization and logging functionality in the detection and segmentation validation modules by reusing the `metrics` object.
- Code cleanup in validation modules, removing unused variable assignments and improving readability.

### 🎯 Purpose & Impact
- The configuration file restructuring makes it easier for users to understand and modify augmentation settings. 💡
- By eliminating redundant code, the updates contribute to easier maintenance and potentially faster validation times. 🛠
- These modifications aim to improve the overall code quality and efficiency of the YOLO project, benefiting developers working on the project and end-users relying on the software for object detection and segmentation tasks. 🚀