### PR TITLE
update docs

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -8,6 +8,7 @@ This is the simplest way of simply using yolo models in a python environment. It
 
         model = YOLO()
         model.new("n.yaml") # pass any model type
+        model(img_tensor) # Or model.forward(). inference.
         model.train(data="coco128.yaml", epochs=5)
         ```
 
@@ -27,8 +28,34 @@ This is the simplest way of simply using yolo models in a python environment. It
 
         model = YOLO()
         model.resume(task="detect") # resume last detection training
-        model.resume(task="detect", model="last.pt") # resume from a given model
+        model.resume(model="last.pt") # resume from a given model/run
         ```
+    
+    === "Visualize/save Predictions"
+    ```python
+    from ultralytics import YOLO
+
+    model = YOLO()
+    model.load("model.pt")
+    model.predict(source="0") # accepts all formats - img/folder/vid.*(mp4/format). 0 for webcam
+    model.predict(source="folder", view_img=True) # Display preds. Accepts all yolo predict arguments
+
+    ```
+
+!!! note "Export and Deployment"
+
+    === "Export, Fuse & info" 
+        ```python
+        from ultralytics import YOLO
+
+        model = YOLO()
+        model.fuse()  
+        model.info(verbose=True)  # Print model information
+        model.export(format=)  # TODO: 
+
+        ```
+    === "Deployment"
+
 
     More functionality coming soon
 


### PR DESCRIPTION
@Laughing-q added docs for model info, predict, fuse, and forward. I'll start building the export function today. I think we can just re-use most of yolov5 export


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to the YOLO SDK for easier model inference, training continuation, visualization of predictions, and export/deployment handling.

### 📊 Key Changes
- Added the ability to perform inference on an image tensor directly using `model(img_tensor)`.
- Simplified resumption of training to accept a run ID or model weight file with `model.resume()`.
- Introduced functionality to visualize and save predictions with `model.predict()`.
- Created stubs and placeholders for model export, fusion, and detailed inspections with model info.

### 🎯 Purpose & Impact
- 🚀 **Streamlined Inference**: Users can now run predictions more straightforwardly, making it easier to deploy models into production.
- ⏱ **Smoother Continuation**: Resuming training from specific checkpoints is simplified, which is beneficial for long training processes.
- 🖼 **Visualization Enhancements**: Directly visualizing predictions aids in immediate result assessment and debugging.
- 🌐 **Deployment Readiness**: Preparation for model export features will enable easier model deployment across various platforms.