### PR TITLE
Change class depending on dataset in model interface

### DIFF
--- a/ultralytics/tests/test_model.py
+++ b/ultralytics/tests/test_model.py
@@ -48,6 +48,12 @@ def test_model_resume():
     except AssertionError:
         print("Successfully caught resume assert!")
 
+def test_model_train_pretrained():
+    model = YOLO()
+    model.load("balloon-detect.pt")
+    model.train(data="coco128.yaml", epochs=1, img_size=32)
+    model.new("yolov5n.yaml")
+    model.train(data="coco128.yaml", epochs=1, img_size=32)
 
 def test():
     test_model_forward()
@@ -56,6 +62,7 @@ def test():
     test_visualize_preds()
     test_val()
     test_model_resume()
+    test_model_train_pretrained()
 
 
 if __name__ == "__main__":

--- a/ultralytics/tests/test_model.py
+++ b/ultralytics/tests/test_model.py
@@ -55,6 +55,8 @@ def test_model_train_pretrained():
     model.train(data="coco128.yaml", epochs=1, img_size=32)
     model.new("yolov5n.yaml")
     model.train(data="coco128.yaml", epochs=1, img_size=32)
+    img = torch.rand(512 * 512 * 3).view(1, 3, 512, 512)
+    model(img)
 
 
 def test():

--- a/ultralytics/tests/test_model.py
+++ b/ultralytics/tests/test_model.py
@@ -48,12 +48,14 @@ def test_model_resume():
     except AssertionError:
         print("Successfully caught resume assert!")
 
+
 def test_model_train_pretrained():
     model = YOLO()
     model.load("balloon-detect.pt")
     model.train(data="coco128.yaml", epochs=1, img_size=32)
     model.new("yolov5n.yaml")
     model.train(data="coco128.yaml", epochs=1, img_size=32)
+
 
 def test():
     test_model_forward()

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -1,6 +1,5 @@
 import torch
 import yaml
-from omegaconf import OmegaConf
 
 from ultralytics import yolo
 from ultralytics.yolo.data.utils import check_dataset, check_dataset_yaml
@@ -11,7 +10,7 @@ from ultralytics.yolo.utils.configs import get_config
 from ultralytics.yolo.utils.files import yaml_load
 from ultralytics.yolo.utils.modeling import attempt_load_weights
 from ultralytics.yolo.utils.modeling.tasks import ClassificationModel, DetectionModel, SegmentationModel
-from ultralytics.yolo.utils.torch_utils import intersect_state_dicts, smart_inference_mode
+from ultralytics.yolo.utils.torch_utils import smart_inference_mode
 
 # map head: [model, trainer, validator, predictor]
 MODEL_MAP = {
@@ -213,14 +212,6 @@ class YOLO:
         predictor_class = eval(pred_lit.replace("TYPE", f"{self.type}"))
 
         return model_class, trainer_class, validator_class, predictor_class
-
-    def _override_model_head(self, nc):
-        if self.task == "classify":
-            pass
-        state_dict = self.model.state_dict()
-        self.model = self.ModelClass(self.model.cfg, nc=nc)
-        csd = intersect_state_dicts(state_dict, self.model.state_dict())
-        self.model.load_state_dict(csd, strict=False)
 
     @smart_inference_mode()
     def __call__(self, imgs):

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -3,6 +3,7 @@ import yaml
 from omegaconf import OmegaConf
 
 from ultralytics import yolo
+from ultralytics.yolo.data.utils import check_dataset, check_dataset_yaml
 from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
 from ultralytics.yolo.utils import LOGGER
 from ultralytics.yolo.utils.checks import check_yaml
@@ -10,8 +11,7 @@ from ultralytics.yolo.utils.configs import get_config
 from ultralytics.yolo.utils.files import yaml_load
 from ultralytics.yolo.utils.modeling import attempt_load_weights
 from ultralytics.yolo.utils.modeling.tasks import ClassificationModel, DetectionModel, SegmentationModel
-from ultralytics.yolo.utils.torch_utils import smart_inference_mode, intersect_state_dicts
-from ultralytics.yolo.data.utils import check_dataset, check_dataset_yaml
+from ultralytics.yolo.utils.torch_utils import intersect_state_dicts, smart_inference_mode
 
 # map head: [model, trainer, validator, predictor]
 MODEL_MAP = {
@@ -160,8 +160,9 @@ class YOLO:
             raise Exception("dataset not provided! Please check if you have defined `data` in you configs")
 
         self.trainer = self.TrainerClass(overrides=overrides)
-        self.trainer.model = self.trainer.load_model(weights=self.ckpt, model_cfg=self.model.yaml if self.task!="classify" else None )
-        self.model = self.trainer.model # override here to save memory
+        self.trainer.model = self.trainer.load_model(weights=self.ckpt,
+                                                     model_cfg=self.model.yaml if self.task != "classify" else None)
+        self.model = self.trainer.model  # override here to save memory
 
         self.trainer.train()
 


### PR DESCRIPTION
@Laughing-q I realized that we can just use the Trainer.load_model for each task to update the nc of the model.
I tested with detection, so the segmentation should also work.. Also tested for classification with a pre-trained weight.

For detection I tried this:
```
def test_model_train_pretrained():
    model = YOLO()
    model.load("balloon-detect.pt") # nc 1
    model.train(data="coco128.yaml", epochs=1, img_size=32) # nc updated dynamically to 80
    model.new("yolov5n.yaml")
    model.train(data="coco128.yaml", epochs=1, img_size=32)
```
Maybe you can also test is like this:
```
model.new("yolov5n.yaml")
model.train("balloon.yaml",epochs=1) # this should change the nc from 80 to 1
```



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model training functionality with pretrained weights and device allocation support.

### 📊 Key Changes
- Added a new test function `test_model_train_pretrained` to ensure proper training with preloaded weights.
- Made changes to the `train` method to support loading a model with pre-trained weights without requiring a checkpoint.
- Added the `to` method to the model, enabling users to allocate the model to a specific device, such as a GPU.

### 🎯 Purpose & Impact
- 🎓 **Training with Pretrained Models**: Users can now easily train models with pretrained weights, improving model performance and reducing training time.
- 🏋️ **Memory Optimization**: The changes to the train method help save memory by overwriting the model with the trainer's version after loading the weights.
- 🖥️ **Device Allocation**: The new `.to()` method allows for more flexible deployment, as users can move the model between devices like CPUs and GPUs for better performance.