### PR TITLE
Command/file generator for DDP

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -107,7 +107,7 @@ class BaseTrainer:
     def train(self):
         world_size = torch.cuda.device_count()
         if world_size > 1 and not ("LOCAL_RANK" in os.environ):
-            command = generate_ddp_command(world_size)
+            command = generate_ddp_command(world_size, self)
             subprocess.Popen(command)
         else:
             self._do_train(int(os.getenv("RANK", -1)), world_size)

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -30,7 +30,6 @@ def generate_ddp_file(trainer):
     trainer.train()'''
     with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", encoding='utf-8', dir=os.path.curdir, delete=False) as file: 
         file.write(content)
-    import pdb;pdb.set_trace()
     return file.name
 
 def generate_ddp_command(world_size, trainer):


### PR DESCRIPTION
@Laughing-q I attempted to create a workflow where the `generate_ddp_command` checks if the command is coming from cli. Then it creates a temp file with the training command inside `if __name__ == "__main__":` block and uses that file to generate the DDP command.

Note:
* the temp file is currently created in the current working dir.. We can change it to ultralytics/ once we confirm that it works
* the temp file probably needs to be deleted manually as it persists. Again, we can do it once DDP works.

I have checked until the command/file generation and the syntax in the file seems correct. Can you check if it works as supposed to with DDP also? 
I have made this PR to your branch instead of committing there directly as I'm not sure if it'll work. Merge this to your branch if this works. 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of multi-GPU training setup in YOLO training engine.

### 📊 Key Changes
- Updated the `train` method in `trainer.py` to pass `self` to `generate_ddp_command`.
- Created a new utility `generate_ddp_file` in `dist.py` that generates a temporary Python file for distributed training configuration.
- Modified `generate_ddp_command` in `dist.py` to handle CLI usage and utilize the new `generate_ddp_file` when necessary.

### 🎯 Purpose & Impact
- 🚀 The changes aim to streamline the setup process for distributed training across multiple GPUs.
- 🛠 By creating a temporary file with training configuration, it simplifies the command generation, particularly when using command line interfaces.
- 🤝 This update is expected to make it easier to initiate distributed training, potentially leading to more efficient and user-friendly multi-GPU training experiences for YOLO models.