### PR TITLE
Update `cache_version = 1.0`

### DIFF
--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -13,7 +13,7 @@ from .utils import HELP_URL, LOCAL_RANK, get_hash, img2label_paths, verify_image
 
 
 class YOLODataset(BaseDataset):
-    cache_version = 0.6  # dataset labels *.cache version
+    cache_version = 1.0  # dataset labels *.cache version, >= 1.0 for YOLOv8
     rand_interp_methods = [cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4]
     """YOLO Dataset.
     Args:


### PR DESCRIPTION
@AyushExel updates *.cache file version to 1.0 (YOLOv5 is at 0.6). This will break YOLOv5 compat though for common datasets like COCO128 that both repos use, so need a better solution, maybe a completely new suffix, i.e. *.labels?

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded YOLO dataset cache version for YOLOv8 compatibility.

### 📊 Key Changes
- Updated `cache_version` from `0.6` to `1.0` in `YOLODataset` class in `dataset.py`.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: Ensures that dataset cache is compatible with the upcoming YOLOv8 model specifications.
- ✨ **Impact**: Users preparing datasets for YOLOv8 will now have cache files that are correctly versioned, leading to potentially better performance and stability with the new model.