### PR TITLE
Add flops, num_params, inference speed logging and best.pt logging

### DIFF
--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -112,11 +112,11 @@ class BaseValidator:
         self.print_results()
 
         # calculate speed only once when training
-        if not self.training or trainer.epoch==0:
+        if not self.training or trainer.epoch == 0:
             t = tuple(x.t / len(self.dataloader.dataset) * 1E3 for x in dt)  # speeds per image
             self.speed = t
-            
-            if not self.training: # print only at inference
+
+            if not self.training:  # print only at inference
                 self.logger.info(
                     'Speed: %.1fms pre-process, %.1fms inference, %.1fms loss, %.1fms post-process per image' % t)
 

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -30,6 +30,7 @@ class BaseValidator:
         self.device = None
         self.batch_i = None
         self.training = True
+        self.speed = None
         self.save_dir = save_dir if save_dir is not None else \
                 increment_path(Path(self.args.project) / self.args.name, exist_ok=self.args.exist_ok)
 
@@ -110,12 +111,14 @@ class BaseValidator:
 
         self.print_results()
 
-        # print speeds
-        if not self.training:
+        # calculate speed only once when training
+        if not self.training or trainer.epoch==0:
             t = tuple(x.t / len(self.dataloader.dataset) * 1E3 for x in dt)  # speeds per image
-            # shape = (self.dataloader.batch_size, 3, imgsz, imgsz)
-            self.logger.info(
-                'Speed: %.1fms pre-process, %.1fms inference, %.1fms loss, %.1fms post-process per image at shape ' % t)
+            self.speed = t
+            
+            if not self.training: # print only at inference
+                self.logger.info(
+                    'Speed: %.1fms pre-process, %.1fms inference, %.1fms loss, %.1fms post-process per image' % t)
 
         if self.training:
             model.float()

--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -45,20 +45,18 @@ def on_val_end(trainer):
         model_info = {
             "inference_speed": infer_speed,
             "flops@640": get_flops(trainer.model),
-            "params": get_num_params(trainer.model)
-        }
+            "params": get_num_params(trainer.model)}
         _log_scalers(model_info, "model")
-       
+
 
 def on_train_end(trainer):
     task = Task.current_task()
     if task:
-        task.update_output_model(model_path=str(trainer.best),
-                                 model_name='Best Model',
-                                 auto_delete_file=False)
+        task.update_output_model(model_path=str(trainer.best), model_name='Best Model', auto_delete_file=False)
+
+
 callbacks = {
     "before_train": before_train,
     "on_val_end": on_val_end,
     "on_batch_end": on_batch_end,
-    "on_train_end": on_train_end
-    }
+    "on_train_end": on_train_end}

--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -1,3 +1,5 @@
+from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+
 try:
     import clearml
     from clearml import Task
@@ -38,8 +40,25 @@ def on_val_end(trainer):
     _log_scalers(val_loss_dict, "val", trainer.epoch)
     _log_scalers(metrics, "metrics", trainer.epoch)
 
+    if trainer.epoch == 0:
+        infer_speed = trainer.validator.speed[1]
+        model_info = {
+            "inference_speed": infer_speed,
+            "flops@640": get_flops(trainer.model),
+            "params": get_num_params(trainer.model)
+        }
+        _log_scalers(model_info, "model")
+       
 
+def on_train_end(trainer):
+    task = Task.current_task()
+    if task:
+        task.update_output_model(model_path=str(trainer.best),
+                                 model_name='Best Model',
+                                 auto_delete_file=False)
 callbacks = {
     "before_train": before_train,
     "on_val_end": on_val_end,
-    "on_batch_end": on_batch_end,}
+    "on_batch_end": on_batch_end,
+    "on_train_end": on_train_end
+    }

--- a/ultralytics/yolo/utils/modeling/modules.py
+++ b/ultralytics/yolo/utils/modeling/modules.py
@@ -14,9 +14,9 @@ import pandas as pd
 import requests
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from PIL import Image, ImageOps
 from torch.cuda import amp
-import torch.nn.functional as F
 from torch.nn.modules.utils import _pair
 
 from ultralytics.yolo.data.augment import LetterBox
@@ -82,6 +82,7 @@ class ConvTranspose(nn.Module):
 
     def forward(self, x):
         return self.act(self.bn(self.conv_transpose(x)))
+
 
 class DFL(nn.Module):
     # DFL module
@@ -449,8 +450,9 @@ class SPPF(nn.Module):
 
 
 class SoftPool2d(nn.Module):
+
     def __init__(self, kernel_size, stride, padding=0):
-        super(SoftPool2d, self).__init__()
+        super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
@@ -463,8 +465,9 @@ class SoftPool2d(nn.Module):
         k = _pair(k)
         s = k if s is None else _pair(s)
         e_x = torch.sum(torch.exp(x), dim=1, keepdim=True)
-        return F.avg_pool2d(x.mul(e_x), k, stride=s, padding=self.padding).div_(
-            F.avg_pool2d(e_x, k, stride=s, padding=self.padding) + 1e-7)
+        return F.avg_pool2d(x.mul(e_x), k, stride=s,
+                            padding=self.padding).div_(F.avg_pool2d(e_x, k, stride=s, padding=self.padding) + 1e-7)
+
 
 class Focus(nn.Module):
     # Focus wh information into c-space

--- a/ultralytics/yolo/utils/modeling/modules.py
+++ b/ultralytics/yolo/utils/modeling/modules.py
@@ -14,9 +14,9 @@ import pandas as pd
 import requests
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from PIL import Image, ImageOps
 from torch.cuda import amp
-import torch.nn.functional as F
 from torch.nn.modules.utils import _pair
 
 from ultralytics.yolo.data.augment import LetterBox
@@ -331,8 +331,9 @@ class SPPF(nn.Module):
 
 
 class SoftPool2d(nn.Module):
+
     def __init__(self, kernel_size, stride, padding=0):
-        super(SoftPool2d, self).__init__()
+        super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
@@ -345,8 +346,9 @@ class SoftPool2d(nn.Module):
         k = _pair(k)
         s = k if s is None else _pair(s)
         e_x = torch.sum(torch.exp(x), dim=1, keepdim=True)
-        return F.avg_pool2d(x.mul(e_x), k, stride=s, padding=self.padding).div_(
-            F.avg_pool2d(e_x, k, stride=s, padding=self.padding) + 1e-7)
+        return F.avg_pool2d(x.mul(e_x), k, stride=s,
+                            padding=self.padding).div_(F.avg_pool2d(e_x, k, stride=s, padding=self.padding) + 1e-7)
+
 
 class Focus(nn.Module):
     # Focus wh information into c-space

--- a/ultralytics/yolo/utils/modeling/modules.py
+++ b/ultralytics/yolo/utils/modeling/modules.py
@@ -14,10 +14,8 @@ import pandas as pd
 import requests
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from PIL import Image, ImageOps
 from torch.cuda import amp
-from torch.nn.modules.utils import _pair
 
 from ultralytics.yolo.data.augment import LetterBox
 from ultralytics.yolo.utils import LOGGER, colorstr

--- a/ultralytics/yolo/utils/modeling/modules.py
+++ b/ultralytics/yolo/utils/modeling/modules.py
@@ -387,7 +387,7 @@ class C3x(C3):
     # C3 module with cross-convolutions
     def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):
         super().__init__(c1, c2, n, shortcut, g, e)
-        c_ = int(c2 * e)
+        self.c_ = int(c2 * e)
         self.m = nn.Sequential(*(Bottleneck(self.c_, self.c_, shortcut, g, k=((1, 3), (3, 1)), e=1) for _ in range(n)))
 
 

--- a/ultralytics/yolo/utils/modeling/modules.py
+++ b/ultralytics/yolo/utils/modeling/modules.py
@@ -208,6 +208,7 @@ class C2(nn.Module):
         a, b = self.cv1(x).split((self.c, self.c), 1)
         return self.cv2(torch.cat((self.m(a), b), 1))
 
+
 class C2f(nn.Module):
     # CSP Bottleneck with 2 convolutions
     def __init__(self, c1, c2, n=1, shortcut=False, g=1, e=0.5):  # ch_in, ch_out, number, shortcut, groups, expansion
@@ -221,6 +222,7 @@ class C2f(nn.Module):
         y = list(self.cv1(x).split((self.c, self.c), 1))
         y.extend(m(y[-1]) for m in self.m)
         return self.cv2(torch.cat(y, 1))
+
 
 class ChannelAttention(nn.Module):
     # Channel-attention module https://github.com/open-mmlab/mmdetection/tree/v3.0.0rc1/configs/rtmdet

--- a/ultralytics/yolo/utils/modeling/modules.py
+++ b/ultralytics/yolo/utils/modeling/modules.py
@@ -16,6 +16,8 @@ import torch
 import torch.nn as nn
 from PIL import Image, ImageOps
 from torch.cuda import amp
+import torch.nn.functional as F
+from torch.nn.modules.utils import _pair
 
 from ultralytics.yolo.data.augment import LetterBox
 from ultralytics.yolo.utils import LOGGER, colorstr
@@ -68,6 +70,34 @@ class DWConvTranspose2d(nn.ConvTranspose2d):
         super().__init__(c1, c2, k, s, p1, p2, groups=math.gcd(c1, c2))
 
 
+class ConvTranspose(nn.Module):
+    # Convolution transpose 2d layer
+    default_act = nn.SiLU()  # default activation
+
+    def __init__(self, c1, c2, k=2, s=2, p=0, bn=True, act=True):
+        super().__init__()
+        self.conv_transpose = nn.ConvTranspose2d(c1, c2, k, s, p, bias=not bn)
+        self.bn = nn.BatchNorm2d(c2) if bn else nn.Identity()
+        self.act = self.default_act if act is True else act if isinstance(act, nn.Module) else nn.Identity()
+
+    def forward(self, x):
+        return self.act(self.bn(self.conv_transpose(x)))
+
+class DFL(nn.Module):
+    # DFL module
+    def __init__(self, c1=16):
+        super().__init__()
+        self.conv = nn.Conv2d(c1, 1, 1, bias=False).requires_grad_(False)
+        x = torch.arange(c1, dtype=torch.float)
+        self.conv.weight.data[:] = nn.Parameter(x.view(1, c1, 1, 1))
+        self.c1 = c1
+
+    def forward(self, x):
+        b, c, a = x.shape  # batch, channels, anchors
+        return self.conv(x.view(b, 4, self.c1, a).transpose(2, 1).softmax(1)).view(b, 4, a)
+        # return self.conv(x.view(b, self.c1, 4, a).softmax(1)).view(b, 4, a)
+
+
 class TransformerLayer(nn.Module):
     # Transformer layer https://arxiv.org/abs/2010.11929 (LayerNorm layers removed for better performance)
     def __init__(self, c, num_heads):
@@ -104,13 +134,26 @@ class TransformerBlock(nn.Module):
         return self.tr(p + self.linear(p)).permute(1, 2, 0).reshape(b, self.c2, w, h)
 
 
-class Bottleneck(nn.Module):
+class BottleneckBase(nn.Module):
     # Standard bottleneck
-    def __init__(self, c1, c2, shortcut=True, g=1, e=0.5):  # ch_in, ch_out, shortcut, groups, expansion
+    def __init__(self, c1, c2, shortcut=True, g=1, k=(1, 3), e=0.5):  # ch_in, ch_out, shortcut, kernels, groups, expand
         super().__init__()
         c_ = int(c2 * e)  # hidden channels
-        self.cv1 = Conv(c1, c_, 1, 1)
-        self.cv2 = Conv(c_, c2, 3, 1, g=g)
+        self.cv1 = Conv(c1, c_, k[0], 1)
+        self.cv2 = Conv(c_, c2, k[1], 1, g=g)
+        self.add = shortcut and c1 == c2
+
+    def forward(self, x):
+        return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
+
+
+class Bottleneck(nn.Module):
+    # Standard bottleneck
+    def __init__(self, c1, c2, shortcut=True, g=1, k=(3, 3), e=0.5):  # ch_in, ch_out, shortcut, kernels, groups, expand
+        super().__init__()
+        c_ = int(c2 * e)  # hidden channels
+        self.cv1 = Conv(c1, c_, k[0], 1)
+        self.cv2 = Conv(c_, c2, k[1], 1, g=g)
         self.add = shortcut and c1 == c2
 
     def forward(self, x):
@@ -164,12 +207,187 @@ class C3(nn.Module):
         return self.cv3(torch.cat((self.m(self.cv1(x)), self.cv2(x)), 1))
 
 
+class C2Base(nn.Module):
+    # CSP Bottleneck with 2 convolutions
+    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):  # ch_in, ch_out, number, shortcut, groups, expansion
+        super().__init__()
+        self.c = int(c2 * e)  # hidden channels
+        self.cv1 = Conv(c1, 2 * self.c, 1, 1)
+        self.cv2 = Conv(2 * self.c, c2, 1)  # optional act=FReLU(c2)
+        # self.attention = ChannelAttention(2 * self.c)  # or SpatialAttention()
+        self.m = nn.Sequential(*(Bottleneck(self.c, self.c, shortcut, g, k=((3, 3), (3, 3)), e=1.0) for _ in range(n)))
+
+    def forward(self, x):
+        a, b = self.cv1(x).split((self.c, self.c), 1)
+        return self.cv2(torch.cat((self.m(a), b), 1))
+
+
+class C2_sum_all(nn.Module):
+    # CSP Bottleneck with 2 convolutions
+    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):  # ch_in, ch_out, number, shortcut, groups, expansion
+        super().__init__()
+        n *= 2
+        self.c = int(c2 * e)  # hidden channels
+        self.cv1 = Conv(c1, 2 * self.c, 1, 1)
+        self.cv2 = Conv(2 * self.c, c2, 1)  # optional act=FReLU(c2)
+        self.cvm = nn.ModuleList(Conv(self.c, self.c, 3) for _ in range(n))
+        self.w = nn.Parameter(torch.zeros(n))
+        self.n = n
+
+    def forward(self, x):
+        a, b = self.cv1(x).split((self.c, self.c), 1)
+        c = a.clone()
+        for i in range(self.n):
+            c = self.cvm[i](c) + a * self.w[i].sigmoid()
+        return self.cv2(torch.cat((c, b), 1))
+
+
+class Down(nn.Module):
+    # CSP Bottleneck with 2 convolutions
+    def __init__(self, c1, c2):  # ch_in, ch_out, number, shortcut, groups, expansion
+        super().__init__()
+        self.pool = nn.MaxPool2d(kernel_size=2, stride=2, padding=0)
+        self.cv1 = Conv(c1, c1, 3, 2)
+        self.cv2 = Conv(c1 * 2, c2, 1)
+
+    def forward(self, x):
+        return self.cv2(torch.cat((self.pool(x), self.cv1(x)), 1))
+
+
+class C2(nn.Module):
+    # CSP Bottleneck with 2 convolutions
+    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):  # ch_in, ch_out, number, shortcut, groups, expansion
+        super().__init__()
+        self.c = int(c2 * e)  # hidden channels
+        self.cv1 = Conv(c1, 2 * self.c, 1, 1)
+        self.cv2 = Conv(2 * self.c, c2, 1)  # optional act=FReLU(c2)
+        # self.attention = ChannelAttention(2 * self.c)  # or SpatialAttention()
+        self.m = nn.Sequential(*(Bottleneck(self.c, self.c, shortcut, g, k=((3, 3), (3, 3)), e=1.0) for _ in range(n)))
+
+    def forward(self, x):
+        a, b = self.cv1(x).split((self.c, self.c), 1)
+        return self.cv2(torch.cat((self.m(a), b), 1))
+
+
+class C2f_orig(nn.Module):
+    # CSP Bottleneck with 2 convolutions
+    def __init__(self, c1, c2, n=1, shortcut=False, g=1, e=0.5):  # ch_in, ch_out, number, shortcut, groups, expansion
+        super().__init__()
+        self.c = int(c2 * e)  # hidden channels
+        self.cv1 = Conv(c1, 2 * self.c, 1, 1)
+        self.cv2 = Conv((2 + n) * self.c, c2, 1)  # optional act=FReLU(c2)
+        self.m = nn.ModuleList(Bottleneck(self.c, self.c, shortcut, g, k=((3, 3), (3, 3)), e=1.0) for _ in range(n))
+
+    def forward(self, x):
+        y = list(self.cv1(x).split((self.c, self.c), 1))
+        y.extend(m(y[-1]) for m in self.m)
+        return self.cv2(torch.cat(y, 1))
+
+
+class C2f(nn.Module):
+    # CSP Bottleneck with 2 convolutions
+    def __init__(self, c1, c2, n=1, shortcut=False, g=1, e=0.5):  # ch_in, ch_out, number, shortcut, groups, expansion
+        super().__init__()
+        self.c = int(c2 * e)  # hidden channels
+        self.cv1 = Conv(c1, 2 * self.c, 1, 1)
+        self.cv2 = Conv((2 + n) * self.c, c2, 1)  # optional act=FReLU(c2)
+        self.m = nn.ModuleList(Bottleneck(self.c, self.c, shortcut, g, k=((3, 3), (3, 3)), e=1.0) for _ in range(n))
+
+    def forward(self, x):
+        y = list(self.cv1(x).split((self.c, self.c), 1))
+        y.extend(m(y[-1]) for m in self.m)
+        return self.cv2(torch.cat(y, 1))
+
+
+class C2x(C2):
+    # Depth-wise convolution
+    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):  # ch_in, ch_out, kernel, stride, dilation, activation
+        super().__init__(c1, c2, n=1, shortcut=True, g=1, e=0.5)
+        self.m = nn.Sequential(*(Bottleneck(self.c, self.c, shortcut, g, k=((1, 3), (3, 1)), e=1.0) for _ in range(n)))
+
+
+class ChannelAttention(nn.Module):
+    # Channel-attention module https://github.com/open-mmlab/mmdetection/tree/v3.0.0rc1/configs/rtmdet
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Conv2d(channels, channels, 1, 1, 0, bias=True)
+        self.act = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.act(self.fc(self.pool(x)))
+
+
+class ChannelAttention2(nn.Module):
+    # Channel-attention module https://github.com/open-mmlab/mmdetection/tree/v3.0.0rc1/configs/rtmdet
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.pool1 = nn.AdaptiveMaxPool2d(1)
+        self.pool2 = nn.AdaptiveAvgPool2d(1)
+        self.cv1 = nn.Conv2d(channels, channels, 1, 1, 0, bias=True)
+        self.act = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.act(self.cv1(self.pool1(x) + self.pool2(x)))
+
+
+class ChannelAttention3(nn.Module):
+    # Channel-attention module https://github.com/open-mmlab/mmdetection/tree/v3.0.0rc1/configs/rtmdet
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.pool1 = nn.AdaptiveMaxPool2d(1)
+        self.pool2 = nn.AdaptiveAvgPool2d(1)
+        self.cv1 = nn.Conv2d(channels, channels // 16, 1, 1, 0, bias=True)
+        self.cv2 = nn.Conv2d(channels // 16, channels, 1, 1, 0, bias=True)
+        self.silu = nn.SiLU()
+        self.act = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.act(self.cv2(self.silu(self.cv1(self.pool1(x)))) + self.cv2(self.silu(self.cv1(self.pool2(x)))))
+
+
+class SpatialAttention(nn.Module):
+    # Spatial-attention module
+    def __init__(self, kernel_size=7):
+        super().__init__()
+        assert kernel_size in (3, 7), 'kernel size must be 3 or 7'
+        padding = 3 if kernel_size == 7 else 1
+        self.cv1 = nn.Conv2d(2, 1, kernel_size, padding=padding, bias=False)
+        self.act = nn.Sigmoid()
+
+    def forward(self, x):
+        return x * self.act(self.cv1(torch.cat([torch.mean(x, 1, keepdim=True), torch.max(x, 1, keepdim=True)[0]], 1)))
+
+
+class CBAM(nn.Module):
+    # CSP Bottleneck with 3 convolutions
+    def __init__(self, c1, ratio=16, kernel_size=7):  # ch_in, ch_out, number, shortcut, groups, expansion
+        super().__init__()
+        self.channel_attention = ChannelAttention(c1)
+        self.spatial_attention = SpatialAttention(kernel_size)
+
+    def forward(self, x):
+        return self.spatial_attention(self.channel_attention(x))
+
+
+class C1(nn.Module):
+    # CSP Bottleneck with 3 convolutions
+    def __init__(self, c1, c2, n=1):  # ch_in, ch_out, number, shortcut, groups, expansion
+        super().__init__()
+        self.cv1 = Conv(c1, c2, 1, 1)
+        self.m = nn.Sequential(*(Conv(c2, c2, 3) for _ in range(n)))
+
+    def forward(self, x):
+        y = self.cv1(x)
+        return self.m(y) + y
+
+
 class C3x(C3):
     # C3 module with cross-convolutions
     def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):
         super().__init__(c1, c2, n, shortcut, g, e)
         c_ = int(c2 * e)
-        self.m = nn.Sequential(*(CrossConv(c_, c_, 3, 1, g, 1.0, shortcut) for _ in range(n)))
+        self.m = nn.Sequential(*(Bottleneck(self.c_, self.c_, shortcut, g, k=((1, 3), (3, 1)), e=1) for _ in range(n)))
 
 
 class C3TR(C3):
@@ -229,6 +447,24 @@ class SPPF(nn.Module):
             y2 = self.m(y1)
             return self.cv2(torch.cat((x, y1, y2, self.m(y2)), 1))
 
+
+class SoftPool2d(nn.Module):
+    def __init__(self, kernel_size, stride, padding=0):
+        super(SoftPool2d, self).__init__()
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+
+    def forward(self, x):
+        x = self.soft_pool2d(x, k=self.kernel_size, s=self.stride)
+        return x
+
+    def soft_pool2d(self, x, k=2, s=None):
+        k = _pair(k)
+        s = k if s is None else _pair(s)
+        e_x = torch.sum(torch.exp(x), dim=1, keepdim=True)
+        return F.avg_pool2d(x.mul(e_x), k, stride=s, padding=self.padding).div_(
+            F.avg_pool2d(e_x, k, stride=s, padding=self.padding) + 1e-7)
 
 class Focus(nn.Module):
     # Focus wh information into c-space

--- a/ultralytics/yolo/utils/modeling/modules.py
+++ b/ultralytics/yolo/utils/modeling/modules.py
@@ -14,10 +14,8 @@ import pandas as pd
 import requests
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from PIL import Image, ImageOps
 from torch.cuda import amp
-from torch.nn.modules.utils import _pair
 
 from ultralytics.yolo.data.augment import LetterBox
 from ultralytics.yolo.utils import LOGGER, colorstr
@@ -133,19 +131,6 @@ class TransformerBlock(nn.Module):
         b, _, w, h = x.shape
         p = x.flatten(2).permute(2, 0, 1)
         return self.tr(p + self.linear(p)).permute(1, 2, 0).reshape(b, self.c2, w, h)
-
-
-class BottleneckBase(nn.Module):
-    # Standard bottleneck
-    def __init__(self, c1, c2, shortcut=True, g=1, k=(1, 3), e=0.5):  # ch_in, ch_out, shortcut, kernels, groups, expand
-        super().__init__()
-        c_ = int(c2 * e)  # hidden channels
-        self.cv1 = Conv(c1, c_, k[0], 1)
-        self.cv2 = Conv(c_, c2, k[1], 1, g=g)
-        self.add = shortcut and c1 == c2
-
-    def forward(self, x):
-        return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
 
 
 class Bottleneck(nn.Module):
@@ -328,26 +313,6 @@ class SPPF(nn.Module):
             y1 = self.m(x)
             y2 = self.m(y1)
             return self.cv2(torch.cat((x, y1, y2, self.m(y2)), 1))
-
-
-class SoftPool2d(nn.Module):
-
-    def __init__(self, kernel_size, stride, padding=0):
-        super().__init__()
-        self.kernel_size = kernel_size
-        self.stride = stride
-        self.padding = padding
-
-    def forward(self, x):
-        x = self.soft_pool2d(x, k=self.kernel_size, s=self.stride)
-        return x
-
-    def soft_pool2d(self, x, k=2, s=None):
-        k = _pair(k)
-        s = k if s is None else _pair(s)
-        e_x = torch.sum(torch.exp(x), dim=1, keepdim=True)
-        return F.avg_pool2d(x.mul(e_x), k, stride=s,
-                            padding=self.padding).div_(F.avg_pool2d(e_x, k, stride=s, padding=self.padding) + 1e-7)
 
 
 class Focus(nn.Module):

--- a/ultralytics/yolo/utils/modeling/modules.py
+++ b/ultralytics/yolo/utils/modeling/modules.py
@@ -135,19 +135,6 @@ class TransformerBlock(nn.Module):
         return self.tr(p + self.linear(p)).permute(1, 2, 0).reshape(b, self.c2, w, h)
 
 
-class BottleneckBase(nn.Module):
-    # Standard bottleneck
-    def __init__(self, c1, c2, shortcut=True, g=1, k=(1, 3), e=0.5):  # ch_in, ch_out, shortcut, kernels, groups, expand
-        super().__init__()
-        c_ = int(c2 * e)  # hidden channels
-        self.cv1 = Conv(c1, c_, k[0], 1)
-        self.cv2 = Conv(c_, c2, k[1], 1, g=g)
-        self.add = shortcut and c1 == c2
-
-    def forward(self, x):
-        return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
-
-
 class Bottleneck(nn.Module):
     # Standard bottleneck
     def __init__(self, c1, c2, shortcut=True, g=1, k=(3, 3), e=0.5):  # ch_in, ch_out, shortcut, kernels, groups, expand
@@ -328,26 +315,6 @@ class SPPF(nn.Module):
             y1 = self.m(x)
             y2 = self.m(y1)
             return self.cv2(torch.cat((x, y1, y2, self.m(y2)), 1))
-
-
-class SoftPool2d(nn.Module):
-
-    def __init__(self, kernel_size, stride, padding=0):
-        super().__init__()
-        self.kernel_size = kernel_size
-        self.stride = stride
-        self.padding = padding
-
-    def forward(self, x):
-        x = self.soft_pool2d(x, k=self.kernel_size, s=self.stride)
-        return x
-
-    def soft_pool2d(self, x, k=2, s=None):
-        k = _pair(k)
-        s = k if s is None else _pair(s)
-        e_x = torch.sum(torch.exp(x), dim=1, keepdim=True)
-        return F.avg_pool2d(x.mul(e_x), k, stride=s,
-                            padding=self.padding).div_(F.avg_pool2d(e_x, k, stride=s, padding=self.padding) + 1e-7)
 
 
 class Focus(nn.Module):

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -133,17 +133,20 @@ def model_info(model, verbose=False, imgsz=640):
             name = name.replace('module_list.', '')
             print('%5g %40s %9s %12g %20s %10.3g %10.3g' %
                   (i, name, p.requires_grad, p.numel(), list(p.shape), p.mean(), p.std()))
-        
+
     flops = get_flops(model)
     fs = f', {flops:.1f} GFLOPs' if flops else ''
     name = Path(model.yaml_file).stem.replace('yolov5', 'YOLOv5') if hasattr(model, 'yaml_file') else 'Model'
     LOGGER.info(f"{name} summary: {len(list(model.modules()))} layers, {n_p} parameters, {n_g} gradients{fs}")
 
+
 def get_num_params(model):
     return sum(x.numel() for x in model.parameters())
 
+
 def get_num_gradients(model):
     return sum(x.numel() for x in model.parameters() if x.requires_grad)
+
 
 def get_flops(model):
     try:
@@ -156,6 +159,7 @@ def get_flops(model):
         return flops
     except Exception:
         return 0
+
 
 def initialize_weights(model):
     for m in model.modules():

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -123,7 +123,7 @@ def fuse_conv_and_bn(conv, bn):
     return fusedconv
 
 
-def model_info(model, verbose=False, imgsz=640):
+def model_info(model, verbose=False):
     # Model information. img_size may be int or list, i.e. img_size=640 or img_size=[640, 320]
     n_p = get_num_params(model)
     n_g = get_num_gradients(model)  # number gradients
@@ -147,8 +147,7 @@ def get_num_params(model):
 def get_num_gradients(model):
     return sum(x.numel() for x in model.parameters() if x.requires_grad)
 
-
-def get_flops(model):
+def get_flops(model, imgsz=640):
     try:
         p = next(model.parameters())
         stride = max(int(model.stride.max()), 32) if hasattr(model, 'stride') else 32  # max stride

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -125,28 +125,37 @@ def fuse_conv_and_bn(conv, bn):
 
 def model_info(model, verbose=False, imgsz=640):
     # Model information. img_size may be int or list, i.e. img_size=640 or img_size=[640, 320]
-    n_p = sum(x.numel() for x in model.parameters())  # number parameters
-    n_g = sum(x.numel() for x in model.parameters() if x.requires_grad)  # number gradients
+    n_p = get_num_params(model)
+    n_g = get_num_gradients(model)  # number gradients
     if verbose:
         print(f"{'layer':>5} {'name':>40} {'gradient':>9} {'parameters':>12} {'shape':>20} {'mu':>10} {'sigma':>10}")
         for i, (name, p) in enumerate(model.named_parameters()):
             name = name.replace('module_list.', '')
             print('%5g %40s %9s %12g %20s %10.3g %10.3g' %
                   (i, name, p.requires_grad, p.numel(), list(p.shape), p.mean(), p.std()))
+        
+    flops = get_flops(model)
+    fs = f', {flops:.1f} GFLOPs' if flops else ''
+    name = Path(model.yaml_file).stem.replace('yolov5', 'YOLOv5') if hasattr(model, 'yaml_file') else 'Model'
+    LOGGER.info(f"{name} summary: {len(list(model.modules()))} layers, {n_p} parameters, {n_g} gradients{fs}")
 
-    try:  # FLOPs
+def get_num_params(model):
+    return sum(x.numel() for x in model.parameters())
+
+def get_num_gradients(model):
+    return sum(x.numel() for x in model.parameters() if x.requires_grad)
+
+def get_flops(model):
+    try:
         p = next(model.parameters())
         stride = max(int(model.stride.max()), 32) if hasattr(model, 'stride') else 32  # max stride
         im = torch.empty((1, p.shape[1], stride, stride), device=p.device)  # input image in BCHW format
         flops = thop.profile(deepcopy(model), inputs=(im,), verbose=False)[0] / 1E9 * 2  # stride GFLOPs
         imgsz = imgsz if isinstance(imgsz, list) else [imgsz, imgsz]  # expand if int/float
-        fs = f', {flops * imgsz[0] / stride * imgsz[1] / stride:.1f} GFLOPs'  # 640x640 GFLOPs
+        flops = flops * imgsz[0] / stride * imgsz[1] / stride  # 640x640 GFLOPs
+        return flops
     except Exception:
-        fs = ''
-
-    name = Path(model.yaml_file).stem.replace('yolov5', 'YOLOv5') if hasattr(model, 'yaml_file') else 'Model'
-    LOGGER.info(f"{name} summary: {len(list(model.modules()))} layers, {n_p} parameters, {n_g} gradients{fs}")
-
+        return 0
 
 def initialize_weights(model):
     for m in model.modules():

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -123,7 +123,7 @@ def fuse_conv_and_bn(conv, bn):
     return fusedconv
 
 
-def model_info(model, verbose=False):
+def model_info(model, verbose=False, imgsz=640):
     # Model information. img_size may be int or list, i.e. img_size=640 or img_size=[640, 320]
     n_p = get_num_params(model)
     n_g = get_num_gradients(model)  # number gradients
@@ -134,7 +134,7 @@ def model_info(model, verbose=False):
             print('%5g %40s %9s %12g %20s %10.3g %10.3g' %
                   (i, name, p.requires_grad, p.numel(), list(p.shape), p.mean(), p.std()))
 
-    flops = get_flops(model)
+    flops = get_flops(model, imgsz)
     fs = f', {flops:.1f} GFLOPs' if flops else ''
     name = Path(model.yaml_file).stem.replace('yolov5', 'YOLOv5') if hasattr(model, 'yaml_file') else 'Model'
     LOGGER.info(f"{name} summary: {len(list(model.modules()))} layers, {n_p} parameters, {n_g} gradients{fs}")

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -147,6 +147,7 @@ def get_num_params(model):
 def get_num_gradients(model):
     return sum(x.numel() for x in model.parameters() if x.requires_grad)
 
+
 def get_flops(model, imgsz=640):
     try:
         p = next(model.parameters())


### PR DESCRIPTION
@glenn-jocher 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced performance tracking and integration with ClearML for Ultralytics YOLO models.

### 📊 Key Changes
- Added `self.speed` attribute in `validator.py` to track model inference speed.
- Modified speed calculation logic, now only calculated once during initial training and during inference.
- Improved ClearML callback to log new `model_info` including inference speed, floating-point operations per second (FLOPs), and model parameters count at the beginning of training.
- Added `on_train_end` method to update the best model in the ClearML experiment.
- Refactored `model_info` function in `torch_utils.py` to use new helper functions `get_num_params`, `get_num_gradients`, and `get_flops` for better code readability and maintenance.

### 🎯 Purpose & Impact
- **For Developers:** These changes offer better insight into model performance and efficiency, highlighting areas for optimization.
- **For Users:** Users gain a clearer understanding of inference speed and resource requirements, allowing for more informed decisions on model deployment.
- **ClearML Integration Impact:** Streamlines tracking and managing model experiments, simplifying model evaluation and deployment workflows.