### PR TITLE
Use integrations only in master process

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -87,7 +87,8 @@ class BaseTrainer:
 
         for callback, func in callbacks.default_callbacks.items():
             self.add_callback(callback, func)
-        callbacks.add_integration_callbacks(self)
+        if RANK in {0, -1}:
+            callbacks.add_integration_callbacks(self)
 
     def add_callback(self, onevent: str, callback):
         """


### PR DESCRIPTION
@glenn-jocher @Laughing-q this PR only uses integration callbacks when in master process

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved conditional integration for distributed training settings.

### 📊 Key Changes
- Altered the conditions under which integration callbacks are added in the training engine.

### 🎯 Purpose & Impact
- 🎨 The change ensures that integration callbacks are only added for the main process or in a single-process scenario, preventing unnecessary callback setup in distributed training environments.
- ✨ This could improve efficiency and resource usage when training models in distributed systems, leading to smoother scaling and potential performance gains for users.