### PR TITLE
Allocated updated pycocotools metrics fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ ipython  # interactive notebook
 psutil  # system utilization
 thop>=0.1.1  # FLOPs computation
 # albumentations>=1.0.3
-# pycocotools>=2.0  # COCO mAP
+# pycocotools>=2.0.6  # COCO mAP
 # roboflow
 
 # HUB -----------------------------------------

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -127,7 +127,7 @@ class BaseValidator:
                     self.logger.info(f"Saving {f.name}...")
                     json.dump(self.jdict, f)  # flatten and save
 
-            self.eval_json()
+            stats = self.eval_json(stats)
             return stats
 
     def get_dataloader(self, dataset_path, batch_size):

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -171,5 +171,5 @@ class BaseValidator:
     def pred_to_json(self, preds, batch):
         pass
 
-    def eval_json(self):
+    def eval_json(self, stats):
         pass

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -210,7 +210,7 @@ class DetectionValidator(BaseValidator):
                     'bbox': [round(x, 3) for x in b],
                     'score': round(p[4], 5)})
 
-    def eval_json(self):
+    def eval_json(self, stats):
         if self.args.save_json and self.is_coco and len(self.jdict):
             anno_json = self.data['path'] / "annotations/instances_val2017.json"  # annotations
             pred_json = self.save_dir / "predictions.json"  # predictions
@@ -230,9 +230,10 @@ class DetectionValidator(BaseValidator):
                 eval.evaluate()
                 eval.accumulate()
                 eval.summarize()
-                self.metrics.metric.map, self.metrics.metric.map50 = eval.stats[:2]  # update mAP50-95 and mAP50
+                stats[self.metric_keys[-1]], stats[self.metric_keys[-2]] = eval.stats[:2]   # update mAP50-95 and mAP50
             except Exception as e:
                 self.logger.warning(f'pycocotools unable to run: {e}')
+        return stats
 
 
 @hydra.main(version_base=None, config_path=str(DEFAULT_CONFIG.parent), config_name=DEFAULT_CONFIG.name)

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -216,7 +216,7 @@ class DetectionValidator(BaseValidator):
             pred_json = self.save_dir / "predictions.json"  # predictions
             self.logger.info(f'\nEvaluating pycocotools mAP using {pred_json} and {anno_json}...')
             try:  # https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocoEvalDemo.ipynb
-                check_requirements('pycocotools')
+                check_requirements('pycocotools>=2.0.6')
                 from pycocotools.coco import COCO  # noqa
                 from pycocotools.cocoeval import COCOeval  # noqa
 

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -230,7 +230,7 @@ class DetectionValidator(BaseValidator):
                 eval.evaluate()
                 eval.accumulate()
                 eval.summarize()
-                stats[self.metric_keys[-1]], stats[self.metric_keys[-2]] = eval.stats[:2]   # update mAP50-95 and mAP50
+                stats[self.metric_keys[-1]], stats[self.metric_keys[-2]] = eval.stats[:2]  # update mAP50-95 and mAP50
             except Exception as e:
                 self.logger.warning(f'pycocotools unable to run: {e}')
         return stats


### PR DESCRIPTION
@AyushExel @glenn-jocher fixed the map issue I met before, could be a temp way.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated dependencies and modified evaluation methods in `validator.py` and `val.py` to use newer pycocotools and enhance the results' handling.

### 📊 Key Changes
- Requirements file `requirements.txt` bumped pycocotools version from `>=2.0` to `>=2.0.6`.
- Both `validator.py` and `val.py` have updated `eval_json` function signatures to accept and return `stats`.
- Pycocotools version check updated to ensure version `2.0.6` or newer is used during JSON evaluation in `val.py`.
- `val.py` mAP calculation now updates `stats` dictionary directly with latest evaluation metrics.

### 🎯 Purpose & Impact
- 🚀 **Enhanced accuracy and compatibility**: Using the latest pycocotools ensures compatibility with the latest methodologies in COCO mAP (Mean Average Precision) calculation.
- 📈 **Improved results management**: Passing `stats` around allows for more flexible and maintainable code, potentially making it easier to incorporate additional metrics or modifications in the future.
- 🗃️ **Reliable evaluation workflow**: Directly updating `stats` ensures that the latest evaluation results are always reflected correctly, leading to more accurate performance tracking and model validation for users.