### PR TITLE
Fix `save_json(predn, batch)`

### DIFF
--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -123,8 +123,7 @@ class BaseValidator:
                 with open(str(self.save_dir / "predictions.json"), 'w') as f:
                     self.logger.info(f"Saving {f.name}...")
                     json.dump(self.jdict, f)  # flatten and save
-
-            stats = self.eval_json(stats)
+                stats = self.eval_json(stats)  # update stats
             return stats
 
     def get_dataloader(self, dataset_path, batch_size):

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -109,9 +109,6 @@ class BaseValidator:
                 self.plot_val_samples(batch, batch_i)
                 self.plot_predictions(batch, preds, batch_i)
 
-            if self.args.save_json:
-                self.pred_to_json(preds, batch)
-
         stats = self.get_stats()
         self.check_stats(stats)
         self.print_results()

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -71,7 +71,7 @@ class DetectionValidator(BaseValidator):
 
     def update_metrics(self, preds, batch):
         # Metrics
-        for si, (pred) in enumerate(preds):
+        for si, pred in enumerate(preds):
             labels = self.targets[self.targets[:, 0] == si, 1:]
             nl, npr = labels.shape[0], pred.shape[0]  # number of labels, predictions
             shape = batch["ori_shape"][si]
@@ -102,6 +102,10 @@ class DetectionValidator(BaseValidator):
                 if self.args.plots:
                     self.confusion_matrix.process_batch(predn, labelsn)
             self.stats.append((correct_bboxes, pred[:, 4], pred[:, 5], labels[:, 0]))  # (conf, pcls, tcls)
+
+             # To JSON
+            if self.args.save_json:
+                self.pred_to_json(preds, batch)
 
             # TODO: Save/log
             '''

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -105,7 +105,7 @@ class DetectionValidator(BaseValidator):
 
             # Save
             if self.args.save_json:
-                self.pred_to_json(predn, batch)
+                self.pred_to_json(predn, batch["im_file"][si])
             # if self.args.save_txt:
             #    save_one_txt(predn, save_conf, shape, file=save_dir / 'labels' / f'{path.stem}.txt')
 
@@ -197,18 +197,17 @@ class DetectionValidator(BaseValidator):
                     fname=self.save_dir / f'val_batch{ni}_pred.jpg',
                     names=self.names)  # pred
 
-    def pred_to_json(self, preds, batch):
-        for i, f in enumerate(batch["im_file"]):
-            stem = Path(f).stem
-            image_id = int(stem) if stem.isnumeric() else stem
-            box = ops.xyxy2xywh(preds[i][:, :4])  # xywh
-            box[:, :2] -= box[:, 2:] / 2  # xy center to top-left corner
-            for p, b in zip(preds[i].tolist(), box.tolist()):
-                self.jdict.append({
-                    'image_id': image_id,
-                    'category_id': self.class_map[int(p[5])],
-                    'bbox': [round(x, 3) for x in b],
-                    'score': round(p[4], 5)})
+    def pred_to_json(self, predn, filename):
+        stem = Path(filename).stem
+        image_id = int(stem) if stem.isnumeric() else stem
+        box = ops.xyxy2xywh(predn[:, :4])  # xywh
+        box[:, :2] -= box[:, 2:] / 2  # xy center to top-left corner
+        for p, b in zip(predn.tolist(), box.tolist()):
+            self.jdict.append({
+                'image_id': image_id,
+                'category_id': self.class_map[int(p[5])],
+                'bbox': [round(x, 3) for x in b],
+                'score': round(p[4], 5)})
 
     def eval_json(self, stats):
         if self.args.save_json and self.is_coco and len(self.jdict):

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -103,15 +103,11 @@ class DetectionValidator(BaseValidator):
                     self.confusion_matrix.process_batch(predn, labelsn)
             self.stats.append((correct_bboxes, pred[:, 4], pred[:, 5], labels[:, 0]))  # (conf, pcls, tcls)
 
-            # To JSON
+            # Save
             if self.args.save_json:
                 self.pred_to_json(predn, batch)
-
-            # TODO: Save/log
-            '''
-            if self.args.save_txt:
-                save_one_txt(predn, save_conf, shape, file=save_dir / 'labels' / f'{path.stem}.txt')
-            '''
+            # if self.args.save_txt:
+            #    save_one_txt(predn, save_conf, shape, file=save_dir / 'labels' / f'{path.stem}.txt')
 
     def get_stats(self):
         stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*self.stats)]  # to numpy

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -103,7 +103,7 @@ class DetectionValidator(BaseValidator):
                     self.confusion_matrix.process_batch(predn, labelsn)
             self.stats.append((correct_bboxes, pred[:, 4], pred[:, 5], labels[:, 0]))  # (conf, pcls, tcls)
 
-             # To JSON
+            # To JSON
             if self.args.save_json:
                 self.pred_to_json(preds, batch)
 

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -105,7 +105,7 @@ class DetectionValidator(BaseValidator):
 
             # To JSON
             if self.args.save_json:
-                self.pred_to_json(preds, batch)
+                self.pred_to_json(predn, batch)
 
             # TODO: Save/log
             '''


### PR DESCRIPTION
@Laughing-q PR to fix pycocotools map by passing native-space predictions bug discovered in https://github.com/ultralytics/ultralytics/issues/54#issuecomment-1366027153

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring of JSON saving logic in validation process for better efficiency.

### 📊 Key Changes
- Removed redundant `save_json` check during the prediction-validation loop.
- Moved JSON saving code to execute only after all predictions have been processed.
- Simplified `update_metrics` method by removing unnecessary parentheses and commented-out code.
- Refactored `pred_to_json` function for clarity and moved the JSON evaluation to only run if JSON saving is enabled.
  
### 🎯 Purpose & Impact
- 🔍 **Purpose**: The main goal of these changes is to streamline the validation process, making it quicker and reducing unnecessary checks and complexity in the code.
- 🚀 **Impact**: Users should experience a more efficient validation step when using the model, with potentially lower overhead and faster processing times. Additionally, the codebase is cleaner and easier to maintain.