### PR TITLE
Make YOLO a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,18 @@ pip install -e .
 ### 1. CLI
 To simply use the latest Ultralytics YOLO models
 ```bash
-yolo task=detect    mode=train  model=s.yaml ...
-          classify       infer        s-cls.yaml
-          segment        val          s-seg.yaml
+yolo task=detect    mode=train     model=yolov8n.yaml ...
+          classify       predict         yolov8n-cls.yaml
+          segment        val             yolov8n-seg.yaml
 ```
 ### 2. Python SDK
 To use pythonic interface of Ultralytics YOLO model
 ```python
-import ultralytics
-from ultralytics import YOLO
-
-model = YOLO()
-model.new("s-seg.yaml") # automatically detects task type
-model.load("s-seg.pt") # load checkpoint
-model.train(data="coco128-segments", epochs=1, lr0=0.01, ...)
+model = YOLO.new('yolov8n.yaml')  # create a new model from scratch
+model = YOLO.load('yolov8n.pt')  # load a pretrained model (recommended for best training results)
+results = model.train(data='coco128.yaml', epochs=100, imgsz=640, ...)
+results = model.val()
+results = model.predict(source='bus.jpg')
+success = model.export(format='onnx')
 ```
 If you're looking to modify YOLO for R&D or to build on top of it, refer to [Using Trainer]() Guide on our docs.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ yolo task=detect    mode=train     model=yolov8n.yaml ...
 ### 2. Python SDK
 To use pythonic interface of Ultralytics YOLO model
 ```python
+from ultralytics import YOLO
+
 model = YOLO.new('yolov8n.yaml')  # create a new model from scratch
 model = YOLO.load('yolov8n.pt')  # load a pretrained model (recommended for best training results)
+
 results = model.train(data='coco128.yaml', epochs=100, imgsz=640, ...)
 results = model.val()
 results = model.predict(source='bus.jpg')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,44 +4,38 @@ from ultralytics import YOLO
 
 
 def test_model_forward():
-    model = YOLO()
-    model.new("yolov8n.yaml")
+    model = YOLO.new("yolov8n.yaml")
     img = torch.rand(512 * 512 * 3).view(1, 3, 512, 512)
     model.forward(img)
     model(img)
 
 
 def test_model_info():
-    model = YOLO()
-    model.new("yolov8n.yaml")
+    model = YOLO.new("yolov8n.yaml")
     model.info()
-    model.load("best.pt")
+    model = model.load("best.pt")
     model.info(verbose=True)
 
 
 def test_model_fuse():
-    model = YOLO()
-    model.new("yolov8n.yaml")
+    model = YOLO.new("yolov8n.yaml")
     model.fuse()
     model.load("best.pt")
     model.fuse()
 
 
 def test_visualize_preds():
-    model = YOLO()
-    model.load("best.pt")
+    model = YOLO.load("best.pt")
     model.predict(source="ultralytics/assets")
 
 
 def test_val():
-    model = YOLO()
-    model.load("best.pt")
+    model = YOLO.load("best.pt")
     model.val(data="coco128.yaml", imgsz=32)
 
 
 def test_model_resume():
-    model = YOLO()
-    model.new("yolov8n.yaml")
+    model = YOLO.new("yolov8n.yaml")
     model.train(epochs=1, imgsz=32, data="coco128.yaml")
     try:
         model.resume(task="detect")
@@ -50,10 +44,9 @@ def test_model_resume():
 
 
 def test_model_train_pretrained():
-    model = YOLO()
-    model.load("best.pt")
+    model = YOLO.load("best.pt")
     model.train(data="coco128.yaml", epochs=1, imgsz=32)
-    model.new("yolov8n.yaml")
+    model = model.new("yolov8n.yaml")
     model.train(data="coco128.yaml", epochs=1, imgsz=32)
     img = torch.rand(512 * 512 * 3).view(1, 3, 512, 512)
     model(img)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -11,6 +11,7 @@ def test_model_init():
         print("Successfully caught constructor assert!")
     raise Exception("constructor error didn't occur")
 
+
 def test_model_forward():
     model = YOLO.new("yolov8n.yaml")
     img = torch.rand(512 * 512 * 3).view(1, 3, 512, 512)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,7 @@ from ultralytics import YOLO
 
 def test_model_init():
     model = YOLO.new("yolov8n.yaml")
+    model.info()
     try:
         YOLO()
     except Exception:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,6 +3,14 @@ import torch
 from ultralytics import YOLO
 
 
+def test_model_init():
+    model = YOLO.new("yolov8n.yaml")
+    try:
+        YOLO()
+    except Exception:
+        print("Successfully caught constructor assert!")
+    raise Exception("constructor error didn't occur")
+
 def test_model_forward():
     model = YOLO.new("yolov8n.yaml")
     img = torch.rand(512 * 512 * 3).view(1, 3, 512, 512)

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -50,10 +50,6 @@ class YOLO:
         self.overrides = {}
         self.init_disabled = False
 
-    @staticmethod
-    def _init_instruction():
-        return "The correct way to initialize a model is: YOLO.new(*.cfg) or YOLO.load('*.pt')"
-
     @classmethod
     def new(cls, cfg: str):
         """

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -5,7 +5,7 @@ from ultralytics import yolo  # noqa required for python usage
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel, attempt_load_weights
 # from ultralytics.yolo.data.utils import check_dataset, check_dataset_yaml
 from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
-from ultralytics.yolo.utils import LOGGER
+from ultralytics.yolo.utils import LOGGER, HELP_MSG
 from ultralytics.yolo.utils.checks import check_yaml
 from ultralytics.yolo.utils.configs import get_config
 from ultralytics.yolo.utils.files import yaml_load
@@ -36,7 +36,7 @@ class YOLO:
             type (str): Type/version of models to use
         """
         if init_key != YOLO.__init_key:
-            raise Exception(YOLO._init_instruction())
+            raise Exception(HELP_MSG)
 
         self.type = type
         self.ModelClass = None

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -5,7 +5,7 @@ from ultralytics import yolo  # noqa required for python usage
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel, attempt_load_weights
 # from ultralytics.yolo.data.utils import check_dataset, check_dataset_yaml
 from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
-from ultralytics.yolo.utils import LOGGER, HELP_MSG
+from ultralytics.yolo.utils import HELP_MSG, LOGGER
 from ultralytics.yolo.utils.checks import check_yaml
 from ultralytics.yolo.utils.configs import get_config
 from ultralytics.yolo.utils.files import yaml_load

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -24,7 +24,7 @@ MODEL_MAP = {
         'yolo.TYPE.segment.SegmentationPredictor']}
 
 
-class YOLO(object):
+class YOLO:
     """
     Python interface which emulates a model-like behaviour by wrapping trainers.
     """

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -58,12 +58,11 @@ class YOLO:
             cfg = yaml.safe_load(f)  # model dict
         obj = cls()
         obj.task = obj._guess_task_from_head(cfg["head"][-1][-2])
-        obj.ModelClass, obj.TrainerClass, obj.ValidatorClass, obj.PredictorClass = obj._guess_ops_from_task(
-            obj.task)
+        obj.ModelClass, obj.TrainerClass, obj.ValidatorClass, obj.PredictorClass = obj._guess_ops_from_task(obj.task)
         obj.model = obj.ModelClass(cfg)  # initialize
 
         return obj
-    
+
     @classmethod
     def load(cls, weights: str):
         """

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -24,7 +24,7 @@ LOGGING_NAME = 'yolov5'
 HELP_MSG = \
     """
     Please refer to below Usage examples for help running YOLOv8
-    For help visit the Ultralytics Community at https://community.ultralytics.com/
+    For help visit Ultralytics Community at https://community.ultralytics.com/
     Submit bug reports to https//github.com/ultralytics/ultralytics
 
     Install:
@@ -41,9 +41,9 @@ HELP_MSG = \
         success = model.export(format='onnx')
 
     CLI usage:
-        yolo task=detect    mode=train     model=s.yaml ...
-                  classify       predict         s-cls.yaml
-                  segment        val             s-seg.yaml
+        yolo task=detect    mode=train     model=yolov8n.yaml ...
+                  classify       predict         yolov8n-cls.yaml
+                  segment        val             yolov8n-seg.yaml
 
     For all arguments see https://github.com/ultralytics/ultralytics/blob/main/ultralytics/yolo/utils/configs/default.yaml
     """

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -26,28 +26,27 @@ HELP_MSG = \
     Please refer to below Usage examples for help running YOLOv8
     For help visit the Ultralytics Community at https://community.ultralytics.com/
     Submit bug reports to https//github.com/ultralytics/ultralytics
-    
+
     Install:
         pip install ultralytics
-    
+
     Python usage:
         from ultralytics import YOLO
-        
+
         model = YOLO.new('yolov8n.yaml')  # create a new model from scratch
         model = YOLO.load('yolov8n.pt')  # load a pretrained model (recommended for best training results)
         results = model.train(data='coco128.yaml')
         results = model.val()
         results = model.predict(source='bus.jpg')
         success = model.export(format='onnx')
-        
+
     CLI usage:
         yolo task=detect    mode=train     model=s.yaml ...
                   classify       predict         s-cls.yaml
                   segment        val             s-seg.yaml
-                  
+
     For all arguments see https://github.com/ultralytics/ultralytics/blob/main/ultralytics/yolo/utils/configs/default.yaml
     """
-
 
 # Settings
 # torch.set_printoptions(linewidth=320, precision=5, profile='long')

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -21,6 +21,33 @@ FONT = 'Arial.ttf'  # https://ultralytics.com/assets/Arial.ttf
 VERBOSE = str(os.getenv('YOLOv5_VERBOSE', True)).lower() == 'true'  # global verbose mode
 TQDM_BAR_FORMAT = '{l_bar}{bar:10}{r_bar}'  # tqdm bar format
 LOGGING_NAME = 'yolov5'
+HELP_MSG = \
+    """
+    Please refer to below Usage examples for help running YOLOv8
+    For help visit the Ultralytics Community at https://community.ultralytics.com/
+    Submit bug reports to https//github.com/ultralytics/ultralytics
+    
+    Install:
+        pip install ultralytics
+    
+    Python usage:
+        from ultralytics import YOLO
+        
+        model = YOLO.new('yolov8n.yaml')  # create a new model from scratch
+        model = YOLO.load('yolov8n.pt')  # load a pretrained model (recommended for best training results)
+        results = model.train(data='coco128.yaml')
+        results = model.val()
+        results = model.predict(source='bus.jpg')
+        success = model.export(format='onnx')
+        
+    CLI usage:
+        yolo task=detect    mode=train     model=s.yaml ...
+                  classify       predict         s-cls.yaml
+                  segment        val             s-seg.yaml
+                  
+    For all arguments see https://github.com/ultralytics/ultralytics/blob/main/ultralytics/yolo/utils/configs/default.yaml
+    """
+
 
 # Settings
 # torch.set_printoptions(linewidth=320, precision=5, profile='long')


### PR DESCRIPTION
@glenn-jocher 
See tests/test_model.py for usage.. You can even run that module if you have a best.pt weight lying around.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated YOLO command-line and Python SDK interfaces with new naming and model instantiation methods.

### 📊 Key Changes
- Changed CLI terminology: `infer` to `predict`, `s.yaml` to `yolov8n.yaml`, etc.
- Updated Python SDK code to create (`YOLO.new`) and load (`YOLO.load`) models directly, with simplified and clearer methods.
- Added error handling to ensure proper usage of the YOLO class instantiation.
- Added a help message (`HELP_MSG`) to assist users in using the YOLO API correctly.

### 🎯 Purpose & Impact
- 🔍 Enhances clarity and eases the usage of the YOLO interface for developers and end-users.
- 🛠️ Streamlines the model creation and loading process, making it more pythonic and less error-prone.
- 📚 Provides a clear help message to guide users in case of improper API usage, reducing potential confusion and support requests.
- 📈 Potentially increases the adoption of the YOLO API by making it more accessible and user-friendly.