### PR TITLE
Update save_dir rank check

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -49,7 +49,7 @@ class BaseTrainer:
         # dirs
         project = self.args.project or f"runs/{self.args.task}"
         name = self.args.name or f"{self.args.mode}"
-        self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK == -1 else True)
+        self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in [-1, 0] else True)
         self.wdir = self.save_dir / 'weights'  # weights dir
         self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
         self.last, self.best = self.wdir / 'last.pt', self.wdir / 'best.pt'  # checkpoint paths

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -51,7 +51,8 @@ class BaseTrainer:
         name = self.args.name or f"{self.args.mode}"
         self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in [-1, 0] else True)
         self.wdir = self.save_dir / 'weights'  # weights dir
-        self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
+        if RANK in [-1, 0]:
+            self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
         self.last, self.best = self.wdir / 'last.pt', self.wdir / 'best.pt'  # checkpoint paths
 
         self.batch_size = self.args.batch_size

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -53,6 +53,8 @@ class BaseTrainer:
         self.wdir = self.save_dir / 'weights'  # weights dir
         if RANK in {-1, 0}:
             self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
+            # Save run settings
+            save_yaml(self.save_dir / 'args.yaml', OmegaConf.to_container(self.args, resolve=True))
         self.last, self.best = self.wdir / 'last.pt', self.wdir / 'best.pt'  # checkpoint paths
 
         self.batch_size = self.args.batch_size
@@ -60,9 +62,6 @@ class BaseTrainer:
         self.start_epoch = 0
         if RANK == -1:
             print_args(dict(self.args))
-
-        # Save run settings
-        save_yaml(self.save_dir / 'args.yaml', OmegaConf.to_container(self.args, resolve=True))
 
         # device
         self.device = utils.torch_utils.select_device(self.args.device, self.batch_size)

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -49,7 +49,7 @@ class BaseTrainer:
         # dirs
         project = self.args.project or f"runs/{self.args.task}"
         name = self.args.name or f"{self.args.mode}"
-        self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in [-1, 0] else True)
+        self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in {-1, 0} else True)
         self.wdir = self.save_dir / 'weights'  # weights dir
         self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
         self.last, self.best = self.wdir / 'last.pt', self.wdir / 'best.pt'  # checkpoint paths

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -51,7 +51,7 @@ class BaseTrainer:
         name = self.args.name or f"{self.args.mode}"
         self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in {-1, 0} else True)
         self.wdir = self.save_dir / 'weights'  # weights dir
-        if RANK in [-1, 0]:
+        if RANK in {-1, 0}:
             self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
         self.last, self.best = self.wdir / 'last.pt', self.wdir / 'best.pt'  # checkpoint paths
 

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -35,7 +35,7 @@ class BaseValidator:
         project = self.args.project or f"runs/{self.args.task}"
         name = self.args.name or f"{self.args.mode}"
         self.save_dir = save_dir or increment_path(Path(project) / name,
-                                                   exist_ok=self.args.exist_ok if RANK == -1 else True)
+                                                   exist_ok=self.args.exist_ok if RANK in [-1, 0] else True)
         (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
 
     @smart_inference_mode()

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -35,7 +35,7 @@ class BaseValidator:
         project = self.args.project or f"runs/{self.args.task}"
         name = self.args.name or f"{self.args.mode}"
         self.save_dir = save_dir or increment_path(Path(project) / name,
-                                                   exist_ok=self.args.exist_ok if RANK in [-1, 0] else True)
+                                                   exist_ok=self.args.exist_ok if RANK in {-1, 0} else True)
         (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
 
     @smart_inference_mode()


### PR DESCRIPTION
@Laughing-q 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing improved file handling for distributed training setups.

### 📊 Key Changes
- Modified `save_dir` path creation to account for the primary (rank 0) process in distributed training.
- Ensured weight directory (`wdir`) creation and the saving of run settings (`args.yaml`) occur only for the primary process or in single-process scenarios (ranks -1 or 0).

### 🎯 Purpose & Impact
- 🛠️ **Enhanced Distributed Training**: Changes are aimed at preventing file system conflicts that may occur when multiple processes try to create the same directory or file in distributed training environments.
- ✅ **More Consistency**: Ensures that only the primary process handles write operations, offering a more consistent and controlled file handling experience across different training modes.
- 🚀 **Potential Performance Gains**: Could result in slightly better performance and less risk of errors when scaling to multiple processes/machines.