### PR TITLE
Import DEFAULT_CONFIG from utils/__init__.py

### DIFF
--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -7,8 +7,7 @@ from tqdm import tqdm
 
 from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.yolo.data.utils import check_dataset, check_dataset_yaml
-from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
-from ultralytics.yolo.utils import LOGGER, RANK, TQDM_BAR_FORMAT
+from ultralytics.yolo.utils import DEFAULT_CONFIG, LOGGER, RANK, TQDM_BAR_FORMAT
 from ultralytics.yolo.utils.files import increment_path
 from ultralytics.yolo.utils.ops import Profile
 from ultralytics.yolo.utils.torch_utils import check_imgsz, de_parallel, select_device, smart_inference_mode

--- a/ultralytics/yolo/v8/classify/predict.py
+++ b/ultralytics/yolo/v8/classify/predict.py
@@ -2,7 +2,7 @@ import hydra
 import torch
 
 from ultralytics.yolo.engine.predictor import BasePredictor
-from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
+from ultralytics.yolo.utils import DEFAULT_CONFIG
 from ultralytics.yolo.utils.plotting import Annotator
 
 

--- a/ultralytics/yolo/v8/classify/val.py
+++ b/ultralytics/yolo/v8/classify/val.py
@@ -2,8 +2,8 @@ import hydra
 import torch
 
 from ultralytics.yolo.data import build_classification_dataloader
-from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
 from ultralytics.yolo.engine.validator import BaseValidator
+from ultralytics.yolo.utils import DEFAULT_CONFIG
 
 
 class ClassificationValidator(BaseValidator):

--- a/ultralytics/yolo/v8/detect/predict.py
+++ b/ultralytics/yolo/v8/detect/predict.py
@@ -2,8 +2,7 @@ import hydra
 import torch
 
 from ultralytics.yolo.engine.predictor import BasePredictor
-from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
-from ultralytics.yolo.utils import ops
+from ultralytics.yolo.utils import DEFAULT_CONFIG, ops
 from ultralytics.yolo.utils.plotting import Annotator, colors, save_one_box
 
 

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -7,9 +7,8 @@ import torch
 
 from ultralytics.yolo.data import build_dataloader
 from ultralytics.yolo.data.dataloaders.v5loader import create_dataloader
-from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
 from ultralytics.yolo.engine.validator import BaseValidator
-from ultralytics.yolo.utils import colorstr, ops
+from ultralytics.yolo.utils import DEFAULT_CONFIG, colorstr, ops
 from ultralytics.yolo.utils.checks import check_file, check_requirements
 from ultralytics.yolo.utils.files import yaml_load
 from ultralytics.yolo.utils.metrics import ConfusionMatrix, DetMetrics, box_iou

--- a/ultralytics/yolo/v8/segment/predict.py
+++ b/ultralytics/yolo/v8/segment/predict.py
@@ -1,8 +1,7 @@
 import hydra
 import torch
 
-from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
-from ultralytics.yolo.utils import ops
+from ultralytics.yolo.utils import DEFAULT_CONFIG, ops
 from ultralytics.yolo.utils.plotting import colors, save_one_box
 
 from ..detect.predict import DetectionPredictor

--- a/ultralytics/yolo/v8/segment/train.py
+++ b/ultralytics/yolo/v8/segment/train.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 
 from ultralytics.nn.tasks import SegmentationModel
 from ultralytics.yolo import v8
-from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
+from ultralytics.yolo.utils import DEFAULT_CONFIG
 from ultralytics.yolo.utils.loss import BboxLoss
 from ultralytics.yolo.utils.ops import crop_mask, xywh2xyxy, xyxy2xywh
 from ultralytics.yolo.utils.plotting import plot_images, plot_results

--- a/ultralytics/yolo/v8/segment/val.py
+++ b/ultralytics/yolo/v8/segment/val.py
@@ -5,8 +5,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from ultralytics.yolo.engine.trainer import DEFAULT_CONFIG
-from ultralytics.yolo.utils import ops
+from ultralytics.yolo.utils import DEFAULT_CONFIG, ops
 from ultralytics.yolo.utils.metrics import ConfusionMatrix, SegmentMetrics, box_iou, mask_iou
 from ultralytics.yolo.utils.plotting import output_to_target, plot_images
 


### PR DESCRIPTION
DEFAULT_CONFIG now defined in utils/__init__.py. PR fixes imports to point here.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring of DEFAULT_CONFIG import path in various Ultralytics YOLO modules.

### 📊 Key Changes
- Moved the `DEFAULT_CONFIG` import from `ultralytics.yolo.engine.trainer` to `ultralytics.yolo.utils` across multiple files.
- Affected files include validator.py, various predict.py and val.py files under classify, detect, and segment modules.

### 🎯 Purpose & Impact
- 🛠️ This change seems intended to streamline the configuration management within the codebase.
- ✅ By centralizing `DEFAULT_CONFIG`, it helps maintain consistency and reduce duplication, making the codebase cleaner and easier to maintain.
- 🚀 For users, this internal change is unlikely to have a direct impact, but it contributes to the overall stability and reliability of the library.