### PR TITLE
Alternative solution to support old config keys

### DIFF
--- a/ultralytics/yolo/configs/__init__.py
+++ b/ultralytics/yolo/configs/__init__.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig, OmegaConf
 from ultralytics.yolo.configs.hydra_patch import check_config_mismatch
 
 
-def get_config(config: Union[str, DictConfig], overrides: Union[str, Dict] = None):
+def get_config(config: Union[str, DictConfig], overrides: Union[str, Dict] = None, force_match=True):
     """
     Load and merge configuration data from a file or dictionary.
 
@@ -28,6 +28,15 @@ def get_config(config: Union[str, DictConfig], overrides: Union[str, Dict] = Non
         overrides = OmegaConf.load(overrides)
     elif isinstance(overrides, Dict):
         overrides = OmegaConf.create(overrides)
+
+    # Patch. Force update the configs.
+    if force_match:
+        if overrides.get("nosave") is not None:
+            overrides.save = not overrides.pop("nosave")
+        if overrides.get("noval") is not None:
+            overrides.val = not overrides.pop("noval")
+        if overrides.get("view_img") is not None:
+            overrides.show = overrides.pop("view_img")
 
     check_config_mismatch(dict(overrides).keys(), dict(config).keys())
 


### PR DESCRIPTION
@glenn-jocher I'm not sure if this is a better solution than manually using only the intersecting dicts.. Choose whatever seems better 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved configuration handling in YOLO model setup 🛠

### 📊 Key Changes
- Added a `force_match` parameter to the `get_config` method.
- Implemented automatic updating of configuration dictionary based on new `force_match` logic.
- Conversion of legacy override parameters like `nosave`, `noval`, and `view_img` to their updated counterparts within the method.

### 🎯 Purpose & Impact
- **Purpose**: To simplify and ensure consistent configuration for model training and inference, while supporting backward compatibility with older configurations.
- **Impact**: Users can more easily manage configuration settings with automatic updates that respect new naming conventions, making it more straightforward to transition from older codebases or configuration files. This change promotes smoother user experience and reduces potential errors due to configuration mismatches. 🔄🚫🐛