### PR TITLE
Fix resume

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -293,6 +293,8 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
 
         # Model compatibility updates
         ckpt.args = {k: v for k, v in args.items() if k in DEFAULT_CONFIG_KEYS}
+        if not hasattr(ckpt, 'stride'):
+            ckpt.stride = torch.tensor([32.])
 
         # Append
         model.append(ckpt.fuse().eval() if fuse and hasattr(ckpt, 'fuse') else ckpt.eval())  # model in eval mode

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -136,6 +136,14 @@ class YOLODataset(BaseDataset):
                    batch_idx=True))
         return transforms
 
+    def close_mosaic(self, hyp):
+        self.transforms = affine_transforms(self.imgsz, hyp)
+        self.transforms.append(Format(bbox_format="xywh",
+                               normalize=True,
+                               return_mask=self.use_segments,
+                               return_keypoint=self.use_keypoints,
+                               batch_idx=True))
+
     def update_labels_info(self, label):
         """custom your label format here"""
         # NOTE: cls is not with bboxes now, classification and semantic segmentation need an independent cls label

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -138,11 +138,12 @@ class YOLODataset(BaseDataset):
 
     def close_mosaic(self, hyp):
         self.transforms = affine_transforms(self.imgsz, hyp)
-        self.transforms.append(Format(bbox_format="xywh",
-                               normalize=True,
-                               return_mask=self.use_segments,
-                               return_keypoint=self.use_keypoints,
-                               batch_idx=True))
+        self.transforms.append(
+            Format(bbox_format="xywh",
+                   normalize=True,
+                   return_mask=self.use_segments,
+                   return_keypoint=self.use_keypoints,
+                   batch_idx=True))
 
     def update_labels_info(self, label):
         """custom your label format here"""

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -91,7 +91,7 @@ class BaseTrainer:
         # Dirs
         project = self.args.project or f"runs/{self.args.task}"
         name = self.args.name or f"{self.args.mode}"
-        self.save_dir = self.args.get("save_dir", increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in {-1, 0} else True))
+        self.save_dir = Path(self.args.get("save_dir", increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in {-1, 0} else True)))
         self.wdir = self.save_dir / 'weights'  # weights dir
         if RANK in {-1, 0}:
             self.wdir.mkdir(parents=True, exist_ok=True)  # make dir

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -199,7 +199,6 @@ class BaseTrainer:
         else:
             self.lf = lambda x: (1 - x / self.epochs) * (1.0 - self.args.lrf) + self.args.lrf  # linear
         self.scheduler = lr_scheduler.LambdaLR(self.optimizer, lr_lambda=self.lf)
-        self.resume_training(ckpt)
         self.scheduler.last_epoch = self.start_epoch - 1  # do not move
 
         # dataloaders
@@ -211,6 +210,7 @@ class BaseTrainer:
             metric_keys = self.validator.metric_keys + self.label_loss_items(prefix="val")
             self.metrics = dict(zip(metric_keys, [0] * len(metric_keys)))  # TODO: init metrics for plot_results()?
             self.ema = ModelEMA(self.model)
+        self.resume_training(ckpt)
         self.run_callbacks("on_pretrain_routine_end")
 
     def _do_train(self, rank=-1, world_size=1):

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -379,8 +379,8 @@ class BaseTrainer:
         if not pretrained:
             model = check_file(model)
         ckpt = self.load_ckpt(model) if pretrained else None
-        self.model = self.load_model(model_cfg=None if pretrained else model,
-                                     weights=ckpt["model"] if pretrained else ckpt)  # model
+        weights = ckpt["model"] if isinstance(ckpt, dict) else ckpt # torchvision weights are not dicts
+        self.model = self.load_model(model_cfg=None if pretrained else model, weights=weights)
         return ckpt
 
     def load_ckpt(self, ckpt):

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -492,8 +492,9 @@ class BaseTrainer:
             args_yaml = last.parent.parent / 'args.yaml'  # train options yaml
             if args_yaml.is_file():
                 args = get_config(args_yaml)  # replace
-            args.model, args.resume = str(last), True  # reinstate
+            args.model, resume = str(last), True  # reinstate
             self.args = args
+        self.resume = resume
 
     def resume_training(self, ckpt):
         if ckpt is None:
@@ -506,7 +507,7 @@ class BaseTrainer:
         if self.ema and ckpt.get('ema'):
             self.ema.ema.load_state_dict(ckpt['ema'].float().state_dict())  # EMA
             self.ema.updates = ckpt['updates']
-        if self.args.resume:
+        if self.resume:
             assert start_epoch > 0, \
                 f'{self.args.model} training to {self.epochs} epochs is finished, nothing to resume.\n' \
                 f"Start a new training without --resume, i.e. 'yolo task=... mode=train model={self.args.model}'"

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -96,7 +96,7 @@ class BaseTrainer:
         if RANK in {-1, 0}:
             self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
             with open_dict(self.args):
-                self.args.save_dir = self.save_dir
+                self.args.save_dir = str(self.save_dir)
             yaml_save(self.save_dir / 'args.yaml', OmegaConf.to_container(self.args, resolve=True))  # save run args
         self.last, self.best = self.wdir / 'last.pt', self.wdir / 'best.pt'  # checkpoint paths
 

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -6,7 +6,6 @@ import os
 import subprocess
 import time
 from collections import defaultdict
-from omegaconf import open_dict
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
@@ -16,6 +15,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from omegaconf import OmegaConf  # noqa
+from omegaconf import open_dict
 from torch.cuda import amp
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import lr_scheduler
@@ -91,7 +91,10 @@ class BaseTrainer:
         # Dirs
         project = self.args.project or f"runs/{self.args.task}"
         name = self.args.name or f"{self.args.mode}"
-        self.save_dir = Path(self.args.get("save_dir", increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in {-1, 0} else True)))
+        self.save_dir = Path(
+            self.args.get(
+                "save_dir",
+                increment_path(Path(project) / name, exist_ok=self.args.exist_ok if RANK in {-1, 0} else True)))
         self.wdir = self.save_dir / 'weights'  # weights dir
         if RANK in {-1, 0}:
             self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
@@ -376,7 +379,8 @@ class BaseTrainer:
         if not pretrained:
             model = check_file(model)
         ckpt = self.load_ckpt(model) if pretrained else None
-        self.model = self.load_model(model_cfg=None if pretrained else model, weights=ckpt["model"] if pretrained else ckpt)  # model
+        self.model = self.load_model(model_cfg=None if pretrained else model,
+                                     weights=ckpt["model"] if pretrained else ckpt)  # model
         return ckpt
 
     def load_ckpt(self, ckpt):

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -379,7 +379,7 @@ class BaseTrainer:
         if not pretrained:
             model = check_file(model)
         ckpt = self.load_ckpt(model) if pretrained else None
-        weights = ckpt["model"] if isinstance(ckpt, dict) else ckpt # torchvision weights are not dicts
+        weights = ckpt["model"] if isinstance(ckpt, dict) else ckpt  # torchvision weights are not dicts
         self.model = self.load_model(model_cfg=None if pretrained else model, weights=weights)
         return ckpt
 

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -367,7 +367,7 @@ class BaseTrainer:
         if not pretrained:
             model = check_file(model)
         ckpt = self.load_ckpt(model) if pretrained else None
-        self.model = self.load_model(model_cfg=None if pretrained else model, weights=ckpt["model"])  # model
+        self.model = self.load_model(model_cfg=None if pretrained else model, weights=ckpt["model"] if pretrained else ckpt)  # model
         return ckpt
 
     def load_ckpt(self, ckpt):

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -111,6 +111,7 @@ class BaseValidator:
                 self.args.workers = 0  # faster CPU val as time dominated by inference, not dataloading
             self.dataloader = self.dataloader or \
                               self.get_dataloader(data.get("val") or data.set("test"), self.args.batch_size)
+            self.data = data
 
         model.eval()
 

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -26,10 +26,10 @@ def generate_ddp_file(trainer):
 
     if not trainer.args.resume:
         shutil.rmtree(trainer.save_dir)  # remove the save_dir
-    content = f'''overrides = {dict(trainer.args)} \nif __name__ == "__main__":
+    content = f'''config = {dict(trainer.args)} \nif __name__ == "__main__":
     from ultralytics.{import_path} import {trainer.__class__.__name__}
 
-    trainer = {trainer.__class__.__name__}(overrides=overrides)
+    trainer = {trainer.__class__.__name__}(config=config)
     trainer.train()'''
     (USER_CONFIG_DIR / 'DDP').mkdir(exist_ok=True)
     with tempfile.NamedTemporaryFile(prefix="_temp_",

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -24,7 +24,8 @@ def find_free_network_port() -> int:
 def generate_ddp_file(trainer):
     import_path = '.'.join(str(trainer.__class__).split(".")[1:-1])
 
-    shutil.rmtree(trainer.save_dir)  # remove the save_dir
+    if not trainer.resume:
+        shutil.rmtree(trainer.save_dir)  # remove the save_dir
     content = f'''overrides = {dict(trainer.args)} \nif __name__ == "__main__":
     from ultralytics.{import_path} import {trainer.__class__.__name__}
 

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -24,7 +24,7 @@ def find_free_network_port() -> int:
 def generate_ddp_file(trainer):
     import_path = '.'.join(str(trainer.__class__).split(".")[1:-1])
 
-    if not trainer.resume:
+    if not trainer.args.resume:
         shutil.rmtree(trainer.save_dir)  # remove the save_dir
     content = f'''overrides = {dict(trainer.args)} \nif __name__ == "__main__":
     from ultralytics.{import_path} import {trainer.__class__.__name__}

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -24,7 +24,7 @@ def find_free_network_port() -> int:
 def generate_ddp_file(trainer):
     import_path = '.'.join(str(trainer.__class__).split(".")[1:-1])
 
-    if not trainer.args.resume:
+    if not trainer.resume:
         shutil.rmtree(trainer.save_dir)  # remove the save_dir
     content = f'''config = {dict(trainer.args)} \nif __name__ == "__main__":
     from ultralytics.{import_path} import {trainer.__class__.__name__}

--- a/ultralytics/yolo/v8/detect/train.py
+++ b/ultralytics/yolo/v8/detect/train.py
@@ -1,7 +1,8 @@
+from copy import copy
+
 import hydra
 import torch
 import torch.nn as nn
-from copy import copy
 
 from ultralytics.nn.tasks import DetectionModel
 from ultralytics.yolo import v8

--- a/ultralytics/yolo/v8/detect/train.py
+++ b/ultralytics/yolo/v8/detect/train.py
@@ -1,6 +1,7 @@
 import hydra
 import torch
 import torch.nn as nn
+from copy import copy
 
 from ultralytics.nn.tasks import DetectionModel
 from ultralytics.yolo import v8
@@ -64,7 +65,7 @@ class DetectionTrainer(BaseTrainer):
         return v8.detect.DetectionValidator(self.test_loader,
                                             save_dir=self.save_dir,
                                             logger=self.console,
-                                            args=self.args)
+                                            args=copy(self.args))
 
     def criterion(self, preds, batch):
         if not hasattr(self, 'compute_loss'):

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -42,10 +42,9 @@ class DetectionValidator(BaseValidator):
 
     def init_metrics(self, model):
         head = model.model[-1] if self.training else model.model.model[-1]
-        if self.data:
-            self.is_coco = self.data.get('val', '').endswith(f'coco{os.sep}val2017.txt')  # is COCO dataset
-            self.class_map = ops.coco80_to_coco91_class() if self.is_coco else list(range(1000))
-            self.args.save_json |= self.is_coco and not self.training  # run on final val if training COCO
+        self.is_coco = self.data.get('val', '').endswith(f'coco{os.sep}val2017.txt')  # is COCO dataset
+        self.class_map = ops.coco80_to_coco91_class() if self.is_coco else list(range(1000))
+        self.args.save_json |= self.is_coco and not self.training  # run on final val if training COCO
         self.nc = head.nc
         self.names = model.names
         self.metrics.names = self.names

--- a/ultralytics/yolo/v8/segment/train.py
+++ b/ultralytics/yolo/v8/segment/train.py
@@ -1,8 +1,9 @@
+from copy import copy
+
 import hydra
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from copy import copy
 
 from ultralytics.nn.tasks import SegmentationModel
 from ultralytics.yolo import v8

--- a/ultralytics/yolo/v8/segment/train.py
+++ b/ultralytics/yolo/v8/segment/train.py
@@ -2,6 +2,7 @@ import hydra
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from copy import copy
 
 from ultralytics.nn.tasks import SegmentationModel
 from ultralytics.yolo import v8
@@ -27,7 +28,7 @@ class SegmentationTrainer(v8.detect.DetectionTrainer):
         return v8.segment.SegmentationValidator(self.test_loader,
                                                 save_dir=self.save_dir,
                                                 logger=self.console,
-                                                args=self.args)
+                                                args=copy(self.args))
 
     def criterion(self, preds, batch):
         if not hasattr(self, 'compute_loss'):

--- a/ultralytics/yolo/v8/segment/val.py
+++ b/ultralytics/yolo/v8/segment/val.py
@@ -37,10 +37,9 @@ class SegmentationValidator(DetectionValidator):
 
     def init_metrics(self, model):
         head = model.model[-1] if self.training else model.model.model[-1]
-        if self.data:
-            self.is_coco = self.data.get('val', '').endswith(f'coco{os.sep}val2017.txt')  # is COCO dataset
-            self.class_map = ops.coco80_to_coco91_class() if self.is_coco else list(range(1000))
-            self.args.save_json |= self.is_coco and not self.training  # run on final val if training COCO
+        self.is_coco = self.data.get('val', '').endswith(f'coco{os.sep}val2017.txt')  # is COCO dataset
+        self.class_map = ops.coco80_to_coco91_class() if self.is_coco else list(range(1000))
+        self.args.save_json |= self.is_coco and not self.training  # run on final val if training COCO
         self.nc = head.nc
         self.nm = head.nm if hasattr(head, "nm") else 32
         self.names = model.names


### PR DESCRIPTION
@AyushExel @glenn-jocher 
- fixed [https://github.com/ultralytics/ultralytics/issues/55#issuecomment-1369144302](https://github.com/ultralytics/ultralytics/issues/55#issuecomment-1369144302) and [https://github.com/ultralytics/ultralytics/issues/55#issuecomment-1367740182](https://github.com/ultralytics/ultralytics/issues/55#issuecomment-1367740182)
- added close-mosaic by recreating dataset.transforms(adding a function `close_mosaic(self, hyp)` in dataset) when epoch reaches close-mosaic epoch, tested and it works.
- I found this line would update the value of `trainer.args.plot`
    [https://github.com/ultralytics/ultralytics/blob/82c849c16374f4b84f0f29f52b186f3d332bd5d1/ultralytics/yolo/engine/validator.py#L85](https://github.com/ultralytics/ultralytics/blob/82c849c16374f4b84f0f29f52b186f3d332bd5d1/ultralytics/yolo/engine/validator.py#L85)
    so I added a copy operation when sending the args to Validator.
    [https://github.com/ultralytics/ultralytics/blob/f9a556a31ad8b47bc4194cd3da211af00193af39/ultralytics/yolo/v8/detect/train.py#L65-L68](https://github.com/ultralytics/ultralytics/blob/f9a556a31ad8b47bc4194cd3da211af00193af39/ultralytics/yolo/v8/detect/train.py#L65-L68)
- also I made the plot_training_sample also plot the first three samples after closing mosaic, which I think it's more clear to know if close-mosaic is working. wondering if you guys agree.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to model loading, training behavior, and validator setup in Ultralytics software.

### 📊 Key Changes
- 🔄 Improved model compatibility by ensuring `ckpt.stride` attribute exists.
- 🧩 Added a new method `close_mosaic` to adjust data transforms during training end phase.
- 🗂️ Updated saving directory handling, allowing override through `args.save_dir`.
- 📉 Introduced `plot_idx` to control plotting of training samples.
- 🔧 Minor modifications to resume training logic and distributed training file generation.
- 🛠️ Refactored how the validator uses the data and how it determines if it's running on the COCO dataset.

### 🎯 Purpose & Impact
- 📈 Ensures that older checkpoints without the `stride` attribute can still be used, improving backward compatibility.
- 🎛️ Allows dynamic changes to data augmentation during certain training phases, potentially improving model performance as training progresses.
- 🧰 Enhanced flexibility for checkpoint directories, making it easier for users to manage output file locations.
- 📊 The `plot_idx` change gives better control over training visualization, which could aid debugging and analysis.
- 🎢 The alterations in resume and distributed training are expected to make the process smoother and more robust.
- ✨ Validator adjustments streamline code and could improve validation metrics, particularly with COCO dataset predictions.