### PR TITLE
Default confidences predict 0.25, val 0.001

### DIFF
--- a/ultralytics/yolo/configs/default.yaml
+++ b/ultralytics/yolo/configs/default.yaml
@@ -39,7 +39,7 @@ dropout: False # use dropout regularization
 val: True # validate/test during training
 save_json: False # save results to JSON file
 save_hybrid: False # save hybrid version of labels (labels + additional predictions)
-conf: 0.001 # object confidence threshold for detection
+conf: null # object confidence threshold for detection (default 0.25 predict, 0.001 val)
 iou: 0.7 # intersection over union (IoU) threshold for NMS
 max_det: 300 # maximum number of detections per image
 half: False # use half precision (FP16)

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -77,7 +77,8 @@ class BasePredictor:
         name = self.args.name or f"{self.args.mode}"
         self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok)
         (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
-
+        if self.args.conf is None:
+            self.args.conf = 0.25  # default conf=0.25
         self.done_setup = False
 
         # Usable if setup is done

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -65,6 +65,9 @@ class BaseValidator:
                                                    exist_ok=self.args.exist_ok if RANK in {-1, 0} else True)
         (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
 
+        if self.args.conf is None:
+            self.args.conf = 0.001  # default conf=0.001
+
         self.callbacks = defaultdict(list, {k: [v] for k, v in callbacks.default_callbacks.items()})  # add callbacks
 
     @smart_inference_mode()


### PR DESCRIPTION
@AyushExel setting default confidences here for predict, val.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment of default object confidence thresholds for prediction and validation.

### 📊 Key Changes
- Changed the default `conf` (confidence threshold) in the `default.yaml` config file from 0.001 to `null`, specifying different defaults for prediction (0.25) and validation (0.001).
- Updated `predictor.py` to set a default confidence of 0.25 if no value is provided.
- Updated `validator.py` to set a default confidence of 0.001 if no value is provided.

### 🎯 Purpose & Impact
- These changes aim to clarify and differentiate the object confidence thresholds between prediction and validation stages, offering better defaults for each case.
- This will likely result in more accurate detection during prediction and stricter validation criteria, improving the overall performance of models without requiring immediate configuration changes from the users. 🎯🔍
- Users can still override these defaults, but now have sensible starting points tailored to the context of use, enhancing the out-of-the-box experience. 🛠️💡