### PR TITLE
Classification label val and train losses

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -66,8 +66,8 @@ class AutoBackend(nn.Module):
             model.half() if fp16 else model.float()
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
         elif pt:  # PyTorch
-            from ultralytics.nn.tasks import attempt_load_one_weight
-            model, _ = attempt_load_one_weight(weights if isinstance(weights, list) else w,
+            from ultralytics.nn.tasks import attempt_load_weights
+            model = attempt_load_weights(weights if isinstance(weights, list) else w,
                                                device=device,
                                                inplace=True,
                                                fuse=fuse)

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -68,9 +68,9 @@ class AutoBackend(nn.Module):
         elif pt:  # PyTorch
             from ultralytics.nn.tasks import attempt_load_weights
             model = attempt_load_weights(weights if isinstance(weights, list) else w,
-                                               device=device,
-                                               inplace=True,
-                                               fuse=fuse)
+                                         device=device,
+                                         inplace=True,
+                                         fuse=fuse)
             stride = max(int(model.stride.max()), 32)  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             model.half() if fp16 else model.float()

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -68,9 +68,9 @@ class AutoBackend(nn.Module):
         elif pt:  # PyTorch
             from ultralytics.nn.tasks import attempt_load_one_weight
             model, _ = attempt_load_one_weight(weights if isinstance(weights, list) else w,
-                                         device=device,
-                                         inplace=True,
-                                         fuse=fuse)
+                                               device=device,
+                                               inplace=True,
+                                               fuse=fuse)
             stride = max(int(model.stride.max()), 32)  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             model.half() if fp16 else model.float()

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -66,8 +66,8 @@ class AutoBackend(nn.Module):
             model.half() if fp16 else model.float()
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
         elif pt:  # PyTorch
-            from ultralytics.nn.tasks import attempt_load_weights
-            model = attempt_load_weights(weights if isinstance(weights, list) else w,
+            from ultralytics.nn.tasks import attempt_load_one_weight
+            model, _ = attempt_load_one_weight(weights if isinstance(weights, list) else w,
                                          device=device,
                                          inplace=True,
                                          fuse=fuse)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -292,7 +292,6 @@ class ClassificationModel(BaseModel):
 
 
 def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
-    LOGGER.info("WARNING: Deprecated in favor of attempt_load_one_weight()")
     # Loads an ensemble of models weights=[a,b,c] or a single model weights=[a] or weights=a
     from ultralytics.yolo.utils.downloads import attempt_download
 

--- a/ultralytics/yolo/v8/classify/train.py
+++ b/ultralytics/yolo/v8/classify/train.py
@@ -2,7 +2,7 @@ import hydra
 import torch
 import torchvision
 
-from ultralytics.nn.tasks import ClassificationModel, attempt_load_weights
+from ultralytics.nn.tasks import ClassificationModel, attempt_load_one_weight
 from ultralytics.yolo import v8
 from ultralytics.yolo.data import build_classification_dataloader
 from ultralytics.yolo.engine.trainer import BaseTrainer
@@ -43,7 +43,7 @@ class ClassificationTrainer(BaseTrainer):
         model = str(self.model)
         # Load a YOLO model locally, from torchvision, or from Ultralytics assets
         if model.endswith(".pt"):
-            self.model = attempt_load_weights(model, device='cpu')
+            self.model, _ = attempt_load_one_weight(model, device='cpu')
         elif model.endswith(".yaml"):
             self.model = self.get_model(cfg=model)
         elif model in torchvision.models.__dict__:

--- a/ultralytics/yolo/v8/classify/train.py
+++ b/ultralytics/yolo/v8/classify/train.py
@@ -76,6 +76,18 @@ class ClassificationTrainer(BaseTrainer):
         loss = torch.nn.functional.cross_entropy(preds, batch["cls"])
         return loss, loss
 
+    def label_loss_items(self, loss_items=None, prefix="train"):
+        """
+        Returns a loss dict with labelled training loss items tensor
+        """
+        # Not needed for classification but necessary for segmentation & detection
+        keys = [f"{prefix}/{x}" for x in self.loss_names]
+        if loss_items is not None:
+            loss_items = [round(float(loss_items), 5)]
+            return dict(zip(keys, loss_items))
+        else:
+            return keys
+
     def resume_training(self, ckpt):
         pass
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Deprecation of `attempt_load_weights` in favor of `attempt_load_one_weight`.

### 📊 Key Changes
- Deprecated the `attempt_load_weights` function.
- Replaced `attempt_load_weights` with `attempt_load_one_weight` in `train.py`.
- Added `label_loss_items` method to handle loss item labeling.

### 🎯 Purpose & Impact
- The deprecation and replacement guide users towards the new standard method (`attempt_load_one_weight`) for loading model weights, ensuring a more streamlined and potentially more efficient loading process. 🔄
- The introduction of `label_loss_items` improves the clarity of loss reporting, benefiting users who need detailed insight during training phases. 📈
- These changes might require users to update their existing code if they rely on the deprecated function but will ultimately align them with Ultralytics' best practices. 🛠️