### PR TITLE
Log lr for param groups

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -317,7 +317,8 @@ class BaseTrainer:
 
                 self.run_callbacks("on_train_batch_end")
 
-            lr = {f"lr{ir}": x['lr'] for ir, x in enumerate(self.optimizer.param_groups)}  # for loggers
+            self.lr = {f"lr/pg{ir}": x['lr'] for ir, x in enumerate(self.optimizer.param_groups)}  # for loggers
+
             self.scheduler.step()
             self.run_callbacks("on_train_epoch_end")
 
@@ -328,7 +329,7 @@ class BaseTrainer:
                 final_epoch = (epoch + 1 == self.epochs)
                 if self.args.val or final_epoch:
                     self.metrics, self.fitness = self.validate()
-                self.save_metrics(metrics={**self.label_loss_items(self.tloss), **self.metrics, **lr})
+                self.save_metrics(metrics={**self.label_loss_items(self.tloss), **self.metrics, **self.lr})
 
                 # Save model
                 if self.args.save or (epoch + 1 == self.epochs):

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -25,6 +25,7 @@ def on_fit_epoch_end(trainer):
 
 def on_train_epoch_end(trainer):
     wandb.run.log(trainer.label_loss_items(trainer.tloss, prefix="train"), step=trainer.epoch + 1)
+    wandb.run.log(trainer.lr, step=trainer.epoch + 1)
     if trainer.epoch == 1:
         wandb.run.log({f.stem: wandb.Image(str(f))
                        for f in trainer.save_dir.glob('train_batch*.jpg')},


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved learning rate (LR) logging in Ultralytics training pipeline.

### 📊 Key Changes
- Learning rate tracking variable was changed from `lr` to `self.lr` to improve consistency.
- Learning rate is now logged with a more descriptive key, showing the parameter group (`pg`) it belongs to in the optimizer.

### 🎯 Purpose & Impact
- The purpose of these changes is to refine how learning rates are recorded and labeled, allowing for clearer visualization and easier understanding of how each parameter group's learning rate changes over time.
- Users can expect more detailed insight into the training process, potentially leading to improved model tuning and debugging capabilities. 📈 This will be especially useful for developers using tools like Weights & Biases (wandb) for experiment tracking.