### PR TITLE
Docs: readme.md contributor image  and quick start code fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ YOLOv8 may also be used directly in a Python environment, and accepts the same [
 from ultralytics import YOLO
 
 # Load a model
-model = YOLO("yolov8n.yaml")  # build a new model from scratch
-model = YOLO("yolov8n.pt")  # load a pretrained model (recommended for training)
+model = YOLO('yolov8n.yaml')  # build a new model from scratch
+model = YOLO('yolov8n.pt')  # load a pretrained model (recommended for training)
 
 # Use the model
-results = model.train(data="coco128.yaml", epochs=3)  # train the model
+results = model.train(data='coco128.yaml', epochs=3)  # train the model
 results = model.val()  # evaluate model performance on the validation set
-results = model("https://ultralytics.com/images/bus.jpg")  # predict on an image
-success = YOLO("yolov8n.pt").export(format="onnx")  # export a model to ONNX format
+results = model('https://ultralytics.com/images/bus.jpg')  # predict on an image
+success = YOLO('yolov8n.pt').export(format='onnx')  # export a model to ONNX format
 ```
 
 [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/yolo/v8/models) download automatically from the latest
@@ -207,9 +207,7 @@ We love your input! YOLOv5 and YOLOv8 would not be possible without help from ou
 
 <!-- SVG image from https://opencollective.com/ultralytics/contributors.svg?width=990 -->
 
-<a href = "https://github.com/ultralytics/ultralytics/graphs/contributors">
-  <img src = "https://contrib.rocks/image?repo=ultralytics/ultralytics"/>
-</a>
+<a href="https://github.com/ultralytics/ultralytics/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors-1280.png"/></a>
 
 ## <div align="center">License</div>
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ YOLOv8 may also be used directly in a Python environment, and accepts the same [
 from ultralytics import YOLO
 
 # Load a model
-model = YOLO('yolov8n.yaml')  # build a new model from scratch
-model = YOLO('yolov8n.pt')  # load a pretrained model (recommended for training)
+model = YOLO("yolov8n.yaml")  # build a new model from scratch
+model = YOLO("yolov8n.pt")  # load a pretrained model (recommended for training)
 
 # Use the model
-results = model.train(data='coco128.yaml', epochs=3)  # train the model
+results = model.train(data="coco128.yaml", epochs=3)  # train the model
 results = model.val()  # evaluate model performance on the validation set
-results = model('https://ultralytics.com/images/bus.jpg')  # predict on an image
-success = YOLO('yolov8n.pt').export(format='onnx')  # export a model to ONNX format
+results = model("https://ultralytics.com/images/bus.jpg")  # predict on an image
+success = YOLO("yolov8n.pt").export(format="onnx")  # export a model to ONNX format
 ```
 
 [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/yolo/v8/models) download automatically from the latest

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ YOLOv8 may also be used directly in a Python environment, and accepts the same [
 from ultralytics import YOLO
 
 # Load a model
-model = YOLO('yolov8n.yaml')    # build a new model from scratch
-model = YOLO('yolov8n.pt')      # load a pretrained model (recommended for training)
+model = YOLO("yolov8n.yaml")  # build a new model from scratch
+model = YOLO("yolov8n.pt")  # load a pretrained model (recommended for training)
 
 # Model usage
-model.train(data='coco128.yaml')                                # train the model
-model.val(data='coco128.yaml')                                  # evaluate model performance on the validation set
-model.predict(source='https://ultralytics.com/images/bus.jpg')  # predict on an image
-YOLO('yolov8n.pt').export(format='onnx')                        # export a model to torchscript format
+model.train(data="coco128.yaml")  # train the model
+model.val(data="coco128.yaml")  # evaluate model performance on the validation set
+model.predict(source="https://ultralytics.com/images/bus.jpg")  # predict on an image
+YOLO("yolov8n.pt").export(format="onnx")  # export a model to torchscript format
 ```
 
 [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/yolo/v8/models) download automatically from the latest

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ model = YOLO("yolov8n.pt")  # load a pretrained model (recommended for training)
 
 # Model usage
 model.train(data="coco128.yaml")  # train the model
-model.val(data="coco128.yaml")  # evaluate model performance on the validation set
+model.val()  # evaluate model performance on the validation set (saved to the model)
 model.predict(source="https://ultralytics.com/images/bus.jpg")  # predict on an image
-YOLO("yolov8n.pt").export(format="onnx")  # export a model to torchscript format
+YOLO("yolov8n.pt").export(format="onnx")  # export a model to ONNX format
 ```
 
 [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/yolo/v8/models) download automatically from the latest

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ YOLOv8 may also be used directly in a Python environment, and accepts the same [
 from ultralytics import YOLO
 
 # Load a model
-model = YOLO("yolov8n.yaml")  # build a new model from scratch
-model = YOLO("yolov8n.pt")  # load a pretrained model (recommended for training)
+model = YOLO('yolov8n.yaml')    # build a new model from scratch
+model = YOLO('yolov8n.pt')      # load a pretrained model (recommended for training)
 
 # Model usage
-model.train(data="coco128.yaml")  # train the model
-model.val()  # evaluate model performance on the validation set (saved to the model)
-model.predict(source="https://ultralytics.com/images/bus.jpg")  # predict on an image
-YOLO("yolov8n.pt").export(format="onnx")  # export a model to ONNX format
+model.train(data='coco128.yaml', epochs=3)                      # train the model
+model.val(data='coco128.yaml')                                  # evaluate model performance on the validation set
+model.predict(source='https://ultralytics.com/images/bus.jpg')  # predict on an image
+YOLO('yolov8n.pt').export(format='onnx')                        # export a model to ONNX format
 ```
 
 [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/yolo/v8/models) download automatically from the latest

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ YOLOv8 may also be used directly in a Python environment, and accepts the same [
 from ultralytics import YOLO
 
 # Load a model
-model = YOLO("yolov8n.yaml")  # build a new model from scratch
-model = YOLO("yolov8n.pt")  # load a pretrained model (recommended for training)
+model = YOLO('yolov8n.yaml')  # build a new model from scratch
+model = YOLO('yolov8n.pt')  # load a pretrained model (recommended for training)
 
-# Model usage
-model.train(data="coco128.yaml", epochs=3)  # train the model
-model.val(data="coco128.yaml")  # evaluate model performance on the validation set
-model.predict(source="https://ultralytics.com/images/bus.jpg")  # predict on an image
-YOLO("yolov8n.pt").export(format="onnx")  # export a model to ONNX format
+# Use the model
+results = model.train(data='coco128.yaml', epochs=3)  # train the model
+results = model.val()  # evaluate model performance on the validation set
+results = model('https://ultralytics.com/images/bus.jpg')  # predict on an image
+success = YOLO('yolov8n.pt').export(format='onnx')  # export a model to ONNX format
 ```
 
 [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/yolo/v8/models) download automatically from the latest

--- a/README.md
+++ b/README.md
@@ -86,12 +86,15 @@ YOLOv8 may also be used directly in a Python environment, and accepts the same [
 ```python
 from ultralytics import YOLO
 
-model = YOLO("yolov8n.pt")  # load a pretrained YOLOv8n model
+# Load a model
+model = YOLO('yolov8n.yaml')    # build a new model from scratch
+model = YOLO('yolov8n.pt')      # load a pretrained model (recommended for training)
 
-model.train(data="coco128.yaml")  # train the model
-model.val()  # evaluate model performance on the validation set
-model.predict(source="https://ultralytics.com/images/bus.jpg")  # predict on an image
-model.export(format="onnx")  # export the model to ONNX format
+# Model usage
+model.train(data='coco128.yaml')                                # train the model
+model.val(data='coco128.yaml')                                  # evaluate model performance on the validation set
+model.predict(source='https://ultralytics.com/images/bus.jpg')  # predict on an image
+YOLO('yolov8n.pt').export(format='onnx')                        # export a model to torchscript format
 ```
 
 [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/yolo/v8/models) download automatically from the latest
@@ -204,7 +207,9 @@ We love your input! YOLOv5 and YOLOv8 would not be possible without help from ou
 
 <!-- SVG image from https://opencollective.com/ultralytics/contributors.svg?width=990 -->
 
-<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors-1280.png"/></a>
+<a href = "https://github.com/ultralytics/ultralytics/graphs/contributors">
+  <img src = "https://contrib.rocks/image?repo=ultralytics/ultralytics"/>
+</a>
 
 ## <div align="center">License</div>
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ YOLOv8 may also be used directly in a Python environment, and accepts the same [
 from ultralytics import YOLO
 
 # Load a model
-model = YOLO('yolov8n.yaml')    # build a new model from scratch
-model = YOLO('yolov8n.pt')      # load a pretrained model (recommended for training)
+model = YOLO("yolov8n.yaml")  # build a new model from scratch
+model = YOLO("yolov8n.pt")  # load a pretrained model (recommended for training)
 
 # Model usage
-model.train(data='coco128.yaml', epochs=3)                      # train the model
-model.val(data='coco128.yaml')                                  # evaluate model performance on the validation set
-model.predict(source='https://ultralytics.com/images/bus.jpg')  # predict on an image
-YOLO('yolov8n.pt').export(format='onnx')                        # export a model to ONNX format
+model.train(data="coco128.yaml", epochs=3)  # train the model
+model.val(data="coco128.yaml")  # evaluate model performance on the validation set
+model.predict(source="https://ultralytics.com/images/bus.jpg")  # predict on an image
+YOLO("yolov8n.pt").export(format="onnx")  # export a model to ONNX format
 ```
 
 [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/yolo/v8/models) download automatically from the latest


### PR DESCRIPTION

- Contributor image was pointed to yoloV5 and changed to this repository via creating automatic way.
- Quick fix/workaround for quick-start code based on  https://github.com/ultralytics/ultralytics/issues/195, for better result.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved YOLO model loading, training, prediction, and export instructions.

### 📊 Key Changes
- Updated model instantiation by providing two options: building a new model from a config file (`yolov8n.yaml`) or loading a pretrained model (`yolov8n.pt`).
- Clarified the train, val, and predict methods to return results and indicate success explicitly.
- Included `epochs` parameter in the training example to define the training duration.
- Refreshed the contributor's image link, pointing it to the correct Ultralytics repository.

### 🎯 Purpose & Impact
- Enhances user understanding of different ways to initialize a YOLO model and outlines the steps to use the model for various tasks.
- Facilitates users to quickly start model training with predefined epochs, making experimentation easier for beginners.
- Makes contributions more visible by fixing the link, fostering a community spirit.
- These changes can help ensure both new and existing users effectively utilize the YOLO models and contribute to the Ultralytics projects. 🚀