### PR TITLE
Fix `__len__` and `single_cls`

### DIFF
--- a/ultralytics/yolo/data/base.py
+++ b/ultralytics/yolo/data/base.py
@@ -110,7 +110,7 @@ class BaseDataset(Dataset):
                 if segments:
                     self.labels[i]["segments"] = segments[j]
             if self.single_cls:
-                self.labels[i]["cls"] = 0
+                self.labels[i]["cls"][:, 0] = 0
 
     def load_image(self, i):
         # Loads 1 image from dataset index 'i', returns (im, resized hw)

--- a/ultralytics/yolo/data/base.py
+++ b/ultralytics/yolo/data/base.py
@@ -191,7 +191,7 @@ class BaseDataset(Dataset):
         return label
 
     def __len__(self):
-        return len(self.im_files)
+        return len(self.labels)
 
     def update_labels_info(self, label):
         """custom your label format here"""


### PR DESCRIPTION
@AyushExel @glenn-jocher 
related issues: [https://github.com/ultralytics/ultralytics/issues/238](https://github.com/ultralytics/ultralytics/issues/238), [https://github.com/ultralytics/ultralytics/issues/229](https://github.com/ultralytics/ultralytics/issues/229)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updating label handling and dataset length reporting in YOLO data processing.

### 📊 Key Changes
- Ensured that class labels are consistently updated to zero for single-class datasets.
- Modified dataset length calculation to be based on the number of labels instead of the number of image files.

### 🎯 Purpose & Impact
- 🎨 The change to class label assignment ensures data correctness, which is crucial for model training accuracy in single-class scenarios.
- 📏 By deriving the dataset length from labels instead of image files, the code reflects a more accurate dataset size, improving dataset integrity and potential error handling in training loops.
- 🚀 These updates might lead to more robust model training performance, as they ensure that the dataset's structure and annotations are correctly interpreted by the training algorithm.