### PR TITLE
Fix program exit

### DIFF
--- a/ultralytics/yolo/configs/hydra_patch.py
+++ b/ultralytics/yolo/configs/hydra_patch.py
@@ -71,7 +71,7 @@ def check_config_mismatch(overrides, cfg):
     for option in mismatched:
         LOGGER.info(f"{colorstr(option)} is not a valid key. Similar keys: {get_close_matches(option, cfg, 3, 0.6)}")
     if mismatched:
-        exit()
+        sys.exit()
 
 
 hydra._internal.config_loader_impl.ConfigLoaderImpl._apply_overrides_to_config = override_config


### PR DESCRIPTION
exit() command did not contain the source library (sys), therefore leading to an error

<!--
Thank you for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as easy for users as possible. A few tips to get you started:

- Search existing Pull Requests to see if a similar PR already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides if applicable.

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling in configuration management.

### 📊 Key Changes
- Replaced a generic `exit()` call with `sys.exit()` for exiting the program.

### 🎯 Purpose & Impact 
- 🎩 Ensures more robust error handling by using the `sys` module's exit function, which is the preferred way of terminating a Python program.
- 🔍 Helps maintain consistency in code and potentially offers better integration with other systems and tools.
- 🔄 Minor change, but it enhances the overall code quality and may improve user experience when encountering configuration errors.