### PR TITLE
Add references to DFL

### DIFF
--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -82,7 +82,7 @@ class ConvTranspose(nn.Module):
 
 
 class DFL(nn.Module):
-    # DFL module
+    # Integral module of Distribution Focal Loss (DFL) proposed in Generalized Focal Loss https://ieeexplore.ieee.org/document/9792391
     def __init__(self, c1=16):
         super().__init__()
         self.conv = nn.Conv2d(c1, 1, 1, bias=False).requires_grad_(False)

--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -47,6 +47,7 @@ class BboxLoss(nn.Module):
     @staticmethod
     def _df_loss(pred_dist, target):
         # Return sum of left and right DFL losses
+        # Distribution Focal Loss (DFL) proposed in Generalized Focal Loss https://ieeexplore.ieee.org/document/9792391
         tl = target.long()  # target left
         tr = tl + 1  # target right
         wl = tr - target  # weight left


### PR DESCRIPTION
I found that yolov8 miss the citation of our work [Generalized Focal Loss: Towards Efficient Representation Learning for Dense Object Detection](https://ieeexplore.ieee.org/abstract/document/9792391) when using DFL.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced the clarity around the use of Distribution Focal Loss (DFL) in the codebase.

### 📊 Key Changes
- Added detailed comments explaining the DFL module, referencing the paper "Generalized Focal Loss".
- Inserted a comment explaining the role of DFL in the loss computation process.

### 🎯 Purpose & Impact
- 🧐 **Purpose**: To improve documentation within the code to help developers understand the rationale behind using DFL and its theoretical background.
- 💡 **Impact**: Developers will have immediate access to the source material, leading to a better understanding of the module's function. It won't directly affect end-users but ensures maintainability and educates interested users on the advanced techniques used in the software.