### PR TITLE
FPS should be an integer value, since a float value produces an error in the MP4 codec. Closes #308

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -240,8 +240,7 @@ class BasePredictor:
                 if isinstance(self.vid_writer[idx], cv2.VideoWriter):
                     self.vid_writer[idx].release()  # release previous video writer
                 if vid_cap:  # video
-                    # fps should be an integer since a float value producess error in MP4 codec
-                    fps = int(vid_cap.get(cv2.CAP_PROP_FPS))
+                    fps = int(vid_cap.get(cv2.CAP_PROP_FPS))  # integer required, floats produce error in MP4 codec
                     w = int(vid_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
                     h = int(vid_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
                 else:  # stream

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -240,7 +240,8 @@ class BasePredictor:
                 if isinstance(self.vid_writer[idx], cv2.VideoWriter):
                     self.vid_writer[idx].release()  # release previous video writer
                 if vid_cap:  # video
-                    fps = vid_cap.get(cv2.CAP_PROP_FPS)
+                    # fps should be an integer since a float value producess error in MP4 codec
+                    fps = int(vid_cap.get(cv2.CAP_PROP_FPS))
                     w = int(vid_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
                     h = int(vid_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
                 else:  # stream


### PR DESCRIPTION
I have read the CLA Document and I sign the CLA.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved video writer compatibility by ensuring FPS is an integer.

### 📊 Key Changes
- Cast FPS to integer in video processing to avoid errors with MP4 codec.

### 🎯 Purpose & Impact
- 🛠 Fixes a bug where float FPS values could cause errors when saving videos.
- ✨ Enhances reliability for users saving video outputs, ensuring a smoother experience without codec issues.