### PR TITLE
Docker layer reorganization 2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ ENV OMP_NUM_THREADS=1
 # t=ultralytics/ultralytics:latest && sudo docker build -f ./docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run
-# t=ultralytics/ultralytics:latest-cpu2 && sudo docker run -it --ipc=host --gpus all $t
+# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
 
 # Pull and Run with local directory access
 # t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,6 @@ FROM nvcr.io/nvidia/pytorch:22.12-py3
 # Remove torch nightly and install torch stable
 RUN rm -rf /opt/pytorch  # remove 1.2GB dir
 RUN pip uninstall -y torchtext torch torchvision
-RUN pip cache purge
 RUN pip install --no-cache torch torchvision
 
 # Downloads to user config dir

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ ENV OMP_NUM_THREADS=1
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/ultralytics:latest && sudo docker build -f utils/docker/Dockerfile -t $t . && sudo docker push $t
+# t=ultralytics/ultralytics:latest && sudo docker build -f ./docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run
 # t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,13 +5,13 @@
 # Start FROM NVIDIA PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
 FROM nvcr.io/nvidia/pytorch:22.12-py3
 
+# Downloads to user config dir
+ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
+
 # Remove torch nightly and install torch stable
 RUN rm -rf /opt/pytorch  # remove 1.2GB dir
 RUN pip uninstall -y torchtext torch torchvision
 RUN pip install --no-cache torch torchvision
-
-# Downloads to user config dir
-ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
 
 # Install linux packages
 RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-mesa-glx
@@ -38,7 +38,7 @@ ENV OMP_NUM_THREADS=1
 # t=ultralytics/ultralytics:latest && sudo docker build -f ./docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run
-# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
+# t=ultralytics/ultralytics:latest-cpu2 && sudo docker run -it --ipc=host --gpus all $t
 
 # Pull and Run with local directory access
 # t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ ENV OMP_NUM_THREADS=1
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/ultralytics:latest && sudo docker build -f ./docker/Dockerfile -t $t . && sudo docker push $t
+# t=ultralytics/ultralytics:latest && sudo docker build -f docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run
 # t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t

--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -31,6 +31,7 @@ RUN pip install --no-cache ultralytics gsutil notebook \
     # tensorflowjs \
     # onnx onnx-simplifier onnxruntime \
     # coremltools openvino-dev \
+
 # Cleanup
 ENV DEBIAN_FRONTEND teletype
 

--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -38,7 +38,7 @@ ENV DEBIAN_FRONTEND teletype
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/ultralytics:latest-arm64 && sudo docker build --platform linux/arm64 -f ./docker/Dockerfile-arm64 -t $t . && sudo docker push $t
+# t=ultralytics/ultralytics:latest-arm64 && sudo docker build --platform linux/arm64 -f docker/Dockerfile-arm64 -t $t . && sudo docker push $t
 
 # Pull and Run
 # t=ultralytics/ultralytics:latest-arm64 && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -37,7 +37,7 @@ ENV DEBIAN_FRONTEND teletype
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/ultralytics:latest-arm64 && sudo docker build --platform linux/arm64 -f utils/docker/Dockerfile-arm64 -t $t . && sudo docker push $t
+# t=ultralytics/ultralytics:latest-arm64 && sudo docker build --platform linux/arm64 -f ./docker/Dockerfile-arm64 -t $t . && sudo docker push $t
 
 # Pull and Run
 # t=ultralytics/ultralytics:latest-arm64 && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -27,9 +27,10 @@ RUN git clone https://github.com/ultralytics/ultralytics /usr/src/ultralytics
 COPY requirements.txt .
 RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache ultralytics gsutil notebook \
-    tensorflow-aarch64 onnx onnx-simplifier onnxruntime coremltools openvino-dev
+    tensorflow-aarch64
     # tensorflowjs \
-
+    # onnx onnx-simplifier onnxruntime \
+    # coremltools openvino-dev \
 # Cleanup
 ENV DEBIAN_FRONTEND teletype
 

--- a/docker/Dockerfile-cpu
+++ b/docker/Dockerfile-cpu
@@ -39,7 +39,7 @@ ENV DEBIAN_FRONTEND teletype
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/ultralytics:latest-cpu && sudo docker build -f utils/docker/Dockerfile-cpu -t $t . && sudo docker push $t
+# t=ultralytics/ultralytics:latest-cpu && sudo docker build -f ./docker/Dockerfile-cpu -t $t . && sudo docker push $t
 
 # Pull and Run
 # t=ultralytics/ultralytics:latest-cpu && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile-cpu
+++ b/docker/Dockerfile-cpu
@@ -38,7 +38,7 @@ ENV DEBIAN_FRONTEND teletype
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/ultralytics:latest-cpu2 && sudo docker build -f ./docker/Dockerfile-cpu -t $t . && sudo docker push $t
+# t=ultralytics/ultralytics:latest-cpu && sudo docker build -f docker/Dockerfile-cpu -t $t . && sudo docker push $t
 
 # Pull and Run
 # t=ultralytics/ultralytics:latest-cpu && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile-cpu
+++ b/docker/Dockerfile-cpu
@@ -27,8 +27,8 @@ RUN git clone https://github.com/ultralytics/ultralytics /usr/src/ultralytics
 COPY requirements.txt .
 RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache ultralytics albumentations gsutil notebook \
-    coremltools onnx onnx-simplifier onnxruntime tensorflow-cpu tensorflowjs \
-    # openvino-dev \
+    coremltools onnx onnx-simplifier onnxruntime tensorflow-cpu \
+    # openvino-dev tensorflowjs \
     --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Cleanup
@@ -38,7 +38,7 @@ ENV DEBIAN_FRONTEND teletype
 # Usage Examples -------------------------------------------------------------------------------------------------------
 
 # Build and Push
-# t=ultralytics/ultralytics:latest-cpu && sudo docker build -f ./docker/Dockerfile-cpu -t $t . && sudo docker push $t
+# t=ultralytics/ultralytics:latest-cpu2 && sudo docker build -f ./docker/Dockerfile-cpu -t $t . && sudo docker push $t
 
 # Pull and Run
 # t=ultralytics/ultralytics:latest-cpu && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile-cpu
+++ b/docker/Dockerfile-cpu
@@ -28,8 +28,7 @@ COPY requirements.txt .
 RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache ultralytics albumentations gsutil notebook \
     coremltools onnx onnx-simplifier onnxruntime tensorflow-cpu tensorflowjs \
-    openvino-dev \
-    # tensorflowjs \
+    # openvino-dev \
     --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Cleanup


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated Ultralytics Dockerfiles for improved stability and cleanliness.

### 📊 Key Changes
- In all Dockerfiles, unused dependencies and comments have been removed, streamlining the build process 🔍.
- The ARM64 Dockerfile now includes only essential dependencies to function with `tensorflow-aarch64` excluding other libraries like ONNX and OpenVINO which are commented out 🌐.
- The CPU Dockerfile has been simplified by removing less commonly used packages such as `openvino-dev` and `tensorflowjs`, leaving a focus on core dependencies 🖥️.
- Font files (`Arial.ttf` and `Arial.Unicode.ttf`) download location has been moved up for better layer caching in Docker 🖋️.
- Removal of `pip cache purge` command for a cleaner Dockerfile 🛠️.
- Corrected Docker build command paths from the legacy `utils/docker/` to the new `docker/` directory in build and push usage comments 📂.

### 🎯 Purpose & Impact
- Simplifying Dockerfiles can reduce image sizes and build times, leading to faster deployment and resource savings ☁️.
- Cleaning up commented code and unused dependencies makes the Dockerfiles easier to read and maintain ✨.
- The changes in the Dockerfiles may lead to more focused and efficient container images for Ultralytics users, especially those on ARM64 and CPU-based platforms 🔋.