### PR TITLE
fix im_files

### DIFF
--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -88,6 +88,7 @@ class YOLODataset(BaseDataset):
         x["results"] = nf, nm, ne, nc, len(self.im_files)
         x["msgs"] = msgs  # warnings
         x["version"] = self.cache_version  # cache version
+        self.im_files = [lb["im_file"] for lb in x["labels"]]
         try:
             np.save(path, x)  # save cache for next time
             path.with_suffix(".cache.npy").rename(path)  # remove .npy suffix


### PR DESCRIPTION
@AyushExel @glenn-jocher 
Fixed the mismatch between `im_files` and `labels` when there're corrupt labels.
This also could be related the issues that users got NaN training loss.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image file handling in YOLO dataset caching.

### 📊 Key Changes
- Cached dataset now includes a list of image file paths directly correlated to the labels.

### 🎯 Purpose & Impact
- **Purpose**: To optimize the process of associating images with their corresponding labels when loading the dataset.
- **Impact**: Users can expect more efficient data loading and potentially faster training times for their YOLO models, as the association between labels and images is streamlined. 🚀