### PR TITLE
Only setup once for predictor

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -134,7 +134,7 @@ class YOLO:
         predictor = self.PredictorClass(overrides=overrides)
 
         predictor.args.imgsz = check_imgsz(predictor.args.imgsz, min_dim=2)  # check image size
-        predictor.setup(model=self.model, source=source)
+        predictor.setup(model=self.model, source=source) if not predictor.done_setup else None
         return predictor(stream=stream, verbose=verbose)
 
     @smart_inference_mode()


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to model prediction setup to avoid unnecessary repetition.

### 📊 Key Changes
- Modified the `predict` method in the model engine to only execute the setup if it has not already been done.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: The change is intended to optimize the prediction flow by checking if the model setup is complete before attempting to run it again.
- 💡 **Impact**: This should lead to slight performance gains during prediction by reducing redundant setup steps, thus enhancing the overall user experience with model inference. Users calling the `predict` method multiple times can expect a more efficient execution.