### PR TITLE
Comment hard-coded cls args

### DIFF
--- a/ultralytics/yolo/v8/classify/train.py
+++ b/ultralytics/yolo/v8/classify/train.py
@@ -140,10 +140,13 @@ class ClassificationTrainer(BaseTrainer):
 def train(cfg):
     cfg.model = cfg.model or "yolov8n-cls.pt"  # or "resnet18"
     cfg.data = cfg.data or "mnist160"  # or yolo.ClassificationDataset("mnist")
-    cfg.lr0 = 0.1
-    cfg.weight_decay = 5e-5
-    cfg.label_smoothing = 0.1
-    cfg.warmup_epochs = 0.0
+
+    # Reproduce ImageNet results
+    # cfg.lr0 = 0.1
+    # cfg.weight_decay = 5e-5
+    # cfg.label_smoothing = 0.1
+    # cfg.warmup_epochs = 0.0
+
     cfg.device = cfg.device if cfg.device is not None else ''
     # trainer = ClassificationTrainer(cfg)
     # trainer.train()


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/445

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to classification training defaults in YOLOv8.

### 📊 Key Changes
- Commented out hardcoded hyperparameters for learning rate, weight decay, label smoothing, and warmup epochs.
- These changes imply a move towards more flexible or externally defined configurations.

### 🎯 Purpose & Impact
- 🎨 **Flexibility**: Allows for more dynamic configuration of training parameters, which could be set elsewhere rather than being fixed within the code.
- 🔑 **Customization**: Users can now provide their own hyperparameter settings more easily, tailoring the training process to their specific datasets and goals.
- 📈 **Potential for Replicability**: Indicating a goal to reproduce ImageNet results suggests a focus on achieving high performance and benchmarking against standard datasets.