### PR TITLE
Setup model only once in predictor

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -20,6 +20,9 @@ class BaseModel(nn.Module):
     """
     The BaseModel class serves as a base class for all the models in the Ultralytics YOLO family.
     """
+    def __init__(self) -> None:
+        super().__init__()
+        self.is_fused = False
 
     def forward(self, x, profile=False, visualize=False):
         """
@@ -92,6 +95,8 @@ class BaseModel(nn.Module):
         Returns:
             (nn.Module): The fused model is returned.
         """
+        if self.is_fused:
+            return self
         LOGGER.info('Fusing layers... ')
         for m in self.model.modules():
             if isinstance(m, (Conv, DWConv)) and hasattr(m, 'bn'):

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -63,7 +63,8 @@ class BaseModel(nn.Module):
 
     def _profile_one_layer(self, m, x, dt):
         """
-        Profile the computation time and FLOPs of a single layer of the model on a given input. Appends the results to the provided list.
+        Profile the computation time and FLOPs of a single layer of the model on a given input.
+        Appends the results to the provided list.
 
         Args:
             m (nn.Module): The layer to be profiled.
@@ -74,10 +75,10 @@ class BaseModel(nn.Module):
             None
         """
         c = m == self.model[-1]  # is final layer, copy input as inplace fix
-        o = thop.profile(m, inputs=(x.copy() if c else x,), verbose=False)[0] / 1E9 * 2 if thop else 0  # FLOPs
+        o = thop.profile(m, inputs=(x.clone() if c else x,), verbose=False)[0] / 1E9 * 2 if thop else 0  # FLOPs
         t = time_sync()
         for _ in range(10):
-            m(x.copy() if c else x)
+            m(x.clone() if c else x)
         dt.append((time_sync() - t) * 100)
         if m == self.model[0]:
             LOGGER.info(f"{'time (ms)':>10s} {'GFLOPs':>10s} {'params':>10s}  module")
@@ -87,19 +88,35 @@ class BaseModel(nn.Module):
 
     def fuse(self):
         """
-        Fuse the `Conv2d()` and `BatchNorm2d()` layers of the model into a single layer, in order to improve the computation efficiency.
+        Fuse the `Conv2d()` and `BatchNorm2d()` layers of the model into a single layer, in order to improve the
+        computation efficiency.
 
         Returns:
             (nn.Module): The fused model is returned.
         """
-        LOGGER.info('Fusing layers... ')
-        for m in self.model.modules():
-            if isinstance(m, (Conv, DWConv)) and hasattr(m, 'bn'):
-                m.conv = fuse_conv_and_bn(m.conv, m.bn)  # update conv
-                delattr(m, 'bn')  # remove batchnorm
-                m.forward = m.forward_fuse  # update forward
-        self.info()
+        if not self.is_fused():
+            LOGGER.info('Fusing... ')
+            for m in self.model.modules():
+                if isinstance(m, (Conv, DWConv)) and hasattr(m, 'bn'):
+                    m.conv = fuse_conv_and_bn(m.conv, m.bn)  # update conv
+                    delattr(m, 'bn')  # remove batchnorm
+                    m.forward = m.forward_fuse  # update forward
+            self.info()
+
         return self
+
+    def is_fused(self, thresh=5):
+        """
+        Check if the model has less than a certain threshold of BatchNorm layers.
+
+        Args:
+            thresh (int, optional): The threshold number of BatchNorm layers. Default is 10.
+
+        Returns:
+            bool: True if the number of BatchNorm layers in the model is less than the threshold, False otherwise.
+        """
+        bn = tuple(v for k, v in nn.__dict__.items() if 'Norm' in k)  # normalization layers, i.e. BatchNorm2d()
+        return sum(isinstance(v, bn) for v in self.modules()) < thresh  # True if < 'thresh' BatchNorm layers in model
 
     def info(self, verbose=False, imgsz=640):
         """
@@ -384,8 +401,8 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
 
         n = n_ = max(round(n * gd), 1) if n > 1 else n  # depth gain
         if m in {
-                Classify, Conv, ConvTranspose, GhostConv, Bottleneck, GhostBottleneck, SPP, SPPF, DWConv, Focus,
-                BottleneckCSP, C1, C2, C2f, C3, C3TR, C3Ghost, nn.ConvTranspose2d, DWConvTranspose2d, C3x}:
+            Classify, Conv, ConvTranspose, GhostConv, Bottleneck, GhostBottleneck, SPP, SPPF, DWConv, Focus,
+            BottleneckCSP, C1, C2, C2f, C3, C3TR, C3Ghost, nn.ConvTranspose2d, DWConvTranspose2d, C3x}:
             c1, c2 = ch[f], args[0]
             if c2 != nc:  # if c2 not equal to number of classes (i.e. for Classify() output)
                 c2 = make_divisible(c2 * gw, 8)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -105,7 +105,7 @@ class BaseModel(nn.Module):
 
         return self
 
-    def is_fused(self, thresh=5):
+    def is_fused(self, thresh=10):
         """
         Check if the model has less than a certain threshold of BatchNorm layers.
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -21,9 +21,6 @@ class BaseModel(nn.Module):
     The BaseModel class serves as a base class for all the models in the Ultralytics YOLO family.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
-
     def forward(self, x, profile=False, visualize=False):
         """
         Forward pass of the model on a single scale.

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -20,6 +20,7 @@ class BaseModel(nn.Module):
     """
     The BaseModel class serves as a base class for all the models in the Ultralytics YOLO family.
     """
+
     def __init__(self) -> None:
         super().__init__()
         self.is_fused = False

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -23,7 +23,6 @@ class BaseModel(nn.Module):
 
     def __init__(self) -> None:
         super().__init__()
-        self.is_fused = False
 
     def forward(self, x, profile=False, visualize=False):
         """
@@ -96,8 +95,6 @@ class BaseModel(nn.Module):
         Returns:
             (nn.Module): The fused model is returned.
         """
-        if self.is_fused:
-            return self
         LOGGER.info('Fusing layers... ')
         for m in self.model.modules():
             if isinstance(m, (Conv, DWConv)) and hasattr(m, 'bn'):

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -43,7 +43,7 @@ class YOLO:
         self.TrainerClass = None  # trainer class
         self.ValidatorClass = None  # validator class
         self.PredictorClass = None  # predictor class
-        self.predictor = None # reuse predictor 
+        self.predictor = None  # reuse predictor
         self.model = None  # model object
         self.trainer = None  # trainer object
         self.task = None  # task type
@@ -133,9 +133,9 @@ class YOLO:
         overrides["mode"] = "predict"
         overrides["save"] = kwargs.get("save", False)  # not save files by default
         if not self.predictor:
-            self.predictor = self.PredictorClass(overrides=overrides) 
+            self.predictor = self.PredictorClass(overrides=overrides)
             self.predictor.setup_model(model=self.model)
-        else: # only update args if predictor is arleady setup
+        else:  # only update args if predictor is arleady setup
             self.predictor.args = get_config(self.predictor.args, overrides)
         return self.predictor(source=source, stream=stream, verbose=verbose)
 

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -7,7 +7,7 @@ from ultralytics.nn.tasks import ClassificationModel, DetectionModel, Segmentati
 from ultralytics.yolo.configs import get_config
 from ultralytics.yolo.engine.exporter import Exporter
 from ultralytics.yolo.utils import DEFAULT_CONFIG, LOGGER, yaml_load
-from ultralytics.yolo.utils.checks import check_imgsz, check_yaml
+from ultralytics.yolo.utils.checks import check_yaml
 from ultralytics.yolo.utils.torch_utils import guess_task_from_head, smart_inference_mode
 
 # Map head to model, trainer, validator, and predictor classes
@@ -43,7 +43,7 @@ class YOLO:
         self.TrainerClass = None  # trainer class
         self.ValidatorClass = None  # validator class
         self.PredictorClass = None  # predictor class
-        self.predictor = None # reuse predictor 
+        self.predictor = None  # reuse predictor
         self.model = None  # model object
         self.trainer = None  # trainer object
         self.task = None  # task type
@@ -133,9 +133,9 @@ class YOLO:
         overrides["mode"] = "predict"
         overrides["save"] = kwargs.get("save", False)  # not save files by default
         if not self.predictor:
-            self.predictor = self.PredictorClass(overrides=overrides) 
+            self.predictor = self.PredictorClass(overrides=overrides)
             self.predictor.setup_model(model=self.model)
-        else: # only update args if predictor is arleady setup
+        else:  # only update args if predictor is already setup
             self.predictor.args = get_config(self.predictor.args, overrides)
         return self.predictor(source=source, stream=stream, verbose=verbose)
 

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -134,7 +134,7 @@ class YOLO:
         predictor = self.PredictorClass(overrides=overrides)
 
         predictor.args.imgsz = check_imgsz(predictor.args.imgsz, min_dim=2)  # check image size
-        predictor.setup(model=self.model, source=source)
+        predictor.setup(model=self.model, source=source) if not predictor.done_setup else None
         return predictor(stream=stream, verbose=verbose)
 
     @smart_inference_mode()

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -78,7 +78,6 @@ class BasePredictor:
         self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok)
         if self.args.conf is None:
             self.args.conf = 0.25  # default conf=0.25
-        self.done_source_setup = False
         self.done_warmup = False
 
         # Usable if setup is done

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -76,15 +76,16 @@ class BasePredictor:
         project = self.args.project or Path(SETTINGS['runs_dir']) / self.args.task
         name = self.args.name or f"{self.args.mode}"
         self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok)
-        if self.args.save:
-            (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
         if self.args.conf is None:
             self.args.conf = 0.25  # default conf=0.25
-        self.done_setup = False
+        self.done_source_setup = False
+        self.done_warmup = False
 
         # Usable if setup is done
         self.model = None
         self.data = self.args.data  # data_dict
+        self.bs = None
+        self.imgsz = None
         self.device = None
         self.dataset = None
         self.vid_path, self.vid_writer = None, None
@@ -105,11 +106,13 @@ class BasePredictor:
     def postprocess(self, preds, img, orig_img):
         return preds
 
-    def setup(self, source=None, model=None):
+    def setup_source(self, source=None):
+        if not self.model:
+            raise Exception("setup model before setting up source!")
         # source
         source, webcam, screenshot, from_img = self.check_source(source)
         # model
-        stride, pt = self.setup_model(model)
+        stride, pt = self.model.stride, self.model.pt
         imgsz = check_imgsz(self.args.imgsz, stride=stride, min_dim=2)  # check image size
 
         # Dataloader
@@ -143,14 +146,12 @@ class BasePredictor:
                                       transforms=getattr(self.model.model, 'transforms', None),
                                       vid_stride=self.args.vid_stride)
         self.vid_path, self.vid_writer = [None] * bs, [None] * bs
-        self.model.warmup(imgsz=(1 if pt or self.model.triton else bs, 3, *imgsz))  # warmup
 
         self.webcam = webcam
         self.screenshot = screenshot
         self.from_img = from_img
         self.imgsz = imgsz
-        self.done_setup = True
-        return model
+        self.bs = bs
 
     @smart_inference_mode()
     def __call__(self, source=None, model=None, verbose=False, stream=False):
@@ -167,8 +168,20 @@ class BasePredictor:
 
     def stream_inference(self, source=None, model=None, verbose=False):
         self.run_callbacks("on_predict_start")
-        if not self.done_setup:
-            self.setup(source, model)
+
+        # setup model
+        if not self.model: 
+            self.setup_model(model)
+        # setup source. Run every time predict is called
+        self.setup_source(source)
+        # check if save_dir/ label file exists
+        if self.args.save:
+            (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
+        # warmup model
+        if not self.done_warmup:
+            self.model.warmup(imgsz=(1 if self.model.pt or self.model.triton else self.bs, 3, *self.imgsz))
+            self.done_warmup = True
+
         self.seen, self.windows, self.dt = 0, [], (ops.Profile(), ops.Profile(), ops.Profile())
         for batch in self.dataset:
             self.run_callbacks("on_predict_batch_start")
@@ -223,11 +236,10 @@ class BasePredictor:
         device = select_device(self.args.device)
         model = model or self.args.model
         self.args.half &= device.type != 'cpu'  # half precision only supported on CUDA
-        model = AutoBackend(model, device=device, dnn=self.args.dnn, fp16=self.args.half)
-        self.model = model
+        self.model = AutoBackend(model, device=device, dnn=self.args.dnn, fp16=self.args.half)
         self.device = device
         self.model.eval()
-        return model.stride, model.pt
+        
 
     def check_source(self, source):
         source = source if source is not None else self.args.source

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -169,7 +169,7 @@ class BasePredictor:
         self.run_callbacks("on_predict_start")
 
         # setup model
-        if not self.model: 
+        if not self.model:
             self.setup_model(model)
         # setup source. Run every time predict is called
         self.setup_source(source)
@@ -238,7 +238,6 @@ class BasePredictor:
         self.model = AutoBackend(model, device=device, dnn=self.args.dnn, fp16=self.args.half)
         self.device = device
         self.model.eval()
-        
 
     def check_source(self, source):
         source = source if source is not None else self.args.source


### PR DESCRIPTION
@glenn-jocher @Laughing-q  what do you think?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model's layer profiling and fusing processes, and optimized the prediction setup and inference for YOLO models.

### 📊 Key Changes
- Changed `x.copy()` to `x.clone()` in model layer profiling for better clarity in code.
- Introduced a `is_fused()` method in nn modules to check if models are fused properly.
- Removed an unnecessary check for image size within the YOLO engine model.
- Reorganized and optimized the prediction setup process to reuse the predictor and only update arguments if the predictor is set.
- Optimized the predictor class to check the model setup before source setup and warm up the model only once.

### 🎯 Purpose & Impact
- **Better Memory Handling**: Cloning tensors instead of copying them during profiling for more transparent memory operations. 🔄
- **Model Optimization Check**: The `is_fused()` method allows easy checking of the model fusion state, ensuring computational efficiency is maintained. 🔍
- **Streamlined Prediction Code**: Reduction in redundant checks and better reuse of prediction configurations speeds up the prediction process. 🚀
- **Warmup Optimization**: By warming up the model only when required, the prediction method is more efficient, improving inference speed.🔥

These changes together contribute to a more efficient, reliable, and maintainable codebase for YOLO users and developers.