### PR TITLE
Add attribute error msgs

### DIFF
--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -96,8 +96,9 @@ class Results:
         return s
 
     def __getattr__(self, attr):
-        LOGGER.info(f"""
-            {attr} is not a valid attribute of Results object. These are the valid attributes:
+        name = self.__class__.__name__
+        raise AttributeError(f"""
+            '{name}' object has no attribute '{attr}'. Valid '{name}' object attributes and properties are:
 
             boxes (Boxes, optional): A Boxes object containing the detection bounding boxes.
             masks (Masks, optional): A Masks object containing the detection masks.
@@ -211,8 +212,9 @@ class Boxes:
         return Boxes(boxes, self.orig_shape)
 
     def __getattr__(self, attr):
-        LOGGER.info(f"""
-            {attr} is not a valid attribute of Boxes object. These are the valid attributes and properties:
+        name = self.__class__.__name__
+        raise AttributeError(f"""
+            '{name}' object has no attribute '{attr}'. Valid '{name}' object attributes and properties are:
 
             Attributes:
                 boxes (torch.Tensor) or (numpy.ndarray): A tensor or numpy array containing the detection boxes,
@@ -291,8 +293,9 @@ class Masks:
         return Masks(masks, self.im_shape, self.orig_shape)
 
     def __getattr__(self, attr):
-        LOGGER.info(f"""
-            {attr} is not a valid attribute of Masks object. These are the valid attributes and properties:
+        name = self.__class__.__name__
+        raise AttributeError(f"""
+            '{name}' object has no attribute '{attr}'. Valid '{name}' object attributes and properties are:
 
             Attributes:
                 masks (torch.Tensor): A tensor containing the detection masks, with shape (num_masks, height, width).

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -96,7 +96,7 @@ class Results:
         return s
 
     def __getattr__(self, attr):
-        LOGGER.info(f"""
+        raise AttributeError(f"""
             {attr} is not a valid attribute of Results object. These are the valid attributes:
 
             boxes (Boxes, optional): A Boxes object containing the detection bounding boxes.
@@ -211,7 +211,7 @@ class Boxes:
         return Boxes(boxes, self.orig_shape)
 
     def __getattr__(self, attr):
-        LOGGER.info(f"""
+        raise AttributeError(f"""
             {attr} is not a valid attribute of Boxes object. These are the valid attributes and properties:
 
             Attributes:
@@ -291,7 +291,7 @@ class Masks:
         return Masks(masks, self.im_shape, self.orig_shape)
 
     def __getattr__(self, attr):
-        LOGGER.info(f"""
+        raise AttributeError(f"""
             {attr} is not a valid attribute of Masks object. These are the valid attributes and properties:
 
             Attributes:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -95,6 +95,15 @@ class Results:
 
         return s
 
+    def __getattr__(self, attr):
+        LOGGER.info(f"""
+            {attr} is not a valid attribute of Results object. These are the valid attributes:
+        
+            boxes (Boxes, optional): A Boxes object containing the detection bounding boxes.
+            masks (Masks, optional): A Masks object containing the detection masks.
+            probs (torch.Tensor, optional): A tensor containing the detection class probabilities.
+            orig_shape (tuple, optional): Original image size.
+            """)
 
 class Boxes:
     """
@@ -200,6 +209,23 @@ class Boxes:
         boxes = self.boxes[idx]
         return Boxes(boxes, self.orig_shape)
 
+    def __getattr__(self, attr):
+        LOGGER.info(f"""
+            {attr} is not a valid attribute of Boxes object. These are the valid attributes and properties:
+        
+            Attributes:
+                boxes (torch.Tensor) or (numpy.ndarray): A tensor or numpy array containing the detection boxes,
+                    with shape (num_boxes, 6).
+                orig_shape (torch.Tensor) or (numpy.ndarray): Original image size, in the format (height, width).
+
+            Properties:
+                xyxy (torch.Tensor) or (numpy.ndarray): The boxes in xyxy format.
+                conf (torch.Tensor) or (numpy.ndarray): The confidence values of the boxes.
+                cls (torch.Tensor) or (numpy.ndarray): The class values of the boxes.
+                xywh (torch.Tensor) or (numpy.ndarray): The boxes in xywh format.
+                xyxyn (torch.Tensor) or (numpy.ndarray): The boxes in xyxy format normalized by original image size.
+                xywhn (torch.Tensor) or (numpy.ndarray): The boxes in xywh format normalized by original image size.
+            """)
 
 class Masks:
     """
@@ -261,7 +287,17 @@ class Masks:
     def __getitem__(self, idx):
         masks = self.masks[idx]
         return Masks(masks, self.im_shape, self.orig_shape)
+    def __getattr__(self, attr):
+        LOGGER.info(f"""
+            {attr} is not a valid attribute of Masks object. These are the valid attributes and properties:
+        
+            Attributes:
+                masks (torch.Tensor): A tensor containing the detection masks, with shape (num_masks, height, width).
+                orig_shape (tuple): Original image size, in the format (height, width).
 
+            Properties:
+                segments (list): A list of segments which includes x,y,w,h,label,confidence, and mask of each detection masks.
+            """)
 
 if __name__ == "__main__":
     # test examples

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -98,12 +98,13 @@ class Results:
     def __getattr__(self, attr):
         LOGGER.info(f"""
             {attr} is not a valid attribute of Results object. These are the valid attributes:
-        
+
             boxes (Boxes, optional): A Boxes object containing the detection bounding boxes.
             masks (Masks, optional): A Masks object containing the detection masks.
             probs (torch.Tensor, optional): A tensor containing the detection class probabilities.
             orig_shape (tuple, optional): Original image size.
             """)
+
 
 class Boxes:
     """
@@ -212,7 +213,7 @@ class Boxes:
     def __getattr__(self, attr):
         LOGGER.info(f"""
             {attr} is not a valid attribute of Boxes object. These are the valid attributes and properties:
-        
+
             Attributes:
                 boxes (torch.Tensor) or (numpy.ndarray): A tensor or numpy array containing the detection boxes,
                     with shape (num_boxes, 6).
@@ -226,6 +227,7 @@ class Boxes:
                 xyxyn (torch.Tensor) or (numpy.ndarray): The boxes in xyxy format normalized by original image size.
                 xywhn (torch.Tensor) or (numpy.ndarray): The boxes in xywh format normalized by original image size.
             """)
+
 
 class Masks:
     """
@@ -287,10 +289,11 @@ class Masks:
     def __getitem__(self, idx):
         masks = self.masks[idx]
         return Masks(masks, self.im_shape, self.orig_shape)
+
     def __getattr__(self, attr):
         LOGGER.info(f"""
             {attr} is not a valid attribute of Masks object. These are the valid attributes and properties:
-        
+
             Attributes:
                 masks (torch.Tensor): A tensor containing the detection masks, with shape (num_masks, height, width).
                 orig_shape (tuple): Original image size, in the format (height, width).
@@ -298,6 +301,7 @@ class Masks:
             Properties:
                 segments (list): A list of segments which includes x,y,w,h,label,confidence, and mask of each detection masks.
             """)
+
 
 if __name__ == "__main__":
     # test examples


### PR DESCRIPTION
@glenn-jocher @Laughing-q 
I've only added Logger.info lever msgs. Maybe it's better to throw Exception instead?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced attribute error handling for YOLO result objects.

### 📊 Key Changes
- Added `__getattr__` methods to `Results`, `Boxes`, and `Masks` classes.
- These methods provide detailed attribute error messages, listing valid properties when an invalid attribute is accessed.

### 🎯 Purpose & Impact
- 🎓 **Educational**: Helps developers understand the correct attributes they can use.
- ⚡️ **User-friendly**: Offers a detailed guide on what valid attributes are available, reducing confusion and improving debugging.
- 🔍 **Improved Readability**: Presents organized information when an attribute-related error occurs, enhancing the overall user experience with clear guidance.