### PR TITLE
fix nan/inf loss

### DIFF
--- a/ultralytics/yolo/v8/detect/train.py
+++ b/ultralytics/yolo/v8/detect/train.py
@@ -177,7 +177,7 @@ class Loss:
             anchor_points * stride_tensor, gt_labels, gt_bboxes, mask_gt)
 
         target_bboxes /= stride_tensor
-        target_scores_sum = target_scores.sum()
+        target_scores_sum = max(target_scores.sum(), 1)
 
         # cls loss
         # loss[1] = self.varifocal_loss(pred_scores, target_scores, target_labels) / target_scores_sum  # VFL way

--- a/ultralytics/yolo/v8/segment/train.py
+++ b/ultralytics/yolo/v8/segment/train.py
@@ -99,7 +99,7 @@ class SegLoss(Loss):
             pred_scores.detach().sigmoid(), (pred_bboxes.detach() * stride_tensor).type(gt_bboxes.dtype),
             anchor_points * stride_tensor, gt_labels, gt_bboxes, mask_gt)
 
-        target_scores_sum = target_scores.sum()
+        target_scores_sum = max(target_scores.sum(), 1)
 
         # cls loss
         # loss[1] = self.varifocal_loss(pred_scores, target_scores, target_labels) / target_scores_sum  # VFL way


### PR DESCRIPTION
@AyushExel @glenn-jocher this PR fixed the nan loss issue. And the cause is that the `target_scores_sum` we're using in loss calculation could be 0 if there're no objects in targets(empty labels, background).

test command:
```bash
yolo detect train model=yolov8n.pt data=custom.yaml imgsz=640 rect=True
```
before fix(losses are nan and mAP stays 0.15):
![pic-selected-230119-1453-35](https://user-images.githubusercontent.com/61612323/213380420-78b7355b-d4d9-411c-ba63-ea86f1a785d3.png)
after fix:
![pic-selected-230119-1521-59](https://user-images.githubusercontent.com/61612323/213380429-c9f49799-e642-47f5-b631-4a0d1c43fb4f.png)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced stability in loss calculation during model training.

### 📊 Key Changes
- Modified the calculation of `target_scores_sum` by ensuring it's never less than 1.

### 🎯 Purpose & Impact
- 🛠 Prevents division by zero errors when calculating loss, increasing the robustness of training.
- ⚖️ Contributors and users of the Ultralytics framework can expect more stable training sessions, particularly in edge cases with sparse detection targets.