### PR TITLE
Update predict.md

### DIFF
--- a/docs/predict.md
+++ b/docs/predict.md
@@ -6,9 +6,9 @@ Inference or prediction of a task returns a list of `Results` objects. Alternati
         inputs = [img, img] # list of np arrays
         results = model(inputs) # List of Results objects
         for result in results:
-            boxes = results.boxes # Boxes object for bbox outputs
-            masks = results.masks # Masks object for segmenation masks outputs
-            probs = results.probs # Class probabilities for classification outputs
+            boxes = result.boxes # Boxes object for bbox outputs
+            masks = result.masks # Masks object for segmenation masks outputs
+            probs = result.probs # Class probabilities for classification outputs
             ...
         ```
     === "Getting a Generator"
@@ -16,9 +16,9 @@ Inference or prediction of a task returns a list of `Results` objects. Alternati
         inputs = [img, img] # list of np arrays
         results = model(inputs, stream=True) # Generator of Results objects
         for result in results:
-            boxes = results.boxes # Boxes object for bbox outputs
-            masks = results.masks # Masks object for segmenation masks outputs
-            probs = results.probs # Class probabilities for classification outputs
+            boxes = result.boxes # Boxes object for bbox outputs
+            masks = result.masks # Masks object for segmenation masks outputs
+            probs = result.probs # Class probabilities for classification outputs
             ...
         ```
 


### PR DESCRIPTION
There is an issue with the [predict docs](https://docs.ultralytics.com/predict/) for the Python SDK. `results` is a list of `torch.Tensor` objects. Running a `for` loop and then saying `boxes = results.boxes` is incorrect and returns an error accordingly. Because the attribute `boxes` is valid for each `result` object and not `List[result]`.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Clarified variable references in prediction documentation for improved accuracy.

### 📊 Key Changes
- Fixed incorrect variable names inside loops within the prediction examples.
- Each loop should correctly reference `result` (singular) instead of `results` (plural) when accessing properties such as `boxes`, `masks`, and `probs`.

### 🎯 Purpose & Impact
- 🛠️ **Enhances Clarity:** Ensures that the documentation examples are free from errors, increasing understandability for developers.
- 🚀 **Improves Usability:** Newcomers and experienced developers alike can follow the examples with confidence, leading to a smoother implementation and integration process.
- 📝 **Reduces Confusion:** Prevents potential misunderstandings that could arise from typos, improving the overall learning experience for users of the Ultralytics documentation.