### PR TITLE
Fix entrypoint(debug=False) to True

### DIFF
--- a/ultralytics/yolo/configs/__init__.py
+++ b/ultralytics/yolo/configs/__init__.py
@@ -115,7 +115,7 @@ def check_config_mismatch(base: Dict, custom: Dict):
         sys.exit()
 
 
-def entrypoint(debug=True):
+def entrypoint(debug=False):
     """
     This function is the ultralytics package entrypoint, it's responsible for parsing the command line arguments passed
     to the package.


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment of the default debug mode setting in the Ultralytics package entry point.

### 📊 Key Changes
- Changed the default value of the `debug` parameter from `True` to `False` in the `entrypoint` function.

### 🎯 Purpose & Impact
- 🛠️ Ensures that the default behavior of the package is now with debug mode off, favoring a cleaner output for most users.
- 🔍 For developers needing to debug, this change will require explicitly setting the debug mode to `True` when invoking the entrypoint.
- ⚙️ Reduces unnecessary debug information for end users, leading to a more user-friendly experience especially for those who may not be accustomed to debug logs.