### PR TITLE
Fix `v.replace(" ", "")`

### DIFF
--- a/ultralytics/yolo/configs/__init__.py
+++ b/ultralytics/yolo/configs/__init__.py
@@ -164,7 +164,7 @@ def entrypoint(debug=False):
                 try:
                     if k == 'device':  # special DDP handling, i.e. device='0,1,2,3'
                         v = v.replace('[', '').replace(']', '')  # handle device=[0,1,2,3]
-                        v = v.replace(" ", "").replace('')  # handle device=[0, 1, 2, 3]
+                        v = v.replace(" ", "")  # handle device=[0, 1, 2, 3]
                         v = v.replace('\\', '')  # handle device=\'0,1,2,3\'
                         overrides[k] = v
                     else:


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved parsing of device configuration settings for enhanced robustness.

### 📊 Key Changes
- Simplified the string replacement logic during the parsing of the `device` configuration.

### 🎯 Purpose & Impact
- 🎨 Increases the robustness of the configuration parser, ensuring that various formats of `device` input are handled correctly.
- 🔧 Reduces the potential for bugs related to device specification, leading to a smoother user experience, especially for those using multiple devices (GPUs).
- ✨ Users specifying devices in their configurations will experience less friction and errors during setup.