### PR TITLE
OpenVINO half=True fix

### DIFF
--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -151,7 +151,7 @@ class Exporter:
         # Load PyTorch model
         self.device = select_device('cpu' if self.args.device is None else self.args.device)
         if self.args.half:
-            if self.device.type == 'cpu' and not coreml:
+            if self.device.type == 'cpu' and not coreml and not xml:
                 LOGGER.info('half=True only compatible with GPU or CoreML export, i.e. use device=0 or format=coreml')
                 self.args.half = False
             assert not self.args.dynamic, '--half not compatible with --dynamic, i.e. use either --half or --dynamic'
@@ -184,7 +184,7 @@ class Exporter:
         y = None
         for _ in range(2):
             y = model(im)  # dry runs
-        if self.args.half and not coreml:
+        if self.args.half and not coreml and not xml:
             im, model = im.half(), model.half()  # to FP16
         shape = tuple((y[0] if isinstance(y, tuple) else y).shape)  # model output shape
         LOGGER.info(
@@ -332,7 +332,7 @@ class Exporter:
         f = str(self.file).replace(self.file.suffix, f'_openvino_model{os.sep}')
         f_onnx = self.file.with_suffix('.onnx')
 
-        cmd = f"mo --input_model {f_onnx} --output_dir {f} --data_type {'FP16' if self.args.half else 'FP32'}"
+        cmd = f"mo --input_model {f_onnx} --output_dir {f} {'--compress_to_fp16' * self.args.half}"
         subprocess.run(cmd.split(), check=True, env=os.environ)  # export
         yaml_save(Path(f) / self.file.with_suffix('.yaml').name, self.metadata)  # add metadata.yaml
         return f, None


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved export compatibility for OpenVINO and CoreML when using half-precision floats.

### 📊 Key Changes
- Modified conditionals to ensure compatibility when exporting to CoreML and OpenVINO formats.
- Changed the command for OpenVINO export to apply FP16 compression when `half=True`.

### 🎯 Purpose & Impact
- Ensures that users can export models to CoreML or OpenVINO without encountering issues related to incompatible half-precision (`FP16`) settings.
- The updated OpenVINO export command makes it more straightforward to apply half-precision, potentially reducing model size and improving performance on supported hardware. 
- Users can benefit from faster inference times and lower memory usage when deploying to devices compatible with FP16 operations. 🚀