### PR TITLE
Add logging information about fitness to torch utilities

### DIFF
--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -391,7 +391,7 @@ class EarlyStopping:
         self.best_epoch = 0
         self.patience = patience or float('inf')  # epochs to wait after fitness stops improving to stop
         self.possible_stop = False  # possible stop may occur next epoch
-        LOGGER.info(f"early stopping initalized, patience: {self.patience}")
+        LOGGER.info(f"early stopping initialized, patience: {self.patience}")
 
     def __call__(self, epoch, fitness):
         """

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -392,15 +392,15 @@ class EarlyStopping:
         delta = epoch - self.best_epoch  # epochs without improvement
         self.possible_stop = delta >= (self.patience - 1)  # possible stop may occur next epoch
         stop = delta >= self.patience  # stop training if patience exceeded
-        
+
         if not improvement:
             if delta == 1:
                 ep = "epoch"
             else:
                 ep = "epochs"
-            
-            LOGGER.info(f"fitness does not improve for {delta} {ep}. patience: {self.patience}") 
-        
+
+            LOGGER.info(f"fitness does not improve for {delta} {ep}. patience: {self.patience}")
+
         if stop:
             LOGGER.info(f'Stopping training early as no improvement observed in last {self.patience} epochs. '
                         f'Best results observed at epoch {self.best_epoch}, best model saved as best.pt.\n'

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -380,14 +380,27 @@ class EarlyStopping:
         self.best_epoch = 0
         self.patience = patience or float('inf')  # epochs to wait after fitness stops improving to stop
         self.possible_stop = False  # possible stop may occur next epoch
+        LOGGER.info(f"early stopping initalized, patience: {self.patience}")
 
     def __call__(self, epoch, fitness):
+        improvement = False
         if fitness >= self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
+            improvement = True
+            LOGGER.info(f"fitness improves from {self.best_fitness} to {fitness}!")
             self.best_epoch = epoch
             self.best_fitness = fitness
         delta = epoch - self.best_epoch  # epochs without improvement
         self.possible_stop = delta >= (self.patience - 1)  # possible stop may occur next epoch
         stop = delta >= self.patience  # stop training if patience exceeded
+        
+        if not improvement:
+            if delta == 1:
+                ep = "epoch"
+            else:
+                ep = "epochs"
+            
+            LOGGER.info(f"fitness does not improve for {delta} {ep}. patience: {self.patience}") 
+        
         if stop:
             LOGGER.info(f'Stopping training early as no improvement observed in last {self.patience} epochs. '
                         f'Best results observed at epoch {self.best_epoch}, best model saved as best.pt.\n'


### PR DESCRIPTION
I have worked with Tensorflow/Keras for a long time. I really enjoyed the debug information of Keras early stopping callback. Therefore, I added simple logging information in this module to have an overview of the state of fitness during the run.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 97b5844</samp>

### Summary
📣🎉⚠️

<!--
1.  📣 - This emoji represents the informative messages that tell the user about the current status of the early stopping mechanism, such as the current best fitness, the current patience, and the number of epochs without improvement.
2.  🎉 - This emoji represents the celebratory messages that congratulate the user when the fitness improves and the early stopping mechanism resets the patience and the best fitness values.
3.  ⚠️ - This emoji represents the warning messages that alert the user when the patience parameter is running low or has reached zero, indicating that the early stopping mechanism will stop the training soon or has already stopped it.
-->
This pull request improves the user feedback for the early stopping feature in `torch_utils.py`. It adds logging messages to indicate the progress, success, and potential issues of the training process.

> _Oh, we're the crew of the `torch_utils.py`_
> _And we log our fitness with glee_
> _We heave and we ho, and we stop when we know_
> _That our patience has run out at sea_

### Walkthrough
*  Add logging messages for early stopping mechanism ([link](https://github.com/ultralytics/ultralytics/pull/592/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8R394), [link](https://github.com/ultralytics/ultralytics/pull/592/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L409-R413), [link](https://github.com/ultralytics/ultralytics/pull/592/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8R419-R427))
  - Inform the user that early stopping is initialized and show the patience parameter ([link](https://github.com/ultralytics/ultralytics/pull/592/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8R394))
  - Celebrate and show the fitness improvement when it occurs ([link](https://github.com/ultralytics/ultralytics/pull/592/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L409-R413))
  - Warn the user that fitness has not improved for a number of epochs and show the remaining patience ([link](https://github.com/ultralytics/ultralytics/pull/592/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8R419-R427))
*  Add a boolean variable `improvement` to track fitness improvement ([link](https://github.com/ultralytics/ultralytics/pull/592/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L409-R413))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved early stopping in YOLO training with clearer logging messages for better user feedback. 🛑📈

### 📊 Key Changes
- Added informative log messages when early stopping is initialized, when fitness improves, and when it does not improve.
- Logs now specify how many epochs have passed without improvement and the patience setting.

### 🎯 Purpose & Impact
- Helps users better understand the early stopping process during training.
- Makes it easier to monitor training progress and diagnose when and why training stops early.
- Enhances transparency and user experience, especially for those tuning training parameters.