### PR TITLE
Lazy initialization of predictor

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -127,3 +127,23 @@ def test_workflow():
     model.val()
     model.predict(SOURCE)
     model.export(format="onnx", opset=12)  # export a model to ONNX format
+
+def test_predict_callback_and_setup():
+    def on_predict_batch_end(predictor):
+        # results -> List[batch_size]
+        path, im, im0s, vid_cap, s = predictor.batch
+        #print('on_predict_batch_end', im0s[0].shape)
+        bs = [predictor.bs for i in range(0, len(path))]
+        predictor.results = zip(predictor.results, im0s, bs)
+    
+    model = YOLO("yolov8n.pt")
+    model.add_callback("on_predict_batch_end", on_predict_batch_end)
+    model.predictor.setup_source(SOURCE)
+    bs, source = model.predictor.bs, model.predictor.source # access predictor properties
+    results = model.predict(stream=True) # source already setup
+    for i, (result, im0, bs) in enumerate(results):
+        print('test_callback', im0.shape)
+        print('test_callback', bs)
+        boxes = result.boxes  # Boxes object for bbox outputs
+        masks = result.masks  # Masks object for segmenation masks outputs
+        probs = result.probs  # Class probabilities for classification outputs

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -143,7 +143,7 @@ def test_predict_callback_and_setup():
     model = YOLO("yolov8n.pt")
     model.add_callback("on_predict_batch_end", on_predict_batch_end)
     model.predictor.setup_source(SOURCE)
-    bs = model.predictor.bs # access predictor properties
+    bs = model.predictor.bs  # access predictor properties
     results = model.predict(stream=True)  # source already setup
     for _, (result, im0, bs) in enumerate(results):
         print('test_callback', im0.shape)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -135,19 +135,18 @@ def test_predict_callback_and_setup():
 
     def on_predict_batch_end(predictor):
         # results -> List[batch_size]
-        path, im, im0s, vid_cap, s = predictor.batch
-        #print('on_predict_batch_end', im0s[0].shape)
+        path, _, im0s, _, _ = predictor.batch
+        # print('on_predict_batch_end', im0s[0].shape)
         bs = [predictor.bs for i in range(0, len(path))]
         predictor.results = zip(predictor.results, im0s, bs)
 
     model = YOLO("yolov8n.pt")
     model.add_callback("on_predict_batch_end", on_predict_batch_end)
     model.predictor.setup_source(SOURCE)
-    bs, source = model.predictor.bs, model.predictor.source  # access predictor properties
+    bs = model.predictor.bs # access predictor properties
     results = model.predict(stream=True)  # source already setup
-    for i, (result, im0, bs) in enumerate(results):
+    for _, (result, im0, bs) in enumerate(results):
         print('test_callback', im0.shape)
         print('test_callback', bs)
         boxes = result.boxes  # Boxes object for bbox outputs
-        masks = result.masks  # Masks object for segmenation masks outputs
-        probs = result.probs  # Class probabilities for classification outputs
+        print(boxes)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -128,19 +128,21 @@ def test_workflow():
     model.predict(SOURCE)
     model.export(format="onnx", opset=12)  # export a model to ONNX format
 
+
 def test_predict_callback_and_setup():
+
     def on_predict_batch_end(predictor):
         # results -> List[batch_size]
         path, im, im0s, vid_cap, s = predictor.batch
         #print('on_predict_batch_end', im0s[0].shape)
         bs = [predictor.bs for i in range(0, len(path))]
         predictor.results = zip(predictor.results, im0s, bs)
-    
+
     model = YOLO("yolov8n.pt")
     model.add_callback("on_predict_batch_end", on_predict_batch_end)
     model.predictor.setup_source(SOURCE)
-    bs, source = model.predictor.bs, model.predictor.source # access predictor properties
-    results = model.predict(stream=True) # source already setup
+    bs, source = model.predictor.bs, model.predictor.source  # access predictor properties
+    results = model.predict(stream=True)  # source already setup
     for i, (result, im0, bs) in enumerate(results):
         print('test_callback', im0.shape)
         print('test_callback', bs)

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -65,7 +65,7 @@ class AutoBackend(nn.Module):
             model = weights.to(device)
             model = model.fuse() if fuse else model
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
-            stride = max(int(model.stride.max()), 32)  # model stride
+            stride = max(int(model.stride.max() if hasattr(model, 'stride') else 0), 32)  # model stride
             model.half() if fp16 else model.float()
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
             pt = True
@@ -75,7 +75,7 @@ class AutoBackend(nn.Module):
                                          device=device,
                                          inplace=True,
                                          fuse=fuse)
-            stride = max(int(model.stride.max()), 32)  # model stride
+            stride = max(int(model.stride.max() if hasattr(model, 'stride') else 0), 32)  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             model.half() if fp16 else model.float()
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -137,7 +137,6 @@ class YOLO:
         overrides = self.overrides.copy()
         overrides["conf"] = 0.25
         overrides.update(kwargs)
-        overrides["mode"] = "predict"
         overrides["save"] = kwargs.get("save", False)  # not save files by default
 
         self.predictor.args = get_cfg(self.predictor.args, overrides)
@@ -236,7 +235,7 @@ class YOLO:
         """
         Used to initialize and setup predictor when model is loaded. Makes predictor accessible to the user.
         """
-        self.predictor = self.PredictorClass()
+        self.predictor = self.PredictorClass(overrides={"mode": "predict"})
         self.predictor.setup_model(model=self.model)
 
     def add_callback(self, event: str, func):

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -137,18 +137,15 @@ class YOLO:
         overrides["conf"] = 0.25
         overrides.update(kwargs)
         overrides["save"] = kwargs.get("save", False)  # not save files by default
-<<<<<<< pred_update
 
         self.predictor.args = get_cfg(self.predictor.args, overrides)
         return self.predictor(source=source, stream=stream, verbose=verbose)
-=======
         if not self.predictor:
             self.predictor = self.PredictorClass(overrides=overrides)
             self.predictor.setup_model(model=self.model)
         else:  # only update args if predictor is already setup
             self.predictor.args = get_cfg(self.predictor.args, overrides)
         return self.predictor(source=source, stream=stream)
->>>>>>> main
 
     @smart_inference_mode()
     def val(self, data=None, **kwargs):
@@ -222,7 +219,13 @@ class YOLO:
             device (str): device
         """
         self.model.to(device)
-
+        
+    def _init_predictor(self):
+        """
+        Used to initialize and setup predictor when model is loaded. Makes predictor accessible to the user.
+        """
+        self.predictor = self.PredictorClass(overrides={"mode": "predict"})
+        self.predictor.setup_model(model=self.model)
     def _assign_ops_from_task(self, task):
         model_class, train_lit, val_lit, pred_lit = MODEL_MAP[task]
         # warning: eval is unsafe. Use with caution
@@ -239,19 +242,8 @@ class YOLO:
         """
         return self.model.names
 
-<<<<<<< pred_update
-    def _init_predictor(self):
-        """
-        Used to initialize and setup predictor when model is loaded. Makes predictor accessible to the user.
-        """
-        self.predictor = self.PredictorClass(overrides={"mode": "predict"})
-        self.predictor.setup_model(model=self.model)
-
-    def add_callback(self, event: str, func):
-=======
     @staticmethod
     def add_callback(event: str, func):
->>>>>>> main
         """
         Add callback
         """

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -58,7 +58,7 @@ class YOLO:
         suffix = Path(model).suffix
         if suffix in load_methods:
             {'.pt': self._load, '.yaml': self._new}[suffix](model)
-            self._init_predictor() # Initialize & setup predictor
+            self._init_predictor()  # Initialize & setup predictor
         else:
             raise NotImplementedError(f"'{suffix}' model loading not implemented")
 
@@ -139,7 +139,7 @@ class YOLO:
         overrides.update(kwargs)
         overrides["mode"] = "predict"
         overrides["save"] = kwargs.get("save", False)  # not save files by default
-    
+
         self.predictor.args = get_cfg(self.predictor.args, overrides)
         return self.predictor(source=source, stream=stream, verbose=verbose)
 
@@ -231,14 +231,13 @@ class YOLO:
          Returns class names of the loaded model.
         """
         return self.model.names
-    
+
     def _init_predictor(self):
         """
         Used to initialize and setup predictor when model is loaded. Makes predictor accessible to the user.
         """
         self.predictor = self.PredictorClass()
         self.predictor.setup_model(model=self.model)
-    
 
     def add_callback(self, event: str, func):
         """

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -219,13 +219,14 @@ class YOLO:
             device (str): device
         """
         self.model.to(device)
-        
+
     def _init_predictor(self):
         """
         Used to initialize and setup predictor when model is loaded. Makes predictor accessible to the user.
         """
         self.predictor = self.PredictorClass(overrides={"mode": "predict"})
         self.predictor.setup_model(model=self.model)
+
     def _assign_ops_from_task(self, task):
         model_class, train_lit, val_lit, pred_lit = MODEL_MAP[task]
         # warning: eval is unsafe. Use with caution

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -139,12 +139,6 @@ class YOLO:
         overrides["save"] = kwargs.get("save", False)  # not save files by default
 
         self.predictor.args = get_cfg(self.predictor.args, overrides)
-        return self.predictor(source=source, stream=stream, verbose=verbose)
-        if not self.predictor:
-            self.predictor = self.PredictorClass(overrides=overrides)
-            self.predictor.setup_model(model=self.model)
-        else:  # only update args if predictor is already setup
-            self.predictor.args = get_cfg(self.predictor.args, overrides)
         return self.predictor(source=source, stream=stream)
 
     @smart_inference_mode()

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -58,6 +58,7 @@ class YOLO:
         suffix = Path(model).suffix
         if suffix in load_methods:
             {'.pt': self._load, '.yaml': self._new}[suffix](model)
+            self._init_predictor() # Initialize & setup predictor
         else:
             raise NotImplementedError(f"'{suffix}' model loading not implemented")
 
@@ -138,11 +139,8 @@ class YOLO:
         overrides.update(kwargs)
         overrides["mode"] = "predict"
         overrides["save"] = kwargs.get("save", False)  # not save files by default
-        if not self.predictor:
-            self.predictor = self.PredictorClass(overrides=overrides)
-            self.predictor.setup_model(model=self.model)
-        else:  # only update args if predictor is already setup
-            self.predictor.args = get_cfg(self.predictor.args, overrides)
+    
+        self.predictor.args = get_cfg(self.predictor.args, overrides)
         return self.predictor(source=source, stream=stream, verbose=verbose)
 
     @smart_inference_mode()
@@ -233,6 +231,14 @@ class YOLO:
          Returns class names of the loaded model.
         """
         return self.model.names
+    
+    def _init_predictor(self):
+        """
+        Used to initialize and setup predictor when model is loaded. Makes predictor accessible to the user.
+        """
+        self.predictor = self.PredictorClass()
+        self.predictor.setup_model(model=self.model)
+    
 
     def add_callback(self, event: str, func):
         """

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -149,6 +149,7 @@ class BasePredictor:
         self.from_img = from_img
         self.imgsz = imgsz
         self.bs = bs
+        self.source = source
 
     @smart_inference_mode()
     def __call__(self, source=None, model=None, verbose=False, stream=False):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -164,8 +164,6 @@ class BasePredictor:
             pass
 
     def stream_inference(self, source=None, model=None, verbose=False):
-        self.run_callbacks("on_predict_start")
-
         # setup model
         if not self.model:
             self.setup_model(model)
@@ -174,6 +172,8 @@ class BasePredictor:
         # check if save_dir/ label file exists
         if self.args.save or self.args.save_txt:
             (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
+        
+        self.run_callbacks("on_predict_start")
         # warmup model
         if not self.done_warmup:
             self.model.warmup(imgsz=(1 if self.model.pt or self.model.triton else self.bs, 3, *self.imgsz))

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -172,7 +172,7 @@ class BasePredictor:
         # check if save_dir/ label file exists
         if self.args.save or self.args.save_txt:
             (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
-        
+
         self.run_callbacks("on_predict_start")
         # warmup model
         if not self.done_warmup:

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -79,6 +79,7 @@ class BasePredictor:
 
         # Usable if setup is done
         self.model = None
+        self.source = None
         self.data = self.args.data  # data_dict
         self.bs = None
         self.imgsz = None
@@ -107,14 +108,14 @@ class BasePredictor:
         if not self.model:
             raise Exception("setup model before setting up source!")
         # source
-        source, webcam, screenshot, from_img = self.check_source(source)
+        source, self.webcam, self.screenshot, self.from_img = self.check_source(source)
         # model
         stride, pt = self.model.stride, self.model.pt
         imgsz = check_imgsz(self.args.imgsz, stride=stride, min_dim=2)  # check image size
 
         # Dataloader
         bs = 1  # batch_size
-        if webcam:
+        if self.webcam:
             self.args.show = check_imshow(warn=True)
             self.dataset = LoadStreams(source,
                                        imgsz=imgsz,
@@ -123,13 +124,13 @@ class BasePredictor:
                                        transforms=getattr(self.model.model, 'transforms', None),
                                        vid_stride=self.args.vid_stride)
             bs = len(self.dataset)
-        elif screenshot:
+        elif self.screenshot:
             self.dataset = LoadScreenshots(source,
                                            imgsz=imgsz,
                                            stride=stride,
                                            auto=pt,
                                            transforms=getattr(self.model.model, 'transforms', None))
-        elif from_img:
+        elif self.from_img:
             self.dataset = LoadPilAndNumpy(source,
                                            imgsz=imgsz,
                                            stride=stride,
@@ -144,9 +145,6 @@ class BasePredictor:
                                       vid_stride=self.args.vid_stride)
         self.vid_path, self.vid_writer = [None] * bs, [None] * bs
 
-        self.webcam = webcam
-        self.screenshot = screenshot
-        self.from_img = from_img
         self.imgsz = imgsz
         self.bs = bs
         self.source = source
@@ -165,11 +163,12 @@ class BasePredictor:
             pass
 
     def stream_inference(self, source=None, model=None, verbose=False):
-        # setup model
+        # setup model. Run only if model is not initialized
         if not self.model:
             self.setup_model(model)
-        # setup source. Run every time predict is called
-        self.setup_source(source)
+        # setup source. Run if self.source isn't initialized or a new source is passed
+        if source is not None or self.source is None:
+            self.setup_source(source)
         # check if save_dir/ label file exists
         if self.args.save or self.args.save_txt:
             (self.save_dir / 'labels' if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
@mikel-brostrom This PR updates the execution order of on_predict_start callback and moves it after the source is setup so it can access self.bs 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to the YOLO predictor callbacks and model loading mechanisms.

### 📊 Key Changes
- New callback feature for `on_predict_batch_end` in `test_predict_callback_and_setup`.
- Improved backend model stride attribute handling with graceful fallback to zero if not available.
- YOLO model class now initializes the predictor during model loading.
- Predictor class can now keep track of the source and has simplified logic for setting up the source and model.

### 🎯 Purpose & Impact
- 🧠 The callback allows users to execute custom functions at the end of a prediction batch, which is useful for post-processing results.
- 🛠️ The backend adjustment ensures compatibility with models that may lack the `stride` attribute, enhancing robustness.
- ♻️ Predictor initialization during model load simplifies the user workflow, making the API easier and more intuitive to use.
- 🔄 Keeping the source within the predictor class and streamlining how the model and source are set up reduces redundancy and could improve prediction efficiency. 

The updates should result in a more user-friendly experience with increased flexibility for developers integrating these models into various applications.