### PR TITLE
Added `torch.distributed.is_available()` check before `torch.distributed.is_initialized()`

### DIFF
--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -31,7 +31,8 @@ WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))
 @contextmanager
 def torch_distributed_zero_first(local_rank: int):
     # Decorator to make all processes in distributed training wait for each local_master to do something
-    initialized = torch.distributed.is_available() and torch.distributed.is_initialized()  # prevent 'Default process group has not been initialized' errors
+    initialized = torch.distributed.is_available() and torch.distributed.is_initialized(
+    )  # prevent 'Default process group has not been initialized' errors
     if initialized and local_rank not in {-1, 0}:
         dist.barrier(device_ids=[local_rank])
     yield

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -31,8 +31,7 @@ WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))
 @contextmanager
 def torch_distributed_zero_first(local_rank: int):
     # Decorator to make all processes in distributed training wait for each local_master to do something
-    initialized = torch.distributed.is_available() and torch.distributed.is_initialized(
-    )  # prevent 'Default process group has not been initialized' errors
+    initialized = torch.distributed.is_available() and torch.distributed.is_initialized()
     if initialized and local_rank not in {-1, 0}:
         dist.barrier(device_ids=[local_rank])
     yield

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -31,7 +31,7 @@ WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))
 @contextmanager
 def torch_distributed_zero_first(local_rank: int):
     # Decorator to make all processes in distributed training wait for each local_master to do something
-    initialized = torch.distributed.is_initialized()  # prevent 'Default process group has not been initialized' errors
+    initialized = torch.distributed.is_available() and torch.distributed.is_initialized()  # prevent 'Default process group has not been initialized' errors
     if initialized and local_rank not in {-1, 0}:
         dist.barrier(device_ids=[local_rank])
     yield


### PR DESCRIPTION
Resolves #612 
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in distributed training initialization check within Ultralytics YOLO utils.

### 📊 Key Changes
- Modified the initialization check in `torch_distributed_zero_first` from `is_initialized` to a combination of `is_available` and `is_initialized`.

### 🎯 Purpose & Impact
- **Purpose:** To prevent the error 'Default process group has not been initialized' during distributed training setups.
- **Impact:** Ensures a more robust check for the availability and initialization of distributed training processes, which can lead to smoother execution and better user experiences for developers using distributed training with Ultralytics YOLO.