### PR TITLE
Add ability to disable EMA from sub-classes of BaseTrainer

### DIFF
--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -247,7 +247,7 @@ class ModelEMA:
     """ Updated Exponential Moving Average (EMA) from https://github.com/rwightman/pytorch-image-models
     Keeps a moving average of everything in the model state_dict (parameters and buffers)
     For EMA details see https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage
-    
+
     To disable this after creation, set the `enabled` attribute to `False`.
     """
 

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -19,9 +19,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 import ultralytics
 from ultralytics.yolo.utils import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER
-from ultralytics.yolo.utils.checks import git_describe
-
-from .checks import check_version
+from ultralytics.yolo.utils.checks import git_describe, check_version
 
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 RANK = int(os.getenv('RANK', -1))
@@ -247,8 +245,7 @@ class ModelEMA:
     """ Updated Exponential Moving Average (EMA) from https://github.com/rwightman/pytorch-image-models
     Keeps a moving average of everything in the model state_dict (parameters and buffers)
     For EMA details see https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage
-
-    To disable this after creation, set the `enabled` attribute to `False`.
+    To disable EMA set the `enabled` attribute to `False`.
     """
 
     def __init__(self, model, decay=0.9999, tau=2000, updates=0):
@@ -261,26 +258,22 @@ class ModelEMA:
         self.enabled = True
 
     def update(self, model):
-        if not self.enabled:
-            return
-
         # Update EMA parameters
-        self.updates += 1
-        d = self.decay(self.updates)
+        if self.enabled:
+            self.updates += 1
+            d = self.decay(self.updates)
 
-        msd = de_parallel(model).state_dict()  # model state_dict
-        for k, v in self.ema.state_dict().items():
-            if v.dtype.is_floating_point:  # true for FP16 and FP32
-                v *= d
-                v += (1 - d) * msd[k].detach()
-        # assert v.dtype == msd[k].dtype == torch.float32, f'{k}: EMA {v.dtype} and model {msd[k].dtype} must be FP32'
+            msd = de_parallel(model).state_dict()  # model state_dict
+            for k, v in self.ema.state_dict().items():
+                if v.dtype.is_floating_point:  # true for FP16 and FP32
+                    v *= d
+                    v += (1 - d) * msd[k].detach()
+                    # assert v.dtype == msd[k].dtype == torch.float32, f'{k}: EMA {v.dtype},  model {msd[k].dtype}'
 
     def update_attr(self, model, include=(), exclude=('process_group', 'reducer')):
-        if not self.enabled:
-            return
-
         # Update EMA attributes
-        copy_attr(self.ema, model, include, exclude)
+        if self.enabled:
+            copy_attr(self.ema, model, include, exclude)
 
 
 def strip_optimizer(f='best.pt', s=''):
@@ -294,8 +287,8 @@ def strip_optimizer(f='best.pt', s=''):
             strip_optimizer(f)
 
     Args:
-        f (str): file path to model state to strip the optimizer from. Default is 'best.pt'.
-        s (str): file path to save the model with stripped optimizer to. Default is ''. If not provided, the original file will be overwritten.
+        f (str): file path to model to strip the optimizer from. Default is 'best.pt'.
+        s (str): file path to save the model with stripped optimizer to. If not provided, 'f' will be overwritten.
 
     Returns:
         None
@@ -373,12 +366,12 @@ class EarlyStopping:
     Early stopping class that stops training when a specified number of epochs have passed without improvement.
     """
 
-    def __init__(self, patience=30):
+    def __init__(self, patience=50):
         """
         Initialize early stopping object
 
         Args:
-            patience (int, optional): Number of epochs to wait after fitness stops improving before stopping. Default is 30.
+            patience (int, optional): Number of epochs to wait after fitness stops improving before stopping.
         """
         self.best_fitness = 0.0  # i.e. mAP
         self.best_epoch = 0

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -19,7 +19,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 import ultralytics
 from ultralytics.yolo.utils import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER
-from ultralytics.yolo.utils.checks import git_describe, check_version
+from ultralytics.yolo.utils.checks import check_version, git_describe
 
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 RANK = int(os.getenv('RANK', -1))


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


In some cases (like when model weights are pruned, or a model is quantized), it is not possible to use EMA. This PR adds a simple flag to ModelEMA class that allows disabling any updates to EMA.

The main use for this is when subclassing from the `BaseTrainer` class, where you have access to `self.ema`. In this case you can disable by running:
```python
self.ema.enabled = False
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements and refactoring in Ultralytics YOLO Torch utils for better maintainability and user control.

### 📊 Key Changes
- 🧹 Simplified import statements by removing unnecessary lines and merging related imports.
- 🚀 Introduced an `enabled` attribute in `ModelEMA` class to allow turning EMA (Exponential Moving Average) on and off.
- 🛠 Fixed assertions by commenting them and improved variable naming for clarity.
- 🔧 Extended the patience parameter in `EarlyStopping` class from 30 to 50 epochs to provide a longer evaluation period before stopping training.
- 📚 Updated method documentations to reflect new defaults and parameter usage more accurately.

### 🎯 Purpose & Impact
- 🌐 The import refactoring reduces clutter in the code, which makes it easier for developers to maintain.
- ✨ Adding an `enabled` attribute to `ModelEMA` gives users control to disable EMA if desired, enhancing usability.
- 🎈 The increased `EarlyStopping` patience offers potentially better training outcomes by allowing more time for model improvement before stopping.
- 📖 The updated comments and documentation improve code readability and make it easier for users to understand how to use the functionalities.