### PR TITLE
Update predictor.py to accept `data` for class names

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -233,7 +233,7 @@ class BasePredictor:
         device = select_device(self.args.device)
         model = model or self.args.model
         self.args.half &= device.type != 'cpu'  # half precision only supported on CUDA
-        self.model = AutoBackend(model, device=device, dnn=self.args.dnn, fp16=self.args.half)
+        self.model = AutoBackend(model, device=device, dnn=self.args.dnn, data=self.args.data, fp16=self.args.half)
         self.device = device
         self.model.eval()
 


### PR DESCRIPTION
To fix missing class name https://github.com/ultralytics/ultralytics/issues/659

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model setup with data parameter integration in the predictor setup.

### 📊 Key Changes
- The `AutoBackend` class instantiation within the `setup_model` method now includes the `data` parameter from `self.args`.

### 🎯 Purpose & Impact
- This change allows the predictor to utilize dataset-specific configurations when setting up the model, potentially improving model performance and accuracy.
- Users may experience more tailored predictions that are optimized for specific datasets.