### PR TITLE
Added the ability to freeze layers (copied from the Yolo5) #562

### DIFF
--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -101,6 +101,7 @@ fliplr: 0.5  # image flip left-right (probability)
 mosaic: 1.0  # image mosaic (probability)
 mixup: 0.0  # image mixup (probability)
 copy_paste: 0.0  # segment copy-paste (probability)
+freeze: 0 # freeze layers count
 
 # Custom config.yaml ---------------------------------------------------------------------------------------------------
 cfg:  # for overriding defaults.yaml

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -239,9 +239,11 @@ class BaseTrainer:
             self.ema = ModelEMA(self.model)
         self.resume_training(ckpt)
         self.run_callbacks("on_pretrain_routine_end")
-		
-		# Freeze layers
-        freeze = [f'model.{x}.' for x in (self.args.freeze if type(self.args.freeze) is list else range(self.args.freeze))]  # layers to freeze
+
+        # Freeze layers
+        freeze = [
+            f'model.{x}.' for x in (self.args.freeze if type(self.args.freeze) is list else range(self.args.freeze))
+        ]  # layers to freeze
         for k, v in self.model.named_parameters():
             v.requires_grad = True  # train all layers
             # v.register_hook(lambda x: torch.nan_to_num(x))  # NaN to 0 (commented for erratic training results)


### PR DESCRIPTION
Hi not sure if helpful but I copied the freeze code from the Yolov5 to enable the freezing of the layers
I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model training customization with layer freezing support.

### 📊 Key Changes
- Added a new `freeze` parameter to `default.yaml` configuration to specify the number of layers to freeze.
- Updated `trainer.py` to process the `freeze` argument and apply the layer freezing during model setup.

### 🎯 Purpose & Impact
- **Purpose**: The ability to freeze layers is intended to allow users to fix the weights of certain parts of the model during training. This can help when fine-tuning a pre-trained model on new data by keeping the base layers static and only adjusting the weights of the higher-level, task-specific layers.
- **Impact**: Users can now improve training efficiency and potentially achieve better performance by customizing which layers get trained. This feature is particularly useful for transfer learning scenarios. 🔄🔒