### PR TITLE
Use new OpenVINO API instead of deprecated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ seaborn>=0.11.0
 # scikit-learn==0.19.2  # CoreML quantization
 # tensorflow>=2.4.1  # TF exports (-cpu, -aarch64, -macos)
 # tensorflowjs>=3.9.0  # TF.js export
-# openvino-dev  # OpenVINO export
+# openvino-dev>=2022.1  # OpenVINO export
 
 # Extras --------------------------------------
 ipython  # interactive notebook

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -320,9 +320,9 @@ class Exporter:
     def _export_openvino(self, prefix=colorstr('OpenVINO:')):
         # YOLOv8 OpenVINO export
         check_requirements('openvino-dev')  # requires openvino-dev: https://pypi.org/project/openvino-dev/
-        import openvino.inference_engine as ie  # noqa
+        import openvino.runtime as ov  # noqa
 
-        LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
+        LOGGER.info(f'\n{prefix} starting export with openvino {ov.__version__}...')
         f = str(self.file).replace(self.file.suffix, f'_openvino_model{os.sep}')
         f_onnx = self.file.with_suffix('.onnx')
 


### PR DESCRIPTION
The new API has been introduced in 2022.1 and the old one is deprecated now (will be removed in the future release). You already have been using the new API in autobackend.py, so I'm fixing it for the exporter also.

There is also a new Python API for Model Optimizer, so we could get rid of the subprocess (bash) calls. However, it would require us to pin the OpenVINO version to >=2022.3

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgrade to OpenVINO support for better model export.

### 📊 Key Changes
- The `requirements.txt` has been updated to specify a minimum version for `openvino-dev`, now requiring version `2022.1` or higher.
- In `ultralytics/yolo/engine/exporter.py`, the code has been modified to use the `openvino.runtime` module instead of the older `openvino.inference_engine`.

### 🎯 Purpose & Impact
- **Ensure compatibility**: The update in `requirements.txt` enforces the use of newer versions of OpenVINO, which may include critical fixes and performance improvements.
- **Reflect API changes**: Changing the import statement to `openvino.runtime` implies adapting to the changes in the OpenVINO API, possibly to leverage new features or maintain support.
- **Potential impact**: Users will experience a smoother export process for models to the OpenVINO format. Improved exports can lead to better model performance and wider deployment options, benefiting applications in production environments. 

Remember to update your OpenVINO installation to keep using the latest export features! 🚀