### PR TITLE
Fixes wrong return type of predict in model.py

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -1,6 +1,7 @@
 # Ultralytics YOLO 🚀, GPL-3.0 license
 
 from pathlib import Path
+from typing import List
 
 import sys
 from ultralytics import yolo  # noqa
@@ -131,7 +132,7 @@ class YOLO:
                        Check the 'configuration' section in the documentation for all available options.
 
         Returns:
-            (dict): The prediction results.
+            (List[ultralytics.yolo.engine.results.Results]): The prediction results.
         """
         overrides = self.overrides.copy()
         overrides["conf"] = 0.25


### PR DESCRIPTION
The doc string claimed the returned type was dict, when in reality a List[Results] is returned



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded return type annotation in the prediction method.

### 📊 Key Changes
- Added an import for the `List` type from the `typing` module.
- Modified the return type in the docstring of the `predict` method from a generic `dict` to a specific `List` of `ultralytics.yolo.engine.results.Results`.

### 🎯 Purpose & Impact
- 📝 Provides more precise type information for developers, enhancing code clarity and assisting in static type checking.
- 👩‍💻 Helps developers understand what kind of results they can expect from the `predict` method, potentially reducing errors and improving integration with IDEs for better coding assistance.
- 🚀 Might lead to better API documentation, enhancing usability for new and existing users.