### PR TITLE
Support datasets as zipfile and links

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -117,12 +117,11 @@ class BaseTrainer:
         # Model and Dataloaders.
         self.model = self.args.model
         self.data = self.args.data
-        if self.data.endswith(".yaml"):
-            self.data = check_det_dataset(self.data)
-        elif self.args.task == 'classify':
+            
+        if self.args.task == 'classify':
             self.data = check_cls_dataset(self.data)
         else:
-            raise FileNotFoundError(emojis(f"Dataset '{self.args.data}' not found ❌"))
+            self.data = check_det_dataset(self.data)
         self.trainset, self.testset = self.get_dataset(self.data)
         self.ema = None
 

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -117,7 +117,7 @@ class BaseTrainer:
         # Model and Dataloaders.
         self.model = self.args.model
         self.data = self.args.data
-            
+
         if self.args.task == 'classify':
             self.data = check_cls_dataset(self.data)
         else:


### PR DESCRIPTION
@glenn-jocher this doesn't work as it's supposed to. It is looking for the yaml in the wrong location though  and it fails here:
```
        data = next((DATASETS_DIR / Path(data).stem).rglob('*.yaml'))

```
It seems related to the dataset_dir setting that I was talking about. Can you take a look and confirm?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data handling in the training module.

### 📊 Key Changes
- Removed the condition that checks if `self.data` ends with ".yaml" for object detection tasks.
- Ensured that `check_det_dataset` is called for object detection regardless of the file extension.
- Simplified the flow to call `check_cls_dataset` for classification tasks without extension checks.

### 🎯 Purpose & Impact
- 🔄 Streamlines the setup process for classification and object detection by refactoring the dataset checks.
- 🧐 Increases flexibility in specifying datasets for training, as it removes the strict requirement for a ".yaml" extension in detection tasks.
- ✅ Potentially reduces user errors by handling detection and classification dataset preparation in a more consistent manner.