### PR TITLE
change datatype of variable ch of parse_model function

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -172,7 +172,7 @@ class DetectionModel(BaseModel):
         if nc and nc != self.yaml['nc']:
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml['nc'] = nc  # override yaml value
-        self.model, self.save = parse_model(deepcopy(self.yaml), ch=[ch], verbose=verbose)  # model, savelist
+        self.model, self.save = parse_model(deepcopy(self.yaml), ch=ch, verbose=verbose)  # model, savelist
         self.names = {i: f'{i}' for i in range(self.yaml['nc'])}  # default names dict
         self.inplace = self.yaml.get('inplace', True)
 
@@ -282,7 +282,7 @@ class ClassificationModel(BaseModel):
         if nc and nc != self.yaml['nc']:
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml['nc'] = nc  # override yaml value
-        self.model, self.save = parse_model(deepcopy(self.yaml), ch=[ch], verbose=verbose)  # model, savelist
+        self.model, self.save = parse_model(deepcopy(self.yaml), ch=ch, verbose=verbose)  # model, savelist
         self.names = {i: f'{i}' for i in range(self.yaml['nc'])}  # default names dict
         self.info()
 
@@ -421,7 +421,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
         Conv.default_act = eval(act)  # redefine default activation, i.e. Conv.default_act = nn.SiLU()
         if verbose:
             LOGGER.info(f"{colorstr('activation:')} {act}")  # print
-
+    ch = [ch]
     layers, save, c2 = [], [], ch[-1]  # layers, savelist, ch out
     for i, (f, n, m, args) in enumerate(d['backbone'] + d['head']):  # from, number, module, args
         m = eval(m) if isinstance(m, str) else m  # eval strings


### PR DESCRIPTION
Changed a datatype of `ch` to int and converted datatype to list in `parse_model(...)`.

`ch` is considered `int` instead of `list` as a function argument. I think that `ch` means input channel, so it should be an `int` value when it comes to a function argument.

https://github.com/ultralytics/ultralytics/blob/3633d4c06b806a971f444919c389ac6e889cdb23/ultralytics/nn/tasks.py#L164-L166

https://github.com/ultralytics/ultralytics/blob/3633d4c06b806a971f444919c389ac6e889cdb23/ultralytics/nn/tasks.py#L244-L247

https://github.com/ultralytics/ultralytics/blob/3633d4c06b806a971f444919c389ac6e889cdb23/ultralytics/nn/tasks.py#L250-L258

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of the channel input specification for model parsing in the Ultralytics neural network code.

### 📊 Key Changes
- The `parse_model` function now directly accepts an integer `ch` instead of a list `[ch]` for the input channels.
- The call to `parse_model` with `ch=[ch]` has been updated to `ch=ch` in two places within the `tasks.py` file.

### 🎯 Purpose & Impact
- 🎨 **Code Simplification**: The change simplifies the way input channels are specified, potentially reducing confusion and risk of errors.
- ⚙️ **Improved Readability**: This minor revision leads to cleaner code, making it easier to maintain and understand for developers.
- 🚀 **Consistency**: Ensures that input channel specifications are consistent throughout the codebase.