### PR TITLE
Added save_period for PR

### DIFF
--- a/docs/cfg.md
+++ b/docs/cfg.md
@@ -75,6 +75,7 @@ task.
 | batch           | 16     | number of images per batch (-1 for AutoBatch)                                  |
 | imgsz           | 640    | size of input images as integer or w,h                                         |
 | save            | True   | save train checkpoints and predict results                                     |
+| save_period     | -1     | Save checkpoint every x epochs (disabled if < 1)                               |
 | cache           | False  | True/ram, disk or False. Use cache for data loading                            |
 | device          | null   | device to run on, i.e. cuda device=0 or device=0,1,2,3 or device=cpu           |
 | workers         | 8      | number of worker threads for data loading (per RANK if DDP)                    |

--- a/ultralytics/yolo/cfg/__init__.py
+++ b/ultralytics/yolo/cfg/__init__.py
@@ -56,7 +56,7 @@ CFG_FRACTION_KEYS = {
     'mixup', 'copy_paste', 'conf', 'iou'}
 CFG_INT_KEYS = {
     'epochs', 'patience', 'batch', 'workers', 'seed', 'close_mosaic', 'mask_ratio', 'max_det', 'vid_stride',
-    'line_thickness', 'workspace', 'nbs'}
+    'line_thickness', 'workspace', 'nbs', 'save_period'}
 CFG_BOOL_KEYS = {
     'save', 'exist_ok', 'pretrained', 'verbose', 'deterministic', 'single_cls', 'image_weights', 'rect', 'cos_lr',
     'overlap_mask', 'val', 'save_json', 'save_hybrid', 'half', 'dnn', 'plots', 'show', 'save_txt', 'save_conf',

--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -12,6 +12,7 @@ patience: 50  # epochs to wait for no observable improvement for early stopping 
 batch: 16  # number of images per batch (-1 for AutoBatch)
 imgsz: 640  # size of input images as integer or w,h
 save: True  # save train checkpoints and predict results
+save_period: -1 # Save checkpoint every x epochs (disabled if < 1)
 cache: False  # True/ram, disk or False. Use cache for data loading
 device:  # device to run on, i.e. cuda device=0 or device=0,1,2,3 or device=cpu
 workers: 8  # number of worker threads for data loading (per RANK if DDP)

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -51,6 +51,7 @@ class BaseTrainer:
         wdir (Path): Directory to save weights.
         last (Path): Path to last checkpoint.
         best (Path): Path to best checkpoint.
+        save_period (int): Save checkpoint every x epochs (disabled if < 1).
         batch_size (int): Batch size for training.
         epochs (int): Number of epochs to train for.
         start_epoch (int): Starting epoch for training.
@@ -101,6 +102,7 @@ class BaseTrainer:
             self.args.save_dir = str(self.save_dir)
             yaml_save(self.save_dir / 'args.yaml', vars(self.args))  # save run args
         self.last, self.best = self.wdir / 'last.pt', self.wdir / 'best.pt'  # checkpoint paths
+        self.save_period = self.args.save_period
 
         self.batch_size = self.args.batch
         self.epochs = self.args.epochs
@@ -392,6 +394,8 @@ class BaseTrainer:
         torch.save(ckpt, self.last)
         if self.best_fitness == self.fitness:
             torch.save(ckpt, self.best)
+        if (self.epoch > 0) and (self.save_period > 0) and (self.epoch % self.save_period == 0):
+            torch.save(ckpt, self.wdir / f'epoch{self.epoch}.pt')
         del ckpt
 
     def get_dataset(self, data):


### PR DESCRIPTION
Added enhancement described in #908 

Saved file will be in same dir as last.pt and best.pt, named epochX.pt .
Usage: default.yaml is set to -1, add 'save_period=10' to args to save each 10 epochs.
Added description in cfd.md .

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing configurable checkpoint saving frequency during training in Ultralytics YOLO.

### 📊 Key Changes
- Added a `save_period` parameter that allows users to specify how often to save training checkpoints.
- Updated configuration files and training code to support the new `save_period` functionality.

### 🎯 Purpose & Impact
- **Purpose**: To give users more control over the checkpoint saving process, enabling them to save model states at regular intervals, as opposed to only saving the last and best models.
- **Impact**: Users can now recover training from more specific points in time, which can be helpful for long training sessions or when fine-tuning model checkpoints. This could potentially save time and resources in the event of interrupted training sessions. 🕒💾