### PR TITLE
Add fuse to args and pass to AutoBackend constructor

### DIFF
--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -47,6 +47,7 @@ max_det: 300  # maximum number of detections per image
 half: False  # use half precision (FP16)
 dnn: False  # use OpenCV DNN for ONNX inference
 plots: True  # save plots during train/val
+fuse: True  # Fuse model before validation
 
 # Prediction settings --------------------------------------------------------------------------------------------------
 source:  # source directory for images or videos

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -95,7 +95,7 @@ class BaseValidator:
             assert model is not None, "Either trainer or model is needed for validation"
             self.device = select_device(self.args.device, self.args.batch)
             self.args.half &= self.device.type != 'cpu'
-            model = AutoBackend(model, device=self.device, dnn=self.args.dnn, fp16=self.args.half)
+            model = AutoBackend(model, device=self.device, dnn=self.args.dnn, fp16=self.args.half, fuse=self.args.fuse)
             self.model = model
             stride, pt, jit, engine = model.stride, model.pt, model.jit, model.engine
             imgsz = check_imgsz(self.args.imgsz, stride=stride)


### PR DESCRIPTION
Currently there is no way to prevent AutoBackend from fusing a model together. If the model has been already fused or quantized elsewhere, then AutoBackend doesn't need to do this.

Conveniently, AutoBackend already has a parameter on whether or not to fuse the model, so this PR just adds this flag to the CLI.

Tested by running:
1. Unfused `yolo val model=https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt`:
```bash
Ultralytics YOLOv8.0.33 🚀 Python-3.9.5 torch-1.12.1+cu113 CUDA:0 (NVIDIA RTX A4000, 16117MiB)
YOLOv8n summary (fused): 168 layers, 3151904 parameters, 0 gradients, 8.7 GFLOPs
val: Scanning /home/corey/datasets/coco128/labels/train2017... 126 images, 2 backgrounds, 0 corrupt: 100%|██████████| 128/128 [00:00<00:00, 1158.13it/s]
val: New cache created: /home/corey/datasets/coco128/labels/train2017.cache
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100%|██████████| 8/8 [00:05<00:00,  1.48it/s]
                   all        128        929      0.642      0.537      0.605      0.446
```

2. Fused `yolo val model=https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt fuse=False`: 
```bash
Ultralytics YOLOv8.0.33 🚀 Python-3.9.5 torch-1.12.1+cu113 CUDA:0 (NVIDIA RTX A4000, 16117MiB)
val: Scanning /home/corey/datasets/coco128/labels/train2017.cache... 126 images, 2 backgrounds, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100%|██████████| 8/8 [00:05<00:00,  1.53it/s]
                   all        128        929       0.64      0.537      0.605      0.446
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Model Optimization with Fusion Option during Validation

### 📊 Key Changes
- Added a new configuration option `fuse: True` in the `default.yaml` file.
- Updated the `validator.py` to accept the new fusion parameter in the `AutoBackend` function call.

### 🎯 Purpose & Impact
- **Purpose:** To enable model fusion before running validation to optimize the model for faster inference and potentially improve performance.
- **Impact:** Users can now take advantage of model fusion which can result in improved validation speeds and efficiency, especially beneficial when deploying models to production environments. 🚀📈