### PR TITLE
Fix resume

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -356,7 +356,7 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
         model = (ckpt.get('ema') or ckpt['model']).to(device).float()  # FP32 model
 
         # Model compatibility updates
-        model.args = {k: v for k, v in args.items() if k in DEFAULT_CFG_KEYS}  # attach args to model
+        model.args = args  # attach args to model
         model.pt_path = weights  # attach *.pt file path to model
         model.task = guess_model_task(model)
         if not hasattr(model, 'stride'):

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -555,6 +555,12 @@ class BaseTrainer:
             self.epochs += ckpt['epoch']  # finetune additional epochs
         self.best_fitness = best_fitness
         self.start_epoch = start_epoch
+        if start_epoch > (self.epochs - self.args.close_mosaic):
+            self.console.info("Closing dataloader mosaic")
+            if hasattr(self.train_loader.dataset, 'mosaic'):
+                self.train_loader.dataset.mosaic = False
+            if hasattr(self.train_loader.dataset, 'close_mosaic'):
+                self.train_loader.dataset.close_mosaic(hyp=self.args)
 
     @staticmethod
     def build_optimizer(model, name='Adam', lr=0.001, momentum=0.9, decay=1e-5):

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -217,12 +217,12 @@ class BaseTrainer:
 
         # Optimizer
         self.accumulate = max(round(self.args.nbs / self.batch_size), 1)  # accumulate loss before optimizing
-        self.args.weight_decay *= self.batch_size * self.accumulate / self.args.nbs  # scale weight_decay
+        weight_decay = self.args.weight_decay * self.batch_size * self.accumulate / self.args.nbs  # scale weight_decay
         self.optimizer = self.build_optimizer(model=self.model,
                                               name=self.args.optimizer,
                                               lr=self.args.lr0,
                                               momentum=self.args.momentum,
-                                              decay=self.args.weight_decay)
+                                              decay=weight_decay)
         # Scheduler
         if self.args.cos_lr:
             self.lf = one_cycle(1, self.args.lrf, self.epochs)  # cosine 1->hyp['lrf']

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -229,7 +229,6 @@ class BaseTrainer:
         else:
             self.lf = lambda x: (1 - x / self.epochs) * (1.0 - self.args.lrf) + self.args.lrf  # linear
         self.scheduler = lr_scheduler.LambdaLR(self.optimizer, lr_lambda=self.lf)
-        self.scheduler.last_epoch = self.start_epoch - 1  # do not move
         self.stopper, self.stop = EarlyStopping(patience=self.args.patience), False
 
         # dataloaders
@@ -242,6 +241,7 @@ class BaseTrainer:
             self.metrics = dict(zip(metric_keys, [0] * len(metric_keys)))  # TODO: init metrics for plot_results()?
             self.ema = ModelEMA(self.model)
         self.resume_training(ckpt)
+        self.scheduler.last_epoch = self.start_epoch - 1  # do not move
         self.run_callbacks("on_pretrain_routine_end")
 
     def _do_train(self, rank=-1, world_size=1):


### PR DESCRIPTION
@glenn-jocher @AyushExel 
- fixed weight_decay, `weight_decay` could be updated in this line so ckpt['train_args'] could keep updated `weight_decay`: [https://github.com/ultralytics/ultralytics/blob/977fd8f0b8764e83d7da964ba87477df6492735d/ultralytics/yolo/engine/trainer.py#L220](https://github.com/ultralytics/ultralytics/blob/977fd8f0b8764e83d7da964ba87477df6492735d/ultralytics/yolo/engine/trainer.py#L220)
- fixed save_dir, `save_dir` is not in `DEFAULT_CFG_KEYS` and it would be removed when loading resume ckpt then a new `save_dir` with an extra number suffix will be created. [https://github.com/ultralytics/ultralytics/blob/977fd8f0b8764e83d7da964ba87477df6492735d/ultralytics/nn/tasks.py#L359](https://github.com/ultralytics/ultralytics/blob/977fd8f0b8764e83d7da964ba87477df6492735d/ultralytics/nn/tasks.py#L359)
- fixed scheduler.last_epoch
- fixed resume if the training was interrupted in close_mosaic epoch.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of model argument handling and weight decay scaling, including improved resume training logic.

### 📊 Key Changes
- **Model Argument Storage**: Previously filtered model arguments to only those in `DEFAULT_CFG_KEYS`; now stores all passed arguments.
- **Weight Decay Calculation**: Moved weight decay scaling logic into a separate variable instead of modifying `args.weight_decay` in place.
- **Scheduler Adjustment**: Moved the `scheduler.last_epoch` setting from optimizer setup to post-resume training logic.
- **Improved Training Continuation**: Incorporated checks to disable dataloader mosaic if resuming training late in the training cycle.

### 🎯 Purpose & Impact
- **Model Compatibility**: Allows for more flexible and comprehensive storage of model arguments, possibly aiding model customization and debugging.
- **Cleaner Code**: Decoupling the weight decay calculation from the `self.args` structure enhances code clarity and might prevent accidental misuse of the original `weight_decay` value.
- **Training Consistency**: Adjusting the scheduler after resuming training ensures correct epoch handling, which is especially important for accurate learning rate adjustments.
- **Enhanced Train Resume**: Disabling the mosaic augmentations when resuming training late avoids potential issues with non-standard data enhancement techniques which might not be needed towards the end of training. This change could lead to more stable and predictable model behavior.

Overall, these updates are likely to improve code maintainability and training behavior, leading to more robust model performance. 🚀