### PR TITLE
Removed code that prevents albumentations being used during eval

### DIFF
--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -201,7 +201,7 @@ class ClassificationDataset(torchvision.datasets.ImageFolder):
     def __init__(self, root, augment, imgsz, cache=False):
         super().__init__(root=root)
         self.torch_transforms = classify_transforms(imgsz)
-        self.album_transforms = classify_albumentations(augment, imgsz) if augment else None
+        self.album_transforms = classify_albumentations(augment, imgsz)
         self.cache_ram = cache is True or cache == "ram"
         self.cache_disk = cache == "disk"
         self.samples = [list(x) + [Path(x[0]).with_suffix(".npy"), None] for x in self.samples]  # file, index, npy, im


### PR DESCRIPTION
Tested on version 8.0.35 on A5500 16GB GPU, 64GB ram, Windows 10 by
```
yolo classify train data=imagenette160 imgsz=160 model=yolov8l-cls.pt epochs=500 batch=512 workers=4 cache=ram
```
Yields the same best top1 accuracy as torchvision transforms og 0.90. To resolve issue with never using albumentations during test/val when augment is set to False; https://github.com/ultralytics/ultralytics/issues/768

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9847a86</samp>

### Summary
:recycle::wrench::sparkles:

<!--
1.  :recycle: This emoji represents the refactoring of the code to improve its structure and readability.
2.  :wrench: This emoji represents the improvement of the data augmentation pipeline and the flexibility of the `classify_albumentations` function.
3.  :sparkles: This emoji represents the addition of a new feature or enhancement to the code.
-->
Refactor data augmentation pipeline for classification tasks. Simplify `ClassificationDataset` class by removing unnecessary condition for `self.album_transforms`.

> _Simplify `augment`_
> _`classify_albumentations`_
> _Handles all cases_

### Walkthrough
*  Simplify data augmentation pipeline for classification tasks by removing redundant condition ([link](https://github.com/ultralytics/ultralytics/pull/943/files?diff=unified&w=0#diff-9e341b944998965225e7749684518d7461f0a0ebc7e6dd53502ca840fb4e686fL204-R204))



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ignore patterns in the project's `.gitignore` file. 

### 📊 Key Changes
- Added `/svv`, `/runs`, and `/wandb` to the `.gitignore` list.

### 🎯 Purpose & Impact
- **Purpose:** Keeps temporary and redundant files like model checkpoints, log files, and experiment logs from cluttering the repository or being inadvertently added to version control.
- **Impact:** Improves developer experience by preventing unneeded files from appearing in Git status and commit changes, reducing the risk of committing unnecessary or sensitive data to the repository.