### PR TITLE
Add metrics property

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -140,6 +140,7 @@ def test_workflow():
     model = YOLO(MODEL)
     model.train(data="coco8.yaml", epochs=1, imgsz=32)
     model.val()
+    print(model.metrics)
     model.predict(SOURCE)
     model.export(format="onnx", opset=12)  # export a model to ONNX format
 
@@ -166,4 +167,3 @@ def test_predict_callback_and_setup():
         print(boxes)
 
 
-test_predict_img()

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -165,5 +165,3 @@ def test_predict_callback_and_setup():
         print('test_callback', bs)
         boxes = result.boxes  # Boxes object for bbox outputs
         print(boxes)
-
-

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -55,6 +55,7 @@ class YOLO:
         self.cfg = None  # if loaded from *.yaml
         self.ckpt_path = None
         self.overrides = {}  # overrides for trainer object
+        self.metrics_data = None
 
         # Load or create new YOLO model
         suffix = Path(model).suffix
@@ -176,6 +177,8 @@ class YOLO:
 
         validator = self.ValidatorClass(args=args)
         validator(model=self.model)
+        self.metrics_data = validator.metrics.results_dict
+
         return validator.metrics
 
     @smart_inference_mode()
@@ -226,6 +229,7 @@ class YOLO:
         if RANK in {0, -1}:
             self.model, _ = attempt_load_one_weight(str(self.trainer.best))
             self.overrides = self.model.args
+        self.metrics_data = self.trainer.metrics
 
     def to(self, device):
         """
@@ -258,6 +262,16 @@ class YOLO:
          Returns transform of the loaded model.
         """
         return self.model.transforms if hasattr(self.model, 'transforms') else None
+
+    @property
+    def metrics(self):
+        """
+        Returns metrics if computed
+        """
+        if not self.metrics_data:
+            LOGGER.info("No metrics data found! Run training or validation operation first.")
+        
+        return self.metrics_data
 
     @staticmethod
     def add_callback(event: str, func):

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -177,7 +177,7 @@ class YOLO:
 
         validator = self.ValidatorClass(args=args)
         validator(model=self.model)
-        self.metrics_data = validator.metrics.results_dict
+        self.metrics_data = validator.metrics
 
         return validator.metrics
 
@@ -229,7 +229,7 @@ class YOLO:
         if RANK in {0, -1}:
             self.model, _ = attempt_load_one_weight(str(self.trainer.best))
             self.overrides = self.model.args
-        self.metrics_data = self.trainer.metrics
+        self.metrics_data = self.trainer.validator.metrics
 
     def to(self, device):
         """

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -270,7 +270,7 @@ class YOLO:
         """
         if not self.metrics_data:
             LOGGER.info("No metrics data found! Run training or validation operation first.")
-        
+
         return self.metrics_data
 
     @staticmethod


### PR DESCRIPTION
Usage
```
    model = YOLO(MODEL)
    model.metrics
    model.train(epochs=1, data="coco128.yaml", imgsz=32)
    print(model.metrics)
    model.val()
    print(model.metrics)

```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model tracking by including metrics printout and data storage during training and validation.

### 📊 Key Changes
- Added printing of model metrics after validation in test workflow.
- Stored validation metrics in the model object after the validation is done.
- Stored training metrics in the model object post-training.
- Implemented a new property method to access the metrics data.

### 🎯 Purpose & Impact
- These changes aim to improve the user experience by allowing them to easily access performance metrics of their models after training and validation runs.
- Users can now get immediate feedback on their model's performance, enhancing debugging and model optimization processes.
- The addition of an easily accessible metrics property potentially impacts automated systems by simplifying the process of retrieving model performance data post-training or validation.