### PR TITLE
Add preload function for fast execution when `predict` is called

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -137,11 +137,11 @@ class YOLO:
     def fuse(self):
         self._check_is_pytorch_model()
         self.model.fuse()
-    
+
     def preload(self, **kwargs):
         """
         Preloads the model for inference.
-        
+
         Args:
              **kwargs : Additional keyword arguments passed to the predictor.
                        Check the 'configuration' section in the documentation for all available options.

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -137,6 +137,26 @@ class YOLO:
     def fuse(self):
         self._check_is_pytorch_model()
         self.model.fuse()
+    
+    def preload(self, **kwargs):
+        """
+        Preloads the model for inference.
+        
+        Args:
+             **kwargs : Additional keyword arguments passed to the predictor.
+                       Check the 'configuration' section in the documentation for all available options.
+
+        Returns:
+            None
+        """
+        overrides = self.overrides.copy()
+        overrides["conf"] = 0.25
+        overrides.update(kwargs)
+        overrides["mode"] = "predict"
+        overrides["save"] = kwargs.get("save", False)  # not save files by default
+        if not self.predictor:
+            self.predictor = self.PredictorClass(overrides=overrides)
+            self.predictor.setup_model(model=self.model)
 
     def predict(self, source=None, stream=False, **kwargs):
         """


### PR DESCRIPTION
#### Current issue
When calling `predict`, it takes a few seconds to build the predictor & run `setup_model`. When running in a pipeline, it's ideal to have the everything loaded and ready to go when a request comes in.

#### Proposed solution
Add a `preload` function which simply creates the predictor without having to call `predict` first and wait.

I have read the CLA Document and I sign the CLA
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added a new `preload` method for initializing the model for inference.

### 📊 Key Changes
- 🛠️ A new `preload` method has been introduced in the `engine/model.py`.
- 🔧 The `preload` method accepts additional keyword arguments (`**kwargs`) for configuration.
- 📈 The `preload` method sets a default confidence threshold (`conf`) of 0.25 unless overridden.

### 🎯 Purpose & Impact
- 🚀 This PR aims to enhance model performance by allowing users to preload the model before conducting inference, which could lead to faster response times when performing predictions.
- 🌐 This change allows greater flexibility and customization of the prediction process by letting users specify their configuration parameters upfront, potentially improving user experience as they won’t need to set up the model every time predictions are made.