### PR TITLE
Update predict.md to correct Results' attributes

### DIFF
--- a/docs/predict.md
+++ b/docs/predict.md
@@ -34,7 +34,8 @@ Results object consists of these component objects:
 
 - `Results.boxes` : `Boxes` object with properties and methods for manipulating bboxes
 - `Results.masks` : `Masks` object used to index masks or to get segment coordinates.
-- `Results.prob`  : `torch.Tensor` containing the class probabilities/logits.
+- `Results.probs` : `torch.Tensor` containing the class probabilities/logits.
+- `Results.orig_shape` : `tuple` containing the original image size as (height, width).
 
 Each result is composed of torch.Tensor by default, in which you can easily use following functionality:
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->

Correct list of attributes of class `Results` by adding `orig_shape`


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Documentation update for prediction results in Ultralytics.

### 📊 Key Changes
- Renamed `Results.prob` to `Results.probs` for clarity.
- Added `Results.orig_shape` to include the original image size.

### 🎯 Purpose & Impact
- 📝 Clarifies the terminology by using plural form (`probs`) to indicate there are multiple class probabilities.
- 🌆 Provides users with the original image dimensions, useful for post-processing or when displaying the results on the original images.