### PR TITLE
Update augment.py

### DIFF
--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -585,6 +585,7 @@ class Albumentations:
                 new = self.transform(image=im, bboxes=bboxes, class_labels=cls)  # transformed
                 labels["img"] = new["image"]
                 labels["cls"] = np.array(new["class_labels"])
+                bboxes = np.array(new["bboxes"])
             labels["instances"].update(bboxes=bboxes)
         return labels
 


### PR DESCRIPTION
Fix: Albumentations to update bboxes. Required for Spatial-level transformations. (like A.ShiftScaleRotate()).


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Data Augmentation Support for Bounding Boxes

### 📊 Key Changes
- The data augmentation pipeline will now update the bounding boxes after transformations.

### 🎯 Purpose & Impact
- 🎨 Ensures augmented images retain accurate bounding box annotations for object detection tasks, leading to better model performance.
- 🛠 Helps maintain the integrity of data consistency during training, potentially improving the robustness of models trained using Ultralytics services.
- ✅ Provides a more seamless and reliable data augmentation experience for developers and researchers using Ultralytics' YOLO implementation.