### PR TITLE
Update augment.py

### DIFF
--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -583,9 +583,10 @@ class Albumentations:
             # TODO: add supports of segments and keypoints
             if self.transform and random.random() < self.p:
                 new = self.transform(image=im, bboxes=bboxes, class_labels=cls)  # transformed
-                labels['img'] = new['image']
-                labels['cls'] = np.array(new['class_labels'])
-                bboxes = np.array(new['bboxes'])
+                if len(new["class_labels"]) > 0: # skip update if no bbox in new im
+                    labels['img'] = new['image']
+                    labels['cls'] = np.array(new['class_labels'])
+                    bboxes = np.array(new['bboxes'])
             labels['instances'].update(bboxes=bboxes)
         return labels
 

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -583,7 +583,7 @@ class Albumentations:
             # TODO: add supports of segments and keypoints
             if self.transform and random.random() < self.p:
                 new = self.transform(image=im, bboxes=bboxes, class_labels=cls)  # transformed
-                if len(new["class_labels"]) > 0: # skip update if no bbox in new im
+                if len(new['class_labels']) > 0:  # skip update if no bbox in new im
                     labels['img'] = new['image']
                     labels['cls'] = np.array(new['class_labels'])
                     bboxes = np.array(new['bboxes'])


### PR DESCRIPTION
Fix: Albumentations to skip update if no bbox in new im. Required if Spatial-level transformations (like A.ShiftScaleRotate()) results in no bbox in new im.

Prevents:
```python
assert bboxes.shape[1] == 4
AssertionError
```

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image augmentation robustness by skipping updates on images without bounding boxes.

### 📊 Key Changes
- Added a conditional check to only update labels if transformed images have at least one bounding box.
- Prevents the loss of label data when no bounding boxes are present after transformations.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: To maintain data integrity during image augmentations, ensuring that only valid images with bounding boxes are used for training machine learning models.
- 📈 **Impact**: This change should result in more stable training processes and potentially higher model accuracy, as it avoids incorporating images that have lost their annotations post-transformation, which could cause confusion for the learning algorithm.