### PR TITLE
Fix ddp callback

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -181,7 +181,7 @@ class BaseTrainer:
                 LOGGER.info(f'Running DDP command {cmd}')
                 subprocess.run(cmd, check=True)
             except Exception as e:
-                LOGGER.warning(e)
+                raise e
             finally:
                 ddp_cleanup(self, str(file))
         else:

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -50,7 +50,9 @@ def generate_ddp_command(world_size, trainer):
         file = generate_ddp_file(trainer)
     dist_cmd = 'torch.distributed.run' if TORCH_1_9 else 'torch.distributed.launch'
     port = find_free_network_port()
-    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file]
+    exclude_args = ['save_dir']
+    args = [f'{k}={v}' for k, v in vars(trainer.args).items() if k not in exclude_args]
+    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file] + args
     return cmd, file
 
 

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -43,14 +43,14 @@ def generate_ddp_file(trainer):
 def generate_ddp_command(world_size, trainer):
     import __main__  # local import to avoid https://github.com/Lightning-AI/lightning/issues/15218
     file = os.path.abspath(sys.argv[0])
-    using_cli = not file.endswith(".py")
+    using_cli = not file.endswith('.py')
     if not trainer.resume:
         shutil.rmtree(trainer.save_dir)  # remove the save_dir
     if using_cli:
         file = generate_ddp_file(trainer)
     dist_cmd = 'torch.distributed.run' if TORCH_1_9 else 'torch.distributed.launch'
     port = find_free_network_port()
-    cmd = [sys.executable, "-m", dist_cmd, "--nproc_per_node", f"{world_size}", "--master_port", f"{port}", file]
+    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file]
     return cmd, file
 
 


### PR DESCRIPTION
@glenn-jocher @AyushExel 
- fixed the callback missing issue when launching DDP
- using `raise` directly rather than `LOGGER.warning` error, fixed the misleading error `FileNotFoundError: not such a file or directory: runs/..../best.pt` in DDP mode.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated error handling and cleanup behavior in distributed training scripts.

### 📊 Key Changes
- Trainer error now raises an exception instead of logging a warning in `trainer.py`.
- Removal of `trainer.save_dir` shifted from DDP file generation to DDP command generation in `dist.py`.
- DDP command generation logic now accounts for command-line interface usage, with conditional `save_dir` cleanup and modified condition for file generation.

### 🎯 Purpose & Impact
- The change in exception handling in `trainer.py` ensures that errors during distributed training are not silently logged but are actively raised, prompting immediate attention. ⚠️
- The adjustments in cleanup logic mean that the `save_dir` will be removed more reliably only when not resuming a training session, preventing potential loss of data when resuming. 🧹
- The DDP command now considers whether it was initiated from a CLI or not, potentially reducing errors related to the training environment setup. This should make the training process smoother and more user-friendly. 👨‍💻👩‍💻