### PR TITLE
Update training validator for plotting when early stopping occurs

### DIFF
--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -102,11 +102,7 @@ class BaseValidator:
             model = model.half() if self.args.half else model.float()
             self.model = model
             self.loss = torch.zeros_like(trainer.loss_items, device=trainer.device)
-            if trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs -
-                                                 1):  # always plot final epoch or for early stopping
-                self.args.plots = True
-            else:
-                self.args.plots = False
+            self.args.plots = trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs - 1)
             model.eval()
         else:
             callbacks.add_integration_callbacks(self)

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -102,7 +102,10 @@ class BaseValidator:
             model = model.half() if self.args.half else model.float()
             self.model = model
             self.loss = torch.zeros_like(trainer.loss_items, device=trainer.device)
-            self.args.plots = trainer.epoch == trainer.epochs - 1  # always plot final epoch
+            if trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs - 1): # always plot final epoch or for early stopping
+                self.args.plots = True
+            else:
+                self.args.plots = False
             model.eval()
         else:
             callbacks.add_integration_callbacks(self)

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -102,7 +102,8 @@ class BaseValidator:
             model = model.half() if self.args.half else model.float()
             self.model = model
             self.loss = torch.zeros_like(trainer.loss_items, device=trainer.device)
-            if trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs - 1): # always plot final epoch or for early stopping
+            if trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs -
+                                                 1):  # always plot final epoch or for early stopping
                 self.args.plots = True
             else:
                 self.args.plots = False


### PR DESCRIPTION
when an early stopping occurs, the training validator does not plot the graphs because the `plots` arg only was changing to `True` when reaching the final epoch. The revised code was tested on a real data and it works as expected.

I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced plotting logic for the validation process in YOLO's codebase.

### 📊 Key Changes
- Validator now checks for possible stopping conditions to decide whether to plot, rather than only plotting in the final epoch.

### 🎯 Purpose & Impact
- **Purpose:** Allows the model validator to generate plots not only at the end of the training but also when early stopping criteria are met.
- **Impact:** Provides users with visual feedback more frequently when a training run may finish early, helping in monitoring and decision-making processes. 🎨🛑📈