### PR TITLE
Prevent `nc` Override

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -286,7 +286,7 @@ class ClassificationModel(BaseModel):
         if nc and nc != self.yaml['nc']:
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml['nc'] = nc  # override yaml value
-        elif not nc and ('nc' not in self.yaml or not self.yaml['nc']):
+        elif not nc and not self.yaml.get('nc', None):
             raise ValueError('nc not specified. Must specify nc in model.yaml or function arguments.')
         self.model, self.save = parse_model(deepcopy(self.yaml), ch=ch, verbose=verbose)  # model, savelist
         self.stride = torch.Tensor([1])  # no stride constraints

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -286,10 +286,8 @@ class ClassificationModel(BaseModel):
         if nc and nc != self.yaml['nc']:
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml['nc'] = nc  # override yaml value
-        elif not nc and ("nc" not in self.yaml or not self.yaml["nc"]):
-            raise ValueError(
-                "nc not specified. Must specify nc in model.yaml or function arguments."
-            )
+        elif not nc and ('nc' not in self.yaml or not self.yaml['nc']):
+            raise ValueError('nc not specified. Must specify nc in model.yaml or function arguments.')
         self.model, self.save = parse_model(deepcopy(self.yaml), ch=ch, verbose=verbose)  # model, savelist
         self.stride = torch.Tensor([1])  # no stride constraints
         self.names = {i: f'{i}' for i in range(self.yaml['nc'])}  # default names dict

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -257,7 +257,7 @@ class ClassificationModel(BaseModel):
                  cfg=None,
                  model=None,
                  ch=3,
-                 nc=1000,
+                 nc=None,
                  cutoff=10,
                  verbose=True):  # yaml, model, channels, number of classes, cutoff index, verbose flag
         super().__init__()
@@ -286,6 +286,10 @@ class ClassificationModel(BaseModel):
         if nc and nc != self.yaml['nc']:
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml['nc'] = nc  # override yaml value
+        elif not nc and ("nc" not in self.yaml or not self.yaml["nc"]):
+            raise ValueError(
+                "nc not specified. Must specify nc in model.yaml or function arguments."
+            )
         self.model, self.save = parse_model(deepcopy(self.yaml), ch=ch, verbose=verbose)  # model, savelist
         self.stride = torch.Tensor([1])  # no stride constraints
         self.names = {i: f'{i}' for i in range(self.yaml['nc'])}  # default names dict


### PR DESCRIPTION
Made it so that the `nc` parameter on `ClassificationModel` has no default so that it can be provided by a yaml file without getting overridden.

Fixes https://github.com/ultralytics/ultralytics/issues/1205

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in model configuration by requiring explicit class count specification.

### 📊 Key Changes
- Changed the default number of classes `nc` from a fixed value (1000) to `None` in the model initialization parameters.
- Added a check to raise a `ValueError` if `nc` (number of classes) is not specified in either the YAML configuration file or as a function argument.

### 🎯 Purpose & Impact
- This update ensures that users must explicitly specify the number of classes to prevent model misconfigurations.
- Raises error earlier in the setup process, facilitating a smoother user experience and preventing potential issues that may arise from undefined parameters.
- Impacts users setting up new models, enforcing better model definition practices and reducing ambiguity. ⚠️