### PR TITLE
Add `nc` Param to `YOLO`

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -67,7 +67,7 @@ class YOLO:
         list(ultralytics.yolo.engine.results.Results): The prediction results.
     """
 
-    def __init__(self, model='yolov8n.pt', task=None, session=None) -> None:
+    def __init__(self, model='yolov8n.pt', task=None, session=None, nc=None) -> None:
         """
         Initializes the YOLO model.
 
@@ -85,6 +85,7 @@ class YOLO:
         self.overrides = {}  # overrides for trainer object
         self.metrics = None  # validation/training metrics
         self.session = session  # HUB session
+        self.nc = nc  # number of classes
 
         # Load or create new YOLO model
         suffix = Path(model).suffix
@@ -114,7 +115,7 @@ class YOLO:
         self.cfg = check_yaml(cfg)  # check YAML
         cfg_dict = yaml_load(self.cfg, append_filename=True)  # model dict
         self.task = task or guess_model_task(cfg_dict)
-        self.model = TASK_MAP[self.task][0](cfg_dict, verbose=verbose and RANK == -1)  # build model
+        self.model = TASK_MAP[self.task][0](cfg_dict, verbose=verbose and RANK == -1, nc=self.nc)  # build model
         self.overrides['model'] = self.cfg
 
         # Below added to allow export from yamls


### PR DESCRIPTION
Added the `nc` param to the `YOLO` class constructor and use it in the `_new` method when instantiating a model class. This allows the setting of `nc` when using `YOLO` to instantiate a class instead of it defaulting to the model class' default.

This is an alternate (and probably better) PR to https://github.com/ultralytics/ultralytics/pull/1216

Fixes https://github.com/ultralytics/ultralytics/issues/1205

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated YOLO model initialization to include a customizable number of classes.

### 📊 Key Changes
- Added a new parameter called `nc` (number of classes) to the YOLO model constructor.
- Modified the model building step to pass `nc` when creating a new model instance.

### 🎯 Purpose & Impact
- The update allows users to specify the number of classes their model should recognize, making the model more flexible for different use cases.
- It enhances usability for those working with datasets that have a different number of classes than the preconfigured number in the model.
- It could potentially impact users by simplifying the process of adapting YOLO models to custom object detection tasks.