### PR TITLE
remove eval in parse_model

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -437,7 +437,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
     ch = [ch]
     layers, save, c2 = [], [], ch[-1]  # layers, savelist, ch out
     for i, (f, n, m, args) in enumerate(d['backbone'] + d['head']):  # from, number, module, args
-        m = eval(m) if isinstance(m, str) else m  # eval strings
+        m = getattr(torch.nn, m[3:]) if "nn." in m else globals()[m] if isinstance(m, str) else m  # eval strings
         for j, a in enumerate(args):
             # TODO: re-implement with eval() removal if possible
             # args[j] = (locals()[a] if a in locals() else ast.literal_eval(a)) if isinstance(a, str) else a

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -437,7 +437,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
     ch = [ch]
     layers, save, c2 = [], [], ch[-1]  # layers, savelist, ch out
     for i, (f, n, m, args) in enumerate(d['backbone'] + d['head']):  # from, number, module, args
-        m = getattr(torch.nn, m[3:]) if "nn." in m else globals()[m] if isinstance(m, str) else m  # eval strings
+        m = getattr(torch.nn, m[3:]) if 'nn.' in m else globals()[m] if isinstance(m, str) else m  # eval strings
         for j, a in enumerate(args):
             # TODO: re-implement with eval() removal if possible
             # args[j] = (locals()[a] if a in locals() else ast.literal_eval(a)) if isinstance(a, str) else a


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->

I made an effort to minimize the number of calls to the eval() function in parse_model() in order to make the code safer.

It is related to #955.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of model parsing logic in Ultralytics neural networking module.

### 📊 Key Changes
- Replaced `eval()` with `getattr(torch.nn, m[3:])` for security and performance when accessing PyTorch layers.
- Added conditional logic to access global symbols if not part of `torch.nn`.

### 🎯 Purpose & Impact
- 🛡️ Improves security by removing `eval()`, which can execute arbitrary code.
- ⚡ Enhances performance and reliability of model initialization.
- 🤖 Ensures more robust and maintainable code, reducing potential bugs and improving ease of future enhancements.

This change should be seamless for users but provides a more secure and efficient foundation for building and training neural network models with the Ultralytics framework.