### PR TITLE
fix a bug for proper resizing of images during prediction

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -130,7 +130,7 @@ class BasePredictor:
                                              imgsz=self.imgsz,
                                              vid_stride=self.args.vid_stride,
                                              stride=self.model.stride,
-                                             auto=self.imgsz[0]!=self.imgsz[1])
+                                             auto=self.imgsz[0] != self.imgsz[1])
         self.source_type = self.dataset.source_type
         self.vid_path, self.vid_writer = [None] * self.dataset.bs, [None] * self.dataset.bs
 

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -130,7 +130,7 @@ class BasePredictor:
                                              imgsz=self.imgsz,
                                              vid_stride=self.args.vid_stride,
                                              stride=self.model.stride,
-                                             auto=self.model.pt)
+                                             auto=self.imgsz[0]!=self.imgsz[1])
         self.source_type = self.dataset.source_type
         self.vid_path, self.vid_writer = [None] * self.dataset.bs, [None] * self.dataset.bs
 


### PR DESCRIPTION
While predicting images with varying sizes, I noticed that although my config had a fixed image size of 512, the images passed to the model were not square-shaped with dimensions of 512-512. Upon investigation, I found that the `LetterBox` class was always passing `auto=True` during prediction, regardless of the image size specified in the config. Consequently, the resized image generated by the LetterBox class could be 512-x (where x is a multiple of 32), which is incorrect for two reasons:

1- The square image size specified in the config is ignored and a rectangular image is passed to the model during prediction.
2- Upon checking the training code, I discovered that the images were correctly resized to 512*512 because `auto` was set to False during training.

To rectify this, I propose that `auto` should be set to False if the image width and height in the config file are equal. This will ensure that resizing and padding are done correctly, resulting in a square image of size x-x (except when x is not divisible by 32, which will result in a small change but still give a square image). On the other hand, if the image size in the configuration file is x-y, then auto should be set to True. In this scenario, the input image will first be resized while maintaining the aspect ratio, and then padded to achieve an image size of x-y, except when the smaller dimension is not divisible by 32, which will be handled by auto.

I did see that @glenn-jocher has responded to an issue [#7611](https://github.com/ultralytics/yolov5/discussions/7611) as "images will be resized to --img-size on the long side, short side handled automatically preserving aspect ratio (circles stay circles). Letterboxing (grey padding) is used to fullfill stride constraints (i.e. 32 or 64 pixel multiples).". These are correct statements, except the padding part. let's say image size is L-S (L for large size and S for small side) and we need to have image size of X in the config. The resizing process would be: 1) check X to see if it does fullfill stride constraints, otherwise, change that. 2) resize the image from L-S to X-Y in a way that aspect ratio is preserved. 3) now if the `auto` is False, grey padding is aded in the Y direction in order to reach an image of X-X, but when `auto` is True, Y side would just have the smallest padding needed to fullfill stride constraints.

I trust that my explanation has provided a clear understanding of the issue :) 

I have read the CLA Document and I sign the CLA.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved precision in handling different input image sizes for object detection.

### 📊 Key Changes
- Modified the `auto` parameter logic when setting up data sources in `predictor.py`.

### 🎯 Purpose & Impact
- 🎨 Ensures that the image resizing behavior is more accurately determined based on whether input images are non-square (i.e., width and height are different).
- 🚀 Enhances the model's adaptability to different image aspect ratios, potentially improving detection accuracy on non-square images for users.