### PR TITLE
Fix plot function not working when pil=True.

### DIFF
--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -145,7 +145,7 @@ class Results:
             text = f"{', '.join(f'{names[j] if names else j} {logits[j]:.2f}' for j in top5i)}, "
             annotator.text((32, 32), text, txt_color=(255, 255, 255))  # TODO: allow setting colors
 
-        return np.asarray(annotator.im) if isinstance(annotator.im, PIL.Image.Image) else annotator.im
+        return np.asarray(annotator.im) if isinstance(annotator.im, Image.Image) else annotator.im
 
 
 class Boxes:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -145,7 +145,7 @@ class Results:
             text = f"{', '.join(f'{names[j] if names else j} {logits[j]:.2f}' for j in top5i)}, "
             annotator.text((32, 32), text, txt_color=(255, 255, 255))  # TODO: allow setting colors
 
-        return np.asarray(annotator.im) if isinstance(annotator.im, Image.Image) else annotator.im
+        return np.asarray(annotator.im) if annotator.pil else annotator.im
 
 
 class Boxes:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -122,8 +122,7 @@ class Results:
         Returns:
             (None) or (PIL.Image): If `pil` is True, a PIL Image is returned. Otherwise, nothing is returned.
         """
-        img = deepcopy(self.orig_img)
-        annotator = Annotator(img, line_width, font_size, font, pil, example)
+        annotator = Annotator(deepcopy(self.orig_img), line_width, font_size, font, pil, example)
         boxes = self.boxes
         masks = self.masks
         logits = self.probs
@@ -136,7 +135,7 @@ class Results:
                 annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
 
         if masks is not None:
-            im = torch.as_tensor(img, dtype=torch.float16, device=masks.data.device).permute(2, 0, 1).flip(0)
+            im = torch.as_tensor(annotator.im, dtype=torch.float16, device=masks.data.device).permute(2, 0, 1).flip(0)
             im = F.resize(im.contiguous(), masks.data.shape[1:]) / 255
             annotator.masks(masks.data, colors=[colors(x, True) for x in boxes.cls], im_gpu=im)
 
@@ -146,7 +145,7 @@ class Results:
             text = f"{', '.join(f'{names[j] if names else j} {logits[j]:.2f}' for j in top5i)}, "
             annotator.text((32, 32), text, txt_color=(255, 255, 255))  # TODO: allow setting colors
 
-        return img
+        return np.asarray(annotator.im) if isinstance(annotator.im, PIL.Image.Image) else annotator.im
 
 
 class Boxes:


### PR DESCRIPTION
when pil=True, Annotator.im is new Image object, draw operation act on it but never used.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimized image plotting in YOLO's results visualization.

### 📊 Key Changes
- Simplified the creation of `Annotator` by directly passing a deep-copied image.
- Changed the source image for mask overlays from `img` to `annotator.im`.
- Updated the method's return statement to provide the annotated image in the appropriate format based on the `pil` flag.

### 🎯 Purpose & Impact
- 🎨 Improves readability and maintainability of the visualization code by reducing redundancy.
- 🖼️ Ensures consistency in image transformation for mask overlays, using the image from the `Annotator` instance.
- 👨‍💻👩‍💻 Provides developers and users with a more flexible image output that is automatically adjusted based on the chosen output type.
- 🚀 These changes can lead to a smoother user experience when visualizing results with YOLO, as they streamline how images are processed and returned.