### PR TITLE
fix type. generator to list.

### DIFF
--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -48,7 +48,7 @@ class Results:
         self.probs = probs if probs is not None else None
         self.names = names
         self.path = path
-        self._keys = (k for k in ('boxes', 'masks', 'probs') if getattr(self, k) is not None)
+        self._keys = [k for k in ('boxes', 'masks', 'probs') if getattr(self, k) is not None]
 
     def pandas(self):
         pass


### PR DESCRIPTION
issue (#1318)
- fix type of `_keys`.
  - generator to list

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved internal results structure for YOLO detection output.

### 📊 Key Changes
- Changed the `_keys` attribute in the `Result` object from a generator to a list.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: This modification ensures a more consistent and potentially more efficient handling of the attribute keys ('boxes', 'masks', 'probs') within the `Result` object.
- 🔍 **Impact**: Users may experience more reliable accesses and iterations over result attributes, leading to fewer coding errors and a smoother integration with other parts of the code that expect these attributes to be in a list format.