### PR TITLE
Replace `lap` with `scipy` for tracking linear assignment

### DIFF
--- a/ultralytics/tracker/track.py
+++ b/ultralytics/tracker/track.py
@@ -3,10 +3,7 @@
 import torch
 
 from ultralytics.yolo.utils import IterableSimpleNamespace, yaml_load
-from ultralytics.yolo.utils.checks import check_requirements, check_yaml
-
-check_requirements('lap')  # for linear_assignment
-
+from ultralytics.yolo.utils.checks import check_yaml
 from .trackers import BOTSORT, BYTETracker
 
 TRACKER_MAP = {'bytetrack': BYTETracker, 'botsort': BOTSORT}

--- a/ultralytics/tracker/track.py
+++ b/ultralytics/tracker/track.py
@@ -3,7 +3,9 @@
 import torch
 
 from ultralytics.yolo.utils import IterableSimpleNamespace, yaml_load
-from ultralytics.yolo.utils.checks import check_yaml
+from ultralytics.yolo.utils.checks import check_requirements, check_yaml
+
+check_requirements('lap')  # for linear_assignment
 
 from .trackers import BOTSORT, BYTETracker
 

--- a/ultralytics/tracker/track.py
+++ b/ultralytics/tracker/track.py
@@ -4,6 +4,7 @@ import torch
 
 from ultralytics.yolo.utils import IterableSimpleNamespace, yaml_load
 from ultralytics.yolo.utils.checks import check_yaml
+
 from .trackers import BOTSORT, BYTETracker
 
 TRACKER_MAP = {'bytetrack': BYTETracker, 'botsort': BOTSORT}

--- a/ultralytics/tracker/utils/matching.py
+++ b/ultralytics/tracker/utils/matching.py
@@ -36,13 +36,13 @@ def _indices_to_matches(cost_matrix, indices, thresh):
     return matches, unmatched_a, unmatched_b
 
 
-def linear_assignment(cost_matrix, thresh=0.0, use_scipy=False):
-    # Linear assignment function with scipy replacing lap.lapjv
+def linear_assignment(cost_matrix, thresh, use_scipy=False):
+    # Linear assignment implementations with scipy and lap.lapjv
     if cost_matrix.size == 0:
         return np.empty((0, 2), dtype=int), tuple(range(cost_matrix.shape[0])), tuple(range(cost_matrix.shape[1]))
 
     if use_scipy:
-        # Scipy linear sum assignment is NOT working correctly, do not use
+        # Scipy linear sum assignment is NOT working correctly, DO NOT USE
         y, x = scipy.optimize.linear_sum_assignment(cost_matrix)  # row y, col x
         matches = np.asarray([[i, x] for i, x in enumerate(x) if cost_matrix[i, x] <= thresh])
         unmatched = np.ones(cost_matrix.shape)

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -23,8 +23,8 @@ from ultralytics.yolo.utils.downloads import download, safe_download, unzip_file
 from ultralytics.yolo.utils.ops import segments2boxes
 
 HELP_URL = 'See https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
-IMG_FORMATS = 'bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp', 'pfm'  # include image suffixes
-VID_FORMATS = 'asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ts', 'wmv'  # include video suffixes
+IMG_FORMATS = 'bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp', 'pfm'  # image suffixes
+VID_FORMATS = 'asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ts', 'wmv', 'webm'  # video suffixes
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 RANK = int(os.getenv('RANK', -1))
 PIN_MEMORY = str(os.getenv('PIN_MEMORY', True)).lower() == 'true'  # global pin_memory for dataloaders


### PR DESCRIPTION
Replaces `lap` with `scipy` for tracking linear assignment, eliminating `lap` dependency. May resolve https://github.com/ultralytics/ultralytics/issues/1328

@Laughing-q 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of object tracking via improved assignment calculations and expanded video support.

### 📊 Key Changes
- 🔄 The `linear_assignment` function in `matching.py` now optionally uses SciPy for calculations.
- 🚀 New `use_scipy` parameter to enable/disable the use of SciPy in `linear_assignment`.
- 🌐 Added 'webm' to supported video formats in `utils.py`.

### 🎯 Purpose & Impact
- 🆙 The update offers an alternative method for solving linear assignment problems, potentially improving tracking efficiency.
- 🎥 Support for 'webm' expands compatibility, allowing users to work with a wider range of video formats.
- 🛠️ Despite the integration, there's a caution against using SciPy due to incorrect results, indicating a need for further validation/testing.
- ⚙️ Users can toggle SciPy usage, allowing them to test performance or revert to the proven original method if necessary.