### PR TITLE
Restore current callbacks after calling check_amp

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -202,7 +202,11 @@ class BaseTrainer:
         ckpt = self.setup_model()
         self.model = self.model.to(self.device)
         self.set_model_attributes()
+        # Backup default_callbacks before checking AMP since they are reset by check_amp
+        callbacks_backup = callbacks.default_callbacks.copy()
         self.amp = check_amp(self.model)
+        # Restore default_callbacks
+        callbacks.default_callbacks = callbacks_backup
         self.scaler = amp.GradScaler(enabled=self.amp)
         if world_size > 1:
             self.model = DDP(self.model, device_ids=[rank])


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->

PR to solve https://github.com/ultralytics/ultralytics/issues/1324

I think it's the simplest solution not involving adding custom checks inside the YOLO class, callbacks are backuped, check_amp will reset them and then they are restored back to the proper value.

Checked also against pre-commit (definitely not happy that I use black as default code formatter :))


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved handling of training callbacks in the presence of automatic mixed precision (AMP).

### 📊 Key Changes
- Backup and restore mechanism for `default_callbacks` implemented in the training setup.
- Protection of callback states before and after AMP check.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: Ensures that custom training callbacks are preserved when automatic mixed precision is enabled, avoiding the accidental reset of important settings.
- 🔍 **Impact**: Developers and users employing custom callbacks with AMP will experience more reliable and consistent training behavior, leading to better support for advanced training scenarios.