### PR TITLE
add confusion matrix to metrics returned in validation

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -254,7 +254,8 @@ class YOLO:
 
         validator = TASK_MAP[self.task][2](args=args)
         validator(model=self.model)
-        validator.metrics.confusion_matrix = validator.confusion_matrix
+        if hasattr(validator, "conffusion_matrix"):
+            validator.metrics.confusion_matrix = validator.confusion_matrix 
         self.metrics = validator.metrics
 
         return validator.metrics

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -254,6 +254,7 @@ class YOLO:
 
         validator = TASK_MAP[self.task][2](args=args)
         validator(model=self.model)
+        validator.metrics.confusion_matrix = validator.confusion_matrix
         self.metrics = validator.metrics
 
         return validator.metrics

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -254,8 +254,8 @@ class YOLO:
 
         validator = TASK_MAP[self.task][2](args=args)
         validator(model=self.model)
-        if hasattr(validator, "conffusion_matrix"):
-            validator.metrics.confusion_matrix = validator.confusion_matrix 
+        if hasattr(validator, 'conffusion_matrix'):
+            validator.metrics.confusion_matrix = validator.confusion_matrix
         self.metrics = validator.metrics
 
         return validator.metrics


### PR DESCRIPTION
Fo validation, all of the metrics are returned through the `validator.metrics` objects. confusion matrix is an important property that we can be used to extract other useful metrics. it is curretrly a property of  `validator` object. I added that to the `validator.metrics` object as well so that CM can be exacted from the output of `model.val()`.

I have been interested is such addition and when I saw a recent [issue](https://github.com/ultralytics/ultralytics/issues/1325) regarding CM, it motivated me to make this PR.

I have read the CLA Document and I sign the CLA




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced validation metrics with confusion matrix tracking in Ultralytics YOLO engine.

### 📊 Key Changes
- Added functionality for tracking the confusion matrix within the validator metrics.

### 🎯 Purpose & Impact
- **Purpose:** To provide users with more detailed performance insights of their YOLO models by including a confusion matrix, which is essential for understanding how well the model differentiates between classes.
- **Impact:** Users can now evaluate their models more thoroughly, leading to better model tuning and improved accuracy, particularly beneficial for developers and researchers working on object detection tasks. 📈🔍