### PR TITLE
Remove ImageNet normalization for classify models

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ['3.10']
         model: [yolov8n]
     steps:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -332,13 +332,6 @@ class AutoBackend(nn.Module):
             y = [self.bindings[x].data for x in sorted(self.output_names)]
         elif self.coreml:  # CoreML
             im = im[0].cpu().numpy()
-            if self.task == 'classify':
-                from ultralytics.yolo.data.utils import IMAGENET_MEAN, IMAGENET_STD
-
-                # im_pil = Image.fromarray(((im / 6 + 0.5) * 255).astype('uint8'))
-                for i in range(3):
-                    im[..., i] *= IMAGENET_STD[i]
-                    im[..., i] += IMAGENET_MEAN[i]
             im_pil = Image.fromarray((im * 255).astype('uint8'))
             # im = im.resize((192, 320), Image.ANTIALIAS)
             y = self.model.predict({'image': im_pil})  # coordinates are xywh normalized

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -9,12 +9,12 @@ import numpy as np
 import torch
 import torchvision.transforms as T
 
-from .utils import polygons2masks, polygons2masks_overlap
 from ..utils import LOGGER, colorstr
 from ..utils.checks import check_version
 from ..utils.instance import Instances
 from ..utils.metrics import bbox_ioa
 from ..utils.ops import segment2box
+from .utils import polygons2masks, polygons2masks_overlap
 
 
 # TODO: we might need a BaseTransform to make all these augments be compatible with both classification and semantic

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -682,7 +682,7 @@ def v8_transforms(dataset, imgsz, hyp):
 
 
 # Classification augmentations -----------------------------------------------------------------------------------------
-def classify_transforms(size=224, mean=(0.0, 0.0, 0.0), std=(0.0, 0.0, 0.0)):  # IMAGENET_MEAN, IMAGENET_STD
+def classify_transforms(size=224, mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0)):  # IMAGENET_MEAN, IMAGENET_STD
     # Transforms to apply if albumentations not installed
     if not isinstance(size, int):
         raise TypeError(f'classify_transforms() size {size} must be integer, not (list, tuple)')
@@ -700,7 +700,7 @@ def classify_albumentations(
         vflip=0.0,
         jitter=0.4,
         mean=(0.0, 0.0, 0.0),  # IMAGENET_MEAN
-        std=(0.0, 0.0, 0.0),  # IMAGENET_STD
+        std=(1.0, 1.0, 1.0),  # IMAGENET_STD
         auto_aug=False,
 ):
     # YOLOv8 classification Albumentations (optional, only used if package is installed)

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -687,7 +687,7 @@ def classify_transforms(size=224, mean=(0.0, 0.0, 0.0), std=(0.0, 0.0, 0.0)):  #
     if not isinstance(size, int):
         raise TypeError(f'classify_transforms() size {size} must be integer, not (list, tuple)')
     if any(mean) or any(std):
-        return T.Compose([CenterCrop(size), ToTensor(), T.Normalize(mean, std)])
+        return T.Compose([CenterCrop(size), ToTensor(), T.Normalize(mean, std, inplace=True)])
     else:
         return T.Compose([CenterCrop(size), ToTensor()])
 
@@ -725,9 +725,7 @@ def classify_albumentations(
                     T += [A.ColorJitter(jitter, jitter, jitter, 0)]  # brightness, contrast, saturation, 0 hue
         else:  # Use fixed crop for eval set (reproducibility)
             T = [A.SmallestMaxSize(max_size=size), A.CenterCrop(height=size, width=size)]
-        if any(mean) or any(std):
-            T += [A.Normalize(mean=mean, std=std)]
-        T += [ToTensorV2()]  # Normalize and convert to Tensor
+        T += [A.Normalize(mean=mean, std=std), ToTensorV2()]  # Normalize and convert to Tensor
         LOGGER.info(prefix + ', '.join(f'{x}'.replace('always_apply=False, ', '') for x in T if x.p))
         return A.Compose(T)
 

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -63,7 +63,6 @@ from ultralytics.nn.autobackend import check_class_names
 from ultralytics.nn.modules import C2f, Detect, Segment
 from ultralytics.nn.tasks import DetectionModel, SegmentationModel
 from ultralytics.yolo.cfg import get_cfg
-from ultralytics.yolo.data.utils import IMAGENET_MEAN, IMAGENET_STD
 from ultralytics.yolo.utils import (DEFAULT_CFG, LINUX, LOGGER, MACOS, __version__, callbacks, colorstr,
                                     get_default_args, yaml_save)
 from ultralytics.yolo.utils.checks import check_imgsz, check_requirements, check_version
@@ -408,8 +407,6 @@ class Exporter:
         scale = 1 / 255
         classifier_config = None
         if self.model.task == 'classify':
-            bias = [-x for x in IMAGENET_MEAN]
-            scale = 1 / 255 / (sum(IMAGENET_STD) / 3)
             classifier_config = ct.ClassifierConfig(list(self.model.names.values())) if self.args.nms else None
             model = self.model
         elif self.model.task == 'detect':

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -633,13 +633,13 @@ def check_amp(model):
     im = f if f.exists() else 'https://ultralytics.com/images/bus.jpg' if ONLINE else np.ones((640, 640, 3))
     prefix = colorstr('AMP: ')
     try:
-        from ultralytics import YOLO
         LOGGER.info(f'{prefix}running Automatic Mixed Precision (AMP) checks with YOLOv8n...')
         try:
+            from ultralytics import YOLO
             assert amp_allclose(YOLO('yolov8n.pt'), im)
             LOGGER.info(f'{prefix}checks passed ✅')
         except ConnectionError:
-            LOGGER.info(f"{prefix}checks skipped ⚠️, offline and unable to download YOLOv8n. Setting 'amp=True'.")
+            LOGGER.warning(f"{prefix}checks skipped ⚠️, offline and unable to download YOLOv8n. Setting 'amp=True'.")
         return True
     except AssertionError:
         LOGGER.warning(f'{prefix}checks failed ❌. Anomalies were detected with AMP on your system that may lead to '

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -604,7 +604,20 @@ class BaseTrainer:
 
 
 def check_amp(model):
-    # Check PyTorch Automatic Mixed Precision (AMP) functionality. Return True on correct operation
+    """
+    This function checks the PyTorch Automatic Mixed Precision (AMP) functionality of a YOLOv8 model.
+    If the checks fail, it means there are anomalies with AMP on the system that may cause NaN losses or zero-mAP
+    results, so AMP will be disabled during training.
+
+    Args:
+        model (nn.Module): A YOLOv8 model instance.
+
+    Returns:
+        bool: Returns True if the AMP functionality works correctly with YOLOv8 model, else False.
+
+    Raises:
+        AssertionError: If the AMP checks fail, indicating anomalies with the AMP functionality on the system.
+    """
     device = next(model.parameters()).device  # get model device
     if device.type in ('cpu', 'mps'):
         return False  # AMP only used on CUDA devices
@@ -622,8 +635,11 @@ def check_amp(model):
     try:
         from ultralytics import YOLO
         LOGGER.info(f'{prefix}running Automatic Mixed Precision (AMP) checks with YOLOv8n...')
-        assert amp_allclose(YOLO('yolov8n.pt'), im)
-        LOGGER.info(f'{prefix}checks passed ✅')
+        try:
+            assert amp_allclose(YOLO('yolov8n.pt'), im)
+            LOGGER.info(f'{prefix}checks passed ✅')
+        except ConnectionError:
+            LOGGER.info(f"{prefix}checks skipped ⚠️, offline and unable to download YOLOv8n. Setting 'amp=True'.")
         return True
     except AssertionError:
         LOGGER.warning(f'{prefix}checks failed ❌. Anomalies were detected with AMP on your system that may lead to '


### PR DESCRIPTION
Experiment for removing input normalization to assist in better classification model exportability to iOS/Android apps.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring normalization parameters and improving AMP check handling.

### 📊 Key Changes
- Removed hard-coded ImageNet normalization in `autobackend.py` during image preprocessing.
- Made normalization parameters configurable by adding `mean` and `std` as arguments in `classify_transforms` function.
- Removed ImageNet normalization constants from `exporter.py` and modified the bias and scale calculation logic.
- Enhanced documentation and error handling for Automatic Mixed Precision (AMP) checks in `trainer.py`.

### 🎯 Purpose & Impact
- 🎨 The changes allow for more flexible image normalization, improving compatibility with different datasets beyond ImageNet.
- 🛠️ By parameterizing normalization, developers can fine-tune preprocessing based on specific use cases or domain needs.
- 🔍 The AMP check improvements ensure more reliable mixed precision training and helps avoid issues like NaN losses or zero-mAP results due to system anomalies.
- 🐛 Better error handling and documentation enhance the developer experience and model robustness for users.