### PR TITLE
Fix bbox prediction for torch.Tensor source

### DIFF
--- a/ultralytics/yolo/v8/detect/predict.py
+++ b/ultralytics/yolo/v8/detect/predict.py
@@ -31,7 +31,10 @@ class DetectionPredictor(BasePredictor):
         for i, pred in enumerate(preds):
             orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs
             shape = orig_img.shape
-            pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
+            if not isinstance(orig_imgs, torch.Tensor):
+                pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
+            else:
+                pred[:, :4] = pred[:, :4].round()
             path, _, _, _, _ = self.batch
             img_path = path[i] if isinstance(path, list) else path
             results.append(Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred))

--- a/ultralytics/yolo/v8/detect/predict.py
+++ b/ultralytics/yolo/v8/detect/predict.py
@@ -30,11 +30,8 @@ class DetectionPredictor(BasePredictor):
         results = []
         for i, pred in enumerate(preds):
             orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs
-            shape = orig_img.shape
             if not isinstance(orig_imgs, torch.Tensor):
-                pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
-            else:
-                pred[:, :4] = pred[:, :4].round()
+                pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
             path, _, _, _, _ = self.batch
             img_path = path[i] if isinstance(path, list) else path
             results.append(Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred))

--- a/ultralytics/yolo/v8/segment/predict.py
+++ b/ultralytics/yolo/v8/segment/predict.py
@@ -31,7 +31,7 @@ class SegmentationPredictor(DetectionPredictor):
             if self.args.retina_masks:
                 if not isinstance(orig_imgs, torch.Tensor):
                     pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
-                masks = ops.process_mask_native(proto[i], pred[:, 6:], pred[:, :4], shape[:2])  # HWC
+                masks = ops.process_mask_native(proto[i], pred[:, 6:], pred[:, :4], orig_img.shape[:2])  # HWC
             else:
                 masks = ops.process_mask(proto[i], pred[:, 6:], pred[:, :4], img.shape[2:], upsample=True)  # HWC
                 if not isinstance(orig_imgs, torch.Tensor):

--- a/ultralytics/yolo/v8/segment/predict.py
+++ b/ultralytics/yolo/v8/segment/predict.py
@@ -23,7 +23,6 @@ class SegmentationPredictor(DetectionPredictor):
         proto = preds[1][-1] if len(preds[1]) == 3 else preds[1]  # second output is len 3 if pt, but only 1 if exported
         for i, pred in enumerate(p):
             orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs
-            shape = orig_img.shape
             path, _, _, _, _ = self.batch
             img_path = path[i] if isinstance(path, list) else path
             if not len(pred):  # save empty boxes
@@ -31,16 +30,12 @@ class SegmentationPredictor(DetectionPredictor):
                 continue
             if self.args.retina_masks:
                 if not isinstance(orig_imgs, torch.Tensor):
-                    pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
-                else:
-                    pred[:, :4] = pred[:, :4].round()
+                    pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
                 masks = ops.process_mask_native(proto[i], pred[:, 6:], pred[:, :4], shape[:2])  # HWC
             else:
                 masks = ops.process_mask(proto[i], pred[:, 6:], pred[:, :4], img.shape[2:], upsample=True)  # HWC
                 if not isinstance(orig_imgs, torch.Tensor):
-                    pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
-                else:
-                    pred[:, :4] = pred[:, :4].round()
+                    pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
             results.append(
                 Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred[:, :6], masks=masks))
         return results

--- a/ultralytics/yolo/v8/segment/predict.py
+++ b/ultralytics/yolo/v8/segment/predict.py
@@ -30,11 +30,17 @@ class SegmentationPredictor(DetectionPredictor):
                 results.append(Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred[:, :6]))
                 continue
             if self.args.retina_masks:
-                pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
+                if not isinstance(orig_imgs, torch.Tensor):
+                    pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
+                else:
+                    pred[:, :4] = pred[:, :4].round()
                 masks = ops.process_mask_native(proto[i], pred[:, 6:], pred[:, :4], shape[:2])  # HWC
             else:
                 masks = ops.process_mask(proto[i], pred[:, 6:], pred[:, :4], img.shape[2:], upsample=True)  # HWC
-                pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
+                if not isinstance(orig_imgs, torch.Tensor):
+                    pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
+                else:
+                    pred[:, :4] = pred[:, :4].round()
             results.append(
                 Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred[:, :6], masks=masks))
         return results


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->
#1371 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image postprocessing compatibility for object detection and segmentation in YOLOv8.

### 📊 Key Changes
- Modified scaling of bounding boxes to only take effect when `orig_imgs` is not a `torch.Tensor`.
- Eliminated redundant `shape` variable and directly referenced `orig_img.shape` when scaling bounding boxes.
- Ensured consistent handling of scaling across both detection and segmentation functions.

### 🎯 Purpose & Impact
- **Purpose:** To streamline postprocessing when handling predictions, enabling the system to be more adaptable to different types of image inputs.
- **Impact:** Improves flexibility in object detection and segmentation tasks, potentially increasing accuracy and efficiency when `orig_imgs` are not tensors. This change is non-disruptive to existing workflows but allows for more robust handling of diverse input formats. 🏗️📈