### PR TITLE
Remove flex ops from all TF exports

### DIFF
--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -411,12 +411,12 @@ class Detect(nn.Module):
             self.anchors, self.strides = (x.transpose(0, 1) for x in make_anchors(x, self.stride, 0.5))
             self.shape = shape
 
-        if self.export and self.format == 'edgetpu':  # FlexSplitV ops issue
-            x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
+        x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
+        if self.export and self.format == 'edgetpu':  # avoids TF FlexSplitV ops
             box = x_cat[:, :self.reg_max * 4]
             cls = x_cat[:, self.reg_max * 4:]
         else:
-            box, cls = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2).split((self.reg_max * 4, self.nc), 1)
+            box, cls = x_cat
         dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
         y = torch.cat((dbox, cls.sigmoid()), 1)
         return y if self.export else (y, x)

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -416,7 +416,7 @@ class Detect(nn.Module):
             box = x_cat[:, :self.reg_max * 4]
             cls = x_cat[:, self.reg_max * 4:]
         else:
-            box, cls = x_cat
+            box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
         dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
         y = torch.cat((dbox, cls.sigmoid()), 1)
         return y if self.export else (y, x)

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -412,7 +412,7 @@ class Detect(nn.Module):
             self.shape = shape
 
         x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
-        if self.export and self.format == 'edgetpu':  # avoids TF FlexSplitV ops
+        if self.export and self.format in ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs'):  # avoid TF FlexSplitV ops
             box = x_cat[:, :self.reg_max * 4]
             cls = x_cat[:, self.reg_max * 4:]
         else:

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -188,7 +188,7 @@ class Exporter:
                 m.dynamic = self.args.dynamic
                 m.export = True
                 m.format = self.args.format
-            elif isinstance(m, C2f) and not edgetpu:
+            elif isinstance(m, C2f) and not any((saved_model, pb, tflite, edgetpu, tfjs)):
                 # EdgeTPU does not support FlexSplitV while split provides cleaner ONNX graph
                 m.forward = m.forward_split
 


### PR DESCRIPTION
@sergiossm this should remove Flex ops from TFLite exports. Let's see what the CI shows.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of model export formats in the Ultralytics codebase.

### 📊 Key Changes
- Refactored the conditional logic to support more TensorFlow-related formats during export.
- Eliminated redundancy in creating a concatenated tensor of box and class predictions.

### 🎯 Purpose & Impact
- 📈 Improves compatibility with TensorFlow export formats (saved_model, pb, tflite, edgetpu, tfjs), avoiding issues with TF specific operations like FlexSplitV.
- 🧹 Results in cleaner, more efficient code that could enhance export functionality and performance.
- 👩‍💻 Provides users with a smoother experience when exporting to various TensorFlow formats.