### PR TITLE
attempt to unify keypoints task

### DIFF
--- a/ultralytics/datasets/coco-kpt.yaml
+++ b/ultralytics/datasets/coco-kpt.yaml
@@ -16,7 +16,7 @@ test: test-dev2017.txt  # 20288 of 40670 images, submit to https://competitions.
 # Keypoints
 nkpt: 17  # number of keypoints
 ndim: 3  # (x, y, visible)
-flip_index: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
+flip_idx: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
 
 # Classes
 names:

--- a/ultralytics/datasets/coco-kpt.yaml
+++ b/ultralytics/datasets/coco-kpt.yaml
@@ -15,6 +15,8 @@ test: test-dev2017.txt  # 20288 of 40670 images, submit to https://competitions.
 
 # Keypoints
 nkpt: 17  # number of keypoints
+ndim: 3  # (x, y, visible)
+flip_index: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
 
 # Classes
 names:

--- a/ultralytics/datasets/coco128-kpt.yaml
+++ b/ultralytics/datasets/coco128-kpt.yaml
@@ -16,7 +16,7 @@ test:  # test images (optional)
 # Keypoints
 nkpt: 17  # number of keypoints
 ndim: 3  # (x, y, visible)
-flip_index: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
+flip_idx: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
 
 # Classes
 names:

--- a/ultralytics/datasets/coco128-kpt.yaml
+++ b/ultralytics/datasets/coco128-kpt.yaml
@@ -15,6 +15,8 @@ test:  # test images (optional)
 
 # Keypoints
 nkpt: 17  # number of keypoints
+ndim: 3  # (x, y, visible)
+flip_index: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
 
 # Classes
 names:

--- a/ultralytics/models/v8/pose/yolov8l-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8l-pose.yaml
@@ -3,6 +3,7 @@
 # Parameters
 nc: 80  # number of classes
 nkpt: 17  # number of keypoints
+ndim: 3  # number of dimension
 depth_multiple: 1.00  # scales module repeats
 width_multiple: 1.00  # scales convolution channels
 

--- a/ultralytics/models/v8/pose/yolov8l-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8l-pose.yaml
@@ -39,4 +39,4 @@ head:
   - [[-1, 9], 1, Concat, [1]]  # cat head P5
   - [-1, 3, C2f, [512]]  # 21 (P5/32-large)
 
-  - [[15, 18, 21], 1, Pose, [nc, nkpt]]  # Detect(P3, P4, P5)
+  - [[15, 18, 21], 1, Pose, [nc, nkpt, ndim]]  # Detect(P3, P4, P5)

--- a/ultralytics/models/v8/pose/yolov8m-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8m-pose.yaml
@@ -3,6 +3,7 @@
 # Parameters
 nc: 80  # number of classes
 nkpt: 17  # number of keypoints
+ndim: 3  # number of dimension
 depth_multiple: 0.67  # scales module repeats
 width_multiple: 0.75  # scales convolution channels
 

--- a/ultralytics/models/v8/pose/yolov8m-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8m-pose.yaml
@@ -39,4 +39,4 @@ head:
   - [[-1, 9], 1, Concat, [1]]  # cat head P5
   - [-1, 3, C2f, [768]]  # 21 (P5/32-large)
 
-  - [[15, 18, 21], 1, Pose, [nc, nkpt]]  # Detect(P3, P4, P5)
+  - [[15, 18, 21], 1, Pose, [nc, nkpt, ndim]]  # Detect(P3, P4, P5)

--- a/ultralytics/models/v8/pose/yolov8n-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8n-pose.yaml
@@ -39,4 +39,4 @@ head:
   - [[-1, 9], 1, Concat, [1]]  # cat head P5
   - [-1, 3, C2f, [1024]]  # 21 (P5/32-large)
 
-  - [[15, 18, 21], 1, Pose, [nc, nkpt]]  # Detect(P3, P4, P5)
+  - [[15, 18, 21], 1, Pose, [nc, nkpt, ndim]]  # Detect(P3, P4, P5)

--- a/ultralytics/models/v8/pose/yolov8n-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8n-pose.yaml
@@ -3,6 +3,7 @@
 # Parameters
 nc: 80  # number of classes
 nkpt: 17  # number of keypoints
+ndim: 3  # number of dimension
 depth_multiple: 0.33  # scales module repeats
 width_multiple: 0.25  # scales convolution channels
 

--- a/ultralytics/models/v8/pose/yolov8s-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8s-pose.yaml
@@ -39,4 +39,4 @@ head:
   - [[-1, 9], 1, Concat, [1]]  # cat head P5
   - [-1, 3, C2f, [1024]]  # 21 (P5/32-large)
 
-  - [[15, 18, 21], 1, Pose, [nc, nkpt]]  # Detect(P3, P4, P5)
+  - [[15, 18, 21], 1, Pose, [nc, nkpt, ndim]]  # Detect(P3, P4, P5)

--- a/ultralytics/models/v8/pose/yolov8s-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8s-pose.yaml
@@ -3,6 +3,7 @@
 # Parameters
 nc: 80  # number of classes
 nkpt: 17  # number of keypoints
+ndim: 3  # number of dimension
 depth_multiple: 0.33  # scales module repeats
 width_multiple: 0.50  # scales convolution channels
 

--- a/ultralytics/models/v8/pose/yolov8x-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8x-pose.yaml
@@ -39,4 +39,4 @@ head:
   - [[-1, 9], 1, Concat, [1]]  # cat head P5
   - [-1, 3, C2f, [512]]  # 21 (P5/32-large)
 
-  - [[15, 18, 21], 1, Pose, [nc, nkpt]]  # Detect(P3, P4, P5)
+  - [[15, 18, 21], 1, Pose, [nc, nkpt, ndim]]  # Detect(P3, P4, P5)

--- a/ultralytics/models/v8/pose/yolov8x-pose.yaml
+++ b/ultralytics/models/v8/pose/yolov8x-pose.yaml
@@ -3,6 +3,7 @@
 # Parameters
 nc: 80  # number of classes
 nkpt: 17  # number of keypoints
+ndim: 3  # number of dimension
 depth_multiple: 1.00  # scales module repeats
 width_multiple: 1.25  # scales convolution channels
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -93,7 +93,7 @@ class AutoBackend(nn.Module):
             model = model.fuse(verbose=verbose) if fuse else model
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             # TODO
-            nkpt = getattr(model, "nkpt", 17)  # backward compatibility
+            nkpt = getattr(model, 'nkpt', 17)  # backward compatibility
             stride = max(int(model.stride.max()), 32)  # model stride
             model.half() if fp16 else model.float()
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
@@ -105,7 +105,7 @@ class AutoBackend(nn.Module):
                                          inplace=True,
                                          fuse=fuse)
             # TODO
-            nkpt = getattr(model, "nkpt", 17)  # backward compatibility
+            nkpt = getattr(model, 'nkpt', 17)  # backward compatibility
             stride = max(int(model.stride.max()), 32)  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             model.half() if fp16 else model.float()

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -92,6 +92,8 @@ class AutoBackend(nn.Module):
             model = weights.to(device)
             model = model.fuse(verbose=verbose) if fuse else model
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
+            # TODO
+            nkpt = getattr(model, "nkpt", 17)  # backward compatibility
             stride = max(int(model.stride.max()), 32)  # model stride
             model.half() if fp16 else model.float()
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
@@ -102,6 +104,8 @@ class AutoBackend(nn.Module):
                                          device=device,
                                          inplace=True,
                                          fuse=fuse)
+            # TODO
+            nkpt = getattr(model, "nkpt", 17)  # backward compatibility
             stride = max(int(model.stride.max()), 32)  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             model.half() if fp16 else model.float()

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -460,6 +460,7 @@ class Pose(Detect):
     def __init__(self, nc=80, nkpt=17, ndim=3, ch=()):
         super().__init__(nc, ch)
         self.nkpt = nkpt  # number of keypoints
+        self.ndim = ndim
         self.no_kpt = self.nkpt * ndim  # xy, cls(kpt)
         self.detect = Detect.forward
 
@@ -469,7 +470,7 @@ class Pose(Detect):
 
     def forward(self, x):
         bs = x[0].shape[0]  # batch size
-        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.no_kpt, -1) for i in range(self.nl)], 2)  # (bs, 17*3, h*w)
+        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nkpt, self.ndim, -1) for i in range(self.nl)], 2)  # (bs, 17, 3, h*w)
         x = self.detect(self, x)
         if self.training:
             return x, kpt

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -478,7 +478,7 @@ class Pose(Detect):
         return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
 
     def kpts_decode(self, kpts):
-        ndim = self.ndim
+        ndim = getattr(self, "ndim", 3)  # Backward compatibility
         y = kpts.clone()
         if ndim == 3:
             y[:, 2::3, :] = y[:, 2::3, :].sigmoid()

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -470,7 +470,7 @@ class Pose(Detect):
 
     def forward(self, x):
         bs = x[0].shape[0]  # batch size
-        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nkpt, self.ndim, -1) for i in range(self.nl)], -1)  # (bs, 17, 3, h*w)
+        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.no_kpt, -1) for i in range(self.nl)], -1)  # (bs, 17*3, h*w)
         x = self.detect(self, x)
         if self.training:
             return x, kpt

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -474,8 +474,7 @@ class Pose(Detect):
         x = self.detect(self, x)
         if self.training:
             return x, kpt
-        bbox = x[:, :4, :] if self.export else x[0][:, :4, :]
-        pred_kpt = self.kpts_decode(kpt, bbox)
+        pred_kpt = self.kpts_decode(kpt)
         return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
 
     def kpts_decode(self, kpts):

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -478,7 +478,7 @@ class Pose(Detect):
         return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
 
     def kpts_decode(self, kpts):
-        ndim = getattr(self, "ndim", 3)  # Backward compatibility
+        ndim = getattr(self, 'ndim', 3)  # Backward compatibility
         y = kpts.clone()
         if ndim == 3:
             y[:, 2::3, :] = y[:, 2::3, :].sigmoid()

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -470,7 +470,7 @@ class Pose(Detect):
 
     def forward(self, x):
         bs = x[0].shape[0]  # batch size
-        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nkpt, self.ndim, -1) for i in range(self.nl)], 2)  # (bs, 17, 3, h*w)
+        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nkpt, self.ndim, -1) for i in range(self.nl)], -1)  # (bs, 17, 3, h*w)
         x = self.detect(self, x)
         if self.training:
             return x, kpt

--- a/ultralytics/nn/modules.py
+++ b/ultralytics/nn/modules.py
@@ -457,10 +457,10 @@ class Segment(Detect):
 
 class Pose(Detect):
     # YOLOv8 Pose head for keypoints models
-    def __init__(self, nc=80, nkpt=17, ch=()):
+    def __init__(self, nc=80, nkpt=17, ndim=3, ch=()):
         super().__init__(nc, ch)
         self.nkpt = nkpt  # number of keypoints
-        self.no_kpt = self.nkpt * 3  # xy, cls(kpt)
+        self.no_kpt = self.nkpt * ndim  # xy, cls(kpt)
         self.detect = Detect.forward
 
         c4 = max(ch[0] // 4, 32)  # NOTE: wanted to set c4 = max(ch[0] // 4, self.no_kpt) but `no_kpt` is an odd number
@@ -469,8 +469,7 @@ class Pose(Detect):
 
     def forward(self, x):
         bs = x[0].shape[0]  # batch size
-        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.no_kpt, -1) for i in range(self.nl)],
-                        2)  # keypoints, (bs, 17*3, h*w)
+        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.no_kpt, -1) for i in range(self.nl)], 2)  # (bs, 17*3, h*w)
         x = self.detect(self, x)
         if self.training:
             return x, kpt
@@ -478,16 +477,13 @@ class Pose(Detect):
         pred_kpt = self.kpts_decode(kpt, bbox)
         return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
 
-    def kpts_decode(self, kpts, bbox=None):
-        # y = kpts.sigmoid()   # (bs, 51, h*w)
-        # y[:, 0::3, :] = (y[:, 0::3, :] - 0.5) * bbox[:, [2], :] + self.anchors[0] * self.strides
-        # y[:, 1::3, :] = (y[:, 1::3, :] - 0.5) * bbox[:, [3], :] + self.anchors[1] * self.strides
-        # y[:, 0::3, :] = (y[:, 0::3, :] - 0.5) * bbox[:, [2], :] + bbox[:, [0], :]
-        # y[:, 1::3, :] = (y[:, 1::3, :] - 0.5) * bbox[:, [3], :] + bbox[:, [1], :]
+    def kpts_decode(self, kpts):
+        ndim = self.ndim
         y = kpts.clone()
-        y[:, 2::3, :] = y[:, 2::3, :].sigmoid()
-        y[:, 0::3, :] = (y[:, 0::3, :] * 2 - 0.5 + self.anchors[0]) * self.strides
-        y[:, 1::3, :] = (y[:, 1::3, :] * 2 - 0.5 + self.anchors[1]) * self.strides
+        if ndim == 3:
+            y[:, 2::3, :] = y[:, 2::3, :].sigmoid()
+        y[:, 0::ndim, :] = (y[:, 0::ndim, :] * 2 - 0.5 + self.anchors[0]) * self.strides
+        y[:, 1::ndim, :] = (y[:, 1::ndim, :] * 2 - 0.5 + self.anchors[1]) * self.strides
         return y
 
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -168,7 +168,6 @@ class DetectionModel(BaseModel):
                  cfg='yolov8n.yaml',
                  ch=3,
                  nc=None,
-                 nkpt=None,
                  verbose=True):  # model, input channels, number of classes
         super().__init__()
         self.yaml = cfg if isinstance(cfg, dict) else yaml_load(check_yaml(cfg), append_filename=True)  # cfg dict
@@ -178,9 +177,6 @@ class DetectionModel(BaseModel):
         if nc and nc != self.yaml['nc']:
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml['nc'] = nc  # override yaml value
-        if nkpt and nkpt != self.yaml['nkpt']:
-            LOGGER.info(f"Overriding model.yaml nkpt={self.yaml['nkpt']} with nkpt={nkpt}")
-            self.yaml['nkpt'] = nkpt
         self.model, self.save = parse_model(deepcopy(self.yaml), ch=ch, verbose=verbose)  # model, savelist
         self.names = {i: f'{i}' for i in range(self.yaml['nc'])}  # default names dict
         self.inplace = self.yaml.get('inplace', True)
@@ -261,7 +257,14 @@ class SegmentationModel(DetectionModel):
 
 class PoseModel(DetectionModel):
 
-    def __init__(self, cfg='yolov5s-kpt.yaml', ch=3, nc=None, nkpt=None, verbose=True):
+    def __init__(self, cfg='yolov8n-pose.yaml', ch=3, nc=None, nkpt=None, ndim=None, verbose=True):
+        cfg = cfg if isinstance(cfg, dict) else yaml_load(check_yaml(cfg), append_filename=True)  # cfg dict
+        if nkpt and nkpt != cfg['nkpt']:
+            LOGGER.info(f"Overriding model.yaml nkpt={self.yaml['nkpt']} with nkpt={nkpt}")
+            cfg['nkpt'] = nkpt
+        if ndim and ndim != cfg['ndim']:
+            LOGGER.info(f"Overriding model.yaml ndim={self.yaml['ndim']} with ndim={ndim}")
+            cfg['ndim'] = ndim
         super().__init__(cfg, ch, nc, nkpt, verbose)
 
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -260,10 +260,10 @@ class PoseModel(DetectionModel):
     def __init__(self, cfg='yolov8n-pose.yaml', ch=3, nc=None, nkpt=None, ndim=None, verbose=True):
         cfg = cfg if isinstance(cfg, dict) else yaml_load(check_yaml(cfg), append_filename=True)  # cfg dict
         if nkpt and nkpt != cfg['nkpt']:
-            LOGGER.info(f"Overriding model.yaml nkpt={self.yaml['nkpt']} with nkpt={nkpt}")
+            LOGGER.info(f"Overriding model.yaml nkpt={cfg['nkpt']} with nkpt={nkpt}")
             cfg['nkpt'] = nkpt
         if ndim and ndim != cfg['ndim']:
-            LOGGER.info(f"Overriding model.yaml ndim={self.yaml['ndim']} with ndim={ndim}")
+            LOGGER.info(f"Overriding model.yaml ndim={cfg['ndim']} with ndim={ndim}")
             cfg['ndim'] = ndim
         super().__init__(cfg, ch, nc, verbose)
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -442,8 +442,10 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
     # Parse a YOLO model.yaml dictionary
     if verbose:
         LOGGER.info(f"\n{'':>3}{'from':>20}{'n':>3}{'params':>10}  {'module':<45}{'arguments':<30}")
-    nc, gd, gw, act = d['nc'], d['depth_multiple'], d['width_multiple'], d.get('activation')
-    nkpt, ndim = d['nkpt'], d['ndim']
+
+    nc, gd, gw = d['nc'], d['depth_multiple'], d['width_multiple']  # required model keys
+    nkpt, ndim, act = d.get('nkpt'), d.get('ndim'), d.get('activation')  # optional model keys
+
     if act:
         Conv.default_act = eval(act)  # redefine default activation, i.e. Conv.default_act = nn.SiLU()
         if verbose:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -265,7 +265,7 @@ class PoseModel(DetectionModel):
         if ndim and ndim != cfg['ndim']:
             LOGGER.info(f"Overriding model.yaml ndim={self.yaml['ndim']} with ndim={ndim}")
             cfg['ndim'] = ndim
-        super().__init__(cfg, ch, nc, nkpt, verbose)
+        super().__init__(cfg, ch, nc, verbose)
 
 
 class ClassificationModel(BaseModel):
@@ -447,7 +447,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
     if verbose:
         LOGGER.info(f"\n{'':>3}{'from':>20}{'n':>3}{'params':>10}  {'module':<45}{'arguments':<30}")
     nc, gd, gw, act = d['nc'], d['depth_multiple'], d['width_multiple'], d.get('activation')
-    nkpt = d.get('nkpt')  # noqa F841
+    nkpt, ndim = d['nkpt'], d['ndim']
     if act:
         Conv.default_act = eval(act)  # redefine default activation, i.e. Conv.default_act = nn.SiLU()
         if verbose:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -164,11 +164,7 @@ class BaseModel(nn.Module):
 
 class DetectionModel(BaseModel):
     # YOLOv8 detection model
-    def __init__(self,
-                 cfg='yolov8n.yaml',
-                 ch=3,
-                 nc=None,
-                 verbose=True):  # model, input channels, number of classes
+    def __init__(self, cfg='yolov8n.yaml', ch=3, nc=None, verbose=True):  # model, input channels, number of classes
         super().__init__()
         self.yaml = cfg if isinstance(cfg, dict) else yaml_load(check_yaml(cfg), append_filename=True)  # cfg dict
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -444,7 +444,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
         LOGGER.info(f"\n{'':>3}{'from':>20}{'n':>3}{'params':>10}  {'module':<45}{'arguments':<30}")
 
     nc, gd, gw = d['nc'], d['depth_multiple'], d['width_multiple']  # required model keys
-    nkpt, ndim, act = d.get('nkpt'), d.get('ndim'), d.get('activation')  # optional model keys
+    nkpt, ndim, act = d.get('nkpt'), d.get('ndim'), d.get('activation')  # noqa F841 optional model keys
 
     if act:
         Conv.default_act = eval(act)  # redefine default activation, i.e. Conv.default_act = nn.SiLU()

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -674,6 +674,9 @@ def v8_transforms(dataset, imgsz, hyp):
             pre_transform=LetterBox(new_shape=(imgsz, imgsz)),
         )])
     flip_idx = dataset.data.get("flip_idx", None)  # for keypoints augmentation
+    if dataset.use_keypoints and flip_idx is None and hyp.fliplr > 0.0:
+        hyp.fliplr = 0.0
+        LOGGER.warning(f"WARNING ⚠️ There's no `flip_idx` provided while training keypoints, closing fliplr augmentation!")
     return Compose([
         pre_transform,
         MixUp(dataset, pre_transform=pre_transform, p=hyp.mixup),

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -316,17 +316,17 @@ class RandomPerspective:
         Return:
             new_keypoints(ndarray): keypoints after affine, [N, 17, 3].
         """
-        n = len(keypoints)
+        n, nkpt = keypoints.shape[:2]
         if n == 0:
             return keypoints
-        xy = np.ones((n * 17, 3))
-        visible = keypoints[..., 2].reshape(n * 17, 1)
-        xy[:, :2] = keypoints[..., :2].reshape(n * 17, 2)  # num_kpt is hardcoded to 17
+        xy = np.ones((n * nkpt, 3))
+        visible = keypoints[..., 2].reshape(n * nkpt, 1)
+        xy[:, :2] = keypoints[..., :2].reshape(n * nkpt, 2)
         xy = xy @ M.T  # transform
         xy = xy[:, :2] / xy[:, 2:3]  # perspective rescale or affine
         out_mask = (xy[:, 0] < 0) | (xy[:, 1] < 0) | (xy[:, 0] > self.size[0]) | (xy[:, 1] > self.size[1])
         visible[out_mask] = 0
-        return np.concatenate([xy, visible], axis=-1).reshape(n, 17, 3)
+        return np.concatenate([xy, visible], axis=-1).reshape(n, nkpt, 3)
 
     def __call__(self, labels):
         """

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -673,13 +673,14 @@ def v8_transforms(dataset, imgsz, hyp):
             perspective=hyp.perspective,
             pre_transform=LetterBox(new_shape=(imgsz, imgsz)),
         )])
+    flip_idx = dataset.data.get("flip_idx", None)  # for keypoints augmentation
     return Compose([
         pre_transform,
         MixUp(dataset, pre_transform=pre_transform, p=hyp.mixup),
         Albumentations(p=1.0),
         RandomHSV(hgain=hyp.hsv_h, sgain=hyp.hsv_s, vgain=hyp.hsv_v),
         RandomFlip(direction='vertical', p=hyp.flipud),
-        RandomFlip(direction='horizontal', p=hyp.fliplr, flip_idx=POSE_FLIPLR_INDEX)])  # transforms
+        RandomFlip(direction='horizontal', p=hyp.fliplr, flip_idx=flip_idx)])  # transforms
 
 
 # Classification augmentations -----------------------------------------------------------------------------------------

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -676,8 +676,7 @@ def v8_transforms(dataset, imgsz, hyp):
     flip_idx = dataset.data.get('flip_idx', None)  # for keypoints augmentation
     if dataset.use_keypoints and flip_idx is None and hyp.fliplr > 0.0:
         hyp.fliplr = 0.0
-        LOGGER.warning(
-            f"WARNING ⚠️ There's no `flip_idx` provided while training keypoints, closing fliplr augmentation!")
+        LOGGER.warning("WARNING ⚠️ No `flip_idx` provided while training keypoints, setting augmentation 'fliplr=0.0'")
     return Compose([
         pre_transform,
         MixUp(dataset, pre_transform=pre_transform, p=hyp.mixup),

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -673,10 +673,11 @@ def v8_transforms(dataset, imgsz, hyp):
             perspective=hyp.perspective,
             pre_transform=LetterBox(new_shape=(imgsz, imgsz)),
         )])
-    flip_idx = dataset.data.get("flip_idx", None)  # for keypoints augmentation
+    flip_idx = dataset.data.get('flip_idx', None)  # for keypoints augmentation
     if dataset.use_keypoints and flip_idx is None and hyp.fliplr > 0.0:
         hyp.fliplr = 0.0
-        LOGGER.warning(f"WARNING ⚠️ There's no `flip_idx` provided while training keypoints, closing fliplr augmentation!")
+        LOGGER.warning(
+            f"WARNING ⚠️ There's no `flip_idx` provided while training keypoints, closing fliplr augmentation!")
     return Compose([
         pre_transform,
         MixUp(dataset, pre_transform=pre_transform, p=hyp.mixup),

--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -634,7 +634,7 @@ class Format:
         labels['cls'] = torch.from_numpy(cls) if nl else torch.zeros(nl)
         labels['bboxes'] = torch.from_numpy(instances.bboxes) if nl else torch.zeros((nl, 4))
         if self.return_keypoint:
-            labels['keypoints'] = torch.from_numpy(instances.keypoints).view(nl, -1) if nl else torch.zeros((nl, 51))
+            labels['keypoints'] = torch.from_numpy(instances.keypoints)
         # then we can use collate_fn
         if self.batch_idx:
             labels['batch_idx'] = torch.zeros(nl)

--- a/ultralytics/yolo/data/build.py
+++ b/ultralytics/yolo/data/build.py
@@ -61,7 +61,7 @@ def seed_worker(worker_id):  # noqa
     random.seed(worker_seed)
 
 
-def build_dataloader(cfg, batch, img_path, stride=32, rect=False, names=None, rank=-1, mode='train'):
+def build_dataloader(cfg, batch, img_path, data_info, stride=32, rect=False, rank=-1, mode='train'):
     assert mode in ['train', 'val']
     shuffle = mode == 'train'
     if cfg.rect and shuffle:
@@ -82,8 +82,8 @@ def build_dataloader(cfg, batch, img_path, stride=32, rect=False, names=None, ra
             prefix=colorstr(f'{mode}: '),
             use_segments=cfg.task == 'segment',
             use_keypoints=cfg.task == 'pose',
-            names=names,
-            classes=cfg.classes)
+            classes=cfg.classes,
+            data=data_info)
 
     batch = min(batch, len(dataset))
     nd = torch.cuda.device_count()  # number of CUDA devices

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -77,7 +77,7 @@ class YOLODataset(BaseDataset):
         nm, nf, ne, nc, msgs = 0, 0, 0, 0, []  # number missing, found, empty, corrupt, messages
         desc = f'{self.prefix}Scanning {path.parent / path.stem}...'
         total = len(self.im_files)
-        nc = len(self.data.pop("names"))
+        nc = len(self.data["names"])
         nkpt = self.data.get("nkpt", 0)
         ndim = self.data.get("ndim", 0)
         if self.use_keypoints:

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -77,17 +77,16 @@ class YOLODataset(BaseDataset):
         nm, nf, ne, nc, msgs = 0, 0, 0, 0, []  # number missing, found, empty, corrupt, messages
         desc = f'{self.prefix}Scanning {path.parent / path.stem}...'
         total = len(self.im_files)
-        nc = len(self.data["names"])
-        nkpt = self.data.get("nkpt", 0)
-        ndim = self.data.get("ndim", 0)
+        nc = len(self.data['names'])
+        nkpt = self.data.get('nkpt', 0)
+        ndim = self.data.get('ndim', 0)
         if self.use_keypoints:
             assert nkpt > 0 and ndim in [2, 3], \
-                    f"Expected `nkpt > 0` and `ndim = 2 or 3` in data.yaml but got `nkpt`: {nkpt}, `ndim`: {ndim}"
+                    f'Expected `nkpt > 0` and `ndim = 2 or 3` in data.yaml but got `nkpt`: {nkpt}, `ndim`: {ndim}'
         with ThreadPool(NUM_THREADS) as pool:
             results = pool.imap(func=verify_image_label,
                                 iterable=zip(self.im_files, self.label_files, repeat(self.prefix),
-                                             repeat(self.use_keypoints), repeat(nc), 
-                                             repeat(nkpt), repeat(ndim)))
+                                             repeat(self.use_keypoints), repeat(nc), repeat(nkpt), repeat(ndim)))
             pbar = tqdm(results, desc=desc, total=total, bar_format=TQDM_BAR_FORMAT)
             for im_file, lb, shape, segments, keypoint, nm_f, nf_f, ne_f, nc_f, msg in pbar:
                 nm += nm_f

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -80,9 +80,8 @@ class YOLODataset(BaseDataset):
         nc = len(self.data['names'])
         nkpt = self.data.get('nkpt', 0)
         ndim = self.data.get('ndim', 0)
-        if self.use_keypoints:
-            assert nkpt > 0 and ndim in [2, 3], \
-                    f'Expected `nkpt > 0` and `ndim = 2 or 3` in data.yaml but got `nkpt`: {nkpt}, `ndim`: {ndim}'
+        if self.use_keypoints and (nkpt <= 0 or ndim not in (2, 3)):
+            raise ValueError(f"Expected nkpt > 0 and ndim = 2 or 3 in data.yaml but got 'nkpt: {nkpt}', 'ndim: {ndim}'")
         with ThreadPool(NUM_THREADS) as pool:
             results = pool.imap(func=verify_image_label,
                                 iterable=zip(self.im_files, self.label_files, repeat(self.prefix),

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -122,10 +122,10 @@ def verify_image_label(args):
         if keypoint:
             keypoints = lb[:, 5:].reshape(-1, nkpt, ndim)
             if ndim ==  2:
-                kpt_mask = np.ones((nl, nkpt, 1), dtype=np.float32)
+                kpt_mask = np.ones(keypoints.shape[:2], dtype=np.float32)
                 kpt_mask = np.where(keypoints[..., 0] < 0, 0.0, kpt_mask)
                 kpt_mask = np.where(keypoints[..., 1] < 0, 0.0, kpt_mask)
-                keypoints = np.concatenate([keypoints, kpt_mask], axis=-1)  # (nl, nkpt, 3)
+                keypoints = np.concatenate([keypoints, kpt_mask[..., None]], axis=-1)  # (nl, nkpt, 3)
         lb = lb[:, :5]
         return im_file, lb, shape, segments, keypoints, nm, nf, ne, nc, msg
     except Exception as e:

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -115,13 +115,14 @@ def verify_image_label(args):
                     msg = f'{prefix}WARNING ⚠️ {im_file}: {nl - len(i)} duplicate labels removed'
             else:
                 ne = 1  # label empty
-                lb = np.zeros((0, (5 + nkpt * ndim)), dtype=np.float32) if keypoint else np.zeros((0, 5), dtype=np.float32)
+                lb = np.zeros((0, (5 + nkpt * ndim)), dtype=np.float32) if keypoint else np.zeros(
+                    (0, 5), dtype=np.float32)
         else:
             nm = 1  # label missing
             lb = np.zeros((0, (5 + nkpt * ndim)), dtype=np.float32) if keypoint else np.zeros((0, 5), dtype=np.float32)
         if keypoint:
             keypoints = lb[:, 5:].reshape(-1, nkpt, ndim)
-            if ndim ==  2:
+            if ndim == 2:
                 kpt_mask = np.ones(keypoints.shape[:2], dtype=np.float32)
                 kpt_mask = np.where(keypoints[..., 0] < 0, 0.0, kpt_mask)
                 kpt_mask = np.where(keypoints[..., 1] < 0, 0.0, kpt_mask)

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -63,7 +63,7 @@ def exif_size(img):
 
 def verify_image_label(args):
     # Verify one image-label pair
-    im_file, lb_file, prefix, keypoint, num_cls = args
+    im_file, lb_file, prefix, keypoint, num_cls, nkpt, ndim = args
     # number (missing, found, empty, corrupt), message, segments, keypoints
     nm, nf, ne, nc, msg, segments, keypoints = 0, 0, 0, 0, '', [], None
     try:
@@ -94,20 +94,19 @@ def verify_image_label(args):
             nl = len(lb)
             if nl:
                 if keypoint:
-                    assert lb.shape[1] == 56, 'labels require 56 columns each'
-                    assert (lb[:, 5::3] <= 1).all(), 'non-normalized or out of bounds coordinate labels'
-                    assert (lb[:, 6::3] <= 1).all(), 'non-normalized or out of bounds coordinate labels'
-                    assert lb.shape[1] == 56, 'labels require 56 columns each after removing occlusion parameter'
+                    assert lb.shape[1] == (5 + nkpt * ndim), f'labels require {(5 + nkpt * ndim)} columns each'
+                    assert (lb[:, 5::ndim] <= 1).all(), 'non-normalized or out of bounds coordinate labels'
+                    assert (lb[:, 6::ndim] <= 1).all(), 'non-normalized or out of bounds coordinate labels'
                 else:
                     assert lb.shape[1] == 5, f'labels require 5 columns, {lb.shape[1]} columns detected'
                     assert (lb[:, 1:] <= 1).all(), \
                         f'non-normalized or out of bounds coordinates {lb[:, 1:][lb[:, 1:] > 1]}'
+                    assert (lb >= 0).all(), f'negative label values {lb[lb < 0]}'
                 # All labels
                 max_cls = int(lb[:, 0].max())  # max label count
                 assert max_cls <= num_cls, \
                     f'Label class {max_cls} exceeds dataset class count {num_cls}. ' \
                     f'Possible class labels are 0-{num_cls - 1}'
-                assert (lb >= 0).all(), f'negative label values {lb[lb < 0]}'
                 _, i = np.unique(lb, axis=0, return_index=True)
                 if len(i) < nl:  # duplicate row check
                     lb = lb[i]  # remove duplicates
@@ -116,12 +115,17 @@ def verify_image_label(args):
                     msg = f'{prefix}WARNING ⚠️ {im_file}: {nl - len(i)} duplicate labels removed'
             else:
                 ne = 1  # label empty
-                lb = np.zeros((0, 56), dtype=np.float32) if keypoint else np.zeros((0, 5), dtype=np.float32)
+                lb = np.zeros((0, (5 + nkpt * ndim)), dtype=np.float32) if keypoint else np.zeros((0, 5), dtype=np.float32)
         else:
             nm = 1  # label missing
-            lb = np.zeros((0, 56), dtype=np.float32) if keypoint else np.zeros((0, 5), dtype=np.float32)
+            lb = np.zeros((0, (5 + nkpt * ndim)), dtype=np.float32) if keypoint else np.zeros((0, 5), dtype=np.float32)
         if keypoint:
-            keypoints = lb[:, 5:].reshape(-1, 17, 3)
+            keypoints = lb[:, 5:].reshape(-1, nkpt, ndim)
+            if ndim ==  2:
+                kpt_mask = np.ones((nl, nkpt, 1), dtype=np.float32)
+                kpt_mask = np.where(keypoints[..., 0] < 0, 0.0, kpt_mask)
+                kpt_mask = np.where(keypoints[..., 1] < 0, 0.0, kpt_mask)
+                keypoints = np.concatenate([keypoints, kpt_mask], axis=-1)  # (nl, nkpt, 3)
         lb = lb[:, :5]
         return im_file, lb, shape, segments, keypoints, nm, nf, ne, nc, msg
     except Exception as e:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -325,7 +325,7 @@ class Masks:
     @lru_cache(maxsize=1)
     def segments(self):
         return [
-            ops.scale_segments(self.masks.shape[1:], x, self.orig_shape, normalize=True)
+            ops.scale_coords(self.masks.shape[1:], x, self.orig_shape, normalize=True)
             for x in ops.masks2segments(self.masks)]
 
     @property

--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -58,11 +58,9 @@ class BboxLoss(nn.Module):
 
 class KeypointLoss(nn.Module):
 
-    def __init__(self, device, nkpt=17) -> None:
+    def __init__(self, sigmas) -> None:
         super().__init__()
-        self.sigmas = torch.ones((nkpt), device=device) / nkpt
-        # TODO
-        # self.sigmas = torch.from_numpy(OKS_SIGMA).to(device)   # for human pose
+        self.sigmas = sigmas
 
     def forward(self, pred_kpts, gt_kpts, kpt_mask, area):
         d = (pred_kpts[..., 0] - gt_kpts[..., 0]) ** 2 + (pred_kpts[..., 1] - gt_kpts[..., 1]) ** 2

--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -60,9 +60,9 @@ class KeypointLoss(nn.Module):
 
     def __init__(self, device, nkpt=17) -> None:
         super().__init__()
-        self.sigmas = torch.ones((nkpt), device=device) / 10
+        # self.sigmas = torch.ones((nkpt), device=device) / 10
         # TODO
-        # self.sigmas = torch.from_numpy(OKS_SIGMA).to(device)   # for human pose
+        self.sigmas = torch.from_numpy(OKS_SIGMA).to(device)   # for human pose
 
     def forward(self, pred_kpts, gt_kpts, kpt_mask, area):
         d = (pred_kpts[..., 0] - gt_kpts[..., 0]) ** 2 + (pred_kpts[..., 1] - gt_kpts[..., 1]) ** 2

--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -60,9 +60,9 @@ class KeypointLoss(nn.Module):
 
     def __init__(self, device, nkpt=17) -> None:
         super().__init__()
-        # self.sigmas = torch.ones((nkpt), device=device) / 10
+        self.sigmas = torch.ones((nkpt), device=device) / nkpt
         # TODO
-        self.sigmas = torch.from_numpy(OKS_SIGMA).to(device)   # for human pose
+        # self.sigmas = torch.from_numpy(OKS_SIGMA).to(device)   # for human pose
 
     def forward(self, pred_kpts, gt_kpts, kpt_mask, area):
         d = (pred_kpts[..., 0] - gt_kpts[..., 0]) ** 2 + (pred_kpts[..., 1] - gt_kpts[..., 1]) ** 2

--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -60,11 +60,12 @@ class KeypointLoss(nn.Module):
 
     def __init__(self, device, nkpt=17) -> None:
         super().__init__()
-        # self.sigmas = torch.ones((nkpt), device=device) / 10
-        self.sigmas = torch.from_numpy(OKS_SIGMA).to(device)
+        self.sigmas = torch.ones((nkpt), device=device) / 10
+        # TODO
+        # self.sigmas = torch.from_numpy(OKS_SIGMA).to(device)   # for human pose
 
     def forward(self, pred_kpts, gt_kpts, kpt_mask, area):
-        d = (pred_kpts[:, 0::3] - gt_kpts[:, 0::3]) ** 2 + (pred_kpts[:, 1::3] - gt_kpts[:, 1::3]) ** 2
+        d = (pred_kpts[..., 0] - gt_kpts[..., 0]) ** 2 + (pred_kpts[..., 1] - gt_kpts[..., 1]) ** 2
         kpt_loss_factor = (torch.sum(kpt_mask != 0) + torch.sum(kpt_mask == 0)) / (torch.sum(kpt_mask != 0) + 1e-9)
         # e = d / (2 * (area * self.sigmas) ** 2 + 1e-9)  # from formula
         e = d / (2 * self.sigmas) ** 2 / (area + 1e-9) / 2  # from cocoeval

--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .metrics import OKS_SIGMA, bbox_iou
+from .metrics import bbox_iou
 from .tal import bbox2dist
 
 

--- a/ultralytics/yolo/utils/metrics.py
+++ b/ultralytics/yolo/utils/metrics.py
@@ -128,7 +128,7 @@ def kpt_iou(kpt1, kpt2, area, eps=1e-7):
     """
     d = (kpt1[:, None, :, 0] - kpt2[..., 0]) ** 2 + (kpt1[:, None, :, 1] - kpt2[..., 1]) ** 2  # (N, M, 17)
     sigma = torch.tensor(OKS_SIGMA, device=kpt1.device, dtype=kpt1.dtype)  # (17, )
-    kpt_mask = kpt1[:, 2::3] != 0  # (N, 17)
+    kpt_mask = kpt1[..., 2] != 0  # (N, 17)
     e = d / (2 * sigma) ** 2 / (area[:, None, None] + eps) / 2  # from cocoeval
     # e = d / ((area[None, :, None] + eps) * sigma) ** 2 / 2  # from formula
     return (torch.exp(-e) * kpt_mask[:, None]).sum(-1) / kpt_mask.sum(-1)[:, None]

--- a/ultralytics/yolo/utils/metrics.py
+++ b/ultralytics/yolo/utils/metrics.py
@@ -122,11 +122,11 @@ def mask_iou(mask1, mask2, eps=1e-7):
 
 def kpt_iou(kpt1, kpt2, area, eps=1e-7):
     """OKS
-    kpt1: [N, 51], gt
-    kpt2: [M, 51], pred
+    kpt1: [N, 17, 3], gt
+    kpt2: [M, 17, 3], pred
     area: [N], areas from gt
     """
-    d = (kpt1[:, None, 0::3] - kpt2[:, 0::3]) ** 2 + (kpt1[:, None, 1::3] - kpt2[:, 1::3]) ** 2  # (N, M, 17)
+    d = (kpt1[:, None, :, 0] - kpt2[..., 0]) ** 2 + (kpt1[:, None, :, 1] - kpt2[..., 1]) ** 2  # (N, M, 17)
     sigma = torch.tensor(OKS_SIGMA, device=kpt1.device, dtype=kpt1.dtype)  # (17, )
     kpt_mask = kpt1[:, 2::3] != 0  # (N, 17)
     e = d / (2 * sigma) ** 2 / (area[:, None, None] + eps) / 2  # from cocoeval

--- a/ultralytics/yolo/utils/metrics.py
+++ b/ultralytics/yolo/utils/metrics.py
@@ -120,18 +120,18 @@ def mask_iou(mask1, mask2, eps=1e-7):
     return intersection / (union + eps)
 
 
-def kpt_iou(kpt1, kpt2, area, eps=1e-7):
+def kpt_iou(kpt1, kpt2, area, sigma, eps=1e-7):
     """OKS
     kpt1: [N, 17, 3], gt
     kpt2: [M, 17, 3], pred
     area: [N], areas from gt
     """
     d = (kpt1[:, None, :, 0] - kpt2[..., 0]) ** 2 + (kpt1[:, None, :, 1] - kpt2[..., 1]) ** 2  # (N, M, 17)
-    sigma = torch.tensor(OKS_SIGMA, device=kpt1.device, dtype=kpt1.dtype)  # (17, )
+    sigma = torch.tensor(sigma, device=kpt1.device, dtype=kpt1.dtype)  # (17, )
     kpt_mask = kpt1[..., 2] != 0  # (N, 17)
     e = d / (2 * sigma) ** 2 / (area[:, None, None] + eps) / 2  # from cocoeval
     # e = d / ((area[None, :, None] + eps) * sigma) ** 2 / 2  # from formula
-    return (torch.exp(-e) * kpt_mask[:, None]).sum(-1) / kpt_mask.sum(-1)[:, None]
+    return (torch.exp(-e) * kpt_mask[:, None]).sum(-1) / (kpt_mask.sum(-1)[:, None] + eps)
 
 
 def smooth_BCE(eps=0.1):  # https://github.com/ultralytics/yolov3/issues/238#issuecomment-598028441

--- a/ultralytics/yolo/utils/ops.py
+++ b/ultralytics/yolo/utils/ops.py
@@ -113,38 +113,6 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None):
     return boxes
 
 
-def scale_kpts(img1_shape, kpts, img0_shape, ratio_pad=None, step=3):
-    """
-    Rescales keypoints from the shape of the image they were originally specified in (img1_shape) to the shape of a
-    different image (img0_shape).
-
-    Args:
-      img1_shape (tuple): The shape of the image that the keypoints are for, in the format of (height, width).
-      kpts (torch.Tensor) or (numpy.ndarray): The keypoints to be rescaled of shape (n, 51).
-      img0_shape (tuple): The shape of the target image, in the format of (height, width).
-      ratio_pad (tuple, optional): A tuple of (ratio, pad) for scaling the keypoints. If not provided, the ratio and
-                                    pad will be calculated based on the size difference between the two images.
-      step (int, optional): The step size to take in indexing kpts,i.e. start at 0, go to the end, taking every step
-                            (default is 3).
-
-    Returns:
-      kpts (torch.Tensor) or (numpy.ndarray): The rescaled keypoints, of the same shape as the input keypoints.
-    """
-    if ratio_pad is None:  # calculate from img0_shape
-        gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new
-        pad = (img1_shape[1] - img0_shape[1] * gain) / 2, (img1_shape[0] - img0_shape[0] * gain) / 2  # wh padding
-    else:
-        gain = ratio_pad[0][0]
-        pad = ratio_pad[1]
-
-    kpts[:, 0::step] -= pad[0]  # x padding
-    kpts[:, 1::step] -= pad[1]  # y padding
-    kpts[:, 0::step] /= gain
-    kpts[:, 1::step] /= gain
-    clip_kpts(kpts, img0_shape, step=step)
-    return kpts
-
-
 def make_divisible(x, divisor):
     """
     Returns the nearest number that is divisible by the given divisor.

--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -166,11 +166,11 @@ class Annotator:
         if kpt_line:
             steps = kpts.shape[-1]
             for sk_id, sk in enumerate(self.skeleton):
-                pos1 = (int(kpts[(sk[0] - 1) * steps]), int(kpts[(sk[0] - 1) * steps + 1]))
-                pos2 = (int(kpts[(sk[1] - 1) * steps]), int(kpts[(sk[1] - 1) * steps + 1]))
+                pos1 = (int(kpts[(sk[0] - 1), 0]), int(kpts[(sk[0] - 1), 1]))
+                pos2 = (int(kpts[(sk[1] - 1), 0]), int(kpts[(sk[1] - 1), 1]))
                 if steps == 3:
-                    conf1 = kpts[(sk[0] - 1) * steps + 2]
-                    conf2 = kpts[(sk[1] - 1) * steps + 2]
+                    conf1 = kpts[(sk[0] - 1), 2]
+                    conf2 = kpts[(sk[1] - 1), 2]
                     if conf1 < 0.5 or conf2 < 0.5:
                         continue
                 if pos1[0] % shape[1] == 0 or pos1[1] % shape[0] == 0 or pos1[0] < 0 or pos1[1] < 0:

--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -154,21 +154,25 @@ class Annotator:
         if self.pil:
             # convert to numpy first
             self.im = np.asarray(self.im).copy()
+        nkpt, ndim = kpts.shape
+        is_pose = nkpt == 17 and ndim == 3
+        kpt_line &= is_pose # `kpt_line=True` for now only supports human pose plotting
         for i, k in enumerate(kpts):
+            color_k = [int(x) for x in self.kpt_color[i]] if is_pose else colors(i)
             x_coord, y_coord = k[0], k[1]
             if x_coord % shape[1] != 0 and y_coord % shape[0] != 0:
                 if len(k) == 3:
                     conf = k[2]
                     if conf < 0.5:
                         continue
-                cv2.circle(self.im, (int(x_coord), int(y_coord)), radius, [int(x) for x in self.kpt_color[i]], -1)
+                cv2.circle(self.im, (int(x_coord), int(y_coord)), radius, color_k, -1)
 
         if kpt_line:
-            steps = kpts.shape[-1]
+            ndim = kpts.shape[-1]
             for sk_id, sk in enumerate(self.skeleton):
                 pos1 = (int(kpts[(sk[0] - 1), 0]), int(kpts[(sk[0] - 1), 1]))
                 pos2 = (int(kpts[(sk[1] - 1), 0]), int(kpts[(sk[1] - 1), 1]))
-                if steps == 3:
+                if ndim == 3:
                     conf1 = kpts[(sk[0] - 1), 2]
                     conf2 = kpts[(sk[1] - 1), 2]
                     if conf1 < 0.5 or conf2 < 0.5:

--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -156,7 +156,7 @@ class Annotator:
             self.im = np.asarray(self.im).copy()
         nkpt, ndim = kpts.shape
         is_pose = nkpt == 17 and ndim == 3
-        kpt_line &= is_pose # `kpt_line=True` for now only supports human pose plotting
+        kpt_line &= is_pose  # `kpt_line=True` for now only supports human pose plotting
         for i, k in enumerate(kpts):
             color_k = [int(x) for x in self.kpt_color[i]] if is_pose else colors(i)
             x_coord, y_coord = k[0], k[1]

--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -143,10 +143,10 @@ class Annotator:
             # convert im back to PIL and update draw
             self.fromarray(self.im)
 
-    def kpts(self, kpts, shape=(640, 640), steps=3, radius=5, kpt_line=True):
+    def kpts(self, kpts, shape=(640, 640), radius=5, kpt_line=True):
         """Plot keypoints.
         Args:
-            kpts (tensor): predicted kpts, shape: [51]
+            kpts (tensor): predicted kpts, shape: [17, 3]
             shape (tuple): image shape, (h, w)
             steps (int): keypoints step
             radius (int): size of drawing points
@@ -154,29 +154,29 @@ class Annotator:
         if self.pil:
             # convert to numpy first
             self.im = np.asarray(self.im).copy()
-        num_kpts = len(kpts) // steps
-        for kid in range(num_kpts):
-            x_coord, y_coord = kpts[steps * kid], kpts[steps * kid + 1]
+        for i, k in enumerate(kpts):
+            x_coord, y_coord = k[0], k[1]
             if x_coord % shape[1] != 0 and y_coord % shape[0] != 0:
-                if steps == 3:
-                    conf = kpts[steps * kid + 2]
+                if len(k) == 3:
+                    conf = k[2]
                     if conf < 0.5:
                         continue
-                cv2.circle(self.im, (int(x_coord), int(y_coord)), radius, [int(x) for x in self.kpt_color[kid]], -1)
+                cv2.circle(self.im, (int(x_coord), int(y_coord)), radius, [int(x) for x in self.kpt_color[i]], -1)
 
-        for sk_id, sk in enumerate(self.skeleton):
-            pos1 = (int(kpts[(sk[0] - 1) * steps]), int(kpts[(sk[0] - 1) * steps + 1]))
-            pos2 = (int(kpts[(sk[1] - 1) * steps]), int(kpts[(sk[1] - 1) * steps + 1]))
-            if steps == 3:
-                conf1 = kpts[(sk[0] - 1) * steps + 2]
-                conf2 = kpts[(sk[1] - 1) * steps + 2]
-                if conf1 < 0.5 or conf2 < 0.5:
+        if kpt_line:
+            steps = kpts.shape[-1]
+            for sk_id, sk in enumerate(self.skeleton):
+                pos1 = (int(kpts[(sk[0] - 1) * steps]), int(kpts[(sk[0] - 1) * steps + 1]))
+                pos2 = (int(kpts[(sk[1] - 1) * steps]), int(kpts[(sk[1] - 1) * steps + 1]))
+                if steps == 3:
+                    conf1 = kpts[(sk[0] - 1) * steps + 2]
+                    conf2 = kpts[(sk[1] - 1) * steps + 2]
+                    if conf1 < 0.5 or conf2 < 0.5:
+                        continue
+                if pos1[0] % shape[1] == 0 or pos1[1] % shape[0] == 0 or pos1[0] < 0 or pos1[1] < 0:
                     continue
-            if pos1[0] % shape[1] == 0 or pos1[1] % shape[0] == 0 or pos1[0] < 0 or pos1[1] < 0:
-                continue
-            if pos2[0] % shape[1] == 0 or pos2[1] % shape[0] == 0 or pos2[0] < 0 or pos2[1] < 0:
-                continue
-            if kpt_line:
+                if pos2[0] % shape[1] == 0 or pos2[1] % shape[0] == 0 or pos2[0] < 0 or pos2[1] < 0:
+                    continue
                 cv2.line(self.im, pos1, pos2, [int(x) for x in self.limb_color[sk_id]], thickness=2)
         if self.pil:
             # convert im back to PIL and update draw
@@ -357,13 +357,13 @@ def plot_images(images,
             if len(kpts):
                 kpts_ = kpts[idx].copy()
                 if len(kpts_):
-                    if kpts_[:, 0::3].max() <= 1.01 or kpts_[:, 1::3].max() <= 1.01:  # if normalized with tolerance .01
-                        kpts_[:, 0::3] *= w  # scale to pixels
-                        kpts_[:, 1::3] *= h
+                    if kpts_[..., 0].max() <= 1.01 or kpts_[..., 1].max() <= 1.01:  # if normalized with tolerance .01
+                        kpts_[..., 0] *= w  # scale to pixels
+                        kpts_[..., 1] *= h
                     elif scale < 1:  # absolute coords need scale if image scales
                         kpts_ *= scale
-                kpts_[:, 0::3] += x
-                kpts_[:, 1::3] += y
+                kpts_[..., 0] += x
+                kpts_[..., 1] += y
                 for j in range(len(kpts_)):
                     if labels or conf[j] > 0.25:  # 0.25 conf thresh
                         annotator.kpts(kpts_[j])

--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -16,7 +16,7 @@ from ultralytics.yolo.utils import LOGGER, TryExcept, threaded
 
 from .checks import check_font, check_version, is_ascii
 from .files import increment_path
-from .ops import clip_coords, scale_image, xywh2xyxy, xyxy2xywh
+from .ops import clip_boxes, scale_image, xywh2xyxy, xyxy2xywh
 
 matplotlib.rc('font', **{'size': 11})
 matplotlib.use('Agg')  # for writing to files only
@@ -263,7 +263,7 @@ def save_one_box(xyxy, im, file=Path('im.jpg'), gain=1.02, pad=10, square=False,
         b[:, 2:] = b[:, 2:].max(1)[0].unsqueeze(1)  # attempt rectangle to square
     b[:, 2:] = b[:, 2:] * gain + pad  # box wh * gain + pad
     xyxy = xywh2xyxy(b).long()
-    clip_coords(xyxy, im.shape)
+    clip_boxes(xyxy, im.shape)
     crop = im[int(xyxy[0, 1]):int(xyxy[0, 3]), int(xyxy[0, 0]):int(xyxy[0, 2]), ::(1 if BGR else -1)]
     if save:
         file.parent.mkdir(parents=True, exist_ok=True)  # make directory

--- a/ultralytics/yolo/v8/detect/train.py
+++ b/ultralytics/yolo/v8/detect/train.py
@@ -41,7 +41,7 @@ class DetectionTrainer(BaseTrainer):
                                  shuffle=mode == 'train',
                                  seed=self.args.seed)[0] if self.args.v5loader else \
             build_dataloader(self.args, batch_size, img_path=dataset_path, stride=gs, rank=rank, mode=mode,
-                             rect=mode == 'val', names=self.data['names'])[0]
+                             rect=mode == 'val', data_info=self.data)[0]
 
     def preprocess_batch(self, batch):
         batch['img'] = batch['img'].to(self.device, non_blocking=True).float() / 255

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -178,7 +178,7 @@ class DetectionValidator(BaseValidator):
                                  prefix=colorstr(f'{self.args.mode}: '),
                                  shuffle=False,
                                  seed=self.args.seed)[0] if self.args.v5loader else \
-            build_dataloader(self.args, batch_size, img_path=dataset_path, stride=gs, names=self.data['names'],
+            build_dataloader(self.args, batch_size, img_path=dataset_path, stride=gs, data_info=self.data,
                              mode='val')[0]
 
     def plot_val_samples(self, batch, ni):

--- a/ultralytics/yolo/v8/pose/predict.py
+++ b/ultralytics/yolo/v8/pose/predict.py
@@ -22,6 +22,7 @@ class PosePredictor(DetectionPredictor):
             orig_img = orig_img[i] if isinstance(orig_img, list) else orig_img
             shape = orig_img.shape
             pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
+            # TODO
             pred[:, 6:] = ops.scale_kpts(img.shape[2:], pred[:, 6:], shape)
             path, _, _, _, _ = self.batch
             img_path = path[i] if isinstance(path, list) else path

--- a/ultralytics/yolo/v8/pose/predict.py
+++ b/ultralytics/yolo/v8/pose/predict.py
@@ -22,7 +22,7 @@ class PosePredictor(DetectionPredictor):
             orig_img = orig_img[i] if isinstance(orig_img, list) else orig_img
             shape = orig_img.shape
             pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
-            pred_kpts = pred[:, 6:].view(len(pred), self.model.nkpts, -1)
+            pred_kpts = pred[:, 6:].view(len(pred), self.model.nkpt, -1) if len(pred) else pred[:, 6:]
             pred_kpts = ops.scale_coords(img.shape[2:], pred_kpts, shape)
             path, _, _, _, _ = self.batch
             img_path = path[i] if isinstance(path, list) else path

--- a/ultralytics/yolo/v8/pose/predict.py
+++ b/ultralytics/yolo/v8/pose/predict.py
@@ -22,8 +22,8 @@ class PosePredictor(DetectionPredictor):
             orig_img = orig_img[i] if isinstance(orig_img, list) else orig_img
             shape = orig_img.shape
             pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], shape).round()
-            # TODO
-            pred[:, 6:] = ops.scale_kpts(img.shape[2:], pred[:, 6:], shape)
+            pred_kpts = pred[:, 6:].view(len(pred), self.model.nkpts, -1)
+            pred_kpts = ops.scale_coords(img.shape[2:], pred_kpts, shape)
             path, _, _, _, _ = self.batch
             img_path = path[i] if isinstance(path, list) else path
             results.append(
@@ -31,7 +31,7 @@ class PosePredictor(DetectionPredictor):
                         path=img_path,
                         names=self.model.names,
                         boxes=pred[:, :6],
-                        keypoints=pred[:, 6:]))
+                        keypoints=pred_kpts))
         return results
 
     def write_results(self, idx, results, batch):

--- a/ultralytics/yolo/v8/pose/train.py
+++ b/ultralytics/yolo/v8/pose/train.py
@@ -122,7 +122,7 @@ class PoseLoss(Loss):
                     gt_kpt[..., 1] /= stride_tensor[fg_mask[i]]
                     area = xyxy2xywh(target_bboxes[i][fg_mask[i]])[:, 2:].prod(1, keepdim=True)
                     pred_kpt = pred_kpts[i][fg_mask[i]]
-                    kpt_mask = gt_kpt[:, 2] != 0
+                    kpt_mask = gt_kpt[..., 2] != 0
                     loss[1] += self.keypoint_loss(pred_kpt, gt_kpt, kpt_mask, area)
                     # kpt_score loss
                     if pred_kpt.shape[-1] == 3:

--- a/ultralytics/yolo/v8/pose/train.py
+++ b/ultralytics/yolo/v8/pose/train.py
@@ -32,6 +32,11 @@ class PoseTrainer(v8.detect.DetectionTrainer):
 
         return model
 
+
+    def set_model_attributes(self):
+        super().set_model_attributes()
+        self.model.nkpt = self.data["nkpt"]
+
     def get_validator(self):
         self.loss_names = 'box_loss', 'pose_loss', 'kobj_loss', 'cls_loss', 'dfl_loss'
         return v8.pose.PoseValidator(self.test_loader, save_dir=self.save_dir, args=copy(self.args))

--- a/ultralytics/yolo/v8/pose/train.py
+++ b/ultralytics/yolo/v8/pose/train.py
@@ -129,12 +129,6 @@ class PoseLoss(Loss):
                     if self.ndim == 3:
                         loss[2] += self.bce_pose(pred_kpt[:, 2::self.ndim], kpt_mask.float())
 
-        # WARNING: Uncomment lines below in case of Multi-GPU DDP unused gradient errors
-        #         else:
-        #             loss[1] += proto.sum() * 0
-        # else:
-        #     loss[1] += proto.sum() * 0
-
         loss[0] *= self.hyp.box  # box gain
         loss[1] *= self.hyp.box / batch_size  # kobj gain
         loss[2] *= self.hyp.box / batch_size  # pose gain

--- a/ultralytics/yolo/v8/pose/train.py
+++ b/ultralytics/yolo/v8/pose/train.py
@@ -26,7 +26,7 @@ class PoseTrainer(v8.detect.DetectionTrainer):
         super().__init__(cfg, overrides)
 
     def get_model(self, cfg=None, weights=None, verbose=True):
-        model = PoseModel(cfg, ch=3, nc=self.data['nc'], nkpt=self.data['nkpt'], verbose=verbose)
+        model = PoseModel(cfg, ch=3, nc=self.data['nc'], nkpt=self.data['nkpt'], ndim=self.data["ndim"], verbose=verbose)
         if weights:
             model.load(weights)
 

--- a/ultralytics/yolo/v8/pose/train.py
+++ b/ultralytics/yolo/v8/pose/train.py
@@ -121,8 +121,7 @@ class PoseLoss(Loss):
                     gt_kpt = keypoints[batch_idx.view(-1) == i][idx]  # (n, 51)
                     gt_kpt[:, 0::self.ndim] /= stride_tensor[fg_mask[i]]
                     gt_kpt[:, 1::self.ndim] /= stride_tensor[fg_mask[i]]
-                    xywh = xyxy2xywh(target_bboxes[i][fg_mask[i]])
-                    area = xywh[:, 2:].prod(1, keepdim=True)
+                    area = xyxy2xywh(target_bboxes[i][fg_mask[i]])[:, 2:].prod(1, keepdim=True)
                     pred_kpt = pred_kpts[i][fg_mask[i]]
                     kpt_mask = gt_kpt[:, 2::self.ndim] != 0
                     loss[1] += self.keypoint_loss(pred_kpt, gt_kpt, kpt_mask, area)

--- a/ultralytics/yolo/v8/pose/train.py
+++ b/ultralytics/yolo/v8/pose/train.py
@@ -79,8 +79,8 @@ class PoseLoss(Loss):
         self.ndim = model.model[-1].ndim
         self.bce_pose = nn.BCEWithLogitsLoss()
         is_pose = self.nkpt == 17 and self.ndim == 3
-        sigmas = torch.from_numpy(OKS_SIGMA).to(self.device) if is_pose else \
-                 torch.ones((self.nkpt), device=self.device) / self.nkpt
+        sigmas = torch.from_numpy(OKS_SIGMA).to(self.device) if is_pose \
+            else torch.ones(self.nkpt, device=self.device) / self.nkpt
         self.keypoint_loss = KeypointLoss(sigmas=sigmas)
 
     def __call__(self, preds, batch):

--- a/ultralytics/yolo/v8/pose/val.py
+++ b/ultralytics/yolo/v8/pose/val.py
@@ -142,10 +142,11 @@ class PoseValidator(DetectionValidator):
                     names=self.names)
 
     def plot_predictions(self, batch, preds, ni):
-        # TODO
+        nk, nd = self.data["nkpt"], self.data["ndim"]
+        pred_kpts = torch.cat([p.view(-1, nk, nd)[:15] for p in preds], 0)
         plot_images(batch['img'],
                     *output_to_target(preds, max_det=15),
-                    kpts=torch.cat([p[:15, 6:] for p in preds], 0),
+                    kpts=pred_kpts,
                     paths=batch['im_file'],
                     fname=self.save_dir / f'val_batch{ni}_pred.jpg',
                     names=self.names)  # pred

--- a/ultralytics/yolo/v8/pose/val.py
+++ b/ultralytics/yolo/v8/pose/val.py
@@ -76,8 +76,8 @@ class PoseValidator(DetectionValidator):
                 ops.scale_boxes(batch['img'][si].shape[1:], tbox, shape,
                                 ratio_pad=batch['ratio_pad'][si])  # native-space labels
                 tkpts = kpts.clone()
-                tkpts[:, 0::3] *= width
-                tkpts[:, 1::3] *= height
+                tkpts[..., 0] *= width
+                tkpts[..., 1] *= height
                 tkpts = ops.scale_kpts(batch['img'][si].shape[1:], tkpts, shape, ratio_pad=batch['ratio_pad'][si])
                 labelsn = torch.cat((cls, tbox), 1)  # native-space labels
                 correct_bboxes = self._process_batch(predn[:, :6], labelsn)

--- a/ultralytics/yolo/v8/pose/val.py
+++ b/ultralytics/yolo/v8/pose/val.py
@@ -7,7 +7,7 @@ import torch
 
 from ultralytics.yolo.utils import DEFAULT_CFG, LOGGER, ops
 from ultralytics.yolo.utils.checks import check_requirements
-from ultralytics.yolo.utils.metrics import PoseMetrics, box_iou, kpt_iou, OKS_SIGMA
+from ultralytics.yolo.utils.metrics import OKS_SIGMA, PoseMetrics, box_iou, kpt_iou
 from ultralytics.yolo.utils.plotting import output_to_target, plot_images
 from ultralytics.yolo.v8.detect import DetectionValidator
 
@@ -41,10 +41,10 @@ class PoseValidator(DetectionValidator):
 
     def init_metrics(self, model):
         super().init_metrics(model)
-        self.nkpt = self.data["nkpt"]
-        self.ndim = self.data["ndim"]
+        self.nkpt = self.data['nkpt']
+        self.ndim = self.data['ndim']
         is_pose = self.nkpt == 17 and self.ndim == 3
-        self.sigma = OKS_SIGMA if is_pose else np.ones((self.nkpt)) / self.nkpt
+        self.sigma = OKS_SIGMA if is_pose else np.ones(self.nkpt) / self.nkpt
 
     def update_metrics(self, preds, batch):
         # Metrics
@@ -54,7 +54,7 @@ class PoseValidator(DetectionValidator):
             bbox = batch['bboxes'][idx]
             kpts = batch['keypoints'][idx]
             nl, npr = cls.shape[0], pred.shape[0]  # number of labels, predictions
-            nk = kpts.shape[1]   # number of keypoints
+            nk = kpts.shape[1]  # number of keypoints
             shape = batch['ori_shape'][si]
             correct_kpts = torch.zeros(npr, self.niou, dtype=torch.bool, device=self.device)  # init
             correct_bboxes = torch.zeros(npr, self.niou, dtype=torch.bool, device=self.device)  # init

--- a/ultralytics/yolo/v8/pose/val.py
+++ b/ultralytics/yolo/v8/pose/val.py
@@ -143,7 +143,7 @@ class PoseValidator(DetectionValidator):
 
     def plot_predictions(self, batch, preds, ni):
         nk, nd = self.data["nkpt"], self.data["ndim"]
-        pred_kpts = torch.cat([p.view(-1, nk, nd)[:15] for p in preds], 0)
+        pred_kpts = torch.cat([p[:, 6:].view(-1, nk, nd)[:15] for p in preds], 0)
         plot_images(batch['img'],
                     *output_to_target(preds, max_det=15),
                     kpts=pred_kpts,

--- a/ultralytics/yolo/v8/pose/val.py
+++ b/ultralytics/yolo/v8/pose/val.py
@@ -83,9 +83,7 @@ class PoseValidator(DetectionValidator):
                 tkpts = ops.scale_coords(batch['img'][si].shape[1:], tkpts, shape, ratio_pad=batch['ratio_pad'][si])
                 labelsn = torch.cat((cls, tbox), 1)  # native-space labels
                 correct_bboxes = self._process_batch(predn[:, :6], labelsn)
-                # TODO: maybe remove these `self.` arguments as they already are member variable
                 correct_kpts = self._process_batch(predn[:, :6], labelsn, pred_kpts, tkpts)
-                # correct_kpts = self._process_batch(predn[:, :6], labelsn)
                 if self.args.plots:
                     self.confusion_matrix.process_batch(predn, labelsn)
 

--- a/ultralytics/yolo/v8/pose/val.py
+++ b/ultralytics/yolo/v8/pose/val.py
@@ -142,6 +142,7 @@ class PoseValidator(DetectionValidator):
                     names=self.names)
 
     def plot_predictions(self, batch, preds, ni):
+        # TODO
         plot_images(batch['img'],
                     *output_to_target(preds, max_det=15),
                     kpts=torch.cat([p[:15, 6:] for p in preds], 0),


### PR DESCRIPTION
@glenn-jocher @AyushExel 
Now training with any number of keypoints is supported. Just modify `nkpt` and `ndim` in the data.yaml and provide corresponding dataset.
To train human-pose from coco:
```yaml
# Keypoints
nkpt: 17  # number of keypoints
ndim: 3  # (x, y, visible)
flip_idx: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15] # for fliplr augmentation
```
To train face landmark from widerface:
```yaml
# Keypoints
nkpt: 5  # number of keypoints
ndim: 2  # (x, y)
flip_idx: [1, 0, 2, 4, 3]  # for fliplr augmentation
```
It's better for users to provide a `flip_idx` in data.yaml which is for `fliplr` augmentation, but it's also fine if users don't, it'll automatically close the `fliplr` augmentation if there's no `flip_idx` in data.yaml.

Some updates:
- I noticed there'll always be a `keypoint_mask` in the end no matter the `ndim=2` or `ndim=3` (refer to [https://github.com/deepcam-cn/yolov5-face/blob/master/utils/loss.py#L257](https://github.com/deepcam-cn/yolov5-face/blob/master/utils/loss.py#L257)). And it is really helpful in the process of augmentation(filter the negative coordinates) and loss calculation(filter the valid predictions to calculate loss), so the current logic of handling gt keypoints is:
  - keep the visible dimension if `ndim=3`
  - automatically add a new visible dimension if `ndim=2`

  so the gt keypoints will be `(n, nkpt, 3)` anyway in our dataloader. The difference between `ndim=3` and `ndim=2` is in predictions, the predictions' shape of the former is `(n, nkpt, 3)` and the latter is `(n, nkpt, 2)`.
- unify the functions `scale_segment` and `scale_kpts` to `scale_coords` since both of segment and keypoint coordinates are `x,y` format.
- good news is that the current loss function of human-pose is also working with other number of keypoints. i.e face landmark.

@glenn-jocher To get the number of keypoints while predicting, we might need an additional variable `nkpt` in `AutoBackend`. I've added it for `pt` format, so currently the predicting from pt file works. I suppose that we probably also need to add it in metadata for other model formats.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing Keypoint detection features with dimension and flipping indexes to YOLOv8 models.

### 📊 Key Changes
- Added `ndim` attribute to keypoints for dimension tracking (x, y, visible).
- Included `flip_idx` to specify mirrored keypoints for data augmentation.
- Adapted model configurations for different sizes (n, m, l, s, x) to accommodate the `ndim` attribute.
- Updated keypoint-related functions to handle the new `ndim` and `flip_idx`.
- Incorporated backward compatibility fixes for older models without the `nkpt` attribute.

### 🎯 Purpose & Impact
- 🎨 These changes improve keypoint detection, providing flexibility in keypoints representations and handling symmetrical augmentations more effectively.
- 🔄 The `ndim` addition makes the codebase comprehensive for models that predict keypoints, considering visibility along with position coordinates.
- ⚙️ Users and developers working with keypoint detection models will now have a more robust and feature-complete system, leading to potential improvements in pose estimation tasks.