### PR TITLE
TFLite INT8 export and inference cleanup

### DIFF
--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -245,7 +245,7 @@ class Exporter:
             if tflite:
                 f[7], _ = self._export_tflite(s_model, nms=False, agnostic_nms=self.args.agnostic_nms)
             if edgetpu:
-                f[8], _ = self._export_edgetpu(tflite_model=Path(f[5]) / f'{self.file.stem}_full_integer_quant.tflite')
+                f[8], _ = self._export_edgetpu(tflite_model=Path(f[5]) / f'{self.file.stem}_integer_quant.tflite')
             if tfjs:
                 f[9], _ = self._export_tfjs()
         if paddle:  # PaddlePaddle

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -245,7 +245,7 @@ class Exporter:
             if tflite:
                 f[7], _ = self._export_tflite(s_model, nms=False, agnostic_nms=self.args.agnostic_nms)
             if edgetpu:
-                f[8], _ = self._export_edgetpu(tflite_model=Path(f[5]) / f'{self.file.stem}_integer_quant.tflite')
+                f[8], _ = self._export_edgetpu(tflite_model=Path(f[5]) / f'{self.file.stem}_full_integer_quant.tflite')
             if tfjs:
                 f[9], _ = self._export_tfjs()
         if paddle:  # PaddlePaddle

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -245,7 +245,7 @@ class Exporter:
             if tflite:
                 f[7], _ = self._export_tflite(s_model, nms=False, agnostic_nms=self.args.agnostic_nms)
             if edgetpu:
-                f[8], _ = self._export_edgetpu(tflite_model=Path(f[5]) / f'{self.file.stem}_integer_quant.tflite')
+                f[8], _ = self._export_edgetpu(tflite_model=Path(f[5]) / f'{self.file.stem}_int8.tflite')
             if tfjs:
                 f[9], _ = self._export_tfjs()
         if paddle:  # PaddlePaddle

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -245,7 +245,7 @@ class Exporter:
             if tflite:
                 f[7], _ = self._export_tflite(s_model, nms=False, agnostic_nms=self.args.agnostic_nms)
             if edgetpu:
-                f[8], _ = self._export_edgetpu(tflite_model=Path(f[5]) / f'{self.file.stem}_int8.tflite')
+                f[8], _ = self._export_edgetpu(tflite_model=Path(f[5]) / f'{self.file.stem}_integer_quant.tflite')
             if tfjs:
                 f[9], _ = self._export_tfjs()
         if paddle:  # PaddlePaddle


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to TensorFlow export and TFLite model naming/management in the Ultralytics export pipeline.

### 📊 Key Changes
- Simplified the Edge TPU export line for clarity and readability.
- Removed unnecessary Tensorflow Lite (TFLite) models with integer quantization and 16-bit activations to clean up the export directory.
- Renamed TFLite models with dynamic range quantization to reflect the use of 8-bit integers (`int8`).
- Updated TFLite metadata addition process to skip files containing `quant_with_int16_act` in their name.

### 🎯 Purpose & Impact
- These changes streamline the code and the export processes, making it more straightforward to understand and maintain. 🧹
- By removing extraneous TFLite files, storage is conserved, and potential confusion about which models to use is minimized. 🗑️➖
- Renaming files improves accuracy in representing the content and properties of the quantized models (full integer vs. dynamic range). 🏷️
- Users can expect a cleaner export directory with more descriptive file names, easing model deployment and integration into applications. 👩‍💻🚀