### PR TITLE
added tracking ids to Results::plot

### DIFF
--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -131,11 +131,12 @@ class Results:
         masks = self.masks
         probs = self.probs
         names = self.names
+        hide_labels, hide_conf = False, not show_conf
         if boxes is not None:
             for d in reversed(boxes):
                 c, conf, id = int(d.cls), float(d.conf), None if d.id is None else int(d.id.item())
                 name = ('' if id is None else f'id:{id} ') + names[c]
-                label = None if self.args.hide_labels else (name if self.args.hide_conf else f'{name} {conf:.2f}')
+                label = None if hide_labels else (name if hide_conf else f'{name} {conf:.2f}')
                 annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
 
         if masks is not None:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -111,12 +111,13 @@ class Results:
     def keys(self):
         return [k for k in self._keys if getattr(self, k) is not None]
 
-    def plot(self, show_conf=True, line_width=None, font_size=None, font='Arial.ttf', pil=False, example='abc'):
+    def plot(self, show_conf=True, show_id=True, line_width=None, font_size=None, font='Arial.ttf', pil=False, example='abc'):
         """
         Plots the detection results on an input RGB image. Accepts a numpy array (cv2) or a PIL Image.
 
         Args:
             show_conf (bool): Whether to show the detection confidence score.
+            show_id (bool): Whether to show the tracked id when using a tracker.
             line_width (float, optional): The line width of the bounding boxes. If None, it is scaled to the image size.
             font_size (float, optional): The font size of the text. If None, it is scaled to the image size.
             font (str): The font to use for the text.
@@ -134,8 +135,11 @@ class Results:
         if boxes is not None:
             for d in reversed(boxes):
                 cls, conf = d.cls.squeeze(), d.conf.squeeze()
+                id = None
+                if show_id and d.id is not None:
+                    id = int(d.id.squeeze())
                 c = int(cls)
-                label = (f'{names[c]}' if names else f'{c}') + (f'{conf:.2f}' if show_conf else '')
+                label = (f'{names[c]}' if names else f'{c}') + (f'{conf:.2f}' if show_conf else '') + (f' {id}' if id is not None else '')
                 annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
 
         if masks is not None:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -111,20 +111,12 @@ class Results:
     def keys(self):
         return [k for k in self._keys if getattr(self, k) is not None]
 
-    def plot(self,
-             show_conf=True,
-             show_id=True,
-             line_width=None,
-             font_size=None,
-             font='Arial.ttf',
-             pil=False,
-             example='abc'):
+    def plot(self, show_conf=True, line_width=None, font_size=None, font='Arial.ttf', pil=False, example='abc'):
         """
         Plots the detection results on an input RGB image. Accepts a numpy array (cv2) or a PIL Image.
 
         Args:
             show_conf (bool): Whether to show the detection confidence score.
-            show_id (bool): Whether to show the tracked id when using a tracker.
             line_width (float, optional): The line width of the bounding boxes. If None, it is scaled to the image size.
             font_size (float, optional): The font size of the text. If None, it is scaled to the image size.
             font (str): The font to use for the text.
@@ -141,13 +133,9 @@ class Results:
         names = self.names
         if boxes is not None:
             for d in reversed(boxes):
-                cls, conf = d.cls.squeeze(), d.conf.squeeze()
-                id = None
-                if show_id and d.id is not None:
-                    id = int(d.id.squeeze())
-                c = int(cls)
-                label = (f'{names[c]}' if names else f'{c}') + (f'{conf:.2f}' if show_conf else
-                                                                '') + (f' {id}' if id is not None else '')
+                c, conf, id = int(d.cls), float(d.conf), None if d.id is None else int(d.id.item())
+                name = ('' if id is None else f'id:{id} ') + self.model.names[c]
+                label = None if self.args.hide_labels else (name if self.args.hide_conf else f'{name} {conf:.2f}')
                 annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
 
         if masks is not None:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -111,7 +111,14 @@ class Results:
     def keys(self):
         return [k for k in self._keys if getattr(self, k) is not None]
 
-    def plot(self, show_conf=True, show_id=True, line_width=None, font_size=None, font='Arial.ttf', pil=False, example='abc'):
+    def plot(self,
+             show_conf=True,
+             show_id=True,
+             line_width=None,
+             font_size=None,
+             font='Arial.ttf',
+             pil=False,
+             example='abc'):
         """
         Plots the detection results on an input RGB image. Accepts a numpy array (cv2) or a PIL Image.
 
@@ -139,7 +146,8 @@ class Results:
                 if show_id and d.id is not None:
                     id = int(d.id.squeeze())
                 c = int(cls)
-                label = (f'{names[c]}' if names else f'{c}') + (f'{conf:.2f}' if show_conf else '') + (f' {id}' if id is not None else '')
+                label = (f'{names[c]}' if names else f'{c}') + (f'{conf:.2f}' if show_conf else
+                                                                '') + (f' {id}' if id is not None else '')
                 annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
 
         if masks is not None:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -129,12 +129,12 @@ class Results:
         annotator = Annotator(deepcopy(self.orig_img), line_width, font_size, font, pil, example)
         boxes = self.boxes
         masks = self.masks
-        logits = self.probs
+        probs = self.probs
         names = self.names
         if boxes is not None:
             for d in reversed(boxes):
                 c, conf, id = int(d.cls), float(d.conf), None if d.id is None else int(d.id.item())
-                name = ('' if id is None else f'id:{id} ') + self.model.names[c]
+                name = ('' if id is None else f'id:{id} ') + names[c]
                 label = None if self.args.hide_labels else (name if self.args.hide_conf else f'{name} {conf:.2f}')
                 annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
 
@@ -143,10 +143,10 @@ class Results:
             im = F.resize(im.contiguous(), masks.data.shape[1:]) / 255
             annotator.masks(masks.data, colors=[colors(x, True) for x in boxes.cls], im_gpu=im)
 
-        if logits is not None:
-            n5 = min(len(self.names), 5)
-            top5i = logits.argsort(0, descending=True)[:n5].tolist()  # top 5 indices
-            text = f"{', '.join(f'{names[j] if names else j} {logits[j]:.2f}' for j in top5i)}, "
+        if probs is not None:
+            n5 = min(len(names), 5)
+            top5i = probs.argsort(0, descending=True)[:n5].tolist()  # top 5 indices
+            text = f"{', '.join(f'{names[j] if names else j} {probs[j]:.2f}' for j in top5i)}, "
             annotator.text((32, 32), text, txt_color=(255, 255, 255))  # TODO: allow setting colors
 
         return np.asarray(annotator.im) if annotator.pil else annotator.im


### PR DESCRIPTION
Tracking ids can now be displayed by yolos default plotting function.

The tracking ids were already stored in the Boxes of the Results, but the default plot-function didn't have the capabilities to display them.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to image annotation labeling in YOLO's result visualization.

### 📊 Key Changes
- Replaced `logits` variable with `probs` for clarity in the code.
- Added `id` to object labels when available, prepending 'id:' to the label.
- Implemented conditional hiding of labels or confidence scores based on the `show_conf` parameter.
- Simplified the calculation of the top-5 probabilities for better readability.

### 🎯 Purpose & Impact
- **Improved Readability**: Renaming to `probs` improves clarity, reflecting that the values are indeed probabilities, not raw logits.
- **Enhanced Debugging**: Object `id` inclusion aids in tracking specific detections, useful for debugging and analysis.
- **User Control**: New options to hide labels or confidence scores allow users to customize the output to their preferences.
- **Simplified Code**: Streamlining top-5 probabilities calculation makes the codebase cleaner and easier to maintain.

The changes should offer users a more intuitive and customizable visualization experience when using YOLO for object detection. 🖼️🔍✨