### PR TITLE
MPS fixes for Pytorch 2.X

### DIFF
--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -27,6 +27,7 @@ WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))
 TORCH_1_9 = check_version(torch.__version__, '1.9.0')
 TORCH_1_11 = check_version(torch.__version__, '1.11.0')
 TORCH_1_12 = check_version(torch.__version__, '1.12.0')
+TORCH_2_X = check_version(torch.__version__, minimum='2.0')
 
 
 @contextmanager
@@ -95,7 +96,8 @@ def select_device(device='', batch=0, newline=False, verbose=True):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
         arg = 'cuda:0'
-    elif mps and getattr(torch, 'has_mps', False) and torch.backends.mps.is_available():  # prefer MPS if available
+    elif mps and getattr(torch, 'has_mps', False) and torch.backends.mps.is_available() and TORCH_2_X:
+        # prefer MPS if available
         s += 'MPS\n'
         arg = 'mps'
     else:  # revert to CPU

--- a/ultralytics/yolo/v8/detect/train.py
+++ b/ultralytics/yolo/v8/detect/train.py
@@ -134,6 +134,7 @@ class Loss:
         else:
             i = targets[:, 0]  # image index
             _, counts = i.unique(return_counts=True)
+            counts = counts.to(dtype=torch.int32)
             out = torch.zeros(batch_size, counts.max(), 5, device=self.device)
             for j in range(batch_size):
                 matches = i == j

--- a/ultralytics/yolo/v8/segment/train.py
+++ b/ultralytics/yolo/v8/segment/train.py
@@ -79,7 +79,7 @@ class SegLoss(Loss):
         # targets
         try:
             batch_idx = batch['batch_idx'].view(-1, 1)
-            targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes']), 1)
+            targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes'].to(dtype)), 1)
             targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
             gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls, xyxy
             mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)


### PR DESCRIPTION
Fixing #246 
- Int64 to Int32
- Float64 to Flaot32
- Allow MPS for Pytorch 2.X only



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to support PyTorch 2.0 and enhance data preprocessing.

### 📊 Key Changes
- Added version check for PyTorch 2.0 (`TORCH_2_X`) in `torch_utils.py`.
- Modified the device selection logic to prefer MPS (Metal Performance Shaders) backend if available and running on PyTorch 2.0 or higher.
- Ensured tensor data type consistency during preprocessing by casting `counts` to `dtype=torch.int32` in `train.py` for YOLOv8 detect.
- Cast `batch['bboxes']` to `dtype` to ensure compatibility with target data type in YOLOv8 segment `train.py`.

### 🎯 Purpose & Impact
- 🆕 The update facilitates compatibility with the latest PyTorch release, enabling users to leverage new features and performance improvements.
- 🏋🏻‍♀️ Enhanced data preprocessing ensures smoother training workflows and reduces potential bugs related to data type mismatches.
- ✨ Users with devices that can use MPS will experience improved compute efficiency when available and using PyTorch 2.0.
- 🐞 These changes may prevent potential errors during model training and inference, leading to a more robust performance.