### PR TITLE
Custom label paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/ultralytics/yolo/data/base.py
+++ b/ultralytics/yolo/data/base.py
@@ -5,7 +5,7 @@ import math
 import os
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union, List
 
 import cv2
 import numpy as np
@@ -25,7 +25,8 @@ class BaseDataset(Dataset):
     """
 
     def __init__(self,
-                 img_path,
+                 img_path: Union[str, List[str]],
+                 label_path: Optional[Union[str, List[str]]] = None,
                  imgsz=640,
                  cache=False,
                  augment=True,
@@ -39,13 +40,23 @@ class BaseDataset(Dataset):
                  classes=None):
         super().__init__()
         self.img_path = img_path
+        self.label_path = label_path
         self.imgsz = imgsz
         self.augment = augment
         self.single_cls = single_cls
         self.prefix = prefix
 
+        # checks for optional image and label paths:
+        if self.label_path is not None:
+            if isinstance(self.label_path, list):
+                if not isinstance(self.img_path, list):
+                    raise ValueError('img_path must be a list if label_path is a list')
+                if len(self.label_path) != len(self.img_path):
+                    raise ValueError('img_path and label_path must have the same length')
+
         self.im_files = self.get_img_files(self.img_path)
         self.labels = self.get_labels()
+        print(self.labels)
         self.update_labels(include_class=classes)  # single_cls and include_class
 
         self.ni = len(self.labels)

--- a/ultralytics/yolo/data/build.py
+++ b/ultralytics/yolo/data/build.py
@@ -61,7 +61,7 @@ def seed_worker(worker_id):  # noqa
     random.seed(worker_seed)
 
 
-def build_dataloader(cfg, batch, img_path, stride=32, rect=False, names=None, rank=-1, mode='train'):
+def build_dataloader(cfg, batch, img_path, stride=32, rect=False, names=None, rank=-1, mode='train', label_path=None):
     assert mode in ['train', 'val']
     shuffle = mode == 'train'
     if cfg.rect and shuffle:
@@ -70,6 +70,7 @@ def build_dataloader(cfg, batch, img_path, stride=32, rect=False, names=None, ra
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = YOLODataset(
             img_path=img_path,
+            label_path=label_path,
             imgsz=cfg.imgsz,
             batch_size=batch,
             augment=mode == 'train',  # augmentation

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -3,17 +3,21 @@
 from itertools import repeat
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
+import glob
+import os
+from os.path import join
 
 import cv2
 import numpy as np
 import torch
 import torchvision
 from tqdm import tqdm
+from typing import Union, List, Optional
 
 from ..utils import NUM_THREADS, TQDM_BAR_FORMAT, is_dir_writeable
 from .augment import Compose, Format, Instances, LetterBox, classify_albumentations, classify_transforms, v8_transforms
 from .base import BaseDataset
-from .utils import HELP_URL, LOCAL_RANK, LOGGER, get_hash, img2label_paths, verify_image_label
+from .utils import HELP_URL, LOCAL_RANK, LOGGER, get_hash, img2label_paths, verify_image_label, IMG_FORMATS
 
 
 class YOLODataset(BaseDataset):
@@ -44,7 +48,8 @@ class YOLODataset(BaseDataset):
     """
 
     def __init__(self,
-                 img_path,
+                 img_path: Union[str, List[str]],
+                 label_path: Union[str, List[str]],
                  imgsz=640,
                  cache=False,
                  augment=True,
@@ -63,7 +68,7 @@ class YOLODataset(BaseDataset):
         self.use_keypoints = use_keypoints
         self.names = names
         assert not (self.use_segments and self.use_keypoints), 'Can not use both segments and keypoints.'
-        super().__init__(img_path, imgsz, cache, augment, hyp, prefix, rect, batch_size, stride, pad, single_cls,
+        super().__init__(img_path, label_path, imgsz, cache, augment, hyp, prefix, rect, batch_size, stride, pad, single_cls,
                          classes)
 
     def cache_labels(self, path=Path('./labels.cache')):
@@ -121,8 +126,46 @@ class YOLODataset(BaseDataset):
             LOGGER.warning(f'{self.prefix}WARNING ⚠️ Cache directory {path.parent} is not writeable, cache not saved.')
         return x
 
+    def get_custom_label_files(self, label_path: Union[str, List[str]]) -> List[str]:
+        """
+        For datasets where the yaml files lists labels folders, the label files are not in the same directory as the images
+        but in unique directories. The filenames should however match the image filenames (except for the extensions,
+        which will be .txt instead of .jpg).
+        This is an adapted version of BaseDataset.get_im_files()
+        """
+        assert self.label_path is not None
+
+        # since we may have the same label filename in multiple different folders, we need to make sure we are
+        # properly mapping label filenames to image filenames. The order of the folders for labels in the yaml file is important,
+        # and we will use that as a basis for mapping.
+
+        # while prior construction doesn't actually hard code this, the usage of YOLO suggests that the folders in self.img_path
+        # should all contain images only in a folder called images.
+        lab_img_folder_map = {lab_folder: join(im_folder, "images") for im_folder, lab_folder in zip(self.img_path if isinstance(self.img_path, list) else [self.img_path],
+                                                                                    label_path if isinstance(label_path, list) else [label_path])}
+        img_lab_folder_map = {v: k for k, v in lab_img_folder_map.items()}
+
+        # get the label files
+        # we assume that the label folder could be anything, and only contains label files as .txt files which are
+        # named the same as the image files (except for the extension) based on the im_lab_folder_map mapping.
+        label_paths = []  # label files
+        for img_folder in self.img_path if isinstance(self.img_path, list) else [self.img_path]:
+            img_folder = join(img_folder, "images")
+            lab_folder = img_lab_folder_map[img_folder]
+            img_folder_Path = Path(img_folder)
+            stems_to_find = [f.stem for f in img_folder_Path.glob("*") if f.suffix.lower()[1:] in IMG_FORMATS]
+            for f_ in img_folder_Path.glob("*"):
+                lab_equivalent = join(lab_folder, f_.stem) + ".txt"
+                if f_.stem not in stems_to_find or not Path(lab_equivalent).exists():
+                    raise FileNotFoundError(f"Could not find label files for images: {stems_to_find}")
+                label_paths.append(lab_equivalent)
+        return label_paths
+
     def get_labels(self):
-        self.label_files = img2label_paths(self.im_files)
+        if self.label_path is None:
+            self.label_files = img2label_paths(self.im_files)
+        else:
+            self.label_files = self.get_custom_label_files(self.label_path)
         cache_path = Path(self.label_files[0]).parent.with_suffix('.cache')
         try:
             cache, exists = np.load(str(cache_path), allow_pickle=True).item(), True  # load dict

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -220,7 +220,7 @@ def check_det_dataset(dataset, autodownload=True):
     if not path.is_absolute():
         path = (DATASETS_DIR / path).resolve()
         data['path'] = path  # download scripts
-    for k in 'train', 'val', 'test':
+    for k in 'train', 'val', 'test', "test_labels", "train_labels", "val_labels":
         if data.get(k):  # prepend path
             if isinstance(data[k], str):
                 x = (path / data[k]).resolve()

--- a/ultralytics/yolo/v8/detect/train.py
+++ b/ultralytics/yolo/v8/detect/train.py
@@ -20,8 +20,7 @@ from ultralytics.yolo.utils.torch_utils import de_parallel
 
 # BaseTrainer python usage
 class DetectionTrainer(BaseTrainer):
-
-    def get_dataloader(self, dataset_path, batch_size, mode='train', rank=0):
+    def get_dataloader(self, dataset_path, batch_size, mode='train', rank=0, label_path=None):
         # TODO: manage splits differently
         # calculate stride - check if model is initialized
         gs = max(int(de_parallel(self.model).stride.max() if self.model else 0), 32)
@@ -41,7 +40,7 @@ class DetectionTrainer(BaseTrainer):
                                  shuffle=mode == 'train',
                                  seed=self.args.seed)[0] if self.args.v5loader else \
             build_dataloader(self.args, batch_size, img_path=dataset_path, stride=gs, rank=rank, mode=mode,
-                             rect=mode == 'val', names=self.data['names'])[0]
+                             rect=mode == 'val', names=self.data['names'], label_path=label_path)[0]
 
     def preprocess_batch(self, batch):
         batch['img'] = batch['img'].to(self.device, non_blocking=True).float() / 255


### PR DESCRIPTION
# Option to use custom label paths in training

## Motivation

One of the limitations of the yolov5/8 data format is that the folder of labels is effectively hard coded as `/set/labels` relative to the `/set/images` folder. This prevents training on datasets distributed over a file system without copying or renaming folders, especially when we want to train or validate different labelled versions of the same images. 

This change was highly motivated by the desired to use `yolov8` in a larger scale production environment, and there have been similar concerns raised [here](https://github.com/ultralytics/yolov5/issues/8246). 

## Feature

### Previous Functionality:

`data.yaml` must list paths to [train, test, valid] sets as either:

```yaml
[train | val | test]: /path/to/folder/with/images/
```

or

```yaml
[train | val | test]:
  - /path/with/images/folder_1
  - ...
  - /path/with/images/folder_n
```

### New Functionality:

The old system works, but in addition you may now specify custom label folders like so:

**Option 1: single folder**

```yaml
[train | val | test]: /path/with/images/folder
[train | val | test]_labs: /path/with/labels.txt/
```

**Option 2: multiple folders**
```yaml
[train | val | test]: 
 - /path/with/images/folder_1
 - ...
 - /path/with/images/folder_n

[train | val | test]_labs:
- /path/with/labels.txt/1
- ...
- /path/with/labels.txt/1
```

**Rules for using option 2:**
- the number of folders must match and map one to one (the nth listed labels folder must match to the nth listed images folder)
- The same requirements on filename must hold (e.g. `example.img_extension` maps to `example.txt`)


### Notes
I understand this is an incremental feature add and may be adding a little but of technical debt. I'm happy to refactor the data loading system in order to make this change more natural and to open up an easier implementation of even more customization for data loading. 


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0d739fd</samp>

### Summary
📁🏷️🛠️

<!--
1.  📁 - This emoji represents the concept of files and folders, which is relevant for the changes that involve modifying or finding label paths in different directories.
2.  🏷️ - This emoji represents the concept of labels or tags, which is relevant for the changes that involve loading or processing label files for the datasets.
3.  🛠️ - This emoji represents the concept of tools or modifications, which is relevant for the changes that involve refactoring or adding new features or arguments to the existing classes or functions.
-->
This pull request adds a new feature to the ultralytics/yolo package that enables users to specify custom label paths for their detection datasets. This allows loading labels from different sources or formats than the default ones. The feature is implemented by modifying the `BaseDataset`, `YOLODataset`, `BaseTrainer`, and `DetectionTrainer` classes, as well as the `build_dataloader` and `check_det_dataset` functions. The files `ultralytics/yolo/data/base.py`, `ultralytics/yolo/data/build.py`, `ultralytics/yolo/data/dataset.py`, `ultralytics/yolo/engine/trainer.py`, `ultralytics/yolo/v8/detect/train.py`, and `ultralytics/yolo/data/utils.py` are affected by these changes.

> _Sing, O Muse, of the skillful code review_
> _That brought new features to the YOLO model,_
> _The swift and accurate detector of objects,_
> _The pride and glory of Ultralytics._

### Walkthrough
*  Add type annotations and optional `label_path` argument to `BaseDataset` class and its methods ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fL8-R8), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fL28-R29), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fR43), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fL47-R59))
*  Pass `label_path` argument to `BaseDataset` class when creating dataset objects in `build_dataloader` function in `ultralytics/yolo/data/build.py` ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-0826103e946e6152ff49d963d1235653adbfbf515878db39fdae798c3a15469fL64-R64), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-0826103e946e6152ff49d963d1235653adbfbf515878db39fdae798c3a15469fR73))
*  Import modules and constants for new method `get_custom_label_files` in `YOLODataset` class in `ultralytics/yolo/data/dataset.py` ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-9e341b944998965225e7749684518d7461f0a0ebc7e6dd53502ca840fb4e686fR6-R8), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-9e341b944998965225e7749684518d7461f0a0ebc7e6dd53502ca840fb4e686fL12-R20))
*  Add `label_path` argument to `YOLODataset` class and its methods and call `get_custom_label_files` method if `label_path` is not None ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-9e341b944998965225e7749684518d7461f0a0ebc7e6dd53502ca840fb4e686fL47-R52), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-9e341b944998965225e7749684518d7461f0a0ebc7e6dd53502ca840fb4e686fL66-R71), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-9e341b944998965225e7749684518d7461f0a0ebc7e6dd53502ca840fb4e686fL124-R168))
*  Define `get_custom_label_files` method in `YOLODataset` class that returns a list of label files based on `label_path` and `img_path` attributes and checks their existence and stem match ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-9e341b944998965225e7749684518d7461f0a0ebc7e6dd53502ca840fb4e686fL124-R168))
*  Include `test_labels`, `train_labels`, and `val_labels` keys in the loop that prepends the path to the data files in `check_det_dataset` function in `ultralytics/yolo/data/utils.py` ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-15f6dd1ea95b187a5b50c885f567bad50d006f1af1180508497a038247e9df58L223-R223))
*  Add `train_labels_folder`, `val_labels_folder`, and `test_labels_folder` attributes to `BaseTrainer` class in `ultralytics/yolo/engine/trainer.py` and assign them using `get_custom_label_paths` method ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1R130-R135), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1R424-R430))
*  Pass `label_path` argument to `get_dataloader` method when creating train and test loaders in `_setup_train` method of `BaseTrainer` class ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L246-R255))
*  Modify `get_dataloader` method of `BaseTrainer` class to accept `label_path` argument and pass it to `build_dataloader` function ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L465-R479))
*  Modify `get_dataloader` method of `DetectionTrainer` class in `ultralytics/yolo/v8/detect/train.py` to accept `label_path` argument and pass it to `BaseTrainer` class's `get_dataloader` method ([link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-c55f9a098f49780316e7ec36ccd2ae059a0dbf9129072e2cb9ce20bbbd5de940L23-R23), [link](https://github.com/ultralytics/ultralytics/pull/1521/files?diff=unified&w=0#diff-c55f9a098f49780316e7ec36ccd2ae059a0dbf9129072e2cb9ce20bbbd5de940L44-R43))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 📊 Key Changes
- Custom label paths can now be specified for image datasets.
- Validation checks ensure img_path is a list if label_path is a list, and that both have the same length
- `.idea` added to .gitignore to ignore JetBrains IDE files.

### 🎯 Purpose & Impact
These changes allow greater flexibility for dataset organization by allowing custom label paths. Users can now organize image and label files in separate directories, addressing previous limitations of needing image and label files in the same directory. It also facilitates training on datasets where such a separation exists or is desired.

### 🌟 Summary
Now users have the ability to specify separate paths for their image data and label files when training their models, immensely improving dataset organization and customizability. 🛠️💾