### PR TITLE
Fix id count

### DIFF
--- a/ultralytics/tracker/trackers/basetrack.py
+++ b/ultralytics/tracker/trackers/basetrack.py
@@ -53,3 +53,7 @@ class BaseTrack:
 
     def mark_removed(self):
         self.state = TrackState.Removed
+
+    @staticmethod
+    def reset_id():
+        BaseTrack._count = 0

--- a/ultralytics/tracker/trackers/byte_tracker.py
+++ b/ultralytics/tracker/trackers/byte_tracker.py
@@ -168,6 +168,7 @@ class BYTETracker:
         self.args = args
         self.max_time_lost = int(frame_rate / 30.0 * args.track_buffer)
         self.kalman_filter = self.get_kalmanfilter()
+        self.reset_id()
 
     def update(self, results, img=None):
         self.frame_id += 1
@@ -298,6 +299,9 @@ class BYTETracker:
 
     def multi_predict(self, tracks):
         STrack.multi_predict(tracks)
+
+    def reset_id(self):
+        STrack.reset_id()
 
     @staticmethod
     def joint_stracks(tlista, tlistb):


### PR DESCRIPTION
@glenn-jocher 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of tracking ID management in Ultralytics object tracking.

### 📊 Key Changes
- Added a static `reset_id` method to `BaseTrack` class to reset tracking ID count.
- Called `reset_id` in the constructor of `ByteTracker` to reset IDs at the start of each new tracking instance.

### 🎯 Purpose & Impact
- Ensures tracking IDs start from zero for each new video or tracking session, which is critical for clarity in tracking scenarios.
- Prevents potential confusion from ID carry-over between separate tracking sessions, making it easier for users to analyze and interpret tracking data. 🔄