### PR TITLE
Add support for saving labels as text (save_txt)

### DIFF
--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -108,8 +108,9 @@ class DetectionValidator(BaseValidator):
             # Save
             if self.args.save_json:
                 self.pred_to_json(predn, batch['im_file'][si])
-            # if self.args.save_txt:
-            #    save_one_txt(predn, save_conf, shape, file=save_dir / 'labels' / f'{path.stem}.txt')
+            if self.args.save_txt:
+                file = self.save_dir / 'labels' / f'{Path(batch["im_file"][si]).stem}.txt'
+                self.save_one_txt(predn, self.args.save_conf, shape, file)
 
     def finalize_metrics(self, *args, **kwargs):
         self.metrics.speed = self.speed
@@ -196,6 +197,14 @@ class DetectionValidator(BaseValidator):
                     paths=batch['im_file'],
                     fname=self.save_dir / f'val_batch{ni}_pred.jpg',
                     names=self.names)  # pred
+
+    def save_one_txt(self, predn, save_conf, shape, file):
+        gn = torch.tensor(shape)[[1, 0, 1, 0]]  # normalization gain whwh
+        for *xyxy, conf, cls in predn.tolist():
+            xywh = (ops.xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
+            line = (cls, *xywh, conf) if save_conf else (cls, *xywh)  # label format
+            with open(file, 'a') as f:
+                f.write(('%g ' * len(line)).rstrip() % line + '\n') 
 
     def pred_to_json(self, predn, filename):
         stem = Path(filename).stem

--- a/ultralytics/yolo/v8/detect/val.py
+++ b/ultralytics/yolo/v8/detect/val.py
@@ -204,7 +204,7 @@ class DetectionValidator(BaseValidator):
             xywh = (ops.xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
             line = (cls, *xywh, conf) if save_conf else (cls, *xywh)  # label format
             with open(file, 'a') as f:
-                f.write(('%g ' * len(line)).rstrip() % line + '\n') 
+                f.write(('%g ' * len(line)).rstrip() % line + '\n')
 
     def pred_to_json(self, predn, filename):
         stem = Path(filename).stem


### PR DESCRIPTION
Implemented `save_one_txt()` function to save labels as text files.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of prediction saving options in validation script.

### 📊 Key Changes
- Uncommented and updated the section of code that saves prediction results to a `.txt` file.
- Added a new function called `save_one_txt` responsible for formatting and saving the predictions in the correct label format.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To provide users with the ability to save model predictions in a text format, which is useful for various post-processing tasks, like evaluating model performance or further analysis.
- 💡 **Impact**: Users can now save detailed prediction results on a per-image basis, facilitating a more granular review process. This can be especially valuable to researchers and practitioners who require an in-depth examination of model outputs.