### PR TITLE
Added P2 model

### DIFF
--- a/ultralytics/models/v8/yolov8-p2.yaml
+++ b/ultralytics/models/v8/yolov8-p2.yaml
@@ -11,7 +11,7 @@ scales: # model compound scaling constants, i.e. 'model=yolov8n.yaml' will call 
   l: [1.00, 1.00, 512]
   x: [1.00, 1.25, 512]
 
-# YOLOv8.0x2 backbone
+# YOLOv8.0 backbone
 backbone:
   # [from, repeats, module, args]
   - [-1, 1, Conv, [64, 3, 2]]  # 0-P1/2
@@ -25,7 +25,7 @@ backbone:
   - [-1, 3, C2f, [1024, True]]
   - [-1, 1, SPPF, [1024, 5]]  # 9
 
-# YOLOv8.0x2 head
+# YOLOv8.0-p2 head
 head:
   - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
   - [[-1, 6], 1, Concat, [1]]  # cat backbone P4
@@ -36,19 +36,19 @@ head:
   - [-1, 3, C2f, [256]]  # 15 (P3/8-small)
 
   - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
-  - [[-1, 2], 1, Concat, [1]]  # cat backbone p2
-  - [-1, 3, C2f, [128]]  # 18 (P3/8-small)
+  - [[-1, 2], 1, Concat, [1]]  # cat backbone P2
+  - [-1, 3, C2f, [128]]  # 18 (P2/4-xsmall)
 
   - [-1, 1, Conv, [128, 3, 2]]
   - [[-1, 15], 1, Concat, [1]]  # cat head P3
-  - [-1, 3, C2f, [256]]  # 21 (P3/8-medium)
+  - [-1, 3, C2f, [256]]  # 21 (P3/8-small)
 
   - [-1, 1, Conv, [256, 3, 2]]
   - [[-1, 12], 1, Concat, [1]]  # cat head P4
-  - [-1, 3, C2f, [512]]  # 21 (P4/16-medium)
+  - [-1, 3, C2f, [512]]  # 24 (P4/16-medium)
 
   - [-1, 1, Conv, [512, 3, 2]]
   - [[-1, 9], 1, Concat, [1]]  # cat head P5
-  - [-1, 3, C2f, [1024]]  # 24 (P5/32-large)
+  - [-1, 3, C2f, [1024]]  # 27 (P5/32-large)
 
-  - [[15, 18, 21, 24], 1, Detect, [nc]]  # Detect(P2, P3, P4, P5)
+  - [[18, 21, 24, 27], 1, Detect, [nc]]  # Detect(P2, P3, P4, P5)

--- a/ultralytics/models/v8/yolov8-p2.yaml
+++ b/ultralytics/models/v8/yolov8-p2.yaml
@@ -1,0 +1,54 @@
+# Ultralytics YOLO 🚀, GPL-3.0 license
+# YOLOv8 object detection model with P2-P5 outputs. For Usage examples see https://docs.ultralytics.com/tasks/detect
+
+# Parameters
+nc: 80  # number of classes
+scales: # model compound scaling constants, i.e. 'model=yolov8n.yaml' will call yolov8.yaml with scale 'n'
+  # [depth, width, max_channels]
+  n: [0.33, 0.25, 1024]
+  s: [0.33, 0.50, 1024]
+  m: [0.67, 0.75, 768]
+  l: [1.00, 1.00, 512]
+  x: [1.00, 1.25, 512]
+
+# YOLOv8.0x2 backbone
+backbone:
+  # [from, repeats, module, args]
+  - [-1, 1, Conv, [64, 3, 2]]  # 0-P1/2
+  - [-1, 1, Conv, [128, 3, 2]]  # 1-P2/4
+  - [-1, 3, C2f, [128, True]]
+  - [-1, 1, Conv, [256, 3, 2]]  # 3-P3/8
+  - [-1, 6, C2f, [256, True]]
+  - [-1, 1, Conv, [512, 3, 2]]  # 5-P4/16
+  - [-1, 6, C2f, [512, True]]
+  - [-1, 1, Conv, [1024, 3, 2]]  # 7-P5/32
+  - [-1, 3, C2f, [1024, True]]
+  - [-1, 1, SPPF, [1024, 5]]  # 9
+
+# YOLOv8.0x2 head
+head:
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 6], 1, Concat, [1]]  # cat backbone P4
+  - [-1, 3, C2f, [512]]  # 12
+
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 4], 1, Concat, [1]]  # cat backbone P3
+  - [-1, 3, C2f, [256]]  # 15 (P3/8-small)
+
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 2], 1, Concat, [1]]  # cat backbone p2
+  - [-1, 3, C2f, [128]]  # 18 (P3/8-small)
+
+  - [-1, 1, Conv, [128, 3, 2]]
+  - [[-1, 15], 1, Concat, [1]]  # cat head P3
+  - [-1, 3, C2f, [256]]  # 21 (P3/8-medium)
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 12], 1, Concat, [1]]  # cat head P4
+  - [-1, 3, C2f, [512]]  # 21 (P4/16-medium)
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 9], 1, Concat, [1]]  # cat head P5
+  - [-1, 3, C2f, [1024]]  # 24 (P5/32-large)
+
+  - [[15, 18, 21, 24], 1, Detect, [nc]]  # Detect(P2, P3, P4, P5)


### PR DESCRIPTION
Added P2 model, based on YOLOv5 p2 model.

**Architecture needs to be reviewed as I'm not an expert on the field**, I just looked how the P2 model was on yoloV5 and reimplemented it here.

Mentionned [here](https://github.com/ultralytics/ultralytics/discussions/895) where I firstly posted the yaml

Will post benchmarks as soon as they are finished running.

One weird behavior needs to be noted.

On Windows 11, with a RTX 3090 ECC Off (24gb vram), I can run 1024x1024 v8@nano at a batch of 20.

With p2 layer, no enough vram at batchsize@10 so I had to lower to 5.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing the new YOLOv8-p2 object detection model configuration.

### 📊 Key Changes
- 📁 Added a new model configuration file `yolov8-p2.yaml`.
- 🚀 Model supports P2-P5 outputs, enhancing multi-scale detection capabilities.
- 🛠️ Includes multiple scaling constants for adapting depth, width, and channel dimensions.
- 🧠 Defines a complex YOLOv8.0 backbone and a specialized YOLOv8.0-p2 head for feature extraction and object detection.

### 🎯 Purpose & Impact
- 🎯 The purpose is to expand the YOLO model family with a configuration that leverages different output scales for potentially improved object detection, particularly for multi-scale detection.
- 💥 Impact includes greater versatility for users who require multi-scale detection features, as well as potential enhancements in detection accuracy and performance across diverse object sizes.