### PR TITLE
Retain filenames from PIL Images

### DIFF
--- a/ultralytics/yolo/data/dataloaders/stream_loaders.py
+++ b/ultralytics/yolo/data/dataloaders/stream_loaders.py
@@ -284,6 +284,7 @@ class LoadPilAndNumpy:
     def __init__(self, im0, imgsz=640, stride=32, auto=True, transforms=None):
         if not isinstance(im0, list):
             im0 = [im0]
+        self.paths = [getattr(im, 'filename', f'image{i}.jpg') for i, im in enumerate(im0)]
         self.im0 = [self._single_check(im) for im in im0]
         self.imgsz = imgsz
         self.stride = stride
@@ -291,7 +292,6 @@ class LoadPilAndNumpy:
         self.transforms = transforms
         self.mode = 'image'
         # generate fake paths
-        self.paths = [getattr(im, 'filename', f'image{i}.jpg') for i, im in enumerate(self.im0)]
         self.bs = len(self.im0)
 
     @staticmethod


### PR DESCRIPTION
Attempt to fix missing results paths. Bug raised in https://github.com/ultralytics/ultralytics/issues/1554

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of file path handling in image loading process.

### 📊 Key Changes
- Streamlined the assignment of file paths to images during the initialization of the image loader.
- Relocated the file path assignment to be directly after image list creation.

### 🎯 Purpose & Impact
- 🎨 The purpose is to ensure the correct file paths are assigned to the corresponding images as soon as they're processed into a list, resulting in cleaner and more logical code organization.
- 🚀 Potential impact includes more reliable image loading, which will benefit developers integrating image data into their machine learning models, resulting in a smoother developer experience and possibly reducing bugs related to file path handling.