### PR TITLE
perf: disable GC to improve label cache load time

### DIFF
--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -125,7 +125,10 @@ class YOLODataset(BaseDataset):
         self.label_files = img2label_paths(self.im_files)
         cache_path = Path(self.label_files[0]).parent.with_suffix('.cache')
         try:
+            import gc
+            gc.disable()
             cache, exists = np.load(str(cache_path), allow_pickle=True).item(), True  # load dict
+            gc.enable()
             assert cache['version'] == self.cache_version  # matches current version
             assert cache['hash'] == get_hash(self.label_files + self.im_files)  # identical hash
         except (FileNotFoundError, AssertionError, AttributeError):

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -126,7 +126,7 @@ class YOLODataset(BaseDataset):
         cache_path = Path(self.label_files[0]).parent.with_suffix('.cache')
         try:
             import gc
-            gc.disable()
+            gc.disable()  # reduce pickle load time https://github.com/ultralytics/ultralytics/pull/1585
             cache, exists = np.load(str(cache_path), allow_pickle=True).item(), True  # load dict
             gc.enable()
             assert cache['version'] == self.cache_version  # matches current version


### PR DESCRIPTION
This is a known workaround to reduce pickle load times.
On my machine, I got a 50% reduction of load time (`16s` -> `8s`).
This greatly reduces friction when experimenting with hyperparameters.

This can probably be *greatly* improved by using a different serialization format,
possibly with an upgrade-to-new-format mechanism.

But this was way easier to implement.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved label loading efficiency in YOLO dataset management.

### 📊 Key Changes
- Added Python garbage collection (`gc`) disabling and enabling around the cache loading process.
- Attempt to load `.cache` file before reverting to recomputing dataset labels.

### 🎯 Purpose & Impact
- 🚀 The purpose of these changes is to decrease the time it takes to load labels from a cache file by temporarily disabling garbage collection.
- 📈 This should result in a speed-up of dataset preparation time, particularly noticeable for large datasets with numerous labels.
- 📉 Potential impact includes smoother and faster initial dataset processing for users when training YOLO models with Ultralytics.