### PR TITLE
fix classify task

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -142,6 +142,7 @@ class YOLO:
             self.task = task or guess_model_task(weights)
             self.ckpt_path = weights
         self.overrides['model'] = weights
+        self.overrides['task'] = self.task
 
     def _check_is_pytorch_model(self):
         """


### PR DESCRIPTION
@glenn-jocher `task` is not updated to `classify` if I inference with cls.onnx model.
reproduce:
```bash
yolo export model=yolov8n-cls.pt format=onnx imgsz=224,224 opset=12
yolo classify predict model=yolov8n-cls.onnx imgsz=224 save
```
![8J398mnjEj](https://user-images.githubusercontent.com/61612323/227407519-9ce0ff02-878e-4104-ab34-3e84293d5efb.jpg)
also the `transforms` is not working properly since the `task` there is not actually `classify`.
[https://github.com/ultralytics/ultralytics/blob/28e48be5b68f11a7a71029b7b7bccf6a3ac26a66/ultralytics/yolo/engine/predictor.py#L124-L127](https://github.com/ultralytics/ultralytics/blob/28e48be5b68f11a7a71029b7b7bccf6a3ac26a66/ultralytics/yolo/engine/predictor.py#L124-L127)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model loading with task specification in Ultralytics YOLO.

### 📊 Key Changes
- Added a new line to set the task override during the model loading process.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** Streamlines the model's ability to recognize the specific task it is being loaded for, ensuring compatibility and expected behavior.
- 💥 **Impact:** Provides clearer model configuration, potentially reducing errors and improving user experience when switching between different tasks (e.g., detection, segmentation, classification). Users can expect a more intuitive interaction when loading pre-trained models for specific tasks.