### PR TITLE
Infer class names by nc

### DIFF
--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -219,8 +219,7 @@ def check_det_dataset(dataset, autodownload=True):
         data['names'] = [f'class_{i}' for i in range(data['nc'])]
     else:
         data['nc'] = len(data['names'])
-        
-        
+
     data['names'] = check_class_names(data['names'])
 
     # Resolve paths

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -220,8 +220,6 @@ def check_det_dataset(dataset, autodownload=True):
         data['names'] = [f'class_{i}' for i in range(data['nc'])]
     else:
         data['nc'] = len(data['names'])
-    import pdb
-    pdb.set_trace()
     data['names'] = check_class_names(data['names'])
 
     # Resolve paths

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -207,12 +207,23 @@ def check_det_dataset(dataset, autodownload=True):
         data = yaml_load(data, append_filename=True)  # dictionary
 
     # Checks
-    for k in 'train', 'val', 'names':
+    for k in 'train', 'val':
         if k not in data:
             raise SyntaxError(
-                emojis(f"{dataset} '{k}:' key missing ❌.\n'train', 'val' and 'names' are required in all data YAMLs."))
+                emojis(f"{dataset} '{k}:' key missing ❌.\n'train', and 'val' are required in all data YAMLs."))
+    if "names" not in data and "nc" not in data:
+        raise SyntaxError(
+                emojis(f"{dataset} : key missing ❌.\n either 'names' or 'nc' is required in all data YAMLs."))
+    if "names" in data and "nc" in data and len(data["names"]) != data["nc"]:
+        raise SyntaxError(
+                emojis(f"{dataset} : 'names' and 'nc' don't match."))
+
+    if "names" not in data:
+        data["names"] = [f"class_{i}" for i in range(data["nc"])]
+    else:
+        data['nc'] = len(data['names'])
+    import pdb;pdb.set_trace()
     data['names'] = check_class_names(data['names'])
-    data['nc'] = len(data['names'])
 
     # Resolve paths
     path = Path(extract_dir or data.get('path') or Path(data.get('yaml_file', '')).parent)  # dataset root

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -211,18 +211,17 @@ def check_det_dataset(dataset, autodownload=True):
         if k not in data:
             raise SyntaxError(
                 emojis(f"{dataset} '{k}:' key missing ❌.\n'train', and 'val' are required in all data YAMLs."))
-    if "names" not in data and "nc" not in data:
-        raise SyntaxError(
-                emojis(f"{dataset} : key missing ❌.\n either 'names' or 'nc' is required in all data YAMLs."))
-    if "names" in data and "nc" in data and len(data["names"]) != data["nc"]:
-        raise SyntaxError(
-                emojis(f"{dataset} : 'names' and 'nc' don't match."))
+    if 'names' not in data and 'nc' not in data:
+        raise SyntaxError(emojis(f"{dataset} : key missing ❌.\n either 'names' or 'nc' is required in all data YAMLs."))
+    if 'names' in data and 'nc' in data and len(data['names']) != data['nc']:
+        raise SyntaxError(emojis(f"{dataset} : 'names' and 'nc' don't match."))
 
-    if "names" not in data:
-        data["names"] = [f"class_{i}" for i in range(data["nc"])]
+    if 'names' not in data:
+        data['names'] = [f'class_{i}' for i in range(data['nc'])]
     else:
         data['nc'] = len(data['names'])
-    import pdb;pdb.set_trace()
+    import pdb
+    pdb.set_trace()
     data['names'] = check_class_names(data['names'])
 
     # Resolve paths

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -210,16 +210,17 @@ def check_det_dataset(dataset, autodownload=True):
     for k in 'train', 'val':
         if k not in data:
             raise SyntaxError(
-                emojis(f"{dataset} '{k}:' key missing ❌.\n'train', and 'val' are required in all data YAMLs."))
+                emojis(f"{dataset} '{k}:' key missing ❌.\n'train' and 'val' are required in all data YAMLs."))
     if 'names' not in data and 'nc' not in data:
-        raise SyntaxError(emojis(f"{dataset} : key missing ❌.\n either 'names' or 'nc' is required in all data YAMLs."))
+        raise SyntaxError(emojis(f"{dataset} key missing ❌.\n either 'names' or 'nc' are required in all data YAMLs."))
     if 'names' in data and 'nc' in data and len(data['names']) != data['nc']:
-        raise SyntaxError(emojis(f"{dataset} : 'names' and 'nc' don't match."))
-
+        raise SyntaxError(emojis(f"{dataset} 'names' length {len(data['names'])} and 'nc: {data['nc']}' must match."))
     if 'names' not in data:
         data['names'] = [f'class_{i}' for i in range(data['nc'])]
     else:
         data['nc'] = len(data['names'])
+        
+        
     data['names'] = check_class_names(data['names'])
 
     # Resolve paths


### PR DESCRIPTION
* if both nc and names  is provided and they don't match throw an error
* If only nc is provided, create class names
* if only names is provided, use that

@glenn-jocher @Laughing-q 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dataset configuration checks for model training in YOLO.

### 📊 Key Changes
- 📝 Added additional dataset configuration validation steps.
- 🔄 Dataset 'names' list and 'nc' (number of classes) checks are more stringent.
- ✨ Automatic generation of class names if 'names' is missing, based on 'nc'.
- 🔧 The 'nc' value is inferred from the length of 'names' if 'nc' is not explicitly provided.

### 🎯 Purpose & Impact
- 🎓 Improves user experience by ensuring dataset configuration correctness and reducing training setup errors.
- 🛠 Helps prevent mismatches between class names and the number of classes, which could lead to model training issues.
- 👁‍🗨 Provides clarity by automatically naming classes or counting them when the user does not, aiding in ease of use and preventing potential confusion.