### PR TITLE
Docker FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,9 +10,9 @@ ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Aria
 
 # Install linux packages
 ENV DEBIAN_FRONTEND noninteractive
-apt update
-TZ=Etc/UTC apt install -y tzdata
-apt install --no-install-recommends -y gcc git zip curl htop libgl1-mesa-glx libglib2.0-0 libpython3-dev gnupg g++
+RUN apt update
+RUN TZ=Etc/UTC apt install -y tzdata
+RUN apt install --no-install-recommends -y gcc git zip curl htop libgl1-mesa-glx libglib2.0-0 libpython3-dev gnupg g++
 # RUN alias python=python3
 
 # Security updates
@@ -44,7 +44,7 @@ ENV DEBIAN_FRONTEND teletype
 # t=ultralytics/ultralytics:latest && sudo docker build -f docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run
-# t=pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
+# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
 
 # Pull and Run with local directory access
 # t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,8 @@
 # Builds ultralytics/ultralytics:latest image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Image is CUDA-optimized for YOLOv8 single/multi-GPU training and inference
 
-# Start FROM NVIDIA PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-# FROM docker.io/pytorch/pytorch:latest
-FROM pytorch/pytorch:latest
+# Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch
+FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
@@ -45,7 +44,8 @@ ENV DEBIAN_FRONTEND teletype
 # t=ultralytics/ultralytics:latest && sudo docker build -f docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run
-# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
+docker pull pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
+# t=pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
 
 # Pull and Run with local directory access
 # t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all -v "$(pwd)"/datasets:/usr/src/datasets $t

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Image is CUDA-optimized for YOLOv8 single/multi-GPU training and inference
 
 # Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch
-FROM pytorch/pytorch:latest
+FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,16 +3,16 @@
 # Image is CUDA-optimized for YOLOv8 single/multi-GPU training and inference
 
 # Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch
-FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
+FROM pytorch/pytorch:latest
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
 
 # Install linux packages
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt update
-RUN TZ=Etc/UTC apt install -y tzdata
-RUN apt install --no-install-recommends -y gcc git zip curl htop libgl1-mesa-glx libglib2.0-0 libpython3-dev gnupg g++
+apt update
+TZ=Etc/UTC apt install -y tzdata
+apt install --no-install-recommends -y gcc git zip curl htop libgl1-mesa-glx libglib2.0-0 libpython3-dev gnupg g++
 # RUN alias python=python3
 
 # Security updates
@@ -44,7 +44,6 @@ ENV DEBIAN_FRONTEND teletype
 # t=ultralytics/ultralytics:latest && sudo docker build -f docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run
-docker pull pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
 # t=pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
 
 # Pull and Run with local directory access


### PR DESCRIPTION
EDIT: Inference profiles slower with this base, hold off for now.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the Ultralytics Dockerfile to use a specific PyTorch image.

### 📊 Key Changes
- Removed the base image that was pulling the latest PyTorch container.
- Specified a new base image `pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime` with fixed versions for CUDA and cuDNN.

### 🎯 Purpose & Impact
- **Consistency**: By pinning the version of the PyTorch image, the environment becomes more predictable and consistent.
- **Compatibility**: Ensures compatibility with CUDA 11.7 and cuDNN 8, helping users avoid potential issues with newer, untested versions.
- **Reliability**: Users can expect the same behavior from the docker container over time, as updates to the base PyTorch image won't affect this Ultralytics image directly. 🚢💪