### PR TITLE
convert name to str

### DIFF
--- a/ultralytics/yolo/v8/detect/predict.py
+++ b/ultralytics/yolo/v8/detect/predict.py
@@ -69,7 +69,7 @@ class DetectionPredictor(BasePredictor):
                 with open(f'{self.txt_path}.txt', 'a') as f:
                     f.write(('%g ' * len(line)).rstrip() % line + '\n')
             if self.args.save or self.args.show:  # Add bbox to image
-                name = ('' if id is None else f'id:{id} ') + self.model.names[c]
+                name = ('' if id is None else f'id:{id} ') + str(self.model.names[c])
                 label = None if self.args.hide_labels else (name if self.args.hide_conf else f'{name} {conf:.2f}')
                 self.annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
             if self.args.save_crop:


### PR DESCRIPTION
fix
  File "C:\Python\Python310\lib\site-packages\ultralytics\yolo\v8\detect\predict.py", line 72, in write_results
    name = ('' if id is None else f'id:{id} ') + self.model.names[c]
TypeError: can only concatenate str (not "int") to str

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced label formatting for object detection outputs in YOLO.

### 📊 Key Changes
- Adjusted object label string conversion to ensure robust text display.
- Modified the way bounding box labels are presented when saving or displaying detection results.

### 🎯 Purpose & Impact
- 🛠️ **Reliability**: This change ensures that object class names are consistently converted to strings, preventing potential type errors that could occur if `self.model.names[c]` is not already a string.
- 👀 **Usability**: Improves the clarity of labels on bounding boxes in saved or displayed images, making it easier for users to recognize and understand detected object classes and their confidence scores (when not hidden).
- ✨ **Experience**: Enhances the user experience by providing clearer visual feedback in the detection output, especially useful for those who utilize the visualization for analysis or presentation purposes.