### PR TITLE
Fix Error when YOLO_CONFIG_DIR is defined.

### DIFF
--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -484,7 +484,7 @@ def get_user_config_dir(sub_dir='Ultralytics'):
     return path
 
 
-USER_CONFIG_DIR = os.getenv('YOLO_CONFIG_DIR', get_user_config_dir())  # Ultralytics settings dir
+USER_CONFIG_DIR = Path(os.getenv('YOLO_CONFIG_DIR', get_user_config_dir()))  # Ultralytics settings dir
 
 
 def emojis(string=''):


### PR DESCRIPTION
Fixed issue #1704 USER_CONFIG_DIR is not a PurePath object and does not support / operation.

I would recommend to add a test for this environment variable as it is apparently not tested at all.

Also, imo, redefining division operator to perform os.path.join task is a bad coding practice which causes more confusion than convenience it brings.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of the user configuration directory handling in Ultralytics software.

### 📊 Key Changes
- The `USER_CONFIG_DIR` variable now explicitly constructs a `Path` object using the `Path()` constructor from Python's `pathlib` module.
- This change replaces the previous string representation of the user’s config directory.

### 🎯 Purpose & Impact
- 🛠️ Enhances compatibility by using `pathlib`, ensuring more reliable path manipulations across different operating systems.
- 🔄 Users can expect more consistent behavior when the software references the config directory, potentially reducing file path errors.