### PR TITLE
Add `antialias=True` for suppress warning

### DIFF
--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -129,7 +129,7 @@ class Results(SimpleClass):
 
         if masks is not None:
             im = torch.as_tensor(annotator.im, dtype=torch.float16, device=masks.data.device).permute(2, 0, 1).flip(0)
-            im = F.resize(im.contiguous(), masks.data.shape[1:]) / 255
+            im = F.resize(im.contiguous(), masks.data.shape[1:], antialias=True) / 255
             annotator.masks(masks.data, colors=[colors(x, True) for x in boxes.cls], im_gpu=im)
 
         if probs is not None:


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->
Add `antialias=True` to F.resize() in `ultralytics/yolo/engine/results.py`  for suppress warning

When I plot the results with `torchvision==0.15.1`
The following warning came out

`
/home/dh/miniconda3/envs/y8/lib/python3.10/site-packages/torchvision/transforms/functional.py:1603: UserWarning: The default value of the antialias parameter of all the resizing transforms (Resize(), RandomResizedCrop(), etc.) will change from None to True in v0.17, in order to be consistent across the PIL and Tensor backends. To suppress this warning, directly pass antialias=True (recommended, future default), antialias=None (current default, which means False for Tensors and True for PIL), or antialias=False (only works on Tensors - PIL will still use antialiasing). This also applies if you are using the inference transforms from the models weights: update the call to weights.transforms(antialias=True).
`


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image resizing quality in YOLO's result visualization.

### 📊 Key Changes
- Added the `antialias` parameter to the `F.resize` function during image resizing for mask rendering.

### 🎯 Purpose & Impact
- **Purpose:** To improve the visual quality of resized images in the context of mask visualization within YOLO's result processing.
- **Impact:** Users should notice smoother and better-quality visualizations of masks on their detection results, leading to a clearer and more accurate representation of object boundaries. This change is particularly beneficial for presentations or when results are used in reports or publications. 🖼✨