### PR TITLE
Fix register_tracker continuously adding callbacks

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -230,8 +230,9 @@ class YOLO:
         return self.predictor.predict_cli(source=source) if is_cli else self.predictor(source=source, stream=stream)
 
     def track(self, source=None, stream=False, **kwargs):
-        from ultralytics.tracker import register_tracker
-        register_tracker(self)
+        if not hasattr(self.predictor, 'trackers'):
+            from ultralytics.tracker import register_tracker
+            register_tracker(self)
         # ByteTrack-based method needs low confidence predictions as input
         conf = kwargs.get('conf') or 0.1
         kwargs['conf'] = conf


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->

Fix register_tracker funcion append callback continously when inferring video by each frame in a loop.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced tracking capability with conditional tracker registration in the YOLO model engine.

### 📊 Key Changes
- Added a condition to check if trackers are already registered with the predictor before registering again.
- Set a default confidence threshold for ByteTrack-based tracking method.

### 🎯 Purpose & Impact
- **Prevents unnecessary re-registration:** Ensures that trackers are only registered if they haven't been already, which can improve efficiency.
- **Improves object tracking:** By specifying a low confidence threshold as default, the tracking algorithm can receive more detections, potentially improving tracking accuracy.
- **User experience:** These changes are under the hood, so users can expect smoother tracking without having to manage the registration process themselves. 🕵️‍♂️✨