### PR TITLE
fix incorrect run command in comment

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -3,16 +3,16 @@
 Run prediction on images, videos, directories, globs, YouTube, webcam, streams, etc.
 
 Usage - sources:
-    $ yolo mode=predict model=yolov8n.pt --source 0                               # webcam
-                                                  img.jpg                         # image
-                                                  vid.mp4                         # video
-                                                  screen                          # screenshot
-                                                  path/                           # directory
-                                                  list.txt                        # list of images
-                                                  list.streams                    # list of streams
-                                                  'path/*.jpg'                    # glob
-                                                  'https://youtu.be/Zgi9g1ksQHc'  # YouTube
-                                                  'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream
+    $ yolo mode=predict model=yolov8n.pt source=0                               # webcam
+                                                img.jpg                         # image
+                                                vid.mp4                         # video
+                                                screen                          # screenshot
+                                                path/                           # directory
+                                                list.txt                        # list of images
+                                                list.streams                    # list of streams
+                                                'path/*.jpg'                    # glob
+                                                'https://youtu.be/Zgi9g1ksQHc'  # YouTube
+                                                'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream
 
 Usage - formats:
     $ yolo mode=predict model=yolov8n.pt                 # PyTorch


### PR DESCRIPTION
I couldn't run `predict` mode when typing `--source` instead of `source=`.

```python
Usage - sources:
    $ yolo mode=predict model=yolov8n.pt --source 0                               # webcam
                                                  img.jpg                         # image
                                                  vid.mp4                         # video
                                                  screen                          # screenshot
                                                  path/                           # directory
                                                  list.txt                        # list of images
                                                  list.streams                    # list of streams
                                                  'path/*.jpg'                    # glob
                                                  'https://youtu.be/Zgi9g1ksQHc'  # YouTube
                                                  'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream
```


<img width="1099" alt="image" src="https://user-images.githubusercontent.com/35001605/228996881-9f5714b3-2898-44dd-91c8-08db3419ed1b.png">

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of command-line argument parsing in YOLO predictor.

### 📊 Key Changes
- Updated the syntax for specifying the source in the prediction command.
- Changed from using `--source` flag to `source=` argument.

### 🎯 Purpose & Impact
- **Purpose:** Improve consistency in command-line arguments, likely aiming for a more uniform user experience.
- **Impact:** Users need to adopt the new syntax for specifying sources when running predictions; however, the change should be straightforward to adapt to. This modification affects all sources, whether it's a webcam, video file, image, or stream. The simplicity in usage may improve overall user satisfaction. 👍🏼