### PR TITLE
Add xy format for segment

### DIFF
--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -280,6 +280,13 @@ class Masks(SimpleClass):
             for x in ops.masks2segments(self.masks)]
 
     @property
+    @lru_cache(maxsize=1)
+    def segments_xy(self):
+        return [
+            np.int32(ops.scale_segments(self.masks.shape[1:], x, self.orig_shape, normalize=False))
+            for x in ops.masks2segments(self.masks)]
+
+    @property
     def shape(self):
         return self.masks.shape
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->
Pull Request for #1726 

I think you should change the name. 😂

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of the segment representation in YOLO results with cached XY coordinates.

### 📊 Key Changes
- A new property method `segments_xy` has been introduced within the `results.py` file.
- The method gets memoized using `lru_cache` to improve performance, with a max size of 1.
- Inside the method, segments are extracted from masks, scaled to the original shape without normalization, and converted to integer 32-bit format.

### 🎯 Purpose & Impact
- **Purpose**: The change aims to provide an additional way to access segment data which is crucial for certain image processing tasks that require segments in their original scale and aspect ratio.
- **Impact**: Users will benefit from faster processing times when repeatedly accessing segment XY coordinates due to the caching mechanism, and those requiring unnormalized segment coordinates will have direct access to this data, potentially improving the integration of YOLO results with other computer vision pipelines. 🏃💨🔍