### PR TITLE
[Docs]: Add predict args with example

### DIFF
--- a/docs/modes/predict.md
+++ b/docs/modes/predict.md
@@ -17,7 +17,7 @@ passing `stream=True` in the predictor's call method.
             probs = result.probs  # Class probabilities for classification outputs
         ```
 
-    === "Return a list with `Stream=True`"
+    === "Return a generator with `Stream=True`"
         ```python
         inputs = [img, img]  # list of numpy arrays
         results = model(inputs, stream=True)  # generator of Results objects
@@ -53,6 +53,40 @@ whether each source can be used in streaming mode with `stream=True` ✅ and an 
 | glob ✅      | `'path/*.jpg'`                             | `str`          | Use `*` operator |
 | YouTube ✅   | `'https://youtu.be/Zgi9g1ksQHc'`           | `str`          |                  |
 | stream ✅    | `'rtsp://example.com/media.mp4'`           | `str`          | RTSP, RTMP, HTTP |
+
+
+## Arguments
+`model.predict` accepts multiple arguments that control the predction operation. These arguments can be passed directly to `model.predict`:
+!!! example
+    ```
+    model.predict(source, save=True, imgsz=320, conf=0.5)
+    ```
+
+All supported arguments:
+
+| Key              | Value                  | Description                                              |
+|------------------|------------------------|----------------------------------------------------------|
+| `source`         | `'ultralytics/assets'` | source directory for images or videos                    |
+| `conf`           | `0.25`                 | object confidence threshold for detection                |
+| `iou`            | `0.7`                  | intersection over union (IoU) threshold for NMS          |
+| `half`           | `False`                | use half precision (FP16)                                |
+| `device`         | `None`                 | device to run on, i.e. cuda device=0/1/2/3 or device=cpu |
+| `show`           | `False`                | show results if possible                                 |
+| `save`           | `False`                | save images with results                                 |
+| `save_txt`       | `False`                | save results as .txt file                                |
+| `save_conf`      | `False`                | save results with confidence scores                      |
+| `save_crop`      | `False`                | save cropped images with results                         |
+| `hide_labels`    | `False`                | hide labels                                              |
+| `hide_conf`      | `False`                | hide confidence scores                                   |
+| `max_det`        | `300`                  | maximum number of detections per image                   |
+| `vid_stride`     | `False`                | video frame-rate stride                                  |
+| `line_thickness` | `3`                    | bounding box thickness (pixels)                          |
+| `visualize`      | `False`                | visualize model features                                 |
+| `augment`        | `False`                | apply image augmentation to prediction sources           |
+| `agnostic_nms`   | `False`                | class-agnostic NMS                                       |
+| `retina_masks`   | `False`                | use high-resolution segmentation masks                   |
+| `classes`        | `None`                 | filter results by class, i.e. class=0, or class=[0,2,3]  |
+| `boxes`          | `True`                 | Show boxes in segmentation predictions                   |
 
 ## Image and Video Formats
 


### PR DESCRIPTION
Fixes https://github.com/ultralytics/ultralytics/issues/1741

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to prediction documentation with detailed arguments info.

### 📊 Key Changes
- Changed the description from "Return a list" to "Return a generator" when `stream=True`.
- Added a detailed "Arguments" section that explains all the possible parameters for `model.predict`.

### 🎯 Purpose & Impact
- **Clarification**: The update in the streaming section prevents confusion, clarifying that the results are a generator, not a list, enhancing understanding of data types returned during streaming predictions.
- **Enhanced Usability**: By adding the arguments section, users now have clear, detailed information on how to configure their predictions, which enables them to fine-tune their usage of the model to their specific needs.
- **Improved Accessibility**: The easy-to-read table format helps users at all levels to quickly find and understand the options available to them, increasing the flexibility and power of the tool for diverse applications.