### PR TITLE
add argparse support

### DIFF
--- a/examples/YOLOv8-OpenCV-ONNX-Python/README.md
+++ b/examples/YOLOv8-OpenCV-ONNX-Python/README.md
@@ -6,7 +6,7 @@ Just simply clone and run
 
 ```bash
 pip install -r requirements.txt
-python main.py
+python main.py --model yolov8n.onnx --img image.jpg
 ```
 
 If you start from scratch:

--- a/examples/YOLOv8-OpenCV-ONNX-Python/main.py
+++ b/examples/YOLOv8-OpenCV-ONNX-Python/main.py
@@ -1,5 +1,6 @@
 import cv2.dnn
 import numpy as np
+import argparse
 
 from ultralytics.yolo.utils import ROOT, yaml_load
 from ultralytics.yolo.utils.checks import check_yaml
@@ -16,9 +17,9 @@ def draw_bounding_box(img, class_id, confidence, x, y, x_plus_w, y_plus_h):
     cv2.putText(img, label, (x - 10, y - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 2)
 
 
-def main():
-    model: cv2.dnn.Net = cv2.dnn.readNetFromONNX('yolov8n.onnx')
-    original_image: np.ndarray = cv2.imread(str(ROOT / 'assets/bus.jpg'))
+def main(onnx_model, input_image):
+    model: cv2.dnn.Net = cv2.dnn.readNetFromONNX(onnx_model)
+    original_image: np.ndarray = cv2.imread(input_image)
     [height, width, _] = original_image.shape
     length = max((height, width))
     image = np.zeros((length, length, 3), np.uint8)
@@ -71,4 +72,8 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model', default='yolov8n.onnx', help="Input your onnx model.")
+    parser.add_argument('--img', default=str(ROOT / 'assets/bus.jpg'), help="Path to input image.")
+    args = parser.parse_args()
+    main(args.model, args.img)

--- a/examples/YOLOv8-OpenCV-ONNX-Python/main.py
+++ b/examples/YOLOv8-OpenCV-ONNX-Python/main.py
@@ -1,6 +1,7 @@
+import argparse
+
 import cv2.dnn
 import numpy as np
-import argparse
 
 from ultralytics.yolo.utils import ROOT, yaml_load
 from ultralytics.yolo.utils.checks import check_yaml
@@ -73,7 +74,7 @@ def main(onnx_model, input_image):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model', default='yolov8n.onnx', help="Input your onnx model.")
-    parser.add_argument('--img', default=str(ROOT / 'assets/bus.jpg'), help="Path to input image.")
+    parser.add_argument('--model', default='yolov8n.onnx', help='Input your onnx model.')
+    parser.add_argument('--img', default=str(ROOT / 'assets/bus.jpg'), help='Path to input image.')
     args = parser.parse_args()
     main(args.model, args.img)


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->
I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced usability of YOLOv8 OpenCV ONNX example with command-line arguments. 🖼️🐍

### 📊 Key Changes
- Added `argparse` to handle command-line arguments for specifying the ONNX model and image file.
- Updated the main function to accept ONNX model and input image as arguments, allowing dynamic input.
- Included the new usage format in the README to reflect how to run the script with custom model and image paths.

### 🎯 Purpose & Impact
- **Flexibility**: Users can now run the script with any ONNX model and image without modifying the code. 🔄
- **Ease of Use**: Simplifies testing different models and images, making the example more user-friendly. 👨‍💻👩‍💻
- **Documentation**: Updated instructions guide users on the new way to use the script, avoiding confusion. 📚