### PR TITLE
fix onnx example code to get same results

### DIFF
--- a/examples/YOLOv8-OpenCV-ONNX-Python/main.py
+++ b/examples/YOLOv8-OpenCV-ONNX-Python/main.py
@@ -27,7 +27,7 @@ def main(onnx_model, input_image):
     image[0:height, 0:width] = original_image
     scale = length / 640
 
-    blob = cv2.dnn.blobFromImage(image, scalefactor=1 / 255, size=(640, 640))
+    blob = cv2.dnn.blobFromImage(image, scalefactor=1 / 255, size=(640, 640), swapRB=True)
     model.setInput(blob)
     outputs = model.forward()
 


### PR DESCRIPTION
I have read the CLA Document and I sign the CLA
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced color handling for YOLOv8 model inference using OpenCV in Python.

### 📊 Key Changes
- Modified the `blobFromImage` function call to include the `swapRB=True` argument.

### 🎯 Purpose & Impact
- 🎨 Ensures accurate color representation by swapping the red and blue channels when processing images.
- 🔍 Improves model inference accuracy since the YOLOv8 model was likely trained on images with the standard RGB format.
- 👁‍🗨 Reduces user confusion by preventing unexpected color-related inference issues, potentially enhancing user satisfaction with Ultralytic's YOLOv8 implementations.