### PR TITLE
Fix callbacks by reference

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -1,9 +1,9 @@
 # Ultralytics YOLO 🚀, GPL-3.0 license
 
 import sys
+from copy import deepcopy
 from pathlib import Path
 from typing import Union
-from copy import deepcopy
 
 from ultralytics import yolo  # noqa
 from ultralytics.nn.tasks import (ClassificationModel, DetectionModel, SegmentationModel, attempt_load_one_weight,

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -75,7 +75,7 @@ class BasePredictor:
         data_path (str): Path to data.
     """
 
-    def __init__(self, cfg=DEFAULT_CFG, overrides=None):
+    def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """
         Initializes the BasePredictor class.
 
@@ -104,7 +104,7 @@ class BasePredictor:
         self.data_path = None
         self.source_type = None
         self.batch = None
-        self.callbacks = defaultdict(list, callbacks.default_callbacks)  # add callbacks
+        self.callbacks = defaultdict(list, _callbacks)
         callbacks.add_integration_callbacks(self)
 
     def preprocess(self, img):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -104,7 +104,7 @@ class BasePredictor:
         self.data_path = None
         self.source_type = None
         self.batch = None
-        self.callbacks = defaultdict(list, _callbacks)
+        self.callbacks = defaultdict(list, _callbacks) if _callbacks else defaultdict(list, callbacks.default_callbacks)
         callbacks.add_integration_callbacks(self)
 
     def preprocess(self, img):


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->

PR for #1781 

`self._reset_callbacks()` => `self.callbacks = deepcopy(callbacks.default_callbacks)`

`self.callbacks = defaultdict(list, callbacks.default_callbacks)` => `self.callbacks = defaultdict(list, _callbacks)`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced callback management in YOLO model engine.

### 📊 Key Changes
- Imported the `deepcopy` method to enable copying callback lists.
- Model class now stores its own copy of callbacks instead of using a static reset method.
- `add_callback` method changed from static to instance method, allowing addition of callbacks to the local copy.
- Modified predictor initialization to accept an optional `_callbacks` parameter, enabling custom callback configurations.

### 🎯 Purpose & Impact
- These changes allow for more flexible and instance-specific callback management. 🎛️
- Users can now customize callbacks for individual model instances, improving the modularity and reusability of code. 🛠️
- The modifications may enhance user experience by providing a more intuitive way to handle events within the YOLO models. 🚀