### PR TITLE
add save_dir to cfg

### DIFF
--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -111,7 +111,7 @@ cfg:  # for overriding defaults.yaml
 # Debug, do not modify -------------------------------------------------------------------------------------------------
 v5loader: False  # use legacy YOLOv5 dataloader
 
-save_dir: 
+save_dir:
 
 # Tracker settings ------------------------------------------------------------------------------------------------------
 tracker: botsort.yaml  # tracker type, ['botsort.yaml', 'bytetrack.yaml']

--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -111,5 +111,7 @@ cfg:  # for overriding defaults.yaml
 # Debug, do not modify -------------------------------------------------------------------------------------------------
 v5loader: False  # use legacy YOLOv5 dataloader
 
+save_dir: 
+
 # Tracker settings ------------------------------------------------------------------------------------------------------
 tracker: botsort.yaml  # tracker type, ['botsort.yaml', 'bytetrack.yaml']


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of configuration options for YOLO with the addition of a save directory setting.

### 📊 Key Changes
- Added a new `save_dir` field to the default configuration file for YOLO models.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: To allow users to specify a directory where output files should be saved, increasing the flexibility of file management in model training and usage.
- 🔁 **Impact**: Users now have more control over where their data gets stored, potentially improving their workflow and data organization. It might require minor adjustments in how users set up their training scripts or automation pipelines.