### PR TITLE
HUB train from `YOLO(APIKEY_MODELID)` support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   HUB:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -72,6 +72,35 @@ jobs:
           key, model_id = key.split('_')
           hub.login(key)
           model = YOLO('https://hub.ultralytics.com/models/' + model_id)
+          model.train()
+      - name: Test HUB training (Python Usage 3)
+        shell: python
+        env:
+          APIKEY: ${{ secrets.ULTRALYTICS_HUB_APIKEY }}
+        run: |
+          import os
+          from pathlib import Path
+          from ultralytics import YOLO, hub
+          from ultralytics.yolo.utils import USER_CONFIG_DIR
+          Path(USER_CONFIG_DIR / 'settings.yaml').unlink()
+          key = os.environ['APIKEY']
+          model = YOLO(key)
+          model.train()
+      - name: Test HUB training (Python Usage 4)
+        shell: python
+        env:
+          APIKEY: ${{ secrets.ULTRALYTICS_HUB_APIKEY }}
+        run: |
+          import os
+          from pathlib import Path
+          from ultralytics import YOLO, hub
+          from ultralytics.yolo.utils import USER_CONFIG_DIR
+          Path(USER_CONFIG_DIR / 'settings.yaml').unlink()
+          key = os.environ['APIKEY']
+          hub.reset_model(key)
+          key, model_id = key.split('_')
+          hub.login(key)
+          model = YOLO(model_id)
           model.train()
 
   Benchmarks:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,7 @@ jobs:
           from ultralytics.yolo.utils import USER_CONFIG_DIR
           Path(USER_CONFIG_DIR / 'settings.yaml').unlink()
           key = os.environ['APIKEY']
+          hub.reset_model(key)
           model = YOLO(key)
           model.train()
       - name: Test HUB training (Python Usage 4)

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -114,9 +114,10 @@ class YOLO:
 
     @staticmethod
     def is_hub_model(model):
-        return any((model.startswith('https://hub.ultralytics.com/models/'),
-                    [len(x) for x in model.split('_')] == [42, 20],  # APIKEY_MODELID
-                    (len(model) == 20 and not Path(model).exists() and not any(x in model for x in './\\'))))  # MODELID
+        return any((
+            model.startswith('https://hub.ultralytics.com/models/'),
+            [len(x) for x in model.split('_')] == [42, 20],  # APIKEY_MODELID
+            (len(model) == 20 and not Path(model).exists() and not any(x in model for x in './\\'))))  # MODELID
 
     def _new(self, cfg: str, task=None, verbose=True):
         """

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -91,7 +91,7 @@ class YOLO:
         model = str(model).strip()  # strip spaces
 
         # Check if Ultralytics HUB model from https://hub.ultralytics.com
-        if model.startswith('https://hub.ultralytics.com/models/'):
+        if model.startswith('https://hub.ultralytics.com/models/') or [len(x) for x in model.split('_')] == [42, 20]:
             from ultralytics.hub.session import HUBTrainingSession
             self.session = HUBTrainingSession(model)
             model = self.session.model_file

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -91,7 +91,7 @@ class YOLO:
         model = str(model).strip()  # strip spaces
 
         # Check if Ultralytics HUB model from https://hub.ultralytics.com
-        if model.startswith('https://hub.ultralytics.com/models/') or [len(x) for x in model.split('_')] == [42, 20]:
+        if self.is_hub_model(model):
             from ultralytics.hub.session import HUBTrainingSession
             self.session = HUBTrainingSession(model)
             model = self.session.model_file
@@ -111,6 +111,12 @@ class YOLO:
     def __getattr__(self, attr):
         name = self.__class__.__name__
         raise AttributeError(f"'{name}' object has no attribute '{attr}'. See valid attributes below.\n{self.__doc__}")
+
+    @staticmethod
+    def is_hub_model(model):
+        return any((model.startswith('https://hub.ultralytics.com/models/'),
+                    [len(x) for x in model.split('_')] == [42, 20],  # APIKEY_MODELID
+                    (len(model) == 20 and not Path(model).exists() and not any(x in model for x in './\\'))))  # MODELID
 
     def _new(self, cfg: str, task=None, verbose=True):
         """


### PR DESCRIPTION
@kalenmike attempts to add support for two additional usages: `model=YOLO(APIKEY_MODELID)` or simply `model=YOLO(MODELID)` with on-demand authentication if not already authenticated.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to Ultralytics HUB Integration & CI Testing Workflow

### 📊 Key Changes
- Temporarily commented out a conditional in the CI workflow that restricts actions to certain events.
- Added new CI test cases for HUB training using different Python usage scenarios.
- Introduced `is_hub_model` static method in `model.py` to check if a model originates from Ultralytics HUB.

### 🎯 Purpose & Impact
- **Purpose**: 
  - To expand automated testing for different HUB API use cases during continuous integration.
  - Improve code maintainability by encapsulating HUB model URL and ID checks in a single method.
- **Impact**: 
  - Ensures that new changes do not break model training via the API.
  - Simplifies the process of verifying whether a model string refers to a HUB model, enhancing code readability and reducing the likelihood of errors related to model source identification.