### PR TITLE
Fix issue where settings yaml can be `None` in yolo/utils

### DIFF
--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -624,7 +624,7 @@ def get_settings(file=USER_CONFIG_DIR / 'settings.yaml', version='0.0.3'):
 
         # Check that settings keys and types match defaults
         correct = \
-            settings    
+            settings
             and settings.keys() == defaults.keys() \
             and all(type(a) == type(b) for a, b in zip(settings.values(), defaults.values())) \
             and check_version(settings['settings_version'], version)

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -624,7 +624,7 @@ def get_settings(file=USER_CONFIG_DIR / 'settings.yaml', version='0.0.3'):
 
         # Check that settings keys and types match defaults
         correct = \
-            settings
+            settings \
             and settings.keys() == defaults.keys() \
             and all(type(a) == type(b) for a, b in zip(settings.values(), defaults.values())) \
             and check_version(settings['settings_version'], version)

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -624,7 +624,8 @@ def get_settings(file=USER_CONFIG_DIR / 'settings.yaml', version='0.0.3'):
 
         # Check that settings keys and types match defaults
         correct = \
-            settings.keys() == defaults.keys() \
+            settings    
+            and settings.keys() == defaults.keys() \
             and all(type(a) == type(b) for a, b in zip(settings.values(), defaults.values())) \
             and check_version(settings['settings_version'], version)
         if not correct:


### PR DESCRIPTION
The issue happens when running ultralytics in multiprocessing scheme, for some reason, the other processes crash in that line.

This will also fix any possible issues with the file not being parsed correctly


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced robustness for settings configuration in YOLO utility functions.

### 📊 Key Changes
- Added a check to ensure `settings` is not None before comparing keys and types with defaults.
- Improved the settings initialization process to prevent potential errors when `settings` is `None`.

### 🎯 Purpose & Impact
- **Purpose**: Prevents crashes and unexpected behavior due to missing or improperly initialized settings when using YOLO utilities.
- **Impact**: Increases stability and reliability for users integrating YOLO utility functions into their projects by handling edge cases more gracefully. 🛠️🔍