### PR TITLE
Generalize is_cli for track

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -220,8 +220,7 @@ class YOLO:
         if source is None:
             source = ROOT / 'assets' if is_git_dir() else 'https://ultralytics.com/images/bus.jpg'
             LOGGER.warning(f"WARNING ⚠️ 'source' is missing. Using 'source={source}'.")
-        is_cli = (sys.argv[0].endswith('yolo') or sys.argv[0].endswith('ultralytics')) and \
-                 ('predict' in sys.argv or 'mode=predict' in sys.argv)
+        is_cli = sys.argv[0].endswith('yolo') or sys.argv[0].endswith('ultralytics')
 
         overrides = self.overrides.copy()
         overrides['conf'] = 0.25


### PR DESCRIPTION
As @Laughing-q pointed 
"""
this condition would not set stream=True when users are using yolo track since there's no predict in it. And users might encounter OOM with tracking.
https://github.com/ultralytics/ultralytics/blob/4198570a4ba98351107527142d85125eb8d0039f/ultralytics/yolo/engine/model.py#L223-L224
[model.py](https://github.com/ultralytics/ultralytics/blob/4198570a4ba98351107527142d85125eb8d0039f/ultralytics/yolo/engine/model.py)
"""
@glenn-jocher @Laughing-q 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved command line detection logic for the YOLO model prediction method.

### 📊 Key Changes
- Simplified the check to determine if the code is being run from the command line interface (CLI).

### 🎯 Purpose & Impact
- The purpose of this change is to make the detection of CLI usage more straightforward and maintainable.
- This change potentially makes it easier for users to run YOLO model predictions without having to specify prediction modes, enhancing user experience.
- There should be no negative impact on users as the functionality remains the same, but the underlying code is cleaner and more efficient. 🧹✨