### PR TITLE
fix is_cli for train amp check

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -228,7 +228,8 @@ class YOLO:
         if source is None:
             source = ROOT / 'assets' if is_git_dir() else 'https://ultralytics.com/images/bus.jpg'
             LOGGER.warning(f"WARNING ⚠️ 'source' is missing. Using 'source={source}'.")
-        is_cli = (sys.argv[0].endswith('yolo') or sys.argv[0].endswith('ultralytics')) and (('predict' in sys.argv or 'mode=predict' in sys.argv) or ('track' in sys.argv or 'mode=track' in sys.argv))
+        is_cli = (sys.argv[0].endswith('yolo') or sys.argv[0].endswith('ultralytics')) and (
+            ('predict' in sys.argv or 'mode=predict' in sys.argv) or ('track' in sys.argv or 'mode=track' in sys.argv))
         overrides = self.overrides.copy()
         overrides['conf'] = 0.25
         overrides.update(kwargs)  # prefer kwargs

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -228,8 +228,7 @@ class YOLO:
         if source is None:
             source = ROOT / 'assets' if is_git_dir() else 'https://ultralytics.com/images/bus.jpg'
             LOGGER.warning(f"WARNING ⚠️ 'source' is missing. Using 'source={source}'.")
-        is_cli = sys.argv[0].endswith('yolo') or sys.argv[0].endswith('ultralytics')
-
+        is_cli = (sys.argv[0].endswith('yolo') or sys.argv[0].endswith('ultralytics')) and (('predict' in sys.argv or 'mode=predict' in sys.argv) or ('track' in sys.argv or 'mode=track' in sys.argv))
         overrides = self.overrides.copy()
         overrides['conf'] = 0.25
         overrides.update(kwargs)  # prefer kwargs


### PR DESCRIPTION
@Laughing-q not sure if this works. Haven't tested it @glenn-jocher 

Fixes https://github.com/ultralytics/ultralytics/issues/1831

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced command-line detection for YOLO model predict/track modes.

### 📊 Key Changes
- Altered the logic that determines whether the script is being run from the command line (CLI) within the YOLO model's `predict` method.
- Previously relied on script name ending checks, now also includes validation for `predict` and `track` arguments being present in the `sys.argv`.

### 🎯 Purpose & Impact
- Ensures that certain settings and defaults are only applied when the model is used from the CLI specifically for prediction or tracking, avoiding unintended behavior when used in other contexts.
- Improves user experience for CLI users by providing more precise control over the model's operation mode.
- Minimizes the potential for errors or confusion when the model is being invoked from various interfaces or scripts. 🛠️✨