### PR TITLE
Fix docs command in yolo pose

### DIFF
--- a/docs/tasks/pose.md
+++ b/docs/tasks/pose.md
@@ -62,13 +62,13 @@ Train a YOLOv8-pose model on the COCO128-pose dataset.
     
         ```bash
         # Build a new model from YAML and start training from scratch
-        yolo detect train data=coco128-pose.yaml model=yolov8n-pose.yaml epochs=100 imgsz=640
+        yolo pose train data=coco128-pose.yaml model=yolov8n-pose.yaml epochs=100 imgsz=640
 
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco128-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
+        yolo pose train data=coco128-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
 
         # Build a new model from YAML, transfer pretrained weights to it and start training
-        yolo detect train data=coco128-pose.yaml model=yolov8n-pose.yaml pretrained=yolov8n-pose.pt epochs=100 imgsz=640
+        yolo pose train data=coco128-pose.yaml model=yolov8n-pose.yaml pretrained=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 ## Val


### PR DESCRIPTION
Just a small fix in the new yolo pose documentation (cli commands)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated command instructions for training pose estimation models.

### 📊 Key Changes
- Modified training command syntax from `yolo detect train` to `yolo pose train`.
- Documentation changes occur in three different training command examples.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** Streamlines and clarifies the training process specifically for pose estimation models.
- 💥 **Impact:** Users now have a dedicated command for training pose estimation, improving usability and reducing potential confusion between detection and pose estimation commands.