### PR TITLE
Fix: handle label free batches

### DIFF
--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -221,6 +221,8 @@ class YOLODataset(BaseDataset):
         for i in range(len(new_batch['batch_idx'])):
             new_batch['batch_idx'][i] += i  # add target image index for build_targets()
         new_batch['batch_idx'] = torch.cat(new_batch['batch_idx'], 0)
+        if len(new_batch['batch_idx']) == 0:
+            return None
         return new_batch
 
 

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -299,6 +299,8 @@ class BaseTrainer:
             self.tloss = None
             self.optimizer.zero_grad()
             for i, batch in pbar:
+                if batch is None:
+                    continue
                 self.run_callbacks('on_train_batch_start')
                 # Warmup
                 ni = i + nb * epoch


### PR DESCRIPTION
One of the issue occurs during multi gpu training is the possibility of having a batch without any labels (i.e., all images in a batch are background image). I am proposing a change in the collate function to return None for a label free batch and then skip the batch in the training loop.

I have read the CLA Document and I sign the CLA



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in data handling during model training.

### 📊 Key Changes
- Added a check to skip empty batches in the dataset collate function.
- Ensured the training loop ignores None-type batches to avoid errors.

### 🎯 Purpose & Impact
- 🛠️ **Prevents crashes**: By handling cases where batches are empty, this reduces the risk of training interruptions.
- 🏃‍♂️ **Maintains training flow**: Skipping None batches helps in maintaining a smooth and uninterrupted training process.
- 🔧 **Improved robustness**: These changes make the training pipeline more stable and resilient to diverse dataset conditions.