### PR TITLE
Wrong corrupt labels count

### DIFF
--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -77,7 +77,6 @@ class YOLODataset(BaseDataset):
         nm, nf, ne, nc, msgs = 0, 0, 0, 0, []  # number missing, found, empty, corrupt, messages
         desc = f'{self.prefix}Scanning {path.parent / path.stem}...'
         total = len(self.im_files)
-        nc = len(self.data['names'])
         nkpt, ndim = self.data.get('kpt_shape', (0, 0))
         if self.use_keypoints and (nkpt <= 0 or ndim not in (2, 3)):
             raise ValueError("'kpt_shape' in data.yaml missing or incorrect. Should be a list with [number of "


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->
Corrupt labels count was initialized with classes count (introduced in 1cb92d7f42a3725a0114dd60df12c059c495c5eb)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved dataset label handling for YOLO models.

### 📊 Key Changes
- Removed an unnecessary variable assignment that counted category names in the dataset.

### 🎯 Purpose & Impact
- 🚀 **Purpose:** Streamlines the dataset loading process by eliminating redundant information tracking, potentially reducing memory usage and improving performance.
- ✅ **Impact:** Users should expect a more efficient label caching process when training YOLO models.