### PR TITLE
Fix exporter.py to support new coreml format (`.mlpackage`)

### DIFF
--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -81,7 +81,7 @@ def export_formats():
         ['ONNX', 'onnx', '.onnx', True, True],
         ['OpenVINO', 'openvino', '_openvino_model', True, False],
         ['TensorRT', 'engine', '.engine', False, True],
-        ['CoreML', 'coreml', '.mlmodel', True, False],
+        ['CoreML', 'coreml', '.mlmodel or .mlpackage', True, False],
         ['TensorFlow SavedModel', 'saved_model', '_saved_model', True, True],
         ['TensorFlow GraphDef', 'pb', '.pb', True, True],
         ['TensorFlow Lite', 'tflite', '.tflite', True, False],
@@ -407,9 +407,11 @@ class Exporter:
         scale = 1 / 255
         classifier_config = None
         if self.model.task == 'classify':
+            f = self.file.with_suffix('.mlpackage')
             classifier_config = ct.ClassifierConfig(list(self.model.names.values())) if self.args.nms else None
             model = self.model
         elif self.model.task == 'detect':
+            f = self.file.with_suffix('.mlpackage')
             model = iOSDetectModel(self.model, self.im) if self.args.nms else self.model
         else:
             # TODO CoreML Segment and Pose model pipelining


### PR DESCRIPTION
NOTE: This PR replaced by https://github.com/ultralytics/ultralytics/pull/4043

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.
-->

While I was trying to run the yolov8 model in my https://github.com/tucan9389/ObjectDetection-CoreML, I encountered that there is a new model format(`.mlpackage`) under some conditions. I didn't search it deeply, but this can convert the `yolov8n.pt` model into `detect` task's `yolov8n.mlpackage` CoreML model (containing postprocessing layers) successfully.

### Conversion script

```python
# mian.py
from ultralytics import YOLO

if __name__ == '__main__':
    model = YOLO("yolov8n.pt", task='detect')  # load a pretrained model
    model.overrides['nms'] = True
    success = model.export(format="coreml")  # export the model to CoreML format
```

```txt
# requirements.txt
/MY/LOCAL/PATH/ultralytics
coremltools
```

### Running command in shell

```shell
pip install -r requirements.txt
python main.py
```

### Encountered error message in coremltools conversion

```
Traceback (most recent call last):
  File "/Users/tucan9389/projects/ondeviceml-repos/yolov8_coreml_exporter/main.py", line 6, in <module>
    success = model.export(format="coreml")  # export the model to CoreML format
  File "/Users/tucan9389/opt/anaconda3/envs/yolov8-coreml/lib/python3.9/site-packages/ultralytics/yolo/engine/model.py", line 319, in export
    return Exporter(overrides=args, _callbacks=self.callbacks)(model=self.model)
  File "/Users/tucan9389/opt/anaconda3/envs/yolov8-coreml/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/Users/tucan9389/opt/anaconda3/envs/yolov8-coreml/lib/python3.9/site-packages/ultralytics/yolo/engine/exporter.py", line 240, in __call__
    f[4], _ = self._export_coreml()
  File "/Users/tucan9389/opt/anaconda3/envs/yolov8-coreml/lib/python3.9/site-packages/ultralytics/yolo/engine/exporter.py", line 436, in _export_coreml
    ct_model.save(str(f))
  File "/Users/tucan9389/opt/anaconda3/envs/yolov8-coreml/lib/python3.9/site-packages/coremltools/models/model.py", line 459, in save
    raise Exception("For an ML Program, extension must be {} (not {})".format(_MLPACKAGE_EXTENSION, ext))
Exception: For an ML Program, extension must be .mlpackage (not .mlmodel)
```

With this changes, we can get the runnable CoreML model(`.mlpackage`) in Xcode and my iOS repo:

<img width="944" alt="Screenshot 2023-04-08 at 7 03 12 AM" src="https://user-images.githubusercontent.com/37643248/230684449-8082d9e0-3a2f-4b90-9f71-81a6ee84ac61.png">

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced CoreML export support with new '.mlpackage' format in Ultralytics YOLO.

### 📊 Key Changes
- Updated the CoreML format export option to support '.mlmlodel or .mlpackage' extensions.
- Included the option to save CoreML models as '.mlpackage' for classification or detection tasks.

### 🎯 Purpose & Impact
- 💡 **Purpose**: To improve the flexibility of model exporting for CoreML users, allowing for a choice between '.mlmodel' and the newer '.mlpackage' format.
- 🛠️ **Impact**: Users can now export their models in a newer CoreML format, potentially benefiting from better integration and features in macOS and iOS applications. This update may also simplify the deployment process for models on Apple platforms.