### PR TITLE
fix pil plot

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -205,6 +205,14 @@ def test_predict_callback_and_setup():
 
 
 def test_result():
+    model = YOLO('yolov8n-pose.pt')
+    res = model([SOURCE, SOURCE])
+    res[0].plot(show_conf=False)  # raises warning
+    res[0].plot(conf=True, boxes=False)
+    res[0].plot(pil=True)
+    res[0] = res[0].cpu().numpy()
+    print(res[0].path, res[0].keypoints)
+
     model = YOLO('yolov8n-seg.pt')
     res = model([SOURCE, SOURCE])
     res[0].plot(show_conf=False)  # raises warning
@@ -212,12 +220,18 @@ def test_result():
     res[0].plot(pil=True)
     res[0] = res[0].cpu().numpy()
     print(res[0].path, res[0].masks.masks)
+
     model = YOLO('yolov8n.pt')
     res = model(SOURCE)
+    res[0].plot(pil=True)
     res[0].plot()
+    res[0] = res[0].cpu().numpy()
     print(res[0].path)
 
     model = YOLO('yolov8n-cls.pt')
     res = model(SOURCE)
     res[0].plot(probs=False)
+    res[0].plot(pil=True)
+    res[0].plot()
+    res[0] = res[0].cpu().numpy()
     print(res[0].path)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -209,6 +209,7 @@ def test_result():
     res = model([SOURCE, SOURCE])
     res[0].plot(show_conf=False)  # raises warning
     res[0].plot(conf=True, boxes=False, masks=True)
+    res[0].plot(pil=True)
     res[0] = res[0].cpu().numpy()
     print(res[0].path, res[0].masks.masks)
     model = YOLO('yolov8n.pt')

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -203,7 +203,7 @@ class Results(SimpleClass):
         keypoints = self.keypoints
         if pred_masks and show_masks:
             if img_gpu is None:
-                img = LetterBox(pred_masks.shape[1:])(image=annotator.im)
+                img = LetterBox(pred_masks.shape[1:])(image=annotator.result())
                 img_gpu = torch.as_tensor(img, dtype=torch.float16, device=pred_masks.masks.device).permute(
                     2, 0, 1).flip(0).contiguous() / 255
             annotator.masks(pred_masks.data, colors=[colors(x, True) for x in pred_boxes.cls], im_gpu=img_gpu)


### PR DESCRIPTION
@glenn-jocher 
`annotator.im` is PIL.Image type when `pil=True` hence letterbox would not work as expected. using `annotator.result()` solved it. 
Also I added a `result.plot(pil=True)` in our test_python.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to plotting methods in YOLO models testing for different prediction types.

### 📊 Key Changes
- Added plotting capabilities for a new model with pose estimation (`yolov8n-pose.pt`).
- Introduced options to disable displaying confidence scores, to show results without bounding boxes, and to use PIL for plotting.
- Enhanced visualizations for different YOLO model outputs, including segmentation (`yolov8n-seg.pt`), classification (`yolov8n-cls.pt`), and default detections.
- Code now converts PyTorch tensors to NumPy arrays for the results to facilitate further processing or analysis.

### 🎯 Purpose & Impact
- **Enhanced Debugging and Visualization**: These changes introduce better visualization tools for different YOLO model predictions, helping developers and users better understand and debug the model's performance.
- **Flexibility**: Users can now visualize predictions with or without certain elements (like confidence scores or bounding boxes), which provides flexibility depending on the end-use case.
- **Integration**: The use of both PyTorch and PIL (Python Imaging Library) for visual representations means easier integration with other Python-based data analysis and visualization workflows.
- **Potential User Impact**: Users will have an improved experience analyzing model predictions, potentially leading to innovation in how results are processed and shared.

🖼️👀🔍🚀