### PR TITLE
Fix image cache always reporting corrupt images

### DIFF
--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -77,7 +77,6 @@ class YOLODataset(BaseDataset):
         nm, nf, ne, nc, msgs = 0, 0, 0, 0, []  # number missing, found, empty, corrupt, messages
         desc = f'{self.prefix}Scanning {path.parent / path.stem}...'
         total = len(self.im_files)
-        nc = len(self.data['names'])
         nkpt, ndim = self.data.get('kpt_shape', (0, 0))
         if self.use_keypoints and (nkpt <= 0 or ndim not in (2, 3)):
             raise ValueError("'kpt_shape' in data.yaml missing or incorrect. Should be a list with [number of "


### PR DESCRIPTION
According to the comment in line 77, `nc` refers to the number of corrupt images and it is used this way in the loop below. However it is initialized with `nc = len(self.data['names'])` as if nc referred to the number of classes.

This means that yolo always reported several images as corrupt no matter what.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data label caching in YOLO dataset.

### 📊 Key Changes
- Removed unnecessary calculation of the number of classes (`nc`) during label caching.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Simplifies the code by removing a redundant variable assignment, as `nc` is not used afterward.
- 🎈 **Impact**: User experience remains largely unchanged, but the code is cleaner and slightly more efficient, potentially reducing memory overhead.