### PR TITLE
Add more informative dataset not found error message

### DIFF
--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -17,7 +17,8 @@ from PIL import ExifTags, Image, ImageOps
 from tqdm import tqdm
 
 from ultralytics.nn.autobackend import check_class_names
-from ultralytics.yolo.utils import DATASETS_DIR, LOGGER, NUM_THREADS, ROOT, USER_CONFIG_DIR, colorstr, emojis, yaml_load
+from ultralytics.yolo.utils import (DATASETS_DIR, LOGGER, NUM_THREADS, ROOT, SETTINGS_YAML, clean_url, colorstr, emojis,
+                                    yaml_load)
 from ultralytics.yolo.utils.checks import check_file, check_font, is_ascii
 from ultralytics.yolo.utils.downloads import download, safe_download, unzip_file
 from ultralytics.yolo.utils.ops import segments2boxes
@@ -241,13 +242,12 @@ def check_det_dataset(dataset, autodownload=True):
     if val:
         val = [Path(x).resolve() for x in (val if isinstance(val, list) else [val])]  # val path
         if not all(x.exists() for x in val):
-            # name = clean_url(dataset)  # dataset name with URL auth stripped
-            # m = f"\nDataset '{name}' images not found ⚠️, missing paths %s" % [str(x) for x in val if not x.exists()]
-            m = f"\nDataset '{dataset}' images not found ⚠️, missing paths %s Please, check: {USER_CONFIG_DIR}/settings.yaml" % [
-                str(x) for x in val if not x.exists()]
+            name = clean_url(dataset)  # dataset name with URL auth stripped
+            m = f"\nDataset '{name}' images not found ⚠️, missing paths %s" % [str(x) for x in val if not x.exists()]
             if s and autodownload:
                 LOGGER.warning(m)
             else:
+                m += f"\nNote dataset download directory is '{DATASETS_DIR}'. You can update this in '{SETTINGS_YAML}'"
                 raise FileNotFoundError(m)
             t = time.time()
             if s.startswith('http') and s.endswith('.zip'):  # URL

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -17,7 +17,7 @@ from PIL import ExifTags, Image, ImageOps
 from tqdm import tqdm
 
 from ultralytics.nn.autobackend import check_class_names
-from ultralytics.yolo.utils import DATASETS_DIR, LOGGER, NUM_THREADS, ROOT, clean_url, colorstr, emojis, yaml_load
+from ultralytics.yolo.utils import DATASETS_DIR, LOGGER, NUM_THREADS, ROOT, USER_CONFIG_DIR , colorstr, emojis, yaml_load
 from ultralytics.yolo.utils.checks import check_file, check_font, is_ascii
 from ultralytics.yolo.utils.downloads import download, safe_download, unzip_file
 from ultralytics.yolo.utils.ops import segments2boxes
@@ -241,8 +241,9 @@ def check_det_dataset(dataset, autodownload=True):
     if val:
         val = [Path(x).resolve() for x in (val if isinstance(val, list) else [val])]  # val path
         if not all(x.exists() for x in val):
-            name = clean_url(dataset)  # dataset name with URL auth stripped
-            m = f"\nDataset '{name}' images not found ⚠️, missing paths %s" % [str(x) for x in val if not x.exists()]
+            # name = clean_url(dataset)  # dataset name with URL auth stripped
+            # m = f"\nDataset '{name}' images not found ⚠️, missing paths %s" % [str(x) for x in val if not x.exists()]
+            m = f"\nDataset '{dataset}' images not found ⚠️, missing paths %s Please, check: {USER_CONFIG_DIR}/settings.yaml" % [str(x) for x in val if not x.exists()]
             if s and autodownload:
                 LOGGER.warning(m)
             else:

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -17,7 +17,7 @@ from PIL import ExifTags, Image, ImageOps
 from tqdm import tqdm
 
 from ultralytics.nn.autobackend import check_class_names
-from ultralytics.yolo.utils import DATASETS_DIR, LOGGER, NUM_THREADS, ROOT, USER_CONFIG_DIR , colorstr, emojis, yaml_load
+from ultralytics.yolo.utils import DATASETS_DIR, LOGGER, NUM_THREADS, ROOT, USER_CONFIG_DIR, colorstr, emojis, yaml_load
 from ultralytics.yolo.utils.checks import check_file, check_font, is_ascii
 from ultralytics.yolo.utils.downloads import download, safe_download, unzip_file
 from ultralytics.yolo.utils.ops import segments2boxes
@@ -243,7 +243,8 @@ def check_det_dataset(dataset, autodownload=True):
         if not all(x.exists() for x in val):
             # name = clean_url(dataset)  # dataset name with URL auth stripped
             # m = f"\nDataset '{name}' images not found ⚠️, missing paths %s" % [str(x) for x in val if not x.exists()]
-            m = f"\nDataset '{dataset}' images not found ⚠️, missing paths %s Please, check: {USER_CONFIG_DIR}/settings.yaml" % [str(x) for x in val if not x.exists()]
+            m = f"\nDataset '{dataset}' images not found ⚠️, missing paths %s Please, check: {USER_CONFIG_DIR}/settings.yaml" % [
+                str(x) for x in val if not x.exists()]
             if s and autodownload:
                 LOGGER.warning(m)
             else:

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -490,6 +490,7 @@ def get_user_config_dir(sub_dir='Ultralytics'):
 
 
 USER_CONFIG_DIR = Path(os.getenv('YOLO_CONFIG_DIR', get_user_config_dir()))  # Ultralytics settings dir
+SETTINGS_YAML = USER_CONFIG_DIR / 'settings.yaml'
 
 
 def emojis(string=''):
@@ -591,7 +592,7 @@ def set_sentry():
             logging.getLogger(logger).setLevel(logging.CRITICAL)
 
 
-def get_settings(file=USER_CONFIG_DIR / 'settings.yaml', version='0.0.3'):
+def get_settings(file=SETTINGS_YAML, version='0.0.3'):
     """
     Loads a global Ultralytics settings YAML file or creates one with default values if it does not exist.
 
@@ -640,7 +641,7 @@ def get_settings(file=USER_CONFIG_DIR / 'settings.yaml', version='0.0.3'):
         return settings
 
 
-def set_settings(kwargs, file=USER_CONFIG_DIR / 'settings.yaml'):
+def set_settings(kwargs, file=SETTINGS_YAML):
     """
     Function that runs on a first-time ultralytics package installation to set up global settings and create necessary
     directories.


### PR DESCRIPTION
Github ultralytics/ultralytics ultralytics #1881
Can't change the default dir where YOLOV8 downloads example datasets
- "USER_CONFIG_DIR" is imported from ultralytics.yolo.utils
- A message to the user is added: "Please, check: {USER_CONFIG_DIR}/settings.yaml"
to allow quick troubleshooting of the issue
Deleted "name variable," which is not used in 
the function: "check_det_dataset()"
Deleted "clean_url" which is not used in shit module. I have read the CLA Document, and I sign the CLA

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c24c89f</samp>

### Summary
📥💬🛠️

<!--
1.  📥 - This emoji can be used to indicate the import of a variable or a module, as well as the download of a dataset. It suggests the idea of bringing something in from an external source.
2.  💬 - This emoji can be used to indicate the addition of a message or a comment to a function or a script. It suggests the idea of communicating something to the user or the developer.
3.  🛠️ - This emoji can be used to indicate the refactoring or improvement of a code module or a function. It suggests the idea of fixing or enhancing something that already exists.
-->
Refactored the `ultralytics.yolo.utils` module to use a variable for the global settings YAML file path and imported it in `ultralytics/yolo/data/utils.py` to improve user experience and customization of dataset download location.

> _Sing, O Muse, of the skillful coder who refactored_
> _The `utils` module of the `yolo` package, and made it more ordered_
> _By using a variable for the `SETTINGS_YAML` path_
> _That guides the users to download the dataset with less wrath_

### Walkthrough
*  Import and use `SETTINGS_YAML` variable to access global settings YAML file in `check_det_dataset` function ([link](https://github.com/ultralytics/ultralytics/pull/1936/files?diff=unified&w=0#diff-15f6dd1ea95b187a5b50c885f567bad50d006f1af1180508497a038247e9df58L20-R21), [link](https://github.com/ultralytics/ultralytics/pull/1936/files?diff=unified&w=0#diff-15f6dd1ea95b187a5b50c885f567bad50d006f1af1180508497a038247e9df58R250))
* Define `SETTINGS_YAML` variable in `ultralytics.yolo.utils` module to store the default path to global settings YAML file ([link](https://github.com/ultralytics/ultralytics/pull/1936/files?diff=unified&w=0#diff-4a5fdbc973a408779ed550a87d5b6bd0d01693002dcc225876d7fb8a3c6d3137R493))
* Replace hardcoded paths with `SETTINGS_YAML` variable in `get_settings` and `set_settings` functions ([link](https://github.com/ultralytics/ultralytics/pull/1936/files?diff=unified&w=0#diff-4a5fdbc973a408779ed550a87d5b6bd0d01693002dcc225876d7fb8a3c6d3137L594-R595), [link](https://github.com/ultralytics/ultralytics/pull/1936/files?diff=unified&w=0#diff-4a5fdbc973a408779ed550a87d5b6bd0d01693002dcc225876d7fb8a3c6d3137L643-R644))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced configuration management for dataset directories.

### 📊 Key Changes
- Added a constant `SETTINGS_YAML` for the settings file path.
- Provided an informative note on how to change the dataset download directory through `SETTINGS_YAML`.

### 🎯 Purpose & Impact
- **Purpose**: To streamline user ability to configure settings and improve error messaging when dataset downloads fail.
- **Impact**: Users now have a clearer pathway to customize their dataset download directory, and receive more helpful error messages when something goes wrong. This contributes to a more user-friendly experience with Ultralytics software.