### PR TITLE
Fix wrong comment in ops.py

### DIFF
--- a/ultralytics/yolo/utils/ops.py
+++ b/ultralytics/yolo/utils/ops.py
@@ -547,9 +547,9 @@ def crop_mask(masks, boxes):
       (torch.Tensor): The masks are being cropped to the bounding box.
     """
     n, h, w = masks.shape
-    x1, y1, x2, y2 = torch.chunk(boxes[:, :, None], 4, 1)  # x1 shape(1,1,n)
-    r = torch.arange(w, device=masks.device, dtype=x1.dtype)[None, None, :]  # rows shape(1,w,1)
-    c = torch.arange(h, device=masks.device, dtype=x1.dtype)[None, :, None]  # cols shape(h,1,1)
+    x1, y1, x2, y2 = torch.chunk(boxes[:, :, None], 4, 1)  # x1 shape(n,1,1)
+    r = torch.arange(w, device=masks.device, dtype=x1.dtype)[None, None, :]  # rows shape(1,1,w)
+    c = torch.arange(h, device=masks.device, dtype=x1.dtype)[None, :, None]  # cols shape(1,h,1)
 
     return masks * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

Tensor shape that write in comment is different with actual tensor shape.
![캡처](https://user-images.githubusercontent.com/56434476/231683671-b0350831-d744-4c2c-b01e-9eb4166426eb.PNG)


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1283424</samp>

### Summary
📝🐛🧮

<!--
1.  📝 This emoji can be used to indicate that a comment was edited or added to the code, as a way of documenting or explaining the logic or functionality of the code.
2.  🐛 This emoji can be used to indicate that a bug was fixed or a mistake was corrected in the code, as a way of highlighting the improvement or enhancement of the code quality or performance.
3.  🧮 This emoji can be used to indicate that a mathematical or numerical operation or expression was modified or updated in the code, as a way of emphasizing the change in the calculation or logic of the code.
-->
Fixed a comment typo in `ultralytics/yolo/utils/ops.py` that described the wrong tensor shape. This change enhances code clarity and correctness.

> _`torch.chunk` splits_
> _x1 shape was wrong before_
> _now it is winter_

### Walkthrough
* Correct the comment for the shape of x1 in `ops.py` ([link](https://github.com/ultralytics/ultralytics/pull/1998/files?diff=unified&w=0#diff-6ab52db19716f4198ed847132149ab432f032ed39c99c264a9de386446bf7f88L550-R552))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in mask cropping within YOLO utils.

### 📊 Key Changes
- Adjusted the shape annotations in comments for `x1`, `r`, and `c` variables to reflect the true shapes after the execution of torch operations like `torch.chunk` and `torch.arange`.

### 🎯 Purpose & Impact
- The update corrects the comments to match the actual tensor dimensions, which clarifies the cropping process for developers and prevents potential confusion.
- This contributes to better code readability and maintainability, although it doesn't change the functionality of the code itself. Users won't experience any direct impact from this change, but developers will have an easier time understanding how the mask cropping function operates. 🛠️