### PR TITLE
fix classify confusion matrix

### DIFF
--- a/ultralytics/yolo/v8/classify/val.py
+++ b/ultralytics/yolo/v8/classify/val.py
@@ -12,7 +12,6 @@ class ClassificationValidator(BaseValidator):
         super().__init__(dataloader, save_dir, pbar, args, _callbacks)
         self.args.task = 'classify'
         self.metrics = ClassifyMetrics()
-        self.save_dir = save_dir
 
     def get_desc(self):
         return ('%22s' + '%11s' * 2) % ('classes', 'top1_acc', 'top5_acc')
@@ -37,6 +36,8 @@ class ClassificationValidator(BaseValidator):
 
     def finalize_metrics(self, *args, **kwargs):
         self.confusion_matrix.process_cls_preds(self.pred, self.targets)
+        if self.args.plots:
+            self.confusion_matrix.plot(save_dir=self.save_dir, names=list(self.names.values()))
         self.metrics.speed = self.speed
         self.metrics.confusion_matrix = self.confusion_matrix
 
@@ -55,8 +56,6 @@ class ClassificationValidator(BaseValidator):
     def print_results(self):
         pf = '%22s' + '%11.3g' * len(self.metrics.keys)  # print format
         LOGGER.info(pf % ('all', self.metrics.top1, self.metrics.top5))
-        if self.args.plots:
-            self.confusion_matrix.plot(save_dir=self.save_dir, names=list(self.names.values()))
 
 
 def val(cfg=DEFAULT_CFG, use_python=False):


### PR DESCRIPTION
@glenn-jocher 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to classification validation in YOLOv8.

### 📊 Key Changes
- Removed redundant `self.save_dir` initialization in the constructor.
- Shifted the plotting of the confusion matrix inside `finalize_metrics()` method.

### 🎯 Purpose & Impact
- 🧹 **Code Cleanup:** The removal of the extra `self.save_dir` helps in keeping the codebase clean and more maintainable.
- 🖼️ **Plotting Logic Consolidation:** Moving the confusion matrix plotting to `finalize_metrics()` consolidates related logic in one place, making it easier to follow the code flow. This ensures that the creation of visual aids to understand model performance is done at the final step of metrics calculation, which is a logical place for such an operation. Users can expect to see their model's performance visualized (if enabled) after all evaluations are complete.