### PR TITLE
confusion matrix values updated after calculation.

### DIFF
--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -174,9 +174,9 @@ class BaseValidator:
             self.run_callbacks('on_val_batch_end')
         stats = self.get_stats()
         self.check_stats(stats)
-        self.print_results()
         self.speed = dict(zip(self.speed.keys(), (x.t / len(self.dataloader.dataset) * 1E3 for x in dt)))
         self.finalize_metrics()
+        self.print_results()
         self.run_callbacks('on_val_end')
         if self.training:
             model.float()


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 593f977</samp>

### Summary
🐛📊🖨️

<!--
1.  🐛 - This emoji represents a bug fix, which was the main motivation for this change. The previous order of the methods caused incorrect or outdated metrics to be printed, which could mislead the users or evaluators of the model.
2.  📊 - This emoji represents data or metrics, which were the main objects of this change. The change involved updating and finalizing the metrics before printing them, to ensure accuracy and consistency. The metrics are also an important aspect of the validation process, as they measure the performance and quality of the model.
3.  🖨️ - This emoji represents printing or output, which was the main action of this change. The change involved swapping the order of the methods that print the results to the console or a file. The printing of the results is also an important part of the validation process, as it communicates the outcomes and feedback of the model.
-->
Fixed a bug in `validator.py` that caused incorrect metrics to be printed during validation. Swapped the order of `self.print_results()` and `self.finalize_metrics()` to ensure metrics are updated before printing.

> _`print_results` first_
> _Metrics must be finalized_
> _Winter bug is fixed_

### Walkthrough
*  Swap the order of `self.print_results()` and `self.finalize_metrics()` to fix a bug in validation metrics ([link](https://github.com/ultralytics/ultralytics/pull/2040/files?diff=unified&w=0#diff-7646fc7a670fe6bbcbf9e637a707139b362bd3b118be7faca28bff7d9b7450c3L177-R179))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved metrics reporting in the validation process.

### 📊 Key Changes
- Changed the order of operations by moving `self.print_results()` after `self.finalize_metrics()` instead of before it.

### 🎯 Purpose & Impact
- This change aims to ensure that metrics are fully processed and finalized before they are reported, which might provide more accurate and meaningful output to the user.
- Users could see an impact in the clarity and timing of validation results, potentially benefiting from more reliable performance reporting.📈