### PR TITLE
add fp16 half precision support for onnx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ seaborn>=0.11.0
 # coremltools>=6.0  # CoreML export
 # onnx>=1.12.0  # ONNX export
 # onnxsim>=0.4.1  # ONNX simplifier
+# onnxconverter-common>=1.13.0 # ONNX converter
 # nvidia-pyindex  # TensorRT export
 # nvidia-tensorrt  # TensorRT export
 # scikit-learn==0.19.2  # CoreML quantization

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -293,6 +293,8 @@ class Exporter:
         requirements = ['onnx>=1.12.0']
         if self.args.simplify:
             requirements += ['onnxsim>=0.4.17', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime']
+        if self.args.half:
+            requirements += ['onnxconverter-common>=1.13.0']
         check_requirements(requirements)
         import onnx  # noqa
 
@@ -324,6 +326,15 @@ class Exporter:
         # Checks
         model_onnx = onnx.load(f)  # load onnx model
         # onnx.checker.check_model(model_onnx)  # check onnx model
+
+        #FP16 half precision
+        if self.args.half:
+            try:
+                from onnxconverter_common import float16
+                LOGGER.info(f'{prefix} FP16 half precision with onnxconverter_common')
+                model_onnx = float16.convert_float_to_float16(model_onnx)
+            except Exception as e:
+                LOGGER.info(f'{prefix} FP16 half precision failure: {e}')
 
         # Simplify
         if self.args.simplify:


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c6917dd</samp>

### Summary
🚀🎁🔧

<!--
1.  🚀 - This emoji represents the improvement in efficiency and performance that the FP16 format can provide for the model deployment and inference.
2.  🎁 - This emoji represents the new feature of exporting the model in FP16 format, which can be useful for users who want to optimize their model size and speed.
3.  🔧 - This emoji represents the tool or dependency that is used to implement the feature, which is the `onnxconverter-common` package.
-->
This pull request enables FP16 export of the YOLO model using `onnxconverter-common`. This can enhance the model performance and reduce the memory footprint.

> _Export the model_
> _In `FP16` format_
> _Winter of bytes_

### Walkthrough
*  Add support for exporting model in half precision (FP16) format ([link](https://github.com/ultralytics/ultralytics/pull/2047/files?diff=unified&w=0#diff-89bbf0a641e1fc4302b73181ac7fccc773b5213720cae9b5cae8aa2393c982fdR296-R297), [link](https://github.com/ultralytics/ultralytics/pull/2047/files?diff=unified&w=0#diff-89bbf0a641e1fc4302b73181ac7fccc773b5213720cae9b5cae8aa2393c982fdR330-R338))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ONNX export with FP16 precision support 🚀

### 📊 Key Changes
- Added `onnxconverter-common>=1.13.0` to `requirements.txt` for ONNX conversion.
- Inserted code to convert ONNX models to FP16 (half precision) when the `--half` flag is used.

### 🎯 Purpose & Impact
- **Purpose**: To allow users to export their models in ONNX format with FP16 precision, reducing model size and potentially increasing inference speed.
- **Impact**: Users exporting models for environments that benefit from reduced precision, like mobile devices or specialized inference hardware, will experience improved performance and efficiency. 💨