### PR TITLE
fix show_labels and show_conf

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -127,7 +127,7 @@ class BasePredictor:
         log_string += result.verbose()
 
         if self.args.save or self.args.show:  # Add bbox to image
-            plot_args = dict(line_width=self.args.line_thickness, boxes=self.args.boxes)
+            plot_args = dict(line_width=self.args.line_thickness, boxes=self.args.boxes, conf=self.args.show_conf, labels=self.args.show_labels)
             if not self.args.retina_masks:
                 plot_args['im_gpu'] = im[idx]
             self.plotted_img = result.plot(**plot_args)

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -127,7 +127,10 @@ class BasePredictor:
         log_string += result.verbose()
 
         if self.args.save or self.args.show:  # Add bbox to image
-            plot_args = dict(line_width=self.args.line_thickness, boxes=self.args.boxes, conf=self.args.show_conf, labels=self.args.show_labels)
+            plot_args = dict(line_width=self.args.line_thickness,
+                             boxes=self.args.boxes,
+                             conf=self.args.show_conf,
+                             labels=self.args.show_labels)
             if not self.args.retina_masks:
                 plot_args['im_gpu'] = im[idx]
             self.plotted_img = result.plot(**plot_args)


### PR DESCRIPTION
Fixes https://github.com/ultralytics/ultralytics/issues/2046
I think this was introduced while removing redundancy of plot() funtion from both results.py and predict.py. 
btw show_label=False should hide everything, right? This is how it was before I think

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced visualization options for object detection results in YOLO predictor.

### 📊 Key Changes
- Introduced additional plotting arguments to the predictor, including confidence scores (`conf`) and class labels (`labels`).
- Adjusted the argument handling to accommodate these new visualization options.

### 🎯 Purpose & Impact
- **Purpose:** This update is designed to provide users with more control over the visualization of detection results. By adding options to display confidence scores and class labels, users can now get a clearer and more informative visual output.
- **Impact:** Users who wish to see the confidence scores and labels directly in the output images can benefit from this change, especially for tasks that require result interpretation or presentation. It enhances the usability of the model's predictions for various applications.