### PR TITLE
Enable half export on cpu [Don't merge]

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -143,7 +143,7 @@ class AutoBackend(nn.Module):
             batch_dim = get_batch(network)
             if batch_dim.is_static:
                 batch_size = batch_dim.get_length()
-            executable_network = ie.compile_model(network, device_name='CPU')  # device_name="MYRIAD" for NCS2
+            executable_network = ie.compile_model(network, device_name='GPU')  # device_name="MYRIAD" for NCS2
             metadata = w.parent / 'metadata.yaml'
         elif engine:  # TensorRT
             LOGGER.info(f'Loading {w} for TensorRT inference...')

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -143,7 +143,7 @@ class AutoBackend(nn.Module):
             batch_dim = get_batch(network)
             if batch_dim.is_static:
                 batch_size = batch_dim.get_length()
-            executable_network = ie.compile_model(network, device_name='GPU')  # device_name="MYRIAD" for NCS2
+            executable_network = ie.compile_model(network, device_name='CPU')  # device_name="MYRIAD" for NCS2
             metadata = w.parent / 'metadata.yaml'
         elif engine:  # TensorRT
             LOGGER.info(f'Loading {w} for TensorRT inference...')

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -157,10 +157,12 @@ class Exporter:
 
         # Load PyTorch model
         self.device = select_device('cpu' if self.args.device is None else self.args.device)
+        '''
         if self.args.half and onnx and self.device.type == 'cpu':
             LOGGER.warning('WARNING ⚠️ half=True only compatible with GPU export, i.e. use device=0')
             self.args.half = False
             assert not self.args.dynamic, 'half=True not compatible with dynamic=True, i.e. use only one.'
+        '''
 
         # Checks
         model.names = check_class_names(model.names)

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -316,8 +316,9 @@ class YOLO:
         overrides = self.model.args.copy()
         overrides.update(kwargs)
         overrides['mode'] = 'benchmark'
+        data = overrides.get("data", None) # do this before merging
         overrides = {**DEFAULT_CFG_DICT, **overrides}  # fill in missing overrides keys with defaults
-        return benchmark(model=self, imgsz=overrides['imgsz'], half=overrides['half'], device=overrides['device'])
+        return benchmark(model=self, imgsz=overrides['imgsz'], half=overrides['half'], device=overrides['device'], int8=overrides['int8'], data=data)
 
     def export(self, **kwargs):
         """

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -316,9 +316,14 @@ class YOLO:
         overrides = self.model.args.copy()
         overrides.update(kwargs)
         overrides['mode'] = 'benchmark'
-        data = overrides.get("data", None) # do this before merging
+        data = overrides.get('data', None)  # do this before merging
         overrides = {**DEFAULT_CFG_DICT, **overrides}  # fill in missing overrides keys with defaults
-        return benchmark(model=self, imgsz=overrides['imgsz'], half=overrides['half'], device=overrides['device'], int8=overrides['int8'], data=data)
+        return benchmark(model=self,
+                         imgsz=overrides['imgsz'],
+                         half=overrides['half'],
+                         device=overrides['device'],
+                         int8=overrides['int8'],
+                         data=data)
 
     def export(self, **kwargs):
         """

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -85,7 +85,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
                 filename = model.ckpt_path or model.cfg
                 export = model  # PyTorch format
             else:
-                filename = model.export(imgsz=imgsz, format=format, half=half, int8=int8, device="GPU" if format=="openvino" else device)  # all others
+                filename = model.export(imgsz=imgsz, format=format, half=half, int8=int8, device=device)  # all others
                 export = YOLO(filename, task=model.task)
                 assert suffix in str(filename), 'export failed'
             emoji = '❎'  # indicates export succeeded
@@ -95,7 +95,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
             assert i != 5 or platform.system() == 'Darwin', 'inference only supported on macOS>=10.13'  # CoreML
             if not (ROOT / 'assets/bus.jpg').exists():
                 download(url='https://ultralytics.com/images/bus.jpg', dir=ROOT / 'assets')
-            export.predict(ROOT / 'assets/bus.jpg', imgsz=imgsz, device="GPU" if format=="openvino" else device, half=half)
+            export.predict(ROOT / 'assets/bus.jpg', imgsz=imgsz, device=device, half=half)
 
             # Validate
             if model.task == 'detect':

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -85,7 +85,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
                 filename = model.ckpt_path or model.cfg
                 export = model  # PyTorch format
             else:
-                filename = model.export(imgsz=imgsz, format=format, half=half, int8=int8, device=device)  # all others
+                filename = model.export(imgsz=imgsz, format=format, half=half, int8=int8, device="GPU" if format=="openvino" else device)  # all others
                 export = YOLO(filename, task=model.task)
                 assert suffix in str(filename), 'export failed'
             emoji = '❎'  # indicates export succeeded
@@ -95,7 +95,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
             assert i != 5 or platform.system() == 'Darwin', 'inference only supported on macOS>=10.13'  # CoreML
             if not (ROOT / 'assets/bus.jpg').exists():
                 download(url='https://ultralytics.com/images/bus.jpg', dir=ROOT / 'assets')
-            export.predict(ROOT / 'assets/bus.jpg', imgsz=imgsz, device=device, half=half)
+            export.predict(ROOT / 'assets/bus.jpg', imgsz=imgsz, device="GPU" if format=="openvino" else device, half=half)
 
             # Validate
             if model.task == 'detect':
@@ -106,7 +106,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
                 data, key = data or 'imagenet100', 'metrics/accuracy_top5'
             elif model.task == 'pose':
                 data, key = data or 'coco8-pose.yaml', 'metrics/mAP50-95(P)'
-
+            
             results = export.val(data=data,
                                  batch=1,
                                  imgsz=imgsz,

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -41,8 +41,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
               int8=False,
               device='cpu',
               hard_fail=False,
-              data=None
-              ):
+              data=None):
     """
     Benchmark a YOLO model across different formats for speed and accuracy.
 

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -40,7 +40,9 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
               half=False,
               int8=False,
               device='cpu',
-              hard_fail=False):
+              hard_fail=False,
+              data=None
+              ):
     """
     Benchmark a YOLO model across different formats for speed and accuracy.
 
@@ -98,13 +100,13 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
 
             # Validate
             if model.task == 'detect':
-                data, key = 'coco8.yaml', 'metrics/mAP50-95(B)'
+                data, key = data or 'coco8.yaml', 'metrics/mAP50-95(B)'
             elif model.task == 'segment':
-                data, key = 'coco8-seg.yaml', 'metrics/mAP50-95(M)'
+                data, key = data or 'coco8-seg.yaml', 'metrics/mAP50-95(M)'
             elif model.task == 'classify':
-                data, key = 'imagenet100', 'metrics/accuracy_top5'
+                data, key = data or 'imagenet100', 'metrics/accuracy_top5'
             elif model.task == 'pose':
-                data, key = 'coco8-pose.yaml', 'metrics/mAP50-95(P)'
+                data, key = data or 'coco8-pose.yaml', 'metrics/mAP50-95(P)'
 
             results = export.val(data=data,
                                  batch=1,

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -85,7 +85,11 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
                 filename = model.ckpt_path or model.cfg
                 export = model  # PyTorch format
             else:
-                filename = model.export(imgsz=imgsz, format=format, half=half, int8=int8, device="GPU" if format=="openvino" else device)  # all others
+                filename = model.export(imgsz=imgsz,
+                                        format=format,
+                                        half=half,
+                                        int8=int8,
+                                        device='GPU' if format == 'openvino' else device)  # all others
                 export = YOLO(filename, task=model.task)
                 assert suffix in str(filename), 'export failed'
             emoji = '❎'  # indicates export succeeded
@@ -95,7 +99,10 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
             assert i != 5 or platform.system() == 'Darwin', 'inference only supported on macOS>=10.13'  # CoreML
             if not (ROOT / 'assets/bus.jpg').exists():
                 download(url='https://ultralytics.com/images/bus.jpg', dir=ROOT / 'assets')
-            export.predict(ROOT / 'assets/bus.jpg', imgsz=imgsz, device="GPU" if format=="openvino" else device, half=half)
+            export.predict(ROOT / 'assets/bus.jpg',
+                           imgsz=imgsz,
+                           device='GPU' if format == 'openvino' else device,
+                           half=half)
 
             # Validate
             if model.task == 'detect':
@@ -106,7 +113,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
                 data, key = data or 'imagenet100', 'metrics/accuracy_top5'
             elif model.task == 'pose':
                 data, key = data or 'coco8-pose.yaml', 'metrics/mAP50-95(P)'
-            
+
             results = export.val(data=data,
                                  batch=1,
                                  imgsz=imgsz,


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancing model inference and benchmarking by supporting GPU usage and customizable data inputs.

### 📊 Key Changes
- Modified the default inference backend to use 'GPU' instead of 'CPU'.
- Commented out a block of code that disabled half-precision (FP16) when exporting to ONNX on CPU, if dynamic shapes were used.
- Added 'int8' and 'data' parameters to benchmark function calls, allowing for INT8 precision benchmarking and custom dataset selection.

### 🎯 Purpose & Impact
- 🚀 Using the GPU for inference can lead to significantly faster model predictions, enhancing user experience with more rapid results.
- 🤖 The option to benchmark with INT8 precision may offer insights into performance on edge devices where low precision operations are common.
- 📈 Allowing a custom dataset for benchmarking enables more relevant and targeted performance measurements tailored to specific use cases.