### PR TITLE
Added clear callback

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -493,6 +493,12 @@ class YOLO:
         Add callback
         """
         self.callbacks[event].append(func)
+    
+    def clear_callback(self, event: str):
+        """
+        Clear / Disable a callback
+        """
+        self.callbacks[event] = [] 
 
     @staticmethod
     def _reset_ckpt_args(args):

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -469,35 +469,25 @@ class YOLO:
 
     @property
     def names(self):
-        """
-        Returns class names of the loaded model.
-        """
+        """Returns class names of the loaded model."""
         return self.model.names if hasattr(self.model, 'names') else None
 
     @property
     def device(self):
-        """
-        Returns device if PyTorch model
-        """
+        """Returns device if PyTorch model."""
         return next(self.model.parameters()).device if isinstance(self.model, nn.Module) else None
 
     @property
     def transforms(self):
-        """
-        Returns transform of the loaded model.
-        """
+        """Returns transform of the loaded model."""
         return self.model.transforms if hasattr(self.model, 'transforms') else None
 
     def add_callback(self, event: str, func):
-        """
-        Add callback
-        """
+        """Add a callback."""
         self.callbacks[event].append(func)
 
     def clear_callback(self, event: str):
-        """
-        Clear / Disable a callback
-        """
+        """Clear all event callbacks."""
         self.callbacks[event] = []
 
     @staticmethod

--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -493,12 +493,12 @@ class YOLO:
         Add callback
         """
         self.callbacks[event].append(func)
-    
+
     def clear_callback(self, event: str):
         """
         Clear / Disable a callback
         """
-        self.callbacks[event] = [] 
+        self.callbacks[event] = []
 
     @staticmethod
     def _reset_ckpt_args(args):


### PR DESCRIPTION
Enable capacity to disable specific callbacks for models, for example to bypass some of them (like mlflow)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring comments and enhancing event callback functionality in Ultralytics YOLO model class.

### 📊 Key Changes
- Simplified comments in the properties `names`, `device`, and `transforms`.
- Added `clear_callback` method to reset event callbacks.

### 🎯 Purpose & Impact
- 🧹 Streamlining code for better readability and maintenance.
- 🔄 The new `clear_callback` method allows users to reset callbacks for specific events, providing better control and flexibility over event handling within the model. This can be particularly useful when dynamically changing the behavior of models during training or inference.