### PR TITLE
[Fix]: cls pretrained mode and tune space

### DIFF
--- a/docs/usage/hyperparameter_tuning.md
+++ b/docs/usage/hyperparameter_tuning.md
@@ -70,7 +70,6 @@ The following table lists the default search space parameters for hyperparameter
 | warmup_momentum | `tune.uniform(0.0, 0.95)`  | Warmup momentum                          |
 | box             | `tune.uniform(0.02, 0.2)`  | Box loss weight                          |
 | cls             | `tune.uniform(0.2, 4.0)`   | Class loss weight                        |
-| fl_gamma        | `tune.uniform(0.0, 2.0)`   | Focal loss gamma                         |
 | hsv_h           | `tune.uniform(0.0, 0.1)`   | Hue augmentation range                   |
 | hsv_s           | `tune.uniform(0.0, 0.9)`   | Saturation augmentation range            |
 | hsv_v           | `tune.uniform(0.0, 0.9)`   | Value (brightness) augmentation range    |

--- a/ultralytics/yolo/utils/tuner.py
+++ b/ultralytics/yolo/utils/tuner.py
@@ -21,7 +21,6 @@ default_space = {
     'warmup_momentum': tune.uniform(0.0, 0.95),  # warmup initial momentum
     'box': tune.uniform(0.02, 0.2),  # box loss gain
     'cls': tune.uniform(0.2, 4.0),  # cls loss gain (scale with pixels)
-    'fl_gamma': tune.uniform(0.0, 2.0),  # focal loss gamma (efficientDet default gamma=1.5)
     'hsv_h': tune.uniform(0.0, 0.1),  # image HSV-Hue augmentation (fraction)
     'hsv_s': tune.uniform(0.0, 0.9),  # image HSV-Saturation augmentation (fraction)
     'hsv_v': tune.uniform(0.0, 0.9),  # image HSV-Value augmentation (fraction)

--- a/ultralytics/yolo/v8/classify/train.py
+++ b/ultralytics/yolo/v8/classify/train.py
@@ -30,7 +30,7 @@ class ClassificationTrainer(BaseTrainer):
         if weights:
             model.load(weights)
 
-        pretrained = False
+        pretrained = self.args.pretrained
         for m in model.modules():
             if not pretrained and hasattr(m, 'reset_parameters'):
                 m.reset_parameters()


### PR DESCRIPTION
Fixes: https://github.com/ultralytics/ultralytics/issues/2169 ,  https://github.com/ultralytics/ultralytics/issues/2196

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ultralytics has refined hyperparameter tuning and model initialization options.

### 📊 Key Changes
- Removed the search space parameter `fl_gamma` for Focal Loss gamma from hyperparameter tuning.
- Updated the model training code to conditionally load pretrained weights based on a provided argument.

### 🎯 Purpose & Impact
- The removal of `fl_gamma` in hyperparameter tuning could mean the team found it to be non-essential or plans to manage it differently, potentially simplifying the tuning process.
- Allowing the option to load pretrained weights more flexibly enables users to choose whether they start with a pretrained model, which can lead to better initial performance and faster convergence in training new models.