### PR TITLE
Fix infer bug

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -298,7 +298,7 @@ class BasePredictor:
             cv2.namedWindow(str(p), cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
             cv2.resizeWindow(str(p), im0.shape[1], im0.shape[0])
         cv2.imshow(str(p), im0)
-        cv2.waitKey(500 if self.batch[4].startswith('image') else 1)  # 1 millisecond
+        cv2.waitKey(500 if self.batch[-1].startswith('image') else 1)  # 1 millisecond
 
     def save_preds(self, vid_cap, idx, save_path):
         """Save video predictions as mp4 at specified path."""


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 06c7fbe</samp>

### Summary
🐛🎥🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It conveys that the code was not working as intended before and that the issue was resolved.
2.  🎥 - This emoji represents a video, which is the type of input that was affected by the bug. It conveys that the change is relevant for video predictions and that the code can now handle different source types correctly.
3.  🚀 - This emoji represents a performance improvement, which is a secondary effect of the change. It conveys that the code is now faster and more efficient when displaying predictions on videos, as it does not wait unnecessarily between frames.
-->
Fixed a bug in `predictor.py` that caused incorrect wait time for video predictions. Changed the index of the batch variable to access the source type correctly.

> _`batch` index fixed_
> _video predictions smooth_
> _autumn bug no more_

### Walkthrough
* Fix bug in cv2.imshow wait time for video predictions ([link](https://github.com/ultralytics/ultralytics/pull/2325/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L301-R301))



Reproduce:
``` python
from ultralytics import YOLO
model = YOLO('yolov8s.pt', task='detect')
model.info(verbose=True)
results = model('ultralytics/assets/zidane.jpg', show=True, save=False)
```

Log:
``` text
YOLOv8s summary: 225 layers, 11166560 parameters, 0 gradients, 28.8 GFLOPs

Traceback (most recent call last):
  File "/home/ubuntu/workspace/github/object_detection/yolov8/export.py", line 11, in <module>
    results = model('ultralytics/assets/zidane.jpg', show=True, save=False)
  File "/home/ubuntu/workspace/github/object_detection/yolov8/ultralytics/yolo/engine/model.py", line 111, in __call__
    return self.predict(source, stream, **kwargs)
  File "/home/ubuntu/miniconda3/envs/torch/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/ubuntu/workspace/github/object_detection/yolov8/ultralytics/yolo/engine/model.py", line 252, in predict
    return self.predictor.predict_cli(source=source) if is_cli else self.predictor(source=source, stream=stream)
  File "/home/ubuntu/workspace/github/object_detection/yolov8/ultralytics/yolo/engine/predictor.py", line 173, in __call__
    return list(self.stream_inference(source, model))  # merge list of Result into one
  File "/home/ubuntu/miniconda3/envs/torch/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 43, in generator_context
    response = gen.send(None)
  File "/home/ubuntu/workspace/github/object_detection/yolov8/ultralytics/yolo/engine/predictor.py", line 251, in stream_inference
    self.show(p)
  File "/home/ubuntu/workspace/github/object_detection/yolov8/ultralytics/yolo/engine/predictor.py", line 301, in show
    cv2.waitKey(500 if self.batch[4].startswith('image') else 1)  # 1 millisecond
IndexError: tuple index out of range

Process finished with exit code 1

```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates the condition for a longer display time in image predictions.

### 📊 Key Changes
- Altered the index used to check the type of media in the prediction (`batch[4]` to `batch[-1]`).

### 🎯 Purpose & Impact
- **Purpose:** To ensure the correct duration of the wait key is applied for images during prediction visualizations.
- **Impact:** This change leads to better user experience by providing appropriate visualization times for image predictions. If the last item in the batch indicates an image, the display will hold for 500 milliseconds, allowing users to see the prediction more clearly.🖼️✨