### PR TITLE
dev(hansbug): add cls_weights for detection model

### DIFF
--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -87,6 +87,7 @@ warmup_bias_lr: 0.1  # warmup initial bias lr
 box: 7.5  # box loss gain
 cls: 0.5  # cls loss gain (scale with pixels)
 dfl: 1.5  # dfl loss gain
+cls_weights: null  # weights for classes, default means all 1.0
 pose: 12.0  # pose loss gain
 kobj: 1.0  # keypoint obj loss gain
 label_smoothing: 0.0  # label smoothing (fraction)


### PR DESCRIPTION
We added a `cls_weights` parameter to the object detection trainer, which is used to specify the weights for different classifications and applied to both `nn.BCEWithLogitsLoss` and `BboxLoss`. When the `cls_weights` parameter is missing, the default weights for all classifications are set to `1.0`.

PS: This section has just completed local testing (to ensure that it runs normally), but further practical testing is still needed. I will start the training task with the modified code and notify here after it is completed.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds support for custom class weights in loss calculations, allowing users to better handle class imbalance during training. ⚖️

### 📊 Key Changes
- Introduced a new `cls_weights` option in the configuration file to specify custom weights for each class.
- Updated loss functions to use these class weights when calculating both classification and bounding box losses.
- Modified training code to pass class weights to relevant loss modules.

### 🎯 Purpose & Impact
- Empowers users to address class imbalance by assigning higher or lower importance to specific classes during training.
- Can lead to improved model performance, especially on datasets where some classes are underrepresented.
- Offers greater flexibility and control for advanced users tuning their models for specialized tasks.