### PR TITLE
Fix batch frames tracking bug.

### DIFF
--- a/ultralytics/tracker/track.py
+++ b/ultralytics/tracker/track.py
@@ -31,9 +31,9 @@ def on_predict_start(predictor, persist=False):
         f"Only support 'bytetrack' and 'botsort' for now, but got '{cfg.tracker_type}'"
     trackers = []
     # for batch of frames of the same video, only use one tracker
-    if predictor.source_type.from_img and predictor.dataset.bs >=1 :
+    if predictor.source_type.from_img and predictor.dataset.bs >= 1:
         trackers.append(TRACKER_MAP[cfg.tracker_type](args=cfg, frame_rate=30))
-    else :
+    else:
         for _ in range(predictor.dataset.bs):
             tracker = TRACKER_MAP[cfg.tracker_type](args=cfg, frame_rate=30)
             trackers.append(tracker)
@@ -45,15 +45,15 @@ def on_predict_postprocess_end(predictor):
     bs = predictor.dataset.bs
     im0s = predictor.batch[2]
     im0s = im0s if isinstance(im0s, list) else [im0s]
-    batch_of_frames= predictor.source_type.from_img and bs >= 1
+    batch_of_frames = predictor.source_type.from_img and bs >= 1
     for i in range(bs):
         det = predictor.results[i].boxes.cpu().numpy()
         if len(det) == 0:
             continue
         # for batch of frames of the same video, only use one tracker
-        if batch_of_frames :
+        if batch_of_frames:
             tracks = predictor.trackers[0].update(det, im0s[i])
-        else :
+        else:
             tracks = predictor.trackers[i].update(det, im0s[i])
         if len(tracks) == 0:
             continue


### PR DESCRIPTION
Changes
Fix a bug that caused wrong detections and tracks when the batch size is greater than 1 and persist=True. This  PR checks if the source is an array of frames so they are related to each other and ensures that only one tracker is responsible for the tracking frames in the same batch and the subsequent batches when persist=True.

Reason for Changes
The current implementation was initializing a tracker for each frame in the batch of the same video, which caused the model to lose detections and tracks in the subsequent batches when persist=True

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b275047</samp>

### Summary
📹🚀🛠️

<!--
1.  📹 This emoji can be used to indicate that the changes are related to video processing or handling, as the tracker module works with video sources and the pull request modifies the tracker creation and update logic based on the source type.
2.  🚀 This emoji can be used to indicate that the changes are intended to improve the performance or efficiency of the tracker module, as the pull request imports cv2, which is a fast and optimized library for computer vision, and removes an empty line, which can reduce the code size and readability.
3.  🛠️ This emoji can be used to indicate that the changes are fixing or enhancing some functionality or feature of the tracker module, as the pull request adjusts the tracker creation and update logic to handle different batch formats, which can prevent errors or bugs when working with different types of video sources.
-->
This pull request enhances the `tracker` module for video sources by importing `cv2` and modifying the tracker logic. It also fixes some minor formatting issues in `track.py`.

> _We'll import `cv2` and track them all, me hearties, yo ho!_
> _We'll trim the code and make it neat, me hearties, yo ho!_
> _We'll adjust the logic for the source, me hearties, yo ho!_
> _And we'll handle any batch format, on the count of three, let's go!_

### Walkthrough
*  Import cv2 module for image processing and drawing functions in `track.py` ([link](https://github.com/ultralytics/ultralytics/pull/2387/files?diff=unified&w=0#diff-753eafe9d4819d55c5306d91e73dc1b5a27c009194bf84f917bb0f4e78a1a9d4R5))
*  Modify logic of creating and assigning trackers for each batch of frames in `track.py`, depending on the source type ([link](https://github.com/ultralytics/ultralytics/pull/2387/files?diff=unified&w=0#diff-753eafe9d4819d55c5306d91e73dc1b5a27c009194bf84f917bb0f4e78a1a9d4L33-R39))
*  Adapt logic of updating and retrieving tracks for each batch of frames in `track.py`, based on the source type and the number of trackers ([link](https://github.com/ultralytics/ultralytics/pull/2387/files?diff=unified&w=0#diff-753eafe9d4819d55c5306d91e73dc1b5a27c009194bf84f917bb0f4e78a1a9d4L42-R57))
*  Remove an empty line in `track.py` for formatting improvement ([link](https://github.com/ultralytics/ultralytics/pull/2387/files?diff=unified&w=0#diff-753eafe9d4819d55c5306d91e73dc1b5a27c009194bf84f917bb0f4e78a1a9d4L22))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in object tracking for batched video frame processing.

### 📊 Key Changes
- Added `cv2` import to the tracking module.
- Updated tracker initiation logic to utilize a single tracker for a batch of frames from the same video.
- Adjusted post-processing function to accommodate the changes in tracker management.
- Changed the indexing method to access the batched frames.

### 🎯 Purpose & Impact
- The purpose of these changes is to optimize the object tracking performance when processing batches of frames from the same video, reducing the creation of unnecessary multiple tracker instances.
- Users processing video data in batches will potentially see improved tracking consistency and performance due to more efficient tracker usage.
- This could lead to less memory usage and possibly faster processing times for videos.

🔍 By using a single tracker instance for all frames in the batch, the system can maintain contextual continuity, possibly enhancing tracking accuracy.