### PR TITLE
Fix batch frames tracking bug

### DIFF
--- a/ultralytics/tracker/track.py
+++ b/ultralytics/tracker/track.py
@@ -30,9 +30,9 @@ def on_predict_start(predictor, persist=False):
         f"Only support 'bytetrack' and 'botsort' for now, but got '{cfg.tracker_type}'"
     trackers = []
     # for batch of frames of the same video, only use one tracker
-    if predictor.source_type.from_img and predictor.dataset.bs >=1 :
+    if predictor.source_type.from_img and predictor.dataset.bs >= 1:
         trackers.append(TRACKER_MAP[cfg.tracker_type](args=cfg, frame_rate=30))
-    else :
+    else:
         for _ in range(predictor.dataset.bs):
             tracker = TRACKER_MAP[cfg.tracker_type](args=cfg, frame_rate=30)
             trackers.append(tracker)
@@ -44,15 +44,15 @@ def on_predict_postprocess_end(predictor):
     bs = predictor.dataset.bs
     im0s = predictor.batch[2]
     im0s = im0s if isinstance(im0s, list) else [im0s]
-    batch_of_frames= predictor.source_type.from_img and bs >= 1
+    batch_of_frames = predictor.source_type.from_img and bs >= 1
     for i in range(bs):
         det = predictor.results[i].boxes.cpu().numpy()
         if len(det) == 0:
             continue
         # for batch of frames of the same video, only use one tracker
-        if batch_of_frames :
+        if batch_of_frames:
             tracks = predictor.trackers[0].update(det, im0s[i])
-        else :
+        else:
             tracks = predictor.trackers[i].update(det, im0s[i])
         if len(tracks) == 0:
             continue

--- a/ultralytics/tracker/track.py
+++ b/ultralytics/tracker/track.py
@@ -19,7 +19,6 @@ def on_predict_start(predictor, persist=False):
     Args:
         predictor (object): The predictor object to initialize trackers for.
         persist (bool, optional): Whether to persist the trackers if they already exist. Defaults to False.
-
     Raises:
         AssertionError: If the tracker_type is not 'bytetrack' or 'botsort'.
     """
@@ -30,21 +29,31 @@ def on_predict_start(predictor, persist=False):
     assert cfg.tracker_type in ['bytetrack', 'botsort'], \
         f"Only support 'bytetrack' and 'botsort' for now, but got '{cfg.tracker_type}'"
     trackers = []
-    for _ in range(predictor.dataset.bs):
-        tracker = TRACKER_MAP[cfg.tracker_type](args=cfg, frame_rate=30)
-        trackers.append(tracker)
+    # for batch of frames of the same video, only use one tracker
+    if predictor.source_type.from_img and predictor.dataset.bs >=1 :
+        trackers.append(TRACKER_MAP[cfg.tracker_type](args=cfg, frame_rate=30))
+    else :
+        for _ in range(predictor.dataset.bs):
+            tracker = TRACKER_MAP[cfg.tracker_type](args=cfg, frame_rate=30)
+            trackers.append(tracker)
     predictor.trackers = trackers
 
 
 def on_predict_postprocess_end(predictor):
     """Postprocess detected boxes and update with object tracking."""
     bs = predictor.dataset.bs
-    im0s = predictor.batch[1]
+    im0s = predictor.batch[2]
+    im0s = im0s if isinstance(im0s, list) else [im0s]
+    batch_of_frames= predictor.source_type.from_img and bs >= 1
     for i in range(bs):
         det = predictor.results[i].boxes.cpu().numpy()
         if len(det) == 0:
             continue
-        tracks = predictor.trackers[i].update(det, im0s[i])
+        # for batch of frames of the same video, only use one tracker
+        if batch_of_frames :
+            tracks = predictor.trackers[0].update(det, im0s[i])
+        else :
+            tracks = predictor.trackers[i].update(det, im0s[i])
         if len(tracks) == 0:
             continue
         idx = tracks[:, -1].tolist()


### PR DESCRIPTION
Changes
Fix a bug that caused wrong detections and tracks when the batch size is greater than 1 and persist=True. This PR checks if the source is an array of frames so they are related to each other and ensures that only one tracker is responsible for the tracking frames in the same batch and the subsequent batches when persist=True.

Reason for Changes
The current implementation was initializing a tracker for each frame in the batch of the same video, which caused the model to lose detections and tracks in the subsequent batches when persist=True

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d45a16a</samp>

### Summary
🎞️🗑️🔄

<!--
1.  🎞️ - This emoji can be used to represent the improvement of tracking objects across multiple frames from the same video source, as it suggests the idea of a film reel or a sequence of images.
2.  🗑️ - This emoji can be used to represent the removal of an unnecessary line of code, as it suggests the idea of throwing away something that is not needed or useful.
3.  🔄 - This emoji can be used to represent the adaptation to the new format of the `predictor.batch` variable, as it suggests the idea of changing or updating something to fit a different situation or standard.
-->
Improve object tracking for video frames by using a single `tracker` instance and updating `track.py` to match `predictor.batch` format.

> _We're sailing on the sea of code, we've got a tracker to unload_
> _We'll use it for the whole batch, and make our predictions match_
> _Heave away, me hearties, heave away_
> _We'll remove the extra line, and make our code look fine_

### Walkthrough
* Improve tracking performance and accuracy for image sources by creating and using one tracker per batch of frames ([link](https://github.com/ultralytics/ultralytics/pull/2388/files?diff=unified&w=0#diff-753eafe9d4819d55c5306d91e73dc1b5a27c009194bf84f917bb0f4e78a1a9d4L33-R38), [link](https://github.com/ultralytics/ultralytics/pull/2388/files?diff=unified&w=0#diff-753eafe9d4819d55c5306d91e73dc1b5a27c009194bf84f917bb0f4e78a1a9d4L42-R56)) in `track.py`




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved tracking efficiency in Ultralytics's tracking algorithm.

### 📊 Key Changes
- Added logic to use a single tracker for a batch of frames from the same video, instead of initializing a tracker for each frame.
- Altered retrieval of image frames within the `on_predict_postprocess_end` function, now accommodating a potential list of images.
- Conditional check added to ensure the tracker update is applied only with one tracker for batches of frames of the same video.

### 🎯 Purpose & Impact
- The update aims to reduce the computational overhead when running predictions on batches from the same video, by using just one tracker for all frames. 
- This can lead to a more efficient tracking process, potentially improving performance and reducing resource usage.
- Users should experience quicker and possibly more consistent tracking results when processing video data in batches.