### PR TITLE
Optimize new absolute confusion matrix

### DIFF
--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -119,7 +119,9 @@ def on_train_end(trainer):
     task = Task.current_task()
     if task:
         # Log final results, CM matrix + PR plots
-        files = ['results.png', 'confusion_matrix.png','confusion_matrix_normalized.png', *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
+        files = [
+            'results.png', 'confusion_matrix.png', 'confusion_matrix_normalized.png',
+            *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
         files = [(trainer.save_dir / f) for f in files if (trainer.save_dir / f).exists()]  # filter
         for f in files:
             _log_plot(title=f.stem, plot_path=f)

--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -119,7 +119,7 @@ def on_train_end(trainer):
     task = Task.current_task()
     if task:
         # Log final results, CM matrix + PR plots
-        files = ['results.png', 'confusion_matrix.png', *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
+        files = ['results.png', 'confusion_matrix.png','confusion_matrix_normalized.png', *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
         files = [(trainer.save_dir / f) for f in files if (trainer.save_dir / f).exists()]  # filter
         for f in files:
             _log_plot(title=f.stem, plot_path=f)

--- a/ultralytics/yolo/utils/callbacks/neptune.py
+++ b/ultralytics/yolo/utils/callbacks/neptune.py
@@ -87,7 +87,8 @@ def on_train_end(trainer):
     """Callback function called at end of training."""
     if run:
         # Log final results, CM matrix + PR plots
-        files = ['results.png', 'confusion_matrix.png', *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
+        files = ['results.png', 'confusion_matrix.png', 'confusion_matrix_normalized.png',
+                 *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
         files = [(trainer.save_dir / f) for f in files if (trainer.save_dir / f).exists()]  # filter
         for f in files:
             _log_plot(title=f.stem, plot_path=f)

--- a/ultralytics/yolo/utils/callbacks/neptune.py
+++ b/ultralytics/yolo/utils/callbacks/neptune.py
@@ -87,8 +87,9 @@ def on_train_end(trainer):
     """Callback function called at end of training."""
     if run:
         # Log final results, CM matrix + PR plots
-        files = ['results.png', 'confusion_matrix.png', 'confusion_matrix_normalized.png',
-                 *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
+        files = [
+            'results.png', 'confusion_matrix.png', 'confusion_matrix_normalized.png',
+            *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
         files = [(trainer.save_dir / f) for f in files if (trainer.save_dir / f).exists()]  # filter
         for f in files:
             _log_plot(title=f.stem, plot_path=f)

--- a/ultralytics/yolo/utils/metrics.py
+++ b/ultralytics/yolo/utils/metrics.py
@@ -321,17 +321,18 @@ class ConfusionMatrix:
         ticklabels = (list(names) + ['background']) if labels else 'auto'
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')  # suppress empty matrix RuntimeWarning: All-NaN slice encountered
-            sn.heatmap(array,
-                       ax=ax,
-                       annot=nc < 30,
-                       annot_kws={
-                           'size': 8},
-                       cmap='Blues',
-                       fmt = '.2f' if normalize else '%d',  # float if normalize else integer
-                       square=True,
-                       vmin=0.0,
-                       xticklabels=ticklabels,
-                       yticklabels=ticklabels).set_facecolor((1, 1, 1))
+            sn.heatmap(
+                array,
+                ax=ax,
+                annot=nc < 30,
+                annot_kws={
+                    'size': 8},
+                cmap='Blues',
+                fmt='.2f' if normalize else '%d',  # float if normalize else integer
+                square=True,
+                vmin=0.0,
+                xticklabels=ticklabels,
+                yticklabels=ticklabels).set_facecolor((1, 1, 1))
         title = 'Confusion Matrix' + ' Normalized' * normalize
         ax.set_xlabel('True')
         ax.set_ylabel('Predicted')

--- a/ultralytics/yolo/utils/metrics.py
+++ b/ultralytics/yolo/utils/metrics.py
@@ -327,7 +327,7 @@ class ConfusionMatrix:
                        annot_kws={
                            'size': 8},
                        cmap='Blues',
-                       fmt = '%d' if normalize else '.2f'
+                       fmt = '.2f' if normalize else '%d'  # float if normalize else integer
                        square=True,
                        vmin=0.0,
                        xticklabels=ticklabels,

--- a/ultralytics/yolo/utils/metrics.py
+++ b/ultralytics/yolo/utils/metrics.py
@@ -327,7 +327,7 @@ class ConfusionMatrix:
                        annot_kws={
                            'size': 8},
                        cmap='Blues',
-                       fmt = '.2f' if normalize else '%d'  # float if normalize else integer
+                       fmt = '.2f' if normalize else '%d',  # float if normalize else integer
                        square=True,
                        vmin=0.0,
                        xticklabels=ticklabels,

--- a/ultralytics/yolo/utils/metrics.py
+++ b/ultralytics/yolo/utils/metrics.py
@@ -327,7 +327,7 @@ class ConfusionMatrix:
                        annot_kws={
                            'size': 8},
                        cmap='Blues',
-                       fmt='.2f' if normalize else '.0f',
+                       fmt = '%d' if normalize else '.2f'
                        square=True,
                        vmin=0.0,
                        xticklabels=ticklabels,

--- a/ultralytics/yolo/utils/metrics.py
+++ b/ultralytics/yolo/utils/metrics.py
@@ -327,7 +327,7 @@ class ConfusionMatrix:
                        annot_kws={
                            'size': 8},
                        cmap='Blues',
-                       fmt='.2f',
+                       fmt='.2f' if normalize else '.0f',
                        square=True,
                        vmin=0.0,
                        xticklabels=ticklabels,


### PR DESCRIPTION
1. When normalized=False, output int in confusion matrix
2. Add confusion_matrix_normalized.png in clearml

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 75cabbd</samp>

### Summary
📊🔄🔎

<!--
1.  📊 This emoji represents the addition of the `confusion_matrix_normalized.png` file, which is a type of chart or graph that shows the performance of the model on different classes. The emoji conveys the idea of data visualization and analysis, which are important aspects of machine learning.
2.  🔄 This emoji represents the addition of the conditional formatting option, which is a type of change or update that modifies the appearance or behavior of the existing code. The emoji conveys the idea of switching or toggling between different modes or formats, which are useful features for user customization and preference.
3.  🔎 This emoji represents the `ConfusionMatrix` class and the `plot` method, which are related to the evaluation and validation of the model. The emoji conveys the idea of inspecting or examining the results and finding errors or discrepancies, which are essential steps for improving the model quality and accuracy.
-->
This pull request enhances the confusion matrix functionality for the YOLOv5 model and its integration with ClearML. It adds the option to log and visualize the normalized confusion matrix in `clearml.py` and to format the values as floats or integers in `metrics.py`.

> _`ClearML` callback_
> _logs confusion matrix plots_
> _autumn of learning_

### Walkthrough
* Enable normalized confusion matrix visualization for ClearML callback ([link](https://github.com/ultralytics/ultralytics/pull/2472/files?diff=unified&w=0#diff-a815296cb22a8ba6127487e136b0996e9885c93d79f23f92ad858437b2c9af66L122-R122))
* Add conditional formatting option to `ConfusionMatrix.plot` method ([link](https://github.com/ultralytics/ultralytics/pull/2472/files?diff=unified&w=0#diff-344fba8bdb2b27681f38b96c45c1182aecb1f9bbcff5976dccce1ebd1d6f25dcL330-R330))



Optimize new confusion matrix
1. When normalized=False, output int in confusion matrix
2. Add confusion_matrix_normalized.png in clearml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of Training Results Visualization in Callbacks

### 📊 Key Changes
- Added 'confusion_matrix_normalized.png' to the list of files logged at the end of training in ClearML and Neptune callbacks.
- Updated the annotation format in confusion matrix plotting function to display floats for normalized matrices and integers for non-normalized matrices.

### 🎯 Purpose & Impact
- Users now benefit from an additional normalized confusion matrix plot, which provides a better view of the model's performance across classes, especially when classes are imbalanced.
- The improved annotation format helps in understanding the actual number of instances or the proportions, depending on whether the matrix is normalized or not, which enhances result interpretation.