### PR TITLE
clearml: show training progress after each epoch

### DIFF
--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -84,10 +84,17 @@ def on_pretrain_routine_start(trainer):
 
 
 def on_train_epoch_end(trainer):
-    """Logs debug samples for the first epoch of YOLO training."""
-    if trainer.epoch == 1 and Task.current_task():
-        _log_debug_samples(sorted(trainer.save_dir.glob('train_batch*.jpg')), 'Mosaic')
+    task = Task.current_task()
 
+    if task:
+        """Logs debug samples for the first epoch of YOLO training."""
+        if trainer.epoch == 1:
+            _log_debug_samples(sorted(trainer.save_dir.glob('train_batch*.jpg')), 'Mosaic')
+
+        """Report the current training progress."""
+        for k, v in trainer.validator.metrics.results_dict.items():
+            task.get_logger().report_scalar(
+                "train", k, v, iteration=trainer.epoch)
 
 def on_fit_epoch_end(trainer):
     """Reports model information to logger at the end of an epoch."""

--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -90,11 +90,10 @@ def on_train_epoch_end(trainer):
         """Logs debug samples for the first epoch of YOLO training."""
         if trainer.epoch == 1:
             _log_debug_samples(sorted(trainer.save_dir.glob('train_batch*.jpg')), 'Mosaic')
-
         """Report the current training progress."""
         for k, v in trainer.validator.metrics.results_dict.items():
-            task.get_logger().report_scalar(
-                "train", k, v, iteration=trainer.epoch)
+            task.get_logger().report_scalar("train", k, v, iteration=trainer.epoch)
+
 
 def on_fit_epoch_end(trainer):
     """Reports model information to logger at the end of an epoch."""

--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -92,7 +92,7 @@ def on_train_epoch_end(trainer):
             _log_debug_samples(sorted(trainer.save_dir.glob('train_batch*.jpg')), 'Mosaic')
         """Report the current training progress."""
         for k, v in trainer.validator.metrics.results_dict.items():
-            task.get_logger().report_scalar("train", k, v, iteration=trainer.epoch)
+            task.get_logger().report_scalar('train', k, v, iteration=trainer.epoch)
 
 
 def on_fit_epoch_end(trainer):


### PR DESCRIPTION
Currently we only display the training progress only after the training has finished. This has an important downside for long training jobs, when failure to react in a suboptimal training, can lead to huge compute resource wast and significant costs.

This commits adds a scalar plot, which is updated at the end of every epoch. It includes the following metrics:
- fitness
- mAP50
- mAP50-95
- precision
- recall

The results can be seen in the following image, with the added plot seen on the right
![image](https://user-images.githubusercontent.com/24351757/236921871-efe07138-e130-45cc-9427-b64848d377f8.png)

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 711923f</samp>

### Summary
📈🚀📝

<!--
1.  📈 This emoji represents the logging and tracking of the training progress, as well as the improvement of the model performance over time.
2.  🚀 This emoji represents the integration of ClearML with YOLOv5, which enables faster and easier experimentation and deployment of the model.
3.  📝 This emoji represents the addition of docstrings, which document and explain the code blocks for better readability and maintainability.
-->
Add ClearML logging to `on_train_epoch_end` function in `ultralytics/yolo/utils/callbacks/clearml.py`. This allows tracking the training progress and metrics of YOLOv5 models using ClearML.

> _`on_train_epoch_end`_
> _reports to ClearML logger_
> _autumn harvest of data_

### Walkthrough
* Integrate ClearML logging and tracking with YOLOv5 framework
  * Report training metrics, losses, and images to ClearML in the `on_train_epoch_end` method of ClearMLCallback ([link](https://github.com/ultralytics/ultralytics/pull/2482/files?diff=unified&w=0#diff-a815296cb22a8ba6127487e136b0996e9885c93d79f23f92ad858437b2c9af66L87-R98))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to logging and reporting in YOLO training callbacks for ClearML.

### 📊 Key Changes
- Debug samples are still logged during the first epoch of YOLO training, but additional condition checks have been introduced.
- The system now reports current training progress metrics to ClearML at the end of each training epoch.

### 🎯 Purpose & Impact
- The changes ensure debug images are only logged when a ClearML `Task` is active, avoiding possible errors when ClearML isn't used.
- Reporting training progress metrics such as validation results provides real-time insight into model performance, enhancing the monitoring capabilities for users utilizing ClearML in their training workflows. Users can now track progress more closely, potentially streamlining model development and debugging. 📈🔍