### PR TITLE
fix: windows c:\ is not writeable

### DIFF
--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -8,7 +8,6 @@ import platform
 import re
 import subprocess
 import sys
-import tempfile
 import threading
 import urllib
 import uuid

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -414,7 +414,7 @@ def is_dir_writeable(dir_path: Union[str, Path]) -> bool:
     Returns:
         bool: True if the directory is writeable, False otherwise.
     """
-    if WINDOWS and str(dir_path).lower() == "c:\\":
+    if WINDOWS and str(dir_path).lower() == 'c:\\':
         return False
 
     try:

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -414,6 +414,9 @@ def is_dir_writeable(dir_path: Union[str, Path]) -> bool:
     Returns:
         bool: True if the directory is writeable, False otherwise.
     """
+    if WINDOWS and str(dir_path).lower() == "c:\\":
+        return False
+
     try:
         with tempfile.TemporaryFile(dir=dir_path):
             pass

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -414,15 +414,7 @@ def is_dir_writeable(dir_path: Union[str, Path]) -> bool:
     Returns:
         bool: True if the directory is writeable, False otherwise.
     """
-    if WINDOWS and str(dir_path).lower() == 'c:\\':
-        return False
-
-    try:
-        with tempfile.TemporaryFile(dir=dir_path):
-            pass
-        return True
-    except OSError:
-        return False
+    return os.access(str(dir_path), os.W_OK)
 
 
 def is_pytest_running():


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 69f403e</samp>

### Summary
🚫🛡️🖥️

<!--
1.  🚫 This emoji can be used to convey the idea of preventing or blocking something, such as writing to the root directory. It can also suggest an error or a warning, which is relevant for the permission issues that could arise from the previous behavior.
2.  🛡️ This emoji can be used to represent protection, security, or defense, which are some of the goals of improving the robustness and compatibility of the framework. It can also imply that the change is beneficial for the users or the system, as it prevents potential harm or damage.
3.  🖥️ This emoji can be used to indicate that the change is specific to Windows systems, as it involves the C drive. It can also suggest that the change is related to the computer or the software environment, rather than the algorithm or the model.
-->
This pull request enhances the YOLOv5 framework by preventing unwanted file writes on Windows systems. It modifies the `ultralytics/yolo/utils/__init__.py` file to add a safeguard against writing to the `C:\` directory.

> _`YOLOv5` detects_
> _No root writes on Windows_
> _Winter of errors_

### Walkthrough
*  Prevent writing to C drive root on Windows ([link](https://github.com/ultralytics/ultralytics/pull/2493/files?diff=unified&w=0#diff-4a5fdbc973a408779ed550a87d5b6bd0d01693002dcc225876d7fb8a3c6d3137R417-R419))



Fixes: #2436

Simply returns False if the directory is c:\\.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of directory writeability check in Ultralytics YOLO utils.

### 📊 Key Changes
- Removed the dependency on Python's `tempfile` module for checking directory writeability.
- Simplified the writeability check using `os.access()` with the write (`os.W_OK`) flag.

### 🎯 Purpose & Impact
- 🚀 **Performance**: This change potentially improves the speed of the writeability check by avoiding temporary file creation.
- ✨ **Simplicity**: Reduces complexity in the code, making it easier to maintain and understand.
- 🔄 **Compatibility**: Users will see no functional change, but the internal operation is more efficient.