### PR TITLE
chore: update hub export to use v1 endpoint

### DIFF
--- a/ultralytics/hub/__init__.py
+++ b/ultralytics/hub/__init__.py
@@ -71,11 +71,9 @@ def export_fmts_hub():
 def export_model(model_id='', format='torchscript'):
     """Export a model to all formats."""
     assert format in export_fmts_hub(), f"Unsupported export format '{format}', valid formats are {export_fmts_hub()}"
-    r = requests.post('https://api.ultralytics.com/export',
-                      json={
-                          'apiKey': Auth().api_key,
-                          'modelId': model_id,
-                          'format': format})
+    r = requests.post(f'https://api.ultralytics.com/v1/models/{model_id}/export',
+                      json={'format': format},
+                      headers={'x-api-key': Auth().api_key})
     assert r.status_code == 200, f'{PREFIX}{format} export failure {r.status_code} {r.reason}'
     LOGGER.info(f'{PREFIX}{format} export started ✅')
 


### PR DESCRIPTION
This PR updates the HUB `export_model` function to use the new v1 endpoint along with the update authorization headers. This new endpoint allows for arguments to be passed to the exports as per the [export docs](https://docs.ultralytics.com/modes/export/#export-formats).

The config matches the YOLOv8 config and can be passed as a root key:

```python
json={"format": "coreml", "imgsz"=[32,32], "nms"=True}
```



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced API endpoint usage for model export functionality in Ultralytics.

### 📊 Key Changes
- Updated the API endpoint for exporting models to a new version.
- Simplified the request payload by removing modelId from the JSON body.
- Added the `x-api-key` to the request headers for authentication.

### 🎯 Purpose & Impact
- Ensures the model export function communicates with the updated API endpoint, maintaining compatibility.
- Streamlines the export request aligning with API changes, which could lead to a more efficient and secure export process.
- This change could provide users a more reliable and potentially faster export experience due to optimized API usage. 🚀