### PR TITLE
add pre-caching stage to avoid nccl timeout

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -192,8 +192,9 @@ class BaseTrainer:
 
     def _pre_caching_dataset(self):
         """
-        Caching dataset before training to avoid NCCL timeout
-        It has to be done before DDP initialization
+        Caching dataset before training to avoid NCCL timeout.
+        Must be done before DDP initialization.
+        See https://github.com/ultralytics/ultralytics/pull/2549 for details.
         """
         if RANK in (-1, 0):
             LOGGER.info('Pre-caching dataset to avoid NCCL timeout')

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -196,7 +196,7 @@ class BaseTrainer:
         It has to be done before DDP initialization
         """
         if RANK in (-1, 0):
-            LOGGER.info(f'Pre-caching dataset to avoid NCCL timeout')
+            LOGGER.info('Pre-caching dataset to avoid NCCL timeout')
             self.get_dataloader(self.trainset, batch_size=1, rank=RANK, mode='train')
             self.get_dataloader(self.testset, batch_size=1, rank=-1, mode='val')
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4d14f7e</samp>

### Summary
🚀🐛🧹

<!--
1.  🚀 This emoji represents the speed improvement that pre-caching the dataset can bring to DDP training, as it reduces the time spent on data loading and synchronization across processes.
2.  🐛 This emoji represents the bug fix that this pull request provides, as it prevents NCCL timeout errors that can occur when using DDP with large datasets and the default batch size.
3.  🧹 This emoji represents the code cleanup that this pull request performs, as it refactors the data loading logic into a separate method and adds some comments to explain the purpose and steps of pre-caching the dataset.
-->
This pull request improves DDP compatibility with large datasets by adding a `_pre_caching_dataset` method to `BaseTrainer` that loads the data before DDP starts.

> _Sing, O Muse, of the cunning `BaseTrainer` class,_
> _That devised a new method to avert a dire impasse,_
> _When the mighty NCCL faced a timeout from the gods,_
> _As it struggled to distribute large datasets with its rods._

### Walkthrough
*  Add a method to cache datasets before DDP initialization ([link](https://github.com/ultralytics/ultralytics/pull/2549/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1R193-R202))
*  Call the caching method in the main training loop ([link](https://github.com/ultralytics/ultralytics/pull/2549/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1R276))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Dataset Caching to Prevent NCCL Timeouts During Training

### 📊 Key Changes
- Introduction of a new method `_pre_caching_dataset` for dataset pre-caching.
- Enhanced logging to inform about the pre-caching process.
- Inclusion of pre-caching steps in the distributed data parallel (DDP) setup for training.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: To address network communication issues (NCCL timeouts) that can occur during distributed training by pre-loading the dataset.
- 💡 **Impact**: Ensures smoother training sessions in distributed environments by avoiding interruptions due to timeouts, which can frustrate users and impede model development.
- 🤝 **User Benefit**: Improved reliability and efficiency for developers running distributed training on Ultralytics' framework.