### PR TITLE
Revert "add pre-caching stage to avoid nccl timeout"

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -190,17 +190,6 @@ class BaseTrainer:
         else:
             self._do_train(world_size)
 
-    def _pre_caching_dataset(self):
-        """
-        Caching dataset before training to avoid NCCL timeout.
-        Must be done before DDP initialization.
-        See https://github.com/ultralytics/ultralytics/pull/2549 for details.
-        """
-        if RANK in (-1, 0):
-            LOGGER.info('Pre-caching dataset to avoid NCCL timeout')
-            self.get_dataloader(self.trainset, batch_size=1, rank=RANK, mode='train')
-            self.get_dataloader(self.testset, batch_size=1, rank=-1, mode='val')
-
     def _setup_ddp(self, world_size):
         """Initializes and sets the DistributedDataParallel parameters for training."""
         torch.cuda.set_device(RANK)
@@ -274,7 +263,6 @@ class BaseTrainer:
     def _do_train(self, world_size=1):
         """Train completed, evaluate and plot if specified by arguments."""
         if world_size > 1:
-            self._pre_caching_dataset()
             self._setup_ddp(world_size)
 
         self._setup_train(world_size)


### PR DESCRIPTION
Reverts ultralytics/ultralytics#2549

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removal of pre-caching dataset functionality in YOLO training routine.

### 📊 Key Changes
- Deleted the `_pre_caching_dataset` method which pre-loaded the dataset to prevent NCCL timeout errors.
- Removed the call to `_pre_caching_dataset` within the `_do_train` method.

### 🎯 Purpose & Impact
- **Purpose**: This change aims to streamline the training process by removing an unnecessary pre-caching step, presuming it's no longer required due to updates in handling datasets or NCCL improvements.
- **Impact**: Users might experience faster preparation times before training starts as the system will no longer preload the dataset. However, there's a slim chance of NCCL timeout errors if the issue still exists in certain environments or configurations. 🚀🕒