### PR TITLE
Update predict.md

### DIFF
--- a/docs/modes/predict.md
+++ b/docs/modes/predict.md
@@ -49,7 +49,7 @@ whether each source can be used in streaming mode with `stream=True` ✅ and an 
 | URL         | `'https://ultralytics.com/images/bus.jpg'` | `str`          |                  |
 | screenshot  | `'screen'`                                 | `str`          |                  |
 | PIL         | `Image.open('im.jpg')`                     | `PIL.Image`    | HWC, RGB         |
-| OpenCV      | `cv2.imread('im.jpg')[:,:,::-1]`           | `np.ndarray`   | HWC, BGR to RGB  |
+| OpenCV      | `cv2.imread('im.jpg')`                     | `np.ndarray`   | HWC, BGR         |
 | numpy       | `np.zeros((640,1280,3))`                   | `np.ndarray`   | HWC              |
 | torch       | `torch.zeros(16,3,320,640)`                | `torch.Tensor` | BCHW, RGB        |
 | CSV         | `'sources.csv'`                            | `str`, `Path`  | RTSP, RTMP, HTTP |         


### PR DESCRIPTION
fix the doc error
img ndarray should be bgr but not rgb


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2fb31c1</samp>

### Summary
📝🐛🎨

<!--
1.  📝 - This emoji represents documentation or writing, and can be used for any changes that involve fixing or updating documentation.
2.  🐛 - This emoji represents a bug or an error, and can be used for any changes that involve fixing or correcting a mistake or a problem in the code or the logic.
3.  🎨 - This emoji represents design or aesthetics, and can be used for any changes that involve improving or modifying the appearance or the style of the code or the output.
-->
This pull request improves the accuracy and readability of the `predict` mode documentation in `docs/modes/predict.md`. It corrects a typo in the `cv2.COLOR_BGR2RGB` constant and a code block indentation.

> _The docs of the `predict` mode_
> _Had some errors that needed a code_
> _A typo was fixed_
> _And a code block was nixed_
> _To make the documentation more ode_

### Walkthrough
* Fix typo in OpenCV source for RGB conversion in `predict` mode documentation ([link](https://github.com/ultralytics/ultralytics/pull/2594/files?diff=unified&w=0#diff-31a8e95fab032c4aff065cd0faacd330d81e4b154c017a7827c9f85d7f8dea49L52-R52))
* Remove extra backtick in code block ending in `predict` mode documentation ([link](https://github.com/ultralytics/ultralytics/pull/2594/files?diff=unified&w=0#diff-31a8e95fab032c4aff065cd0faacd330d81e4b154c017a7827c9f85d7f8dea49L282-R282))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated documentation for image loading consistency.

### 📊 Key Changes
- Modified the example of loading an image using OpenCV in the documentation to remove the color space conversion step.

### 🎯 Purpose & Impact
- Ensures the OpenCV image loading example aligns with common practices, avoiding unnecessary confusion for the user.
- 📈 Potential to improve user understanding of image input formats and enhance ease of integration with the Ultralytics pipeline.