### PR TITLE
Fix typo in byte_tracker.py

### DIFF
--- a/ultralytics/tracker/trackers/byte_tracker.py
+++ b/ultralytics/tracker/trackers/byte_tracker.py
@@ -181,7 +181,7 @@ class BYTETracker:
     def update(self, results, img=None):
         """Updates object tracker with new detections and returns tracked object bounding boxes."""
         self.frame_id += 1
-        activated_starcks = []
+        activated_stracks = []
         refind_stracks = []
         lost_stracks = []
         removed_stracks = []
@@ -230,7 +230,7 @@ class BYTETracker:
             det = detections[idet]
             if track.state == TrackState.Tracked:
                 track.update(det, self.frame_id)
-                activated_starcks.append(track)
+                activated_stracks.append(track)
             else:
                 track.re_activate(det, self.frame_id, new_id=False)
                 refind_stracks.append(track)
@@ -246,7 +246,7 @@ class BYTETracker:
             det = detections_second[idet]
             if track.state == TrackState.Tracked:
                 track.update(det, self.frame_id)
-                activated_starcks.append(track)
+                activated_stracks.append(track)
             else:
                 track.re_activate(det, self.frame_id, new_id=False)
                 refind_stracks.append(track)
@@ -262,7 +262,7 @@ class BYTETracker:
         matches, u_unconfirmed, u_detection = matching.linear_assignment(dists, thresh=0.7)
         for itracked, idet in matches:
             unconfirmed[itracked].update(detections[idet], self.frame_id)
-            activated_starcks.append(unconfirmed[itracked])
+            activated_stracks.append(unconfirmed[itracked])
         for it in u_unconfirmed:
             track = unconfirmed[it]
             track.mark_removed()
@@ -273,7 +273,7 @@ class BYTETracker:
             if track.score < self.args.new_track_thresh:
                 continue
             track.activate(self.kalman_filter, self.frame_id)
-            activated_starcks.append(track)
+            activated_stracks.append(track)
         # Step 5: Update state
         for track in self.lost_stracks:
             if self.frame_id - track.end_frame > self.max_time_lost:
@@ -281,7 +281,7 @@ class BYTETracker:
                 removed_stracks.append(track)
 
         self.tracked_stracks = [t for t in self.tracked_stracks if t.state == TrackState.Tracked]
-        self.tracked_stracks = self.joint_stracks(self.tracked_stracks, activated_starcks)
+        self.tracked_stracks = self.joint_stracks(self.tracked_stracks, activated_stracks)
         self.tracked_stracks = self.joint_stracks(self.tracked_stracks, refind_stracks)
         self.lost_stracks = self.sub_stracks(self.lost_stracks, self.tracked_stracks)
         self.lost_stracks.extend(lost_stracks)


### PR DESCRIPTION
"activated_starcks" -> "activated_stracks"


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 262f036</samp>

### Summary
🐛🔧📝

<!--
1.  🐛 - This emoji represents a bug fix, as the typo could potentially cause errors or confusion in the code execution or readability.
2.  🔧 - This emoji represents a tool or a configuration change, as the variable name is part of the internal logic of the tracker and does not affect the external functionality or interface of the module.
3.  📝 - This emoji represents a documentation or comment change, as the variable name is also used in some comments and docstrings that explain the code.
-->
Fix a typo in the variable name `activated_stracks` in the file `./ultralytics/tracker/trackers/byte_tracker.py`. This improves the readability and consistency of the code that handles the tracking of detected objects in video frames.

> _`activated_stracks`_
> _A typo in the tracker_
> _Fixed in this pull_

### Walkthrough
*  Fix typo in variable name `activated_starcks` to `activated_stracks` in `byte_tracker.py` ([link](https://github.com/ultralytics/ultralytics/pull/2598/files?diff=unified&w=0#diff-317c8460d2f887c9f03f21c8918bae301234c93ab37847e0f6f8802aae9592a5L184-R184), [link](https://github.com/ultralytics/ultralytics/pull/2598/files?diff=unified&w=0#diff-317c8460d2f887c9f03f21c8918bae301234c93ab37847e0f6f8802aae9592a5L233-R233), [link](https://github.com/ultralytics/ultralytics/pull/2598/files?diff=unified&w=0#diff-317c8460d2f887c9f03f21c8918bae301234c93ab37847e0f6f8802aae9592a5L249-R249), [link](https://github.com/ultralytics/ultralytics/pull/2598/files?diff=unified&w=0#diff-317c8460d2f887c9f03f21c8918bae301234c93ab37847e0f6f8802aae9592a5L265-R265), [link](https://github.com/ultralytics/ultralytics/pull/2598/files?diff=unified&w=0#diff-317c8460d2f887c9f03f21c8918bae301234c93ab37847e0f6f8802aae9592a5L276-R276), [link](https://github.com/ultralytics/ultralytics/pull/2598/files?diff=unified&w=0#diff-317c8460d2f887c9f03f21c8918bae301234c93ab37847e0f6f8802aae9592a5L284-R284))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fix variable misspelling in object tracking update method.

### 📊 Key Changes
- Corrected the variable name from `activated_starcks` to `activated_stracks` in multiple lines.

### 🎯 Purpose & Impact
- **Purpose:** The changes correct typos to ensure consistency and clarity in the code base.
- **Impact:** No impact on functionality, but improves code readability and maintainability.