### PR TITLE
fix load_image

### DIFF
--- a/ultralytics/yolo/data/base.py
+++ b/ultralytics/yolo/data/base.py
@@ -145,7 +145,7 @@ class BaseDataset(Dataset):
             r = self.imgsz / max(h0, w0)  # ratio
             if r != 1:  # if sizes are not equal
                 interp = cv2.INTER_LINEAR if (self.augment or r > 1) else cv2.INTER_AREA
-                im = cv2.resize(im, (math.ceil(w0 * r), math.ceil(h0 * r)), interpolation=interp)
+                im = cv2.resize(im, (min(math.ceil(w0 * r), self.imgsz), min(math.ceil(h0 * r), self.imgsz)), interpolation=interp)
             return im, (h0, w0), im.shape[:2]  # im, hw_original, hw_resized
         return self.ims[i], self.im_hw0[i], self.im_hw[i]  # im, hw_original, hw_resized
 

--- a/ultralytics/yolo/data/base.py
+++ b/ultralytics/yolo/data/base.py
@@ -145,7 +145,8 @@ class BaseDataset(Dataset):
             r = self.imgsz / max(h0, w0)  # ratio
             if r != 1:  # if sizes are not equal
                 interp = cv2.INTER_LINEAR if (self.augment or r > 1) else cv2.INTER_AREA
-                im = cv2.resize(im, (min(math.ceil(w0 * r), self.imgsz), min(math.ceil(h0 * r), self.imgsz)), interpolation=interp)
+                im = cv2.resize(im, (min(math.ceil(w0 * r), self.imgsz), min(math.ceil(h0 * r), self.imgsz)),
+                                interpolation=interp)
             return im, (h0, w0), im.shape[:2]  # im, hw_original, hw_resized
         return self.ims[i], self.im_hw0[i], self.im_hw[i]  # im, hw_original, hw_resized
 


### PR DESCRIPTION
@glenn-jocher 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 603a857</samp>

### Summary
🐛📷🚀

<!--
1.  🐛 - This emoji represents a bug fix, as the change is intended to solve a problem that affects the functionality or performance of the code.
2.  📷 - This emoji represents an image-related change, as the change affects the way images are resized and loaded for the model.
3.  🚀 - This emoji represents a performance improvement, as the change potentially reduces the memory usage and the computation time of the model by avoiding unnecessarily large images.
-->
Fix image size bug in `BaseDataset` class. Limit the resized image to the desired model size using `cv2.resize` in `load_image`.

> _`cv2.resize` changed_
> _Limit image size to `imgsz`_
> _Avoid memory errors_

### Walkthrough
*  Limit the maximum size of the resized image to the desired image size for the model in the `load_image` method of the `BaseDataset` class ([link](https://github.com/ultralytics/ultralytics/pull/2612/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fL148-R148)). This fixes a bug related to the image size handling in the data loading process in the `ultralytics/yolo/data/base.py` file.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in image resizing logic for YOLO data processing.

### 📊 Key Changes
- Modified the `cv2.resize` function to cap the resizing at `self.imgsz` for both width and height.

### 🎯 Purpose & Impact
- 🎨 Ensures that during image preprocessing, the resized image dimensions do not exceed the defined input size `self.imgsz`.
- 🚀 Potentially prevents introducing distortions or unexpected aspects in training data due to oversized image dimensions.
- 💡 Helps in maintaining consistent input data size, which is important for model performance and stability.