### PR TITLE
fix loss

### DIFF
--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -34,7 +34,7 @@ class BboxLoss(nn.Module):
 
     def forward(self, pred_dist, pred_bboxes, anchor_points, target_bboxes, target_scores, target_scores_sum, fg_mask):
         """IoU loss."""
-        weight = target_scores.sum(-1)[fg_mask]
+        weight = target_scores.sum(-1)[fg_mask].unsqueeze(-1)
         iou = bbox_iou(pred_bboxes[fg_mask], target_bboxes[fg_mask], xywh=False, CIoU=True)
         loss_iou = ((1.0 - iou) * weight).sum() / target_scores_sum
 


### PR DESCRIPTION
@glenn-jocher @AyushExel 
before:
![image](https://github.com/ultralytics/ultralytics/assets/61612323/f90c6243-7800-4f9d-ad02-c5b43fa93560)

after:
![image](https://github.com/ultralytics/ultralytics/assets/61612323/dca9d27b-0c44-483f-9e34-2aaa401e8c50)


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d733f6d</samp>

### Summary
🐛🧮🚀

<!--
1.  🐛 - This emoji represents a bug fix, since the original code had a broadcasting error that caused incorrect loss values.
2.  🧮 - This emoji represents a mathematical or numerical operation, since the unsqueeze and multiplication are both tensor operations that manipulate the shape and values of the tensors.
3.  🚀 - This emoji represents a performance improvement, since the correct loss calculation can lead to better training results and faster convergence of the model.
-->
Fix IoU loss bug in `loss.py` by unsqueezing `weight` tensor. This ensures correct weighting of the IoU loss for the YOLOv5 model.

> _`weight` unsqueezed_
> _to match `iou` shape_
> _autumn bug fixing_

### Walkthrough
*  Unsqueeze `weight` tensor to match `iou` shape and avoid broadcasting errors in IoU loss calculation ([link](https://github.com/ultralytics/ultralytics/pull/2614/files?diff=unified&w=0#diff-7376f8301a51997a10901e6d8d5ef6a497f074f7c7d7209e003282245c4c6e2dL37-R37))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced IoU loss calculation by updating weight tensor dimensions.

### 📊 Key Changes
- Altered the shape of the `weight` tensor in the IoU loss function by adding a singleton dimension with `unsqueeze`.

### 🎯 Purpose & Impact
- **Purpose:** To ensure the weight tensor aligns correctly with other tensors during element-wise operations.
- **Impact:** Improves the stability of loss calculations, potentially leading to better training performance and model accuracy. This change is likely to be transparent to most users but could enhance the model's learning process behind the scenes. 🧠📈