### PR TITLE
Pre-caching dataset to avoid NCCL timeout before running DDP command

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -181,6 +181,8 @@ class BaseTrainer:
             # Command
             cmd, file = generate_ddp_command(world_size, self)
             try:
+                LOGGER.info('Pre-caching dataset to avoid NCCL timeout before running DDP command')
+                deepcopy(self)._setup_train(world_size=0)
                 LOGGER.info(f'Running DDP command {cmd}')
                 subprocess.run(cmd, check=True)
             except Exception as e:


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a5caa27</samp>

### Summary
🚀🛡️🗄️

<!--
1.  🚀 This emoji can be used to indicate that the change is aimed at improving the performance and speed of the DDP training mode, as well as avoiding a potential error. The rocket emoji can also convey a sense of excitement and enthusiasm for the change.
2.  🛡️ This emoji can be used to indicate that the change is intended to protect the DDP training mode from a possible timeout error caused by NCCL. The shield emoji can also suggest a sense of security and reliability for the change.
3.  🗄️ This emoji can be used to indicate that the change involves pre-caching the dataset before running the DDP command. The file cabinet emoji can also imply a sense of organization and preparation for the change.
-->
This pull request improves the DDP training mode by pre-caching the dataset in `trainer.py` to prevent NCCL timeout errors.

> _`NCCL` may fail_
> _pre-cache the dataset first_
> _winter of DDP_

### Walkthrough
* Pre-cache the dataset before DDP command to avoid NCCL timeout error ([link](https://github.com/ultralytics/ultralytics/pull/2616/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1R184-R185))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved distributed data parallel (DDP) training stability by pre-caching datasets.

### 📊 Key Changes
- Added a pre-caching step of the dataset before initiating the DDP command.
- Inserted informative logging to acknowledge the pre-caching process.

### 🎯 Purpose & Impact
- **Prevents NCCL timeouts:** Pre-caching ensures all necessary data is available before DDP, reducing the risk of timeout errors.
- **Enhanced user feedback:** Logging provides clear communication to the user about the pre-caching action, enhancing transparency.
- **Smoother user experience:** This change aims to create a more stable and reliable training process for users leveraging DDP in their workflows. 🚀