### PR TITLE
fix bug not same device

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -346,7 +346,7 @@ class RTDETRDecoder(nn.Module):
         bs, _, _ = memory.shape
         # prepare input for decoder
         anchors, valid_mask = self._generate_anchors(spatial_shapes, dtype=memory.dtype, device=memory.device)
-        memory = torch.where(valid_mask, memory, torch.tensor(0.).to(memory.device))
+        memory = torch.where(valid_mask, memory, 0)
         output_memory = self.enc_output(memory)
 
         enc_outputs_class = self.enc_score_head(output_memory)  # (bs, h*w, nc)

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -346,7 +346,7 @@ class RTDETRDecoder(nn.Module):
         bs, _, _ = memory.shape
         # prepare input for decoder
         anchors, valid_mask = self._generate_anchors(spatial_shapes, dtype=memory.dtype, device=memory.device)
-        memory = torch.where(valid_mask, memory, torch.tensor(0.))
+        memory = torch.where(valid_mask, memory, torch.tensor(0.).to(memory.device))
         output_memory = self.enc_output(memory)
 
         enc_outputs_class = self.enc_score_head(output_memory)  # (bs, h*w, nc)


### PR DESCRIPTION
fix bug 
for detr prediction. tensor is not in same device
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7fad851</samp>

### Summary
🐛🚀🎛️

<!--
1.  🐛 - This emoji represents a bug fix, as the change resolves an error that was caused by a mismatch of device types.
2.  🚀 - This emoji represents a performance improvement, as the change avoids unnecessary data transfers between CPU and GPU, which can slow down the training process.
3.  🎛️ - This emoji represents a configuration or compatibility enhancement, as the change makes the code more robust and adaptable to different settings, such as mixed precision and CUDA.
-->
Fix a bug in `head.py` that causes an error when using mixed precision training with CUDA. Add device compatibility to the memory masking tensor.

> _`memory.device`_
> _aligns the zero tensor_
> _a bug fix for CUDA_

### Walkthrough
*  Fix bug with mixed precision training and CUDA by matching device of zero tensor to memory tensor ([link](https://github.com/ultralytics/ultralytics/pull/2628/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L349-R349))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved decoder memory handling in neural network module.

### 📊 Key Changes
- Replaced `torch.tensor(0.)` with a scalar `0` in the `torch.where` call within the neural network's decoder.

### 🎯 Purpose & Impact
- **Consistency:** Using a scalar instead of a tensor for a single value is more conventional and aligned with general PyTorch practices.
- **Performance:** Potentially reduces overhead by not creating a new tensor for a single value, which may slightly improve memory usage and performance.
- **Code Readability:** Increases readability as using a scalar is more straightforward for this context, making the codebase cleaner and easier to understand for developers.