### PR TITLE
Revert Mosaic from n=9 to n=4

### DIFF
--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -128,7 +128,7 @@ class Mosaic(BaseMixTransform):
         n (int, optional): The grid size, either 4 (for 2x2) or 9 (for 3x3).
     """
 
-    def __init__(self, dataset, imgsz=640, p=1.0, n=9):
+    def __init__(self, dataset, imgsz=640, p=1.0, n=4):
         """Initializes the object with a dataset, image size, probability, and border."""
         assert 0 <= p <= 1.0, f'The probability should be in range [0, 1], but got {p}.'
         assert n in (4, 9), 'grid must be equal to 4 or 9.'


### PR DESCRIPTION
Need to experiment some more.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 91dc561</samp>

### Summary
🖼️🚀💾

<!--
1.  🖼️ This emoji represents the mosaic image augmentation technique, which combines four images into one for training the object detection model. It can also be seen as a way of expressing the visual aspect of the change.
2.  🚀 This emoji represents the improvement in performance and efficiency that the change brings, as well as the alignment with the original paper. It can also be seen as a way of expressing the speed and innovation of the change.
3.  💾 This emoji represents the reduction in computational cost and memory usage that the change brings, as well as the optimization of the model. It can also be seen as a way of expressing the resourcefulness and saving of the change.
-->
Reduced the number of images used for mosaic augmentation in `ultralytics/yolo/data/augment.py`. This improved the speed and memory usage of the YOLOv5 model and followed the original paper's settings.

> _`Mosaic` augments_
> _With fewer images now_
> _Winter of training_

### Walkthrough
* Reduce the number of images in mosaic augmentation from 9 to 4 ([link](https://github.com/ultralytics/ultralytics/pull/2633/files?diff=unified&w=0#diff-13d355434447b3961ec61d1c80bedc2b6db2d98ab0df572eb036f4e8b536aee9L131-R131)). This improves efficiency and aligns with the original paper.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image augmentation efficiency by changing the default mosaic grid size.

### 📊 Key Changes
- Changed the default mosaic grid size from 3x3 (n=9) to 2x2 (n=4) in the image augmentation process.

### 🎯 Purpose & Impact
- **Purpose**: To optimize the mosaic augmentation by using a simpler and possibly more effective grid configuration.
- **Impact**: This could potentially speed up the data augmentation process during training and may improve the generalization ability of models trained with these images by focusing on larger, possibly more informative regions of mosaic images. Users may notice quicker training times and possibly better model performance. 🏃💨📈