### PR TITLE
update imgsz=224 in classify

### DIFF
--- a/ultralytics/yolo/v8/classify/train.py
+++ b/ultralytics/yolo/v8/classify/train.py
@@ -19,6 +19,8 @@ class ClassificationTrainer(BaseTrainer):
         if overrides is None:
             overrides = {}
         overrides['task'] = 'classify'
+        if overrides.get("imgsz") is None:
+            overrides['imgsz'] = 224 
         super().__init__(cfg, overrides, _callbacks)
 
     def set_model_attributes(self):
@@ -39,10 +41,6 @@ class ClassificationTrainer(BaseTrainer):
                 m.p = self.args.dropout  # set dropout
         for p in model.parameters():
             p.requires_grad = True  # for training
-
-        # Update defaults
-        if self.args.imgsz == 640:
-            self.args.imgsz = 224
 
         return model
 

--- a/ultralytics/yolo/v8/classify/train.py
+++ b/ultralytics/yolo/v8/classify/train.py
@@ -19,8 +19,8 @@ class ClassificationTrainer(BaseTrainer):
         if overrides is None:
             overrides = {}
         overrides['task'] = 'classify'
-        if overrides.get("imgsz") is None:
-            overrides['imgsz'] = 224 
+        if overrides.get('imgsz') is None:
+            overrides['imgsz'] = 224
         super().__init__(cfg, overrides, _callbacks)
 
     def set_model_attributes(self):


### PR DESCRIPTION

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 36f5b1d</samp>

### Summary
📷🔄🎯

<!--
1.  📷 - This emoji represents the change in image size, since it is related to photography and image quality.
2.  🔄 - This emoji represents the removal of unnecessary code, since it implies simplifying and streamlining the codebase.
3.  🎯 - This emoji represents the improvement in consistency and simplicity, since it suggests achieving a clear and focused goal.
-->
This pull request updates the classification training code in `ultralytics/yolo/v8/classify/train.py` to use a standard image size and remove redundant code. This makes the code more efficient and easier to maintain.

> _`224` pixels_
> _A clear and simple vision_
> _Code sheds winter coat_

### Walkthrough
* Set the default image size for classification training to 224 pixels ([link](https://github.com/ultralytics/ultralytics/pull/2637/files?diff=unified&w=0#diff-734f7c7d5e997138ddb17cffc50e37008364bb3fdba26403ee9d145ce2764f69R22-R23))
* Remove the redundant code that updates the image size to 224 pixels ([link](https://github.com/ultralytics/ultralytics/pull/2637/files?diff=unified&w=0#diff-734f7c7d5e997138ddb17cffc50e37008364bb3fdba26403ee9d145ce2764f69L43-L46))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplification of image size configuration for classification in YOLOv8.

### 📊 Key Changes
- Set default image size (`imgsz`) for classification task to 224 if not specified in overrides.
- Removal of size adjustment condition within the `get_model` function.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: Streamlines the default setting for image size, making it more consistent for the classification task.
- ✨ **Impact**: Users will benefit from a cleaner, more intuitive default configuration, reducing potential confusion and simplifying the process of starting projects related to image classification.