### PR TITLE
Fix FP16 for NVIDIA Triton models

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -80,7 +80,7 @@ class AutoBackend(nn.Module):
         w = str(weights[0] if isinstance(weights, list) else weights)
         nn_module = isinstance(weights, torch.nn.Module)
         pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle, triton = self._model_type(w)
-        fp16 &= pt or jit or onnx or engine or nn_module  # FP16
+        fp16 &= pt or jit or onnx or engine or nn_module or triton  # FP16
         nhwc = coreml or saved_model or pb or tflite or edgetpu  # BHWC formats (vs torch BCWH)
         stride = 32  # default stride
         model, metadata = None, None


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d36ebd</samp>

### Summary
:sparkles::wrench::rocket:

<!--
1.  :sparkles: - This emoji can be used to indicate a new feature or enhancement, such as adding support for a new backend.
2.  :wrench: - This emoji can be used to indicate a tool or configuration change, such as adding a new option for FP16 format.
3.  :rocket: - This emoji can be used to indicate a performance improvement or optimization, such as enabling faster inference with FP16 precision.
-->
Add `triton` as an FP16 option in `autobackend.py`. This enables ultralytics models to use NVIDIA Triton Inference Server as a backend for faster and more scalable inference.

> _`fp16` expands_
> _Triton joins the inference_
> _Winter of models_

### Walkthrough
* Add support for NVIDIA Triton Inference Server as a backend for ultralytics models ([link](https://github.com/ultralytics/ultralytics/pull/2652/files?diff=unified&w=0#diff-2e3ad5da4ba57eb68a9b5aaddf0c40c784d888b7619ed337ce31dfea4f6380f9L83-R83))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced precision support for Triton models in Ultralytics NN backend.

### 📊 Key Changes
- Added FP16 (half-precision) support for the Triton backend within the neural network module.

### 🎯 Purpose & Impact
- The update allows the Triton backend to utilize half-precision floating-point, which can improve performance and reduce memory usage during model inference.
- Users deploying models using the Triton backend can now leverage the benefits of FP16, potentially achieving faster inference times and cost savings on compatible hardware. 🚀