### PR TITLE
Increase DDP timeout to 3600s

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -195,6 +195,7 @@ class BaseTrainer:
         torch.cuda.set_device(RANK)
         self.device = torch.device('cuda', RANK)
         LOGGER.info(f'DDP settings: RANK {RANK}, WORLD_SIZE {world_size}, DEVICE {self.device}')
+        os.environ['NCCL_BLOCKING_WAIT'] = '1'  # set to enforce timeout
         dist.init_process_group('nccl' if dist.is_nccl_available() else 'gloo',
                                 timeout=timedelta(seconds=3600),
                                 rank=RANK,

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -9,7 +9,7 @@ import os
 import subprocess
 import time
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
@@ -181,8 +181,6 @@ class BaseTrainer:
             # Command
             cmd, file = generate_ddp_command(world_size, self)
             try:
-                LOGGER.info('Pre-caching dataset to avoid NCCL timeout before running DDP command')
-                deepcopy(self)._setup_train(world_size=0)
                 LOGGER.info(f'Running DDP command {cmd}')
                 subprocess.run(cmd, check=True)
             except Exception as e:
@@ -197,7 +195,10 @@ class BaseTrainer:
         torch.cuda.set_device(RANK)
         self.device = torch.device('cuda', RANK)
         LOGGER.info(f'DDP settings: RANK {RANK}, WORLD_SIZE {world_size}, DEVICE {self.device}')
-        dist.init_process_group('nccl' if dist.is_nccl_available() else 'gloo', rank=RANK, world_size=world_size)
+        dist.init_process_group('nccl' if dist.is_nccl_available() else 'gloo',
+                                timeout=timedelta(seconds=3600),
+                                rank=RANK,
+                                world_size=world_size)
 
     def _setup_train(self, world_size):
         """


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/2642

@developer0hye 

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 89b808c</samp>

### Summary
🕒🚫🚀

<!--
1.  🕒 - This emoji can be used to indicate the addition of the `timedelta` module and the custom timeout duration for the distributed training initialization. It suggests that the changes are related to time management and performance optimization.
2.  🚫 - This emoji can be used to indicate the removal of the pre-caching of the dataset that caused memory issues. It suggests that the changes are related to fixing a bug or avoiding a problem.
3.  🚀 - This emoji can be used to indicate the improvement of the distributed training functionality of the YOLO engine. It suggests that the changes are related to enhancing the speed, efficiency, or scalability of the model.
-->
This pull request enhances the distributed training performance and memory efficiency of the `ultralytics/yolo` engine by adjusting the timeout and pre-caching settings in `trainer.py`.

> _Sing, O Muse, of the valiant YOLO engine, that swiftly trains_
> _the keen-eyed models to detect the objects in the images._
> _It faced a mighty challenge, when the training was distributed_
> _across the nodes, and had to synchronize the processes._

### Walkthrough
* Increase the timeout duration for distributed process group initialization to prevent NCCL timeout error ([link](https://github.com/ultralytics/ultralytics/pull/2657/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L12-R12), [link](https://github.com/ultralytics/ultralytics/pull/2657/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L200-R201)) in `trainer.py`




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness of distributed training setup in Ultralytics YOLO.

### 📊 Key Changes
- Removed pre-caching of the dataset before running DDP (Distributed Data Parallel) command to streamline the process.
- Set an environment variable `NCCL_BLOCKING_WAIT` to enforce a timeout in distributed training.
- Added a timeout parameter to `dist.init_process_group` to handle potential deadlocks in distributed training.

### 🎯 Purpose & Impact
- 🚀 Enhancing the training process by removing unnecessary steps, aiming to reduce startup time.
- 🛡️ Increasing the reliability of distributed training with better error handling for potential hang-ups or delays.
- 🤖 Users can benefit from more stable and efficient training experience for large-scale machine learning tasks.