### PR TITLE
block duplicate logging bug

### DIFF
--- a/ultralytics/yolo/data/build.py
+++ b/ultralytics/yolo/data/build.py
@@ -102,7 +102,7 @@ def build_dataloader(dataset, batch, workers, shuffle=True, rank=-1):
                               shuffle=shuffle and sampler is None,
                               num_workers=nw,
                               sampler=sampler,
-                              pin_memory=PIN_MEMORY,
+                              pin_memory=PIN_MEMORY and torch.cuda.is_available(),
                               collate_fn=getattr(dataset, 'collate_fn', None),
                               worker_init_fn=seed_worker,
                               generator=generator)

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -182,7 +182,8 @@ class BaseTrainer:
             cmd, file = generate_ddp_command(world_size, self)
             try:
                 LOGGER.info('Pre-caching dataset to avoid NCCL timeout before running DDP command')
-                self.callbacks.clear() # block duplicate logging bug https://github.com/ultralytics/ultralytics/issues/2642
+                self.callbacks.clear(
+                )  # block duplicate logging bug https://github.com/ultralytics/ultralytics/issues/2642
                 deepcopy(self)._setup_train(world_size=0)
                 LOGGER.info(f'Running DDP command {cmd}')
                 subprocess.run(cmd, check=True)

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -182,6 +182,7 @@ class BaseTrainer:
             cmd, file = generate_ddp_command(world_size, self)
             try:
                 LOGGER.info('Pre-caching dataset to avoid NCCL timeout before running DDP command')
+                self.callbacks.clear() # block duplicate logging bug https://github.com/ultralytics/ultralytics/issues/2642
                 deepcopy(self)._setup_train(world_size=0)
                 LOGGER.info(f'Running DDP command {cmd}')
                 subprocess.run(cmd, check=True)

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -184,6 +184,7 @@ class BaseTrainer:
                 LOGGER.info('Pre-caching dataset to avoid NCCL timeout before running DDP command')
                 self.callbacks.clear(
                 )  # block duplicate logging bug https://github.com/ultralytics/ultralytics/issues/2642
+                self.device = select_device('cpu', self.args.batch)
                 deepcopy(self)._setup_train(world_size=0)
                 LOGGER.info(f'Running DDP command {cmd}')
                 subprocess.run(cmd, check=True)

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -57,8 +57,9 @@ def select_device(device='', batch=0, newline=False, verbose=True):
         device = device.replace(remove, '')  # to string, 'cuda:0' -> '0' and '(0, 1)' -> '0,1'
     cpu = device == 'cpu'
     mps = device == 'mps'  # Apple Metal Performance Shaders (MPS)
-    if cpu or mps:
-        os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
+    if cpu or mps:  # force torch.cuda.is_available() = False
+        torch.cuda.is_available = lambda: False
+        os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  
     elif device:  # non-cpu device requested
         visible = os.environ.get('CUDA_VISIBLE_DEVICES', None)
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable - must be before assert is_available()


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 39b1c49</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change.
2.  📝 - This emoji represents logging or documentation, which is related to the output of the callbacks and the metrics they report.
3.  🚀 - This emoji represents performance or speed, which is improved by clearing the callbacks and avoiding memory leaks.
-->
Fix callback bug in `trainer.py` that caused memory leaks and incorrect outputs. Clear callbacks list before each epoch to avoid duplication.

> _Clear `callbacks` list_
> _Before each epoch starts - kireji_
> _No more memory leaks_

### Walkthrough
* Fix bug of duplicate callbacks by clearing callbacks list before each epoch ([link](https://github.com/ultralytics/ultralytics/pull/2660/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1R185))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves device handling and data loading for better stability and compatibility, especially when using CPUs or Apple devices. 🚀

### 📊 Key Changes
- Ensures `pin_memory` is only enabled if a CUDA GPU is available, preventing errors on CPU-only systems.
- Fixes a duplicate logging issue during distributed training by clearing callbacks before setup.
- Improves device selection logic to reliably disable CUDA when using CPU or Apple MPS, preventing related bugs.

### 🎯 Purpose & Impact
- Prevents crashes and unexpected behavior when running on CPUs or Apple hardware (like Macs with MPS).
- Makes distributed training (DDP) more robust and less prone to logging bugs.
- Enhances user experience by automatically adapting settings to the available hardware, reducing manual troubleshooting.