### PR TITLE
Remove hard dependency on `thop` (fixes #1622)

### DIFF
--- a/docker/Dockerfile-jetson
+++ b/docker/Dockerfile-jetson
@@ -25,7 +25,7 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt /u
 
 # Install pip packages manually for TensorRT compatibility https://github.com/NVIDIA/TensorRT/issues/2567
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache tqdm matplotlib pyyaml psutil thop pandas onnx "numpy==1.23"
+RUN pip install --no-cache tqdm matplotlib pyyaml psutil pandas onnx "numpy==1.23"
 RUN pip install --no-cache -e .
 
 # Set environment variables

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ seaborn>=0.11.0
 
 # Extras --------------------------------------
 psutil  # system utilization
-thop>=0.1.1  # FLOPs computation
+# thop>=0.1.1  # FLOPs computation
 # ipython  # interactive notebook
 # albumentations>=1.0.3
 # pycocotools>=2.0.6  # COCO mAP

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -4,7 +4,6 @@ import contextlib
 from copy import deepcopy
 from pathlib import Path
 
-import thop
 import torch
 import torch.nn as nn
 
@@ -17,6 +16,11 @@ from ultralytics.yolo.utils.checks import check_requirements, check_suffix, chec
 from ultralytics.yolo.utils.plotting import feature_visualization
 from ultralytics.yolo.utils.torch_utils import (fuse_conv_and_bn, fuse_deconv_and_bn, initialize_weights,
                                                 intersect_dicts, make_divisible, model_info, scale_img, time_sync)
+
+try:
+    import thop
+except ImportError:
+    thop = None
 
 
 class BaseModel(nn.Module):


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a3c2f2f</samp>

### Summary
🐛🚀🧹

<!--
1.  🐛 - This emoji represents a bug fix, as the pull request fixes the errors that occur when thop is not installed and the FLOPs calculation is requested.
2.  🚀 - This emoji represents a performance improvement, as the pull request enables the FLOPs calculation for models, which can help measure their efficiency and compare them with other models.
3.  🧹 - This emoji represents a code cleanup, as the pull request removes a redundant import of thop and simplifies the code.
-->
The pull request improves the compatibility and functionality of the optional thop module for FLOPs calculation. It fixes the import errors in `ultralytics/nn/tasks.py` and `ultralytics/yolo/utils/torch_utils.py` and removes unnecessary imports.

> _`thop` is optional_
> _catch errors gracefully now_
> _autumn of imports_

### Walkthrough
*  Handle optional dependency of thop module for calculating FLOPs of models ([link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-e2650ac65b6525f6d9c0594a226066d396afbcba637c054d29abe04e62f410c4L7), [link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-e2650ac65b6525f6d9c0594a226066d396afbcba637c054d29abe04e62f410c4L21-R25), [link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L14), [link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8R23-R27), [link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L196-R200), [link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L381-R385))
  * Remove unused `import thop` from `ultralytics/nn/tasks.py` ([link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-e2650ac65b6525f6d9c0594a226066d396afbcba637c054d29abe04e62f410c4L7))
  * Add `import thop` inside try-except block in `ultralytics/nn/tasks.py` and `ultralytics/yolo/utils/torch_utils.py` ([link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-e2650ac65b6525f6d9c0594a226066d396afbcba637c054d29abe04e62f410c4L21-R25), [link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8R23-R27))
  * Add conditional check for thop module before calling `thop.profile` in `get_flops` and `profile` functions in `ultralytics/yolo/utils/torch_utils.py` ([link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L196-R200), [link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L381-R385))
  * Return 0 as default value for flops if thop is not available ([link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L196-R200), [link](https://github.com/ultralytics/ultralytics/pull/2664/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8L381-R385))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved compatibility with optional dependencies.

### 📊 Key Changes
- Removed `thop` from the required packages list in Dockerfile and requirements.txt.
- Made `thop` an optional dependency; it's now imported conditionally.
- Modified FLOPs computation to handle cases where `thop` is not installed.

### 🎯 Purpose & Impact
- 🛠️ **Purpose:** The changes are designed to ensure that users who don't need `thop` or face issues installing it aren't forced to have it, reducing installation issues and improving flexibility.
- 🏃‍♂️ **Impact:** Users can now use Ultralytics tools without installing `thop`, making it easier for those on platforms where `thop` may not be necessary or easily available. Performance calculations that depend on `thop` will return zero if it isn't installed, so users interested in FLOPs would need to ensure it's installed manually.