### PR TITLE
dill module support

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -414,12 +414,18 @@ class BaseTrainer:
             'date': datetime.now().isoformat(),
             'version': __version__}
 
+        # Use dill (if exists) to serialize the lambda functions where pickle does not do this
+        try:
+            import dill as pickle
+        except (ImportError, AssertionError):
+            import pickle
+
         # Save last, best and delete
-        torch.save(ckpt, self.last)
+        torch.save(ckpt, self.last, pickle_module=pickle)
         if self.best_fitness == self.fitness:
-            torch.save(ckpt, self.best)
+            torch.save(ckpt, self.best, pickle_module=pickle)
         if (self.epoch > 0) and (self.save_period > 0) and (self.epoch % self.save_period == 0):
-            torch.save(ckpt, self.wdir / f'epoch{self.epoch}.pt')
+            torch.save(ckpt, self.wdir / f'epoch{self.epoch}.pt', pickle_module=pickle)
         del ckpt
 
     @staticmethod

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -416,16 +416,16 @@ class BaseTrainer:
 
         # Use dill (if exists) to serialize the lambda functions where pickle does not do this
         try:
-            import dill as pickle
+            import dill as dill_pickle
         except (ImportError, AssertionError):
-            import pickle
+            import pickle as dill_pickle
 
         # Save last, best and delete
-        torch.save(ckpt, self.last, pickle_module=pickle)
+        torch.save(ckpt, self.last, pickle_module=dill_pickle)
         if self.best_fitness == self.fitness:
-            torch.save(ckpt, self.best, pickle_module=pickle)
+            torch.save(ckpt, self.best, pickle_module=dill_pickle)
         if (self.epoch > 0) and (self.save_period > 0) and (self.epoch % self.save_period == 0):
-            torch.save(ckpt, self.wdir / f'epoch{self.epoch}.pt', pickle_module=pickle)
+            torch.save(ckpt, self.wdir / f'epoch{self.epoch}.pt', pickle_module=dill_pickle)
         del ckpt
 
     @staticmethod

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -343,9 +343,9 @@ def strip_optimizer(f: Union[str, Path] = 'best.pt', s: str = '') -> None:
     """
     # Use dill (if exists) to serialize the lambda functions where pickle does not do this
     try:
-        import dill as pickle
+        import dill as dill_pickle
     except (ImportError, AssertionError):
-        import pickle
+        import pickle as dill_pickle
 
     x = torch.load(f, map_location=torch.device('cpu'))
     args = {**DEFAULT_CFG_DICT, **x['train_args']}  # combine model args with default args, preferring model args
@@ -359,7 +359,7 @@ def strip_optimizer(f: Union[str, Path] = 'best.pt', s: str = '') -> None:
         p.requires_grad = False
     x['train_args'] = {k: v for k, v in args.items() if k in DEFAULT_CFG_KEYS}  # strip non-default keys
     # x['model'].args = x['train_args']
-    torch.save(x, s or f, pickle_module=pickle)
+    torch.save(x, s or f, pickle_module=dill_pickle)
     mb = os.path.getsize(s or f) / 1E6  # filesize
     LOGGER.info(f"Optimizer stripped from {f},{f' saved as {s},' if s else ''} {mb:.1f}MB")
 

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -341,6 +341,12 @@ def strip_optimizer(f: Union[str, Path] = 'best.pt', s: str = '') -> None:
         for f in Path('/Users/glennjocher/Downloads/weights').rglob('*.pt'):
             strip_optimizer(f)
     """
+    # Use dill (if exists) to serialize the lambda functions where pickle does not do this
+    try:
+        import dill as pickle
+    except (ImportError, AssertionError):
+        import pickle
+
     x = torch.load(f, map_location=torch.device('cpu'))
     args = {**DEFAULT_CFG_DICT, **x['train_args']}  # combine model args with default args, preferring model args
     if x.get('ema'):
@@ -353,7 +359,7 @@ def strip_optimizer(f: Union[str, Path] = 'best.pt', s: str = '') -> None:
         p.requires_grad = False
     x['train_args'] = {k: v for k, v in args.items() if k in DEFAULT_CFG_KEYS}  # strip non-default keys
     # x['model'].args = x['train_args']
-    torch.save(x, s or f)
+    torch.save(x, s or f, pickle_module=pickle)
     mb = os.path.getsize(s or f) / 1E6  # filesize
     LOGGER.info(f"Optimizer stripped from {f},{f' saved as {s},' if s else ''} {mb:.1f}MB")
 


### PR DESCRIPTION
Replacing pickle with dill (if installed) to save model safer (see [https://github.com/ultralytics/ultralytics/issues/2668](https://github.com/ultralytics/ultralytics/issues/2668)).


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7deccdc</samp>

### Summary
🐛🚀💬

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request.
2.  🚀 - This emoji represents a performance improvement, which is a possible benefit of using `dill` instead of `pickle` for saving checkpoints, as `dill` can handle more complex objects and reduce the size of the saved file.
3.  💬 - This emoji represents a comment, which is added to the code to explain the reason for using `dill`.
-->
Use `dill` module to save and load checkpoints with lambda functions. Fix bug in `trainer.py` that prevented loading checkpoints with `hyp` dictionary.

> _`dill` can save lambdas_
> _`pickle` fails to do so_
> _a bug fix for spring_

### Walkthrough
* Import `dill` module to save lambda functions in checkpoint ([link](https://github.com/ultralytics/ultralytics/pull/2697/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L417-R428))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model serialization by integrating dill for saving lambda functions.

### 📊 Key Changes
- Integrated the use of `dill`, an advanced serialization library, as an alternative to `pickle`.
- Updated `torch.save` calls to use `dill` as the `pickle_module` if `dill` is available, impacting the saving of model checkpoints.
- Implemented these changes in both `trainer.py` and `torch_utils.py` for consistency and reliability in the serialization process.

### 🎯 Purpose & Impact
- **Purpose**: To enable the serialization (saving) of more complex objects, like lambda functions, which the default `pickle` module cannot handle.
- **Impact**: This change ensures that users can reliably save and load their models, including those with lambda functions, which could improve the usability of Ultralytics frameworks for more advanced use cases. 🚀