### PR TITLE
Fix classify validate on non-existent split

### DIFF
--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -300,9 +300,9 @@ def check_cls_dataset(dataset: str, split=''):
     val_set = data_dir / 'val' if (data_dir / 'val').exists() else None  # data/test or data/val
     test_set = data_dir / 'test' if (data_dir / 'test').exists() else None  # data/val or data/test
     if split == 'val' and not val_set:
-        LOGGER.info(f"WARNING ⚠️ Dataset 'split=val' not found, using 'split=test' instead.")
+        LOGGER.info("WARNING ⚠️ Dataset 'split=val' not found, using 'split=test' instead.")
     elif split == 'test' and not test_set:
-        LOGGER.info(f"WARNING ⚠️ Dataset 'split=test' not found, using 'split=val' instead.")
+        LOGGER.info("WARNING ⚠️ Dataset 'split=test' not found, using 'split=val' instead.")
 
     nc = len([x for x in (data_dir / 'train').glob('*') if x.is_dir()])  # number of classes
     names = [x.name for x in (data_dir / 'train').iterdir() if x.is_dir()]  # class names list

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -266,7 +266,7 @@ def check_det_dataset(dataset, autodownload=True):
     return data  # dictionary
 
 
-def check_cls_dataset(dataset: str):
+def check_cls_dataset(dataset: str, split: str):
     """
     Check a classification dataset such as Imagenet.
 
@@ -275,6 +275,7 @@ def check_cls_dataset(dataset: str):
 
     Args:
         dataset (str): Name of the dataset.
+        split (str): Dataset split, either 'val', 'test', or ''
 
     Returns:
         data (dict): A dictionary containing the following keys and values:
@@ -298,10 +299,15 @@ def check_cls_dataset(dataset: str):
     train_set = data_dir / 'train'
     val_set = data_dir / 'val' if (data_dir / 'val').exists() else None  # data/test or data/val
     test_set = data_dir / 'test' if (data_dir / 'test').exists() else None  # data/val or data/test
+    if split=='val' and not val_set:
+        LOGGER.info(f"WARNING ⚠️ Dataset 'split=val' not found, using 'split=test' instead.")
+    elif split=='test' and not test_set:
+        LOGGER.info(f"WARNING ⚠️ Dataset 'split=test' not found, using 'split=val' instead.")
+
     nc = len([x for x in (data_dir / 'train').glob('*') if x.is_dir()])  # number of classes
     names = [x.name for x in (data_dir / 'train').iterdir() if x.is_dir()]  # class names list
     names = dict(enumerate(sorted(names)))
-    return {'train': train_set, 'val': val_set, 'test': test_set, 'nc': nc, 'names': names}
+    return {'train': train_set, 'val': val_set or test_set, 'test': test_set or val_set, 'nc': nc, 'names': names}
 
 
 class HUBDatasetStats():

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -266,7 +266,7 @@ def check_det_dataset(dataset, autodownload=True):
     return data  # dictionary
 
 
-def check_cls_dataset(dataset: str, split: str):
+def check_cls_dataset(dataset: str, split=''):
     """
     Check a classification dataset such as Imagenet.
 
@@ -275,7 +275,7 @@ def check_cls_dataset(dataset: str, split: str):
 
     Args:
         dataset (str): Name of the dataset.
-        split (str): Dataset split, either 'val', 'test', or ''
+        split (str, optional): Dataset split, either 'val', 'test', or ''. Defaults to ''.
 
     Returns:
         data (dict): A dictionary containing the following keys and values:

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -299,9 +299,9 @@ def check_cls_dataset(dataset: str, split: str):
     train_set = data_dir / 'train'
     val_set = data_dir / 'val' if (data_dir / 'val').exists() else None  # data/test or data/val
     test_set = data_dir / 'test' if (data_dir / 'test').exists() else None  # data/val or data/test
-    if split=='val' and not val_set:
+    if split == 'val' and not val_set:
         LOGGER.info(f"WARNING ⚠️ Dataset 'split=val' not found, using 'split=test' instead.")
-    elif split=='test' and not test_set:
+    elif split == 'test' and not test_set:
         LOGGER.info(f"WARNING ⚠️ Dataset 'split=test' not found, using 'split=val' instead.")
 
     nc = len([x for x in (data_dir / 'train').glob('*') if x.is_dir()])  # number of classes

--- a/ultralytics/yolo/engine/validator.py
+++ b/ultralytics/yolo/engine/validator.py
@@ -126,7 +126,7 @@ class BaseValidator:
             if isinstance(self.args.data, str) and self.args.data.endswith('.yaml'):
                 self.data = check_det_dataset(self.args.data)
             elif self.args.task == 'classify':
-                self.data = check_cls_dataset(self.args.data)
+                self.data = check_cls_dataset(self.args.data, split=self.args.split)
             else:
                 raise FileNotFoundError(emojis(f"Dataset '{self.args.data}' for task={self.args.task} not found ❌"))
 

--- a/ultralytics/yolo/v8/classify/val.py
+++ b/ultralytics/yolo/v8/classify/val.py
@@ -60,8 +60,7 @@ class ClassificationValidator(BaseValidator):
         return self.metrics.results_dict
 
     def build_dataset(self, img_path):
-        dataset = ClassificationDataset(root=img_path, args=self.args, augment=False)
-        return dataset
+        return ClassificationDataset(root=img_path, args=self.args, augment=False)
 
     def get_dataloader(self, dataset_path, batch_size):
         """Builds and returns a data loader for classification tasks with given parameters."""


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/2774

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1421bde</samp>

### Summary
📞🗑️🔀

<!--
1.  📞 for the change in the `__call__` method, since it involves passing an argument to another function.
2.  🗑️ for the change in the `build_dataset` method, since it involves removing an unnecessary variable assignment.
3.  🔀 for the change in the `check_cls_dataset` function, since it involves adding a new option for different dataset splits.
-->
Added support for validating or testing on different dataset splits for classification tasks. Modified `check_cls_dataset`, `BaseValidator`, and `ClassificationValidator` classes and updated `ultralytics/yolo/data/utils.py`, `ultralytics/yolo/engine/validator.py`, and `ultralytics/yolo/v8/classify/val.py` accordingly.

> _`BaseValidator` calls_
> _`check_cls_dataset` with split_
> _simpler, safer code_

### Walkthrough
*  Add `split` argument to `check_cls_dataset` function to specify dataset split for validation or testing ([link](https://github.com/ultralytics/ultralytics/pull/2775/files?diff=unified&w=0#diff-15f6dd1ea95b187a5b50c885f567bad50d006f1af1180508497a038247e9df58L269-R269),[link](https://github.com/ultralytics/ultralytics/pull/2775/files?diff=unified&w=0#diff-15f6dd1ea95b187a5b50c885f567bad50d006f1af1180508497a038247e9df58R278),[link](https://github.com/ultralytics/ultralytics/pull/2775/files?diff=unified&w=0#diff-15f6dd1ea95b187a5b50c885f567bad50d006f1af1180508497a038247e9df58L301-R310))
*  Pass `split` argument from `args` attribute to `check_cls_dataset` function in `BaseValidator` class when `task` is 'classify' ([link](https://github.com/ultralytics/ultralytics/pull/2775/files?diff=unified&w=0#diff-7646fc7a670fe6bbcbf9e637a707139b362bd3b118be7faca28bff7d9b7450c3L129-R129))
*  Simplify `build_dataset` method in `ClassificationValidator` class to return `ClassificationDataset` object directly ([link](https://github.com/ultralytics/ultralytics/pull/2775/files?diff=unified&w=0#diff-96394c180886ae66c7b7b74458274315cc049499272c79ecf2ef04e34315f2fcL63-R63))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dataset checking and improved validation procedure for classification tasks in Ultralytics YOLO software.

### 📊 Key Changes
- Added a `split` parameter to `check_cls_dataset` function to handle dataset splits explicitly.
- Modified the `validator.py` to pass the `split` argument when checking the classification dataset.
- Simplified `build_dataset` method in `val.py` by directly returning the constructed dataset.

### 🎯 Purpose & Impact
- The introduction of the `split` parameter allows users to specify which part of the dataset to validate ('val' or 'test'), resulting in more precise dataset management.
- The change can prevent potential errors when a dataset split is expected but does not exist, improving reliability.
- Streamlined dataset building enhances code readability and may slightly reduce the complexity of the validation process.

📈 Users can expect more flexible and error-resistant handling of their data during validation, which is particularly beneficial for developers working with machine learning models that require regular evaluation across different dataset partitions.