### PR TITLE
Add DVC experiments logger with DVCLive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ tqdm>=4.64.0
 
 # Logging -------------------------------------
 # tensorboard>=2.13.0
+# dvclive>=2.11.0
 # clearml
 # comet
 

--- a/ultralytics/yolo/utils/callbacks/base.py
+++ b/ultralytics/yolo/utils/callbacks/base.py
@@ -198,6 +198,7 @@ def add_integration_callbacks(instance):
     """
     from .clearml import callbacks as clearml_cb
     from .comet import callbacks as comet_cb
+    from .dvc import callbacks as dvc_cb
     from .hub import callbacks as hub_cb
     from .mlflow import callbacks as mlflow_cb
     from .neptune import callbacks as neptune_cb
@@ -205,7 +206,7 @@ def add_integration_callbacks(instance):
     from .tensorboard import callbacks as tensorboard_cb
     from .wb import callbacks as wb_cb
 
-    for x in clearml_cb, comet_cb, hub_cb, mlflow_cb, neptune_cb, tune_cb, tensorboard_cb, wb_cb:
+    for x in clearml_cb, comet_cb, hub_cb, mlflow_cb, neptune_cb, tune_cb, tensorboard_cb, wb_cb, dvc_cb:
         for k, v in x.items():
             if v not in instance.callbacks[k]:  # prevent duplicate callbacks addition
                 instance.callbacks[k].append(v)  # callback[name].append(func)

--- a/ultralytics/yolo/utils/callbacks/dvc.py
+++ b/ultralytics/yolo/utils/callbacks/dvc.py
@@ -1,0 +1,135 @@
+# Ultralytics YOLO 🚀, GPL-3.0 license
+import os
+
+from ultralytics.yolo.utils import LOGGER, TESTS_RUNNING
+from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+
+try:
+    from importlib.metadata import version
+
+    import dvclive
+
+    assert not TESTS_RUNNING  # do not log pytest
+    assert version('dvclive')
+except (ImportError, AssertionError):
+    dvclive = None
+
+# DVCLive logger instance
+live = None
+_processed_plots = {}
+
+# `on_fit_epoch_end` is called on final validation (probably need to be fixed)
+# for now this is the way we distinguish final evaluation of the best model vs
+# last epoch validation
+_training_epoch = False
+
+
+def _logger_disabled():
+    return os.getenv('ULTRALYTICS_DVC_DISABLED', 'false').lower() == 'true'
+
+
+def _log_images(image_path, prefix=''):
+    if live:
+        live.log_image(os.path.join(prefix, image_path.name), image_path)
+
+
+def _log_plots(plots, prefix=''):
+    for name, params in plots.items():
+        timestamp = params['timestamp']
+        if _processed_plots.get(name, None) != timestamp:
+            _log_images(name, prefix)
+            _processed_plots[name] = timestamp
+
+
+def _log_confusion_matrix(validator):
+    targets = []
+    preds = []
+    matrix = validator.confusion_matrix.matrix
+    names = list(validator.names.values())
+    if validator.confusion_matrix.task == 'detect':
+        names += ['background']
+
+    for ti, pred in enumerate(matrix.T.astype(int)):
+        for pi, num in enumerate(pred):
+            targets.extend([names[ti]] * num)
+            preds.extend([names[pi]] * num)
+
+    live.log_sklearn_plot('confusion_matrix', targets, preds, name='cf.json', normalized=True)
+
+
+def on_pretrain_routine_start(trainer):
+    try:
+        global live
+        if not _logger_disabled():
+            live = dvclive.Live(save_dvc_exp=True)
+            LOGGER.info(
+                'DVCLive is detected and auto logging is enabled (can be disabled with `ULTRALYTICS_DVC_DISABLED=true`).'
+            )
+        else:
+            LOGGER.debug('DVCLive is detected and auto logging is disabled via `ULTRALYTICS_DVC_DISABLED`.')
+            live = None
+    except Exception as e:
+        LOGGER.warning(f'WARNING ⚠️ DVCLive installed but not initialized correctly, not logging this run. {e}')
+
+
+def on_pretrain_routine_end(trainer):
+    _log_plots(trainer.plots, 'train')
+
+
+def on_train_start(trainer):
+    if live:
+        live.log_params(trainer.args)
+
+
+def on_train_epoch_start(trainer):
+    global _training_epoch
+    _training_epoch = True
+
+
+def on_fit_epoch_end(trainer):
+    global _training_epoch
+    if live and _training_epoch:
+        all_metrics = {**trainer.label_loss_items(trainer.tloss, prefix='train'), **trainer.metrics, **trainer.lr}
+        for metric, value in all_metrics.items():
+            live.log_metric(metric, value)
+
+        if trainer.epoch == 0:
+            model_info = {
+                'model/parameters': get_num_params(trainer.model),
+                'model/GFLOPs': round(get_flops(trainer.model), 3),
+                'model/speed(ms)': round(trainer.validator.speed['inference'], 3)}
+
+            for metric, value in model_info.items():
+                live.log_metric(metric, value, plot=False)
+
+        _log_plots(trainer.plots, 'train')
+        _log_plots(trainer.validator.plots, 'val')
+
+        live.next_step()
+        _training_epoch = False
+
+
+def on_train_end(trainer):
+    if live:
+        # At the end log the best metrics. It runs validator on the best model internally.
+        all_metrics = {**trainer.label_loss_items(trainer.tloss, prefix='train'), **trainer.metrics, **trainer.lr}
+        for metric, value in all_metrics.items():
+            live.log_metric(metric, value, plot=False)
+
+        _log_plots(trainer.plots, 'eval')
+        _log_plots(trainer.validator.plots, 'eval')
+        _log_confusion_matrix(trainer.validator)
+
+        if trainer.best.exists():
+            live.log_artifact(trainer.best, copy=True)
+
+        live.end()
+
+
+callbacks = {
+    'on_pretrain_routine_start': on_pretrain_routine_start,
+    'on_pretrain_routine_end': on_pretrain_routine_end,
+    'on_train_start': on_train_start,
+    'on_train_epoch_start': on_train_epoch_start,
+    'on_fit_epoch_end': on_fit_epoch_end,
+    'on_train_end': on_train_end} if dvclive else {}


### PR DESCRIPTION
Adds [DVC](https://dvc.org) experiments logger with [DVCLive](https://dvc.org/doc/dvclive). It gives local experience (+ VS Code extension to see the table of experiments, plots, etc) similar to the existing `runs` directory, but with a way to track in real-time, compare all plots side by side for multiple experiments, capturing weights into DVC (can be pushed to S3, Google Drive, any other storage).

Here is how it looks like on Codespaces with GPU (not GA yet):

## Live plots and metrics

https://github.com/ultralytics/ultralytics/assets/3659196/6b8d2465-d7fa-45f6-af70-b37beeae1fc4

## Compare experiments tab

https://github.com/ultralytics/ultralytics/assets/3659196/13528bac-eccf-4f1e-ae1a-c0425c17f145

## Compare experiment plots

https://github.com/ultralytics/ultralytics/assets/3659196/8c2ffa61-fa88-43ca-936f-6adfd805c9fe

## (Optional) Studio integration

https://github.com/ultralytics/ultralytics/assets/3659196/945d16fe-65bb-477f-ad9b-4ecdd259365b


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 31c61a1</samp>

### Summary
📈🎨🕵️‍♂️

<!--
1.  📈 - This emoji represents the DVCLive integration and the logging of metrics, plots, and images to track and compare the experiments.
2.  🎨 - This emoji represents the addition of the `on_plot` argument and the helper functions to format and log the plots generated by the trainer and validator classes.
3.  🕵️‍♂️ - This emoji represents the object detection task and the use of the `ap_per_class` function to plot the precision-recall curves and the mAP for each class.
-->
This pull request adds DVCLive integration to the ultralytics/yolo package, which enables users to track and compare their machine learning experiments using `dvc`. It introduces a new `callbacks.dvc` module that defines the DVCLive callbacks and their logic, and modifies the `metrics` module to support logging the precision-recall curves and mAP to DVCLive.

> _If you want to track your YOLO runs_
> _With DVCLive and plots for fun_
> _Use `callbacks.dvc`_
> _And `dvc` with ease_
> _And see how your metrics are done_

### Walkthrough
*  Add DVCLive integration callbacks for logging metrics, plots, images, artifacts, and parameters during training and evaluation ([link](https://github.com/ultralytics/ultralytics/pull/2792/files?diff=unified&w=0#diff-9fc76880dc9f2de05ad711555618b1501ea5a833756ff6884e0839fe2b150f0bR201), [link](https://github.com/ultralytics/ultralytics/pull/2792/files?diff=unified&w=0#diff-9fc76880dc9f2de05ad711555618b1501ea5a833756ff6884e0839fe2b150f0bL208-R209), [link](https://github.com/ultralytics/ultralytics/pull/2792/files?diff=unified&w=0#diff-052c6262efa033fb56c6ac6241d151d7eb373ee01daa36cf70077f332078a216R1-R134))
  * Import `dvc` module from `callbacks` subpackage in `base.py` ([link](https://github.com/ultralytics/ultralytics/pull/2792/files?diff=unified&w=0#diff-9fc76880dc9f2de05ad711555618b1501ea5a833756ff6884e0839fe2b150f0bR201))
  * Add `dvc_cb` dictionary to the list of integration callbacks in `base.py` ([link](https://github.com/ultralytics/ultralytics/pull/2792/files?diff=unified&w=0#diff-9fc76880dc9f2de05ad711555618b1501ea5a833756ff6884e0839fe2b150f0bL208-R209))
  * Define DVCLive callbacks and their logic in `dvc.py` ([link](https://github.com/ultralytics/ultralytics/pull/2792/files?diff=unified&w=0#diff-052c6262efa033fb56c6ac6241d151d7eb373ee01daa36cf70077f332078a216R1-R134))
* Add `on_plot` argument to the `ap_per_class` function call in `metrics.py` ([link](https://github.com/ultralytics/ultralytics/pull/2792/files?diff=unified&w=0#diff-344fba8bdb2b27681f38b96c45c1182aecb1f9bbcff5976dccce1ebd1d6f25dcL710-R716))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Integration of DVCLive for enhanced training metrics and logging.

### 📊 Key Changes
- Added `dvclive` as a dependency in `requirements.txt`.
- Incorporated DVCLive callback functions for various training stages.
- Established a new `callbacks/dvc.py` file that defines DVCLive callback methods.

### 🎯 Purpose & Impact
- Allows logging of training metrics, images, and model artifacts 📈.
- Enhances visualization and tracking of model performance using DVCLive 🎨.
- Facilitates better experiment tracking and model evaluation, which can be beneficial for both researchers and practitioners 🔍.