### PR TITLE
Update train.py

### DIFF
--- a/ultralytics/vit/rtdetr/train.py
+++ b/ultralytics/vit/rtdetr/train.py
@@ -6,7 +6,6 @@ from val import RTDETRDataset, RTDETRValidator
 from ultralytics.register import REGISTER
 from ultralytics.vit.utils.loss import DETRLoss
 from ultralytics.yolo.utils import DEFAULT_CFG, colorstr
-from ultralytics.yolo.utils.torch_utils import de_parallel
 from ultralytics.yolo.v8.detect import DetectionTrainer
 
 
@@ -116,8 +115,9 @@ class RTDETRLoss(DETRLoss):
             if num_gt > 0:
                 gt_idx = torch.arange(end=num_gt, dtype=torch.int64)
                 gt_idx = gt_idx.repeat(dn_num_group)
-                assert len(dn_positive_idx[i]) == len(gt_idx), \
-                        f'Expected the same length, but got {len(dn_positive_idx[i])} and {len(gt_idx)} respectively.'
+                assert len(dn_positive_idx[i]) == len(gt_idx), f'Expected the s'
+                f'ame length, but got {len(dn_positive_idx[i])} and '
+                f'{len(gt_idx)} respectively.'
                 dn_match_indices.append((dn_positive_idx[i], gt_idx))
             else:
                 dn_match_indices.append((torch.zeros([0], dtype=torch.int64), torch.zeros([0], dtype=torch.int64)))


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 39e455c</samp>

### Summary
🧹🎨📝

<!--
1.  🧹 This emoji can be used to indicate that some code was cleaned up or removed, such as unused imports or whitespace.
2.  🎨 This emoji can be used to indicate that some code was improved in terms of style, formatting, or aesthetics, such as aligning an assert statement.
3.  📝 This emoji can be used to indicate that some code was documented or commented, such as adding a docstring or an explanation for an assert statement.
-->
Improved code quality and style in `train.py`. Removed an unused import and reformatted an assert statement.

> _We're cleaning up the code, me hearties, yo ho ho_
> _We're dropping what we don't need, like `import` and so_
> _We're making it more readable, with `assert` in a row_
> _We're sailing on with style and grace, me hearties, yo ho ho_

### Walkthrough
*  Remove unused import of `de_parallel` ([link](https://github.com/ultralytics/ultralytics/pull/2813/files?diff=unified&w=0#diff-8a66cf362cd3564a7f891959d28c06ed784550e4ae420756626be0a1cf6258f4L9))



Fix by stopping pep8 warning

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of training scripts in Ultralytics vision transformer repository.

### 📊 Key Changes
- Removed unused import: `de_parallel` from `ultralytics.yolo.utils.torch_utils`.
- Adjusted assertion message formatting for clarity and line length conformity.

### 🎯 Purpose & Impact
- 🧹 Cleanup: Removing the unused import helps maintain clean, readable code, potentially improving maintenance and reducing confusion.
- 📝 Readability: Reformatted long assertion message to adhere to line length standards, enhancing readability for developers.