### PR TITLE
fix error based on pep8 message for train.py

### DIFF
--- a/ultralytics/vit/rtdetr/train.py
+++ b/ultralytics/vit/rtdetr/train.py
@@ -6,7 +6,6 @@ from val import RTDETRDataset, RTDETRValidator
 from ultralytics.register import REGISTER
 from ultralytics.vit.utils.loss import DETRLoss
 from ultralytics.yolo.utils import DEFAULT_CFG, colorstr
-from ultralytics.yolo.utils.torch_utils import de_parallel
 from ultralytics.yolo.v8.detect import DetectionTrainer
 
 
@@ -116,8 +115,9 @@ class RTDETRLoss(DETRLoss):
             if num_gt > 0:
                 gt_idx = torch.arange(end=num_gt, dtype=torch.int64)
                 gt_idx = gt_idx.repeat(dn_num_group)
-                assert len(dn_positive_idx[i]) == len(gt_idx), \
-                        f'Expected the same length, but got {len(dn_positive_idx[i])} and {len(gt_idx)} respectively.'
+                assert len(dn_positive_idx[i]) == len(gt_idx), 'Expected the sa'
+                f'me length, but got {len(dn_positive_idx[i])} and '
+                f'{len(gt_idx)} respectively.'
                 dn_match_indices.append((dn_positive_idx[i], gt_idx))
             else:
                 dn_match_indices.append((torch.zeros([0], dtype=torch.int64), torch.zeros([0], dtype=torch.int64)))


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eba9216</samp>

### Summary
🧹🎨🔧

<!--
1.  🧹 for removing an unused import (cleaning up the code)
2.  🎨 for formatting a long assert message (improving the code style)
3.  🔧 for fixing a minor issue (the assert message was missing a space)
-->
This pull request refactors the `train.py` module for the `vit/rtdetr` model to follow better coding practices. It eliminates an unnecessary dependency and improves the readability of an error message.

> _We're the crew of the vit/rtdetr_
> _We train our model with skill and care_
> _We don't need no unused import_
> _We format our assert with a long report_

### Walkthrough
* Remove unused import from `torch_utils` module ([link](https://github.com/ultralytics/ultralytics/pull/2817/files?diff=unified&w=0#diff-8a66cf362cd3564a7f891959d28c06ed784550e4ae420756626be0a1cf6258f4L9))
* Wrap long assert message into two lines to follow PEP8 style guide ([link](https://github.com/ultralytics/ultralytics/pull/2817/files?diff=unified&w=0#diff-8a66cf362cd3564a7f891959d28c06ed784550e4ae420756626be0a1cf6258f4L119-R120))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of error handling in RT-DETR training code.

### 📊 Key Changes
- Removed unused `de_parallel` import from `torch_utils`.
- Refined an assert statement error message to properly format when printed.

### 🎯 Purpose & Impact
- 🔍 **Maintainability**: Removing unused imports cleans up the codebase, making it easier to maintain.
- 🚨 **Error Clarity**: The update in the assert statement ensures that error messages are clear and properly formatted, aiding in troubleshooting. There is no immediate impact on functionality, but it improves the developer experience.