### PR TITLE
remove repeat defined function get_model

### DIFF
--- a/ultralytics/vit/rtdetr/train.py
+++ b/ultralytics/vit/rtdetr/train.py
@@ -37,13 +37,6 @@ class RTDETRTrainer(DetectionTrainer):
             prefix=colorstr(f'{mode}: '),
             data=self.data)
 
-    def get_model(self, cfg=None, weights=None, verbose=True):
-        """Return a YOLO detection model."""
-        model = RTDETRDetectionModel(cfg, nc=self.data['nc'], verbose=verbose and RANK == -1)
-        if weights:
-            model.load(weights)
-        return model
-
     def get_validator(self):
         """Returns a DetectionValidator for RTDETR model validation."""
         self.loss_names = 'giou_loss', 'cls_loss', 'l1_loss'


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5039c68</samp>

### Summary
🗑️🔄🧹

<!--
1.  🗑️ - This emoji means "wastebasket" and can be used to indicate that something was deleted or removed from the code. In this case, the `get_model` method was removed from the `RTDETRTrainer` class.
2.  🔄 - This emoji means "repeat" or "refresh" and can be used to indicate that something was updated or replaced by something else. In this case, the `get_model` method was replaced by the inherited method from the `YOLOTrainer` class.
3.  🧹 - This emoji means "broom" and can be used to indicate that something was cleaned up or simplified. In this case, the code was simplified by avoiding duplication and redundancy.
-->
Removed the `get_model` method from the `RTDETRTrainer` class in `ultralytics/vit/rtdetr/train.py` to avoid redundancy with the parent class. This improves code clarity and maintainability.

> _`RTDETRTrainer`_
> _No need for `get_model` -_
> _Inherited code._

### Walkthrough
*  Remove redundant `get_model` method from `RTDETRTrainer` class ([link](https://github.com/ultralytics/ultralytics/pull/2833/files?diff=unified&w=0#diff-8a66cf362cd3564a7f891959d28c06ed784550e4ae420756626be0a1cf6258f4L40-L46)). This method was inherited from the `YOLOTrainer` class and did not need to be overridden in the subclass. This simplifies the code and avoids duplication in `ultralytics/vit/rtdetr/train.py`.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplification of Real-Time DETR (RTDETR) training code in Ultralytics repository.

### 📊 Key Changes
- **Removed `get_model` method:** The code related to the instantiation and weight loading of the RTDETRDetectionModel has been eliminated.

### 🎯 Purpose & Impact
- **Refactoring:** The removal of `get_model` in favor of presumably handling model creation elsewhere streamlines the training script, making it more focused and potentially easier to maintain.
- **Impact on Users:** Users might need to adapt their code if they rely on `get_model` to instantiate models within the `train.py` script. The change might require users to use an updated method for model creation and weight initialization. This could lead to clearer separation of concerns in codebase, where model setup is separated from training logic. 🧩🔧