### PR TITLE
Replace `GIoULoss()` with `1.0 - bbox_iou()`

### DIFF
--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -7,7 +7,6 @@ import torch.nn.functional as F
 from ultralytics.yolo.utils.metrics import OKS_SIGMA
 from ultralytics.yolo.utils.ops import crop_mask, xywh2xyxy, xyxy2xywh
 from ultralytics.yolo.utils.tal import TaskAlignedAssigner, dist2bbox, make_anchors
-
 from .metrics import bbox_iou
 from .tal import bbox2dist
 
@@ -42,84 +41,13 @@ class FocalLoss(nn.Module):
         # loss *= self.alpha * (1.000001 - p_t) ** self.gamma  # non-zero power for gradient stability
 
         # TF implementation https://github.com/tensorflow/addons/blob/v0.7.1/tensorflow_addons/losses/focal_loss.py
-        pred_prob = torch.sigmoid(pred)  # prob from logits
+        pred_prob = pred.sigmoid()  # prob from logits
         p_t = label * pred_prob + (1 - label) * (1 - pred_prob)
         alpha_factor = label * alpha + (1 - label) * (1 - alpha)
         modulating_factor = (1.0 - p_t) ** gamma
         loss *= alpha_factor * modulating_factor
 
         return loss.mean(1).sum() / normalizer
-
-
-class GIoULoss:
-    """
-    Generalized Intersection over Union, see https://arxiv.org/abs/1902.09630
-    Args:
-        loss_weight (float): giou loss weight, default as 1
-        eps (float): epsilon to avoid divide by zero, default as 1e-10
-        reduction (string): Options are "none", "mean" and "sum". default as none
-    """
-
-    def __init__(self, loss_weight=1., eps=1e-10, reduction='none'):
-        self.loss_weight = loss_weight
-        self.eps = eps
-        assert reduction in ('none', 'mean', 'sum')
-        self.reduction = reduction
-
-    def bbox_overlap(self, box1, box2, eps=1e-10):
-        """calculate the iou of box1 and box2
-        Args:
-            box1 (Tensor): box1 with the shape (..., 4)
-            box2 (Tensor): box1 with the shape (..., 4)
-            eps (float): epsilon to avoid divide by zero
-        Return:
-            iou (Tensor): iou of box1 and box2
-            overlap (Tensor): overlap of box1 and box2
-            union (Tensor): union of box1 and box2
-        """
-        x1, y1, x2, y2 = box1
-        x1g, y1g, x2g, y2g = box2
-
-        xkis1 = torch.maximum(x1, x1g)
-        ykis1 = torch.maximum(y1, y1g)
-        xkis2 = torch.minimum(x2, x2g)
-        ykis2 = torch.minimum(y2, y2g)
-        w_inter = (xkis2 - xkis1).clip(0)
-        h_inter = (ykis2 - ykis1).clip(0)
-        overlap = w_inter * h_inter
-
-        area1 = (x2 - x1) * (y2 - y1)
-        area2 = (x2g - x1g) * (y2g - y1g)
-        union = area1 + area2 - overlap + eps
-        iou = overlap / union
-
-        return iou, overlap, union
-
-    def __call__(self, pbox, gbox, iou_weight=1., loc_reweight=None):
-        x1, y1, x2, y2 = pbox.chunk(4, dim=-1)
-        x1g, y1g, x2g, y2g = gbox.chunk(4, dim=-1)
-        box1 = [x1, y1, x2, y2]
-        box2 = [x1g, y1g, x2g, y2g]
-        iou, overlap, union = self.bbox_overlap(box1, box2, self.eps)
-        xc1 = torch.minimum(x1, x1g)
-        yc1 = torch.minimum(y1, y1g)
-        xc2 = torch.maximum(x2, x2g)
-        yc2 = torch.maximum(y2, y2g)
-
-        area_c = (xc2 - xc1) * (yc2 - yc1) + self.eps
-        miou = iou - ((area_c - union) / area_c)
-        if loc_reweight is not None:
-            loc_thresh = 0.9
-            giou = 1 - (1 - loc_thresh) * miou - loc_thresh * miou * loc_reweight.view(-1, 1)
-        else:
-            giou = 1 - miou
-        if self.reduction == 'none':
-            loss = giou
-        elif self.reduction == 'sum':
-            loss = torch.sum(giou * iou_weight)
-        else:
-            loss = torch.mean(giou * iou_weight)
-        return loss * self.loss_weight
 
 
 class BboxLoss(nn.Module):

--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 from ultralytics.yolo.utils.metrics import OKS_SIGMA
 from ultralytics.yolo.utils.ops import crop_mask, xywh2xyxy, xyxy2xywh
 from ultralytics.yolo.utils.tal import TaskAlignedAssigner, dist2bbox, make_anchors
+
 from .metrics import bbox_iou
 from .tal import bbox2dist
 


### PR DESCRIPTION
@AyushExel @Laughing-q removes GIoULoss() as it was redundant with `1.0 - bbox_iou()`. I checked for torch.allclose() in both locations, output is close to 1e-6 tolerance. 

Speed of our function is about 20-50% faster in both locations, also we can eliminate the xywh2xyxy conversion on the inputs since our function accepts this format natively.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1a791ad</samp>

### Summary
🚀🧹🔄

<!--
1.  🚀 - This emoji represents the improved performance and efficiency of the code by removing the unnecessary dependency on `GIoULoss` and using `bbox_iou` instead.
2.  🧹 - This emoji represents the cleanup and simplification of the code by removing unused and redundant classes and functions.
3.  🔄 - This emoji represents the consistency and compatibility of the code by using the same function for computing the GIoU metric in both `DETRLoss` and `HungarianMatcher` classes.
-->
The pull request removes the `GIoULoss` class from `ultralytics/vit/utils/loss.py` and `ultralytics/yolo/utils/loss.py` and replaces it with the `bbox_iou` function for computing the GIoU metric. This simplifies the code, improves the performance and consistency of the GIoU calculation, and avoids code duplication.

> _`GIoULoss` gone_
> _`bbox_iou` computes cost_
> _Code is lean and clear_

### Walkthrough
*  Replace `GIoULoss` class with `bbox_iou` function for computing GIoU metric and cost in `DETRLoss` and `HungarianMatcher` classes ([link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-23d48c8beef123f219ad06db989623001af8745b723eb4dc06b264d50c062eeeL7-R7), [link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-23d48c8beef123f219ad06db989623001af8745b723eb4dc06b264d50c062eeeL51), [link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-23d48c8beef123f219ad06db989623001af8745b723eb4dc06b264d50c062eeeL95-R94), [link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-6cb28ec52ed79bd2a4d1bb54ee150d2f97def575ed6b845e557118579a1de328L8-R8), [link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-6cb28ec52ed79bd2a4d1bb54ee150d2f97def575ed6b845e557118579a1de328L35-L36), [link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-6cb28ec52ed79bd2a4d1bb54ee150d2f97def575ed6b845e557118579a1de328L84-R82))
* Remove `GIoULoss` class from `ultralytics/yolo/utils/loss.py` as it is no longer used ([link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-7376f8301a51997a10901e6d8d5ef6a497f074f7c7d7209e003282245c4c6e2dL10), [link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-7376f8301a51997a10901e6d8d5ef6a497f074f7c7d7209e003282245c4c6e2dL54-L124))
* Use `sigmoid` method of tensor instead of `torch.sigmoid` function in `FocalLoss` class ([link](https://github.com/ultralytics/ultralytics/pull/2836/files?diff=unified&w=0#diff-7376f8301a51997a10901e6d8d5ef6a497f074f7c7d7209e003282245c4c6e2dL45-R44))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to bounding box loss calculation in Vision Transformer (ViT) and YOLO utils.

### 📊 Key Changes
- Removed `GIoULoss` class and its usage in ViT and YOLO utils.
- Updated bounding box loss computation to use `bbox_iou` directly, with GIoU and xywh options.
- Changed `torch.sigmoid(pred)` to `pred.sigmoid()` to calculate prediction probabilities.

### 🎯 Purpose & Impact
- 💡 Simplify the implementation of loss functions by removing redundant code.
- 📈 Improve efficiency and clarity by using existing IOU utilities.
- 🚀 Enable more straightforward maintenance and future improvements by utilizing PyTorch built-in functions (e.g., sigmoid on tensor).
- Impact: Users will experience seamless integration of these internal changes without any action required. The quality and performance of models using these loss functions might improve due to more consistent and streamlined calculations.