### PR TITLE
New dataset `fraction=1.0` argument

### DIFF
--- a/docs/modes/train.md
+++ b/docs/modes/train.md
@@ -82,6 +82,7 @@ task.
 | `close_mosaic`    | `0`      | (int) disable mosaic augmentation for final epochs                          |
 | `resume`          | `False`  | resume training from last checkpoint                                        |
 | `amp`             | `True`   | Automatic Mixed Precision (AMP) training, choices=[True, False]             |
+| `fraction`        | `1.0`    | dataset fraction to train on (default is 1.0, all images in train set)      |
 | `lr0`             | `0.01`   | initial learning rate (i.e. SGD=1E-2, Adam=1E-3)                            |
 | `lrf`             | `0.01`   | final learning rate (lr0 * lrf)                                             |
 | `momentum`        | `0.937`  | SGD momentum/Adam beta1                                                     |

--- a/docs/usage/cfg.md
+++ b/docs/usage/cfg.md
@@ -104,6 +104,7 @@ The training settings for YOLO models encompass various hyperparameters and conf
 | `close_mosaic`    | `0`      | (int) disable mosaic augmentation for final epochs                          |
 | `resume`          | `False`  | resume training from last checkpoint                                        |
 | `amp`             | `True`   | Automatic Mixed Precision (AMP) training, choices=[True, False]             |
+| `fraction`        | `1.0`    | dataset fraction to train on (default is 1.0, all images in train set)      |
 | `lr0`             | `0.01`   | initial learning rate (i.e. SGD=1E-2, Adam=1E-3)                            |
 | `lrf`             | `0.01`   | final learning rate (lr0 * lrf)                                             |
 | `momentum`        | `0.937`  | SGD momentum/Adam beta1                                                     |

--- a/ultralytics/yolo/cfg/__init__.py
+++ b/ultralytics/yolo/cfg/__init__.py
@@ -66,7 +66,7 @@ CLI_HELP_MSG = \
 CFG_FLOAT_KEYS = 'warmup_epochs', 'box', 'cls', 'dfl', 'degrees', 'shear'
 CFG_FRACTION_KEYS = ('dropout', 'iou', 'lr0', 'lrf', 'momentum', 'weight_decay', 'warmup_momentum', 'warmup_bias_lr',
                      'label_smoothing', 'hsv_h', 'hsv_s', 'hsv_v', 'translate', 'scale', 'perspective', 'flipud',
-                     'fliplr', 'mosaic', 'mixup', 'copy_paste', 'conf', 'iou')  # fractional floats limited to 0.0 - 1.0
+                     'fliplr', 'mosaic', 'mixup', 'copy_paste', 'conf', 'iou', 'fraction')  # fraction floats 0.0 - 1.0
 CFG_INT_KEYS = ('epochs', 'patience', 'batch', 'workers', 'seed', 'close_mosaic', 'mask_ratio', 'max_det', 'vid_stride',
                 'line_width', 'workspace', 'nbs', 'save_period')
 CFG_BOOL_KEYS = ('save', 'exist_ok', 'verbose', 'deterministic', 'single_cls', 'rect', 'cos_lr', 'overlap_mask', 'val',

--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -30,6 +30,7 @@ cos_lr: False  # use cosine learning rate scheduler
 close_mosaic: 0  # (int) disable mosaic augmentation for final epochs
 resume: False  # resume training from last checkpoint
 amp: True  # Automatic Mixed Precision (AMP) training, choices=[True, False], True runs AMP check
+fraction: 1.0  # dataset fraction to train on (default is 1.0, all images in train set)
 # Segmentation
 overlap_mask: True  # masks should overlap during training (segment train only)
 mask_ratio: 4  # mask downsample ratio (segment train only)

--- a/ultralytics/yolo/data/base.py
+++ b/ultralytics/yolo/data/base.py
@@ -36,6 +36,7 @@ class BaseDataset(Dataset):
         pad (float, optional): Padding. Defaults to 0.0.
         single_cls (bool, optional): If True, single class training is used. Defaults to False.
         classes (list): List of included classes. Default is None.
+        fraction (float): Fraction of dataset to utilize. Default is 1.0 (use all data).
 
     Attributes:
         im_files (list): List of image file paths.
@@ -58,13 +59,15 @@ class BaseDataset(Dataset):
                  stride=32,
                  pad=0.5,
                  single_cls=False,
-                 classes=None):
+                 classes=None,
+                 fraction=1.0):
         super().__init__()
         self.img_path = img_path
         self.imgsz = imgsz
         self.augment = augment
         self.single_cls = single_cls
         self.prefix = prefix
+        self.fraction = fraction
         self.im_files = self.get_img_files(self.img_path)
         self.labels = self.get_labels()
         self.update_labels(include_class=classes)  # single_cls and include_class
@@ -114,6 +117,8 @@ class BaseDataset(Dataset):
             assert im_files, f'{self.prefix}No images found'
         except Exception as e:
             raise FileNotFoundError(f'{self.prefix}Error loading data from {img_path}\n{HELP_URL}') from e
+        if self.fraction < 1:
+            im_files = im_files[:round(len(im_files) * self.fraction)]
         return im_files
 
     def update_labels(self, include_class: Optional[list]):

--- a/ultralytics/yolo/data/build.py
+++ b/ultralytics/yolo/data/build.py
@@ -69,7 +69,7 @@ def seed_worker(worker_id):  # noqa
     random.seed(worker_seed)
 
 
-def build_yolo_dataset(cfg, img_path, batch, data_info, mode='train', rect=False, stride=32):
+def build_yolo_dataset(cfg, img_path, batch, data, mode='train', rect=False, stride=32):
     """Build YOLO Dataset"""
     return YOLODataset(
         img_path=img_path,
@@ -86,7 +86,8 @@ def build_yolo_dataset(cfg, img_path, batch, data_info, mode='train', rect=False
         use_segments=cfg.task == 'segment',
         use_keypoints=cfg.task == 'pose',
         classes=cfg.classes,
-        data=data_info)
+        data=data,
+        fraction=cfg.fraction if mode == 'train' else 1.0)
 
 
 def build_dataloader(dataset, batch, workers, shuffle=True, rank=-1):

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -226,6 +226,8 @@ class ClassificationDataset(torchvision.datasets.ImageFolder):
             cache (Union[bool, str], optional): Cache setting, can be True, False, 'ram' or 'disk'. Defaults to False.
         """
         super().__init__(root=root)
+        if augment and args.fraction < 1.0:  # reduce training fraction
+            self.samples = self.samples[:round(len(self.samples) * args.fraction)]
         self.cache_ram = cache is True or cache == 'ram'
         self.cache_disk = cache == 'disk'
         self.samples = [list(x) + [Path(x[0]).with_suffix('.npy'), None] for x in self.samples]  # file, index, npy, im
@@ -269,4 +271,4 @@ class SemanticDataset(BaseDataset):
 
     def __init__(self):
         """Initialize a SemanticDataset object."""
-        pass
+        super().__init__()


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0db8736</samp>

### Summary
📝🛠️📊

<!--
1.  📝 - This emoji represents documentation, writing, or editing, and can be used to indicate the changes to the `docs/modes/train.md` and `docs/usage/cfg.md` files.
2.  🛠️ - This emoji represents tools, settings, or configuration, and can be used to indicate the changes to the `ultralytics/yolo/cfg/default.yaml` file and the `train` section of the configuration file.
3.  📊 - This emoji represents data, statistics, or analysis, and can be used to indicate the changes to the `BaseDataset` class and its subclasses, and the `build_yolo_dataset` function.
-->
This pull request adds a new feature to the `ultralytics/yolo` package that allows users to train the model on a fraction of the dataset. It modifies the `BaseDataset` class, the `build_yolo_dataset` function, and the documentation and configuration files to support this feature.

> _Sing, O Muse, of the skillful code review_
> _That added `fraction` to the `train` mode_
> _And to the docs and config file, to give_
> _The users more control over their load._

### Walkthrough
*  Add `fraction` argument to `train` mode and configuration file to allow training on a subset of the dataset ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-4a4a3691b08dc4cb045c88d4405e25fe3e154c35ddf71370e94e336b5f3b417dR85), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-a21b6f90c80bba2698f9a8e30b1a002078a425376e5eb2864f078e0a97d32a3bR107), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-9d692d4ad15d420a92105fcd432fb1d2221b71d5af055bea3bd2b70523ce6743R33), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fR39), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fL61-R63), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fR70), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fR120-R121), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-0826103e946e6152ff49d963d1235653adbfbf515878db39fdae798c3a15469fL89-R90))
  * Update documentation of `train` mode and configuration file in `docs/modes/train.md` and `docs/usage/cfg.md` to explain the usage and default value of `fraction` ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-4a4a3691b08dc4cb045c88d4405e25fe3e154c35ddf71370e94e336b5f3b417dR85), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-a21b6f90c80bba2698f9a8e30b1a002078a425376e5eb2864f078e0a97d32a3bR107))
  * Add default value of `fraction` to `ultralytics/yolo/cfg/default.yaml` file, which is 1.0 ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-9d692d4ad15d420a92105fcd432fb1d2221b71d5af055bea3bd2b70523ce6743R33))
  * Add `fraction` argument to `BaseDataset` class in `ultralytics/yolo/data/base.py`, which is the parent class of all dataset classes ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fR39), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fL61-R63), [link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fR70))
  * Add conditional statement to `get_img_files` method of `BaseDataset` class to slice the list of image files according to `fraction` ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-d4f87aa47a90813d564caeabb5ae15de1efa1d46df10306d374cbc1fac29fd2fR120-R121))
  * Add `fraction` argument to `YOLODataset` constructor call in `build_yolo_dataset` function in `ultralytics/yolo/data/build.py`, which is a helper function that creates a `YOLODataset` instance ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-0826103e946e6152ff49d963d1235653adbfbf515878db39fdae798c3a15469fL89-R90))
  * Pass `fraction` argument from `cfg.fraction` attribute, which is read from the configuration file or the command line argument ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-0826103e946e6152ff49d963d1235653adbfbf515878db39fdae798c3a15469fL89-R90))
  * Set `fraction` argument to 1.0 for validation and test modes, meaning that they use the full dataset ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-0826103e946e6152ff49d963d1235653adbfbf515878db39fdae798c3a15469fL89-R90))
* Rename `data_info` parameter to `data` in `build_yolo_dataset` function in `ultralytics/yolo/data/build.py` to make it consistent with the `data` argument of the `YOLODataset` constructor and the `data` section of the configuration file ([link](https://github.com/ultralytics/ultralytics/pull/2860/files?diff=unified&w=0#diff-0826103e946e6152ff49d963d1235653adbfbf515878db39fdae798c3a15469fL72-R72))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implemented dataset fraction training feature for data efficiency in training.

### 📊 Key Changes
- Added `fraction` configuration option in various configuration files and documentation.
- Modified dataset loading to accept the `fraction` parameter, allowing a subset of the data to be used for training.
- Integrated the `fraction` setting into the dataset construction and build process for YOLO models.

### 🎯 Purpose & Impact
- **Purpose**: To enable users to specify a fraction of the dataset for training, which can be useful for experimenting with smaller datasets or for faster training on limited resources.
- **Impact**: Users can now train models more flexibly and efficiently by focusing on a selected part of the dataset, which can save time and computational resources. This is particularly beneficial for preliminary trials and hyperparameter tuning. 🚀📈💾