### PR TITLE
New train `profile` argument for loggers

### DIFF
--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -24,7 +24,7 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt /u
 
 # Install pip packages
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache -e .
+RUN pip install --no-cache -e . thop
 
 
 # Usage Examples -------------------------------------------------------------------------------------------------------

--- a/docker/Dockerfile-cpu
+++ b/docker/Dockerfile-cpu
@@ -25,7 +25,7 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt /u
 
 # Install pip packages
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache -e . --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache -e . thop --extra-index-url https://download.pytorch.org/whl/cpu
 
 
 # Usage Examples -------------------------------------------------------------------------------------------------------

--- a/docker/Dockerfile-jetson
+++ b/docker/Dockerfile-jetson
@@ -25,7 +25,7 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt /u
 
 # Install pip packages manually for TensorRT compatibility https://github.com/NVIDIA/TensorRT/issues/2567
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache tqdm matplotlib pyyaml psutil pandas onnx "numpy==1.23"
+RUN pip install --no-cache tqdm matplotlib pyyaml psutil pandas onnx thop "numpy==1.23"
 RUN pip install --no-cache -e .
 
 # Set environment variables

--- a/docs/modes/train.md
+++ b/docs/modes/train.md
@@ -83,6 +83,7 @@ task.
 | `resume`          | `False`  | resume training from last checkpoint                                        |
 | `amp`             | `True`   | Automatic Mixed Precision (AMP) training, choices=[True, False]             |
 | `fraction`        | `1.0`    | dataset fraction to train on (default is 1.0, all images in train set)      |
+| `profile`         | `False`  | profile ONNX and TensorRT speeds during training for loggers                |
 | `lr0`             | `0.01`   | initial learning rate (i.e. SGD=1E-2, Adam=1E-3)                            |
 | `lrf`             | `0.01`   | final learning rate (lr0 * lrf)                                             |
 | `momentum`        | `0.937`  | SGD momentum/Adam beta1                                                     |

--- a/docs/usage/cfg.md
+++ b/docs/usage/cfg.md
@@ -105,6 +105,7 @@ The training settings for YOLO models encompass various hyperparameters and conf
 | `resume`          | `False`  | resume training from last checkpoint                                        |
 | `amp`             | `True`   | Automatic Mixed Precision (AMP) training, choices=[True, False]             |
 | `fraction`        | `1.0`    | dataset fraction to train on (default is 1.0, all images in train set)      |
+| `profile`         | `False`  | profile ONNX and TensorRT speeds during training for loggers                |
 | `lr0`             | `0.01`   | initial learning rate (i.e. SGD=1E-2, Adam=1E-3)                            |
 | `lrf`             | `0.01`   | final learning rate (lr0 * lrf)                                             |
 | `momentum`        | `0.937`  | SGD momentum/Adam beta1                                                     |

--- a/ultralytics/yolo/cfg/__init__.py
+++ b/ultralytics/yolo/cfg/__init__.py
@@ -1,4 +1,5 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
+
 import contextlib
 import re
 import shutil

--- a/ultralytics/yolo/cfg/__init__.py
+++ b/ultralytics/yolo/cfg/__init__.py
@@ -73,7 +73,7 @@ CFG_INT_KEYS = ('epochs', 'patience', 'batch', 'workers', 'seed', 'close_mosaic'
 CFG_BOOL_KEYS = ('save', 'exist_ok', 'verbose', 'deterministic', 'single_cls', 'rect', 'cos_lr', 'overlap_mask', 'val',
                  'save_json', 'save_hybrid', 'half', 'dnn', 'plots', 'show', 'save_txt', 'save_conf', 'save_crop',
                  'show_labels', 'show_conf', 'visualize', 'augment', 'agnostic_nms', 'retina_masks', 'boxes', 'keras',
-                 'optimize', 'int8', 'dynamic', 'simplify', 'nms', 'v5loader')
+                 'optimize', 'int8', 'dynamic', 'simplify', 'nms', 'v5loader', 'profile')
 
 
 def cfg2dict(cfg):

--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -31,7 +31,7 @@ close_mosaic: 0  # (int) disable mosaic augmentation for final epochs
 resume: False  # resume training from last checkpoint
 amp: True  # Automatic Mixed Precision (AMP) training, choices=[True, False], True runs AMP check
 fraction: 1.0  # dataset fraction to train on (default is 1.0, all images in train set)
-profile: False  # profile ONNX and TensorRT speeds when training for loggers
+profile: False  # profile ONNX and TensorRT speeds during training for loggers
 # Segmentation
 overlap_mask: True  # masks should overlap during training (segment train only)
 mask_ratio: 4  # mask downsample ratio (segment train only)

--- a/ultralytics/yolo/cfg/default.yaml
+++ b/ultralytics/yolo/cfg/default.yaml
@@ -30,6 +30,7 @@ cos_lr: False  # use cosine learning rate scheduler
 close_mosaic: 0  # (int) disable mosaic augmentation for final epochs
 resume: False  # resume training from last checkpoint
 amp: True  # Automatic Mixed Precision (AMP) training, choices=[True, False], True runs AMP check
+profile: False  # profile ONNX and TensorRT speeds when training for loggers
 # Segmentation
 overlap_mask: True  # masks should overlap during training (segment train only)
 mask_ratio: 4  # mask downsample ratio (segment train only)

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -238,7 +238,7 @@ class ProfileModels:
 
         # Warmup runs
         model = YOLO(engine_file)
-        input_data = np.random.rand(self.imgsz, self.imgsz, 3).astype(np.float32)
+        input_data = np.random.rand(self.imgsz, self.imgsz, 3).astype(np.float16)
         for _ in range(self.num_warmup_runs):
             model(input_data, verbose=False)
 

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -163,7 +163,7 @@ class ProfileModels:
         profile(): Profiles the models and prints the result.
     """
 
-    def __init__(self, paths: list, num_timed_runs=300, num_warmup_runs=30, imgsz=640, trt=True, device=None):
+    def __init__(self, paths: list, num_timed_runs=100, num_warmup_runs=10, imgsz=640, trt=True, device=None):
         self.paths = paths
         self.num_timed_runs = num_timed_runs
         self.num_warmup_runs = num_warmup_runs
@@ -244,7 +244,7 @@ class ProfileModels:
 
         # Timed runs
         run_times = []
-        for _ in tqdm(range(self.num_timed_runs * 30), desc=engine_file):
+        for _ in tqdm(range(self.num_timed_runs * 50), desc=engine_file):
             results = model(input_data, verbose=False)
             run_times.append(results[0].speed['inference'])  # Convert to milliseconds
 

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -292,7 +292,7 @@ class ProfileModels:
             sess.run([output_name], {input_name: input_data})
             run_times.append((time.time() - start_time) * 1000)  # Convert to milliseconds
 
-        run_times = self.iterative_sigma_clipping(np.array(run_times), sigma=2, max_iters=3)  # sigma clipping
+        run_times = self.iterative_sigma_clipping(np.array(run_times), sigma=2, max_iters=5)  # sigma clipping
         return np.mean(run_times), np.std(run_times)
 
     def generate_table_row(self, model_name, t_onnx, t_engine, model_info):

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -301,11 +301,12 @@ class ProfileModels:
 
     def generate_results_dict(self, model_name, t_onnx, t_engine, model_info):
         layers, params, gradients, flops = model_info
-        return {'model/name': model_name,
-                'model/parameters': params,
-                'model/GFLOPs': round(flops, 3),
-                'model/speed_ONNX(ms)': round(t_onnx[0], 3),
-                'model/speed_TensorRT(ms)': round(t_engine[0], 3)}
+        return {
+            'model/name': model_name,
+            'model/parameters': params,
+            'model/GFLOPs': round(flops, 3),
+            'model/speed_ONNX(ms)': round(t_onnx[0], 3),
+            'model/speed_TensorRT(ms)': round(t_engine[0], 3)}
 
     def print_table(self, table_rows):
         gpu = torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'GPU'

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -258,6 +258,7 @@ class ProfileModels:
         # Session with either 'TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'
         sess_options = ort.SessionOptions()
         sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        sess_options.intra_op_num_threads = 8  # Limit the number of threads
         sess = ort.InferenceSession(onnx_file, sess_options, providers=['CPUExecutionProvider'])
 
         input_tensor = sess.get_inputs()[0]

--- a/ultralytics/yolo/utils/callbacks/__init__.py
+++ b/ultralytics/yolo/utils/callbacks/__init__.py
@@ -1,3 +1,5 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+
 from .base import add_integration_callbacks, default_callbacks, get_default_callbacks
 
 __all__ = 'add_integration_callbacks', 'default_callbacks', 'get_default_callbacks'

--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -5,7 +5,7 @@ import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 
 from ultralytics.yolo.utils import LOGGER, TESTS_RUNNING
-from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+from ultralytics.yolo.utils.torch_utils import model_info_for_loggers
 
 try:
     import clearml
@@ -105,11 +105,7 @@ def on_fit_epoch_end(trainer):
                                         value=trainer.epoch_time,
                                         iteration=trainer.epoch)
         if trainer.epoch == 0:
-            model_info = {
-                'model/parameters': get_num_params(trainer.model),
-                'model/GFLOPs': round(get_flops(trainer.model), 3),
-                'model/speed(ms)': round(trainer.validator.speed['inference'], 3)}
-            for k, v in model_info.items():
+            for k, v in model_info_for_loggers(trainer).items():
                 task.get_logger().report_single_value(k, v)
 
 

--- a/ultralytics/yolo/utils/callbacks/clearml.py
+++ b/ultralytics/yolo/utils/callbacks/clearml.py
@@ -1,4 +1,5 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
+
 import re
 
 import matplotlib.image as mpimg

--- a/ultralytics/yolo/utils/callbacks/comet.py
+++ b/ultralytics/yolo/utils/callbacks/comet.py
@@ -1,4 +1,5 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
+
 import os
 from pathlib import Path
 

--- a/ultralytics/yolo/utils/callbacks/comet.py
+++ b/ultralytics/yolo/utils/callbacks/comet.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from ultralytics.yolo.utils import LOGGER, RANK, TESTS_RUNNING, ops
-from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+from ultralytics.yolo.utils.torch_utils import model_info_for_loggers
 
 try:
     import comet_ml
@@ -324,11 +324,7 @@ def on_fit_epoch_end(trainer):
     experiment.log_metrics(trainer.metrics, step=curr_step, epoch=curr_epoch)
     experiment.log_metrics(trainer.lr, step=curr_step, epoch=curr_epoch)
     if curr_epoch == 1:
-        model_info = {
-            'model/parameters': get_num_params(trainer.model),
-            'model/GFLOPs': round(get_flops(trainer.model), 3),
-            'model/speed(ms)': round(trainer.validator.speed['inference'], 3), }
-        experiment.log_metrics(model_info, step=curr_step, epoch=curr_epoch)
+        experiment.log_metrics(model_info_for_loggers(trainer), step=curr_step, epoch=curr_epoch)
 
     if not save_assets:
         return

--- a/ultralytics/yolo/utils/callbacks/hub.py
+++ b/ultralytics/yolo/utils/callbacks/hub.py
@@ -5,7 +5,7 @@ from time import time
 
 from ultralytics.hub.utils import PREFIX, events
 from ultralytics.yolo.utils import LOGGER
-from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+from ultralytics.yolo.utils.torch_utils import model_info_for_loggers
 
 
 def on_pretrain_routine_end(trainer):
@@ -24,11 +24,7 @@ def on_fit_epoch_end(trainer):
         # Upload metrics after val end
         all_plots = {**trainer.label_loss_items(trainer.tloss, prefix='train'), **trainer.metrics}
         if trainer.epoch == 0:
-            model_info = {
-                'model/parameters': get_num_params(trainer.model),
-                'model/GFLOPs': round(get_flops(trainer.model), 3),
-                'model/speed(ms)': round(trainer.validator.speed['inference'], 3)}
-            all_plots = {**all_plots, **model_info}
+            all_plots = {**all_plots, **model_info_for_loggers(trainer)}
         session.metrics_queue[trainer.epoch] = json.dumps(all_plots)
         if time() - session.timers['metrics'] > session.rate_limits['metrics']:
             session.upload_metrics()

--- a/ultralytics/yolo/utils/callbacks/neptune.py
+++ b/ultralytics/yolo/utils/callbacks/neptune.py
@@ -1,4 +1,5 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
+
 import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 

--- a/ultralytics/yolo/utils/callbacks/neptune.py
+++ b/ultralytics/yolo/utils/callbacks/neptune.py
@@ -3,7 +3,7 @@ import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 
 from ultralytics.yolo.utils import LOGGER, TESTS_RUNNING
-from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+from ultralytics.yolo.utils.torch_utils import model_info_for_loggers
 
 try:
     import neptune
@@ -68,11 +68,7 @@ def on_train_epoch_end(trainer):
 def on_fit_epoch_end(trainer):
     """Callback function called at end of each fit (train+val) epoch."""
     if run and trainer.epoch == 0:
-        model_info = {
-            'parameters': get_num_params(trainer.model),
-            'GFLOPs': round(get_flops(trainer.model), 3),
-            'speed(ms)': round(trainer.validator.speed['inference'], 3)}
-        run['Configuration/Model'] = model_info
+        run['Configuration/Model'] = model_info_for_loggers(trainer)
     _log_scalars(trainer.metrics, trainer.epoch + 1)
 
 

--- a/ultralytics/yolo/utils/callbacks/raytune.py
+++ b/ultralytics/yolo/utils/callbacks/raytune.py
@@ -1,3 +1,5 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+
 try:
     import ray
     from ray import tune

--- a/ultralytics/yolo/utils/callbacks/tensorboard.py
+++ b/ultralytics/yolo/utils/callbacks/tensorboard.py
@@ -1,4 +1,5 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
+
 from ultralytics.yolo.utils import LOGGER, TESTS_RUNNING, colorstr
 
 try:

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -14,8 +14,7 @@ except (ImportError, AssertionError):
 
 def on_pretrain_routine_start(trainer):
     """Initiate and start project if module is present."""
-    wb.init(project=trainer.args.project or 'YOLOv8', name=trainer.args.name, config=vars(
-        trainer.args)) if not wb.run else wb.run
+    wb.run or wb.init(project=trainer.args.project or 'YOLOv8', name=trainer.args.name, config=vars(trainer.args))
 
 
 def on_fit_epoch_end(trainer):

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -1,11 +1,13 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
+from ultralytics.yolo.utils import TESTS_RUNNING
 from ultralytics.yolo.utils.torch_utils import model_info_for_loggers
 
 try:
     import wandb as wb
 
     assert hasattr(wb, '__version__')
+    assert not TESTS_RUNNING  # do not log pytest
 except (ImportError, AssertionError):
     wb = None
 

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -14,7 +14,8 @@ except (ImportError, AssertionError):
 
 def on_pretrain_routine_start(trainer):
     """Initiate and start project if module is present."""
-    wb.run or wb.init(project=trainer.args.project or 'YOLOv8', name=trainer.args.name, config=vars(trainer.args))
+    wb.init(project=trainer.args.project or 'YOLOv8', name=trainer.args.name,
+            config=vars(trainer.args)) if not wb.run else wb.run
 
 
 def on_fit_epoch_end(trainer):

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+from ultralytics.yolo.utils.torch_utils import model_info_for_loggers
 
 try:
     import wandb as wb
@@ -12,19 +12,14 @@ except (ImportError, AssertionError):
 
 def on_pretrain_routine_start(trainer):
     """Initiate and start project if module is present."""
-    wb.init(project=trainer.args.project or 'YOLOv8', name=trainer.args.name, config=vars(
-        trainer.args)) if not wb.run else wb.run
+    wb.run or wb.init(project=trainer.args.project or 'YOLOv8', name=trainer.args.name, config=vars(trainer.args))
 
 
 def on_fit_epoch_end(trainer):
     """Logs training metrics and model information at the end of an epoch."""
     wb.run.log(trainer.metrics, step=trainer.epoch + 1)
     if trainer.epoch == 0:
-        model_info = {
-            'model/parameters': get_num_params(trainer.model),
-            'model/GFLOPs': round(get_flops(trainer.model), 3),
-            'model/speed(ms)': round(trainer.validator.speed['inference'], 3)}
-        wb.run.log(model_info, step=trainer.epoch + 1)
+        wb.run.log(model_info_for_loggers(trainer), step=trainer.epoch + 1)
 
 
 def on_train_epoch_end(trainer):

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -14,8 +14,8 @@ except (ImportError, AssertionError):
 
 def on_pretrain_routine_start(trainer):
     """Initiate and start project if module is present."""
-    wb.init(project=trainer.args.project or 'YOLOv8', name=trainer.args.name,
-            config=vars(trainer.args)) if not wb.run else wb.run
+    wb.init(project=trainer.args.project or 'YOLOv8', name=trainer.args.name, config=vars(
+        trainer.args)) if not wb.run else wb.run
 
 
 def on_fit_epoch_end(trainer):

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -29,7 +29,9 @@ def on_train_epoch_end(trainer):
     wb.run.log(trainer.label_loss_items(trainer.tloss, prefix='train'), step=trainer.epoch + 1)
     wb.run.log(trainer.lr, step=trainer.epoch + 1)
     if trainer.epoch == 1:
-        wb.run.log({f.stem: wb.Image(str(f)) for f in trainer.save_dir.glob('train_batch*.jpg')}, step=trainer.epoch + 1)
+        wb.run.log({f.stem: wb.Image(str(f))
+                    for f in trainer.save_dir.glob('train_batch*.jpg')},
+                   step=trainer.epoch + 1)
 
 
 def on_train_end(trainer):

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -29,9 +29,7 @@ def on_train_epoch_end(trainer):
     wb.run.log(trainer.label_loss_items(trainer.tloss, prefix='train'), step=trainer.epoch + 1)
     wb.run.log(trainer.lr, step=trainer.epoch + 1)
     if trainer.epoch == 1:
-        wb.run.log({f.stem: wb.Image(str(f))
-                    for f in trainer.save_dir.glob('train_batch*.jpg')},
-                   step=trainer.epoch + 1)
+        wb.run.log({f.stem: wb.Image(str(f)) for f in trainer.save_dir.glob('train_batch*.jpg')}, step=trainer.epoch + 1)
 
 
 def on_train_end(trainer):

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -192,6 +192,28 @@ def get_num_gradients(model):
     return sum(x.numel() for x in model.parameters() if x.requires_grad)
 
 
+def model_info_for_loggers(trainer):
+    """
+    Return model info dict with useful model information.
+
+    Example for YOLOv8n:
+        {'model/parameters': 3151904,
+         'model/GFLOPs': 8.746,
+         'model/speed_ONNX(ms)': 41.244,
+         'model/speed_TensorRT(ms)': 3.211,
+         'model/speed_PyTorch(ms)': 18.755}
+    """
+    if trainer.args.profile:  # profile ONNX and TensorRT times
+        from ultralytics.yolo.utils.benchmarks import ProfileModels
+        results = ProfileModels([trainer.last]).profile()[0]
+        results.pop('model/name')
+    else:  # only return PyTorch times from most recent validation
+        results = {'model/parameters': get_num_params(trainer.model),
+                   'model/GFLOPs': round(get_flops(trainer.model), 3)}
+    results['model/speed_PyTorch(ms)'] = round(trainer.validator.speed['inference'], 3)
+    return results
+
+
 def get_flops(model, imgsz=640):
     """Return a YOLO model's FLOPs."""
     try:

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -208,8 +208,9 @@ def model_info_for_loggers(trainer):
         results = ProfileModels([trainer.last]).profile()[0]
         results.pop('model/name')
     else:  # only return PyTorch times from most recent validation
-        results = {'model/parameters': get_num_params(trainer.model),
-                   'model/GFLOPs': round(get_flops(trainer.model), 3)}
+        results = {
+            'model/parameters': get_num_params(trainer.model),
+            'model/GFLOPs': round(get_flops(trainer.model), 3)}
     results['model/speed_PyTorch(ms)'] = round(trainer.validator.speed['inference'], 3)
     return results
 

--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -205,7 +205,7 @@ def model_info_for_loggers(trainer):
     """
     if trainer.args.profile:  # profile ONNX and TensorRT times
         from ultralytics.yolo.utils.benchmarks import ProfileModels
-        results = ProfileModels([trainer.last]).profile()[0]
+        results = ProfileModels([trainer.last], device=trainer.device).profile()[0]
         results.pop('model/name')
     else:  # only return PyTorch times from most recent validation
         results = {


### PR DESCRIPTION
@AyushExel @Laughing-q 

Profiles model speeds on ONNX and TensorRT after epoch 1 is finished and uploads results to all loggers.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ce48cf7</samp>

### Summary
📝🚀🧹

<!--
1.  📝 This emoji represents the changes that add comments, empty lines, and license information for documentation and formatting purposes.
2.  🚀 This emoji represents the changes that add the new option `profile` and the function `model_info_for_loggers()` for enabling and reporting the ONNX and TensorRT profiling speeds, which can improve the performance and efficiency of the model.
3.  🧹 This emoji represents the changes that improve the formatting, code reuse, readability, and maintainability of the callbacks and the `ProfileModels` class.
-->
This pull request improves the model profiling and logging functionality of the `ultralytics/yolo` package. It adds a new option `profile` to the configuration file to enable or disable ONNX and TensorRT profiling. It also adds a new function `model_info_for_loggers()` to generate a model info dictionary for the loggers. It refactors and updates the ClearML, Comet, Hub, Neptune, and Weights & Biases callbacks to use this function and improve code readability and maintainability.

> _We are the loggers of the night_
> _We profile the models with our might_
> _We use the `model_info_for_loggers()` function_
> _To report the speed and the dimension_

### Walkthrough
*  Add `profile` option to enable or disable ONNX and TensorRT profiling for loggers ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-9d692d4ad15d420a92105fcd432fb1d2221b71d5af055bea3bd2b70523ce6743R33))
*  Implement `model_info_for_loggers()` function to generate model info dictionary for loggers ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8R195-R216))
*  Replace manual creation of model info dictionary with `model_info_for_loggers()` function in ClearML, Comet, Hub, Neptune, and Weights & Biases callbacks ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-a815296cb22a8ba6127487e136b0996e9885c93d79f23f92ad858437b2c9af66L108-R109), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-88156d2cb2225824b539d2eeeece9b6157773bd05beabc136066535690b0d046L327-R328), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-525fb733ac418d064f18eecf36263fdd635b2e0db15efe3c8f38397ba31cec9cL27-R27), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-f8f8e03100d2e72d11a0064665a329b37cf7a9804ca4b55e484f59617c02dfedL71-R72), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-1365dac64b857511656e6f9948f7c04022f4a9c14f7732ee26b4ca29d930f0a2L23-R24))
*  Add `.profile()` method to `ProfileModels` class to run profiling of models and return results ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510R181), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510R187), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L200-R204))
*  Add `generate_results_dict()` helper method to `ProfileModels` class to format results for loggers ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510R302-R309))
*  Add missing `.profile()` method call to usage example of `ProfileModels` class ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L7-R7))
*  Remove redundant `.profile()` method call in `__init__` method of `ProfileModels` class ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L172))
*  Add license information to `ultralytics/yolo/utils/callbacks/__init__.py` and `ultralytics/yolo/utils/callbacks/raytune.py` ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-f89d6c361a487bfa626ca33ddf7db21a1df807fb50e142d305cd36ee0bfa04acR1-R2), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-fc87378d52ab79f3c996bad383d2e49722c2841db7c7414ceb8876aff0f6a2c8R1-R2))
*  Add empty lines to the beginning of `ultralytics/yolo/cfg/__init__.py`, `ultralytics/yolo/utils/callbacks/clearml.py`, and `ultralytics/yolo/utils/callbacks/tensorboard.py` for formatting consistency ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-daf1714127b012666c9fed39d0e75184c60be83f0c6bd3f9863f27113b1a6c22R2), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-a815296cb22a8ba6127487e136b0996e9885c93d79f23f92ad858437b2c9af66R2), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-7a5a4b862d4fe6ad4d3fab269c6cf4d16c8efac6d577f55bee25a0461b7fed32R2))
*  Import `TESTS_RUNNING` variable from `ultralytics/yolo/utils.py` in Comet and Weights & Biases callbacks to check if pytest is running and avoid logging ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-88156d2cb2225824b539d2eeeece9b6157773bd05beabc136066535690b0d046L2-R7), [link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-1365dac64b857511656e6f9948f7c04022f4a9c14f7732ee26b4ca29d930f0a2L3-R4))
*  Add assertion to `on_pretrain_routine_start()` method of Weights & Biases callback to raise exception if pytest is running ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-1365dac64b857511656e6f9948f7c04022f4a9c14f7732ee26b4ca29d930f0a2R10))
*  Simplify logic of `on_pretrain_routine_start()` method of Weights & Biases callback with `or` operator ([link](https://github.com/ultralytics/ultralytics/pull/2862/files?diff=unified&w=0#diff-1365dac64b857511656e6f9948f7c04022f4a9c14f7732ee26b4ca29d930f0a2L15-R17))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model profiling during training with ONNX, TensorRT, and PyTorch.

### 📊 Key Changes
- Added `thop` package installation in Dockerfiles to calculate FLOPs.
- Added a new `profile` configuration option to profile model performance.
- Modified the benchmarking system to support selective profiling based on the new `profile` configuration.
- Updated callback and logging systems to include profiling data for various platforms (ONNX, TensorRT, PyTorch).
- Improved result recording by switching from table output to a dictionary output for profiling data.

### 🎯 Purpose & Impact
- 🏎️ Users can now obtain detailed performance metrics (GFLOPs, inference speed, etc.) for the models across different platforms.
- 📈 This aids in better understanding and optimization of model performance, particularly for deployment scenarios.
- 🔄 Selective profiling (controlled by the `profile` config option) provides flexibility, enabling or disabling performance measurements as needed, thus saving resources during training if profiling is not necessary.