### PR TITLE
Add ProfileModel `min_time=60`s argument

### DIFF
--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -250,10 +250,6 @@ class ProfileModels:
         input_data = np.random.rand(self.imgsz, self.imgsz, 3).astype(np.float32)  # must be FP32
 
         # Warmup runs
-        for _ in range(self.num_warmup_runs):
-            model(input_data, verbose=False)
-
-        # Warmup runs
         elapsed = 0.0
         for _ in range(3):
             start_time = time.time()

--- a/ultralytics/yolo/utils/benchmarks.py
+++ b/ultralytics/yolo/utils/benchmarks.py
@@ -156,17 +156,26 @@ class ProfileModels:
     Attributes:
         paths (list): Paths of the models to profile.
         num_timed_runs (int): Number of timed runs for the profiling. Default is 100.
-        num_warmup_runs (int): Number of warmup runs before profiling. Default is 3.
+        num_warmup_runs (int): Number of warmup runs before profiling. Default is 10.
+        min_time (float): Minimum number of seconds to profile for. Default is 60.
         imgsz (int): Image size used in the models. Default is 640.
 
     Methods:
         profile(): Profiles the models and prints the result.
     """
 
-    def __init__(self, paths: list, num_timed_runs=100, num_warmup_runs=10, imgsz=640, trt=True, device=None):
+    def __init__(self,
+                 paths: list,
+                 num_timed_runs=100,
+                 num_warmup_runs=10,
+                 min_time=60,
+                 imgsz=640,
+                 trt=True,
+                 device=None):
         self.paths = paths
         self.num_timed_runs = num_timed_runs
         self.num_warmup_runs = num_warmup_runs
+        self.min_time = min_time
         self.imgsz = imgsz
         self.trt = trt  # run TensorRT profiling
         self.device = device or torch.device(0 if torch.cuda.is_available() else 'cpu')
@@ -236,15 +245,28 @@ class ProfileModels:
         if not self.trt or not Path(engine_file).is_file():
             return 0.0, 0.0
 
-        # Warmup runs
+        # Model and input
         model = YOLO(engine_file)
         input_data = np.random.rand(self.imgsz, self.imgsz, 3).astype(np.float32)  # must be FP32
+
+        # Warmup runs
         for _ in range(self.num_warmup_runs):
             model(input_data, verbose=False)
 
+        # Warmup runs
+        elapsed = 0.0
+        for _ in range(3):
+            start_time = time.time()
+            for _ in range(self.num_warmup_runs):
+                model(input_data, verbose=False)
+            elapsed = time.time() - start_time
+
+        # Compute number of runs as higher of min_time or num_timed_runs
+        num_runs = max(round(self.min_time / elapsed * self.num_warmup_runs), self.num_timed_runs * 50)
+
         # Timed runs
         run_times = []
-        for _ in tqdm(range(self.num_timed_runs * 50), desc=engine_file):
+        for _ in tqdm(range(num_runs), desc=engine_file):
             results = model(input_data, verbose=False)
             run_times.append(results[0].speed['inference'])  # Convert to milliseconds
 
@@ -283,12 +305,19 @@ class ProfileModels:
         output_name = sess.get_outputs()[0].name
 
         # Warmup runs
-        for _ in range(self.num_warmup_runs):
-            sess.run([output_name], {input_name: input_data})
+        elapsed = 0.0
+        for _ in range(3):
+            start_time = time.time()
+            for _ in range(self.num_warmup_runs):
+                sess.run([output_name], {input_name: input_data})
+            elapsed = time.time() - start_time
+
+        # Compute number of runs as higher of min_time or num_timed_runs
+        num_runs = max(round(self.min_time / elapsed * self.num_warmup_runs), self.num_timed_runs)
 
         # Timed runs
         run_times = []
-        for _ in tqdm(range(self.num_timed_runs), desc=onnx_file):
+        for _ in tqdm(range(num_runs), desc=onnx_file):
             start_time = time.time()
             sess.run([output_name], {input_name: input_data})
             run_times.append((time.time() - start_time) * 1000)  # Convert to milliseconds


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 84135da</samp>

### Summary
🕒📈🔧

<!--
1.  🕒 This emoji represents the concept of time, which is relevant for both the minimum profiling time and the number of runs parameters.
2.  📈 This emoji represents the idea of improving or increasing something, which is what the accuracy and consistency of the benchmarking results aim to achieve.
3.  🔧 This emoji represents the notion of adjusting or tweaking something, which is what the number of runs is doing based on the minimum profiling time.
-->
Improved model benchmarking accuracy and consistency by adding a `min_time` parameter to `ProfileModels`. This parameter controls how long each model is profiled for, and adjusts the number of runs accordingly. Modified `ultralytics/yolo/utils/benchmarks.py` to implement this feature.

> _Oh we are the coders of the `ProfileModels` class_
> _We make it run faster and better with every pass_
> _We set a minimum time for each model to shine_
> _And we adjust the runs on the count of three, me lads, on the count of three_

### Walkthrough
*  Add `min_time` parameter to `ProfileModels` class to specify minimum profiling duration for each model ([link](https://github.com/ultralytics/ultralytics/pull/2881/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L159-R160), [link](https://github.com/ultralytics/ultralytics/pull/2881/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L166-R178))
*  Use `min_time` and average warmup time to dynamically compute number of runs for `profile_tensorrt_model` and `profile_onnx_model` methods ([link](https://github.com/ultralytics/ultralytics/pull/2881/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L239-R269), [link](https://github.com/ultralytics/ultralytics/pull/2881/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L286-R320))
*  Repeat warmup runs three times and move model and input creation outside warmup loop to reduce variance and overhead in `profile_tensorrt_model` and `profile_onnx_model` methods ([link](https://github.com/ultralytics/ultralytics/pull/2881/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L239-R269), [link](https://github.com/ultralytics/ultralytics/pull/2881/files?diff=unified&w=0#diff-c038bb1fb2230068e97816bf63a783fbad880483c14f4517404d9fc3fe8e8510L286-R320))



Should provide more stable profiling results, as I saw that YOLOv8n was only profiling for about 5-10s and YOLOv8x for more than a minute.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model profiling with dynamic run count and extended warmup for TensorRT and ONNX models.

### 📊 Key Changes
- Default number of warmup runs increased from 3 to 10.
- Introduced a new `min_time` parameter with a default of 60 seconds to ensure sufficient profiling duration.
- Updated the profiling logic to calculate the number of runs based on the greater of `min_time` or a multiple of the configured timed runs.
- Modified the warmup phase by measuring its duration to more accurately estimate the total number of runs needed.

### 🎯 Purpose & Impact
- 🔍 **Improved Accuracy**: Extending the number of warmup iterations may lead to more stable performance measurements by better preparing the models and hardware.
- ⏲ **Dynamic Benchmarking**: The `min_time` feature ensures that models are profiled for a minimum duration, leading to more reliable metrics, especially for faster models or systems.
- 💡 **Better Insights for Users**: With more representative profiling, users can make better decisions when comparing model performance or optimizing their systems.

These adjustments provide users with more robust and reliable profiling results, critical for performance tuning and comparisons in machine learning applications.