### PR TITLE
Fix DDP classify train `imgsz`

### DIFF
--- a/ultralytics/yolo/v8/classify/train.py
+++ b/ultralytics/yolo/v8/classify/train.py
@@ -19,7 +19,7 @@ class ClassificationTrainer(BaseTrainer):
         if overrides is None:
             overrides = {}
         overrides['task'] = 'classify'
-        if overrides.get('imgsz') is None:
+        if overrides.get('imgsz') is None and cfg['imgsz'] == DEFAULT_CFG.imgsz == 640:
             overrides['imgsz'] = 224
         super().__init__(cfg, overrides, _callbacks)
 


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/2893

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fbdc73b</samp>

### Summary
🐛📷🛠️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request and the change.
2.  📷 - This emoji represents an image or a camera, which is related to the image size and resizing issue that the change addresses.
3.  🛠️ - This emoji represents a tool or a wrench, which is related to the configuration and customization aspect of the change.
-->
Fix image resizing bug in classification trainer. Prevent `train.py` from changing the image size in `cfg` if it is not the default value of 640.

> _`imgsz` checked in `cfg`_
> _avoid wrong resizing, cropping_
> _bug fixed in autumn_

### Walkthrough
*  Prevent image resizing and cropping bug in classification trainer by checking image size in configuration ([link](https://github.com/ultralytics/ultralytics/pull/2897/files?diff=unified&w=0#diff-734f7c7d5e997138ddb17cffc50e37008364bb3fdba26403ee9d145ce2764f69L22-R22))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced default image size configuration for classification training in YOLOv8.

### 📊 Key Changes
- Modified the condition that sets the default image size (`imgsz`) during classification training.
- The default image size is now set to 224 only if `imgsz` is not provided in overrides ***and*** the current configuration `imgsz` ***and*** the `DEFAULT_CFG.imgsz` are both equal to 640.

### 🎯 Purpose & Impact
- Provides a more intuitive default setting for users who do not specify an image size when training a classifier.
- Ensures that only when the user has not tampered with the size defaults will the size be adjusted to a typical default for classification tasks, improving user experience and reducing potential confusion. 
- 🚀 Mildly impacts anyone relying on the old behavior for setting default image sizes, nudging them towards more explicit configuration.