### PR TITLE
Update `generate_ddp_file` for improved `overrides`

### DIFF
--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -286,7 +286,7 @@ class Results(SimpleClass):
                     seg = masks[j].xyn[0].copy().reshape(-1)  # reversed mask.xyn, (n,2) to (n*2)
                     line = (c, *seg)
                 if kpts is not None:
-                    kpt = (kpts[j][:, :2] / d.orig_shape[[1, 0]]).reshape(-1).tolist()
+                    kpt = (kpts[j][:, :2].cpu() / d.orig_shape[[1, 0]]).reshape(-1).tolist()
                     line += (*kpt, )
                 line += (conf, ) * save_conf + (() if id is None else (id, ))
                 texts.append(('%g ' * len(line)).rstrip() % line)

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -286,7 +286,7 @@ class Results(SimpleClass):
                     seg = masks[j].xyn[0].copy().reshape(-1)  # reversed mask.xyn, (n,2) to (n*2)
                     line = (c, *seg)
                 if kpts is not None:
-                    kpt = (kpts[j][:, :2].cpu() / d.orig_shape[[1, 0]]).reshape(-1).tolist()
+                    kpt = (kpts[j][:, :2] / d.orig_shape[[1, 0]]).reshape(-1).tolist()
                     line += (*kpt, )
                 line += (conf, ) * save_conf + (() if id is None else (id, ))
                 texts.append(('%g ' * len(line)).rstrip() % line)

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -182,7 +182,7 @@ class BaseTrainer:
             # Command
             cmd, file = generate_ddp_command(world_size, self)
             try:
-                LOGGER.info(f'Running DDP command {cmd}')
+                LOGGER.info(f'DDP command: {cmd}')
                 subprocess.run(cmd, check=True)
             except Exception as e:
                 raise e
@@ -195,7 +195,7 @@ class BaseTrainer:
         """Initializes and sets the DistributedDataParallel parameters for training."""
         torch.cuda.set_device(RANK)
         self.device = torch.device('cuda', RANK)
-        LOGGER.info(f'DDP settings: RANK {RANK}, WORLD_SIZE {world_size}, DEVICE {self.device}')
+        LOGGER.info(f'DDP info: RANK {RANK}, WORLD_SIZE {world_size}, DEVICE {self.device}')
         os.environ['NCCL_BLOCKING_WAIT'] = '1'  # set to enforce timeout
         dist.init_process_group('nccl' if dist.is_nccl_available() else 'gloo',
                                 timeout=timedelta(seconds=3600),

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -30,7 +30,7 @@ def generate_ddp_file(trainer):
     content = f'''cfg = {vars(trainer.args)} \nif __name__ == "__main__":
     from {module} import {name}
 
-    trainer = {name}(cfg=cfg)
+    trainer = {name}(overrides=cfg)
     trainer.train()'''
     (USER_CONFIG_DIR / 'DDP').mkdir(exist_ok=True)
     with tempfile.NamedTemporaryFile(prefix='_temp_',

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -32,7 +32,7 @@ def generate_ddp_file(trainer):
     from ultralytics.yolo.utils import DEFAULT_CFG_DICT
 
     cfg = DEFAULT_CFG_DICT.copy()
-    cfg.update(save_dir='')
+    cfg.update(save_dir='')   # handle the extra key 'save_dir'
     trainer = {name}(cfg=cfg, overrides=overrides)
     trainer.train()'''
     (USER_CONFIG_DIR / 'DDP').mkdir(exist_ok=True)

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -29,9 +29,9 @@ def generate_ddp_file(trainer):
 
     content = f'''cfg = {vars(trainer.args)} \nif __name__ == "__main__":
     from {module} import {name}
+    from ultralytics.yolo.utils import DEFAULT_CFG_DICT
 
-    cfg.pop('save_dir')
-    trainer = {name}(overrides=cfg)
+    trainer = {name}(cfg=DEFAULT_CFG_DICT.update(save_dir=''), overrides=cfg)
     trainer.train()'''
     (USER_CONFIG_DIR / 'DDP').mkdir(exist_ok=True)
     with tempfile.NamedTemporaryFile(prefix='_temp_',

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -54,9 +54,7 @@ def generate_ddp_command(world_size, trainer):
         file = generate_ddp_file(trainer)
     dist_cmd = 'torch.distributed.run' if TORCH_1_9 else 'torch.distributed.launch'
     port = find_free_network_port()
-    exclude_args = ['save_dir']
-    args = [f'{k}={v}' for k, v in vars(trainer.args).items() if k not in exclude_args]
-    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file] + args
+    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file]
     return cmd, file
 
 

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -27,11 +27,13 @@ def generate_ddp_file(trainer):
     """Generates a DDP file and returns its file name."""
     module, name = f'{trainer.__class__.__module__}.{trainer.__class__.__name__}'.rsplit('.', 1)
 
-    content = f'''cfg = {vars(trainer.args)} \nif __name__ == "__main__":
+    content = f'''overrides = {vars(trainer.args)} \nif __name__ == "__main__":
     from {module} import {name}
     from ultralytics.yolo.utils import DEFAULT_CFG_DICT
 
-    trainer = {name}(cfg=DEFAULT_CFG_DICT.update(save_dir=''), overrides=cfg)
+    cfg = DEFAULT_CFG_DICT.copy()
+    cfg.update(save_dir='')
+    trainer = {name}(cfg=cfg, overrides=overrides)
     trainer.train()'''
     (USER_CONFIG_DIR / 'DDP').mkdir(exist_ok=True)
     with tempfile.NamedTemporaryFile(prefix='_temp_',

--- a/ultralytics/yolo/utils/dist.py
+++ b/ultralytics/yolo/utils/dist.py
@@ -30,6 +30,7 @@ def generate_ddp_file(trainer):
     content = f'''cfg = {vars(trainer.args)} \nif __name__ == "__main__":
     from {module} import {name}
 
+    cfg.pop('save_dir')
     trainer = {name}(overrides=cfg)
     trainer.train()'''
     (USER_CONFIG_DIR / 'DDP').mkdir(exist_ok=True)

--- a/ultralytics/yolo/v8/classify/train.py
+++ b/ultralytics/yolo/v8/classify/train.py
@@ -19,7 +19,7 @@ class ClassificationTrainer(BaseTrainer):
         if overrides is None:
             overrides = {}
         overrides['task'] = 'classify'
-        if overrides.get('imgsz') is None and cfg['imgsz'] == DEFAULT_CFG.imgsz == 640:
+        if overrides.get('imgsz') is None:
             overrides['imgsz'] = 224
         super().__init__(cfg, overrides, _callbacks)
 


### PR DESCRIPTION
@glenn-jocher To make `overrides=cfg` work I have to additionally import the `DEFEAULT_CFG_DICT` and manually add `save_dir` key. might make it a bit odd but I think it's fine since we can keep all the configs in overrides. This allows us to focus on `overrides` when we want to add logic for default values i.e `if overrides.get('imgsz') is None: overrides['imgsz'] = 224` condition for ClassifyTrainer.
I tested training on current branch and main branch, and the curves are identical.
![results](https://github.com/ultralytics/ultralytics/assets/61612323/b69e7844-c0a0-4813-9cf0-35ebdf44c027)
Also tested classify training with ddp mode, and set `imgsz=640` to see if it works, and it works! with the logic we write before:
```python
        if overrides.get('imgsz') is None:
            overrides['imgsz'] = 224
```

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 69f3ca7</samp>

### Summary
🎛️🗑️🚀

<!--
1.  🎛️ - This emoji can represent the simplification of the configuration and the use of the `overrides` argument, as it suggests adjusting or tuning some settings or parameters.
2.  🗑️ - This emoji can represent the removal of the unnecessary loop, as it suggests discarding or deleting something that is not needed or useful.
3.  🚀 - This emoji can represent the distributed training setup, as it suggests speed, performance, or scalability.
-->
Simplify distributed training setup and remove redundant code in `ultralytics/yolo/utils/dist.py`. Use a default config and an `overrides` argument to pass command-line options to the trainer.

> _Simplify training_
> _Use `overrides` to pass args_
> _No loop in winter_

### Walkthrough
*  Modify `generate_ddp_file` function to use `overrides` argument instead of `cfg` and handle `save_dir` separately ([link](https://github.com/ultralytics/ultralytics/pull/2909/files?diff=unified&w=0#diff-a31d86d9438ec57c7f3af4c7dfa34548a4c0c3acc80c53b53e471db4d02d62f1L30-R36))
* Simplify `generate_ddp_command` function to remove unnecessary loop and pass command-line arguments through `overrides` ([link](https://github.com/ultralytics/ultralytics/pull/2909/files?diff=unified&w=0#diff-a31d86d9438ec57c7f3af4c7dfa34548a4c0c3acc80c53b53e471db4d02d62f1L57-R60))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Distributed Data Parallel (DDP) logging and configuration in the training engine.

### 📊 Key Changes
- Updated log messages for better clarity when running DDP commands.
- Simplified DDP command generation by removing superfluous arguments.
- Introduced a default configuration dictionary for more robust handling of configuration overrides.

### 🎯 Purpose & Impact
- 🎯 The PR ensures users are better informed with concise log messages, enhancing debuggability.
- 🔧 Simplification of the DDP command may lead to fewer errors and a cleaner codebase.
- 🛠️ By standardizing the configuration override process, there's a reduced risk of misconfiguration, leading to a more user-friendly experience, especially for those less familiar with the DDP setup.
- Overall, users should experience smoother distributed training sessions with clearer communication from the system.