### PR TITLE
Optionally `train_args` on attempt_load_weights()

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -507,7 +507,7 @@ def torch_safe_load(weight):
         return torch.load(file, map_location='cpu'), file  # load
 
 
-def attempt_load_weights(weights, device=None, inplace=True, fuse=False, attach_args=True):
+def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
     """Loads an ensemble of models weights=[a,b,c] or a single model weights=[a] or weights=a."""
 
     ensemble = Ensemble()

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -513,7 +513,9 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False, attach_
     ensemble = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt, w = torch_safe_load(w)  # load ckpt
-        args = {**DEFAULT_CFG_DICT, **ckpt['train_args']}  if attach_args else None # combine model and default args, preferring model args
+        args = {
+            **DEFAULT_CFG_DICT,
+            **ckpt['train_args']} if attach_args else None  # combine model and default args, preferring model args
         model = (ckpt.get('ema') or ckpt['model']).to(device).float()  # FP32 model
 
         # Model compatibility updates

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -513,9 +513,7 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False, attach_
     ensemble = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt, w = torch_safe_load(w)  # load ckpt
-        args = {
-            **DEFAULT_CFG_DICT,
-            **ckpt['train_args']} if attach_args else None  # combine model and default args, preferring model args
+        args = {**DEFAULT_CFG_DICT, **ckpt['train_args']} if 'train_args' in ckpt else None  # combined args
         model = (ckpt.get('ema') or ckpt['model']).to(device).float()  # FP32 model
 
         # Model compatibility updates

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -507,13 +507,13 @@ def torch_safe_load(weight):
         return torch.load(file, map_location='cpu'), file  # load
 
 
-def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
+def attempt_load_weights(weights, device=None, inplace=True, fuse=False, attach_args=True):
     """Loads an ensemble of models weights=[a,b,c] or a single model weights=[a] or weights=a."""
 
     ensemble = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt, w = torch_safe_load(w)  # load ckpt
-        args = {**DEFAULT_CFG_DICT, **ckpt['train_args']}  # combine model and default args, preferring model args
+        args = {**DEFAULT_CFG_DICT, **ckpt['train_args']}  if attach_args else None # combine model and default args, preferring model args
         model = (ckpt.get('ema') or ckpt['model']).to(device).float()  # FP32 model
 
         # Model compatibility updates


### PR DESCRIPTION
This will allow us to use this function in v5.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f731078</samp>

### Summary
🆕🔧🏋️

<!--
1.  🆕 - This emoji indicates that a new feature or option was added to the code.
2.  🔧 - This emoji signifies that some compatibility or configuration issues were fixed or improved by the changes.
3.  🏋️ - This emoji suggests that the changes involve loading or saving model weights, which can be seen as a form of training or lifting.
-->
Added a new feature to `nn.tasks.py` to allow more flexible loading of model weights. This helps users work with models that have different checkpoint arguments.

> _No more chains of `checkpoint` on your soul_
> _Free your model from the weight of old control_
> _Load the power that you need for your own goal_
> _Break the compatibility that limits your role_

### Walkthrough
*  Add `attach_args` parameter to `attempt_load_weights` function to control whether model arguments from checkpoint are attached to model or not ([link](https://github.com/ultralytics/ultralytics/pull/2928/files?diff=unified&w=0#diff-e2650ac65b6525f6d9c0594a226066d396afbcba637c054d29abe04e62f410c4L510-R510))
*  Set `args` to None if `attach_args` is False to avoid unnecessary or conflicting model attributes ([link](https://github.com/ultralytics/ultralytics/pull/2928/files?diff=unified&w=0#diff-e2650ac65b6525f6d9c0594a226066d396afbcba637c054d29abe04e62f410c4L516-R516))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in model weight loading by handling missing training arguments.

### 📊 Key Changes
- Modified the weight-loading function to check for the presence of 'train_args' in checkpoints.
- Ensures compatibility with checkpoints that do not include 'train_args' by setting default arguments to None if 'train_args' is missing.

### 🎯 Purpose & Impact
- 🛠️ Enhances the model loading process to avoid potential errors when training arguments are absent in checkpoints.
- 🤖 Ensures backward compatibility with older models that may not have 'train_args' in their checkpoints.
- 🔧 Provides a more graceful and error-free experience when users attempt to load various weights into their models.