### PR TITLE
Fix `workspace` and `verbose` arguments in TensorRT export

### DIFF
--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -232,7 +232,7 @@ class Exporter:
         if jit:  # TorchScript
             f[0], _ = self.export_torchscript()
         if engine:  # TensorRT required before ONNX
-            f[1], _ = self.export_engine()
+            f[1], _ = self.export_engine(workspace=self.args.workspace, verbose=self.args.verbose)
         if onnx or xml:  # OpenVINO requires ONNX
             f[2], _ = self.export_onnx()
         if xml:  # OpenVINO

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -232,7 +232,7 @@ class Exporter:
         if jit:  # TorchScript
             f[0], _ = self.export_torchscript()
         if engine:  # TensorRT required before ONNX
-            f[1], _ = self.export_engine(workspace=self.args.workspace, verbose=self.args.verbose)
+            f[1], _ = self.export_engine()
         if onnx or xml:  # OpenVINO requires ONNX
             f[2], _ = self.export_onnx()
         if xml:  # OpenVINO
@@ -423,7 +423,7 @@ class Exporter:
         return f, ct_model
 
     @try_export
-    def export_engine(self, workspace=4, verbose=False, prefix=colorstr('TensorRT:')):
+    def export_engine(self, prefix=colorstr('TensorRT:')):
         """YOLOv8 TensorRT export https://developer.nvidia.com/tensorrt."""
         assert self.im.device.type != 'cpu', "export running on CPU but must be on GPU, i.e. use 'device=0'"
         try:
@@ -441,12 +441,12 @@ class Exporter:
         assert Path(f_onnx).exists(), f'failed to export ONNX file: {f_onnx}'
         f = self.file.with_suffix('.engine')  # TensorRT engine file
         logger = trt.Logger(trt.Logger.INFO)
-        if verbose:
+        if self.args.verbose:
             logger.min_severity = trt.Logger.Severity.VERBOSE
 
         builder = trt.Builder(logger)
         config = builder.create_builder_config()
-        config.max_workspace_size = workspace * 1 << 30
+        config.max_workspace_size = self.args.workspace * 1 << 30
         # config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace << 30)  # fix TRT 8.4 deprecation notice
 
         flag = (1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

`workspace` and `verbose` arguments weren't used when exporting to TensorRT.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of the TensorRT model exporting process in the Ultralytics YOLO codebase.

### 📊 Key Changes
- Removed the `workspace` and `verbose` parameters from the `export_engine` method signature.
- Added usage of `self.args.verbose` for setting the verbosity level.
- Updated `config.max_workspace_size` to use `self.args.workspace`.

### 🎯 Purpose & Impact
- The refactoring leads to cleaner code by making use of the internal object attributes instead of explicit function parameters.
- This change simplifies the model exporting interface and prepares for more flexible command-line integration.
- Users can expect a more streamlined and consistent experience when exporting models to the TensorRT platform, with potential ease in setting verbosity and managing workspace constraints.