### PR TITLE
Make show command ~13ms faster on every frame of video shown

### DIFF
--- a/ultralytics/yolo/data/dataloaders/stream_loaders.py
+++ b/ultralytics/yolo/data/dataloaders/stream_loaders.py
@@ -94,7 +94,7 @@ class LoadStreams:
     def __next__(self):
         """Returns source paths, transformed and original images for processing YOLOv5."""
         self.count += 1
-        if not all(x.is_alive() for x in self.threads) or cv2.waitKey(1) == ord('q'):  # q to quit
+        if not all(x.is_alive() for x in self.threads):
             cv2.destroyAllWindows()
             raise StopIteration
 

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -224,9 +224,9 @@ class BasePredictor:
             self.done_warmup = True
 
         use_threads = True
+        profilers = ops.Profile(), ops.Profile(), ops.Profile()
         self.threads = {}
-        self.seen, self.windows, self.batch, profilers, quit = 0, [], None, (ops.Profile(), ops.Profile(),
-                                                                             ops.Profile()), False
+        self.seen, self.windows, self.batch, quit = 0, [], None, False
         self.run_callbacks('on_predict_start')
         for batch in self.dataset:
             self.run_callbacks('on_predict_batch_start')

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -28,9 +28,9 @@ Usage - formats:
                               yolov8n_paddle_model       # PaddlePaddle
 """
 import platform
+import time
 from pathlib import Path
 from threading import Thread
-import time
 
 import cv2
 import numpy as np
@@ -110,9 +110,9 @@ class BasePredictor:
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
         callbacks.add_integration_callbacks(self)
 
-        self.end = [time.time()] * 5 # TEST
-        self.start = [time.time()] * 5 # TEST
-        self.elapsed = [time.time()] * 5 # TEST
+        self.end = [time.time()] * 5  # TEST
+        self.start = [time.time()] * 5  # TEST
+        self.elapsed = [time.time()] * 5  # TEST
 
     def preprocess(self, im):
         """Prepares input image before inference.
@@ -231,8 +231,8 @@ class BasePredictor:
         use_threads = True
         profilers = ops.Profile(), ops.Profile(), ops.Profile()
         self.threads = {}
-        self.fps = None # TEST
-        self.ifps = None # TEST
+        self.fps = None  # TEST
+        self.ifps = None  # TEST
         self.seen, self.windows, self.batch, quit = 0, [], None, False
         self.run_callbacks('on_predict_start')
         for batch in self.dataset:
@@ -271,11 +271,11 @@ class BasePredictor:
                     s += self.write_results(i, self.results, (p, im, im0))
 
                 if self.args.show and self.plotted_img is not None:
-                    if (self.fps == None): # TEST
-                        self.fps = [None] * n # TEST
-                        self.ifps = [None] * n # TEST
-                    self.fps[i] = 1 / self.elapsed[0] # TEST
-                    self.ifps[i] = 1 / profilers[1].dt # TEST
+                    if (self.fps == None):  # TEST
+                        self.fps = [None] * n  # TEST
+                        self.ifps = [None] * n  # TEST
+                    self.fps[i] = 1 / self.elapsed[0]  # TEST
+                    self.ifps[i] = 1 / profilers[1].dt  # TEST
                     if (use_threads and not self.batch[3].startswith('image')):
                         if self.threads.get(i) is None:
                             self.threads[i] = Thread(target=self.show_thread, args=([p, i]), daemon=True)
@@ -289,9 +289,9 @@ class BasePredictor:
             self.run_callbacks('on_predict_batch_end')
             yield from self.results
 
-            self.end[i] = time.time() # TEST
-            self.elapsed[i] = self.end[i] - self.start[i] # TEST
-            self.start[i] = time.time() # TEST
+            self.end[i] = time.time()  # TEST
+            self.elapsed[i] = self.end[i] - self.start[i]  # TEST
+            self.start[i] = time.time()  # TEST
 
             # Print time (inference-only) + TEST Total time per frame
             if self.args.verbose:
@@ -348,8 +348,8 @@ class BasePredictor:
             cv2.namedWindow(str(p), cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
             cv2.resizeWindow(str(p), self.plotted_img.shape[1], self.plotted_img.shape[0])
         while (True):
-            cv2.putText(self.plotted_img, f"{self.fps[i]:.2f} fps {self.ifps[i]:.2f} ifps", (15, 30), cv2.FONT_HERSHEY_SIMPLEX,
-                    0.6, (0, 255, 0), 2) # TEST
+            cv2.putText(self.plotted_img, f'{self.fps[i]:.2f} fps {self.ifps[i]:.2f} ifps', (15, 30),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2)  # TEST
             cv2.imshow(str(p), self.plotted_img)
             if cv2.waitKey(1) == ord('q'):
                 cv2.destroyAllWindows()

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -225,7 +225,8 @@ class BasePredictor:
 
         use_threads = True
         self.threads = {}
-        self.seen, self.windows, self.batch, profilers, quit = 0, [], None, (ops.Profile(), ops.Profile(), ops.Profile()), False
+        self.seen, self.windows, self.batch, profilers, quit = 0, [], None, (ops.Profile(), ops.Profile(),
+                                                                             ops.Profile()), False
         self.run_callbacks('on_predict_start')
         for batch in self.dataset:
             self.run_callbacks('on_predict_batch_start')
@@ -323,7 +324,6 @@ class BasePredictor:
             cv2.resizeWindow(str(p), im0.shape[1], im0.shape[0])
         cv2.imshow(str(p), im0)
         cv2.waitKey(500 if self.batch[3].startswith('image') else 1)  # 1 millisecond
-
 
     def show_thread(self, p):
         """Display an image in a window using OpenCV imshow() inside a thread."""


### PR DESCRIPTION
Faster video playback.
Using a thread for imgshow on non images.
quit flag for quiting when "q" is pressed.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1fcd83a</samp>

### Summary
🧵🖼️🛑

<!--
1.  🧵 - This emoji represents the use of threads for displaying images, as threads are often depicted as spools of thread or sewing needles.
2.  🖼️ - This emoji represents the display of images using OpenCV, as images are often shown as framed pictures or paintings.
3.  🛑 - This emoji represents the ability to exit the mode by pressing 'q', as stop signs or red octagons are common symbols for stopping or quitting.
-->
This pull request improves the user experience of stream inference mode by enabling threaded image display and a quit option. It changes the `BasePredictor` class in `ultralytics/yolo/engine/predictor.py` to implement these features.

> _To display images in a stream_
> _This pull request adds a new scheme_
> _It uses threads for `show`_
> _And lets you exit with 'q'_
> _It modifies `BasePredictor` and `show_thread`_

### Walkthrough
*  Import `threading` module and add variables for thread management and user input ([link](https://github.com/ultralytics/ultralytics/pull/2994/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675R32), [link](https://github.com/ultralytics/ultralytics/pull/2994/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L225-R229))
*  Create and join threads for displaying images in stream inference mode using `self.show_thread` method ([link](https://github.com/ultralytics/ultralytics/pull/2994/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L263-R273), [link](https://github.com/ultralytics/ultralytics/pull/2994/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675R328-R339))
*  Break the loop if the user presses 'q' to exit stream inference mode ([link](https://github.com/ultralytics/ultralytics/pull/2994/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675R284-R286))



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves video stream prediction in Ultralytics by adding threaded image display and real-time FPS metrics for smoother, more informative visualizations. 🚀🖼️

### 📊 Key Changes
- Introduces threaded display of prediction results, allowing images to be shown in separate threads for better performance.
- Adds real-time FPS (frames per second) and inference FPS overlays to displayed images, helping users monitor processing speed.
- Removes the requirement to press 'q' to quit video streams, streamlining the workflow.
- Refactors code to better manage display windows and thread lifecycles.

### 🎯 Purpose & Impact
- 🏎️ **Smoother Visualization:** Threaded display prevents UI lag, especially when processing multiple video streams.
- 📈 **Performance Insights:** Real-time FPS overlays give users immediate feedback on model and system performance.
- 🧑‍💻 **Improved Usability:** No longer requires manual quitting, making the prediction process more user-friendly and automated.
- 🔧 **Foundation for Future Enhancements:** Sets up a more robust framework for handling video and image display in Ultralytics tools.

These updates make video inference more efficient and informative for both developers and end-users.