### PR TITLE
Set alternative Comet project name through environment variables

### DIFF
--- a/ultralytics/yolo/utils/callbacks/comet.py
+++ b/ultralytics/yolo/utils/callbacks/comet.py
@@ -67,7 +67,10 @@ def _create_experiment(args):
         return
     try:
         comet_mode = _get_comet_mode()
-        experiment = _get_experiment_type(comet_mode, args.project)
+        
+        _project_name = os.environ.get('COMET_PROJECT_NAME', args.project)
+        experiment = _get_experiment_type(comet_mode, _project_name)
+        
         experiment.log_parameters(vars(args))
         experiment.log_others({
             'eval_batch_logging_interval': _get_eval_batch_logging_interval(),

--- a/ultralytics/yolo/utils/callbacks/comet.py
+++ b/ultralytics/yolo/utils/callbacks/comet.py
@@ -67,10 +67,10 @@ def _create_experiment(args):
         return
     try:
         comet_mode = _get_comet_mode()
-        
+
         _project_name = os.environ.get('COMET_PROJECT_NAME', args.project)
         experiment = _get_experiment_type(comet_mode, _project_name)
-        
+
         experiment.log_parameters(vars(args))
         experiment.log_others({
             'eval_batch_logging_interval': _get_eval_batch_logging_interval(),


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 19fcb18</samp>

### Summary
🏷️🗂️📝

<!--
1.  🏷️ - This emoji represents the concept of naming or labeling something, which is relevant for specifying a project name.
2.  🗂️ - This emoji represents the concept of organizing or sorting something, which is relevant for grouping experiments in different workspaces or folders.
3.  📝 - This emoji represents the concept of writing or logging something, which is relevant for the Comet.ml integration.
-->
Added support for custom project names in Comet.ml logging. Refactored `ultralytics/yolo/utils/callbacks/comet.py` to use a local variable for the project name.

> _`COMET_PROJECT_NAME`_
> _A new env var for logging_
> _Autumn leaves organize_

### Walkthrough
*  Add support for custom project name for Comet.ml logging ([link](https://github.com/ultralytics/ultralytics/pull/3013/files?diff=unified&w=0#diff-88156d2cb2225824b539d2eeeece9b6157773bd05beabc136066535690b0d046L70-R73))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to support dynamic Comet project names in the Ultralytics YOLO library.

### 📊 Key Changes
- COMET_PROJECT_NAME environment variable support added.
- Falling back to command line `args.project` if the environment variable is not set.
- Logging updated to include both `args` parameters and the current Comet project name.

### 🎯 Purpose & Impact
- 🔧 This change increases flexibility by allowing users to easily switch between different Comet projects without altering code.
- 🧩 It aids in organizing and comparing different experimental runs or training sessions.
- 📈 Users will benefit from a more streamlined workflow when using Comet.ml with the Ultralytics YOLO models.