### PR TITLE
fix(loggers): DVCLive add package version check

### DIFF
--- a/ultralytics/yolo/utils/callbacks/dvc.py
+++ b/ultralytics/yolo/utils/callbacks/dvc.py
@@ -1,6 +1,8 @@
 # Ultralytics YOLO 🚀, GPL-3.0 license
 import os
 
+import pkg_resources as pkg
+
 from ultralytics.yolo.utils import LOGGER, TESTS_RUNNING
 from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
 
@@ -10,8 +12,12 @@ try:
     import dvclive
 
     assert not TESTS_RUNNING  # do not log pytest
-    assert version('dvclive')
-except (ImportError, AssertionError):
+
+    ver = version('dvclive')
+    if pkg.parse_version(ver) < pkg.parse_version('2.11.0'):
+        LOGGER.debug(f'DVCLive is detected but version {ver} is incompatible (>=2.11 required).')
+        dvclive = None  # noqa: F811
+except (ImportError, AssertionError, TypeError):
     dvclive = None
 
 # DVCLive logger instance


### PR DESCRIPTION
Fixes #3092 

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3cfce39</samp>

### Summary
🆕🔧🐛

<!--
1.  🆕 - This emoji can be used to indicate that a new feature or functionality was added, such as the version check for `dvclive`.
2.  🔧 - This emoji can be used to indicate that some configuration or settings were changed or fixed, such as disabling `dvclive` if incompatible.
3.  🐛 - This emoji can be used to indicate that a bug was fixed or prevented, such as avoiding errors or crashes due to incompatible `dvclive` versions.
-->
Improved compatibility of `dvc.py` callback with different versions of `dvclive` package. Added logging and error handling for version mismatch.

> _Sing, O Muse, of the skillful coder who devised_
> _A clever check for `dvclive`, the package of renown,_
> _And disabled it with `LOGGER` if its version was despised_
> _By the mighty `pkg_resources`, the arbiter of the crown._

### Walkthrough
* Import `pkg_resources` module to compare `dvclive` version ([link](https://github.com/ultralytics/ultralytics/pull/3112/files?diff=unified&w=0#diff-052c6262efa033fb56c6ac6241d151d7eb373ee01daa36cf70077f332078a216R4-R5))
* Check `dvclive` version and disable it if lower than 2.11.0 or invalid ([link](https://github.com/ultralytics/ultralytics/pull/3112/files?diff=unified&w=0#diff-052c6262efa033fb56c6ac6241d151d7eb373ee01daa36cf70077f332078a216L13-R20))
* Catch `TypeError` exception from `pkg.parse_version` and print debug message with `LOGGER` ([link](https://github.com/ultralytics/ultralytics/pull/3112/files?diff=unified&w=0#diff-052c6262efa033fb56c6ac6241d151d7eb373ee01daa36cf70077f332078a216L13-R20))
* Add `noqa: F811` comment to suppress flake8 warning about redefining `dvclive` ([link](https://github.com/ultralytics/ultralytics/pull/3112/files?diff=unified&w=0#diff-052c6262efa033fb56c6ac6241d151d7eb373ee01daa36cf70077f332078a216L13-R20))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced DVCLive compatibility check in YOLO callbacks.

### 📊 Key Changes
- Added `pkg_resources` import for version checking.
- Extended the DVCLive import process to verify the version requirement.
- Included a debug message when an incompatible version of DVCLive is detected.

### 🎯 Purpose & Impact
- **Purpose:** To ensure the DVCLive logging tool used within the YOLO callbacks is compatible with the current codebase.
- **Impact:** Prevents potential issues due to version incompatibility by providing a clear debug message, leading to better stability and user-awareness when using the YOLO framework. Users require DVCLive version 2.11.0 or greater for optimal functionality.