### PR TITLE
Add `device=cuda` support

### DIFF
--- a/ultralytics/yolo/utils/torch_utils.py
+++ b/ultralytics/yolo/utils/torch_utils.py
@@ -64,6 +64,8 @@ def select_device(device='', batch=0, newline=False, verbose=True):
     if cpu or mps:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
+        if device == 'cuda':
+            device = '0'
         visible = os.environ.get('CUDA_VISIBLE_DEVICES', None)
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable - must be before assert is_available()
         if not (torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(',', ''))):


### PR DESCRIPTION
Also supports `device=CUDA`. @fcakyon


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d3677f1</samp>

### Summary
🚀🎛️🐛

<!--
1.  🚀 This emoji can signify that the change is a performance improvement or a feature enhancement, as using a GPU can speed up the computation and enable more complex models.
2.  🎛️ This emoji can signify that the change is related to configuration or settings, as the device argument is a parameter that controls how the code runs on different hardware.
3.  🐛 This emoji can signify that the change is a bug fix, as the pull request mentions that it addresses some issues with the current device selection logic.
-->
Improve device selection logic and fix bugs in `ultralytics/yolo/utils/torch_utils.py`. Set default device to first GPU if 'cuda' is given.

> _`cuda` by default_
> _a gift for GPU users_
> _autumn bug fixing_

### Walkthrough
* Set the default device to the first GPU if the device argument is 'cuda' ([link](https://github.com/ultralytics/ultralytics/pull/3133/files?diff=unified&w=0#diff-b19b7e7ce0f018a381bc8c238cc1554454d0b5ea2b4c2880a822b732f05535d8R67-R68))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved device selection logic for CUDA in the torch_utils module.

### 📊 Key Changes
- Added a condition to default `device='cuda'` to `device='0'`, ensuring explicit GPU selection.

### 🎯 Purpose & Impact
- **Purpose**: Streamlines the process of selecting the first GPU when `cuda` is specified without an explicit device index.
- **Impact**: Provides a user-friendly way to use the default GPU, preventing potential confusion and simplifying the code needed to run models on a GPU. 🖥️💡