### PR TITLE
Fix platform set to tuple

### DIFF
--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -37,7 +37,7 @@ AUTOINSTALL = str(os.getenv('YOLO_AUTOINSTALL', True)).lower() == 'true'  # glob
 VERBOSE = str(os.getenv('YOLO_VERBOSE', True)).lower() == 'true'  # global verbose mode
 TQDM_BAR_FORMAT = '{l_bar}{bar:10}{r_bar}'  # tqdm bar format
 LOGGING_NAME = 'ultralytics'
-MACOS, LINUX, WINDOWS = (platform.system() == x for x in {'Darwin', 'Linux', 'Windows'})  # environment booleans
+MACOS, LINUX, WINDOWS = (platform.system() == x for x in ['Darwin', 'Linux', 'Windows'])  # environment booleans
 HELP_MSG = \
     """
     Usage examples for running YOLOv8:

--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -37,7 +37,7 @@ AUTOINSTALL = str(os.getenv('YOLO_AUTOINSTALL', True)).lower() == 'true'  # glob
 VERBOSE = str(os.getenv('YOLO_VERBOSE', True)).lower() == 'true'  # global verbose mode
 TQDM_BAR_FORMAT = '{l_bar}{bar:10}{r_bar}'  # tqdm bar format
 LOGGING_NAME = 'ultralytics'
-MACOS, LINUX, WINDOWS = (platform.system() == x for x in ['Darwin', 'Linux', 'Windows'])  # environment booleans
+MACOS, LINUX, WINDOWS = (platform.system() == x for x in ('Darwin', 'Linux', 'Windows'))  # environment booleans
 HELP_MSG = \
     """
     Usage examples for running YOLOv8:


### PR DESCRIPTION
@glenn-jocher 
`set` in python is unordered hence this way to get platform ends with incorrect results.
```python
import platform
for x in {'Darwin', 'Linux', 'Windows'}:
    print(x, platform.system() == x)
```
output:
```bash
Windows False
Darwin False
Linux True
```
but what we expect is this order:
```bash
Darwin False
Linux True
Windows False
```

The package currently is identifying my system a macos.
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c2a8850</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 - This emoji represents a bug fix, since the original code could have caused unexpected behavior depending on the order of the set elements.
2.  📝 - This emoji represents a code quality improvement, since the list is more explicit and readable than the set, and avoids the need for a comment explaining the order of the platforms.
3.  🚀 - This emoji represents a performance improvement, since the list is faster to iterate over than the set, and avoids the overhead of hashing and checking for duplicates.
-->
This pull request fixes some minor issues and improves the code quality of the `ultralytics/yolo` module. One of the changes is to use a list instead of a set for the platform names in `ultralytics/yolo/utils/__init__.py` to ensure a consistent order.

> _`set` becomes `list`_
> _Order matters for booleans_
> _A bug fixed in fall_

### Walkthrough
* Use a list instead of a set for platform names to ensure consistent order ([link](https://github.com/ultralytics/ultralytics/pull/3136/files?diff=unified&w=0#diff-4a5fdbc973a408779ed550a87d5b6bd0d01693002dcc225876d7fb8a3c6d3137L40-R40))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved platform detection with tuple usage in environment booleans.

### 📊 Key Changes
- Replaced curly braces `{}` with parentheses `()` in environment booleans to ensure correct platform detection.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: The change ensures the platform detection (for macOS, Linux, Windows) works correctly by using a tuple to create a generator expression instead of a set, which could lead to unordered execution and incorrect assignments.
- ✅ **Impact**: Users across different operating systems can now rely on more consistent behavior of the platform-specific code, leading to fewer environment-related bugs.