### PR TITLE
Comet Updates

### DIFF
--- a/ultralytics/yolo/utils/callbacks/comet.py
+++ b/ultralytics/yolo/utils/callbacks/comet.py
@@ -361,8 +361,8 @@ def on_train_end(trainer):
     _comet_image_prediction_count = 0
 
 
-callbacks = ({
+callbacks = {
     'on_pretrain_routine_start': on_pretrain_routine_start,
     'on_train_epoch_end': on_train_epoch_end,
     'on_fit_epoch_end': on_fit_epoch_end,
-    'on_train_end': on_train_end, } if comet_ml else {})
+    'on_train_end': on_train_end} if comet_ml else {}

--- a/ultralytics/yolo/utils/callbacks/comet.py
+++ b/ultralytics/yolo/utils/callbacks/comet.py
@@ -72,7 +72,7 @@ def _create_experiment(args):
         experiment.log_parameters(vars(args))
         experiment.log_others({
             'eval_batch_logging_interval': _get_eval_batch_logging_interval(),
-            'log_confusion_matrix': _should_log_confusion_matrix(),
+            'log_confusion_matrix_on_eval': _should_log_confusion_matrix(),
             'log_image_predictions': _should_log_image_predictions(),
             'max_image_predictions': _get_max_image_predictions_to_log(), })
         experiment.log_other('Created from', 'yolov8')


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

This PR introduces the following changes:

1. We noticed that the Confusion Matrix logged before the final epoch only consists of zeros. This changes the default behavior for logging a Confusion Matrix after every epoch to only logging a Confusion Matrix at the end of training. The user can enable logging after every epoch via an environment variable flag if necessary. 
2. Adds the option of specifying the Comet project name via Environment variable without having it be overwritten by the `project` argument. This is useful if a user wants their local directory name for the run to be different from their Comet project name. Related Issue: https://github.com/ultralytics/ultralytics/issues/2932

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e5e8eb</samp>

### Summary
:wrench::rocket::chart_with_upwards_trend:

<!--
1.  :wrench: - This emoji represents a tool or a fix, and can be used to indicate the changes that modify the default behavior and fix a typo in the Comet callback file.
2.  :rocket: - This emoji represents a launch or a boost, and can be used to indicate the changes that improve the readability and user control of the Comet callback file, as well as the change that allows specifying a custom project name for logging to Comet.
3.  :chart_with_upwards_trend: - This emoji represents a growth or an improvement, and can be used to indicate the overall goal of the changes, which is to enhance the logging and analysis capabilities of the YOLOv5 framework with Comet.
-->
The pull request updates the `comet.py` file to enhance the Comet logging functionality for the YOLO model. It allows users to specify the project name, reduces the amount of logged data, and fixes a typo and readability issues.

> _No more confusion, no more waste_
> _We log to Comet with our own taste_
> _We fix the typo, we make it clear_
> _We are the masters of the `comet.py` sphere_

### Walkthrough
* Change the default behavior of logging confusion matrix to Comet to be opt-in instead of opt-in ([link](https://github.com/ultralytics/ultralytics/pull/3186/files?diff=unified&w=0#diff-88156d2cb2225824b539d2eeeece9b6157773bd05beabc136066535690b0d046L49-R49))
* Allow the user to specify a different project name for Comet than the local directory structure using an environment variable ([link](https://github.com/ultralytics/ultralytics/pull/3186/files?diff=unified&w=0#diff-88156d2cb2225824b539d2eeeece9b6157773bd05beabc136066535690b0d046L70-R75))
* Fix a typo in the docstring of the `_log_confusion_matrix` function ([link](https://github.com/ultralytics/ultralytics/pull/3186/files?diff=unified&w=0#diff-88156d2cb2225824b539d2eeeece9b6157773bd05beabc136066535690b0d046L198-R199))
* Improve the readability of the `callbacks` dictionary by wrapping it in parentheses ([link](https://github.com/ultralytics/ultralytics/pull/3186/files?diff=unified&w=0#diff-88156d2cb2225824b539d2eeeece9b6157773bd05beabc136066535690b0d046L363-R368))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Comet.ml integration with better environment variable management and confusion matrix logging defaults.

### 📊 Key Changes
- Default behavior for confusion matrix logging on Comet.ml changed from `true` to `false`.
- Project name for Comet.ml can now be set using an environment variable `COMET_PROJECT_NAME`.
- The key for logging the confusion matrix during evaluation has been updated to `log_confusion_matrix_on_eval`.

### 🎯 Purpose & Impact
- 📉 Reduces unnecessary logging: Changing the default behavior for confusion matrix logging minimizes clutter on Comet.ml unless explicitly enabled.
- 🛠 Customization ease: Users can easily set the project name for Comet.ml through environment variables, offering more flexibility.
- 🎨 Clarity in logging: Renaming the key to `log_confusion_matrix_on_eval` clarifies when confusion matrices are logged, leading to better understanding and control over logging behavior.