### PR TITLE
Add world_size check before setting up DDP train

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -217,7 +217,7 @@ class BaseTrainer:
             callbacks_backup = callbacks.default_callbacks.copy()  # backup callbacks as check_amp() resets them
             self.amp = torch.tensor(check_amp(self.model), device=self.device)
             callbacks.default_callbacks = callbacks_backup  # restore callbacks
-        if RANK > -1:  # DDP
+        if RANK > -1 and world_size > 1:  # DDP
             dist.broadcast(self.amp, src=0)  # broadcast the tensor from rank 0 to all other ranks (returns None)
         self.amp = bool(self.amp)  # as boolean
         self.scaler = amp.GradScaler(enabled=self.amp)


### PR DESCRIPTION
There are situations where `RANK=0` even when `WORLD_SIZE=1` (as of Apache Spark 3.4.0) . Therefore, `RANK > -1` is an insufficient condition to prevent YOLO from running `dist.broadcast`, even though DDP was not (and could not be) initialized.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e9d2e93</samp>

### Summary
🌎📡🚀

<!--
1.  🌎 - This emoji represents the world size, which is the number of processes involved in the DDP training. The change affects how the world size is used to determine whether to broadcast the `self.amp` tensor or not.
2.  📡 - This emoji represents the communication overhead, which is the cost of sending and receiving data between processes. The change aims to reduce the communication overhead when there is only one process, by skipping the unnecessary broadcast operation.
3.  🚀 - This emoji represents the performance and scalability, which are the goals of the DDP training. The change is expected to improve the performance and scalability of the DDP training by avoiding wasteful communication.
-->
Improved DDP performance by broadcasting `self.amp` only when needed. Modified the condition in `ultralytics/yolo/engine/trainer.py`.

> _`self.amp` tensor_
> _broadcasts when world is large_
> _saving time in fall_

### Walkthrough
*  Modify the condition for broadcasting the `self.amp` tensor in DDP mode to check if the world size is greater than one ([link](https://github.com/ultralytics/ultralytics/pull/3191/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L220-R220)). This improves the performance and scalability of the DDP training by avoiding unnecessary communication overhead when there is only one process.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Distributed Data Parallel (DDP) initialization logic for scaling gradients.

### 📊 Key Changes
- Adjusted the condition for broadcasting AMP (Automatic Mixed Precision) status across distributed training workers.
- Broadcasting will now only occur if the world size is greater than 1, meaning there is more than one worker in the distributed setup.

### 🎯 Purpose & Impact
- 🎭 **Purpose**: Ensures that tensor broadcasting for AMP status is only attempted in multi-worker environments, optimizing resources and preventing unnecessary operations.
- ✨ **Impact**: Users leveraging distributed training will experience more efficient training startup, especially in single-worker scenarios. This change helps avoid redundant communications in non-distributed or single-worker setups.