### PR TITLE
Jetson Docker fix `opencv-python>=4.5.0`

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,6 +6,16 @@ name: Publish Docker Images
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      image:
+        type: choice
+        description: Select Docker Image
+        options:
+        - Arm64
+        - Jetson
+        - CPU
+        - GPU
 
 jobs:
   docker:
@@ -29,6 +39,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push arm64 image
+        if: github.event_name == 'push' || github.event.inputs.choice == 'Arm64'
         uses: docker/build-push-action@v4
         continue-on-error: true
         with:
@@ -39,6 +50,7 @@ jobs:
           tags: ultralytics/ultralytics:latest-arm64
 
       - name: Build and push Jetson image
+        if: github.event_name == 'push' || github.event.inputs.choice == 'Jetson'
         uses: docker/build-push-action@v4
         continue-on-error: true
         with:
@@ -49,6 +61,7 @@ jobs:
           tags: ultralytics/ultralytics:latest-jetson
 
       - name: Build and push CPU image
+        if: github.event_name == 'push' || github.event.inputs.choice == 'CPU'
         uses: docker/build-push-action@v4
         continue-on-error: true
         with:
@@ -58,6 +71,7 @@ jobs:
           tags: ultralytics/ultralytics:latest-cpu
 
       - name: Build and push GPU image
+        if: github.event_name == 'push' || github.event.inputs.choice == 'GPU'
         uses: docker/build-push-action@v4
         continue-on-error: true
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push arm64 image
-        if: github.event_name == 'push' || github.event.inputs.choice == 'Arm64'
+        if: github.event_name == 'push' || github.event.inputs.image == 'Arm64'
         uses: docker/build-push-action@v4
         continue-on-error: true
         with:
@@ -50,7 +50,7 @@ jobs:
           tags: ultralytics/ultralytics:latest-arm64
 
       - name: Build and push Jetson image
-        if: github.event_name == 'push' || github.event.inputs.choice == 'Jetson'
+        if: github.event_name == 'push' || github.event.inputs.image == 'Jetson'
         uses: docker/build-push-action@v4
         continue-on-error: true
         with:
@@ -61,7 +61,7 @@ jobs:
           tags: ultralytics/ultralytics:latest-jetson
 
       - name: Build and push CPU image
-        if: github.event_name == 'push' || github.event.inputs.choice == 'CPU'
+        if: github.event_name == 'push' || github.event.inputs.image == 'CPU'
         uses: docker/build-push-action@v4
         continue-on-error: true
         with:
@@ -71,7 +71,7 @@ jobs:
           tags: ultralytics/ultralytics:latest-cpu
 
       - name: Build and push GPU image
-        if: github.event_name == 'push' || github.event.inputs.choice == 'GPU'
+        if: github.event_name == 'push' || github.event.inputs.image == 'GPU'
         uses: docker/build-push-action@v4
         continue-on-error: true
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Base ----------------------------------------
 matplotlib>=3.2.2
-opencv-python>=4.6.0
+opencv-python>=4.5.0  # <=4.5.0 required for Jetson Docker https://github.com/ultralytics/ultralytics/issues/3183
 Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0


### PR DESCRIPTION
May resolve https://github.com/ultralytics/ultralytics/issues/3183

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1e664e0</samp>

### Summary





### Walkthrough





## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Docker build flexibility and Jetson Docker compatibility.

### 📊 Key Changes
- Added `workflow_dispatch` with image selection for Docker builds (`Arm64`, `Jetson`, `CPU`, `GPU`).
- Conditional Docker image build steps based on push events or manual dispatch selections.
- Downgraded `opencv-python` minimum version requirement for Jetson Docker compatibility.

### 🎯 Purpose & Impact
- 🔁 Allows manual triggering of Docker builds for specific images, offering more control and efficiency in the CI/CD pipeline.
- 🛠️ Ensures compatibility with Nvidia Jetson devices by requiring an `opencv-python` version that aligns with their constraints.
- 👥 Broadens support and accessibility for various platforms, benefiting developers who work with diverse hardware setups.