### PR TITLE
Update save_dir on new predict args

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -250,6 +250,8 @@ class YOLO:
             self.predictor.setup_model(model=self.model, verbose=is_cli)
         else:  # only update args if predictor is already setup
             self.predictor.args = get_cfg(self.predictor.args, overrides)
+            if 'project' in overrides or 'name' in overrides:
+                self.predictor.save_dir = self.predictor.get_save_dir()
         return self.predictor.predict_cli(source=source) if is_cli else self.predictor(source=source, stream=stream)
 
     def track(self, source=None, stream=False, persist=False, **kwargs):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -65,14 +65,13 @@ class BasePredictor:
     Attributes:
         args (SimpleNamespace): Configuration for the predictor.
         save_dir (Path): Directory to save results.
-        done_setup (bool): Whether the predictor has finished setup.
+        done_warmup (bool): Whether the predictor has finished setup.
         model (nn.Module): Model used for prediction.
         data (dict): Data configuration.
         device (torch.device): Device used for prediction.
         dataset (Dataset): Dataset used for prediction.
         vid_path (str): Path to video file.
         vid_writer (cv2.VideoWriter): Video writer for saving video output.
-        annotator (Annotator): Annotator used for prediction.
         data_path (str): Path to data.
     """
 
@@ -85,9 +84,7 @@ class BasePredictor:
             overrides (dict, optional): Configuration overrides. Defaults to None.
         """
         self.args = get_cfg(cfg, overrides)
-        project = self.args.project or Path(SETTINGS['runs_dir']) / self.args.task
-        name = self.args.name or f'{self.args.mode}'
-        self.save_dir = increment_path(Path(project) / name, exist_ok=self.args.exist_ok)
+        self.save_dir = self.get_save_dir()
         if self.args.conf is None:
             self.args.conf = 0.25  # default conf=0.25
         self.done_warmup = False
@@ -107,6 +104,11 @@ class BasePredictor:
         self.batch = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
         callbacks.add_integration_callbacks(self)
+
+    def get_save_dir(self):
+        project = self.args.project or Path(SETTINGS['runs_dir']) / self.args.task
+        name = self.args.name or f'{self.args.mode}'
+        return increment_path(Path(project) / name, exist_ok=self.args.exist_ok)
 
     def preprocess(self, im):
         """Prepares input image before inference.


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/3189

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd21b39</samp>

### Summary
🛠️♻️📁

<!--
1.  🛠️ for adding a condition to check for overridden arguments and updating the save directory accordingly. This emoji conveys the idea of fixing or improving something.
2.  ♻️ for refactoring the BasePredictor class, by renaming and removing some attributes, and adding a new method. This emoji conveys the idea of recycling or reusing code, or making it more efficient or clean.
3.  📁 for handling the output directory and saving the prediction results. This emoji conveys the idea of organizing or storing files or data.
-->
This pull request improves the YOLO predictor by refactoring the `BasePredictor` class in `predictor.py` and adding a feature to customize the output directory in `model.py`.

> _The YOLO predictor had a flaw_
> _It ignored the arguments you saw_
> _So they added a check_
> _To update the `save_dir`_
> _And refactored the `BasePredictor` raw_

### Walkthrough
*  Add condition to update save directory if project or name are overridden ([link](https://github.com/ultralytics/ultralytics/pull/3215/files?diff=unified&w=0#diff-555e5fdee1244b9d95b48487cfd502d068e5bfcd51001d5f5b3f4a33007bda7cR253-R254))
*  Rename `done_setup` attribute to `done_warmup` for clarity ([link](https://github.com/ultralytics/ultralytics/pull/3215/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L68-R68))
*  Remove unused and redundant `annotator` attribute ([link](https://github.com/ultralytics/ultralytics/pull/3215/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L75))
*  Simplify initialization of `save_dir` attribute by calling `get_save_dir` method ([link](https://github.com/ultralytics/ultralytics/pull/3215/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L88-R87))
*  Add `get_save_dir` method to return output directory based on arguments ([link](https://github.com/ultralytics/ultralytics/pull/3215/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675R108-R112))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update in save directory handling for Ultralytics YOLO predictor.

### 📊 Key Changes
- Added a clause to update the `save_dir` for the predictor when `project` or `name` is overridden.
- Removed duplicate directory setup, now using a new `get_save_dir` method.
- Renamed attribute `done_setup` to `done_warmup` for clarity.
- Removed unnecessary `annotator` attribute initialization from the predictor.

### 🎯 Purpose & Impact
- 🔧 **Simplified Save Directory Logic**: Ensures that save directory is updated dynamically when `project` or `name` settings are changed without the need to fully set up the model again.
- 🧹 **Code Cleanup**: Removal of redundant code and clearer attribute names improve code maintainability and readability for developers.
- 👥 **User Clarity:** By simplifying how directories are handled, users can more easily customize where their output is saved, leading to an enhanced user experience.
  
These updates streamline internal processes, reduce potential bugs, and provide users with more control over their workflow.