### PR TITLE
Fix `batch=-1` for exports

### DIFF
--- a/ultralytics/yolo/engine/model.py
+++ b/ultralytics/yolo/engine/model.py
@@ -335,7 +335,7 @@ class YOLO:
         overrides['mode'] = 'export'
         if overrides.get('imgsz') is None:
             overrides['imgsz'] = self.model.args['imgsz']  # use trained imgsz unless custom value is passed
-        if overrides.get('batch') is None:
+        if 'batch' not in kwargs:
             overrides['batch'] = 1  # default to 1 if not modified
         args = get_cfg(cfg=DEFAULT_CFG, overrides=overrides)
         args.task = self.task

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -229,7 +229,7 @@ class BaseTrainer:
         # Batch size
         if self.batch_size == -1:
             if RANK == -1:  # single-GPU only, estimate best batch size
-                self.batch_size = check_train_batch_size(self.model, self.args.imgsz, self.amp)
+                self.args.batch = self.batch_size = check_train_batch_size(self.model, self.args.imgsz, self.amp)
             else:
                 SyntaxError('batch=-1 to use AutoBatch is only available in Single-GPU training. '
                             'Please pass a valid batch size value for Multi-GPU DDP training, i.e. batch=16')

--- a/ultralytics/yolo/utils/autobatch.py
+++ b/ultralytics/yolo/utils/autobatch.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import numpy as np
 import torch
 
-from ultralytics.yolo.utils import LOGGER, colorstr
+from ultralytics.yolo.utils import LOGGER, DEFAULT_CFG, colorstr
 from ultralytics.yolo.utils.torch_utils import profile
 
 
@@ -29,7 +29,7 @@ def check_train_batch_size(model, imgsz=640, amp=True):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
 
 
-def autobatch(model, imgsz=640, fraction=0.67, batch_size=16):
+def autobatch(model, imgsz=640, fraction=0.67, batch_size=DEFAULT_CFG.batch):
     """
     Automatically estimate the best YOLO batch size to use a fraction of the available CUDA memory.
 

--- a/ultralytics/yolo/utils/autobatch.py
+++ b/ultralytics/yolo/utils/autobatch.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import numpy as np
 import torch
 
-from ultralytics.yolo.utils import LOGGER, DEFAULT_CFG, colorstr
+from ultralytics.yolo.utils import DEFAULT_CFG, LOGGER, colorstr
 from ultralytics.yolo.utils.torch_utils import profile
 
 


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/1680

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ad55d5d</samp>

### Summary
🐛🔄🔧

<!--
1.  🐛 for fixing a bug in the `export` function.
2.  🔄 for updating the `args.batch` attribute to match the `batch_size` attribute.
3.  🔧 for adding a configurable default batch size to the `autobatch` function.
-->
This pull request improves the `autobatch` feature, fixes a bug in the `export` function, and updates the `args.batch` attribute of the `BaseTrainer` class. These changes enhance the usability, compatibility, and consistency of the `ultralytics/yolo` module.

> _Sing, O Muse, of the cunning code review_
> _That fixed the bug in the `export` function_
> _And made the `batch` key obey the `kwargs`_
> _And not the `overrides`' false instruction_

### Walkthrough
* Fix bug in `export` function of `YOLO` class that ignored `kwargs` argument for batch size ([link](https://github.com/ultralytics/ultralytics/pull/3217/files?diff=unified&w=0#diff-555e5fdee1244b9d95b48487cfd502d068e5bfcd51001d5f5b3f4a33007bda7cL338-R338))
* Update `args.batch` attribute of `BaseTrainer` class when using `autobatch` feature to estimate optimal batch size ([link](https://github.com/ultralytics/ultralytics/pull/3217/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L232-R232))
* Use `DEFAULT_CFG.batch` constant as default value for `batch_size` parameter in `autobatch` function ([link](https://github.com/ultralytics/ultralytics/pull/3217/files?diff=unified&w=0#diff-2219b9ffd8005b856c41f0688f7facd9f0e940bdd80868380c6f28a3ba5c44c8L11-R11), [link](https://github.com/ultralytics/ultralytics/pull/3217/files?diff=unified&w=0#diff-2219b9ffd8005b856c41f0688f7facd9f0e940bdd80868380c6f28a3ba5c44c8L32-R32))
* Import `DEFAULT_CFG` constant from `ultralytics.yolo.utils` module in `autobatch.py` file ([link](https://github.com/ultralytics/ultralytics/pull/3217/files?diff=unified&w=0#diff-2219b9ffd8005b856c41f0688f7facd9f0e940bdd80868380c6f28a3ba5c44c8L11-R11))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to batch size configuration during YOLO model training and export.

### 📊 Key Changes
- Changed the condition to default batch size to 1 only if 'batch' is not specified in the override arguments during model export.
- Ensured `self.args.batch` is assigned when determining the optimal batch size automatically for single-GPU training.
- Updated autobatch function to use `DEFAULT_CFG.batch` as the initial batch size when estimating the best batch size to utilize available CUDA memory.

### 🎯 Purpose & Impact
- These changes improve the flexibility and reliability of batch size configuration, ensuring the export function and AutoBatch correctly acknowledge user-provided batch sizes.
- The updates help streamline the training process by preventing potential errors or confusion regarding batch size settings, leading to a smoother user experience. 🚀
- Users will benefit from these changes through more intuitive settings and potentially more efficient memory usage during training on a single GPU. 💻