### PR TITLE
Fix PIL `getsize()` deprecation warning

### DIFF
--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -8,8 +8,7 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from PIL import Image, ImageDraw, ImageFont
-from PIL import __version__ as pil_version
+from PIL import Image, ImageDraw, ImageFont, __version__ as pil_version
 from scipy.ndimage import gaussian_filter1d
 
 from ultralytics.yolo.utils import LOGGER, TryExcept, plt_settings, threaded
@@ -54,7 +53,6 @@ class Annotator:
         non_ascii = not is_ascii(example)  # non-latin labels, i.e. asian, arabic, cyrillic
         self.pil = pil or non_ascii
         if self.pil:  # use PIL
-            self.pil_9_2_0_check = check_version(pil_version, '9.2.0')  # deprecation check
             self.im = im if isinstance(im, Image.Image) else Image.fromarray(im)
             self.draw = ImageDraw.Draw(self.im)
             try:
@@ -64,7 +62,7 @@ class Annotator:
             except Exception:
                 self.font = ImageFont.load_default()
             # Deprecation fix for w, h = getsize(string) -> _, _, w, h = getbox(string)
-            if self.pil_9_2_0_check:
+            if check_version(pil_version, '9.2.0') :
                 self.font.getsize = lambda x: self.font.getbbox(x)[2:4]  # text width, height
         else:  # use cv2
             self.im = im

--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -8,7 +8,8 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from PIL import Image, ImageDraw, ImageFont, __version__ as pil_version
+from PIL import Image, ImageDraw, ImageFont
+from PIL import __version__ as pil_version
 from scipy.ndimage import gaussian_filter1d
 
 from ultralytics.yolo.utils import LOGGER, TryExcept, plt_settings, threaded
@@ -62,7 +63,7 @@ class Annotator:
             except Exception:
                 self.font = ImageFont.load_default()
             # Deprecation fix for w, h = getsize(string) -> _, _, w, h = getbox(string)
-            if check_version(pil_version, '9.2.0') :
+            if check_version(pil_version, '9.2.0'):
                 self.font.getsize = lambda x: self.font.getbbox(x)[2:4]  # text width, height
         else:  # use cv2
             self.im = im

--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -63,6 +63,9 @@ class Annotator:
                 self.font = ImageFont.truetype(str(font), size)
             except Exception:
                 self.font = ImageFont.load_default()
+            # Deprecation fix for w, h = getsize(string) -> _, _, w, h = getbox(string)
+            if self.pil_9_2_0_check:
+                self.font.getsize = lambda x: self.font.getbbox(x)[2:4]  # text width, height
         else:  # use cv2
             self.im = im
         self.lw = line_width or max(round(sum(im.shape) / 2 * 0.003), 2)  # line width
@@ -80,10 +83,7 @@ class Annotator:
         if self.pil or not is_ascii(label):
             self.draw.rectangle(box, width=self.lw, outline=color)  # box
             if label:
-                if self.pil_9_2_0_check:
-                    _, _, w, h = self.font.getbbox(label)  # text width, height (New)
-                else:
-                    w, h = self.font.getsize(label)  # text width, height (Old, deprecated in 9.2.0)
+                w, h = self.font.getsize(label)  # text width, height
                 outside = box[1] - h >= 0  # label fits outside box
                 self.draw.rectangle(
                     (box[0], box[1] - h if outside else box[1], box[0] + w + 1,


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1142ab0</samp>

### Summary
🛠️📊🧹

<!--
1.  🛠️ - This emoji represents a fix or a repair, and can be used to indicate that the pull request fixes a bug or an issue.
2.  📊 - This emoji represents a chart or a graph, and can be used to indicate that the pull request involves plotting or data visualization.
3.  🧹 - This emoji represents a broom or a cleanup, and can be used to indicate that the pull request removes some redundant or unnecessary code.
-->
This pull request improves the plotting functionality of the `yolo` package by fixing a bug with PIL 9.2.0 and simplifying the code in `plotting.py`.

> _The font of doom has changed its size_
> _We must adapt or face demise_
> _No more we need the bounding box_
> _We plot our graphs and defy the locks_

### Walkthrough
*  Fix PIL deprecation issue for text size calculation ([link](https://github.com/ultralytics/ultralytics/pull/3234/files?diff=unified&w=0#diff-7e75b3f968b9868ef6f0a86148cf6c16a5224e7fdd45f5c2eb5e9bc0fc744756R66-R68))
* Simplify text size calculation by removing conditional branch ([link](https://github.com/ultralytics/ultralytics/pull/3234/files?diff=unified&w=0#diff-7e75b3f968b9868ef6f0a86148cf6c16a5224e7fdd45f5c2eb5e9bc0fc744756L83-R86))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved PIL font handling in Ultralytics' YOLO plotting utility.

### 📊 Key Changes
- Eliminated deprecated font size check against PIL version 9.2.0.
- Introduced a conditional to handle `getsize` deprecation in PIL by using new `getbbox` method.

### 🎯 Purpose & Impact
- **Maintain Compatibility:** Ensures the plotting utility can handle text rendering without issues as PIL evolves.
- **Reduce Redundancy:** Cleans up code by removing the version check that is no longer necessary.
- **Future-Proofing:** Adjusts to PIL's new font sizing method, which helps to avoid deprecation warnings or errors in future versions. 
- **User Clarity:** Text on images will continue to display correctly, important for accurate image labeling in machine learning applications.