### PR TITLE
Return `save_dir` with prediction results

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -102,6 +102,8 @@ class BasePredictor:
         self.data_path = None
         self.source_type = None
         self.batch = None
+        self.results = None
+        self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
         callbacks.add_integration_callbacks(self)
 
@@ -260,12 +262,13 @@ class BasePredictor:
 
                 if self.args.verbose or self.args.save or self.args.save_txt or self.args.show:
                     s += self.write_results(i, self.results, (p, im, im0))
-
+                if self.args.save or self.args.save_txt:
+                    self.results[i].save_dir = self.save_dir.__str__()
                 if self.args.show and self.plotted_img is not None:
                     self.show(p)
-
                 if self.args.save and self.plotted_img is not None:
                     self.save_preds(vid_cap, i, str(self.save_dir / p.name))
+
             self.run_callbacks('on_predict_batch_end')
             yield from self.results
 

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -101,6 +101,7 @@ class Results(SimpleClass):
         self.speed = {'preprocess': None, 'inference': None, 'postprocess': None}  # milliseconds per image
         self.names = names
         self.path = path
+        self.save_dir = None
         self._keys = ('boxes', 'masks', 'probs', 'keypoints')
 
     def __getitem__(self, idx):


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/1329

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7a34ae8</samp>

### Summary
:sparkles::floppy_disk::wrench:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the `self.save_dir` attribute and the ability to save results and transforms for each batch.
2.  :floppy_disk: This emoji represents the saving of data or files, which is what the `save` and `save_txt` methods of the `Results` class do.
3.  :wrench: This emoji represents the adjustment or improvement of an existing functionality, which is the `predict` method of the `BasePredictor` class.
-->
This pull request adds the functionality to save the prediction results and transforms for each batch in a custom directory. It modifies the `BasePredictor` and `Results` classes in `ultralytics/yolo/engine/predictor.py` and `ultralytics/yolo/engine/results.py` respectively.

> _To store and save predictions per batch_
> _The `BasePredictor` got a new patch_
> _It assigns `self.save_dir`_
> _To the `Results` class, where_
> _The labels and transforms are a match_

### Walkthrough
*  Add `self.results` and `self.transforms` attributes to `BasePredictor` class to store predictions, metrics, and transforms for each batch ([link](https://github.com/ultralytics/ultralytics/pull/3240/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675R105-R106))
*  Assign `self.save_dir` attribute of `Results` object to current save directory in `predict` method of `BasePredictor` class to allow different save paths for different batches ([link](https://github.com/ultralytics/ultralytics/pull/3240/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L263-R271))
*  Add `self.save_dir` attribute to `Results` class in `results.py` to store the save path for predictions and labels ([link](https://github.com/ultralytics/ultralytics/pull/3240/files?diff=unified&w=0#diff-c3050afb0dfa35a0115c36c0acd91e2587f4349023d5f8a47e8c44e6b30121c5R104))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced save functionality for inference results in YOLO predictor.

### 📊 Key Changes
- Added `results` and `transforms` as new attributes to the YOLO `Predictor` class.
- Included a `save_dir` attribute in the `Results` class to specify where to save the output.
- Modified the `stream_inference` method to set the result's save directory before saving or showing the predictions.

### 🎯 Purpose & Impact
- These changes aim to improve the results management by keeping track of transformation operations and facilitating the results' saving process.
- Users will benefit from an organized way to save their inference outputs, potentially making post-processing and analysis more efficient. 🔄
- By having dedicated attributes for results and transforms, it simplifies the process of modifying and accessing prediction outcomes within custom workflows. 🗂️