### PR TITLE
Update datasets/classify/index.md Docs

### DIFF
--- a/docs/datasets/classify/index.md
+++ b/docs/datasets/classify/index.md
@@ -97,7 +97,7 @@ In this example, the `train` directory contains subdirectories for each class in
     
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=path/to/data model=yolov8n-seg.pt epochs=100 imgsz=640
+        yolo detect train data=path/to/data model=yolov8n-cls.pt epochs=100 imgsz=640
         ```
 
 ## Supported Datasets

--- a/docs/datasets/pose/index.md
+++ b/docs/datasets/pose/index.md
@@ -12,7 +12,7 @@ keywords: pose estimation, datasets, supported formats, YAML file, object class 
 
 ** Label Format **
 
-The dataset format used for training YOLO segmentation models is as follows:
+The dataset format used for training YOLO pose models is as follows:
 
 1. One text file per image: Each image in the dataset has a corresponding text file with the same name as the image file and the ".txt" extension.
 2. One row per object: Each row in the text file corresponds to one object instance in the image.

--- a/docs/datasets/pose/index.md
+++ b/docs/datasets/pose/index.md
@@ -52,7 +52,6 @@ names: [<class-1>, <class-2>, ..., <class-n>]
 # Keypoints
 kpt_shape: [num_kpts, dim]  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
 flip_idx: [n1, n2 ... , n(num_kpts)]
-
 ```
 
 The `train` and `val` fields specify the paths to the directories containing the training and validation images, respectively.
@@ -65,7 +64,7 @@ NOTE: Either `nc` or `names` must be defined. Defining both are not mandatory
 
 Alternatively, you can directly define class names like this:
 
-```
+```yaml
 names:
   0: person
   1: bicycle
@@ -118,7 +117,7 @@ TODO
 
 ### COCO dataset format to YOLO format
 
-```
+```python
 from ultralytics.yolo.data.converter import convert_coco
 
 convert_coco(labels_dir='../coco/annotations/', use_keypoints=True)


### PR DESCRIPTION
replace `yolov8n-seg.pt` with `yolov8n-cls.pt`


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 48cd5f2</samp>

### Summary
:memo::wrench::label:

<!--
1.  :memo: This emoji represents documentation updates, which is the main purpose of the pull request.
2.  :wrench: This emoji represents fixing or improving something, which is what the change in the model argument does for the training command.
3.  :label: This emoji represents changing or adding labels, which is related to the classification task that the model performs.
-->
Fixed a typo in the training command for the `classify` dataset. Changed the `model` argument to use the correct classification model `yolov8n-cls.pt`.

> _`model` argument_
> _changed for classification_
> _fall leaves are labeled_

### Walkthrough
* Change the `model` argument in the training command for the `classify` dataset to use a classification model instead of a segmentation model ([link](https://github.com/ultralytics/ultralytics/pull/3244/files?diff=unified&w=0#diff-e6e24f508630460bb2e91be72538d462137085a373cde5b7f0ffc9fd6ea6452dL100-R105))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of documentation for YOLO classification and pose estimation models.

### 📊 Key Changes
- Updated the command example for training classification models to use the correct pretrained model file (`yolov8n-cls.pt` instead of `yolov8n-seg.pt`).
- Clarified label format section by specifying it's for YOLO pose models.
- Removed an unnecessary blank line in the pose dataset documentation.
- Changed `flip_idx` code block from plain to YAML format.
- Provided a code example of converting COCO dataset format to YOLO format, specifically for pose estimation with keypoints.

### 🎯 Purpose & Impact
- Ensures users initiate training with the correct pretrained model, preventing confusion and potential errors for those working on classification tasks. 👩‍💻
- Clarifies documentation on pose estimation, making it easier to understand and follow, especially for users new to YOLO's pose model datasets. 🧘
- Code clean-up and conversion example addition facilitates a smoother dataset transition for developers working with COCO keypoints, leading to more efficient model training. 🔄🔑