### PR TITLE
Uninstall `wandb` from notebook environments

### DIFF
--- a/ultralytics/yolo/utils/checks.py
+++ b/ultralytics/yolo/utils/checks.py
@@ -20,8 +20,8 @@ import torch
 from matplotlib import font_manager
 
 from ultralytics.yolo.utils import (AUTOINSTALL, LOGGER, ONLINE, ROOT, USER_CONFIG_DIR, TryExcept, clean_url, colorstr,
-                                    downloads, emojis, is_colab, is_docker, is_kaggle, is_online, is_pip_package,
-                                    url2file)
+                                    downloads, emojis, is_colab, is_docker, is_kaggle, is_jupyter, is_online,
+                                    is_pip_package, url2file)
 
 
 def is_ascii(s) -> bool:
@@ -254,7 +254,7 @@ def check_suffix(file='yolov8n.pt', suffix='.pt', msg=''):
     """Check file(s) for acceptable suffix."""
     if file and suffix:
         if isinstance(suffix, str):
-            suffix = (suffix, )
+            suffix = (suffix,)
         for f in file if isinstance(file, (list, tuple)) else [file]:
             s = Path(f).suffix.lower().strip()  # file suffix
             if len(s):
@@ -325,8 +325,11 @@ def check_yolo(verbose=True, device=''):
     """Return a human-readable YOLO software and hardware summary."""
     from ultralytics.yolo.utils.torch_utils import select_device
 
-    if is_colab():
-        shutil.rmtree('sample_data', ignore_errors=True)  # remove colab /sample_data directory
+    if is_jupyter():
+        if check_requirements('wandb', install=False):
+            os.system('pip uninstall wandb')  # uninstall wandb: unwanted account creation prompt with infinite hang
+        if is_colab():
+            shutil.rmtree('sample_data', ignore_errors=True)  # remove colab /sample_data directory
 
     if verbose:
         # System info

--- a/ultralytics/yolo/utils/checks.py
+++ b/ultralytics/yolo/utils/checks.py
@@ -20,7 +20,7 @@ import torch
 from matplotlib import font_manager
 
 from ultralytics.yolo.utils import (AUTOINSTALL, LOGGER, ONLINE, ROOT, USER_CONFIG_DIR, TryExcept, clean_url, colorstr,
-                                    downloads, emojis, is_colab, is_docker, is_kaggle, is_jupyter, is_online,
+                                    downloads, emojis, is_colab, is_docker, is_jupyter, is_kaggle, is_online,
                                     is_pip_package, url2file)
 
 
@@ -254,7 +254,7 @@ def check_suffix(file='yolov8n.pt', suffix='.pt', msg=''):
     """Check file(s) for acceptable suffix."""
     if file and suffix:
         if isinstance(suffix, str):
-            suffix = (suffix,)
+            suffix = (suffix, )
         for f in file if isinstance(file, (list, tuple)) else [file]:
             s = Path(f).suffix.lower().strip()  # file suffix
             if len(s):

--- a/ultralytics/yolo/utils/checks.py
+++ b/ultralytics/yolo/utils/checks.py
@@ -327,7 +327,7 @@ def check_yolo(verbose=True, device=''):
 
     if is_jupyter():
         if check_requirements('wandb', install=False):
-            os.system('pip uninstall wandb')  # uninstall wandb: unwanted account creation prompt with infinite hang
+            os.system('pip uninstall -y wandb')  # uninstall wandb: unwanted account creation prompt with infinite hang
         if is_colab():
             shutil.rmtree('sample_data', ignore_errors=True)  # remove colab /sample_data directory
 


### PR DESCRIPTION
Due to unwanted behavior in https://www.kaggle.com/code/ultralytics/yolov8/comments#2306977


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 602c0ed</samp>

### Summary
📝🛠️🚀

<!--
1.  📝 - This emoji can be used to indicate that the changes involve documentation or code comments, as the `is_jupyter` function has a docstring that explains its purpose and usage.
2.  🛠️ - This emoji can be used to indicate that the changes involve fixing or improving some functionality, as the `check_yolo` function has a new logic branch that handles Jupyter notebook environments and avoids creating unwanted files or processes.
3.  🚀 - This emoji can be used to indicate that the changes involve enhancing or optimizing some performance or user experience, as the `check_yolo` function now supports Jupyter notebook environments and allows users to run the `ultralytics.yolo` package more smoothly and conveniently.
-->
Improved compatibility and usability of `ultralytics.yolo` package for Jupyter notebooks. Added `is_jupyter` import and conditional logic to `check_yolo` function in `checks.py`.

> _Sing, O Muse, of the cunning code that checked the yolo_
> _And how it learned to adapt to the Jupyter's changing form_
> _For `is_jupyter` was the function that revealed its nature_
> _And guided it to clear the clutter and avoid the storm_

### Walkthrough
*  Add logic to handle Jupyter notebook environments in `checks.py` ([link](https://github.com/ultralytics/ultralytics/pull/3247/files?diff=unified&w=0#diff-d922fcb35a1250f2fd0185742d3da8123d5baffd4ec5ba7d313e2fca7b001305L23-R24), [link](https://github.com/ultralytics/ultralytics/pull/3247/files?diff=unified&w=0#diff-d922fcb35a1250f2fd0185742d3da8123d5baffd4ec5ba7d313e2fca7b001305L328-R332))
* Remove whitespace after comma in `suffix = (suffix, )` line in `checks.py` ([link](https://github.com/ultralytics/ultralytics/pull/3247/files?diff=unified&w=0#diff-d922fcb35a1250f2fd0185742d3da8123d5baffd4ec5ba7d313e2fca7b001305L257-R257))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced environment checks and cleanup for Jupyter notebooks in Ultralytics YOLO utils.

### 📊 Key Changes
- Updated environment utility functions to include `is_jupyter()` check for better identification of Jupyter notebook environments.
- Modified the cleanup process to apply to any Jupyter environment, with additional removal of the `wandb` package if present.
- Preserved the specific action for Google Colab environments to remove the `sample_data` directory.

### 🎯 Purpose & Impact
- 🎨 The inclusion of `is_jupyter()` aims to streamline operations for all Jupyter-based environments, beyond just Colab or Kaggle, providing a more robust check.
- 🧹 By automatically uninstalling `wandb` in Jupyter environments, the update avoids unwanted prompts and potential system hangs that can hinder user experience.
- 🚀 Users working in Jupyter, Colab, or any related platforms will benefit from a cleaner and more tailored setup, leading to a smoother development workflow and project setup.