### PR TITLE
Add CLI support for SAM, RTDETR

### DIFF
--- a/ultralytics/vit/sam/model.py
+++ b/ultralytics/vit/sam/model.py
@@ -17,6 +17,7 @@ class SAM:
             # Should raise AssertionError instead?
             raise NotImplementedError('Segment anything prediction requires pre-trained checkpoint')
         self.model = build_sam(model)
+        self.task = 'segment'  # required
         self.predictor = None  # reuse predictor
 
     def predict(self, source, stream=False, **kwargs):

--- a/ultralytics/yolo/cfg/__init__.py
+++ b/ultralytics/yolo/cfg/__init__.py
@@ -368,13 +368,13 @@ def entrypoint(debug=''):
         LOGGER.warning(f"WARNING ⚠️ 'model' is missing. Using default 'model={model}'.")
     overrides['model'] = model
     if 'rtdetr' in model.lower():  # guess architecture
-        from ultralytics.yolo.engine.model import RTDETR
+        from ultralytics import RTDETR
         model = RTDETR(model)  # no task argument
     elif 'sam' in model.lower():
         from ultralytics import SAM
         model = SAM(model)
     else:
-        from ultralytics.yolo.engine.model import YOLO
+        from ultralytics import YOLO
         model = YOLO(model, task=task)
     if isinstance(overrides.get('pretrained'), str):
         model.load(overrides['pretrained'])

--- a/ultralytics/yolo/cfg/__init__.py
+++ b/ultralytics/yolo/cfg/__init__.py
@@ -366,9 +366,16 @@ def entrypoint(debug=''):
     if model is None:
         model = 'yolov8n.pt'
         LOGGER.warning(f"WARNING ⚠️ 'model' is missing. Using default 'model={model}'.")
-    from ultralytics.yolo.engine.model import YOLO
     overrides['model'] = model
-    model = YOLO(model, task=task)
+    if 'rtdetr' in model.lower():  # guess architecture
+        from ultralytics.yolo.engine.model import RTDETR
+        model = RTDETR(model)  # no task argument
+    elif 'sam' in model.lower():
+        from ultralytics import SAM
+        model = SAM(model)
+    else:
+        from ultralytics.yolo.engine.model import YOLO
+        model = YOLO(model, task=task)
     if isinstance(overrides.get('pretrained'), str):
         model.load(overrides['pretrained'])
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9fc1f2c</samp>

### Summary
🚀🐛🔧

<!--
1.  🚀 This emoji represents the addition of a new feature or functionality, such as the `task` attribute for the `SAM` class and the support for multiple self-attention models.
2.  🐛 This emoji represents the fixing of a bug or an error, such as the removal of the unnecessary `task` argument from the `RTDETR` constructor.
3.  🔧 This emoji represents the improvement or modification of an existing feature or functionality, such as the conditional branches in the `entrypoint` function to handle different model names.
-->
This pull request adds support for two new models that use self-attention mechanisms for object detection: `SAM` and `RTDETR`. It modifies the `ultralytics` package to include the new model classes and the `entrypoint` function to handle different model names.

> _`SAM` and `RTDETR`_
> _Self-attention for vision_
> _Autumn leaves detect_

### Walkthrough
*  Add support for multiple models that use self-attention mechanisms for object detection ([link](https://github.com/ultralytics/ultralytics/pull/3253/files?diff=unified&w=0#diff-3e4f758232806036f3dd1eb7a5787beadf9f4472a3de52d8b95b2ea510765ff7R20), [link](https://github.com/ultralytics/ultralytics/pull/3253/files?diff=unified&w=0#diff-daf1714127b012666c9fed39d0e75184c60be83f0c6bd3f9863f27113b1a6c22L369-R378))
  * Add a `task` attribute to the `SAM` class in `ultralytics/vit/sam/model.py` to specify the vision task type ([link](https://github.com/ultralytics/ultralytics/pull/3253/files?diff=unified&w=0#diff-3e4f758232806036f3dd1eb7a5787beadf9f4472a3de52d8b95b2ea510765ff7R20))
  * Modify the `entrypoint` function in `ultralytics/yolo/cfg/__init__.py` to import and instantiate the `RTDETR` and `SAM` classes from the `ultralytics` package based on the model name ([link](https://github.com/ultralytics/ultralytics/pull/3253/files?diff=unified&w=0#diff-daf1714127b012666c9fed39d0e75184c60be83f0c6bd3f9863f27113b1a6c22L369-R378))
  * Remove the unused `task` argument from the `RTDETR` constructor ([link](https://github.com/ultralytics/ultralytics/pull/3253/files?diff=unified&w=0#diff-daf1714127b012666c9fed39d0e75184c60be83f0c6bd3f9863f27113b1a6c22L369-R378))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model initialization flexibility in the Ultralytics Vision Models.

### 📊 Key Changes
- Added an explicit `task` attribute to the SAM model initialization in `vit/sam/model.py`.
- Refined the model selection process in `yolo/cfg/__init__.py` to automatically determine the model type by the model name and create an appropriate object.

### 🎯 Purpose & Impact
- Ensuring the SAM model defaults to a 'segmentation' task, which clarifies its intended use.
- Streamlining the user experience by automatically choosing the correct model type (YOLO, SAM, or RTDETR) based on given input, reducing manual configuration.
- Potential impact includes a more intuitive setup for users working with different Ultralytics vision models, leading to a smoother development process. 🚀👁️