### PR TITLE
[RTDETR]fix "Grad strides do not match bucket view strides" when training with DDP

### DIFF
--- a/ultralytics/nn/modules/transformer.py
+++ b/ultralytics/nn/modules/transformer.py
@@ -77,7 +77,7 @@ class AIFI(TransformerEncoderLayer):
         pos_embed = self.build_2d_sincos_position_embedding(w, h, c)
         # flatten [B, C, H, W] to [B, HxW, C]
         x = super().forward(x.flatten(2).permute(0, 2, 1), pos=pos_embed.to(device=x.device, dtype=x.dtype))
-        return x.permute((0, 2, 1)).view([-1, c, h, w])
+        return x.permute(0, 2, 1).view([-1, c, h, w]).contiguous()
 
     @staticmethod
     def build_2d_sincos_position_embedding(w, h, embed_dim=256, temperature=10000.):

--- a/ultralytics/vit/utils/ops.py
+++ b/ultralytics/vit/utils/ops.py
@@ -31,9 +31,6 @@ class HungarianMatcher(nn.Module):
         _cost_mask(bs, num_gts, masks=None, gt_mask=None): Computes the mask cost and dice cost if masks are predicted.
     """
 
-    class HungarianMatcher(nn.Module):
-        ...
-
     def __init__(self, cost_gain=None, use_fl=True, with_mask=False, num_sample_points=12544, alpha=0.25, gamma=2.0):
         super().__init__()
         if cost_gain is None:


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b3f4652</samp>

### Summary
🛠️🚀🔧

<!--
1.  🛠️ - This emoji represents a bug fix or a tool improvement, which is the main purpose of this change.
2.  🚀 - This emoji represents a performance boost or a speed improvement, which is a possible benefit of this change.
3.  🔧 - This emoji represents a configuration or a compatibility adjustment, which is another aspect of this change.
-->
Fixed a bug in `AIFI` module that caused an error when using `nn.DataParallel`. Added `.contiguous()` method to output tensor in `transformer.py`.

> _`AIFI` returns_
> _contiguous tensor now_
> _fixes bug in fall_

### Walkthrough
* Fix bug in `AIFI` module that caused error when using `nn.DataParallel` ([link](https://github.com/ultralytics/ultralytics/pull/3255/files?diff=unified&w=0#diff-fc9bd8e217a8c71a55895011182403a8a55b9fe8751949a92dc3b9d75d45ce57L80-R80))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved transformer outputs and code cleanup for better performance and maintainability.

### 📊 Key Changes
- Ensured the tensor output of the transformer is contiguous, potentially improving memory access patterns.
- Removed redundant nested class definition in the HungarianMatcher module.

### 🎯 Purpose & Impact
- 🚀 The adjustment to make the tensor contiguous ensures that subsequent operations on the output tensor are more efficient, potentially leading to performance improvements in models using these transformers.
- 🧹 The code cleanup removes unnecessary complexity, helping developers better understand and maintain the codebase.
- 🛠 For users, these changes contribute to a smoother experience when using Ultralytics libraries, with no direct action required.