### PR TITLE
Allow setting MLFlow experiment name through env var

### DIFF
--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -27,8 +27,8 @@ def on_pretrain_routine_end(trainer):
         mlflow.set_tracking_uri(mlflow_location)
 
         experiment_name = os.environ.get(
-            "MLFLOW_EXPERIMENT", # use MLFLOW_EXPERIMENT env var if available...
-            (trainer.args.project or "/Shared/YOLOv8") # ... or use these defaults
+            'MLFLOW_EXPERIMENT',  # use MLFLOW_EXPERIMENT env var if available...
+            (trainer.args.project or '/Shared/YOLOv8')  # ... or use these defaults
         )
 
         experiment = mlflow.get_experiment_by_name(experiment_name)

--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -26,11 +26,7 @@ def on_pretrain_routine_end(trainer):
         mlflow_location = os.environ['MLFLOW_TRACKING_URI']  # "http://192.168.xxx.xxx:5000"
         mlflow.set_tracking_uri(mlflow_location)
 
-        experiment_name = os.environ.get(
-            'MLFLOW_EXPERIMENT',  # use MLFLOW_EXPERIMENT env var if available...
-            (trainer.args.project or '/Shared/YOLOv8')  # ... or use these defaults
-        )
-
+        experiment_name = os.environ.get('MLFLOW_EXPERIMENT') or trainer.args.project or '/Shared/YOLOv8'
         experiment = mlflow.get_experiment_by_name(experiment_name)
         if experiment is None:
             mlflow.create_experiment(experiment_name)

--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -26,7 +26,11 @@ def on_pretrain_routine_end(trainer):
         mlflow_location = os.environ['MLFLOW_TRACKING_URI']  # "http://192.168.xxx.xxx:5000"
         mlflow.set_tracking_uri(mlflow_location)
 
-        experiment_name = trainer.args.project or '/Shared/YOLOv8'
+        experiment_name = os.environ.get(
+            "MLFLOW_EXPERIMENT", # use MLFLOW_EXPERIMENT env var if available...
+            (trainer.args.project or "/Shared/YOLOv8") # ... or use these defaults
+        )
+
         experiment = mlflow.get_experiment_by_name(experiment_name)
         if experiment is None:
             mlflow.create_experiment(experiment_name)


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 513dd29</samp>

### Summary
🌟🔄🚀

<!--
1.  🌟 - This emoji can represent the new feature or enhancement of allowing the user to specify the MLflow experiment name using an environment variable, which can make the code more flexible and customizable.
2.  🔄 - This emoji can represent the change or update of the logic for determining the experiment name, which now checks the environment variable first before using the previous sources. This can also imply that the change is backward compatible and does not break the existing functionality.
3.  🚀 - This emoji can represent the improvement or optimization of the MLflow integration, which can help the user to track and compare different experiments more easily and efficiently. This can also imply that the change is beneficial for the performance or quality of the code.
-->
Added support for setting MLflow experiment name via environment variable `MLFLOW_EXPERIMENT` in `ultralytics/yolo/utils/callbacks/mlflow.py`. This enables more flexibility and convenience for running different experiments with YOLOv8.

> _`MLFLOW_EXPERIMENT`_
> _A new way to run trials_
> _Fall is for learning_

### Walkthrough
*  Add support for setting MLflow experiment name via environment variable `MLFLOW_EXPERIMENT` ([link](https://github.com/ultralytics/ultralytics/pull/3266/files?diff=unified&w=0#diff-30b3338b115e9e6057d5c19cf6a7de077ab273cd001e4e7e24f5162730d4657eL29-R33))
*  Use `trainer.args.project` or default `/Shared/YOLOv8` as fallback experiment name if environment variable is not set ([link](https://github.com/ultralytics/ultralytics/pull/3266/files?diff=unified&w=0#diff-30b3338b115e9e6057d5c19cf6a7de077ab273cd001e4e7e24f5162730d4657eL29-R33))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced MLflow experiment naming flexibility in YOLOv8 callbacks.

### 📊 Key Changes
- MLflow experiment name can now be set via an environment variable (`MLFLOW_EXPERIMENT`).
- If the environment variable is not set, the system falls back to using the trainer's project name or the default `/Shared/YOLOv8`.

### 🎯 Purpose & Impact
- **Customization**: Users can more easily customize experiment names in MLflow for better organization and tracking.
- **Flexibility**: Setting the experiment name through an environment variable adds flexibility for different runtime environments.
- **Backwards Compatibility**: The change retains compatibility with the previous setup, avoiding disruption for existing workflows.