### PR TITLE
Fix RT-DETR exported onnx model

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -270,7 +270,7 @@ class RTDETRDecoder(nn.Module):
         anchors = torch.cat(anchors, 1)  # (1, h*w*nl, 4)
         valid_mask = ((anchors > eps) * (anchors < 1 - eps)).all(-1, keepdim=True)  # 1, h*w*nl, 1
         anchors = torch.log(anchors / (1 - anchors))
-        anchors = torch.where(valid_mask, anchors, torch.tensor(torch.inf, dtype=torch.float32))
+        anchors = anchors.masked_fill(~valid_mask, float("inf"))
         return anchors, valid_mask
 
     def _get_encoder_input(self, x):
@@ -294,7 +294,7 @@ class RTDETRDecoder(nn.Module):
         bs = len(feats)
         # prepare input for decoder
         anchors, valid_mask = self._generate_anchors(shapes, dtype=feats.dtype, device=feats.device)
-        features = self.enc_output(torch.where(valid_mask, feats, torch.tensor(0, dtype=torch.float32)))  # bs, h*w, 256
+        features = self.enc_output(valid_mask * feats)  # bs, h*w, 256
 
         enc_outputs_scores = self.enc_score_head(features)  # (bs, h*w, nc)
         # dynamic anchors + static content

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -270,7 +270,7 @@ class RTDETRDecoder(nn.Module):
         anchors = torch.cat(anchors, 1)  # (1, h*w*nl, 4)
         valid_mask = ((anchors > eps) * (anchors < 1 - eps)).all(-1, keepdim=True)  # 1, h*w*nl, 1
         anchors = torch.log(anchors / (1 - anchors))
-        anchors = anchors.masked_fill(~valid_mask, float("inf"))
+        anchors = anchors.masked_fill(~valid_mask, float('inf'))
         return anchors, valid_mask
 
     def _get_encoder_input(self, x):

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -270,7 +270,7 @@ class RTDETRDecoder(nn.Module):
         anchors = torch.cat(anchors, 1)  # (1, h*w*nl, 4)
         valid_mask = ((anchors > eps) * (anchors < 1 - eps)).all(-1, keepdim=True)  # 1, h*w*nl, 1
         anchors = torch.log(anchors / (1 - anchors))
-        anchors = torch.where(valid_mask, anchors, torch.inf)
+        anchors = torch.where(valid_mask, anchors, torch.tensor(torch.inf, dtype=torch.float32))
         return anchors, valid_mask
 
     def _get_encoder_input(self, x):
@@ -294,7 +294,7 @@ class RTDETRDecoder(nn.Module):
         bs = len(feats)
         # prepare input for decoder
         anchors, valid_mask = self._generate_anchors(shapes, dtype=feats.dtype, device=feats.device)
-        features = self.enc_output(torch.where(valid_mask, feats, 0))  # bs, h*w, 256
+        features = self.enc_output(torch.where(valid_mask, feats, torch.tensor(0, dtype=torch.float32)))  # bs, h*w, 256
 
         enc_outputs_scores = self.enc_score_head(features)  # (bs, h*w, nc)
         # dynamic anchors + static content


### PR DESCRIPTION
fix RT-DETR exported onnx model, cast data in the where operations to float32


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f753db5</samp>

### Summary
🐛🔧🚀

<!--
1.  🐛 for fixing a bug
2.  🔧 for improving the code quality
3.  🚀 for enhancing the performance
-->
Fix type mismatch errors in `Head` module when using mixed precision training. Ensure tensors with constants have `torch.float32` dtype in `ultralytics/nn/modules/head.py`.

> _`torch.where` fails_
> _with mixed precision training_
> _snowflakes of `float32`_

### Walkthrough
*  Fix type mismatch errors when using torch.where with torch.inf or 0 in `head.py` ([link](https://github.com/ultralytics/ultralytics/pull/3317/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L273-R273), [link](https://github.com/ultralytics/ultralytics/pull/3317/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L297-R297))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved anchor generation and feature encoding in Ultralytics neural network module. 

### 📊 Key Changes
- Replaced `torch.where` with `masked_fill` for anchor adjustment.
- Simplified feature masking using element-wise multiplication instead of `torch.where`.

### 🎯 Purpose & Impact
- 🚀 Improves code clarity and potentially enhances computational efficiency.
- 🛠️ These changes ensure better maintenance and readability of the code, which is crucial for developers working on the project.
- 🔄 Users might experience subtle performance improvements due to more efficient operations without any direct changes to functionality.