### PR TITLE
Increase NCCL timeout from 1 hour to 3 hours

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -196,12 +196,11 @@ class BaseTrainer:
         torch.cuda.set_device(RANK)
         self.device = torch.device('cuda', RANK)
         LOGGER.info(f'DDP info: RANK {RANK}, WORLD_SIZE {world_size}, DEVICE {self.device}')
-        os.environ['NCCL_BLOCKING_WAIT'] = '0'  # set to enforce timeout
-        dist.init_process_group(
-            'nccl' if dist.is_nccl_available() else 'gloo',
-            timeout=timedelta(seconds=72000000),  # if you use dataset around 2TB
-            rank=RANK,
-            world_size=world_size)
+        os.environ['NCCL_BLOCKING_WAIT'] = '1'  # set to enforce timeout
+        dist.init_process_group('nccl' if dist.is_nccl_available() else 'gloo',
+                                timeout=timedelta(seconds=10800),  # 3 hours
+                                rank=RANK,
+                                world_size=world_size)
 
     def _setup_train(self, world_size):
         """

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -196,9 +196,9 @@ class BaseTrainer:
         torch.cuda.set_device(RANK)
         self.device = torch.device('cuda', RANK)
         LOGGER.info(f'DDP info: RANK {RANK}, WORLD_SIZE {world_size}, DEVICE {self.device}')
-        os.environ['NCCL_BLOCKING_WAIT'] = '1'  # set to enforce timeout
+        os.environ['NCCL_BLOCKING_WAIT'] = '0'  # set to enforce timeout
         dist.init_process_group('nccl' if dist.is_nccl_available() else 'gloo',
-                                timeout=timedelta(seconds=3600),
+                                timeout=timedelta(seconds=72000000), # if you use dataset around 2TB
                                 rank=RANK,
                                 world_size=world_size)
 

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -197,10 +197,11 @@ class BaseTrainer:
         self.device = torch.device('cuda', RANK)
         LOGGER.info(f'DDP info: RANK {RANK}, WORLD_SIZE {world_size}, DEVICE {self.device}')
         os.environ['NCCL_BLOCKING_WAIT'] = '1'  # set to enforce timeout
-        dist.init_process_group('nccl' if dist.is_nccl_available() else 'gloo',
-                                timeout=timedelta(seconds=10800),  # 3 hours
-                                rank=RANK,
-                                world_size=world_size)
+        dist.init_process_group(
+            'nccl' if dist.is_nccl_available() else 'gloo',
+            timeout=timedelta(seconds=10800),  # 3 hours
+            rank=RANK,
+            world_size=world_size)
 
     def _setup_train(self, world_size):
         """

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -197,10 +197,11 @@ class BaseTrainer:
         self.device = torch.device('cuda', RANK)
         LOGGER.info(f'DDP info: RANK {RANK}, WORLD_SIZE {world_size}, DEVICE {self.device}')
         os.environ['NCCL_BLOCKING_WAIT'] = '0'  # set to enforce timeout
-        dist.init_process_group('nccl' if dist.is_nccl_available() else 'gloo',
-                                timeout=timedelta(seconds=72000000), # if you use dataset around 2TB
-                                rank=RANK,
-                                world_size=world_size)
+        dist.init_process_group(
+            'nccl' if dist.is_nccl_available() else 'gloo',
+            timeout=timedelta(seconds=72000000),  # if you use dataset around 2TB
+            rank=RANK,
+            world_size=world_size)
 
     def _setup_train(self, world_size):
         """


### PR DESCRIPTION
in case of using multi GPU and large dataset, _setup_ddp function makes the process stop while scanning datasets or any other which takes longer than 30 mins -> time limit changed into 2 hours

error message : Watchdog caught collective operation timeout

related open issue : https://github.com/ultralytics/ultralytics/issues/1439


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cefc80d</samp>

### Summary
🚀🌎⏳

<!--
1.  🚀 This emoji can represent speed, performance, or improvement, and can be used to indicate that disabling blocking wait mode can potentially speed up the NCCL operations and avoid deadlock or timeout issues.
2.  🌎 This emoji can represent the world, global, or large-scale, and can be used to indicate that the changes are aimed at improving the scalability of the DDP mode for training YOLO models on large-scale datasets.
3.  ⏳ This emoji can represent time, patience, or waiting, and can be used to indicate that the timeout argument for the process group initialization was increased to a very large value to avoid premature termination of the training process when using very large datasets.
-->
Adjusted NCCL and DDP settings in `trainer.py` to prevent deadlock and timeout issues when training on large-scale datasets.

> _`NCCL_BLOCKING_WAIT`_
> _Off, no deadlock or timeout_
> _Winter training long_

### Walkthrough
*  Disable blocking wait mode and increase timeout for DDP mode ([link](https://github.com/ultralytics/ultralytics/pull/3343/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L199-R201))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Extended distributed training timeout to improve stability.

### 📊 Key Changes
- Increased timeout in `init_process_group` from 1 hour to 3 hours.

### 🎯 Purpose & Impact
- 🕒 **Extended Timeout:** Helps to prevent premature termination of distributed training jobs, especially in environments where setup or communication takes longer.
- 🔄 **Improved Stability:** Aims to reduce crashes due to timeout issues during long training sessions, leading to more reliable model training for users.