### PR TITLE
Fix video writing

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = 'avc1' # if MACOS else 'MP4V' if WINDOWS else 'MJPG'  # video codec for saving video results
+        self.fourcc = 'avc1' if MACOS else 'mp4v' if WINDOWS else 'mjpg'  # video codec for saving video results
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = 'avc1' if MACOS else 'mp4v' if WINDOWS else 'mp4v'  # video codec for saving video results
+        self.fourcc = 'avc1' if MACOS else 'wmv2' if WINDOWS else 'divx'  # video codec for saving video results
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = 'avc1' if MACOS else 'mp4v' if WINDOWS else 'mjpg'  # video codec for saving video results
+        self.fourcc = 'avc1' if MACOS else 'mp4v' if WINDOWS else 'mp4v'  # video codec for saving video results
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = list('avc1' if MACOS else 'wmv2' if WINDOWS else 'mjpg')
+        self.fourcc = 'avc1' if MACOS else 'wmv2' if WINDOWS else 'mjpg'
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = 'AVC1' if MACOS else 'MP4V' if WINDOWS else 'MJPG'  # video codec for saving video results
+        self.fourcc = 'AVC1' # if MACOS else 'MP4V' if WINDOWS else 'MJPG'  # video codec for saving video results
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -38,7 +38,7 @@ from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.yolo.cfg import get_cfg
 from ultralytics.yolo.data import load_inference_source
 from ultralytics.yolo.data.augment import LetterBox, classify_transforms
-from ultralytics.yolo.utils import DEFAULT_CFG, LOGGER, SETTINGS, callbacks, colorstr, ops
+from ultralytics.yolo.utils import DEFAULT_CFG, LOGGER, MACOS, SETTINGS, WINDOWS, callbacks, colorstr, ops
 from ultralytics.yolo.utils.checks import check_imgsz, check_imshow
 from ultralytics.yolo.utils.files import increment_path
 from ultralytics.yolo.utils.torch_utils import select_device, smart_inference_mode
@@ -105,6 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
+        self.fourcc = 'AVC1' if MACOS else 'MP4V' if WINDOWS else 'MJPG'  # video codec for saving video results
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):
@@ -342,7 +343,7 @@ class BasePredictor:
                 else:  # stream
                     fps, w, h = 30, im0.shape[1], im0.shape[0]
                 save_path = str(Path(save_path).with_suffix('.mp4'))  # force *.mp4 suffix on results videos
-                self.vid_writer[idx] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
+                self.vid_writer[idx] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*self.fourcc), fps, (w, h))
             self.vid_writer[idx].write(im0)
 
     def run_callbacks(self, event: str):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = list('avc1' if MACOS else 'wmv2' if WINDOWS else 'mp4v')
+        self.fourcc = list('avc1' if MACOS else 'wmv2' if WINDOWS else 'mjpg')
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,6 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = 'avc1' if MACOS else 'wmv2' if WINDOWS else 'mjpg'
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):
@@ -342,8 +341,10 @@ class BasePredictor:
                     h = int(vid_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
                 else:  # stream
                     fps, w, h = 30, im0.shape[1], im0.shape[0]
-                save_path = str(Path(save_path).with_suffix('.mp4'))  # force *.mp4 suffix on results videos
-                self.vid_writer[idx] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*self.fourcc), fps, (w, h))
+                suffix = '.mp4' if MACOS else '.avi' if WINDOWS else '.avi'
+                fourcc = 'avc1' if MACOS else 'WMV2' if WINDOWS else 'MJPG'
+                save_path = str(Path(save_path).with_suffix(suffix))
+                self.vid_writer[idx] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*fourcc), fps, (w, h))
             self.vid_writer[idx].write(im0)
 
     def run_callbacks(self, event: str):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = 'AVC1' # if MACOS else 'MP4V' if WINDOWS else 'MJPG'  # video codec for saving video results
+        self.fourcc = 'avc1' # if MACOS else 'MP4V' if WINDOWS else 'MJPG'  # video codec for saving video results
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):

--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -105,7 +105,7 @@ class BasePredictor:
         self.results = None
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        self.fourcc = 'avc1' if MACOS else 'wmv2' if WINDOWS else 'divx'  # video codec for saving video results
+        self.fourcc = list('avc1' if MACOS else 'wmv2' if WINDOWS else 'mp4v')
         callbacks.add_integration_callbacks(self)
 
     def get_save_dir(self):


### PR DESCRIPTION
May resolve https://github.com/ultralytics/ultralytics/issues/3377

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 70d979c</samp>

### Summary
🎥🍎🪟

<!--
1.  🎥 - This emoji represents the video-related functionality of the code, as it uses the `fourcc` attribute to specify the video codec for saving the output videos.
2.  🍎 - This emoji represents the macOS operating system, which is one of the possible values of the `MACOS` variable and affects the choice of the video codec.
3.  🪟 - This emoji represents the Windows operating system, which is another possible value of the `WINDOWS` variable and affects the choice of the video codec.
-->
This change enables cross-platform video output for the `BasePredictor` class by using appropriate video codecs from the `ultralytics.yolo.utils` module. It affects the file `ultralytics/yolo/engine/predictor.py`.

> _To support different codecs for video_
> _The code imports `MACOS` and `WINDOWS` too_
> _It assigns `self.fourcc`_
> _To the `BasePredictor` class_
> _And thus adapts to the OS it runs through_

### Walkthrough
*  Import and use `MACOS` and `WINDOWS` variables to determine video codec for different operating systems ([link](https://github.com/ultralytics/ultralytics/pull/3379/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L41-R41), [link](https://github.com/ultralytics/ultralytics/pull/3379/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675R108), [link](https://github.com/ultralytics/ultralytics/pull/3379/files?diff=unified&w=0#diff-bd2831d027341da2474db760605211ea00b347396b0d708a4343a2b709eb3675L345-R346)) in `predictor.py`




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced video saving compatibility across different operating systems in YOLO's engine predictor.

### 📊 Key Changes
- 🛠 Added operating system checks before saving videos.
- 🔄 Changed video saving format based on the operating system: `.mp4` for macOS, `.avi` for both Windows and other platforms.
- 💾 Modified video codec selection to `avc1` for macOS, `WMV2` for Windows, and `MJPG` for others.

### 🎯 Purpose & Impact
- 💻 Ensures compatibility and optimizes video writing on different operating systems.
- 📹 Improves user experience by automatically selecting the best video format for their OS.
- 🔁 Users from varying platforms can expect consistent behavior and video output quality when using YOLO's prediction capabilities.