### PR TITLE
`lapx` package replacement for `lap`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ['3.11']
         model: [yolov8n]
         torch: [latest]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         model: [yolov8n]
         torch: [latest]
         include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.11']
         model: [yolov8n]
         torch: [latest]
         include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
         model: [yolov5n]
     steps:
       - uses: actions/checkout@v3
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
         model: [yolov8n]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11']
+        python-version: ['3.10']
         model: [yolov8n]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10']
         model: [yolov8n]
         torch: [latest]

--- a/ultralytics/tracker/utils/matching.py
+++ b/ultralytics/tracker/utils/matching.py
@@ -13,8 +13,7 @@ try:
 except (ImportError, AssertionError, AttributeError):
     from ultralytics.yolo.utils.checks import check_requirements
 
-    check_requirements('cython')  # required before installing lap from source
-    check_requirements('git+https://github.com/gatagat/lap.git')  # more reliable than 'pip install lap'
+    check_requirements('lapx>=0.5.2')  # update to lap package from https://github.com/rathaROG/lapx
     import lap
 
 


### PR DESCRIPTION
Regarding https://github.com/rathaROG/lapx/issues/1#issuecomment-1606336123


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fda8026</samp>

### Summary
🆕🐛🚀

<!--
1.  🆕 - This emoji can be used to indicate that a new version of a dependency has been used or introduced, and to highlight the benefits of the upgrade.
2.  🐛 - This emoji can be used to indicate that some bugs have been fixed or avoided by using the new version of the dependency, and to emphasize the reliability and quality of the code.
3.  🚀 - This emoji can be used to indicate that some performance improvements have been achieved by using the new version of the dependency, and to showcase the speed and efficiency of the code.
-->
Updated `matching.py` to use lapx instead of lap for linear assignment problems. This improves performance and simplifies installation.

> _`lapx` replaces `lap`_
> _Faster and easier to install_
> _No cython needed_

### Walkthrough
*  Switch to lapx package for linear assignment problems ([link](https://github.com/ultralytics/ultralytics/pull/3383/files?diff=unified&w=0#diff-c0f31e0ae934e7ee2136442e0bcee33fb63c71365c39f1fd339c69e2101b3bc1L16-R16))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to Python 3.11 and use lapx package for object tracking

### 📊 Key Changes
- 🐍 Changed CI workflow to test against Python 3.11 instead of Python 3.10.
- 📦 Transitioned to using the `lapx` package version `0.5.2` or higher for linear assignment in object tracking.

### 🎯 Purpose & Impact
- 🔍 The update in Python version for CI tests ensures compatibility with the latest Python release, future-proofing the project.
- 🚀 The switch to `lapx` for object matching seeks to provide a more reliable dependency source and potentially improve tracking performance or maintainability.
- ✅ Users might see improved stability and support, while developers can test their contributions against the latest Python environment.