### PR TITLE
Fix dataset multiple unzip behavior

### DIFF
--- a/ultralytics/yolo/utils/downloads.py
+++ b/ultralytics/yolo/utils/downloads.py
@@ -62,12 +62,6 @@ def unzip_file(file, path=None, exclude=('.DS_Store', '__MACOSX'), exist_ok=Fals
     if path is None:
         path = Path(file).parent  # default path
 
-    # Check if destination directory already exists and contains files
-    if Path(path).exists() and any(Path(path).iterdir()) and not exist_ok:
-        # If it exists and is not empty, return the path without unzipping
-        LOGGER.info(f'Found {file} is already unzipped, skipping unzip.')
-        return path
-
     # Unzip the file contents
     with ZipFile(file) as zipObj:
         file_list = [f for f in zipObj.namelist() if all(x not in f for x in exclude)]
@@ -75,6 +69,12 @@ def unzip_file(file, path=None, exclude=('.DS_Store', '__MACOSX'), exist_ok=Fals
 
         if len(top_level_dirs) > 1 or not file_list[0].endswith('/'):
             path = Path(path) / Path(file).stem  # define new unzip directory
+
+        # Check if destination directory already exists and contains files
+        if Path(path).exists() and any(Path(path).iterdir()) and not exist_ok:
+            # If it exists and is not empty, return the path without unzipping
+            LOGGER.info(f'Found {file} already unzipped, skipping unzip.')
+            return path
 
         for f in file_list:
             zipObj.extract(f, path=path)

--- a/ultralytics/yolo/utils/downloads.py
+++ b/ultralytics/yolo/utils/downloads.py
@@ -71,9 +71,10 @@ def unzip_file(file, path=None, exclude=('.DS_Store', '__MACOSX'), exist_ok=Fals
             path = Path(path) / Path(file).stem  # define new unzip directory
 
         # Check if destination directory already exists and contains files
-        if Path(path).exists() and any(Path(path).iterdir()) and not exist_ok:
+        extract_path = Path(path) / list(top_level_dirs)[0]
+        if extract_path.exists() and any(extract_path.iterdir()) and not exist_ok:
             # If it exists and is not empty, return the path without unzipping
-            LOGGER.info(f'Found {file} already unzipped, skipping unzip.')
+            LOGGER.info(f'Skipping {file} unzip (already unzipped)')
             return path
 
         for f in file_list:

--- a/ultralytics/yolo/utils/downloads.py
+++ b/ultralytics/yolo/utils/downloads.py
@@ -37,7 +37,7 @@ def is_url(url, check=True):
     return False
 
 
-def unzip_file(file, path=None, exclude=('.DS_Store', '__MACOSX')):
+def unzip_file(file, path=None, exclude=('.DS_Store', '__MACOSX'), exist_ok=False):
     """
     Unzips a *.zip file to the specified path, excluding files containing strings in the exclude list.
 
@@ -49,6 +49,7 @@ def unzip_file(file, path=None, exclude=('.DS_Store', '__MACOSX')):
         file (str): The path to the zipfile to be extracted.
         path (str, optional): The path to extract the zipfile to. Defaults to None.
         exclude (tuple, optional): A tuple of filename strings to be excluded. Defaults to ('.DS_Store', '__MACOSX').
+        exist_ok (bool, optional): Whether to overwrite existing contents if they exist. Defaults to False.
 
     Raises:
         BadZipFile: If the provided file does not exist or is not a valid zipfile.
@@ -61,6 +62,13 @@ def unzip_file(file, path=None, exclude=('.DS_Store', '__MACOSX')):
     if path is None:
         path = Path(file).parent  # default path
 
+    # Check if destination directory already exists and contains files
+    if Path(path).exists() and any(Path(path).iterdir()) and not exist_ok:
+        # If it exists and is not empty, return the path without unzipping
+        LOGGER.info(f'Found {file} is already unzipped, skipping unzip.')
+        return path
+
+    # Unzip the file contents
     with ZipFile(file) as zipObj:
         file_list = [f for f in zipObj.namelist() if all(x not in f for x in exclude)]
         top_level_dirs = {Path(f).parts[0] for f in file_list}


### PR DESCRIPTION
@kalenmike should resolve HUB user issue of multiple unzips.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 18cc4d9</samp>

### Summary
📦🛠️📝

<!--
1.  📦 - This emoji can represent the act of unzipping a file, which is the main functionality of the function.
2.  🛠️ - This emoji can represent the act of modifying or improving the function by adding a new argument and updating the logic.
3.  📝 - This emoji can represent the act of updating the docstring to reflect the new argument and behavior of the function.
-->
Added an option to `unzip_file` to avoid overwriting existing files. This allows more flexibility and control when downloading and extracting data from zip archives.

> _Oh, we're the coders of the sea, and we work on every file_
> _We unzip them with a function, and we do it with a smile_
> _But sometimes we need to overwrite, and sometimes we need to skip_
> _So we added an `exist_ok` argument, and we gave it a little tip_

### Walkthrough
*  Add `exist_ok` argument to `unzip_file` function to control overwrite behavior ([link](https://github.com/ultralytics/ultralytics/pull/3413/files?diff=unified&w=0#diff-9bc1504ab4553f31c8ad4205083c67ac4fac833eea921bdea0c2dcee0bd57c03L40-R40), [link](https://github.com/ultralytics/ultralytics/pull/3413/files?diff=unified&w=0#diff-9bc1504ab4553f31c8ad4205083c67ac4fac833eea921bdea0c2dcee0bd57c03R52), [link](https://github.com/ultralytics/ultralytics/pull/3413/files?diff=unified&w=0#diff-9bc1504ab4553f31c8ad4205083c67ac4fac833eea921bdea0c2dcee0bd57c03R65-R71))
  * Update docstring of `unzip_file` to document the new argument ([link](https://github.com/ultralytics/ultralytics/pull/3413/files?diff=unified&w=0#diff-9bc1504ab4553f31c8ad4205083c67ac4fac833eea921bdea0c2dcee0bd57c03R52))
  * Check if destination directory exists and contains files before unzipping ([link](https://github.com/ultralytics/ultralytics/pull/3413/files?diff=unified&w=0#diff-9bc1504ab4553f31c8ad4205083c67ac4fac833eea921bdea0c2dcee0bd57c03R65-R71))
  * Return path without unzipping if `exist_ok` is False and destination is not empty ([link](https://github.com/ultralytics/ultralytics/pull/3413/files?diff=unified&w=0#diff-9bc1504ab4553f31c8ad4205083c67ac4fac833eea921bdea0c2dcee0bd57c03R65-R71))
  * Log a message to inform the user of the skipping behavior ([link](https://github.com/ultralytics/ultralytics/pull/3413/files?diff=unified&w=0#diff-9bc1504ab4553f31c8ad4205083c67ac4fac833eea921bdea0c2dcee0bd57c03R65-R71))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in handling ZIP file extraction with new overwrite option.

### 📊 Key Changes
- Added an `exist_ok` parameter to the `unzip_file` function.
- Implemented a check to prevent overwriting existing files if `exist_ok` is set to False.

### 🎯 Purpose & Impact
- 🚀 Allows developers to control whether to overwrite existing files during unzip operations. This can prevent unintended data loss.
- 🌈 Increases the robustness of the code by handling scenarios where the target directory for extraction already contains files.
- 🛠 Users can benefit from finer control over their file management workflows, potentially improving automation and reducing the risk of errors.