### PR TITLE
Fixes DDP with rt-detr checkpoints #3439

### DIFF
--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -581,10 +581,11 @@ class BaseTrainer:
         if ckpt is None:
             return
         best_fitness = 0.0
-        start_epoch = ckpt['epoch'] + 1
-        if ckpt['optimizer'] is not None:
+        start_epoch = (ckpt['epoch'] + 1) if 'epoch' in ckpt else -1
+        if 'optimizer' in ckpt and ckpt['optimizer'] is not None:
             self.optimizer.load_state_dict(ckpt['optimizer'])  # optimizer
-            best_fitness = ckpt['best_fitness']
+            if 'best_fitness' in ckpt:
+                best_fitness = ckpt['best_fitness']
         if self.ema and ckpt.get('ema'):
             self.ema.ema.load_state_dict(ckpt['ema'].float().state_dict())  # EMA
             self.ema.updates = ckpt['updates']


### PR DESCRIPTION
The pickle file of RT-DETR is missing some keys like optimizer, last epoch (should be -1).

Small pytorch warning after the first epoch but it seems to work so far, will close PR if it fails on the way.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d70986a</samp>

### Summary
🛠️🔄🚫

<!--
1.  🛠️ - This emoji represents a wrench or a tool, and can be used to indicate a fix or an improvement to the code or functionality.
2.  🔄 - This emoji represents a refresh or a reload, and can be used to indicate a change that affects the resuming or restarting of a process or a task.
3.  🚫 - This emoji represents a stop or a prohibition, and can be used to indicate a change that prevents or avoids an error or a crash.
-->
Fix potential errors when resuming training from incomplete checkpoints. Add checks for checkpoint keys and set default values for missing fields in `trainer.py`.

> _`checkpoint` keys checked_
> _avoid errors when resuming_
> _cold winter training_

### Walkthrough
*  Add checks for checkpoint keys and set default values for missing fields ([link](https://github.com/ultralytics/ultralytics/pull/3440/files?diff=unified&w=0#diff-1dc4dec7a1716e080109cc732dc44c6e843b30bcdd324e0141e679ebf718c2b1L584-R588)). This improves the robustness and compatibility of the resume training feature in `trainer.py`.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved checkpoint handling and fault tolerance in training resume functionality.

### 📊 Key Changes
- Added checks for dictionary keys before resuming training from a checkpoint.
- Ensures `start_epoch`, `optimizer`, and `best_fitness` are only accessed if they exist in the checkpoint.
- Added a fallback for `start_epoch` to be `-1` if the `'epoch'` key is not present.

### 🎯 Purpose & Impact
- 🛠️ **Increases Robustness**: Prevents potential crashes due to missing keys, allowing training to resume more reliably.
- ⏱️ **Saves Time**: Saves users from needing to restart training entirely if the checkpoint is missing some expected information.
- 🔄 **Flexible Checkpoints**: Enables the use of various checkpoint files that may not contain all the traditional state keys.