### PR TITLE
Add torch.Tensor image saving

### DIFF
--- a/ultralytics/yolo/engine/predictor.py
+++ b/ultralytics/yolo/engine/predictor.py
@@ -230,10 +230,6 @@ class BasePredictor:
             self.model.warmup(imgsz=(1 if self.model.pt or self.model.triton else self.dataset.bs, 3, *self.imgsz))
             self.done_warmup = True
 
-        # Checks
-        if self.source_type.tensor and (self.args.save or self.args.save_txt or self.args.show):
-            LOGGER.warning("WARNING ⚠️ 'save', 'save_txt' and 'show' arguments not enabled for torch.Tensor inference.")
-
         self.seen, self.windows, self.batch, profilers = 0, [], None, (ops.Profile(), ops.Profile(), ops.Profile())
         self.run_callbacks('on_predict_start')
         for batch in self.dataset:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -201,7 +201,8 @@ class Results(SimpleClass):
         np_of_orig_img = None
         if img is None and isinstance(self.orig_img, torch.Tensor):
             # LOGGER.warning('WARNING ⚠️ Results plotting is not supported for torch.Tensor image types.')
-            np_of_orig_img=np.ascontiguousarray(torch.permute(torch.squeeze(self.orig_img,0),(1,2,0)).cpu().detach().numpy())*255
+            np_of_orig_img = np.ascontiguousarray(
+                torch.permute(torch.squeeze(self.orig_img, 0), (1, 2, 0)).cpu().detach().numpy()) * 255
             # return
 
         # Deprecation warn TODO: remove in 8.2
@@ -216,12 +217,13 @@ class Results(SimpleClass):
             assert type(line_width) == int, '`line_width` should be of int type, i.e, line_width=3'
 
         names = self.names
-        annotator = Annotator(deepcopy(self.orig_img if img is None else img) if np_of_orig_img is None else deepcopy(np_of_orig_img),
-                              line_width,
-                              font_size,
-                              font,
-                              pil,
-                              example=names)
+        annotator = Annotator(
+            deepcopy(self.orig_img if img is None else img) if np_of_orig_img is None else deepcopy(np_of_orig_img),
+            line_width,
+            font_size,
+            font,
+            pil,
+            example=names)
         pred_boxes, show_boxes = self.boxes, boxes
         pred_masks, show_masks = self.masks, masks
         pred_probs, show_probs = self.probs, probs

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -198,12 +198,8 @@ class Results(SimpleClass):
         Returns:
             (numpy.ndarray): A numpy array of the annotated image.
         """
-        np_of_orig_img = None
         if img is None and isinstance(self.orig_img, torch.Tensor):
-            # LOGGER.warning('WARNING ⚠️ Results plotting is not supported for torch.Tensor image types.')
-            np_of_orig_img = np.ascontiguousarray(
-                torch.permute(torch.squeeze(self.orig_img, 0), (1, 2, 0)).cpu().detach().numpy()) * 255
-            # return
+            img = np.ascontiguousarray(self.orig_img[0].permute(1, 2, 0).cpu().detach().numpy()) * 255
 
         # Deprecation warn TODO: remove in 8.2
         if 'show_conf' in kwargs:
@@ -217,13 +213,12 @@ class Results(SimpleClass):
             assert type(line_width) == int, '`line_width` should be of int type, i.e, line_width=3'
 
         names = self.names
-        annotator = Annotator(
-            deepcopy(self.orig_img if img is None else img) if np_of_orig_img is None else deepcopy(np_of_orig_img),
-            line_width,
-            font_size,
-            font,
-            pil,
-            example=names)
+        annotator = Annotator(deepcopy(self.orig_img if img is None else img),
+                              line_width,
+                              font_size,
+                              font,
+                              pil,
+                              example=names)
         pred_boxes, show_boxes = self.boxes, boxes
         pred_masks, show_masks = self.masks, masks
         pred_probs, show_probs = self.probs, probs
@@ -296,8 +291,8 @@ class Results(SimpleClass):
                     line = (c, *seg)
                 if kpts is not None:
                     kpt = kpts[j].xyn.reshape(-1).tolist()
-                    line += (*kpt, )
-                line += (conf, ) * save_conf + (() if id is None else (id, ))
+                    line += (*kpt,)
+                line += (conf,) * save_conf + (() if id is None else (id,))
                 texts.append(('%g ' * len(line)).rstrip() % line)
 
         if texts:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -198,9 +198,11 @@ class Results(SimpleClass):
         Returns:
             (numpy.ndarray): A numpy array of the annotated image.
         """
+        np_of_orig_img = None
         if img is None and isinstance(self.orig_img, torch.Tensor):
-            LOGGER.warning('WARNING ⚠️ Results plotting is not supported for torch.Tensor image types.')
-            return
+            # LOGGER.warning('WARNING ⚠️ Results plotting is not supported for torch.Tensor image types.')
+            np_of_orig_img=np.ascontiguousarray(torch.permute(torch.squeeze(self.orig_img,0),(1,2,0)).cpu().detach().numpy())*255
+            # return
 
         # Deprecation warn TODO: remove in 8.2
         if 'show_conf' in kwargs:
@@ -214,7 +216,7 @@ class Results(SimpleClass):
             assert type(line_width) == int, '`line_width` should be of int type, i.e, line_width=3'
 
         names = self.names
-        annotator = Annotator(deepcopy(self.orig_img if img is None else img),
+        annotator = Annotator(deepcopy(self.orig_img if img is None else img) if np_of_orig_img is None else deepcopy(np_of_orig_img),
                               line_width,
                               font_size,
                               font,

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -291,8 +291,8 @@ class Results(SimpleClass):
                     line = (c, *seg)
                 if kpts is not None:
                     kpt = kpts[j].xyn.reshape(-1).tolist()
-                    line += (*kpt,)
-                line += (conf,) * save_conf + (() if id is None else (id,))
+                    line += (*kpt, )
+                line += (conf, ) * save_conf + (() if id is None else (id, ))
                 texts.append(('%g ' * len(line)).rstrip() % line)
 
         if texts:


### PR DESCRIPTION
Issue #3332 reported a bug where model.predict() does not save the predictions as images when the input type is torch.Tensor. I made changes in the function named plot of the class Result. Now the predictions are saved as images when the input type is torch.Tensor.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in YOLO Inference Checks and Results Plotting

### 📊 Key Changes
- Removed unnecessary checks before starting predictions when working with tensor inputs.
- Streamlined the image preparation process in the `plot` function when no image is provided but a tensor is available.

### 🎯 Purpose & Impact
- The removal of checks in `predictor.py` simplifies the code and potentially speeds up the inference setup, especially for users with custom workflows that involve tensors.
- The update in `results.py` ensures that if no image is provided for plotting, the original tensor is automatically converted to a NumPy array and prepared for annotation, enhancing ease of use and maintaining functionality for visualization tasks. 🖼️
- These changes can lead to more efficient code execution with less overhead for users working directly with YOLO's prediction and visualization components.