### PR TITLE
Use opencv-python-headless with [headless] extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Pip install the ultralytics package including all [requirements](https://github.
 pip install ultralytics
 ```
 
+or for a headless install
+
+```bash
+pip install ultralytics[headless]
+```
+
 For alternative installation methods including Conda, Docker, and Git, please refer to the [Quickstart Guide](https://docs.ultralytics.com/quickstart).
 
 </details>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 
 # Base ----------------------------------------
 matplotlib>=3.2.2
-opencv-python>=4.6.0
 Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ PARENT = FILE.parent  # root directory
 README = (PARENT / 'README.md').read_text(encoding='utf-8')
 REQUIREMENTS = [f'{x.name}{x.specifier}' for x in pkg.parse_requirements((PARENT / 'requirements.txt').read_text())]
 
-
 def get_version():
     file = PARENT / 'ultralytics/__init__.py'
     return re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]', file.read_text(encoding='utf-8'), re.M)[1]
@@ -38,6 +37,8 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     extras_require={
+        '': ['opencv-python>=4.6.0'],
+        'headless': ['opencv-python-headless>=4.6.0'],
         'dev': [
             'check-manifest',
             'pytest',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ PARENT = FILE.parent  # root directory
 README = (PARENT / 'README.md').read_text(encoding='utf-8')
 REQUIREMENTS = [f'{x.name}{x.specifier}' for x in pkg.parse_requirements((PARENT / 'requirements.txt').read_text())]
 
+
 def get_version():
     file = PARENT / 'ultralytics/__init__.py'
     return re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]', file.read_text(encoding='utf-8'), re.M)[1]


### PR DESCRIPTION
…v-python


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 991463d</samp>

### Summary
🚀📦🧹

<!--
1.  🚀 for adding a new feature or option to the package.
2.  📦 for updating the packaging or installation process of the package.
3.  🧹 for improving the formatting or code quality of the package.
-->
This pull request enhances the ultralytics package installation by adding an option to skip the GUI dependencies of OpenCV. This affects the `setup.py` and `README.md` files and allows users to run the package in headless environments.

> _`OpenCV` is the eye of the beast_
> _But we don't need its GUI feast_
> _We install `ultralytics` in headless mode_
> _And unleash the power of the code_

### Walkthrough
* Add option to install without GUI dependencies ([link](https://github.com/ultralytics/ultralytics/pull/3480/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68-R73), [link](https://github.com/ultralytics/ultralytics/pull/3480/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R40-R41))
* Improve formatting of `setup.py` ([link](https://github.com/ultralytics/ultralytics/pull/3480/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L15))

I have read the CLA Document and I sign the CLA

This is a small patch to enable a headless install of Ultralytics.

`opencv-python` is a dependency of Ultralytics, however, for some use-cases, `opencv-python-headless` is required in favour of `opencv-python`. Moving the `opencv-python*` dependency to setup.py lets us define the desired dependency to use with [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/).

I've added `headless` as a new dependency specifier. When installing with `[headless]`, `opencv-python-headless` will be installed as a dependency, otherwise `opencv-python` will be installed.

Additional instructions in the readme describe how to install in headless mode. To test this locally:
Clone the repo and check out this branch. Then run `pip install -e .[headless]`.
Then run `pip list | grep opencv`, it should output that `opencv-python-headless` is in the environment (as the only version of `opencv-python*` installed)
Create a fresh environment and run `pip install -e .`.
Then run `pip list | grep opencv`, it should output that `opencv-python` is in the environment (as the only version of `opencv-python*` installed)

resolves https://github.com/ultralytics/ultralytics/issues/2179 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduced headless installation option for Ultralytics package.

### 📊 Key Changes
- Added a "headless" installation command in `README.md`.
- Removed `opencv-python` from the base `requirements.txt`.
- Modified `setup.py` to conditionally include `opencv-python` or `opencv-python-headless` based on the installation type.

### 🎯 Purpose & Impact
- 🎨 Provides flexibility for users who do not need GUI functionality, allowing for installations on servers or environments without display capabilities.
- ⚙️ May reduce the installation footprint and improve setup times for headless environments.
- 📦 Users who perform a regular installation will still get `opencv-python` as a dependency, ensuring backward compatibility.