### PR TITLE
Update ViT ops.py to `torch.long`

### DIFF
--- a/ultralytics/vit/utils/loss.py
+++ b/ultralytics/vit/utils/loss.py
@@ -284,11 +284,11 @@ class RTDETRDetectionLoss(DETRLoss):
         idx_groups = torch.as_tensor([0, *gt_groups[:-1]]).cumsum_(0)
         for i, num_gt in enumerate(gt_groups):
             if num_gt > 0:
-                gt_idx = torch.arange(end=num_gt, dtype=torch.int32) + idx_groups[i]
+                gt_idx = torch.arange(end=num_gt, dtype=torch.long) + idx_groups[i]
                 gt_idx = gt_idx.repeat(dn_num_group)
                 assert len(dn_pos_idx[i]) == len(gt_idx), 'Expected the same length, '
                 f'but got {len(dn_pos_idx[i])} and {len(gt_idx)} respectively.'
                 dn_match_indices.append((dn_pos_idx[i], gt_idx))
             else:
-                dn_match_indices.append((torch.zeros([0], dtype=torch.int32), torch.zeros([0], dtype=torch.int32)))
+                dn_match_indices.append((torch.zeros([0], dtype=torch.long), torch.zeros([0], dtype=torch.long)))
         return dn_match_indices

--- a/ultralytics/vit/utils/ops.py
+++ b/ultralytics/vit/utils/ops.py
@@ -107,7 +107,7 @@ class HungarianMatcher(nn.Module):
         indices = [linear_sum_assignment(c[i]) for i, c in enumerate(C.split(gt_groups, -1))]
         gt_groups = torch.as_tensor([0, *gt_groups[:-1]]).cumsum_(0)
         # (idx for queries, idx for gt)
-        return [(torch.tensor(i, dtype=torch.int32), torch.tensor(j, dtype=torch.int32) + gt_groups[k])
+        return [(torch.tensor(i, dtype=torch.long), torch.tensor(j, dtype=torch.long) + gt_groups[k])
                 for k, (i, j) in enumerate(indices)]
 
     def _cost_mask(self, bs, num_gts, masks=None, gt_mask=None):

--- a/ultralytics/vit/utils/ops.py
+++ b/ultralytics/vit/utils/ops.py
@@ -71,7 +71,7 @@ class HungarianMatcher(nn.Module):
         bs, nq, nc = pred_scores.shape
 
         if sum(gt_groups) == 0:
-            return [(torch.tensor([], dtype=torch.int32), torch.tensor([], dtype=torch.int32)) for _ in range(bs)]
+            return [(torch.tensor([], dtype=torch.long), torch.tensor([], dtype=torch.long)) for _ in range(bs)]
 
         # We flatten to compute the cost matrices in a batch
         # [batch_size * num_queries, num_classes]


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/3306

@Laughing-q 


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e51b48c</samp>

### Summary
🐛🚀🧮

<!--
1.  🐛 - This emoji represents the bug that was fixed by changing the dtype of the tensors. It is a common symbol for software bugs and errors, and it conveys that the change was motivated by resolving an issue that affected the functionality of the code.
2.  🚀 - This emoji represents the performance improvement and compatibility enhancement that the change brought to the ViT model. It is a common symbol for speed, efficiency, and innovation, and it conveys that the change was motivated by making the code faster and more adaptable to different scenarios and environments.
3.  🧮 - This emoji represents the mathematical and numerical aspect of the change, which involved manipulating the dtype of the tensors and the indices. It is a symbol for calculation, computation, and logic, and it conveys that the change was motivated by ensuring the correctness and consistency of the operations performed on the tensors.
-->
Fixed a bug in `HungarianMatcher` that caused an error with mixed precision training. Changed the dtype of the tensors returned by the matcher to `torch.long` to match the indices.

> _`HungarianMatcher`_
> _dtype changed to fix a bug_
> _apex likes `torch.long`_

### Walkthrough
*  Fix bug in HungarianMatcher by changing dtype of tensors to torch.long ([link](https://github.com/ultralytics/ultralytics/pull/3508/files?diff=unified&w=0#diff-6cb28ec52ed79bd2a4d1bb54ee150d2f97def575ed6b845e557118579a1de328L110-R110))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated data type for index calculations from `int32` to `long` in the Ultralytics vision transformer (ViT) utility functions.

### 📊 Key Changes
- Changed dtype from `torch.int32` to `torch.long` for tensors used in `get_dn_match_indices` and `forward` functions involved in indexing and matching operations.
- Modified the return types of empty tensors to `torch.long` when there are no ground truth groups to match with.

### 🎯 Purpose & Impact
- **Purpose:** The update ensures compatibility with larger tensors, which require 64-bit integer (`torch.long`) indices, thus preventing potential integer overflow issues when working with big datasets or large number of objects.
- **Impact:** This change allows for scaling to larger problems without encountering errors due to data type limitations, offering a smoother and more robust experience for developers and users dealing with large-scale vision tasks. 

✨ This update brings enhanced reliability for users working on machine learning models that involve more extensive amounts of data.