### PR TITLE
[RTDETR]fix mosaic<1.0

### DIFF
--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -427,7 +427,7 @@ class RandomPerspective:
         """
         if self.pre_transform and 'mosaic_border' not in labels:
             labels = self.pre_transform(labels)
-            labels.pop('ratio_pad')  # do not need ratio pad
+        labels.pop('ratio_pad', None)  # do not need ratio pad
 
         img = labels['img']
         cls = labels['cls']


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ce2acb9</samp>

### Summary
🐛🚀🎨

<!--
1.  🐛 - This emoji represents a bug fix, since the original code could raise an exception if the `ratio_pad` key was missing.
2.  🚀 - This emoji represents a performance improvement, since the default value of `None` avoids an unnecessary lookup in the dictionary and simplifies the logic of the `pop` method.
3.  🎨 - This emoji represents a code style improvement, since the default value of `None` makes the code more concise and readable.
-->
Improved data augmentation for YOLOv5 by handling missing `ratio_pad` key in `labels` dictionary. Modified `pop` method in `ultralytics/yolo/data/augment.py` to use a default value of `None`.

> _`pop` with default_
> _avoids key error in spring_
> _augmenting data_

### Walkthrough
*  Prevent `KeyError` exception by using default value for `pop` method (`[link](https://github.com/ultralytics/ultralytics/pull/3518/files?diff=unified&w=0#diff-13d355434447b3961ec61d1c80bedc2b6db2d98ab0df572eb036f4e8b536aee9L430-R430)`)




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced robustness in data augmentation code.

### 📊 Key Changes
- Modified the `labels.pop('ratio_pad')` method call to include a default value.

### 🎯 Purpose & Impact
- **Prevents Errors**: Including a default value (`None`) prevents a `KeyError` if `'ratio_pad'` is not in the dictionary.
- **Improves Stability**: The change makes the data augmentation process more robust, ensuring smoother training workflows for users.
- **User Experience**: Non-expert users are less likely to encounter issues during data pre-processing, resulting in a more user-friendly experience. 🛠️✨