### PR TITLE
Update ops.py (change time.time() to time.perf_counter())

### DIFF
--- a/ultralytics/yolo/utils/ops.py
+++ b/ultralytics/yolo/utils/ops.py
@@ -52,7 +52,7 @@ class Profile(contextlib.ContextDecorator):
         """
         if self.cuda:
             torch.cuda.synchronize()
-        return time.time()
+        return time.perf_counter()
 
 
 def coco80_to_coco91_class():  # converts 80-index (val2014) to 91-index (paper)
@@ -203,7 +203,7 @@ def non_max_suppression(
     prediction = prediction.transpose(-1, -2)  # shape(1,84,6300) to shape(1,6300,84)
     prediction[..., :4] = xywh2xyxy(prediction[..., :4])  # xywh to xyxy
 
-    t = time.time()
+    t = time.perf_counter()
     output = [torch.zeros((0, 6 + nm), device=prediction.device)] * bs
     for xi, x in enumerate(prediction):  # image index, image inference
         # Apply constraints
@@ -263,7 +263,7 @@ def non_max_suppression(
         output[xi] = x[i]
         if mps:
             output[xi] = output[xi].to(device)
-        if (time.time() - t) > time_limit:
+        if (time.perf_counter() - t) > time_limit:
             LOGGER.warning(f'WARNING ⚠️ NMS time limit {time_limit:.3f}s exceeded')
             break  # time limit exceeded
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 27ab017</samp>

### Summary
🕒📈🛠️

<!--
1.  🕒 - This emoji represents the concept of time and could be used to indicate that the changes involve time-related functions or measurements.
2.  📈 - This emoji represents the idea of improvement or enhancement and could be used to indicate that the changes improve the accuracy and consistency of the time measurements.
3.  🛠️ - This emoji represents the notion of fixing or repairing and could be used to indicate that the changes address a potential issue or limitation of the previous code.
-->
Improved time measurement accuracy in `yolo/utils/ops.py` by using `time.perf_counter` instead of `time.time` for performance profiling and NMS algorithm.

> _To measure the time of each function_
> _The old method had some compunction_
> _It used `time.time`_
> _Which could vary and lie_
> _So they switched to `time.perf_counter` junction_

### Walkthrough
*  Use `time.perf_counter` instead of `time.time` for more accurate and consistent performance measurements ([link](https://github.com/ultralytics/ultralytics/pull/3534/files?diff=unified&w=0#diff-6ab52db19716f4198ed847132149ab432f032ed39c99c264a9de386446bf7f88L55-R55), [link](https://github.com/ultralytics/ultralytics/pull/3534/files?diff=unified&w=0#diff-6ab52db19716f4198ed847132149ab432f032ed39c99c264a9de386446bf7f88L206-R206), [link](https://github.com/ultralytics/ultralytics/pull/3534/files?diff=unified&w=0#diff-6ab52db19716f4198ed847132149ab432f032ed39c99c264a9de386446bf7f88L266-R266)) in `ops.py`




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved timing accuracy in YOLO utility functions.

### 📊 Key Changes
- Replaced `time.time()` with `time.perf_counter()` in three instances within the `ops.py` file.

### 🎯 Purpose & Impact
- **Greater Precision:** The use of `time.perf_counter()` provides more precise time measurements, particularly beneficial for performance profiling. 🕒
- **Consistency:** This change aligns timing functions with best practices for benchmarking code sections. 👌
- **User Experience:** Users might notice more accurate timing information when using YOLO models for inference or training, potentially aiding in optimizing their workflows. ⏱️

Overall, this change may seem minor, but it adds up to finer timing control which can be critical in high-performance computing scenarios.