### PR TITLE
Add alias `"best"` for the model checkpoint artifact

### DIFF
--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -50,7 +50,7 @@ def on_train_end(trainer):
     art = wb.Artifact(type='model', name=f'run_{wb.run.id}_model')
     if trainer.best.exists():
         art.add_file(trainer.best)
-        wb.run.log_artifact(art)
+        wb.run.log_artifact(art, aliases=["best"])
 
 
 callbacks = {

--- a/ultralytics/yolo/utils/callbacks/wb.py
+++ b/ultralytics/yolo/utils/callbacks/wb.py
@@ -50,7 +50,7 @@ def on_train_end(trainer):
     art = wb.Artifact(type='model', name=f'run_{wb.run.id}_model')
     if trainer.best.exists():
         art.add_file(trainer.best)
-        wb.run.log_artifact(art, aliases=["best"])
+        wb.run.log_artifact(art, aliases=['best'])
 
 
 callbacks = {


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cde5e84</samp>

### Summary
🏆🏷️🔗

<!--
1.  🏆 - This emoji can be used to signify the best model or the best performance, as well as the concept of ranking or comparing different models.
2.  🏷️ - This emoji can be used to represent the alias or the label that is assigned to the best model, as well as the idea of naming or categorizing artifacts.
3.  🔗 - This emoji can be used to represent the integration or the connection between wb and YOLOv5, as well as the idea of linking or referencing artifacts.
-->
The pull request enhances the wb integration with YOLOv5 by adding a "best" alias to the best model artifact. This change affects the file `ultralytics/yolo/utils/callbacks/wb.py`.

> _`best` alias logged_
> _to wb with YOLOv5_
> _cutting edge in fall_

### Walkthrough
*  Add "best" alias to the best model artifact logged to wb ([link](https://github.com/ultralytics/ultralytics/pull/3558/files?diff=unified&w=0#diff-1365dac64b857511656e6f9948f7c04022f4a9c14f7732ee26b4ca29d930f0a2L53-R53))



This PR adds alias `"best"` for the model checkpoint artifact logged to W&B at the end of training.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved artifact logging for model training in the Ultralytics framework.

### 📊 Key Changes
- A single line modification was made to the `wb.py` file within the callback functions.
- When the `on_train_end` function logs the training artifact, an alias `'best'` is now specified.

### 🎯 Purpose & Impact
- The main purpose of this change is to provide clearer identification of the best model artifact that results from the training process.
- This can potentially make it easier for users to locate and utilize their best-performing models after the training concludes.
- The impact on the user experience is better organization and retrieval of trained models in the context of experiment tracking and model management. 🚀