### PR TITLE
[pose]fix flip_idx

### DIFF
--- a/ultralytics/yolo/data/augment.py
+++ b/ultralytics/yolo/data/augment.py
@@ -772,10 +772,10 @@ def v8_transforms(dataset, imgsz, hyp, stretch=False):
             perspective=hyp.perspective,
             pre_transform=None if stretch else LetterBox(new_shape=(imgsz, imgsz)),
         )])
-    flip_idx = dataset.data.get('flip_idx', None)  # for keypoints augmentation
+    flip_idx = dataset.data.get('flip_idx', [])  # for keypoints augmentation
     if dataset.use_keypoints:
         kpt_shape = dataset.data.get('kpt_shape', None)
-        if flip_idx is None and hyp.fliplr > 0.0:
+        if len(flip_idx) == 0 and hyp.fliplr > 0.0:
             hyp.fliplr = 0.0
             LOGGER.warning("WARNING ⚠️ No 'flip_idx' array defined in data.yaml, setting augmentation 'fliplr=0.0'")
         elif flip_idx and (len(flip_idx) != kpt_shape[0]):


### PR DESCRIPTION
#3574
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2106447</samp>

### Summary
🐛🚨🆕

<!--
1.  🐛 - This emoji represents a bug fix, which is part of the motivation for this change. The previous code could cause an error when applying horizontal flip augmentation to keypoints without a `flip_idx` array.
2.  🚨 - This emoji represents a warning, which is what the new code logs when no `flip_idx` array is defined and horizontal flip augmentation is disabled. This emoji can also indicate a potential breaking change, as the default behavior of the augmentation is different from before.
3.  🆕 - This emoji represents a new feature, which is the improved keypoints augmentation functionality that this change is part of. The new code allows for more flexibility and control over the keypoints augmentation, as well as fixing some bugs.
-->
Change the default value of `flip_idx` in `ultralytics/yolo/data/augment.py` to avoid errors and warnings when applying horizontal flip augmentation to keypoints. This is part of a pull request to improve keypoints augmentation.

> _`flip_idx` defaults_
> _to empty list, not `None` -_
> _fixes keypoint bugs_

### Walkthrough
* Change the default value of `flip_idx` from `None` to an empty list and use `len(flip_idx) == 0` to check for its absence in `ultralytics/yolo/data/augment.py` ([link](https://github.com/ultralytics/ultralytics/pull/3577/files?diff=unified&w=0#diff-13d355434447b3961ec61d1c80bedc2b6db2d98ab0df572eb036f4e8b536aee9L775-R778)). This prevents an error when applying horizontal flip augmentation to keypoints and logs a warning if no `flip_idx` array is defined in the data.yaml file. This improves the keypoints augmentation functionality and fixes a bug.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to keypoints augmentation in YOLOv8.

### 📊 Key Changes
- Default `flip_idx` changed from `None` to an empty list (`[]`).
- Added condition to override `hyp.fliplr` to `0.0` only when `flip_idx` is empty and `hyp.fliplr` is greater than `0.0`.

### 🎯 Purpose & Impact
- Ensures that horizontal flip probability (`hyp.fliplr`) is set correctly when no keypoints flip index is provided, preventing errors during data augmentation.
- The update maintains data integrity when working with keypoints, which is critical for tasks like pose estimation. 🤸
- Users will experience more reliable training with datasets containing keypoints. This change could potentially improve the model's performance and generalization on such data. 📈