### PR TITLE
`ultralytics 8.0.130` revert 'Fix PyPI build warnings' updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 import pkg_resources as pkg
-from setuptools import find_namespace_packages, setup
+from setuptools import find_packages, setup
 
 # Settings
 FILE = Path(__file__).resolve()
@@ -34,7 +34,7 @@ setup(
         'Source': 'https://github.com/ultralytics/ultralytics'},
     author='Ultralytics',
     author_email='hello@ultralytics.com',
-    packages=find_namespace_packages(include=['ultralytics.*']),
+    packages=find_packages(),  # required
     include_package_data=True,
     install_requires=REQUIREMENTS,
     extras_require={

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.129'
+__version__ = '8.0.130'
 
 from ultralytics.hub import start
 from ultralytics.vit.rtdetr import RTDETR


### PR DESCRIPTION
Reverts ultralytics/ultralytics#3565 that is causing PyPI build errors.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to package discovery method and version bump.

### 📊 Key Changes
- Switched from `find_namespace_packages` to `find_packages` in `setup.py`.
- Incremented the project version from 8.0.129 to 8.0.130.

### 🎯 Purpose & Impact
- 🔄 The change in package discovery method ensures that all packages are correctly identified and installed, regardless of whether they follow the namespace package convention.
- 🆕 This update simplifies the installation process and could potentially resolve issues where some sub-packages were not being included.
- 📈 Users will receive the latest version with updated dependencies, which may include bug fixes, performance improvements, or new features.