### PR TITLE
Avoid Python 3.9 with_stem

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10']
         model: [yolov8n]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11']
-        model: [yolov5n]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -80,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         model: [yolov8n]
     steps:
       - uses: actions/checkout@v3

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -684,7 +684,7 @@ def yaml_model_load(path):
     if path.stem in (f'yolov{d}{x}6' for x in 'nsmlx' for d in (5, 8)):
         new_stem = re.sub(r'(\d+)([nslmx])6(.+)?$', r'\1\2-p6\3', path.stem)
         LOGGER.warning(f'WARNING ⚠️ Ultralytics YOLO P6 models now use -p6 suffix. Renaming {path.stem} to {new_stem}.')
-        path = path.with_stem(new_stem)
+        path = path.with_name(new_stem+path.suffix)
 
     unified_path = re.sub(r'(\d+)([nslmx])(.+)?$', r'\1\3', str(path))  # i.e. yolov8x.yaml -> yolov8.yaml
     yaml_file = check_yaml(unified_path, hard=False) or check_yaml(path)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -684,7 +684,7 @@ def yaml_model_load(path):
     if path.stem in (f'yolov{d}{x}6' for x in 'nsmlx' for d in (5, 8)):
         new_stem = re.sub(r'(\d+)([nslmx])6(.+)?$', r'\1\2-p6\3', path.stem)
         LOGGER.warning(f'WARNING ⚠️ Ultralytics YOLO P6 models now use -p6 suffix. Renaming {path.stem} to {new_stem}.')
-        path = path.with_name(new_stem+path.suffix)
+        path = path.with_name(new_stem + path.suffix)
 
     unified_path = re.sub(r'(\d+)([nslmx])(.+)?$', r'\1\3', str(path))  # i.e. yolov8x.yaml -> yolov8.yaml
     yaml_file = check_yaml(unified_path, hard=False) or check_yaml(path)

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -591,7 +591,7 @@ class Exporter:
         # Remove/rename TFLite models
         if self.args.int8:
             for file in f.rglob('*_dynamic_range_quant.tflite'):
-                file.rename(file.with_name(file.stem.replace('_dynamic_range_quant', '_int8')+file.suffix))
+                file.rename(file.with_name(file.stem.replace('_dynamic_range_quant', '_int8') + file.suffix))
             for file in f.rglob('*_integer_quant_with_int16_act.tflite'):
                 file.unlink()  # delete extra fp16 activation TFLite files
 

--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -591,7 +591,7 @@ class Exporter:
         # Remove/rename TFLite models
         if self.args.int8:
             for file in f.rglob('*_dynamic_range_quant.tflite'):
-                file.rename(file.with_stem(file.stem.replace('_dynamic_range_quant', '_int8')))
+                file.rename(file.with_name(file.stem.replace('_dynamic_range_quant', '_int8')+file.suffix))
             for file in f.rglob('*_integer_quant_with_int16_act.tflite'):
                 file.unlink()  # delete extra fp16 activation TFLite files
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

Fixes crash when exporting `tflite` models using a Python version < 3.9, as the `Path.with_stem` method was only introduced in Python 3.9.

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refined model naming and CI configuration in Ultralytics repository.

### 📊 Key Changes
- Removed a specific model (YOLOv5n) from the continuous integration (CI) testing matrix.
- Updated file renaming processes for YAML model loading and TFLite model exporting.

### 🎯 Purpose & Impact
- **CI Streamlining**: 
  - By omitting YOLOv5n in CI tests, the team might be adjusting their test suite for efficiency or relevance.
- **Improved Consistency**:
  - The modifications in file renaming ensure that the file's extension is preserved, preventing potential issues with file recognition and usage by users or other systems.
- **User Experience**:
  - These changes could improve the clarity of model naming for users, making it easier to identify and work with different model files.