### PR TITLE
Filter `matplotlib>=3.7.2` tight layout warning

### DIFF
--- a/ultralytics/yolo/engine/exporter.py
+++ b/ultralytics/yolo/engine/exporter.py
@@ -201,7 +201,7 @@ class Exporter:
         if self.args.half and (engine or onnx) and self.device.type != 'cpu':
             im, model = im.half(), model.half()  # to FP16
 
-        # Warnings
+        # Filter warnings
         warnings.filterwarnings('ignore', category=torch.jit.TracerWarning)  # suppress TracerWarning
         warnings.filterwarnings('ignore', category=UserWarning)  # suppress shape prim::Constant missing ONNX warning
         warnings.filterwarnings('ignore', category=DeprecationWarning)  # suppress CoreML np.bool deprecation warning

--- a/ultralytics/yolo/utils/plotting.py
+++ b/ultralytics/yolo/utils/plotting.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import math
+import warnings
 from pathlib import Path
 
 import cv2
@@ -232,6 +233,9 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(''), on_plot=None):
     """Save and plot image with no axis or spines."""
     import pandas as pd
     import seaborn as sn
+
+    # Filter matplotlib>=3.7.2 warning
+    warnings.filterwarnings('ignore', category=UserWarning, message='The figure layout has changed to tight')
 
     # Plot dataset labels
     LOGGER.info(f"Plotting labels to {save_dir / 'labels.jpg'}... ")


### PR DESCRIPTION
Not sure why this started appearing in the latest release of Matplotlib, but there seems to be no reason for it, so I'm filtering to avoid unnecessary user confusion/worry.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fc1707e</samp>

### Summary
📝🔇📊

<!--
1.  📝 - This emoji can be used to indicate a change in documentation or comments, as well as general writing or editing tasks.
2.  🔇 - This emoji can be used to indicate a change that silences or suppresses some output, such as warnings, logs, or errors.
3.  📊 - This emoji can be used to indicate a change that affects data visualization, such as plots, charts, or graphs.
-->
Filtered unwanted warnings from `matplotlib`, `torch.jit`, and `onnx` in `plot_labels` and `exporter` modules. This improves the user experience and the output quality of the plots and the exported models.

> _Suppress the warnings of the fire_
> _`torch.jit` and `onnx` cannot stop our desire_
> _Plot the labels of the dark_
> _`matplotlib` cannot break our spark_

### Walkthrough
*  Filter specific warnings from `torch.jit`, `onnx`, and `matplotlib` to improve output clarity and consistency ([link](https://github.com/ultralytics/ultralytics/pull/3614/files?diff=unified&w=0#diff-89bbf0a641e1fc4302b73181ac7fccc773b5213720cae9b5cae8aa2393c982fdL204-R204), [link](https://github.com/ultralytics/ultralytics/pull/3614/files?diff=unified&w=0#diff-7e75b3f968b9868ef6f0a86148cf6c16a5224e7fdd45f5c2eb5e9bc0fc744756R5), [link](https://github.com/ultralytics/ultralytics/pull/3614/files?diff=unified&w=0#diff-7e75b3f968b9868ef6f0a86148cf6c16a5224e7fdd45f5c2eb5e9bc0fc744756R237-R239))
*  Update comment to better describe warning filtering in `exporter.py` ([link](https://github.com/ultralytics/ultralytics/pull/3614/files?diff=unified&w=0#diff-89bbf0a641e1fc4302b73181ac7fccc773b5213720cae9b5cae8aa2393c982fdL204-R204))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of warnings handling in YOLO's exporter and plotting utilities.

### 📊 Key Changes
- Filtering specific categories of warnings in the exporter script.
- Adding a filter for a specific UserWarning related to figure layout in Matplotlib in the plotting script.

### 🎯 Purpose & Impact
- 🛠️ Improves user experience by hiding irrelevant or non-actionable warnings during model export and data visualization.
- 🧹 Results in cleaner console output, which makes it easier for users to focus on important messages and reduces confusion for those who may not be familiar with these warnings.
- 🎨 Ensures a smooth plotting process without distracting warnings, particularly for users with the latest version of Matplotlib.