### PR TITLE
Fix `MLFLOW_EXPERIMENT_NAME` env var

### DIFF
--- a/ultralytics/yolo/utils/callbacks/mlflow.py
+++ b/ultralytics/yolo/utils/callbacks/mlflow.py
@@ -26,7 +26,7 @@ def on_pretrain_routine_end(trainer):
         mlflow_location = os.environ['MLFLOW_TRACKING_URI']  # "http://192.168.xxx.xxx:5000"
         mlflow.set_tracking_uri(mlflow_location)
 
-        experiment_name = os.environ.get('MLFLOW_EXPERIMENT') or trainer.args.project or '/Shared/YOLOv8'
+        experiment_name = os.environ.get('MLFLOW_EXPERIMENT_NAME') or trainer.args.project or '/Shared/YOLOv8'
         run_name = os.environ.get('MLFLOW_RUN') or trainer.args.name
         experiment = mlflow.get_experiment_by_name(experiment_name)
         if experiment is None:


### PR DESCRIPTION
Given [this MLFlow documentation](https://mlflow.org/docs/latest/tracking.html#organizing-runs-in-experiments), the mlflow experiment name can be set with the `MLFLOW_EXPERIMENT_NAME` env var, but the yolov8 mlflow callback look up for  `MLFLOW_EXPERIMENT` env var instead.
This is an issue when some tools integrated with mlflow automatically set up the `MLFLOW_EXPERIMENT_NAME` env var. For example AzureML set up the `MLFLOW_EXPERIMENT_NAME` env var. If we merge this fix the integration with MLFlow will work without the need to set up the env var or the project name.
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8882717</samp>

### Summary
🔄📝🚀

<!--
1.  🔄 - This emoji can be used to indicate a renaming or refactoring of a variable or a function. It suggests that something was changed without altering its functionality or meaning.
2. 📝 - This emoji can be used to indicate a documentation or comment update. It suggests that something was explained or clarified for the user or the developer.
3. 🚀 - This emoji can be used to indicate a new feature or improvement. It suggests that something was added or enhanced to make the project more useful or compatible.
-->
Renamed `MLFLOW_EXPERIMENT` to `MLFLOW_EXPERIMENT_NAME` in `ultralytics/yolo/utils/callbacks/mlflow.py` to enable user-defined experiment names for MLflow logging.

> _`MLFLOW_EXPERIMENT`_
> _Now a name, not an ID_
> _Clearer for logging_

### Walkthrough
*  Rename `MLFLOW_EXPERIMENT` to `MLFLOW_EXPERIMENT_NAME` to specify the name of the MLflow experiment ([link](https://github.com/ultralytics/ultralytics/pull/3668/files?diff=unified&w=0#diff-30b3338b115e9e6057d5c19cf6a7de077ab273cd001e4e7e24f5162730d4657eL29-R29))





## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced MLflow integration by refining environment variables for experiment naming.

### 📊 Key Changes
- Modified the environment variable for MLflow experiment naming from `MLFLOW_EXPERIMENT` to `MLFLOW_EXPERIMENT_NAME`.
- Ensured a fallback to trainer arguments or a default shared YOLOv8 path if the environment variable is not set.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Improves clarity and consistency in how environment variables are used for naming MLflow experiments, aligning with typical MLflow naming conventions.
- 💥 **Impact**: Users will experience more intuitive MLflow tracking, with clearer customization of experiment names via environment variables, impacting anyone using MLflow for experiment tracking and versioning.