### PR TITLE
Changed default device to AUTO in OpenVINO

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -137,17 +137,18 @@ class AutoBackend(nn.Module):
             LOGGER.info(f'Loading {w} for OpenVINO inference...')
             check_requirements('openvino')  # requires openvino-dev: https://pypi.org/project/openvino-dev/
             from openvino.runtime import Core, Layout, get_batch  # noqa
-            ie = Core()
+            core = Core()
             w = Path(w)
             if not w.is_file():  # if not *.xml
                 w = next(w.glob('*.xml'))  # get *.xml file from *_openvino_model dir
-            network = ie.read_model(model=str(w), weights=w.with_suffix('.bin'))
-            if network.get_parameters()[0].get_layout().empty:
-                network.get_parameters()[0].set_layout(Layout('NCHW'))
-            batch_dim = get_batch(network)
+            ov_model = core.read_model(model=str(w), weights=w.with_suffix('.bin'))
+            if ov_model.get_parameters()[0].get_layout().empty:
+                ov_model.get_parameters()[0].set_layout(Layout('NCHW'))
+            batch_dim = get_batch(ov_model)
             if batch_dim.is_static:
                 batch_size = batch_dim.get_length()
-            executable_network = ie.compile_model(network, device_name='CPU')  # device_name="MYRIAD" for NCS2
+            # AUTO will select the best available device
+            ov_compiled_model = core.compile_model(ov_model, device_name='AUTO')
             metadata = w.parent / 'metadata.yaml'
         elif engine:  # TensorRT
             LOGGER.info(f'Loading {w} for TensorRT inference...')
@@ -339,7 +340,7 @@ class AutoBackend(nn.Module):
             y = self.session.run(self.output_names, {self.session.get_inputs()[0].name: im})
         elif self.xml:  # OpenVINO
             im = im.cpu().numpy()  # FP32
-            y = list(self.executable_network([im]).values())
+            y = list(self.ov_compiled_model([im]).values())
         elif self.engine:  # TensorRT
             if self.dynamic and im.shape != self.bindings['images'].shape:
                 i = self.model.get_binding_index('images')

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -147,8 +147,7 @@ class AutoBackend(nn.Module):
             batch_dim = get_batch(ov_model)
             if batch_dim.is_static:
                 batch_size = batch_dim.get_length()
-            # AUTO will select the best available device
-            ov_compiled_model = core.compile_model(ov_model, device_name='AUTO')
+            ov_compiled_model = core.compile_model(ov_model, device_name='AUTO')  # AUTO selects best available device
             metadata = w.parent / 'metadata.yaml'
         elif engine:  # TensorRT
             LOGGER.info(f'Loading {w} for TensorRT inference...')


### PR DESCRIPTION
I changed the device to AUTO, which selects the best available device improving the performance even more (if Intel GPU exists)., and renamed some vars by the way.

I can provide more improvements e.g. shared memory if we can make an assumption the input won't change in the meantime.
More improvements are listed in https://github.com/openvinotoolkit/openvino_notebooks/blob/main/notebooks/109-performance-tricks/109-latency-tricks.ipynb

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 15101e8</samp>

### Summary
:recycle::zap::gear:

<!--
1.  :recycle: This emoji can be used to indicate that some variables were renamed or refactored to improve readability or consistency.
2.  :zap: This emoji can be used to indicate that some variables were changed to enable faster or more efficient performance, such as automatic device selection for inference.
3.  :gear: This emoji can be used to indicate that some variables were modified to adjust the configuration or settings of the backend, such as the device type or the inference engine.
-->
Updated `autobackend.py` to support OpenVINO device detection and naming.

> _Sing, O Muse, of the skillful coder who refined_
> _The `autobackend.py` script, with wisdom in mind,_
> _To match the names of variables with OpenVINO's lore_
> _And let the inference run on any device, as before._

### Walkthrough
*  Rename variables related to OpenVINO inference to improve readability and consistency ([link](https://github.com/ultralytics/ultralytics/pull/3699/files?diff=unified&w=0#diff-2e3ad5da4ba57eb68a9b5aaddf0c40c784d888b7619ed337ce31dfea4f6380f9L140-R151), [link](https://github.com/ultralytics/ultralytics/pull/3699/files?diff=unified&w=0#diff-2e3ad5da4ba57eb68a9b5aaddf0c40c784d888b7619ed337ce31dfea4f6380f9L342-R343)) in `autobackend.py`




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved OpenVINO integration in Ultralytics's neural network backend.

### 📊 Key Changes
- Renamed `ie` to `core` to better represent the OpenVINO runtime Core object.
- Changed variable `network` to `ov_model` for better clarity.
- Updated setting layouts of model parameters from `network` to `ov_model`.
- Modified `executable_network` to `ov_compiled_model` with device selection changing from 'CPU' to 'AUTO'.
- Altered code for executing inference from using `executable_network` to `ov_compiled_model`.

### 🎯 Purpose & Impact
- **Clarity and Readability**: Updated variable names for better understanding of the code.
- **Device Optimization**: The use of 'AUTO' for device selection allows OpenVINO to automatically pick the best available device, potentially improving performance.
- **Maintenance and Extensibility**: These changes are likely part of ongoing maintenance and improvement to ensure compatibility with the latest OpenVINO features, resulting in a more robust inferencing backend for users.

These updates will enhance the user experience for those employing OpenVINO with Ultralytics's software, potentially providing better performance with less manual configuration needed.