### PR TITLE
created addition of a bad.file list, this will return an exit(1) if a…

### DIFF
--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -259,7 +259,14 @@ class ClassificationDataset(torchvision.datasets.ImageFolder):
         if self.album_transforms:
             sample = self.album_transforms(image=cv2.cvtColor(im, cv2.COLOR_BGR2RGB))['image']
         else:
-            sample = self.torch_transforms(im)
+            try:
+                sample = self.torch_transforms(im)
+            except AttributeError: # bad image files force the creation of a 'bad list', will not do multiple files at once in current configuration
+                q = open('bad.file', 'w+')
+                q.write(f+"\n")
+                q.close()
+                print('Warning: corrupt image files, see bad.file for faulty image')
+                exit(1)
         return {'img': sample, 'cls': j}
 
     def __len__(self) -> int:

--- a/ultralytics/yolo/data/dataset.py
+++ b/ultralytics/yolo/data/dataset.py
@@ -261,9 +261,9 @@ class ClassificationDataset(torchvision.datasets.ImageFolder):
         else:
             try:
                 sample = self.torch_transforms(im)
-            except AttributeError: # bad image files force the creation of a 'bad list', will not do multiple files at once in current configuration
+            except AttributeError:  # bad image files force the creation of a 'bad list', will not do multiple files at once in current configuration
                 q = open('bad.file', 'w+')
-                q.write(f+"\n")
+                q.write(f + '\n')
                 q.close()
                 print('Warning: corrupt image files, see bad.file for faulty image')
                 exit(1)


### PR DESCRIPTION
…n image raises a NoneType object has no attribute shape error from corrupt image files during classifying tasks. I have not tested it on object detection, segmentation, or pose tasks (didn't have a lot of time). In it's current state it will only return the bad file that hangs it and not a full list of them, but better than nothing at the moment. Might try to make an updated pull request when I have more time. Thanks!


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b581c7f</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 - This emoji represents a bug fix, as the change addresses a potential error that could crash the program or produce incorrect results.
2.  📝 - This emoji represents a documentation update, as the change writes the name of the bad image file to a file for the user's reference.
3.  🚀 - This emoji represents a performance improvement, as the change avoids wasting time and resources on processing corrupt or invalid image files.
-->
Added error handling for corrupt or invalid image files in `torch_transforms` method of `ultralytics/yolo/data/dataset.py`. The change logs the faulty image names to `bad.file` and exits with an error message.

> _`torch_transforms` fails_
> _corrupt image spoils the batch_
> _write to `bad.file`_

### Walkthrough
*  Handle corrupt or invalid image files in classification dataset ([link](https://github.com/ultralytics/ultralytics/pull/3757/files?diff=unified&w=0#diff-9e341b944998965225e7749684518d7461f0a0ebc7e6dd53502ca840fb4e686fL262-R269))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling for corrupt image files in the YOLO dataset processing.

### 📊 Key Changes
- Added a `try-except` block around image transformation.
- Introduced a mechanism to detect and log corrupt image files to a `bad.file`.
- Provides a warning message and halts execution if a corrupt file is found.

### 🎯 Purpose & Impact
- Enhances robustness by preventing crashes due to corrupt image files.
- Alerts users to problematic files, helping them clean their datasets.
- Improves dataset processing reliability, ensuring smoother training experiences. 🛠️🔍