### PR TITLE
Fix `eval` to `val` in dvc.py

### DIFF
--- a/ultralytics/utils/callbacks/dvc.py
+++ b/ultralytics/utils/callbacks/dvc.py
@@ -104,7 +104,7 @@ def on_fit_epoch_end(trainer):
                 live.log_metric(metric, value, plot=False)
 
         _log_plots(trainer.plots, 'train')
-        _log_plots(trainer.validator.plots, 'eval')
+        _log_plots(trainer.validator.plots, 'val')
 
         live.next_step()
         _training_epoch = False
@@ -117,8 +117,8 @@ def on_train_end(trainer):
         for metric, value in all_metrics.items():
             live.log_metric(metric, value, plot=False)
 
-        _log_plots(trainer.plots, 'eval')
-        _log_plots(trainer.validator.plots, 'eval')
+        _log_plots(trainer.plots, 'val')
+        _log_plots(trainer.validator.plots, 'val')
         _log_confusion_matrix(trainer.validator)
 
         if trainer.best.exists():

--- a/ultralytics/utils/callbacks/dvc.py
+++ b/ultralytics/utils/callbacks/dvc.py
@@ -104,7 +104,7 @@ def on_fit_epoch_end(trainer):
                 live.log_metric(metric, value, plot=False)
 
         _log_plots(trainer.plots, 'train')
-        _log_plots(trainer.validator.plots, 'val')
+        _log_plots(trainer.validator.plots, 'eval')
 
         live.next_step()
         _training_epoch = False


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ac7fe2a</samp>

### Summary
:recycle::art::memo:

<!--
1.  :recycle: This emoji can be used to indicate a code refactor or improvement that does not change the functionality or output, but makes the code more readable, maintainable, or consistent.
2.  :art: This emoji can be used to indicate a code improvement that enhances the style, format, or structure of the code, such as indentation, spacing, or alignment.
3.  :memo: This emoji can be used to indicate a code improvement that updates the documentation, comments, or annotations of the code, such as adding or editing docstrings, comments, or type hints.
-->
Refactor validation plot naming in `dvc.py`. Replace `val` with `eval` to match other ultralytics modules.

> _`eval` not `val`_
> _Naming conventions matter_
> _Cutting through the code_

### Walkthrough
*  Rename `val` to `eval` for consistency in validation plots ([link](https://github.com/ultralytics/ultralytics/pull/3771/files?diff=unified&w=0#diff-de628cfc894d2baa2dd71371e662adce88686d7fbbef1b939186daeb5866384bL107-R107))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced data visualization categorization in training callbacks.

### 📊 Key Changes
- Changed the label from `'eval'` to `'val'` for logging plots associated with evaluation during training.

### 🎯 Purpose & Impact
- The change clarifies the distinction between evaluation and validation data by standardizing the terminology. Users can now more easily recognize that the plots correspond to the validation set rather than a general evaluation.
- This can improve the understanding of the training process for users as they interpret the logged visual data.