### PR TITLE
Update Classify `fitness` definition to mean of top1, top5

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -963,8 +963,8 @@ class ClassifyMetrics(SimpleClass):
 
     @property
     def fitness(self):
-        """Returns top-5 accuracy as fitness score."""
-        return self.top5
+        """Returns mean of top-1 and top-5 accuracies as fitness score."""
+        return (self.top1 + self.top5) / 2
 
     @property
     def results_dict(self):


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/3763

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at db97031</samp>

### Summary
📈🏅🧮

<!--
1.  📈 This emoji can be used to indicate that the change is intended to improve or increase the performance or quality of the classification metrics, as the fitness score is a measure of how well the model can classify the input images. The upward arrow also suggests a positive direction of change.
2.  🏅 This emoji can be used to indicate that the change is related to the ranking or comparison of different models or hyperparameters, as the fitness score is used to sort and select the best candidates for the classification task. The medal also suggests a notion of achievement or reward for the models with higher fitness scores.
3.  🧮 This emoji can be used to indicate that the change is related to the calculation or formula of the fitness score, as the mean of top-1 and top-5 accuracies is a different way of computing the fitness value than just the top-5 accuracy. The abacus also suggests a notion of arithmetic or computation.
-->
Modified the `fitness` property of the `ClassifyMetrics` class in `ultralytics/utils/metrics.py` to use the mean of top-1 and top-5 accuracies. This improves the fitness score calculation for classification tasks in the ultralytics framework.

> _`fitness` changes_
> _mean of top accuracies_
> _autumn of issue_

### Walkthrough
*  Modify `fitness` property of `ClassifyMetrics` class to return mean of top-1 and top-5 accuracies ([link](https://github.com/ultralytics/ultralytics/pull/3789/files?diff=unified&w=0#diff-fb567871ecb755681f83f6e1edeb903d3a5757316d9caa1a28bd2be993bf4fc8L966-R967))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated fitness score calculation to the mean of top-1 and top-5 accuracies in Ultralytics utils.

### 📊 Key Changes
- Altered the `fitness` property method within the metrics module.
- The fitness score now calculates as the average of top-1 and top-5 accuracies, instead of just using the top-5 accuracy.

### 🎯 Purpose & Impact
- **Purpose:** This change is likely meant to provide a more balanced evaluation metric that reflects both high precision (top-1) and good generalization (top-5).
- **Impact:** Users can expect the fitness score to more accurately represent overall model performance, which could impact model selection, tuning, and comparison. 🎯💪