### PR TITLE
Fix tflite int8 scaling

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -421,7 +421,7 @@ class AutoBackend(nn.Module):
                         # xywh are normalized in TFLite/EdgeTPU to mitigate quantization error of integer models
                         # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
                         # This construction ensures whwh gets broadcasted correctly
-                        x[:, :4] *= whwh.reshape(whwh.shape + (1, ) * (b.ndim - 2))
+                        x[:, :4] *= whwh.reshape(whwh.shape + (1, ) * (x.ndim - 2))
                     y.append(x)
             # TF segment fixes: export is reversed vs ONNX export and protos are transposed
             if len(y) == 2:  # segment with (det, proto) output order reversed

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -410,7 +410,6 @@ class AutoBackend(nn.Module):
                 self.interpreter.set_tensor(input['index'], im)
                 self.interpreter.invoke()
                 y = []
-                whwh = np.array([w, h, w, h])
                 for output in self.output_details:
                     x = self.interpreter.get_tensor(output['index'])
                     if int8:
@@ -420,8 +419,10 @@ class AutoBackend(nn.Module):
                         # Unnormalize xywh with input image size
                         # xywh are normalized in TFLite/EdgeTPU to mitigate quantization error of integer models
                         # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
-                        # This construction ensures whwh gets broadcasted correctly
-                        x[:, :4] *= whwh.reshape(whwh.shape + (1, ) * (x.ndim - 2))
+                        x[:, 0] *= w
+                        x[:, 1] *= h
+                        x[:, 2] *= w
+                        x[:, 3] *= h
                     y.append(x)
             # TF segment fixes: export is reversed vs ONNX export and protos are transposed
             if len(y) == 2:  # segment with (det, proto) output order reversed

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -415,6 +415,14 @@ class AutoBackend(nn.Module):
                     if int8:
                         scale, zero_point = output['quantization']
                         x = (x.astype(np.float32) - zero_point) * scale  # re-scale
+                    if x.ndim != 2:  # if task is not classification
+                        # Unnormalize xywh with input image size
+                        # xywh are normalized in TFLite/EdgeTPU to mitigate quantization error of integer models
+                        # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
+                        x[:, 0] *= w
+                        x[:, 1] *= h
+                        x[:, 2] *= w
+                        x[:, 3] *= h
                     y.append(x)
             # TF segment fixes: export is reversed vs ONNX export and protos are transposed
             if len(y) == 2:  # segment with (det, proto) output order reversed
@@ -422,7 +430,6 @@ class AutoBackend(nn.Module):
                     y = list(reversed(y))  # should be y = (1, 116, 8400), (1, 160, 160, 32)
                 y[1] = np.transpose(y[1], (0, 3, 1, 2))  # should be y = (1, 116, 8400), (1, 32, 160, 160)
             y = [x if isinstance(x, np.ndarray) else x.numpy() for x in y]
-            # y[0][..., :4] *= [w, h, w, h]  # xywh normalized to pixels
 
         # for x in y:
         #     print(type(x), len(x)) if isinstance(x, (list, tuple)) else print(type(x), x.shape)  # debug shapes

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -419,10 +419,7 @@ class AutoBackend(nn.Module):
                         # Unnormalize xywh with input image size
                         # xywh are normalized in TFLite/EdgeTPU to mitigate quantization error of integer models
                         # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
-                        x[:, 0] *= w
-                        x[:, 1] *= h
-                        x[:, 2] *= w
-                        x[:, 3] *= h
+                        x[:, :4] *= [w, h, w, h]
                     y.append(x)
             # TF segment fixes: export is reversed vs ONNX export and protos are transposed
             if len(y) == 2:  # segment with (det, proto) output order reversed

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -419,7 +419,7 @@ class AutoBackend(nn.Module):
                         # Unnormalize xywh with input image size
                         # xywh are normalized in TFLite/EdgeTPU to mitigate quantization error of integer models
                         # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
-                        x[:, :4] *= [w, h, w, h]
+                        x[:, :4] *= np.array([w, h, w, h], dtype=x.dtype)[:, np.newaxis]
                     y.append(x)
             # TF segment fixes: export is reversed vs ONNX export and protos are transposed
             if len(y) == 2:  # segment with (det, proto) output order reversed

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -421,7 +421,7 @@ class AutoBackend(nn.Module):
                         # xywh are normalized in TFLite/EdgeTPU to mitigate quantization error of integer models
                         # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
                         # This construction ensures whwh gets broadcasted correctly
-                        x[:, :4] *= whwh.reshape(whwh.shape+(1,)*(b.ndim-2))
+                        x[:, :4] *= whwh.reshape(whwh.shape + (1, ) * (b.ndim - 2))
                     y.append(x)
             # TF segment fixes: export is reversed vs ONNX export and protos are transposed
             if len(y) == 2:  # segment with (det, proto) output order reversed


### PR DESCRIPTION
Part of #1695, with calibration section removed until further testing can be made.

This PR merges the changes manually into main, accounting for the file structure changes.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b81eb61</samp>

### Summary
🛠️🚀🌐

<!--
1.  🛠️ - This emoji represents a fix or improvement of existing code or functionality, which is what this pull request does by adjusting the normalization of xywh coordinates.
2.  🚀 - This emoji represents a performance improvement or optimization, which is what this pull request achieves by mitigating the quantization error of integer models and ensuring consistency across the model layers.
3.  🌐 - This emoji represents a compatibility or portability enhancement, which is what this pull request offers by improving the accuracy and compatibility of TFLite and EdgeTPU models.
-->
This pull request enhances the TFLite and EdgeTPU compatibility of the model by normalizing and unnormalizing the `xywh` coordinates of bounding boxes and default boxes. This reduces the quantization error and improves the accuracy of integer models.

> _Sing, O Muse, of the skillful coder who refined the model_
> _Of bounding boxes, that swift and accurate detector_
> _Of objects in the images, and made it more compatible_
> _With TFLite and EdgeTPU, those tiny and wise predictors._

### Walkthrough
*  Mitigate quantization error of integer models for TFLite and EdgeTPU by normalizing xywh coordinates of bounding boxes and default boxes with input image size when exporting the model ([link](https://github.com/ultralytics/ultralytics/pull/3837/files?diff=unified&w=0#diff-2e3ad5da4ba57eb68a9b5aaddf0c40c784d888b7619ed337ce31dfea4f6380f9R418-R425), [link](https://github.com/ultralytics/ultralytics/pull/3837/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639R61-R70))
* Simplify code logic by removing redundant normalization of xywh coordinates to pixels when not exporting the model in `autobackend.py` ([link](https://github.com/ultralytics/ultralytics/pull/3837/files?diff=unified&w=0#diff-2e3ad5da4ba57eb68a9b5aaddf0c40c784d888b7619ed337ce31dfea4f6380f9L425))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model accuracy for non-classification tasks in TFLite/EdgeTPU.

### 📊 Key Changes
- 🧮 Added post-processing to re-scale bounding box coordinates with image size in TFLite/EdgeTPU models.
- ✂️ Removed redundant scaling code that normalized bounding boxes to pixel values.
- 🔄 Added normalization of bounding box coordinates during export to TFLite/EdgeTPU format to mitigate quantization error.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To improve the accuracy of bounding box predictions for object detection tasks by compensating for quantization errors during model export.
- 💡 **Impact**: Users can expect more accurate object localization from models deployed on TFLite/EdgeTPU platforms, particularly for tasks other than classification. This change could be crucial for applications requiring precise object detection, like automated driving or surveillance.