### PR TITLE
fix: pin coremltools to 6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             'mkdocs-redirects',  # for 301 redirects
             'mkdocs-ultralytics-plugin>=0.0.21',  # for meta descriptions and images, dates and authors
         ],
-        'export': ['coremltools>=6.0', 'openvino-dev>=2023.0', 'tensorflowjs'],  # automatically installs tensorflow
+        'export': ['coremltools==6.2', 'openvino-dev>=2023.0', 'tensorflowjs'],  # automatically installs tensorflow
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             'mkdocs-redirects',  # for 301 redirects
             'mkdocs-ultralytics-plugin>=0.0.21',  # for meta descriptions and images, dates and authors
         ],
-        'export': ['coremltools<=6.2', 'openvino-dev>=2023.0', 'tensorflowjs'],  # automatically installs tensorflow
+        'export': ['coremltools>=6.0,<=6.2', 'openvino-dev>=2023.0', 'tensorflowjs'],  # automatically installs tensorflow
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             'mkdocs-redirects',  # for 301 redirects
             'mkdocs-ultralytics-plugin>=0.0.21',  # for meta descriptions and images, dates and authors
         ],
-        'export': ['coremltools==6.2', 'openvino-dev>=2023.0', 'tensorflowjs'],  # automatically installs tensorflow
+        'export': ['coremltools<=6.2', 'openvino-dev>=2023.0', 'tensorflowjs'],  # automatically installs tensorflow
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
             'mkdocs-redirects',  # for 301 redirects
             'mkdocs-ultralytics-plugin>=0.0.21',  # for meta descriptions and images, dates and authors
         ],
-        'export': ['coremltools>=6.0,<=6.2', 'openvino-dev>=2023.0', 'tensorflowjs'],  # automatically installs tensorflow
+        'export': ['coremltools>=6.0,<=6.2', 'openvino-dev>=2023.0',
+                   'tensorflowjs'],  # automatically installs tensorflow
     },
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
CoreMLTools 6.3.0 does not allow exports using nms=True, pinning to 6.2 fixes this.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 48f8c24</samp>

### Summary
🐛🔒🍏

<!--
1.  🐛 - This emoji represents a bug fix, as the change was made to resolve an error that prevented the expected functionality of the code.
2.  🔒 - This emoji represents a security or dependency update, as the change was made to fix the version of a third-party library that could potentially introduce breaking changes or vulnerabilities in the future.
3.  🍏 - This emoji represents a platform-specific improvement, as the change was made to enhance the compatibility of the code with the Core ML format, which is mainly used for Apple devices.
-->
Fixed `coremltools` dependency version in `setup.py` to enable Core ML export. This resolves a compatibility issue reported by a user.

> _`coremltools` fixed_
> _export error in winter_
> _cut by issue link_

### Walkthrough
* Fix `coremltools` dependency version to 6.2 to avoid compatibility issues with Core ML export ([link](https://github.com/ultralytics/ultralytics/pull/3852/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L51-R51))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved specificity in package dependencies for model export functionality.

### 📊 Key Changes
- Modified the `coremltools` package version range in `setup.py` to be between `6.0` and `6.2`.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To prevent potential compatibility issues with future versions of `coremltools` by specifying a maximum version.
- 🎯 **Impact**: Ensures more reliable exports of machine learning models to Core ML format by using known stable versions of Core ML tools, leading to fewer unexpected issues for developers and users working with Ultralytics software.