### PR TITLE
Benchmark with custom `data.yaml`

### DIFF
--- a/docs/modes/benchmark.md
+++ b/docs/modes/benchmark.md
@@ -30,27 +30,29 @@ full list of export arguments.
         from ultralytics.utils.benchmarks import benchmark
         
         # Benchmark on GPU
-        benchmark(model='yolov8n.pt', imgsz=640, half=False, device=0)
+        benchmark(model='yolov8n.pt', data='data.yaml', imgsz=640, half=False, device=0)
         ```
     === "CLI"
     
         ```bash
-        yolo benchmark model=yolov8n.pt imgsz=640 half=False device=0
+        yolo benchmark model=yolov8n.pt data='data.yaml' imgsz=640 half=False device=0
         ```
 
 ## Arguments
 
-Arguments such as `model`, `imgsz`, `half`, `device`, and `hard_fail` provide users with the flexibility to fine-tune
+Arguments such as `model`, `data`, `imgsz`, `half`, `device`, and `hard_fail` provide users with the flexibility to fine-tune
 the benchmarks to their specific needs and compare the performance of different export formats with ease.
 
-| Key         | Value   | Description                                                          |
-|-------------|---------|----------------------------------------------------------------------|
-| `model`     | `None`  | path to model file, i.e. yolov8n.pt, yolov8n.yaml                    |
-| `imgsz`     | `640`   | image size as scalar or (h, w) list, i.e. (640, 480)                 |
-| `half`      | `False` | FP16 quantization                                                    |
-| `int8`      | `False` | INT8 quantization                                                    |
-| `device`    | `None`  | device to run on, i.e. cuda device=0 or device=0,1,2,3 or device=cpu |
-| `hard_fail` | `False` | do not continue on error (bool), or val floor threshold (float)      |
+| Key         | Value   | Description                                                                |
+|-------------|---------|----------------------------------------------------------------------------|
+| `model`     | `None`  | path to model file, i.e. yolov8n.pt, yolov8n.yaml                          |
+| `data`      | `None`  | path to yaml referencing the benchmarking dataset (under `val` label) |
+| `imgsz`     | `640`   | image size as scalar or (h, w) list, i.e. (640, 480)                       |
+| `half`      | `False` | FP16 quantization                                                          |
+| `int8`      | `False` | INT8 quantization                                                          |
+| `device`    | `None`  | device to run on, i.e. cuda device=0 or device=0,1,2,3 or device=cpu       |
+| `hard_fail` | `False` | do not continue on error (bool), or val floor threshold (float)            |
+
 
 ## Export Formats
 

--- a/docs/modes/benchmark.md
+++ b/docs/modes/benchmark.md
@@ -53,7 +53,6 @@ the benchmarks to their specific needs and compare the performance of different 
 | `device`    | `None`  | device to run on, i.e. cuda device=0 or device=0,1,2,3 or device=cpu       |
 | `hard_fail` | `False` | do not continue on error (bool), or val floor threshold (float)            |
 
-
 ## Export Formats
 
 Benchmarks will attempt to run automatically on all possible export formats below.

--- a/docs/modes/benchmark.md
+++ b/docs/modes/benchmark.md
@@ -30,12 +30,12 @@ full list of export arguments.
         from ultralytics.utils.benchmarks import benchmark
         
         # Benchmark on GPU
-        benchmark(model='yolov8n.pt', data='data.yaml', imgsz=640, half=False, device=0)
+        benchmark(model='yolov8n.pt', data='coco8.yaml', imgsz=640, half=False, device=0)
         ```
     === "CLI"
     
         ```bash
-        yolo benchmark model=yolov8n.pt data='data.yaml' imgsz=640 half=False device=0
+        yolo benchmark model=yolov8n.pt data='coco8.yaml' imgsz=640 half=False device=0
         ```
 
 ## Arguments
@@ -46,7 +46,7 @@ the benchmarks to their specific needs and compare the performance of different 
 | Key         | Value   | Description                                                                |
 |-------------|---------|----------------------------------------------------------------------------|
 | `model`     | `None`  | path to model file, i.e. yolov8n.pt, yolov8n.yaml                          |
-| `data`      | `None`  | path to yaml referencing the benchmarking dataset (under `val` label) |
+| `data`      | `None`  | path to yaml referencing the benchmarking dataset (under `val` label)      |
 | `imgsz`     | `640`   | image size as scalar or (h, w) list, i.e. (640, 480)                       |
 | `half`      | `False` | FP16 quantization                                                          |
 | `int8`      | `False` | INT8 quantization                                                          |

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -243,7 +243,7 @@ their specific use case based on their requirements for speed and accuracy.
         from ultralytics.utils.benchmarks import benchmark
         
         # Benchmark
-        benchmark(model='yolov8n.pt', data='data.yaml', imgsz=640, half=False, device=0)
+        benchmark(model='yolov8n.pt', data='coco8.yaml', imgsz=640, half=False, device=0)
         ```
 
 [Benchmark Examples](../modes/benchmark.md){ .md-button .md-button--primary}

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -243,7 +243,7 @@ their specific use case based on their requirements for speed and accuracy.
         from ultralytics.utils.benchmarks import benchmark
         
         # Benchmark
-        benchmark(model='yolov8n.pt', imgsz=640, half=False, device=0)
+        benchmark(model='yolov8n.pt', data='data.yaml', imgsz=640, half=False, device=0)
         ```
 
 [Benchmark Examples](../modes/benchmark.md){ .md-button .md-button--primary}

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -56,7 +56,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
     Args:
         model (str | Path | optional): Path to the model file or directory. Default is
             Path(SETTINGS['weights_dir']) / 'yolov8n.pt'.
-        data (int, optional): Data yaml file to locate the validation dataset.
+        data (str, optional): Dataset to evaluate on, inherited from TASK2DATA if not passed. Default is None.
         imgsz (int, optional): Image size for the benchmark. Default is 160.
         half (bool, optional): Use half-precision for the model if True. Default is False.
         int8 (bool, optional): Use int8-precision for the model if True. Default is False.

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -5,7 +5,7 @@ Benchmark a YOLO model formats for speed and accuracy
 Usage:
     from ultralytics.utils.benchmarks import ProfileModels, benchmark
     ProfileModels(['yolov8n.yaml', 'yolov8s.yaml']).profile()
-    run_benchmarks(model='yolov8n.pt', imgsz=160)
+    benchmark(model='yolov8n.pt', imgsz=160)
 
 Format                  | `format=argument`         | Model
 ---                     | ---                       | ---
@@ -44,6 +44,7 @@ from ultralytics.utils.torch_utils import select_device
 
 
 def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
+              data=None,
               imgsz=160,
               half=False,
               int8=False,
@@ -55,6 +56,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
     Args:
         model (str | Path | optional): Path to the model file or directory. Default is
             Path(SETTINGS['weights_dir']) / 'yolov8n.pt'.
+        data (int, optional): Data yaml file to locate the validation dataset.
         imgsz (int, optional): Image size for the benchmark. Default is 160.
         half (bool, optional): Use half-precision for the model if True. Default is False.
         int8 (bool, optional): Use int8-precision for the model if True. Default is False.
@@ -106,7 +108,7 @@ def benchmark(model=Path(SETTINGS['weights_dir']) / 'yolov8n.pt',
             export.predict(ROOT / 'assets/bus.jpg', imgsz=imgsz, device=device, half=half)
 
             # Validate
-            data = TASK2DATA[model.task]  # task to dataset, i.e. coco8.yaml for task=detect
+            data = data or TASK2DATA[model.task]  # task to dataset, i.e. coco8.yaml for task=detect
             key = TASK2METRIC[model.task]  # task to metric, i.e. metrics/mAP50-95(B) for task=detect
             results = export.val(data=data,
                                  batch=1,


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented (https://github.com/ultralytics/ultralytics/issues/3849)
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b59d1d0</samp>

### Summary
📝🗂️🛠️

<!--
1.  📝 - This emoji represents the documentation update in `docs/modes/benchmark.md` and `docs/usage/python.md`, as it is commonly used to indicate writing or editing text.
2.  🗂️ - This emoji represents the addition of the `data` argument, which allows users to specify the yaml file that references the validation dataset for the benchmarking task. This emoji is often used to indicate files, folders, or data management.
3.  🛠️ - This emoji represents the modification of the `benchmark` function in `ultralytics/utils/benchmarks.py`, which involves changing the code logic and functionality. This emoji is often used to indicate tools, repairs, or improvements.
-->
Renamed and modified the `benchmark` function in `ultralytics/utils/benchmarks.py` to accept a `data` argument that specifies the validation dataset for benchmarking. Updated the documentation in `docs/modes/benchmark.md` and `docs/usage/python.md` to reflect the new argument and show examples of its usage.

> _Sing, O Muse, of the skillful code review_
> _That brought new features to the benchmark mode_
> _And made the docs and scripts more clear and true_
> _To help the users run their models on the road_

### Walkthrough
*  Rename `run_benchmarks` function to `benchmark` for consistency and clarity ([link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-0aaacfa9e7ed54c1a6234cf053efec57da412817e8d8cf176f06e532359f06aaL8-R8))
*  Add `data` argument to `benchmark` function to allow users to specify the validation dataset yaml file ([link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-bb5cf7919612f5a526e139896c15b09fba0cf48c14cfaf740566eb7d621aee7bL33-R56), [link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-c126129d1acbfd2e959449cfc21aa78cd3b1c64661368ca387341b3ee69b3520L246-R246), [link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-0aaacfa9e7ed54c1a6234cf053efec57da412817e8d8cf176f06e532359f06aaR47), [link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-0aaacfa9e7ed54c1a6234cf053efec57da412817e8d8cf176f06e532359f06aaR59), [link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-0aaacfa9e7ed54c1a6234cf053efec57da412817e8d8cf176f06e532359f06aaL109-R111))
*  Use `data` argument in `benchmark` function to override the default `TASK2DATA` dictionary if provided, or fall back to it otherwise ([link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-0aaacfa9e7ed54c1a6234cf053efec57da412817e8d8cf176f06e532359f06aaL109-R111))
*  Update `docs/modes/benchmark.md` and `docs/usage/python.md` to reflect the new `data` argument and show an example of its usage ([link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-bb5cf7919612f5a526e139896c15b09fba0cf48c14cfaf740566eb7d621aee7bL33-R56), [link](https://github.com/ultralytics/ultralytics/pull/3858/files?diff=unified&w=0#diff-c126129d1acbfd2e959449cfc21aa78cd3b1c64661368ca387341b3ee69b3520L246-R246))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced benchmarking functionality in Ultralytics with dataset specification.

### 📊 Key Changes
- Added `data` argument to `benchmark` method for specifying a dataset.
- Updated documentation to include the `data` argument in the benchmark examples.
- Ensured `benchmark` function uses the new `data` parameter, defaulting to `TASK2DATA[model.task]` if not provided.

### 🎯 Purpose & Impact
- **Purpose**: This change allows users to specify which dataset to use when benchmarking models, providing greater flexibility and control over the benchmarking process.
- **Impact**: Users can now benchmark models against different datasets more easily, which enhances experiment reproducibility and comparison across various benchmarks. It also ensures that benchmarks are more accurate by running them directly on the intended data.