### PR TITLE
Cleanup NCNN export files

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -432,16 +432,24 @@ class Exporter:
             Path(asset).unlink()  # delete zip
             pnnx.chmod(0o777)  # set read, write, and execute permissions for everyone
 
-        cmd = [
-            str(pnnx),
-            str(f_ts),
+        use_ncnn = True
+        ncnn_args = [
+            f'ncnnparam={f / "model.ncnn.param"}',
+            f'ncnnbin={f / "model.ncnn.bin"}',
+            f'ncnnpy={f / "model_ncnn.py"}', ] if use_ncnn else []
+
+        use_pnnx = False
+        pnnx_args = [
             f'pnnxparam={f / "model.pnnx.param"}',
             f'pnnxbin={f / "model.pnnx.bin"}',
             f'pnnxpy={f / "model_pnnx.py"}',
-            f'pnnxonnx={f / "model.pnnx.onnx"}',
-            f'ncnnparam={f / "model.ncnn.param"}',
-            f'ncnnbin={f / "model.ncnn.bin"}',
-            f'ncnnpy={f / "model_ncnn.py"}',
+            f'pnnxonnx={f / "model.pnnx.onnx"}', ] if use_pnnx else []
+
+        cmd = [
+            str(pnnx),
+            str(f_ts),
+            *ncnn_args,
+            *pnnx_args,
             f'fp16={int(self.args.half)}',
             f'device={self.device.type}',
             f'inputshape="{[self.args.batch, 3, *self.imgsz]}"', ]


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b814d07</samp>

### Summary
🔄🧠🚀

<!--
1.  🔄 This emoji can be used to indicate that the code was refactored or restructured, as it suggests a circular or rotational motion.
2.  🧠 This emoji can be used to indicate that the code was made more intelligent or adaptable, as it suggests brain power or cognition.
3.  🚀 This emoji can be used to indicate that the code was improved for performance or compatibility, as it suggests speed or launch.
-->
Refactored `exporter.py` to use boolean variables for NCNN and PNNX export options. Simplified the command construction and improved readability and flexibility.

> _`use_ncnn`, `use_pnnx`_
> _control the export formats_
> _refactor in spring_

### Walkthrough
*  Refactor code to use boolean variables for NCNN and PNNX export formats ([link](https://github.com/ultralytics/ultralytics/pull/3925/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL435-R452))
*  Separate NCNN and PNNX arguments into two lists and unpack them into the `cmd` list using the `*` operator ([link](https://github.com/ultralytics/ultralytics/pull/3925/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL435-R452))
*  Improve the readability and flexibility of the exporter module of the ultralytics repository, which provides tools for exporting YOLOv5 models to various platforms ([link](https://github.com/ultralytics/ultralytics/pull/3925/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL435-R452))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved export process for NCNN and PNNX in the Ultralytics AI framework.

### 📊 Key Changes
- Introduced boolean flags `use_ncnn` and `use_pnnx` to toggle the export process for different formats.
- Added separate argument lists for NCNN (`ncnn_args`) and PNNX (`pnnx_args`).
- Modified the command (`cmd`) to dynamically include arguments based on the selected export format.

### 🎯 Purpose & Impact
- 🎛 Provides flexibility to choose between exporting to NCNN and PNNX formats.
- ⚙️ Enhances the modularity of the code, allowing for clear distinctions and easier maintenance.
- 🚀 Potentially speeds up the export process by skipping unnecessary steps based on user requirements.