### PR TITLE
Fix `imgsz` in docs to integer to train, val

### DIFF
--- a/docs/modes/predict.md
+++ b/docs/modes/predict.md
@@ -295,6 +295,7 @@ All supported arguments:
 | `source`       | `'ultralytics/assets'` | source directory for images or videos                                          |
 | `conf`         | `0.25`                 | object confidence threshold for detection                                      |
 | `iou`          | `0.7`                  | intersection over union (IoU) threshold for NMS                                |
+| `imgsz`        | `640`                  | image size as scalar or (h, w) list, i.e. (640, 480)                           |
 | `half`         | `False`                | use half precision (FP16)                                                      |
 | `device`       | `None`                 | device to run on, i.e. cuda device=0/1/2/3 or device=cpu                       |
 | `show`         | `False`                | show results if possible                                                       |

--- a/docs/modes/train.md
+++ b/docs/modes/train.md
@@ -143,7 +143,7 @@ Training settings for YOLO models refer to the various hyperparameters and confi
 | `epochs`          | `100`    | number of epochs to train for                                                     |
 | `patience`        | `50`     | epochs to wait for no observable improvement for early stopping of training       |
 | `batch`           | `16`     | number of images per batch (-1 for AutoBatch)                                     |
-| `imgsz`           | `640`    | size of input images as integer or w,h                                            |
+| `imgsz`           | `640`    | size of input images as integer                                                   |
 | `save`            | `True`   | save train checkpoints and predict results                                        |
 | `save_period`     | `-1`     | Save checkpoint every x epochs (disabled if < 1)                                  |
 | `cache`           | `False`  | True/ram, disk or False. Use cache for data loading                               |

--- a/docs/modes/val.md
+++ b/docs/modes/val.md
@@ -48,7 +48,7 @@ Validation settings for YOLO models refer to the various hyperparameters and con
 | Key           | Value   | Description                                                        |
 |---------------|---------|--------------------------------------------------------------------|
 | `data`        | `None`  | path to data file, i.e. coco128.yaml                               |
-| `imgsz`       | `640`   | image size as scalar or (h, w) list, i.e. (640, 480)               |
+| `imgsz`       | `640`   | size of input images as integer                                    |
 | `batch`       | `16`    | number of images per batch (-1 for AutoBatch)                      |
 | `save_json`   | `False` | save results to JSON file                                          |
 | `save_hybrid` | `False` | save hybrid version of labels (labels + additional predictions)    |


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2360f2b</samp>

### Summary
:sparkles::hammer::hammer:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the case for the first change that adds a new argument to the documentation.
2.  :hammer: This emoji represents the modification or improvement of an existing feature or code, which is the case for the second change that simplifies the argument usage.
3.  :hammer: This emoji also represents the modification or improvement of an existing feature or code, which is the case for the third change that clarifies the argument description.
-->
This pull request updates the documentation of the `imgsz` argument for the prediction, training, and validation modes. It adds a new `imgsz` argument for the prediction mode in the `Inference Arguments` section, and changes the existing `imgsz` argument for the prediction mode in the `Arguments` section to accept only an integer.

> _`imgsz` argument_
> _changed from list to integer_
> _simpler in winter_

### Walkthrough
*  Add `imgsz` argument to `Inference Arguments` section of `docs/modes/predict.md` to allow custom image size for prediction mode ([link](https://github.com/ultralytics/ultralytics/pull/3941/files?diff=unified&w=0#diff-31a8e95fab032c4aff065cd0faacd330d81e4b154c017a7827c9f85d7f8dea49R298))
*  Simplify `imgsz` argument in `Arguments` section of `docs/modes/train.md` and `docs/modes/val.md` to accept only an integer as the image size for training and validation modes ([link](https://github.com/ultralytics/ultralytics/pull/3941/files?diff=unified&w=0#diff-4a4a3691b08dc4cb045c88d4405e25fe3e154c35ddf71370e94e336b5f3b417dL146-R146), [link](https://github.com/ultralytics/ultralytics/pull/3941/files?diff=unified&w=0#diff-74b90ccc22a7bc2090af95f3501c89ffe7b4c02228118951b3d32191d01a49ecL51-R51))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image size parameter handling for prediction, training, and validation modes in documentation.

### 📊 Key Changes
- Added a new `imgsz` parameter to the predict mode allowing specification of image size as either a scalar or a tuple (e.g., (640, 480)).
- Modified the `imgsz` parameter in the train and val modes documentation to specify image size strictly as an integer.

### 🎯 Purpose & Impact
- The addition in predict mode provides users with greater flexibility to define input image dimensions, allowing for potential improvement in model prediction performance or processing speed. 👩‍💻
- The clarification in train and val documentation ensures consistency in how users should input image size parameters, preventing confusion and potential errors. ✅