### PR TITLE
Create CI `workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,24 @@ on:
     branches: [main]
   schedule:
     - cron: '0 0 * * *'  # runs at 00:00 UTC every day
+  workflow_dispatch:
+    inputs:
+      hub:
+        description: 'Run HUB job'
+        default: true
+        type: boolean
+      tests:
+        description: 'Run Tests job'
+        default: true
+        type: boolean
+      benchmarks:
+        description: 'Run Benchmarks job'
+        default: true
+        type: boolean
 
 jobs:
   HUB:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tests == 'true'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -74,6 +88,7 @@ jobs:
           print(json.dumps(response.json(), indent=2))
 
   Benchmarks:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.benchmarks == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -126,6 +141,7 @@ jobs:
           echo "$(cat benchmarks.log)" >> $GITHUB_STEP_SUMMARY
 
   Tests:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.tests == 'true'
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,15 +14,15 @@ on:
     inputs:
       hub:
         description: 'Run HUB'
-        default: true
+        default: false
         type: boolean
       tests:
         description: 'Run Tests'
-        default: true
+        default: false
         type: boolean
       benchmarks:
         description: 'Run Benchmarks'
-        default: true
+        default: false
         type: boolean
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,15 +13,15 @@ on:
   workflow_dispatch:
     inputs:
       hub:
-        description: 'Run HUB job'
+        description: 'Run HUB'
         default: true
         type: boolean
       tests:
-        description: 'Run Tests job'
+        description: 'Run Tests'
         default: true
         type: boolean
       benchmarks:
-        description: 'Run Benchmarks job'
+        description: 'Run Benchmarks'
         default: true
         type: boolean
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 644983d</samp>

### Summary
🚀🔧🧪

<!--
1.  🚀 for adding the ability to manually trigger the CI workflow
2.  🔧 for using `workflow_dispatch` inputs and conditions to control the job execution
3.  🧪 for running the `HUB`, `Tests`, and `Benchmarks` jobs
-->
This change enables manual CI runs and job selection. It modifies the `.github/workflows/ci.yaml` file to use `workflow_dispatch` inputs and conditions.

> _`workflow_dispatch`_
> _Choose which jobs to run now_
> _A manual spring_

### Walkthrough
*  Add manual trigger option to CI workflow with inputs for HUB, Tests, and Benchmarks jobs ([link](https://github.com/ultralytics/ultralytics/pull/3954/files?diff=unified&w=0#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL13-R30))
*  Condition HUB job to run only if `hub` input is true or `workflow_dispatch` event is not triggered ([link](https://github.com/ultralytics/ultralytics/pull/3954/files?diff=unified&w=0#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL13-R30))
*  Condition Benchmarks job to run only if `benchmarks` input is true or `workflow_dispatch` event is not triggered ([link](https://github.com/ultralytics/ultralytics/pull/3954/files?diff=unified&w=0#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR91))
*  Condition Tests job to run only if `tests` input is true or `workflow_dispatch` event is not triggered ([link](https://github.com/ultralytics/ultralytics/pull/3954/files?diff=unified&w=0#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR144))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to CI Workflow Customization 🛠️

### 📊 Key Changes
- Added `workflow_dispatch` event with inputs for HUB, tests, and benchmarks to trigger workflows manually. 🕹
- Modified the conditionals in job definitions to accommodate manual triggers alongside scheduled and push triggers. ⚙️

### 🎯 Purpose & Impact
- **Purpose:** Enables more control over when and how GitHub Actions run, allowing manual execution of specific jobs like HUB, tests, and benchmarks. 🎛️
- **Impact:** Developers can now manually trigger CI tasks, which is useful for testing changes without waiting for automatic triggers (e.g., daily schedules or pushes). This ensures a more efficient development process and faster feedback. 📈