### PR TITLE
Add HUB URL environment variables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   HUB:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tests == 'true'))
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.hub == 'true'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -14,6 +14,9 @@ from ultralytics.utils.checks import check_file, check_imgsz, check_pip_update_a
 from ultralytics.utils.downloads import GITHUB_ASSET_STEMS
 from ultralytics.utils.torch_utils import smart_inference_mode
 
+from ultralytics.data.utils import HUBDatasetStats
+from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT
+
 
 class Model:
     """
@@ -100,7 +103,7 @@ class Model:
     def is_hub_model(model):
         """Check if the provided model is a HUB model."""
         return any((
-            model.startswith('https://hub.ultralytics.com/models/'),  # i.e. https://hub.ultralytics.com/models/MODEL_ID
+            model.startswith(f'{HUB_WEB_ROOT}/models/'),  # i.e. https://hub.ultralytics.com/models/MODEL_ID
             [len(x) for x in model.split('_')] == [42, 20],  # APIKEY_MODELID
             len(model) == 20 and not Path(model).exists() and all(x not in model for x in './\\')))  # MODELID
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -6,9 +6,8 @@ from pathlib import Path
 from typing import Union
 
 from ultralytics.cfg import get_cfg
-from ultralytics.data.utils import HUBDatasetStats
 from ultralytics.engine.exporter import Exporter
-from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT
+from ultralytics.hub.utils import HUB_WEB_ROOT
 from ultralytics.nn.tasks import attempt_load_one_weight, guess_model_task, nn, yaml_model_load
 from ultralytics.utils import (DEFAULT_CFG, DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER, RANK, ROOT, callbacks,
                                is_git_dir, yaml_load)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -6,16 +6,15 @@ from pathlib import Path
 from typing import Union
 
 from ultralytics.cfg import get_cfg
+from ultralytics.data.utils import HUBDatasetStats
 from ultralytics.engine.exporter import Exporter
+from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT
 from ultralytics.nn.tasks import attempt_load_one_weight, guess_model_task, nn, yaml_model_load
 from ultralytics.utils import (DEFAULT_CFG, DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER, RANK, ROOT, callbacks,
                                is_git_dir, yaml_load)
 from ultralytics.utils.checks import check_file, check_imgsz, check_pip_update_available, check_yaml
 from ultralytics.utils.downloads import GITHUB_ASSET_STEMS
 from ultralytics.utils.torch_utils import smart_inference_mode
-
-from ultralytics.data.utils import HUBDatasetStats
-from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT
 
 
 class Model:

--- a/ultralytics/hub/__init__.py
+++ b/ultralytics/hub/__init__.py
@@ -4,7 +4,7 @@ import requests
 
 from ultralytics.data.utils import HUBDatasetStats
 from ultralytics.hub.auth import Auth
-from ultralytics.hub.utils import PREFIX, HUB_API_ROOT, HUB_WEB_ROOT
+from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT, PREFIX
 from ultralytics.utils import LOGGER, SETTINGS, USER_CONFIG_DIR, yaml_save
 
 

--- a/ultralytics/hub/__init__.py
+++ b/ultralytics/hub/__init__.py
@@ -4,7 +4,7 @@ import requests
 
 from ultralytics.data.utils import HUBDatasetStats
 from ultralytics.hub.auth import Auth
-from ultralytics.hub.utils import PREFIX
+from ultralytics.hub.utils import PREFIX, HUB_API_ROOT, HUB_WEB_ROOT
 from ultralytics.utils import LOGGER, SETTINGS, USER_CONFIG_DIR, yaml_save
 
 
@@ -50,13 +50,13 @@ WARNING ⚠️ ultralytics.start() is deprecated after 8.0.60. Updated usage to 
 from ultralytics import YOLO, hub
 
 hub.login('{api_key}')
-model = YOLO('https://hub.ultralytics.com/models/{model_id}')
+model = YOLO('{HUB_WEB_ROOT}/models/{model_id}')
 model.train()""")
 
 
 def reset_model(model_id=''):
     """Reset a trained model to an untrained state."""
-    r = requests.post('https://api.ultralytics.com/model-reset', json={'apiKey': Auth().api_key, 'modelId': model_id})
+    r = requests.post(f'{HUB_API_ROOT}/model-reset', json={'apiKey': Auth().api_key, 'modelId': model_id})
     if r.status_code == 200:
         LOGGER.info(f'{PREFIX}Model reset successfully')
         return
@@ -72,7 +72,7 @@ def export_fmts_hub():
 def export_model(model_id='', format='torchscript'):
     """Export a model to all formats."""
     assert format in export_fmts_hub(), f"Unsupported export format '{format}', valid formats are {export_fmts_hub()}"
-    r = requests.post(f'https://api.ultralytics.com/v1/models/{model_id}/export',
+    r = requests.post(f'{HUB_API_ROOT}/v1/models/{model_id}/export',
                       json={'format': format},
                       headers={'x-api-key': Auth().api_key})
     assert r.status_code == 200, f'{PREFIX}{format} export failure {r.status_code} {r.reason}'
@@ -82,7 +82,7 @@ def export_model(model_id='', format='torchscript'):
 def get_export(model_id='', format='torchscript'):
     """Get an exported model dictionary with download URL."""
     assert format in export_fmts_hub(), f"Unsupported export format '{format}', valid formats are {export_fmts_hub()}"
-    r = requests.post('https://api.ultralytics.com/get-export',
+    r = requests.post(f'{HUB_API_ROOT}/get-export',
                       json={
                           'apiKey': Auth().api_key,
                           'modelId': model_id,
@@ -110,7 +110,7 @@ def check_dataset(path='', task='detect'):
         ```
     """
     HUBDatasetStats(path=path, task=task).get_json()
-    LOGGER.info('Checks completed correctly ✅. Upload this dataset to https://hub.ultralytics.com/datasets/.')
+    LOGGER.info(f'Checks completed correctly ✅. Upload this dataset to {HUB_WEB_ROOT}/datasets/.')
 
 
 if __name__ == '__main__':

--- a/ultralytics/hub/auth.py
+++ b/ultralytics/hub/auth.py
@@ -2,10 +2,10 @@
 
 import requests
 
-from ultralytics.hub.utils import HUB_API_ROOT, PREFIX, request_with_credentials
+from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT, PREFIX, request_with_credentials
 from ultralytics.utils import LOGGER, SETTINGS, emojis, is_colab
 
-API_KEY_URL = 'https://hub.ultralytics.com/settings?tab=api+keys'
+API_KEY_URL = f'{HUB_WEB_ROOT}/settings?tab=api+keys'
 
 
 class Auth:

--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -6,7 +6,7 @@ from time import sleep
 
 import requests
 
-from ultralytics.hub.utils import HUB_API_ROOT, PREFIX, smart_request
+from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT, PREFIX, smart_request
 from ultralytics.utils import LOGGER, __version__, checks, emojis, is_colab, threaded
 from ultralytics.utils.errors import HUBModelError
 
@@ -49,21 +49,21 @@ class HUBTrainingSession:
         from ultralytics.hub.auth import Auth
 
         # Parse input
-        if url.startswith('https://hub.ultralytics.com/models/'):
-            url = url.split('https://hub.ultralytics.com/models/')[-1]
+        if url.startswith(f'{HUB_WEB_ROOT}/models/'):
+            url = url.split(f'{HUB_WEB_ROOT}/models/')[-1]
         if [len(x) for x in url.split('_')] == [42, 20]:
             key, model_id = url.split('_')
         elif len(url) == 20:
             key, model_id = '', url
         else:
             raise HUBModelError(f"model='{url}' not found. Check format is correct, i.e. "
-                                f"model='https://hub.ultralytics.com/models/MODEL_ID' and try again.")
+                                f"model='{HUB_WEB_ROOT}/models/MODEL_ID' and try again.")
 
         # Authorize
         auth = Auth(key)
         self.agent_id = None  # identifies which instance is communicating with server
         self.model_id = model_id
-        self.model_url = f'https://hub.ultralytics.com/models/{model_id}'
+        self.model_url = f'{HUB_WEB_ROOT}/models/{model_id}'
         self.api_url = f'{HUB_API_ROOT}/v1/models/{model_id}'
         self.auth_header = auth.get_auth_header()
         self.rate_limits = {'metrics': 3.0, 'ckpt': 900.0, 'heartbeat': 300.0}  # rate limits (seconds)

--- a/ultralytics/hub/utils.py
+++ b/ultralytics/hub/utils.py
@@ -18,6 +18,7 @@ from ultralytics.utils.downloads import GITHUB_ASSET_NAMES
 PREFIX = colorstr('Ultralytics HUB: ')
 HELP_MSG = 'If this issue persists please visit https://github.com/ultralytics/hub/issues for assistance.'
 HUB_API_ROOT = os.environ.get('ULTRALYTICS_HUB_API', 'https://api.ultralytics.com')
+HUB_WEB_ROOT = os.environ.get('ULTRALYTICS_HUB_WEB', 'https://hub.ultralytics.com')
 
 
 def request_with_credentials(url: str) -> any:

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -13,7 +13,7 @@ def on_pretrain_routine_end(trainer):
     session = getattr(trainer, 'hub_session', None)
     if session:
         # Start timer for upload rate limit
-        LOGGER.info(f'{PREFIX}View model at https://hub.ultralytics.com/models/{session.model_id} 🚀')
+        LOGGER.info(f'{PREFIX}View model at {HUB_WEB_ROOT}/models/{session.model_id} 🚀')
         session.timers = {'metrics': time(), 'ckpt': time()}  # start timer on session.rate_limit
 
 
@@ -39,7 +39,7 @@ def on_model_save(trainer):
         # Upload checkpoints with rate limiting
         is_best = trainer.best_fitness == trainer.fitness
         if time() - session.timers['ckpt'] > session.rate_limits['ckpt']:
-            LOGGER.info(f'{PREFIX}Uploading checkpoint https://hub.ultralytics.com/models/{session.model_id}')
+            LOGGER.info(f'{PREFIX}Uploading checkpoint {HUB_WEB_ROOT}/models/{session.model_id}')
             session.upload_model(trainer.epoch, trainer.last, is_best)
             session.timers['ckpt'] = time()  # reset timer
 
@@ -53,7 +53,7 @@ def on_train_end(trainer):
         session.upload_model(trainer.epoch, trainer.best, map=trainer.metrics.get('metrics/mAP50-95(B)', 0), final=True)
         session.alive = False  # stop heartbeats
         LOGGER.info(f'{PREFIX}Done ✅\n'
-                    f'{PREFIX}View model at https://hub.ultralytics.com/models/{session.model_id} 🚀')
+                    f'{PREFIX}View model at {HUB_WEB_ROOT}/models/{session.model_id} 🚀')
 
 
 def on_train_start(trainer):

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -3,7 +3,7 @@
 import json
 from time import time
 
-from ultralytics.hub.utils import PREFIX, events
+from ultralytics.hub.utils import HUB_WEB_ROOT, PREFIX, events
 from ultralytics.utils import LOGGER, SETTINGS
 from ultralytics.utils.torch_utils import model_info_for_loggers
 


### PR DESCRIPTION
This PR allows developers to set the HUB_API_ROOT and HUB_WEB_ROOT. This allows developers to not only use the pip package with the production HUB but also with the development and staging HUB.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring and simplification of web and API URLs for Ultralytics services.

### 📊 Key Changes
- CI condition updated to trigger HUB jobs based on `hub` input rather than `tests`.
- Use of a new `HUB_WEB_ROOT` constant to standardize web URL generation for model access and interactions.
- Shifted API interactions to utilize a new `HUB_API_ROOT` constant for consistent API endpoint construction.
- Simplified the way model URLs are constructed and verified within various modules.

### 🎯 Purpose & Impact
- 🚀 **Consistency**: Centralizing web and API root URLs makes the codebase more maintainable and reduces the chance of typos or inconsistent URL usage.
- 🛠️ **Maintainability**: Future updates to the base URLs now require changes in only one location, reducing the effort needed for updates.
- 🌍 **User Transparency**: These changes are primarily internal; end users will experience no direct impact, but they may benefit indirectly through more stable and maintainable code.