### PR TITLE
Add `kpt_radius` plotting arg to Results object

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -76,7 +76,6 @@ class Results(SimpleClass):
         probs (torch.tensor, optional): A 1D tensor of probabilities of each class for classification task.
         keypoints (List[List[float]], optional): A list of detected keypoints for each object.
 
-
     Attributes:
         orig_img (numpy.ndarray): The original image as a numpy array.
         orig_shape (tuple): The original image shape in (height, width) format.

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -191,7 +191,7 @@ class Results(SimpleClass):
             pil (bool): Whether to return the image as a PIL Image.
             img (numpy.ndarray): Plot to another image. if not, plot to original image.
             im_gpu (torch.Tensor): Normalized image in gpu with shape (1, 3, 640, 640), for faster mask plotting.
-	    kpt_radius (int, optional): Radius of the drawn keypoints. Default is 5.
+            kpt_radius (int, optional): Radius of the drawn keypoints. Default is 5.
             kpt_line (bool): Whether to draw lines connecting keypoints.
             labels (bool): Whether to plot the label of bounding boxes.
             boxes (bool): Whether to plot the bounding boxes.

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -191,7 +191,7 @@ class Results(SimpleClass):
             pil (bool): Whether to return the image as a PIL Image.
             img (numpy.ndarray): Plot to another image. if not, plot to original image.
             im_gpu (torch.Tensor): Normalized image in gpu with shape (1, 3, 640, 640), for faster mask plotting.
-			kpt_radius (int, optional): Radius of the drawn keypoints. Default is 5.
+	    kpt_radius (int, optional): Radius of the drawn keypoints. Default is 5.
             kpt_line (bool): Whether to draw lines connecting keypoints.
             labels (bool): Whether to plot the label of bounding boxes.
             boxes (bool): Whether to plot the bounding boxes.

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -172,6 +172,7 @@ class Results(SimpleClass):
             pil=False,
             img=None,
             im_gpu=None,
+			kpt_radius=5,
             kpt_line=True,
             labels=True,
             boxes=True,
@@ -190,6 +191,7 @@ class Results(SimpleClass):
             pil (bool): Whether to return the image as a PIL Image.
             img (numpy.ndarray): Plot to another image. if not, plot to original image.
             im_gpu (torch.Tensor): Normalized image in gpu with shape (1, 3, 640, 640), for faster mask plotting.
+			kpt_radius (int, optional): Radius of the drawn keypoints. Default is 5.
             kpt_line (bool): Whether to draw lines connecting keypoints.
             labels (bool): Whether to plot the label of bounding boxes.
             boxes (bool): Whether to plot the bounding boxes.
@@ -251,7 +253,7 @@ class Results(SimpleClass):
         # Plot Pose results
         if self.keypoints is not None:
             for k in reversed(self.keypoints.data):
-                annotator.kpts(k, self.orig_shape, kpt_line=kpt_line)
+                annotator.kpts(k, self.orig_shape, radius=kpt_radius, kpt_line=kpt_line)
 
         return annotator.result()
 

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -172,7 +172,7 @@ class Results(SimpleClass):
             pil=False,
             img=None,
             im_gpu=None,
-			kpt_radius=5,
+            kpt_radius=5,
             kpt_line=True,
             labels=True,
             boxes=True,


### PR DESCRIPTION
Add the ability to control keypoint radius when calling plot.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cd45a9a</samp>

### Summary
🆕📝🎨

<!--
1.  🆕 for adding a new feature
2.  📝 for updating the documentation
3.  🎨 for improving the visual appearance of the plot
-->
This pull request enhances the `Results` class with a new `radius` parameter for keypoints. It also updates the `plot` method and the documentation to reflect this change.

> _Unleash the power of the `Results`_
> _Plot your vision with custom radius_
> _No more default keypoints on your images_
> _You are the master of your analysis_

### Walkthrough
*  Add `kpt_radius` attribute to `Results` class to customize keypoint size ([link](https://github.com/ultralytics/ultralytics/pull/4022/files?diff=unified&w=0#diff-24af401e53ffc5ce49197395e1e3d7111344ad31b08cbb2bee9377614da98955R175), [link](https://github.com/ultralytics/ultralytics/pull/4022/files?diff=unified&w=0#diff-24af401e53ffc5ce49197395e1e3d7111344ad31b08cbb2bee9377614da98955R194))
*  Use `kpt_radius` attribute in `plot` method of `Results` class to draw keypoints with user-defined radius ([link](https://github.com/ultralytics/ultralytics/pull/4022/files?diff=unified&w=0#diff-24af401e53ffc5ce49197395e1e3d7111344ad31b08cbb2bee9377614da98955L254-R256))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to keypoints visualization in Ultralytics' results plotting.

### 📊 Key Changes
- Removed an unnecessary blank line in the `Results` class documentation.
- Added a new `kpt_radius` parameter to the `plot` function, allowing for adjustable keypoint radius.
- Updated the `plot` function's call to `annotator.kpts` to utilize the new `kpt_radius` parameter.

### 🎯 Purpose & Impact
- 🧹 The minor cleanup improves code readability and maintainability.
- 🎨 The new `kpt_radius` parameter gives users flexibility to choose the size of keypoints when visualizing results, improving the utility and customizability of the plotting function.
- 🔍 This change enhances the user experience by allowing better tailoring of visual outputs to suit different purposes, such as presentations or detailed analyses.