### PR TITLE
Fix issue when config dir is created even if YOLO_CONFIG_DIR is set

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -568,9 +568,10 @@ def get_user_config_dir(sub_dir='Ultralytics'):
         raise ValueError(f'Unsupported operating system: {platform.system()}')
 
     # GCP and AWS lambda fix, only /tmp is writeable
-    if not is_dir_writeable(str(path.parent)):
-        path = Path('/tmp') / sub_dir
-        LOGGER.warning(f"WARNING ⚠️ user config directory is not writeable, defaulting to '{path}'.")
+    if not is_dir_writeable(path.parent):
+        LOGGER.warning(f"WARNING ⚠️ user config directory {path} is not writeable, defaulting to '/tmp' or CWD."
+                       f'Alternatively you can define a YOLO_CONFIG_DIR environment variable for this path.')
+        path = Path('/tmp') / sub_dir if is_dir_writeable('/tmp') else Path().cwd() / sub_dir
 
     # Create the subdirectory if it does not exist
     path.mkdir(parents=True, exist_ok=True)
@@ -578,13 +579,7 @@ def get_user_config_dir(sub_dir='Ultralytics'):
     return path
 
 
-# Ultralytics settings dir, avoid calling function in any case
-USER_CONFIG_DIR = os.getenv('YOLO_CONFIG_DIR')
-if USER_CONFIG_DIR is None:
-    USER_CONFIG_DIR = Path(get_user_config_dir())
-else:
-    USER_CONFIG_DIR = Path(USER_CONFIG_DIR)
-
+USER_CONFIG_DIR = Path(os.getenv('YOLO_CONFIG_DIR') or get_user_config_dir())  # Ultralytics settings dir
 SETTINGS_YAML = USER_CONFIG_DIR / 'settings.yaml'
 
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -578,7 +578,13 @@ def get_user_config_dir(sub_dir='Ultralytics'):
     return path
 
 
-USER_CONFIG_DIR = Path(os.getenv('YOLO_CONFIG_DIR', get_user_config_dir()))  # Ultralytics settings dir
+# Ultralytics settings dir, avoid calling function in any case
+USER_CONFIG_DIR = os.getenv('YOLO_CONFIG_DIR')
+if USER_CONFIG_DIR is None:
+    USER_CONFIG_DIR = Path(get_user_config_dir())
+else:
+    USER_CONFIG_DIR = Path(USER_CONFIG_DIR)
+
 SETTINGS_YAML = USER_CONFIG_DIR / 'settings.yaml'
 
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -569,8 +569,8 @@ def get_user_config_dir(sub_dir='Ultralytics'):
 
     # GCP and AWS lambda fix, only /tmp is writeable
     if not is_dir_writeable(path.parent):
-        LOGGER.warning(f"WARNING ⚠️ user config directory {path} is not writeable, defaulting to '/tmp' or CWD."
-                       f'Alternatively you can define a YOLO_CONFIG_DIR environment variable for this path.')
+        LOGGER.warning(f"WARNING ⚠️ user config directory '{path}' is not writeable, defaulting to '/tmp' or CWD."
+                       'Alternatively you can define a YOLO_CONFIG_DIR environment variable for this path.')
         path = Path('/tmp') / sub_dir if is_dir_writeable('/tmp') else Path().cwd() / sub_dir
 
     # Create the subdirectory if it does not exist


### PR DESCRIPTION
This also fixed crash when /tmp is not writeable.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ffb27d9</samp>

### Summary
🚀🌎🛠️

<!--
1.  🚀 This emoji can be used to indicate that the change is a performance improvement or a speed boost, as the rocket symbolizes fast and efficient movement.
2.  🌎 This emoji can be used to indicate that the change is related to environment variables or global settings, as the earth symbolizes the scope and impact of these variables.
3.  🛠️ This emoji can be used to indicate that the change is a bug fix or a minor adjustment, as the hammer and wrench symbolize tools for repairing or tweaking something.
-->
Improved user configuration handling in `ultralytics/utils/__init__.py`. Used `Path` constructor and checked `YOLO_CONFIG_DIR` environment variable before calling `get_user_config_dir()` function.

> _`USER_CONFIG_DIR`_
> _Faster and safer with `Path`_
> _Autumn leaves no trace_

### Walkthrough
* Improve performance and avoid conflicts by checking environment variable before calling function (`[link](https://github.com/ultralytics/ultralytics/pull/4054/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faL581-R587)`)




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced configuration directory handling with fallback options for limited file system permissions.

### 📊 Key Changes
- Improved check for directory writability to use `path.parent` directly.
- Added additional feedback in error messages to guide users in case of inadequate directory permissions.
- Implemented a conditional fallback to use the current working directory (`Path().cwd()`) if neither the usual config directory nor `/tmp` is writable.
- Refined the assignment of `USER_CONFIG_DIR` to use an environment variable `YOLO_CONFIG_DIR` if set, otherwise it calls the `get_user_config_dir()` function.

### 🎯 Purpose & Impact
- 🛠️ Ensures that the application can still function and save necessary configuration files even if the default directories are not writable, increasing robustness.
- 🌐 Offers a more user-friendly experience by providing helpful error messages and automatic fallback solutions.
- 🚀 Potential to reduce user friction in environments with strict permissions, such as cloud platforms or server environments, making it easier for a wider audience to use Ultralytics software.