### PR TITLE
Bump slackapi/slack-github-action from 1.23.0 to 1.24.0

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Notify on failure
         if: github.event_name == 'push' && (cancelled() || failure())
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |
             {"text": "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"}

--- a/docs/datasets/detect/coco.md
+++ b/docs/datasets/detect/coco.md
@@ -21,7 +21,7 @@ The COCO dataset is split into three subsets:
 
 1. **Train2017**: This subset contains 118K images for training object detection, segmentation, and captioning models.
 2. **Val2017**: This subset has 5K images used for validation purposes during model training.
-3. **Test2017**: This subset consists of 20K images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://competitions.codalab.org/competitions/5181) for performance evaluation.
+3. **Test2017**: This subset consists of 20K images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7384) for performance evaluation.
 
 ## Applications
 

--- a/docs/datasets/pose/coco.md
+++ b/docs/datasets/pose/coco.md
@@ -22,7 +22,7 @@ The COCO-Pose dataset is split into three subsets:
 
 1. **Train2017**: This subset contains a portion of the 118K images from the COCO dataset, annotated for training pose estimation models.
 2. **Val2017**: This subset has a selection of images used for validation purposes during model training.
-3. **Test2017**: This subset consists of images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://competitions.codalab.org/competitions/5181) for performance evaluation.
+3. **Test2017**: This subset consists of images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7384) for performance evaluation.
 
 ## Applications
 

--- a/docs/datasets/segment/coco.md
+++ b/docs/datasets/segment/coco.md
@@ -21,7 +21,7 @@ The COCO-Seg dataset is partitioned into three subsets:
 
 1. **Train2017**: This subset contains 118K images for training instance segmentation models.
 2. **Val2017**: This subset includes 5K images used for validation purposes during model training.
-3. **Test2017**: This subset encompasses 20K images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://competitions.codalab.org/competitions/5181) for performance evaluation.
+3. **Test2017**: This subset encompasses 20K images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7383) for performance evaluation.
 
 ## Applications
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -568,9 +568,10 @@ def get_user_config_dir(sub_dir='Ultralytics'):
         raise ValueError(f'Unsupported operating system: {platform.system()}')
 
     # GCP and AWS lambda fix, only /tmp is writeable
-    if not is_dir_writeable(str(path.parent)):
-        path = Path('/tmp') / sub_dir
-        LOGGER.warning(f"WARNING ⚠️ user config directory is not writeable, defaulting to '{path}'.")
+    if not is_dir_writeable(path.parent):
+        LOGGER.warning(f"WARNING ⚠️ user config directory '{path}' is not writeable, defaulting to '/tmp' or CWD."
+                       'Alternatively you can define a YOLO_CONFIG_DIR environment variable for this path.')
+        path = Path('/tmp') / sub_dir if is_dir_writeable('/tmp') else Path().cwd() / sub_dir
 
     # Create the subdirectory if it does not exist
     path.mkdir(parents=True, exist_ok=True)
@@ -578,7 +579,7 @@ def get_user_config_dir(sub_dir='Ultralytics'):
     return path
 
 
-USER_CONFIG_DIR = Path(os.getenv('YOLO_CONFIG_DIR', get_user_config_dir()))  # Ultralytics settings dir
+USER_CONFIG_DIR = Path(os.getenv('YOLO_CONFIG_DIR') or get_user_config_dir())  # Ultralytics settings dir
 SETTINGS_YAML = USER_CONFIG_DIR / 'settings.yaml'
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4444009</samp>

### Summary
:arrow_up::link::bug:

<!--
1.  :arrow_up: for updating the slack-github-action version.
2.  :link: for fixing the broken links to the COCO evaluation servers.
3.  :bug: for fixing the bugs in the slack-github-action.
-->
This pull request updates the slack-github-action version in the docker workflow and fixes the broken links to the COCO evaluation servers in the docs for the detect, pose, and segment datasets. These changes improve the reliability and accuracy of the documentation and the notification system.

> _`slack-github-action`_
> _Updated for better alerts_
> _A useful fix_

### Walkthrough
*  Update slack-github-action to v1.15.0 in `.github/workflows/docker.yaml` ([link](https://github.com/ultralytics/ultralytics/pull/4066/files?diff=unified&w=0#diff-17e3400d876978d12bbad517dcf82312b54fa62723408b1ce011b2755458bdafL89-R89))
*  Fix broken links to COCO evaluation server for detect, pose, and segment datasets in `docs/datasets` ([link](https://github.com/ultralytics/ultralytics/pull/4066/files?diff=unified&w=0#diff-3be162f9bc4e41934566fdb055cf4c4bf915607560239a468f17d35ca18a82dcL24-R24), [link](https://github.com/ultralytics/ultralytics/pull/4066/files?diff=unified&w=0#diff-1df15b484f9a51df9ca5427b468f97c9f82f8e3509a3b0c4bcbad9abdc8f5d83L25-R25), [link](https://github.com/ultralytics/ultralytics/pull/4066/files?diff=unified&w=0#diff-56e06d127bef7fff032e5a8ca7a9cb9e2ad171a79346a9416645a564a6c35225L24-R24))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updating Slack GitHub Action and COCO evaluation server links in documentation.

### 📊 Key Changes
- Updated the Slack GitHub Action version from `v1.23.0` to `v1.24.0`.
- Changed the COCO evaluation server links to a new URL in the documentation for the detect, pose, and segment sections.

### 🎯 Purpose & Impact
- **GitHub Action Update**: Ensures the GitHub Action for Slack notifications uses the latest version, which might include bug fixes, new features, or performance improvements.
- **COCO Links Update**: Provides users with the correct links to the COCO evaluation server, ensuring developers can continue to benchmark their models accurately without hitting dead links. This is crucial for the AI community relying on COCO dataset benchmarks. 📈