### PR TITLE
Removed redundency in RTDETRDecoder

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -318,7 +318,7 @@ class RTDETRDecoder(nn.Module):
         top_k_features = features[batch_ind, topk_ind].view(bs, self.num_queries, -1)
         # (bs, num_queries, 4)
         top_k_anchors = anchors[:, topk_ind].view(bs, self.num_queries, -1)
-        
+
         refer_bbox = self.enc_bbox_head(top_k_features) + top_k_anchors
 
         enc_bboxes = refer_bbox.sigmoid()

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -307,8 +307,6 @@ class RTDETRDecoder(nn.Module):
         features = self.enc_output(valid_mask * feats)  # bs, h*w, 256
 
         enc_outputs_scores = self.enc_score_head(features)  # (bs, h*w, nc)
-        # dynamic anchors + static content
-        enc_outputs_bboxes = self.enc_bbox_head(features) + anchors  # (bs, h*w, 4)
 
         # query selection
         # (bs, num_queries)
@@ -316,9 +314,12 @@ class RTDETRDecoder(nn.Module):
         # (bs, num_queries)
         batch_ind = torch.arange(end=bs, dtype=topk_ind.dtype).unsqueeze(-1).repeat(1, self.num_queries).view(-1)
 
-        # Unsigmoided
-        refer_bbox = enc_outputs_bboxes[batch_ind, topk_ind].view(bs, self.num_queries, -1)
-        # refer_bbox = torch.gather(enc_outputs_bboxes, 1, topk_ind.reshape(bs, self.num_queries).unsqueeze(-1).repeat(1, 1, 4))
+        # (bs, num_queries, 256)
+        top_k_features = features[batch_ind, topk_ind].view(bs, self.num_queries, -1)
+        # (bs, num_queries, 4)
+        top_k_anchors = anchors[:, topk_ind].view(bs, self.num_queries, -1)
+        
+        refer_bbox = self.enc_bbox_head(top_k_features) + top_k_anchors
 
         enc_bboxes = refer_bbox.sigmoid()
         if dn_bbox is not None:
@@ -330,7 +331,7 @@ class RTDETRDecoder(nn.Module):
         if self.learnt_init_query:
             embeddings = self.tgt_embed.weight.unsqueeze(0).repeat(bs, 1, 1)
         else:
-            embeddings = features[batch_ind, topk_ind].view(bs, self.num_queries, -1)
+            embeddings = top_k_features
             if self.training:
                 embeddings = embeddings.detach()
         if dn_embed is not None:


### PR DESCRIPTION
Changed the order of operations in RTDETRDecoder._get_decoder_input
By first selecting the top k features and selecting the top k anchors, one can reduce the input to the linear layer by a large margin.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 685aac3</samp>

### Summary
:zap::top::broom:

<!--
1.  :zap: This emoji means "fast, high speed, or lightning" and can be used to indicate that the changes improve the efficiency and performance of the module.
2.  :top: This emoji means "top" or "highest" and can be used to indicate that the changes use the top k features and anchors from the encoder output logits.
3.  :broom: This emoji means "broom" or "cleaning" and can be used to indicate that the changes simplify and clean up some redundant or unnecessary code.
-->
This pull request enhances the `encoder_bbox_head` module to use more relevant features and anchors for bounding box prediction. It also removes some redundant or unnecessary code from `ultralytics/nn/modules/head.py`.

> _`encoder_bbox_head`_
> _Faster with top k features_
> _Winter pruning code_

### Walkthrough
*  Use top k features and anchors instead of encoder output bboxes for decoder input and loss computation ([link](https://github.com/ultralytics/ultralytics/pull/4118/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L310-L311), [link](https://github.com/ultralytics/ultralytics/pull/4118/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L319-R322), [link](https://github.com/ultralytics/ultralytics/pull/4118/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L333-R334))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of encoder-to-decoder data flow in the Ultralytics neural network architecture.

### 📊 Key Changes
- Removed the addition of anchors at every encoder output position, now adding dynamically generated anchors only to selected top-k positions.
- Avoided redundant computation by sharing the computation between reference bounding boxes and embedding features for non-learnt queries.
- Ensured detachment of certain tensors during training to prevent undesired gradient calculations.

### 🎯 Purpose & Impact
- 🔍 **Increased Efficiency:** Focusing computation on top-k features reduces computational load and potentially increases inference speed.
- 🛠️ **Code Simplification:** The changes simplify the data preparation process from encoder to decoder, making the code more maintainable.
- 🏋️‍♂️ **Training Stability:** Detaching specific tensors during training helps in avoiding unintended backpropagation, leading to more stable training updates.