### PR TITLE
fix #11933

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -293,7 +293,7 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(''), on_plot=None):
 
 def save_one_box(xyxy, im, file=Path('im.jpg'), gain=1.02, pad=10, square=False, BGR=False, save=True):
     """Save image crop as {file} with crop size multiple {gain} and {pad} pixels. Save and/or return crop."""
-    b = xyxy2xywh(xyxy.view(-1, 4))  # boxes
+    b = xyxy2xywh(torch.stack(xyxy).view(-1, 4))  # boxes
     if square:
         b[:, 2:] = b[:, 2:].max(1)[0].unsqueeze(1)  # attempt rectangle to square
     b[:, 2:] = b[:, 2:] * gain + pad  # box wh * gain + pad


### PR DESCRIPTION
Fixed:  return and saved results as detections crops using results.crop(save=True) #11933 

https://github.com/ultralytics/yolov5/issues/11933

I have read the CLA Document and I sign the CLA

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 05ed2a5</samp>

### Summary
🐛📷🚀

<!--
1.  🐛 - This emoji represents a bug fix, as the change resolves an error that prevented the image cropping from working properly.
2.  📷 - This emoji represents a camera, as the change relates to the image cropping functionality of the plotting module, which is used to visualize the results of the object detection model.
3.  🚀 - This emoji represents a rocket, as the change is part of a pull request that improves the performance and usability of the image cropping feature, making it faster and more flexible.
-->
Fix a bug in `plotting.py` that prevented saving cropped images. Stack the list of `xyxy` tensors before converting to `xywh` format.

> _Stack `xyxy` list_
> _Fix bug in image cropping_
> _Autumn leaves falling_

### Walkthrough
* Fix bug in image cropping by stacking list of tensors before calling `xyxy2xywh` ([link](https://github.com/ultralytics/ultralytics/pull/4119/files?diff=unified&w=0#diff-471dc6902e48f880561beca675bfee38e440de6cd49a3de9432de27305d3cc6bL296-R296))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving image cropping functionality in Ultralytics utilities.

### 📊 Key Changes
- Fixed a bug in the `save_one_box` function by ensuring input coordinates are correctly converted to a tensor before manipulation.

### 🎯 Purpose & Impact
- 🛠 Ensures greater reliability and accuracy when the function is used for image cropping, thereby enhancing the quality of saved image crops.
- 📸 Users can expect consistent and correct output images when specifying crop regions, which is crucial for tasks like dataset preparation and augmentation in machine learning projects.