### PR TITLE
Mark DVC `trainer.best` artifact as `type=model`

### DIFF
--- a/ultralytics/utils/callbacks/dvc.py
+++ b/ultralytics/utils/callbacks/dvc.py
@@ -123,7 +123,7 @@ def on_train_end(trainer):
         _log_confusion_matrix(trainer.validator)
 
         if trainer.best.exists():
-            live.log_artifact(trainer.best, copy=True)
+            live.log_artifact(trainer.best, copy=True, type='model')
 
         live.end()
 


### PR DESCRIPTION
This will automatically make the artifact visible in the [DVC Studio Model Registry](https://dvc.org/doc/studio/user-guide/model-registry/what-is-a-model-registry)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of artifact logging during model training.

### 📊 Key Changes
- Added the artifact type `model` to `log_artifact` call for better clarity.

### 🎯 Purpose & Impact
- Purpose: To specify that the best model saved during training is indeed a model artifact, which could help in artifact categorization and retrieval.
- Impact: Improves the organization and tracking of logged artifacts in the Ultralytics framework, thus aiding users in managing their machine learning models more effectively. 🏷️✨