### PR TITLE
Add `retry` option to `get_github_assets()` function

### DIFF
--- a/docs/modes/predict.md
+++ b/docs/modes/predict.md
@@ -410,7 +410,7 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 | `save_crop()`   | `None`          | Save cropped predictions to `save_dir/cls/file_name.jpg`.                           |
 | `tojson()`      | `None`          | Convert the object to JSON format.                                                  |
 
-For more details see the `Results` class [documentation](../reference/engine/results.md#-results).
+For more details see the `Results` class [documentation](../reference/engine/results.md).
 
 ### Boxes
 
@@ -448,7 +448,7 @@ Here is a table for the `Boxes` class methods and properties, including their na
 | `xyxyn`   | Property (`torch.Tensor`) | Return the boxes in xyxy format normalized by original image size. |
 | `xywhn`   | Property (`torch.Tensor`) | Return the boxes in xywh format normalized by original image size. |
 
-For more details see the `Boxes` class [documentation](../reference/engine/results.md#boxes).
+For more details see the `Boxes` class [documentation](../reference/engine/results.md).
 
 ### Masks
 
@@ -481,7 +481,7 @@ Here is a table for the `Masks` class methods and properties, including their na
 | `xyn`      | Property (`torch.Tensor`) | A list of normalized segments represented as tensors.           |
 | `xy`       | Property (`torch.Tensor`) | A list of segments in pixel coordinates represented as tensors. |
 
-For more details see the `Masks` class [documentation](../reference/engine/results.md#masks).
+For more details see the `Masks` class [documentation](../reference/engine/results.md).
 
 ### Keypoints
 
@@ -515,7 +515,7 @@ Here is a table for the `Keypoints` class methods and properties, including thei
 | `xy`      | Property (`torch.Tensor`) | A list of keypoints in pixel coordinates represented as tensors.  |
 | `conf`    | Property (`torch.Tensor`) | Returns confidence values of keypoints if available, else None.   |
 
-For more details see the `Keypoints` class [documentation](../reference/engine/results.md#keypoints).
+For more details see the `Keypoints` class [documentation](../reference/engine/results.md).
 
 ### Probs
 
@@ -539,20 +539,20 @@ For more details see the `Keypoints` class [documentation](../reference/engine/r
 
 Here's a table summarizing the methods and properties for the `Probs` class:
 
-| Name       | Type                    | Description                                                             |
-|------------|-------------------------|-------------------------------------------------------------------------|
-| `cpu()`    | Method                  | Returns a copy of the probs tensor on CPU memory.                       |
-| `numpy()`  | Method                  | Returns a copy of the probs tensor as a numpy array.                    |
-| `cuda()`   | Method                  | Returns a copy of the probs tensor on GPU memory.                       |
-| `to()`     | Method                  | Returns a copy of the probs tensor with the specified device and dtype. |
-| `top1`     | Property `int`          | Index of the top 1 class.                                               |
-| `top5`     | Property `list[int]`    | Indices of the top 5 classes.                                           |
-| `top1conf` | Property `torch.Tensor` | Confidence of the top 1 class.                                          |
-| `top5conf` | Property `torch.Tensor` | Confidences of the top 5 classes.                                       |
+| Name       | Type                      | Description                                                             |
+|------------|---------------------------|-------------------------------------------------------------------------|
+| `cpu()`    | Method                    | Returns a copy of the probs tensor on CPU memory.                       |
+| `numpy()`  | Method                    | Returns a copy of the probs tensor as a numpy array.                    |
+| `cuda()`   | Method                    | Returns a copy of the probs tensor on GPU memory.                       |
+| `to()`     | Method                    | Returns a copy of the probs tensor with the specified device and dtype. |
+| `top1`     | Property (`int`)          | Index of the top 1 class.                                               |
+| `top5`     | Property (`list[int]`)    | Indices of the top 5 classes.                                           |
+| `top1conf` | Property (`torch.Tensor`) | Confidence of the top 1 class.                                          |
+| `top5conf` | Property (`torch.Tensor`) | Confidences of the top 5 classes.                                       |
 
-For more details see the `Probs` class [documentation](../reference/engine/results.md#probs).
+For more details see the `Probs` class [documentation](../reference/engine/results.md).
 
-## Plotting Results
+## Plotting ResultsF
 
 You can the `plot()` method of a `Result` objects to plot predictions. It plots all prediction types (boxes, masks, keypoints, probabilities, etc.) contained in the `Results` object.
 

--- a/docs/modes/predict.md
+++ b/docs/modes/predict.md
@@ -552,7 +552,7 @@ Here's a table summarizing the methods and properties for the `Probs` class:
 
 For more details see the `Probs` class [documentation](../reference/engine/results.md).
 
-## Plotting ResultsF
+## Plotting Results
 
 You can the `plot()` method of a `Result` objects to plot predictions. It plots all prediction types (boxes, masks, keypoints, probabilities, etc.) contained in the `Results` object.
 

--- a/docs/modes/predict.md
+++ b/docs/modes/predict.md
@@ -472,14 +472,14 @@ For more details see the `Boxes` class [documentation](../reference/engine/resul
 
 Here is a table for the `Masks` class methods and properties, including their name, type, and description:
 
-| Name       | Type                      | Description                                                     |
-|------------|---------------------------|-----------------------------------------------------------------|
-| `cpu()`    | Method                    | Returns the masks tensor on CPU memory.                         |
-| `numpy()`  | Method                    | Returns the masks tensor as a numpy array.                      |
-| `cuda()`   | Method                    | Returns the masks tensor on GPU memory.                         |
-| `to()`     | Method                    | Returns the masks tensor with the specified device and dtype.   |
-| `xyn`      | Property (`torch.Tensor`) | A list of normalized segments represented as tensors.           |
-| `xy`       | Property (`torch.Tensor`) | A list of segments in pixel coordinates represented as tensors. |
+| Name      | Type                      | Description                                                     |
+|-----------|---------------------------|-----------------------------------------------------------------|
+| `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                         |
+| `numpy()` | Method                    | Returns the masks tensor as a numpy array.                      |
+| `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                         |
+| `to()`    | Method                    | Returns the masks tensor with the specified device and dtype.   |
+| `xyn`     | Property (`torch.Tensor`) | A list of normalized segments represented as tensors.           |
+| `xy`      | Property (`torch.Tensor`) | A list of segments in pixel coordinates represented as tensors. |
 
 For more details see the `Masks` class [documentation](../reference/engine/results.md).
 
@@ -554,7 +554,7 @@ For more details see the `Probs` class [documentation](../reference/engine/resul
 
 ## Plotting ResultsF
 
-You can the `plot()` method of a `Result` objects to plot predictions. It plots all prediction types (boxes, masks, keypoints, probabilities, etc.) contained in the `Results` object.
+You can use the `plot()` method of a `Result` objects to visualize predictions. It plots all prediction types (boxes, masks, keypoints, probabilities, etc.) contained in the `Results` object onto a numpy array that can then be shown or saved.
 
 !!! example "Plotting"
 
@@ -570,8 +570,10 @@ You can the `plot()` method of a `Result` objects to plot predictions. It plots 
 
     # Show the results
     for r in results:
-        im = r.plot()  # plot a BGR numpy array of predictions
-        Image.fromarray(im[..., ::-1]).show()  # show RGB image
+        im_array = r.plot()  # plot a BGR numpy array of predictions
+        im = Image.fromarray(im[..., ::-1])  # RGB PIL image
+        im.show()  # show image
+        im.save('results.jpg')  # save image
     ```
     
     The `plot()` method has the following arguments available:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -422,7 +422,7 @@ class Exporter:
                 f'{prefix} WARNING ⚠️ PNNX not found. Attempting to download binary file from '
                 'https://github.com/pnnx/pnnx/.\nNote PNNX Binary file must be placed in current working directory '
                 f'or in {ROOT}. See PNNX repo for full installation instructions.')
-            _, assets = get_github_assets(repo='pnnx/pnnx')
+            _, assets = get_github_assets(repo='pnnx/pnnx', retry=True)
             asset = [x for x in assets if ('macos' if MACOS else 'ubuntu' if LINUX else 'windows') in x][0]
             attempt_download_asset(asset, repo='pnnx/pnnx', release='latest')
             unzip_dir = Path(asset).with_suffix('')

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -208,8 +208,10 @@ class Results(SimpleClass):
             model = YOLO('yolov8n.pt')
             results = model('bus.jpg')  # results list
             for r in results:
-                im = r.plot()  # BGR numpy array
-                Image.fromarray(im[..., ::-1]).show()  # show RGB image
+                im_array = r.plot()  # plot a BGR numpy array of predictions
+                im = Image.fromarray(im[..., ::-1])  # RGB PIL image
+                im.show()  # show image
+                im.save('results.jpg')  # save image
             ```
         """
         if img is None and isinstance(self.orig_img, torch.Tensor):

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -202,13 +202,13 @@ def safe_download(url,
         return unzip_dir
 
 
-def get_github_assets(repo='ultralytics/assets', version='latest'):
+def get_github_assets(repo='ultralytics/assets', version='latest', retry=True):
     """Return GitHub repo tag and assets (i.e. ['yolov8n.pt', 'yolov8s.pt', ...])."""
     if version != 'latest':
         version = f'tags/{version}'  # i.e. tags/v6.2
     url = f'https://api.github.com/repos/{repo}/releases/{version}'
     r = requests.get(url)  # github api
-    if r.status_code != 200:
+    if r.status_code != 200 and retry:
         r = requests.get(url)  # try again
     data = r.json()
     return data['tag_name'], [x['name'] for x in data['assets']]  # tag, assets
@@ -241,10 +241,10 @@ def attempt_download_asset(file, repo='ultralytics/assets', release='v0.0.0'):
         # GitHub assets
         assets = GITHUB_ASSET_NAMES
         try:
-            tag, assets = get_github_assets(repo, release)
+            tag, assets = get_github_assets(repo, release, retry=False)
         except Exception:
             try:
-                tag, assets = get_github_assets(repo)  # latest release
+                tag, assets = get_github_assets(repo, retry=False)  # latest release
             except Exception:
                 try:
                     tag = subprocess.check_output(['git', 'tag']).decode().split()[-1]

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -206,8 +206,12 @@ def get_github_assets(repo='ultralytics/assets', version='latest'):
     """Return GitHub repo tag and assets (i.e. ['yolov8n.pt', 'yolov8s.pt', ...])."""
     if version != 'latest':
         version = f'tags/{version}'  # i.e. tags/v6.2
-    response = requests.get(f'https://api.github.com/repos/{repo}/releases/{version}').json()  # github api
-    return response['tag_name'], [x['name'] for x in response['assets']]  # tag, assets
+    url = f'https://api.github.com/repos/{repo}/releases/{version}'
+    r = requests.get(url)  # github api
+    if r.status_code != 200:
+        r = requests.get(url)  # try again
+    data = r.json()
+    return data['tag_name'], [x['name'] for x in data['assets']]  # tag, assets
 
 
 def attempt_download_asset(file, repo='ultralytics/assets', release='v0.0.0'):

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -202,7 +202,7 @@ def safe_download(url,
         return unzip_dir
 
 
-def get_github_assets(repo='ultralytics/assets', version='latest', retry=True):
+def get_github_assets(repo='ultralytics/assets', version='latest', retry=False):
     """Return GitHub repo tag and assets (i.e. ['yolov8n.pt', 'yolov8s.pt', ...])."""
     if version != 'latest':
         version = f'tags/{version}'  # i.e. tags/v6.2
@@ -241,10 +241,10 @@ def attempt_download_asset(file, repo='ultralytics/assets', release='v0.0.0'):
         # GitHub assets
         assets = GITHUB_ASSET_NAMES
         try:
-            tag, assets = get_github_assets(repo, release, retry=False)
+            tag, assets = get_github_assets(repo, release)
         except Exception:
             try:
-                tag, assets = get_github_assets(repo, retry=False)  # latest release
+                tag, assets = get_github_assets(repo)  # latest release
             except Exception:
                 try:
                     tag = subprocess.check_output(['git', 'tag']).decode().split()[-1]


### PR DESCRIPTION
Should improve robustness to temporary connectivity issues.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 171db68</samp>

### Summary
:repeat::octocat::package:

<!--
1.  :repeat: This emoji represents the retry logic that the change introduces, as it tries to repeat the request until it succeeds or reaches a maximum number of attempts.
2.  :octocat: This emoji represents the github api that the change interacts with, as it is the source of the assets that the function downloads.
3.  :package: This emoji represents the assets that the change downloads, as they are the files that contain the models or weights that the function returns.
-->
Improved error handling for downloading assets from github. Added a retry mechanism in `get_github_assets` in `ultralytics/utils/downloads.py` to handle non-200 responses.

> _`get_github_assets`_
> _Sometimes fails, so try again_
> _Winter network woes_

### Walkthrough
* Add a retry mechanism for github api requests ([link](https://github.com/ultralytics/ultralytics/pull/4148/files?diff=unified&w=0#diff-2ef123c1fc0c4f685921e72b3670f41388f4711085232d8157daf56ac9e230e1L209-R214)). This change improves the robustness of the `get_github_assets` function in `ultralytics/utils/downloads.py`, which downloads the assets from the ultralytics repository.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `get_github_assets` reliability, improved prediction plotting, and documentation updates.

### 📊 Key Changes
- Updated links in documentation to remove specific anchors, pointing now to general sections.
- Improved the `plot()` method descriptions for visualization of results, including saving images.
- Enhanced `get_github_assets` function with an optional `retry` parameter for reliability.

### 🎯 Purpose & Impact
- 📖 Documentation changes ensure users find the appropriate information without broken links due to section anchors changing.
- 🎨 Visualization improvements make it easier for users to both view and save prediction results, enhancing the usability of the `plot()` method.
- 🔄 The `retry` option in the `get_github_assets` function can reduce the likelihood of failures due to temporary network issues, providing a more robust experience when retrieving repository assets.