### PR TITLE
Add verbosity flag for quantization info

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -301,7 +301,7 @@ class Exporter:
         """YOLOv8 ONNX export."""
         requirements = ['onnx>=1.12.0']
         if self.args.simplify:
-            requirements += ['onnxsim>=0.4.17', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime']
+            requirements += ['onnxsim>=0.4.33', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime']
         check_requirements(requirements)
         import onnx  # noqa
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -580,7 +580,8 @@ class Exporter:
             import tensorflow as tf  # noqa
         check_requirements(
             ('onnx', 'onnx2tf>=1.15.4', 'sng4onnx>=1.0.1', 'onnxsim>=0.4.33', 'onnx_graphsurgeon>=0.3.26',
-             'tflite_support', 'onnxruntime-gpu' if cuda else 'onnxruntime'))
+             'tflite_support', 'onnxruntime-gpu' if cuda else 'onnxruntime'),
+            cmds='--extra-index-url https://pypi.ngc.nvidia.com')  # onnx_graphsurgeon only on NVIDIA
 
         LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
         f = Path(str(self.file).replace(self.file.suffix, '_saved_model'))

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -572,16 +572,15 @@ class Exporter:
     @try_export
     def export_saved_model(self, prefix=colorstr('TensorFlow SavedModel:')):
         """YOLOv8 TensorFlow SavedModel export."""
+        cuda = torch.cuda.is_available()
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            cuda = torch.cuda.is_available()
             check_requirements(f"tensorflow{'-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'}")
             import tensorflow as tf  # noqa
         check_requirements(
             ('onnx', 'onnx2tf>=1.15.4', 'sng4onnx>=1.0.1', 'onnxsim>=0.4.33', 'onnx_graphsurgeon>=0.3.26',
-             'tflite_support', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime'),
-            cmds='--extra-index-url https://pypi.ngc.nvidia.com')
+             'tflite_support', 'onnxruntime-gpu' if cuda else 'onnxruntime'))
 
         LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
         f = Path(str(self.file).replace(self.file.suffix, '_saved_model'))
@@ -596,6 +595,7 @@ class Exporter:
         # Export to TF
         tmp_file = f / 'tmp_tflite_int8_calibration_images.npy'  # int8 calibration images file
         if self.args.int8:
+            verbosity = '--verbosity info'
             if self.args.data:
                 import numpy as np
 
@@ -620,8 +620,6 @@ class Exporter:
                 int8 = f'-oiqt -qt per-tensor -cind images "{tmp_file}" "[[[[0, 0, 0]]]]" "[[[[255, 255, 255]]]]"'
             else:
                 int8 = '-oiqt -qt per-tensor'
-
-            verbosity = '--verbosity info'
         else:
             verbosity = '--non_verbose'
             int8 = ''

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -578,9 +578,10 @@ class Exporter:
             cuda = torch.cuda.is_available()
             check_requirements(f"tensorflow{'-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'}")
             import tensorflow as tf  # noqa
-        check_requirements(('onnx', 'onnx2tf>=1.15.4', 'sng4onnx>=1.0.1', 'onnxsim>=0.4.33', 'onnx_graphsurgeon>=0.3.26',
-                            'tflite_support', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime'),
-                           cmds='--extra-index-url https://pypi.ngc.nvidia.com')
+        check_requirements(
+            ('onnx', 'onnx2tf>=1.15.4', 'sng4onnx>=1.0.1', 'onnxsim>=0.4.33', 'onnx_graphsurgeon>=0.3.26',
+             'tflite_support', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime'),
+            cmds='--extra-index-url https://pypi.ngc.nvidia.com')
 
         LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
         f = Path(str(self.file).replace(self.file.suffix, '_saved_model'))

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -578,7 +578,7 @@ class Exporter:
             cuda = torch.cuda.is_available()
             check_requirements(f"tensorflow{'-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'}")
             import tensorflow as tf  # noqa
-        check_requirements(('onnx', 'onnx2tf>=1.9.1', 'sng4onnx>=1.0.1', 'onnxsim>=0.4.17', 'onnx_graphsurgeon>=0.3.26',
+        check_requirements(('onnx', 'onnx2tf>=1.15.4', 'sng4onnx>=1.0.1', 'onnxsim>=0.4.33', 'onnx_graphsurgeon>=0.3.26',
                             'tflite_support', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime'),
                            cmds='--extra-index-url https://pypi.ngc.nvidia.com')
 
@@ -619,10 +619,13 @@ class Exporter:
                 int8 = f'-oiqt -qt per-tensor -cind images "{tmp_file}" "[[[[0, 0, 0]]]]" "[[[[255, 255, 255]]]]"'
             else:
                 int8 = '-oiqt -qt per-tensor'
+
+            verbosity = '--verbosity info'
         else:
+            verbosity = '--non_verbose'
             int8 = ''
 
-        cmd = f'onnx2tf -i "{f_onnx}" -o "{f}" -nuo --non_verbose {int8}'.strip()
+        cmd = f'onnx2tf -i "{f_onnx}" -o "{f}" -nuo {verbosity} {int8}'.strip()
         LOGGER.info(f"{prefix} running '{cmd}'")
         subprocess.run(cmd, shell=True)
         yaml_save(f / 'metadata.yaml', self.metadata)  # add metadata.yaml


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

Adds some more output for quantization information when running with int8 exports. Logs look something like this:
![image](https://github.com/ultralytics/ultralytics/assets/32407067/6b152687-f2b1-46cf-85dc-a6e99c7cbe4e)

Additionally, upgrading onnx2tf does not seem to have an impact on performance, as tested by exporting tflite before and after the change and observing that `yolo val` mAP results are identical.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 812d202</samp>

### Summary
🆙🗒️🛠️

<!--
1.  🆙 - This emoji can be used to indicate that something has been updated or upgraded, which is the case for the ONNX-related dependencies in this change.
2.  🗒️ - This emoji can be used to represent logging, writing, or documenting something, which is the case for the logging option added for the TensorFlow SavedModel conversion. This emoji can also convey the idea of providing more information or feedback, which is the goal of the logging option.
3.  🛠️ - This emoji can be used to represent fixing, improving, or enhancing something, which is the case for the compatibility and usability of the `export_saved_model` function. This emoji can also convey the idea of working on something or making it more reliable, which is the intention of the changes.
-->
Improved ONNX and TensorFlow export functionality in `exporter.py`. Added logging option and updated dependencies for better compatibility and usability.

> _Sing, O Muse, of the skillful Exporter, who converts_
> _the models of TensorFlow to the format of ONNX,_
> _and adds a logging option for the users to observe_
> _the progress of the transformation and its effects._

### Walkthrough
*  Update `onnx2tf` and `onnxsim` requirements to fix compatibility issues with TensorFlow 2.7 and ONNX 1.10 ([link](https://github.com/ultralytics/ultralytics/pull/4151/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL581-R581))
*  Add `verbosity` option to `onnx2tf` command to control logging level of ONNX to TensorFlow conversion ([link](https://github.com/ultralytics/ultralytics/pull/4151/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL622-R628))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to ONNX and TensorFlow SavedModel export compatibility in the Ultralytics engine.

### 📊 Key Changes
- Updated the version requirement for `onnxsim` to `0.4.33` from `0.4.17` for ONNX exports.
- Moved the `torch.cuda.is_available()` call to occur prior to TensorFlow import in the SavedModel export logic.
- Bumped the minimum required versions for `onnx2tf` to `1.15.4` and `onnxsim` to `0.4.33` in the TensorFlow SavedModel export requirements.
- Added a verbosity control variable within the TensorFlow SavedModel export function for better log information management.

### 🎯 Purpose & Impact
- Ensuring compatibility with the latest package versions of `onnxsim` and `onnx2tf` improves stability and supports new features or bug fixes.
- Rearranging the CUDA availability check optimizes the TensorFlow import process.
- Introducing verbosity control offers developers and users better logging management, potentially making debugging and monitoring the export process more efficient.