### PR TITLE
Add Docs example for plotting tracks over time

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Pip install the ultralytics package including all [requirements](https://github.
 pip install ultralytics
 ```
 
-For alternative installation methods including Conda, Docker, and Git, please refer to the [Quickstart Guide](https://docs.ultralytics.com/quickstart).
+For alternative installation methods including [Conda](https://anaconda.org/conda-forge/ultralytics), [Docker](https://hub.docker.com/r/ultralytics/ultralytics), and Git, please refer to the [Quickstart Guide](https://docs.ultralytics.com/quickstart).
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,7 +65,7 @@
 pip install ultralytics
 ```
 
-如需使用包括Conda、Docker和Git在内的其他安装方法，请参考[快速入门指南](https://docs.ultralytics.com/quickstart)。
+如需使用包括[Conda](https://anaconda.org/conda-forge/ultralytics)、[Docker](https://hub.docker.com/r/ultralytics/ultralytics)和Git在内的其他安装方法，请参考[快速入门指南](https://docs.ultralytics.com/quickstart)。
 
 </details>
 

--- a/docs/modes/track.md
+++ b/docs/modes/track.md
@@ -205,9 +205,8 @@ In the following example, we demonstrate how to utilize YOLOv8's tracking capabi
                     track.pop(0)
     
                 # Draw the tracking lines
-                if len(track) > 1:
-                    points = np.hstack(track).astype(np.int32).reshape((-1, 1, 2))
-                    cv2.polylines(annotated_frame, [points], isClosed=False, color=(230, 230, 230), thickness=10)
+                points = np.hstack(track).astype(np.int32).reshape((-1, 1, 2))
+                cv2.polylines(annotated_frame, [points], isClosed=False, color=(230, 230, 230), thickness=10)
     
             # Display the annotated frame
             cv2.imshow("YOLOv8 Tracking", annotated_frame)

--- a/docs/modes/track.md
+++ b/docs/modes/track.md
@@ -122,7 +122,7 @@ Here is a Python script using OpenCV (`cv2`) and YOLOv8 to run object tracking o
     model = YOLO('yolov8n.pt')
 
     # Open the video file
-    video_path = "path/to/your/video/file.mp4"
+    video_path = "path/to/video.mp4"
     cap = cv2.VideoCapture(video_path)
 
     # Loop through the video frames
@@ -153,6 +153,76 @@ Here is a Python script using OpenCV (`cv2`) and YOLOv8 to run object tracking o
     ```
 
 Please note the change from `model(frame)` to `model.track(frame)`, which enables object tracking instead of simple detection. This modified script will run the tracker on each frame of the video, visualize the results, and display them in a window. The loop can be exited by pressing 'q'.
+
+### Plotting Tracks Over Time
+
+Visualizing object tracks over consecutive frames can provide valuable insights into the movement patterns and behavior of detected objects within a video. With Ultralytics YOLOv8, plotting these tracks is a seamless and efficient process.
+
+In the following example, we demonstrate how to utilize YOLOv8's tracking capabilities to plot the movement of detected objects across multiple video frames. This script involves opening a video file, reading it frame by frame, and utilizing the YOLO model to identify and track various objects. By retaining the center points of the detected bounding boxes and connecting them, we can draw lines that represent the paths followed by the tracked objects.
+
+!!! example "Plotting tracks over multiple video frames"
+
+    ```python
+    from collections import defaultdict
+    
+    import cv2
+    import numpy as np
+    
+    from ultralytics import YOLO
+    
+    # Load the YOLOv8 model
+    model = YOLO('yolov8n.pt')
+    
+    # Open the video file
+    video_path = "path/to/video.mp4"
+    cap = cv2.VideoCapture(video_path)
+    
+    # Store the track history
+    track_history = defaultdict(lambda: [])
+    
+    # Loop through the video frames
+    while cap.isOpened():
+        # Read a frame from the video
+        success, frame = cap.read()
+    
+        if success:
+            # Run YOLOv8 tracking on the frame, persisting tracks between frames
+            results = model.track(frame, persist=True)
+    
+            # Get the boxes and track IDs
+            boxes = results[0].boxes.xywh
+            track_ids = results[0].boxes.id.int().tolist()
+    
+            # Visualize the results on the frame
+            annotated_frame = results[0].plot()
+    
+            # Plot the tracks
+            for box, track_id in zip(boxes, track_ids):
+                x, y, w, h = box
+                track = track_history[track_id]
+                track.append((x, y))  # x, y center point
+                if len(track) > 90:  # retain 90 tracks for 90 frames
+                    track.pop(0)
+    
+                # Draw the tracking lines
+                if len(track) > 1:
+                    points = np.hstack(track).astype(np.int32).reshape((-1, 1, 2))
+                    cv2.polylines(annotated_frame, [points], isClosed=False, color=(200, 200, 200), thickness=10)
+    
+            # Display the annotated frame
+            cv2.imshow("YOLOv8 Tracking", annotated_frame)
+    
+            # Break the loop if 'q' is pressed
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                break
+        else:
+            # Break the loop if the end of the video is reached
+            break
+    
+    # Release the video capture object and close the display window
+    cap.release()
+    cv2.destroyAllWindows()
+    ```
 
 ### Multithreaded Tracking
 

--- a/docs/modes/track.md
+++ b/docs/modes/track.md
@@ -201,13 +201,13 @@ In the following example, we demonstrate how to utilize YOLOv8's tracking capabi
                 x, y, w, h = box
                 track = track_history[track_id]
                 track.append((x, y))  # x, y center point
-                if len(track) > 90:  # retain 90 tracks for 90 frames
+                if len(track) > 30:  # retain tracks for 30 frames
                     track.pop(0)
     
                 # Draw the tracking lines
                 if len(track) > 1:
                     points = np.hstack(track).astype(np.int32).reshape((-1, 1, 2))
-                    cv2.polylines(annotated_frame, [points], isClosed=False, color=(200, 200, 200), thickness=10)
+                    cv2.polylines(annotated_frame, [points], isClosed=False, color=(230, 230, 230), thickness=10)
     
             # Display the annotated frame
             cv2.imshow("YOLOv8 Tracking", annotated_frame)

--- a/docs/modes/track.md
+++ b/docs/modes/track.md
@@ -190,8 +190,8 @@ In the following example, we demonstrate how to utilize YOLOv8's tracking capabi
             results = model.track(frame, persist=True)
     
             # Get the boxes and track IDs
-            boxes = results[0].boxes.xywh
-            track_ids = results[0].boxes.id.int().tolist()
+            boxes = results[0].boxes.xywh.cpu()
+            track_ids = results[0].boxes.id.int().cpu().tolist()
     
             # Visualize the results on the frame
             annotated_frame = results[0].plot()
@@ -200,8 +200,8 @@ In the following example, we demonstrate how to utilize YOLOv8's tracking capabi
             for box, track_id in zip(boxes, track_ids):
                 x, y, w, h = box
                 track = track_history[track_id]
-                track.append((x, y))  # x, y center point
-                if len(track) > 30:  # retain tracks for 30 frames
+                track.append((float(x), float(y)))  # x, y center point
+                if len(track) > 30:  # retain 90 tracks for 90 frames
                     track.pop(0)
     
                 # Draw the tracking lines


### PR DESCRIPTION
@Burhan-Q docs example for plotting multi-frame tracks. I used (200, 200, 200), light gray color for now. I can update this to plot tracks in class color, but that will require a bit more work.

EDIT: Maybe 200 is too dark, I'll do 225.

<img width="892" alt="Screenshot 2023-08-04 at 20 57 35" src="https://github.com/ultralytics/ultralytics/assets/26833433/5101578a-c124-4723-abcd-03e5b92bf58a">

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 10ff3aa</samp>

### Summary
📝📊📌

<!--
1.  📝 - This emoji represents documentation or writing, and can be used to indicate that the changes involve updating the documentation for the track mode of YOLOv8.
2.  📊 - This emoji represents charts or graphs, and can be used to indicate that the changes involve plotting object tracks over multiple frames using the track mode of YOLOv8.
3.  📌 - This emoji represents a pin or a reference, and can be used to indicate that the changes include a note box with a reference to the source file where the track mode of YOLOv8 is implemented.
-->
Improved the documentation for the track mode of YOLOv8 by adding an example and a reference. The example shows how to use `model.track` with the `persist` argument to plot object tracks over multiple frames. The reference points to the source file where the track mode is implemented.

> _We're sailing on the YOLOv8, the finest ship in town_
> _We've got a mode for tracking, that can plot the objects down_
> _We'll show you how to use it, with a snippet and a note_
> _So grab your `model.track` and `persist`, and sing along this boat_

### Walkthrough
*  Update video path to a placeholder in the example code ([link](https://github.com/ultralytics/ultralytics/pull/4170/files?diff=unified&w=0#diff-28a675294ad148751845f8d4fd08d1a73a30bde0bf27a269e7f8294d1537bbcfL125-R125))
*  Add a subsection to the documentation to show how to plot object tracks over multiple frames ([link](https://github.com/ultralytics/ultralytics/pull/4170/files?diff=unified&w=0#diff-28a675294ad148751845f8d4fd08d1a73a30bde0bf27a269e7f8294d1537bbcfR157-R226))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced installation instructions and expanded tracking documentation with a plotting example.

### 📊 Key Changes
- **README Updates**: Added direct links to Conda and Docker installation methods in both English and Chinese READMEs.
- **Tracking Guide Enhancements**: Inserted a new section on plotting object tracks over time in videos using YOLOv8.
- **Code Example Included**: Provided a comprehensive Python example for visualizing movement paths of identified objects.

### 🎯 Purpose & Impact
- **Improved Accessibility**: Clear links help users quickly find alternative installation methods, improving the setup experience. 🛠️
- **Enhanced Understanding**: The new tracking example educates users on creating visual tracks, aiding in more complex analyses of object motion. 🏃‍♂️📈
- **Increased Efficiency**: Example serves as a ready-to-use template, saving users time and effort in implementing tracking visualizations. ⏱️🎨