### PR TITLE
Fix error with exporting quantized saved model when labels cache not present

### DIFF
--- a/ultralytics/data/annotator.py
+++ b/ultralytics/data/annotator.py
@@ -24,13 +24,13 @@ def auto_annotate(data, det_model='yolov8x.pt', sam_model='sam_b.pt', device='',
     det_results = det_model(data, stream=True, device=device)
 
     for result in det_results:
-        boxes = result.boxes.xyxy  # Boxes object for bbox outputs
         class_ids = result.boxes.cls.int().tolist()  # noqa
         if len(class_ids):
+            boxes = result.boxes.xyxy  # Boxes object for bbox outputs
             sam_results = sam_model(result.orig_img, bboxes=boxes, verbose=False, save=False, device=device)
             segments = sam_results[0].masks.xyn  # noqa
 
-            with open(str(Path(output_dir) / Path(result.path).stem) + '.txt', 'w') as f:
+            with open(f'{str(Path(output_dir) / Path(result.path).stem)}.txt', 'w') as f:
                 for i in range(len(segments)):
                     s = segments[i]
                     if len(s) == 0:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -605,7 +605,8 @@ class Exporter:
 
                 # Generate calibration data for integer quantization
                 LOGGER.info(f"{prefix} collecting INT8 calibration images from 'data={self.args.data}'")
-                dataset = YOLODataset(check_det_dataset(self.args.data)['val'], imgsz=self.imgsz[0], augment=False)
+                data = check_det_dataset(self.args.data)
+                dataset = YOLODataset(data['val'], data=data, imgsz=self.imgsz[0], augment=False)
                 images = []
                 n_images = 100  # maximum number of images
                 for n, batch in enumerate(dataset):


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

Attempting to export a model using a dataset file that doesn't already have a labels cache generated will throw an error:
```
$ yolo export model=yolov8n.pt format=tflite int8 data=coco128.yaml
...
Traceback (most recent call last):
  File "ultralytics/ultralytics/data/dataset.py", line 111, in get_labels
    assert cache['version'] == self.cache_version  # matches current version
AssertionError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".pyenv/versions/3.10.5/bin/yolo", line 33, in <module>
    sys.exit(load_entry_point('ultralytics', 'console_scripts', 'yolo')())
  File "ultralytics/ultralytics/cfg/__init__.py", line 427, in entrypoint
    getattr(model, mode)(**overrides)  # default args from model
  File "ultralytics/ultralytics/engine/model.py", line 344, in export
    return Exporter(overrides=args, _callbacks=self.callbacks)(model=self.model)
  File ".pyenv/versions/3.10.5/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "ultralytics/ultralytics/engine/exporter.py", line 250, in __call__
    f[5], s_model = self.export_saved_model()
  File "ultralytics/ultralytics/engine/exporter.py", line 119, in outer_func
    raise e
  File "ultralytics/ultralytics/engine/exporter.py", line 114, in outer_func
    f, model = inner_func(*args, **kwargs)
  File "ultralytics/ultralytics/engine/exporter.py", line 608, in export_saved_model
    dataset = YOLODataset(check_det_dataset(self.args.data)['val'], imgsz=self.imgsz[0], augment=False)
  File "ultralytics/ultralytics/data/dataset.py", line 40, in __init__
    super().__init__(*args, **kwargs)
  File "ultralytics/ultralytics/data/base.py", line 73, in __init__
    self.labels = self.get_labels()
  File "ultralytics/ultralytics/data/dataset.py", line 114, in get_labels
    cache, exists = self.cache_labels(cache_path), False  # run cache ops
  File "ultralytics/ultralytics/data/dataset.py", line 53, in cache_labels
    nkpt, ndim = self.data.get('kpt_shape', (0, 0))
AttributeError: 'NoneType' object has no attribute 'get'
```
This is because the `data` attribute was never initialized in the creation of `YOLODataset`, resulting in an operation on a None value. Although this may be indicative of a larger issue where the `data` attribute is required to initialize a YOLODataset (as the BaseDataset constructor calls `get_labels()`, which will ask to `cache_labels` if the labels cache does not exist, thus querying `data`), the more required fix is simply passing in the `dataset.yaml` dictionary into the `YOLODataset` constructor, which this PR adds.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3894685</samp>

### Summary
🔄📦🆕

<!--
1.  🔄 This emoji can be used to indicate that the change is part of an update or a refactor that modifies the existing code to adapt to new requirements or improve performance. It can also suggest that the change involves some kind of transformation or conversion of data or formats.
2.  📦 This emoji can be used to indicate that the change is related to the dataset or the data loading process, which are essential components of any machine learning project. It can also suggest that the change involves packaging or organizing the data in a specific way.
3.  🆕 This emoji can be used to indicate that the change introduces new functionality or features to the dataset class, such as supporting different data formats or sources. It can also suggest that the change is part of a new version or a major improvement of the code.
-->
Update `exporter.py` to use the new `YOLODataset` class. This allows exporting models with different data formats and sources.

> _`YOLODataset` needs_
> _`data` argument now_
> _Winter of changes_

### Walkthrough
*  Pass `data` argument to `YOLODataset` constructor to support different data formats and sources ([link](https://github.com/ultralytics/ultralytics/pull/4174/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL608-R609))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced annotation and TensorFlow export functionality.

### 📊 Key Changes
- Optimized the order of operations in `annotator.py`, delaying the retrieval of bounding boxes to be inside a conditional.
- Improved file path handling using f-string for elegance and better readability.
- Modified `exporter.py` to ensure dataset consistency during INT8 calibration by passing the complete `data` dictionary to `YOLODataset`.

### 🎯 Purpose & Impact
- By adjusting when bounding boxes are computed, we reduce unnecessary computations and potentially improve performance when no classes are detected.
- The use of f-strings for file paths simplifies the code, making it easier to read and maintain.
- Changes in the TensorFlow exporter lead to a more reliable quantization process, which can improve model compatibility and performance in resource-constrained environments like mobile or embedded systems.