### PR TITLE
Add `sys.path.append()` to Ensure Correct Path Resolution

### DIFF
--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -1,16 +1,16 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-import torch
-import sys
 import os
+import sys
 from pathlib import Path
+
+import torch
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[4]  # Root Directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # Add ROOT to PATH
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
-
 
 from ultralytics.engine.predictor import BasePredictor
 from ultralytics.engine.results import Results

--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -1,6 +1,16 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 import torch
+import sys
+import os
+from pathlib import Path
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
+
 
 from ultralytics.engine.predictor import BasePredictor
 from ultralytics.engine.results import Results

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -1,10 +1,11 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
+import os
+import sys
+from pathlib import Path
+
 import torch
 import torchvision
-import sys
-import os
-from pathlib import Path
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[4]  # Root Directory

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -2,6 +2,15 @@
 
 import torch
 import torchvision
+import sys
+import os
+from pathlib import Path
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
 
 from ultralytics.data import ClassificationDataset, build_dataloader
 from ultralytics.engine.trainer import BaseTrainer

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -1,9 +1,10 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-import torch
-import sys
 import os
+import sys
 from pathlib import Path
+
+import torch
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[4]  # Root Directory

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -1,6 +1,15 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 import torch
+import sys
+import os
+from pathlib import Path
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
 
 from ultralytics.data import ClassificationDataset, build_dataloader
 from ultralytics.engine.validator import BaseValidator

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -1,6 +1,15 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 import torch
+import sys
+import os
+from pathlib import Path
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
 
 from ultralytics.engine.predictor import BasePredictor
 from ultralytics.engine.results import Results

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -1,9 +1,10 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-import torch
-import sys
 import os
+import sys
 from pathlib import Path
+
+import torch
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[4]  # Root Directory

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -1,8 +1,16 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-from copy import copy
-
 import numpy as np
+import sys
+import os
+from copy import copy
+from pathlib import Path
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
 
 from ultralytics.data import build_dataloader, build_yolo_dataset
 from ultralytics.engine.trainer import BaseTrainer

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -1,10 +1,11 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-import numpy as np
-import sys
 import os
+import sys
 from copy import copy
 from pathlib import Path
+
+import numpy as np
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[4]  # Root Directory

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -1,7 +1,14 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 import os
+import sys
 from pathlib import Path
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
 
 import numpy as np
 import torch

--- a/ultralytics/models/yolo/pose/predict.py
+++ b/ultralytics/models/yolo/pose/predict.py
@@ -1,7 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-import sys
 import os
+import sys
 from pathlib import Path
 
 FILE = Path(__file__).resolve()

--- a/ultralytics/models/yolo/pose/predict.py
+++ b/ultralytics/models/yolo/pose/predict.py
@@ -1,5 +1,15 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
+import sys
+import os
+from pathlib import Path
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
+
 from ultralytics.engine.results import Results
 from ultralytics.models.yolo.detect.predict import DetectionPredictor
 from ultralytics.utils import DEFAULT_CFG, LOGGER, ROOT, ops

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -1,7 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-import sys
 import os
+import sys
 from copy import copy
 from pathlib import Path
 

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -1,6 +1,15 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
+import sys
+import os
 from copy import copy
+from pathlib import Path
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
 
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import PoseModel

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -1,9 +1,16 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
+import sys
+import os
+import torch
+import numpy as np
 from pathlib import Path
 
-import numpy as np
-import torch
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[4]  # Root Directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # Add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # Relative Path
 
 from ultralytics.models.yolo.detect import DetectionValidator
 from ultralytics.utils import DEFAULT_CFG, LOGGER, ops

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -1,10 +1,11 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-import sys
 import os
-import torch
-import numpy as np
+import sys
 from pathlib import Path
+
+import numpy as np
+import torch
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[4]  # Root Directory


### PR DESCRIPTION
Hello, I found the `from ultralytics import ...` here will raise the `ModuleNotFoundError: No module named 'ultralytics'` error. This can be resolved by adding the `sys.path.append()` operation. 

I also thought if the code here is meant to import **ultralytics** from pip installation, rather than the **ultralytics** in the code folder, but there is no **ultralytics** item in the [`requirements.txt`](https://github.com/ultralytics/ultralytics/blob/main/requirements.txt).

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 23e0d58</samp>

### Summary
🐍📂🛠️

<!--
1.  🐍 - This emoji represents the Python language and the PYTHONPATH variable that is modified by the changes.
2.  📂 - This emoji represents the file system and the FILE and ROOT variables that are defined by the changes.
3.  🛠️ - This emoji represents the tools and modules that are imported or reordered by the changes.
-->
This pull request adds the code to dynamically adjust the `PYTHONPATH` to include the root directory of the `ultralytics` package to all the scripts in the `yolo` subpackages. This is done to avoid import errors when running the scripts from different locations or environments. The pull request also reorders some imports to follow the PEP8 style guide.

> _`PYTHONPATH` fixed_
> _imports reordered neatly_
> _autumn cleaning code_

### Walkthrough
*  Add code to adjust `PYTHONPATH` to include the root directory of the `ultralytics` package to avoid import errors ([link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-663b5aaaf7a04b1a7fe40326af039d2baf50df166e9738332eacbae9271ec55fL4-R14), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-cee7d47e5437733bc9f004074d2fe9e6567950bdd3f9c486c7574a514c6f787eL5-R14), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-480ef38c26df7841454032f8454605031a24c665a21b72f9c364e9a3cd722c5eL4-R13), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-9dded00f5e51a32b00c6266aa445990bae22fe6ea0bbb9d2c8898f4fcdb8cb23L4-R13), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-d65f53ba236420b68c8dded0a5b817050a77ec804b5975d67e448a17b0d17e0aL3-R13), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-023bb20ae0db3d69310690d02fbea0e2a6d57e5cf3878f00ea1cd097761fd7b5L4-R12), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-383afc92a2a66556c136cd357f28db596eed25b3472abe26b7e778208a365571R3-R12), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-88c62952209ca3b3ac038358fb03af3906146b5b9074199322aaf0169ec7e382L3-R13), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-87c04c65554f867c15a5425248ea5642ba95c9ed23cca06db823a369d47d1d9fL3-R13))
* Reorder imports to follow the PEP8 style guide in the `train.py` and `val.py` scripts of the `classify`, `detect`, and `pose` subpackages ([link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-cee7d47e5437733bc9f004074d2fe9e6567950bdd3f9c486c7574a514c6f787eL5-R14), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-d65f53ba236420b68c8dded0a5b817050a77ec804b5975d67e448a17b0d17e0aL3-R13), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-88c62952209ca3b3ac038358fb03af3906146b5b9074199322aaf0169ec7e382L3-R13), [link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-87c04c65554f867c15a5425248ea5642ba95c9ed23cca06db823a369d47d1d9fL3-R13))
* Move the import of the `copy` module to the top of the file in the `detect/train.py` script ([link](https://github.com/ultralytics/ultralytics/pull/4277/files?diff=unified&w=0#diff-d65f53ba236420b68c8dded0a5b817050a77ec804b5975d67e448a17b0d17e0aL3-R13))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved module path handling in YOLO classification, detection, and pose estimation scripts.

### 📊 Key Changes
- Added imports for `os` and `sys` across various YOLO scripts (classify, detect, pose).
- Utilized `pathlib` to resolve the file path and to set the root directory relative to the current working directory.
- Modified the system path to include the root directory if it's not already present.

### 🎯 Purpose & Impact
- 🔄 The updates ensure consistent module importing regardless of the execution context.
- ⚙️ Helps avoid potential import errors when the scripts are executed from different directories.
- 🛠 Makes the codebase more maintainable and reduces the chance of file path-related bugs, providing a smoother experience for developers and users alike.