### PR TITLE
Mosaic3 1

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -156,7 +156,6 @@ class Mosaic(BaseMixTransform):
         """Create a 1x3 image mosaic."""
         mosaic_labels = []
         s = self.imgsz
-        hp, wp = -1, -1  # height, width previous
         for i in range(3):
             labels_patch = labels if i == 0 else labels['mix_labels'][i - 1]
             # Load image

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -176,7 +176,6 @@ class Mosaic(BaseMixTransform):
             padw, padh = c[:2]
             x1, y1, x2, y2 = (max(x, 0) for x in c)  # allocate coords
 
-
             img3[y1:y2, x1:x2] = img[y1 - padh:, x1 - padw:]  # img3[ymin:ymax, xmin:xmax]
             hp, wp = h, w  # height, width previous for next iteration
 

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -177,7 +177,7 @@ class Mosaic(BaseMixTransform):
             x1, y1, x2, y2 = (max(x, 0) for x in c)  # allocate coords
 
             img3[y1:y2, x1:x2] = img[y1 - padh:, x1 - padw:]  # img3[ymin:ymax, xmin:xmax]
-            hp, wp = h, w  # height, width previous for next iteration
+            # hp, wp = h, w  # height, width previous for next iteration
 
             # Labels assuming imgsz*2 mosaic size
             labels_patch = self._update_labels(labels_patch, padw + self.border[0], padh + self.border[1])

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -129,10 +129,10 @@ class Mosaic(BaseMixTransform):
         n (int, optional): The grid size, either 4 (for 2x2) or 9 (for 3x3).
     """
 
-    def __init__(self, dataset, imgsz=640, p=1.0, n=4):
+    def __init__(self, dataset, imgsz=640, p=1.0, n=3):
         """Initializes the object with a dataset, image size, probability, and border."""
         assert 0 <= p <= 1.0, f'The probability should be in range [0, 1], but got {p}.'
-        assert n in (4, 9), 'grid must be equal to 4 or 9.'
+        assert n in (3, 4, 9), 'grid must be equal to 3, 4 or 9.'
         super().__init__(dataset=dataset, p=p)
         self.dataset = dataset
         self.imgsz = imgsz
@@ -150,7 +150,43 @@ class Mosaic(BaseMixTransform):
         """Apply mixup transformation to the input image and labels."""
         assert labels.get('rect_shape', None) is None, 'rect and mosaic are mutually exclusive.'
         assert len(labels.get('mix_labels', [])), 'There are no other images for mosaic augment.'
-        return self._mosaic4(labels) if self.n == 4 else self._mosaic9(labels)
+        return self._mosaic3(labels) if self.n == 3 else self._mosaic4(labels) if self.n == 4 else self._mosaic9(labels)
+
+    def _mosaic3(self, labels):
+        """Create a 1x3 image mosaic."""
+        mosaic_labels = []
+        s = self.imgsz
+        hp, wp = -1, -1  # height, width previous
+        for i in range(3):
+            labels_patch = labels if i == 0 else labels['mix_labels'][i - 1]
+            # Load image
+            img = labels_patch['img']
+            h, w = labels_patch.pop('resized_shape')
+
+            # Place img in img3
+            if i == 0:  # center
+                img3 = np.full((s * 3, s * 3, img.shape[2]), 114, dtype=np.uint8)  # base image with 3 tiles
+                h0, w0 = h, w
+                c = s, s, s + w, s + h  # xmin, ymin, xmax, ymax (base) coordinates
+            elif i == 1:  # right
+                c = s + w0, s, s + w0 + w, s + h
+            elif i == 2:  # left
+                c = s - w, s + h0 - h, s, s + h0
+
+            padw, padh = c[:2]
+            x1, y1, x2, y2 = (max(x, 0) for x in c)  # allocate coords
+
+
+            img3[y1:y2, x1:x2] = img[y1 - padh:, x1 - padw:]  # img3[ymin:ymax, xmin:xmax]
+            hp, wp = h, w  # height, width previous for next iteration
+
+            # Labels assuming imgsz*2 mosaic size
+            labels_patch = self._update_labels(labels_patch, padw + self.border[0], padh + self.border[1])
+            mosaic_labels.append(labels_patch)
+        final_labels = self._cat_labels(mosaic_labels)
+
+        final_labels['img'] = img3[-self.border[0]:self.border[0], -self.border[1]:self.border[1]]
+        return final_labels
 
     def _mosaic4(self, labels):
         """Create a 2x2 image mosaic."""


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1fb7c8e</samp>

### Summary
🆕🖼️🏷️

<!--
1.  🆕 - This emoji can be used to indicate that a new feature or functionality was added, such as the support for 1x3 image mosaic data augmentation.
2.  🖼️ - This emoji can be used to represent the image-related aspect of the changes, such as the creation of the mosaic from three images.
3.  🏷️ - This emoji can be used to signify the labeling of the mosaic, which involves assigning the correct bounding boxes and classes to the regions of interest.
-->
Added a new data augmentation technique for 1x3 image mosaics in `ultralytics/data/augment.py`. This can improve the performance of object detection models on wide images.

> _To augment images with some flair_
> _The `Mosaic` class got a new pair_
> _Of methods to stitch_
> _Three pics in a niche_
> _And label the `_mosaic3` square_

### Walkthrough
*  Enable 1x3 image mosaic augmentation for the `Mosaic` class ([link](https://github.com/ultralytics/ultralytics/pull/4278/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L132-R135), [link](https://github.com/ultralytics/ultralytics/pull/4278/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L153-R188), )
  - Modify the constructor to accept a grid size of 3 and update the assert statement and the docstring ([link](https://github.com/ultralytics/ultralytics/pull/4278/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L132-R135))
  - Modify the `_mix_transform` method to call the `_mosaic3` method if the grid size is 3 ([link](https://github.com/ultralytics/ultralytics/pull/4278/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L153-R188))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Mosaic Augmentation with 1x3 Grid Option 🖼️🎨

### 📊 Key Changes
- Added support for a new 1x3 grid size in Mosaic augmentation.
- Adjusted the Mosaic class initialization to allow for the new grid option.
- Implemented the `_mosaic3` function to create a 1x3 image mosaic.
- Enforced a broader range of allowed grid sizes: now includes 3, 4, or 9.

### 🎯 Purpose & Impact
- 🏞 Provides more flexibility for data augmentation by allowing a new grid pattern for the mosaic of images.
- 🐛 Ensures compatibility by asserting that the grid size can only be 3, 4, or 9, which helps prevent errors.
- ⚙️ Enhances the learning process by introducing variability, which can help the model generalize better.
- 📈 Potentially increases dataset diversity, which may lead to improvements in model accuracy for users.