### PR TITLE
Fix `torch.Tensor` inference results plotting

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -215,7 +215,7 @@ class Results(SimpleClass):
             ```
         """
         if img is None and isinstance(self.orig_img, torch.Tensor):
-            img = np.ascontiguousarray(self.orig_img[0].permute(1, 2, 0).cpu().detach().numpy()) * 255
+            img = (self.orig_img[0].detach().permute(1, 2, 0).cpu().contiguous() * 255).to(torch.uint8).numpy()
 
         # Deprecation warn TODO: remove in 8.2
         if 'show_conf' in kwargs:


### PR DESCRIPTION
May resolve https://github.com/ultralytics/ultralytics/issues/4295


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5857a97</samp>

### Summary
🛠️🚀🎨

<!--
1.  🛠️ - This emoji can be used to indicate that the change was a bug fix or an improvement to the existing code. The deprecation warning and the performance issue can be considered as bugs or suboptimal features that were fixed by the change.
2.  🚀 - This emoji can be used to indicate that the change was a performance enhancement or a speed improvement. The casting to torch.uint8 before calling numpy() reduces the memory and computational overhead of the conversion, making the image plotting faster and more efficient.
3.  🎨 - This emoji can be used to indicate that the change was a cosmetic or aesthetic improvement. The casting to torch.uint8 before calling numpy() also ensures that the image values are in the correct range of [0, 255] for plotting, which can improve the visual quality and clarity of the images.
-->
Updated the tensor-to-array conversion in `ultralytics/engine/results.py` to use a better method and avoid warnings. This improves the image plotting functionality of the Results class.

> _`torch.uint8` cast_
> _avoids warning, speeds up_
> _plotting images_

### Walkthrough
*  Update tensor to numpy conversion method to avoid deprecation warning and improve performance ([link](https://github.com/ultralytics/ultralytics/pull/4297/files?diff=unified&w=0#diff-24af401e53ffc5ce49197395e1e3d7111344ad31b08cbb2bee9377614da98955L218-R218))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified image conversion in plotting function.

### 📊 Key Changes
- Refactored the image conversion code within the `plot` method.
- Removed the use of `numpy.ascontiguousarray` function and instead directly utilized PyTorch tensor methods for conversion.

### 🎯 Purpose & Impact
- 🚀 Enhances code simplicity and readability.
- 🧠 Potentially improves performance by reducing the overhead of switching between PyTorch and NumPy.
- 🔍 Users may experience a smoother and perhaps slightly faster visual representation generation in applications using this method.