### PR TITLE
Fix incorrect device selection when resuming training

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -80,8 +80,8 @@ class BaseTrainer:
             overrides (dict, optional): Configuration overrides. Defaults to None.
         """
         self.args = get_cfg(cfg, overrides)
-        self.device = select_device(self.args.device, self.args.batch)
         self.check_resume()
+        self.device = select_device(self.args.device, self.args.batch)
         self.validator = None
         self.model = None
         self.metrics = None


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 40a9ce4</samp>

### Summary
🐛🔄🖥️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. It indicates that the previous order of the statements caused an error and that the new order resolves it.
2.  🔄 - This emoji represents a change or an update, which is the effect of this change. It indicates that the order of the statements was swapped or reversed to achieve the desired functionality.
3.  🖥️ - This emoji represents a device or a computer, which is the subject of this change. It indicates that the change involves selecting and setting the device for the trainer and the checkpoint.
-->
Fixed a device mismatch bug in `BaseTrainer` by changing the order of `select_device` and `check_resume` calls in `trainer.py`. This ensures that the trainer resumes from a checkpoint on the same device as the user or the checkpoint.

> _`check_resume` first_
> _fixes device mismatch bug_
> _cold winter checkpoint_

### Walkthrough
* Fix device selection bug in `BaseTrainer` class ([link](https://github.com/ultralytics/ultralytics/pull/4301/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL83-R84))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated device selection process in the training initialization.

### 📊 Key Changes
- Changed the order of operations in `Trainer` initialization, specifically the device selection step.

### 🎯 Purpose & Impact
- This update ensures that device selection occurs after attempting to resume from a checkpoint.
- This rearrangement could potentially avoid issues related to device allocation when resuming training, leading to a smoother user experience. 🛠️
- Users may see improved error handling and resource management during the training resume process. 🔄