### PR TITLE
Improved Classify dataset splits and introspection

### DIFF
--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -304,7 +304,8 @@ def check_cls_dataset(dataset: str, split=''):
         s = f"Dataset download success ✅ ({time.time() - t:.1f}s), saved to {colorstr('bold', data_dir)}\n"
         LOGGER.info(s)
     train_set = data_dir / 'train'
-    val_set = data_dir / 'val' if (data_dir / 'val').exists() else None  # data/test or data/val
+    val_set = data_dir / 'val' if (data_dir / 'val').exists() else data_dir / 'validation' if (
+        data_dir / 'validation').exists() else None  # data/test or data/val
     test_set = data_dir / 'test' if (data_dir / 'test').exists() else None  # data/val or data/test
     if split == 'val' and not val_set:
         LOGGER.info("WARNING ⚠️ Dataset 'split=val' not found, using 'split=test' instead.")
@@ -314,6 +315,17 @@ def check_cls_dataset(dataset: str, split=''):
     nc = len([x for x in (data_dir / 'train').glob('*') if x.is_dir()])  # number of classes
     names = [x.name for x in (data_dir / 'train').iterdir() if x.is_dir()]  # class names list
     names = dict(enumerate(sorted(names)))
+
+    # Print to console
+    for k, v in {'train': train_set, 'val': val_set, 'test': test_set}.items():
+        if v is None:
+            LOGGER.info(colorstr(k) + f': {v}')
+        else:
+            files = [path for path in v.rglob('*.*') if path.suffix[1:].lower() in IMG_FORMATS]
+            nf = len(files)  # number of files
+            nd = len({file.parent for file in files})  # number of directories
+            LOGGER.info(colorstr(k) + f': {v}... found {nf} images in {nd} classes ✅ ')  # keep trailing space
+
     return {'train': train_set, 'val': val_set or test_set, 'test': test_set or val_set, 'nc': nc, 'names': names}
 
 


### PR DESCRIPTION
May resolve #4310 

<img width="903" alt="Screenshot 2023-08-11 at 20 20 30" src="https://github.com/ultralytics/ultralytics/assets/26833433/f15f97df-419c-41d1-8248-e327421733ec">


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6d63c1c</samp>

### Summary
🛠️🆕📊

<!--
1.  🛠️ - This emoji represents improvement or fixing something, and it can be used to indicate that the function was improved to handle different validation set names and to provide more feedback on the dataset structure and contents.
2.  🆕 - This emoji represents something new or added, and it can be used to indicate that the function can now recognize `validation` as a valid name for the validation split.
3.  📊 - This emoji represents data or statistics, and it can be used to indicate that the function prints the number of images and classes for each set.
-->
Improved `check_cls_dataset` function in `ultralytics/data/utils.py` to support more validation set names and provide better dataset information.

> _`check_cls_dataset` is the key to our fate_
> _It validates our data with no mistake_
> _It counts the images and classes we create_
> _It handles any split name we can make_

### Walkthrough
*  Add support for `validation` as a possible name for the validation set in `check_cls_dataset` ([link](https://github.com/ultralytics/ultralytics/pull/4312/files?diff=unified&w=0#diff-ec08ff3087043c4949ebd4c16ec17073bdb827e25ff1840d1eb7c87841b8911cL307-R308))
*  Print more information about the train, val, and test sets in `check_cls_dataset`, using color and emoji for clarity ([link](https://github.com/ultralytics/ultralytics/pull/4312/files?diff=unified&w=0#diff-ec08ff3087043c4949ebd4c16ec17073bdb827e25ff1840d1eb7c87841b8911cR318-R328))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to dataset validation flexibility in `ultralytics/data/utils.py`.

### 📊 Key Changes
- Added support for a 'validation' folder when checking for validation datasets.
- Enhanced console logging to include counts of files and directories for each dataset split (train, validation, test).

### 🎯 Purpose & Impact
- **Purpose**: The change allows for more flexible dataset folder naming by recognizing both 'val' and 'validation' as valid validation dataset directories.
- **Impact**: Users with datasets that use 'validation' instead of 'val' can use Ultralytics' tools without renaming their directories. The additional logging provides clearer insight into dataset contents, enhancing user awareness and debugging capabilities. 👍