### PR TITLE
ORT_CPP add CUDA FP16 inference

### DIFF
--- a/examples/YOLOv8-ONNXRuntime-CPP/CMakeLists.txt
+++ b/examples/YOLOv8-ONNXRuntime-CPP/CMakeLists.txt
@@ -16,6 +16,10 @@ find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 
+# -------------- Compile CUDA for FP16 inference if needed  ------------------#
+find_package(CUDA REQUIRED)
+include_directories(${CUDA_INCLUDE_DIRS})
+
 
 # ONNXRUNTIME
 
@@ -51,9 +55,9 @@ set(PROJECT_SOURCES
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})
 
 if(WIN32)
-    target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${ONNXRUNTIME_ROOT}/lib/onnxruntime.lib)
+    target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${ONNXRUNTIME_ROOT}/lib/onnxruntime.lib ${CUDA_LIBRARIES})
 elseif(LINUX)
-    target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${ONNXRUNTIME_ROOT}/lib/libonnxruntime.so)
+    target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${ONNXRUNTIME_ROOT}/lib/libonnxruntime.so ${CUDA_LIBRARIES})
 elseif(APPLE)
     target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${ONNXRUNTIME_ROOT}/lib/libonnxruntime.dylib)
 endif()

--- a/examples/YOLOv8-ONNXRuntime-CPP/README.md
+++ b/examples/YOLOv8-ONNXRuntime-CPP/README.md
@@ -6,8 +6,7 @@ This example demonstrates how to perform inference using YOLOv8 in C++ with ONNX
 
 - Friendly for deployment in the industrial sector.
 - Faster than OpenCV's DNN inference on both CPU and GPU.
-- Supports CUDA acceleration.
-- Easy to add FP16 inference (using template functions).
+- Supports FP32 and FP16 CUDA acceleration.
 
 ## Exporting YOLOv8 Models
 
@@ -47,13 +46,12 @@ Note: The dependency on C++17 is due to the usage of the C++17 filesystem featur
 DCSP_INIT_PARAM params{ model_path, YOLO_ORIGIN_V8, {imgsz_w, imgsz_h}, 0.1, 0.5, false};
 // GPU inference
 DCSP_INIT_PARAM params{ model_path, YOLO_ORIGIN_V8, {imgsz_w, imgsz_h}, 0.1, 0.5, true};
-
 // Load your image
 cv::Mat img = cv::imread(img_path);
+// Init Inference Session
+char* ret = yoloDetector->CreateSession(params);
 
-char* ret = p1->CreateSession(params);
-
-ret = p->RunSession(img, res);
+ret = yoloDetector->RunSession(img, res);
 ```
 
 This repository should also work for YOLOv5, which needs a permute operator for the output of the YOLOv5 model, but this has not been implemented yet.

--- a/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
+++ b/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
@@ -287,7 +287,7 @@ char* DCSP_CORE::WarmUpSession()
 		std::vector<int64_t> YOLO_input_node_dims = { 1,3,imgSize.at(0),imgSize.at(1) };
 		Ort::Value input_tensor = Ort::Value::CreateTensor<half>(Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU), blob, 3 * imgSize.at(0) * imgSize.at(1), YOLO_input_node_dims.data(), YOLO_input_node_dims.size());
 		auto output_tensors = session->Run(options, inputNodeNames.data(), &input_tensor, 1, outputNodeNames.data(), outputNodeNames.size());
-		delete blob;
+		delete[] blob;
 		clock_t starttime_4 = clock();
 		double post_process_time = (double)(starttime_4 - starttime_1) / CLOCKS_PER_SEC * 1000;
 		if (cudaEnable)

--- a/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
+++ b/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
@@ -15,6 +15,13 @@ DCSP_CORE::~DCSP_CORE()
 }
 
 
+namespace Ort
+{
+	template<>
+	struct TypeToTensorType<half> { static constexpr ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16; };
+}
+
+
 template<typename T>
 char* BlobFromImage(cv::Mat& iImg, T& iBlob)
 {
@@ -56,7 +63,7 @@ char* DCSP_CORE::CreateSession(DCSP_INIT_PARAM &iParams)
 	bool result = std::regex_search(iParams.ModelPath, pattern);
 	if (result)
 	{
-		Ret = "[DCSP_ONNX]:model path error.change your model path without chinese characters.";
+		Ret = "[DCSP_ONNX]:Model path error.Change your model path without chinese characters.";
 		std::cout << Ret << std::endl;
 		return Ret;
 	}
@@ -109,9 +116,7 @@ char* DCSP_CORE::CreateSession(DCSP_INIT_PARAM &iParams)
 		}
 		options = Ort::RunOptions{ nullptr };
 		WarmUpSession();
-		//std::cout << OrtGetApiBase()->GetVersionString() << std::endl;;
-		Ret = RET_OK;
-		return Ret;
+		return RET_OK;
 	}
 	catch (const std::exception& e)
 	{
@@ -122,7 +127,6 @@ char* DCSP_CORE::CreateSession(DCSP_INIT_PARAM &iParams)
 		std::strcpy(merged, result.c_str());
 		std::cout << merged << std::endl;
 		delete[] merged;
-		//return merged;
 		return "[DCSP_ONNX]:Create session failed.";
 	}
 
@@ -141,6 +145,13 @@ char* DCSP_CORE::RunSession(cv::Mat &iImg, std::vector<DCSP_RESULT>& oResult)
 	if (modelType < 4)
 	{
 		float* blob = new float[processedImg.total() * 3];
+		BlobFromImage(processedImg, blob);
+		std::vector<int64_t> inputNodeDims = { 1,3,imgSize.at(0),imgSize.at(1) };
+		TensorProcess(starttime_1, iImg, blob, inputNodeDims, oResult);
+	}
+	else
+	{
+		half* blob = new half[processedImg.total() * 3];
 		BlobFromImage(processedImg, blob);
 		std::vector<int64_t> inputNodeDims = { 1,3,imgSize.at(0),imgSize.at(1) };
 		TensorProcess(starttime_1, iImg, blob, inputNodeDims, oResult);
@@ -169,7 +180,8 @@ char* DCSP_CORE::TensorProcess(clock_t& starttime_1, cv::Mat& iImg, N& blob, std
 	delete blob;
 	switch (modelType)
 	{
-	case 1:
+	case 1://V8_ORIGIN_FP32
+	case 4://V8_ORIGIN_FP16
 	{
 		int strideNum = outputNodeDims[2];
 		int signalResultNum = outputNodeDims[1];
@@ -243,15 +255,13 @@ char* DCSP_CORE::TensorProcess(clock_t& starttime_1, cv::Mat& iImg, N& blob, std
 		break;
 	}
 	}
-	char* Ret = RET_OK;
-	return Ret;
+	return RET_OK;
 }
 
 
 char* DCSP_CORE::WarmUpSession()
 {
 	clock_t starttime_1 = clock();
-	char* Ret = RET_OK;
 	cv::Mat iImg = cv::Mat(cv::Size(imgSize.at(0), imgSize.at(1)), CV_8UC3);
 	cv::Mat processedImg;
 	PostProcess(iImg, imgSize, processedImg);
@@ -270,5 +280,20 @@ char* DCSP_CORE::WarmUpSession()
 			std::cout << "[DCSP_ONNX(CUDA)]: " << "Cuda warm-up cost " << post_process_time << " ms. " << std::endl;
 		}
 	}
-	return Ret;
+	else
+	{
+		half* blob = new half[iImg.total() * 3];
+		BlobFromImage(processedImg, blob);
+		std::vector<int64_t> YOLO_input_node_dims = { 1,3,imgSize.at(0),imgSize.at(1) };
+		Ort::Value input_tensor = Ort::Value::CreateTensor<half>(Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU), blob, 3 * imgSize.at(0) * imgSize.at(1), YOLO_input_node_dims.data(), YOLO_input_node_dims.size());
+		auto output_tensors = session->Run(options, inputNodeNames.data(), &input_tensor, 1, outputNodeNames.data(), outputNodeNames.size());
+		delete blob;
+		clock_t starttime_4 = clock();
+		double post_process_time = (double)(starttime_4 - starttime_1) / CLOCKS_PER_SEC * 1000;
+		if (cudaEnable)
+		{
+			std::cout << "[DCSP_ONNX(CUDA)]: " << "Cuda warm-up cost " << post_process_time << " ms. " << std::endl;
+		}
+	}
+	return RET_OK;
 }

--- a/examples/YOLOv8-ONNXRuntime-CPP/inference.h
+++ b/examples/YOLOv8-ONNXRuntime-CPP/inference.h
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <opencv2/opencv.hpp>
 #include "onnxruntime_cxx_api.h"
+#include <cuda_fp16.h>
 
 
 enum MODEL_TYPE
@@ -21,7 +22,10 @@ enum MODEL_TYPE
 	YOLO_ORIGIN_V5 = 0,
 	YOLO_ORIGIN_V8 = 1,//only support v8 detector currently
 	YOLO_POSE_V8 = 2,
-	YOLO_CLS_V8 = 3
+	YOLO_CLS_V8 = 3,
+	YOLO_ORIGIN_V8_HALF = 4,
+	YOLO_POSE_V8_HALF = 5,
+	YOLO_CLS_V8_HALF = 6
 };
 
 

--- a/examples/YOLOv8-ONNXRuntime-CPP/main.cpp
+++ b/examples/YOLOv8-ONNXRuntime-CPP/main.cpp
@@ -82,13 +82,15 @@ int read_coco_yaml(DCSP_CORE*& p)
 
 int main()
 {
-	DCSP_CORE* p1 = new DCSP_CORE;
+	DCSP_CORE* yoloDetector = new DCSP_CORE;
 	std::string model_path = "yolov8n.onnx";
-    read_coco_yaml(p1);
-	// GPU inference
+    read_coco_yaml(yoloDetector);
+	// GPU FP32 inference
 	DCSP_INIT_PARAM params{ model_path, YOLO_ORIGIN_V8, {640, 640},  0.1, 0.5, true };
+    // GPU FP16 inference
+	// DCSP_INIT_PARAM params{ model_path, YOLO_ORIGIN_V8_HALF, {640, 640},  0.1, 0.5, true };
 	// CPU inference
     // DCSP_INIT_PARAM params{ model_path, YOLO_ORIGIN_V8, {640, 640},  0.1, 0.5, false };
-    p1->CreateSession(params);
-	file_iterator(p1);
+    yoloDetector->CreateSession(params);
+	file_iterator(yoloDetector);
 }


### PR DESCRIPTION
Hello!
My work on the semi-precision inference code was complete.Here I create this PR to add the function to this demo.

# Summary
I added a new feature for semi-precision inference to this project, and added the corresponding content in the ReadMe file and the CMake file simultaneously.

# Walkthrough
1. Adding a specialization of the TypeToTensorType class template in the Ort namespace to map the half (16-bit floating point) type to the ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 type in the ONNX API. [link](https://github.com/ultralytics/ultralytics/pull/4320/files#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8R18-R24)
2. Fix some spelling issues in the return of error reports. [link](https://github.com/ultralytics/ultralytics/pull/4320/files#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8R66)
3. Add semi-precision model names to the enumeration of ModelTypes. [link](https://github.com/ultralytics/ultralytics/pull/4320/files#diff-f5d599dd06fc6fe16f8d0baa50c155992f0769af08495431ad265ad74dc4f90fR25-R28)
4. Add fp16 inference post-process code. [link](https://github.com/ultralytics/ultralytics/pull/4320/files#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8R152-R158)
5. Add fp16 model warm-up code. [link](https://github.com/ultralytics/ultralytics/compare/main...DennisJcy:ORT_CPP_AddFP16?expand=1#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8R283-R298)
6. Fix the demo code in ReadMe file.[link](https://github.com/ultralytics/ultralytics/pull/4320/files#diff-8dcaf249262d078e57bbf538f19ad18478ae52f4909bd5d3eb32dd923cd95a4bR51-R54)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CUDA integration and FP16 support in YOLOv8 C++ ONNXRuntime example.

### 📊 Key Changes
- 🤖 Added CUDA as a required package in CMake and linked CUDA libraries for both Windows and Linux builds.
- 💾 Simplified README with unified CUDA acceleration instructions for both FP32 and FP16.
- 👾 Updated `inference.cpp` to include specialization for FP16 tensor types and adjusted error handling.
- 🏎️ Extended enum `MODEL_TYPE` in `inference.h` to support FP16 model variants.

### 🎯 Purpose & Impact
- 🚀 Enhanced performance by enabling FP16 inference, which allows for faster computations on GPUs supporting half-precision.
- 🔧 Streamlined the build process with CMake, making it easier to compile and run the example with required dependencies.
- 🔍 Improved error messages and code readability, offering a smoother developer experience and ease of troubleshooting.
- 📈 Broadened support for different model types and precision, catering to a variety of use cases and hardware capabilities.