### PR TITLE
fix ddp command missing when use custom train.py

### DIFF
--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -57,7 +57,9 @@ def generate_ddp_command(world_size, trainer):
         file = generate_ddp_file(trainer)
     dist_cmd = 'torch.distributed.run' if TORCH_1_9 else 'torch.distributed.launch'
     port = find_free_network_port()
-    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file, *sys.argv[1:] ]
+    cmd = [
+        sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file,
+        *sys.argv[1:]]
     return cmd, file
 
 

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -57,7 +57,7 @@ def generate_ddp_command(world_size, trainer):
         file = generate_ddp_file(trainer)
     dist_cmd = 'torch.distributed.run' if TORCH_1_9 else 'torch.distributed.launch'
     port = find_free_network_port()
-    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file]
+    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file, *sys.argv[1:] ]
     return cmd, file
 
 


### PR DESCRIPTION
Yolov8 provides two ways to start a training: CLI and Python code, but when we want to pass arguments to our own Python training code like below:
```
from ultralytics import YOLO
import yaml
import argparse

parser = argparse.ArgumentParser()
parser.add_argument('--data', type=str, default='configs/data/phd.yaml', help='dataset.yaml path')
parser.add_argument('--epochs', type=int, default=300, help='number of epochs')
parser.add_argument('--start-epoch', type=int, default=0, help='start of epoch')

parser.add_argument('--hyp', type=str, default='configs/hyp.yaml', help='size of each image batch')
parser.add_argument('--model', type=str, default='weights/yolov8n.pt', help='pretrained weights or model.config path')
parser.add_argument('--batch-size', type=int, default=64, help='size of each image batch')
parser.add_argument('--img-size', type=int, default=320, help='size of each image dimension')
parser.add_argument('--device', type=str, default='0', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
parser.add_argument('--project', type=str, default='yolo', help='project name')
parser.add_argument('--name', type=str, default='pretrain', help='name of the experiment')
parser.add_argument('--resume', nargs='?', const=True, default=False, help='resume most recent training')

args = parser.parse_args()

assert args.data, 'argument --data path is required'
assert args.model, 'argument --model path is required'

if __name__ == '__main__':
    # Initialize
    model = YOLO(args.model)
    hyperparams = yaml.safe_load(open(args.hyp))
    hyperparams['epochs'] = args.epochs
    hyperparams['batch'] = args.batch_size
    hyperparams['imgsz'] = args.img_size
    hyperparams['device'] = args.device
    hyperparams['project'] = args.project
    hyperparams['name'] = args.name
    hyperparams['resume'] = args.resume
    hyperparams['start_epoch'] = args.start_epoch

    model.train(data= args.data, **hyperparams)
```
if we train with single gpu, it works ok. but if we want to train with ddp, below error will occur:
```
assert args.model, 'argument --model path is required'
```
the reason of this error is when yolov8 construct ddp command, the comand arguments are ignored:
```
cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file]
```
to fix this, we should add command arguments behand file.
```
cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file, *sys.argv[1:]]
```

I have read the CLA Document and I sign the CLA
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e5691ec</samp>

### Summary
🚀🌐🛠️

<!--
1.  🚀 This emoji can be used to indicate a new feature or improvement that enhances the performance, usability, or functionality of the project. In this case, the change allows more flexibility and control over the distributed training process by enabling custom arguments.
2.  🌐 This emoji can be used to indicate a change related to internationalization, localization, or globalization of the project. In this case, the change affects the distributed command, which is used to launch multiple workers across different machines or regions. The emoji can also imply scalability or parallelism, which are relevant aspects of distributed training.
3.  🛠️ This emoji can be used to indicate a bug fix, maintenance, or refactoring of the project. In this case, the change fixes a potential issue where the distributed workers would not receive the same arguments as the main script, leading to inconsistent or erroneous results. The emoji can also imply improvement or optimization, which are desirable outcomes of distributed training.
-->
Append command line arguments to distributed command in `ultralytics/utils/dist.py`. This enables customizing the distributed training settings and outputs.

> _`ultralytics` trains_
> _with distributed workers_
> _passing `args` in fall_

### Walkthrough
*  Append command line arguments to distributed command ([link](https://github.com/ultralytics/ultralytics/pull/4362/files?diff=unified&w=0#diff-6d6c6436fc82e51c808c2c794bc3f4f74c8d960fccb1157ea2899feeca50fd10L60-R60)) to enable customizing distributed workers with configuration files, hyperparameters, or output directories.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved distributed training command generation in Ultralytics utils.

### 📊 Key Changes
- Modified the distributed data parallel (DDP) command generation logic.
- Command list now includes `sys.argv[1:]` to pass all command-line arguments to the worker processes.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: The change ensures that any additional command-line arguments provided during the initial script call are propagated to each subprocess when using DPP, enhancing configurability and ease of use.
- 📈 **Impact**: Users can expect more flexible and convenient distributed training, as all worker nodes will receive the full set of command-line arguments, leading to potentially more efficient and customized training workflows.