### PR TITLE
Update kfold-cross-validation.md

### DIFF
--- a/docs/guides/kfold-cross-validation.md
+++ b/docs/guides/kfold-cross-validation.md
@@ -198,7 +198,7 @@ The ideal scenario is for all class ratios to be reasonably similar for each spl
     
         with open(dataset_yaml, 'w') as ds_y:
             yaml.safe_dump({
-                'path': save_path.as_posix(),
+                'path': split_dir.as_posix(),
                 'train': 'train',
                 'val': 'val',
                 'names': classes


### PR DESCRIPTION
Change `save_path.as_posix()` on line 200 to `split_dir.as_posix()`
I have read the CLA Document and I sign the CLA.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  


Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b3caa99</samp>

### Summary
🐛📁🔀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request.
2.  📁 - This emoji represents a folder or directory, which is the type of value that was changed in the dataset YAML file.
3.  🔀 - This emoji represents a shuffle or a split, which is the operation that creates the different directories for each fold of the cross-validation.
-->
Fix a bug in the k-fold cross-validation tutorial by correcting the `path` value in the dataset YAML file. This ensures that the dataset YAML file matches the actual location of the train and val images for each split.

> _`path` value changed_
> _to fix cross-validation_
> _bug in the spring tutorial_

### Walkthrough
* Fix bug in k-fold cross-validation tutorial by changing dataset YAML file path ([link](https://github.com/ultralytics/ultralytics/pull/4401/files?diff=unified&w=0#diff-4d0af84477c7d01bebacec01f16efc5e3cf2c71ba5a081b1edf8964fbbd2e02bL201-R201))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated k-fold cross-validation documentation for dataset path management.

### 📊 Key Changes
- Corrected the output path in k-fold cross-validation guide's YAML configuration.

### 🎯 Purpose & Impact
- 🛠️ Fixes the dataset path to point to the specific split directory, ensuring the YAML configuration works as intended.
- 🚀 Improves user experience by providing accurate instructions for setting up cross-validation, leading to more reliable machine learning model training and evaluation.