### PR TITLE
Update kfold-cross-validation.md

### DIFF
--- a/docs/guides/kfold-cross-validation.md
+++ b/docs/guides/kfold-cross-validation.md
@@ -198,7 +198,7 @@ The ideal scenario is for all class ratios to be reasonably similar for each spl
     
         with open(dataset_yaml, 'w') as ds_y:
             yaml.safe_dump({
-                'path': save_path.as_posix(),
+                'path': split_dir.as_posix(),
                 'train': 'train',
                 'val': 'val',
                 'names': classes


### PR DESCRIPTION
Change save_path.as_posix() on line 200 to split_dir.as_posix(). I closed the old head by mistake 😅
I have read the CLA Document and I sign the CLA

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6add134</samp>

### Summary
:recycle::wrench::file_folder:

<!--
1.  :recycle: This emoji can be used to indicate that something was renamed or refactored, as in this case the `path` value was changed to a more accurate and descriptive name.
2.  :wrench: This emoji can be used to indicate that something was fixed or improved, as in this case the `path` value was changed to point to the correct location of the images for each split.
3.  :file_folder: This emoji can be used to indicate that something was related to files or directories, as in this case the `path` value was changed to reflect the structure of the data folders.
-->
Updated the dataset YAML file for k-fold cross validation to use the correct `path` value. This fixes a bug where the wrong images were used for training and validation in each fold.

> _`path` value changed_
> _from `save_path` to `split_dir`_
> _autumn leaves falling_

### Walkthrough
*  Update the dataset YAML file to use `split_dir` instead of `save_path` for the `path` value ([link](https://github.com/ultralytics/ultralytics/pull/4415/files?diff=unified&w=0#diff-4d0af84477c7d01bebacec01f16efc5e3cf2c71ba5a081b1edf8964fbbd2e02bL201-R201))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced clarity in k-fold cross-validation guide.

### 📊 Key Changes
- Corrected the key in dataset YAML from `path` to `split_dir`.

### 🎯 Purpose & Impact
- 🛠 Fixes a potential point of confusion by ensuring that the YAML configuration accurately reflects the directory structure.
- 📈 Improves user comprehension and ease of implementation for k-fold cross-validation, potentially leading to more robust model training outcomes.