### PR TITLE
Docker-python fix for `get_ubuntu_version()`

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -85,7 +85,7 @@ jobs:
           docker push ultralytics/ultralytics:${{ matrix.tags }}
 
       - name: Notify on failure
-        if: github.event_name == 'push' && (cancelled() || failure())
+        if: github.event_name == 'push' && failure()  # do not notify on cancelled() as cancelling is performed by hand
         uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -295,10 +295,8 @@ def test_events():
 
 
 def test_utils_init():
-    from ultralytics.utils import (get_git_branch, get_git_origin_url, get_ubuntu_version, is_github_actions_ci,
-                                   is_ubuntu)
+    from ultralytics.utils import get_git_branch, get_git_origin_url, get_ubuntu_version, is_github_actions_ci
 
-    is_ubuntu()
     get_ubuntu_version()
     is_github_actions_ci()
     get_git_origin_url()

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -424,7 +424,9 @@ class Exporter:
                 'https://github.com/pnnx/pnnx/.\nNote PNNX Binary file must be placed in current working directory '
                 f'or in {ROOT}. See PNNX repo for full installation instructions.')
             _, assets = get_github_assets(repo='pnnx/pnnx', retry=True)
-            asset = [x for x in assets if ('macos' if MACOS else 'ubuntu' if LINUX else 'windows') in x][0]
+            system = 'macos' if MACOS else 'ubuntu' if LINUX else 'windows'  # operating system
+            asset = [x for x in assets if system in x][0] if assets else \
+                f'https://github.com/pnnx/pnnx/releases/download/20230816/pnnx-20230816-{system}.zip'  # fallback
             attempt_download_asset(asset, repo='pnnx/pnnx', release='latest')
             unzip_dir = Path(asset).with_suffix('')
             pnnx = ROOT / pnnx_filename  # new location

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -571,9 +571,10 @@ def get_ubuntu_version():
     Returns:
         (str): Ubuntu version or None if not an Ubuntu OS.
     """
-    with contextlib.suppress(FileNotFoundError, AttributeError):
-        with open('/etc/os-release') as f:
-            return re.search(r'VERSION_ID="(\d+\.\d+)"', f.read())[1]
+    if is_ubuntu():
+        with contextlib.suppress(FileNotFoundError, AttributeError):
+            with open('/etc/os-release') as f:
+                return re.search(r'VERSION_ID="(\d+\.\d+)"', f.read())[1]
 
 
 def get_user_config_dir(sub_dir='Ultralytics'):


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 28dd040</samp>

### Summary
🚫🧹🐛

<!--
1.  🚫 for excluding cancelled runs from the notification condition.
2.  🧹 for removing unused imports from the test function.
3.  🐛 for fixing the logic for finding the asset and checking the OS version.
-->
This pull request improves the robustness and readability of some code and workflow components. It fixes the docker failure notification condition, removes unused imports from a test function, enhances the pnnx asset finding logic, and adds an OS check to the `get_ubuntu_version` function.

> _`test_utils_init`_
> _Cleans imports, no errors_
> _Autumn leaves falling_

### Walkthrough
*  Exclude cancelled runs from failure notification in Docker workflow ([link](https://github.com/ultralytics/ultralytics/pull/4430/files?diff=unified&w=0#diff-17e3400d876978d12bbad517dcf82312b54fa62723408b1ce011b2755458bdafL88-R88))
*  Remove unused imports from `test_utils_init` function in `tests/test_python.py` ([link](https://github.com/ultralytics/ultralytics/pull/4430/files?diff=unified&w=0#diff-51deb1ccb3a8b618784df2e2abfbc3b056436f1db72d1896d5102f9906978492L298-R299))
*  Improve asset finding logic for pnnx installation in `ultralytics/engine/exporter.py` ([link](https://github.com/ultralytics/ultralytics/pull/4430/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL427-R429))
*  Check OS before reading `/etc/os-release` in `get_ubuntu_version` function in `ultralytics/utils/__init__.py` ([link](https://github.com/ultralytics/ultralytics/pull/4430/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faL574-R577))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to Docker notifications, code clean-up, and improved exporter functionality.

### 📊 Key Changes
- Updated Docker GitHub Actions workflow to prevent Slack notifications on manual cancellation.
- Simplified import statements and removed an unnecessary function call in utility tests.
- Streamlined operating system detection and fallback mechanism in the model exporter for NCNN.

### 🎯 Purpose & Impact
- Users will no longer receive unnecessary Slack notifications when a Docker action is cancelled manually, reducing notification noise. 🤫
- Codebase is cleaner with better readability, making maintenance and contributions easier. 🧹
- The NCNN export process now better handles different operating systems and provides a clearer fallback, enhancing user experience across platforms. 🔄