### PR TITLE
Fix conversion ops using `clone` and `copy`

### DIFF
--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -13,7 +13,7 @@ import requests
 import torch
 from tqdm import tqdm
 
-from ultralytics.utils import LOGGER, checks, clean_url, emojis, is_online, url2file
+from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, checks, clean_url, emojis, is_online, url2file
 
 GITHUB_ASSET_NAMES = [f'yolov8{k}{suffix}.pt' for k in 'nsmlx' for suffix in ('', '6', '-cls', '-seg', '-pose')] + \
                      [f'yolov5{k}u.pt' for k in 'nsmlx'] + \
@@ -287,7 +287,6 @@ def safe_download(url,
                     if method == 'torch':
                         torch.hub.download_url_to_file(url, f, progress=progress)
                     else:
-                        from ultralytics.utils import TQDM_BAR_FORMAT
                         with request.urlopen(url) as response, tqdm(total=int(response.getheader('Content-Length', 0)),
                                                                     desc=desc,
                                                                     disable=not progress,

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -24,15 +24,15 @@ to_2tuple = _ntuple(2)
 to_4tuple = _ntuple(4)
 
 # `xyxy` means left top and right bottom
-# `xywh` means center x, center y and width, height(yolo format)
-# `ltwh` means left top and width, height(coco format)
+# `xywh` means center x, center y and width, height(YOLO format)
+# `ltwh` means left top and width, height(COCO format)
 _formats = ['xyxy', 'xywh', 'ltwh']
 
 __all__ = 'Bboxes',  # tuple or list
 
 
 class Bboxes:
-    """Now only numpy is supported."""
+    """Bounding Boxes class. Only numpy variables are supported."""
 
     def __init__(self, bboxes, format='xyxy') -> None:
         assert format in _formats, f'Invalid bounding box format: {format}, format must be one of {_formats}'
@@ -43,40 +43,18 @@ class Bboxes:
         self.format = format
         # self.normalized = normalized
 
-    # def convert(self, format):
-    #     assert format in _formats
-    #     if self.format == format:
-    #         bboxes = self.bboxes
-    #     elif self.format == "xyxy":
-    #         if format == "xywh":
-    #             bboxes = xyxy2xywh(self.bboxes)
-    #         else:
-    #             bboxes = xyxy2ltwh(self.bboxes)
-    #     elif self.format == "xywh":
-    #         if format == "xyxy":
-    #             bboxes = xywh2xyxy(self.bboxes)
-    #         else:
-    #             bboxes = xywh2ltwh(self.bboxes)
-    #     else:
-    #         if format == "xyxy":
-    #             bboxes = ltwh2xyxy(self.bboxes)
-    #         else:
-    #             bboxes = ltwh2xywh(self.bboxes)
-    #
-    #     return Bboxes(bboxes, format)
-
     def convert(self, format):
         """Converts bounding box format from one type to another."""
         assert format in _formats, f'Invalid bounding box format: {format}, format must be one of {_formats}'
         if self.format == format:
             return
         elif self.format == 'xyxy':
-            bboxes = xyxy2xywh(self.bboxes) if format == 'xywh' else xyxy2ltwh(self.bboxes)
+            func = xyxy2xywh if format == 'xywh' else xyxy2ltwh
         elif self.format == 'xywh':
-            bboxes = xywh2xyxy(self.bboxes) if format == 'xyxy' else xywh2ltwh(self.bboxes)
+            func = xywh2xyxy if format == 'xyxy' else xywh2ltwh
         else:
-            bboxes = ltwh2xyxy(self.bboxes) if format == 'xyxy' else ltwh2xywh(self.bboxes)
-        self.bboxes = bboxes
+            func = ltwh2xyxy if format == 'xyxy' else ltwh2xywh
+        self.bboxes = func(self.boxes)
         self.format = format
 
     def areas(self):

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -54,7 +54,7 @@ class Bboxes:
             func = xywh2xyxy if format == 'xyxy' else xywh2ltwh
         else:
             func = ltwh2xyxy if format == 'xyxy' else ltwh2xywh
-        self.bboxes = func(self.boxes)
+        self.bboxes = func(self.bboxes)
         self.format = format
 
     def areas(self):

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -446,7 +446,7 @@ def xywh2ltwh(x):
     Returns:
         y (np.ndarray | torch.Tensor): The bounding box coordinates in the xyltwh format
     """
-    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x) 
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
     y[:, 0] = x[:, 0] - x[:, 2] / 2  # top left x
     y[:, 1] = x[:, 1] - x[:, 3] / 2  # top left y
     return y

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -431,7 +431,7 @@ def xyn2xy(x, w=640, h=640, padw=0, padh=0):
     Returns:
         y (np.ndarray | torch.Tensor): The x and y coordinates of the top left corner of the bounding box
     """
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
     y[..., 0] = w * x[..., 0] + padw  # top left x
     y[..., 1] = h * x[..., 1] + padh  # top left y
     return y

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -467,7 +467,7 @@ def xywh2ltwh(x):
     Returns:
         y (np.ndarray | torch.Tensor): The bounding box coordinates in the xyltwh format
     """
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x) 
     y[:, 0] = x[:, 0] - x[:, 2] / 2  # top left x
     y[:, 1] = x[:, 1] - x[:, 3] / 2  # top left y
     return y
@@ -482,7 +482,7 @@ def xyxy2ltwh(x):
     Returns:
       y (np.ndarray | torch.Tensor): The bounding box coordinates in the xyltwh format.
     """
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
     y[:, 2] = x[:, 2] - x[:, 0]  # width
     y[:, 3] = x[:, 3] - x[:, 1]  # height
     return y
@@ -495,7 +495,7 @@ def ltwh2xywh(x):
     Args:
       x (torch.Tensor): the input tensor
     """
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
     y[:, 0] = x[:, 0] + x[:, 2] / 2  # center x
     y[:, 1] = x[:, 1] + x[:, 3] / 2  # center y
     return y
@@ -590,7 +590,7 @@ def ltwh2xyxy(x):
     Returns:
       y (np.ndarray | torch.Tensor): the xyxy coordinates of the bounding boxes.
     """
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
     y[:, 2] = x[:, 2] + x[:, 0]  # width
     y[:, 3] = x[:, 3] + x[:, 1]  # height
     return y

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -344,7 +344,8 @@ def xyxy2xywh(x):
     Returns:
         y (np.ndarray | torch.Tensor): The bounding box coordinates in (x, y, width, height) format.
     """
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    assert x.shape[-1] == 4, f'input shape last dimension expected 4 but input shape is {x.shape}'
+    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)  # faster than clone/copy
     y[..., 0] = (x[..., 0] + x[..., 2]) / 2  # x center
     y[..., 1] = (x[..., 1] + x[..., 3]) / 2  # y center
     y[..., 2] = x[..., 2] - x[..., 0]  # width
@@ -362,7 +363,8 @@ def xywh2xyxy(x):
     Returns:
         y (np.ndarray | torch.Tensor): The bounding box coordinates in (x1, y1, x2, y2) format.
     """
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    assert x.shape[-1] == 4, f'input shape last dimension expected 4 but input shape is {x.shape}'
+    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)  # faster than clone/copy
     dw = x[..., 2] / 2  # half-width
     dh = x[..., 3] / 2  # half-height
     y[..., 0] = x[..., 0] - dw  # top left x
@@ -386,7 +388,8 @@ def xywhn2xyxy(x, w=640, h=640, padw=0, padh=0):
         y (np.ndarray | torch.Tensor): The coordinates of the bounding box in the format [x1, y1, x2, y2] where
             x1,y1 is the top-left corner, x2,y2 is the bottom-right corner of the bounding box.
     """
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    assert x.shape[-1] == 4, f'input shape last dimension expected 4 but input shape is {x.shape}'
+    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)  # faster than clone/copy
     y[..., 0] = w * (x[..., 0] - x[..., 2] / 2) + padw  # top left x
     y[..., 1] = h * (x[..., 1] - x[..., 3] / 2) + padh  # top left y
     y[..., 2] = w * (x[..., 0] + x[..., 2] / 2) + padw  # bottom right x
@@ -410,7 +413,8 @@ def xyxy2xywhn(x, w=640, h=640, clip=False, eps=0.0):
     """
     if clip:
         clip_boxes(x, (h - eps, w - eps))  # warning: inplace clip
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)
+    assert x.shape[-1] == 4, f'input shape last dimension expected 4 but input shape is {x.shape}'
+    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)  # faster than clone/copy
     y[..., 0] = ((x[..., 0] + x[..., 2]) / 2) / w  # x center
     y[..., 1] = ((x[..., 1] + x[..., 3]) / 2) / h  # y center
     y[..., 2] = (x[..., 2] - x[..., 0]) / w  # width
@@ -447,8 +451,8 @@ def xywh2ltwh(x):
         y (np.ndarray | torch.Tensor): The bounding box coordinates in the xyltwh format
     """
     y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
-    y[:, 0] = x[:, 0] - x[:, 2] / 2  # top left x
-    y[:, 1] = x[:, 1] - x[:, 3] / 2  # top left y
+    y[..., 0] = x[..., 0] - x[..., 2] / 2  # top left x
+    y[..., 1] = x[..., 1] - x[..., 3] / 2  # top left y
     return y
 
 
@@ -462,8 +466,8 @@ def xyxy2ltwh(x):
       y (np.ndarray | torch.Tensor): The bounding box coordinates in the xyltwh format.
     """
     y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
-    y[:, 2] = x[:, 2] - x[:, 0]  # width
-    y[:, 3] = x[:, 3] - x[:, 1]  # height
+    y[..., 2] = x[..., 2] - x[..., 0]  # width
+    y[..., 3] = x[..., 3] - x[..., 1]  # height
     return y
 
 
@@ -475,8 +479,8 @@ def ltwh2xywh(x):
       x (torch.Tensor): the input tensor
     """
     y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
-    y[:, 0] = x[:, 0] + x[:, 2] / 2  # center x
-    y[:, 1] = x[:, 1] + x[:, 3] / 2  # center y
+    y[..., 0] = x[..., 0] + x[..., 2] / 2  # center x
+    y[..., 1] = x[..., 1] + x[..., 3] / 2  # center y
     return y
 
 
@@ -570,8 +574,8 @@ def ltwh2xyxy(x):
       y (np.ndarray | torch.Tensor): the xyxy coordinates of the bounding boxes.
     """
     y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
-    y[:, 2] = x[:, 2] + x[:, 0]  # width
-    y[:, 3] = x[:, 3] + x[:, 1]  # height
+    y[..., 2] = x[..., 2] + x[..., 0]  # width
+    y[..., 3] = x[..., 3] + x[..., 1]  # height
     return y
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3e564e6</samp>

### Summary
🔄📦🛠️

<!--
1.  🔄 This emoji can be used to indicate that something has been changed or replaced, such as a method or a variable name.
2.  📦 This emoji can be used to indicate that something relates to tensors or arrays, which are often represented as boxes or containers of data.
3.  🛠️ This emoji can be used to indicate that something has been fixed or improved, such as a potential error or a performance issue.
-->
This pull request improves the robustness of bounding box conversion functions in `ultralytics/utils/ops.py` by using `clone` or `copy` instead of `empty_like` to create new tensors or arrays. This avoids unintended side effects when modifying the output values.

> _No more `empty_like` in the dark_
> _We clone and copy to leave our mark_
> _We shape the bounding boxes of our fate_
> _We resist the errors that await_

### Walkthrough
*  Replace `empty_like` with `clone` or `copy` to create new tensors or arrays with the same values as the input in four functions that convert bounding box coordinates between different formats (`xywh2ltwh`, `xyxy2ltwh`, `ltwh2xywh`, `ltwh2xyxy`) in `ultralytics/utils/ops.py` ([link](https://github.com/ultralytics/ultralytics/pull/4438/files?diff=unified&w=0#diff-4c045e45231b1287ae6222068d75c8a96d1e2bf450c5ecf9dc0959eaec04dfe6L449-R449), [link](https://github.com/ultralytics/ultralytics/pull/4438/files?diff=unified&w=0#diff-4c045e45231b1287ae6222068d75c8a96d1e2bf450c5ecf9dc0959eaec04dfe6L464-R464), [link](https://github.com/ultralytics/ultralytics/pull/4438/files?diff=unified&w=0#diff-4c045e45231b1287ae6222068d75c8a96d1e2bf450c5ecf9dc0959eaec04dfe6L477-R477), [link](https://github.com/ultralytics/ultralytics/pull/4438/files?diff=unified&w=0#diff-4c045e45231b1287ae6222068d75c8a96d1e2bf450c5ecf9dc0959eaec04dfe6L572-R572))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements in bounding box format conversions and download functions.

### 📊 Key Changes
- Refactored download-related code to use `TQDM_BAR_FORMAT` from `utils` without re-importing it.
- Improved `Bboxes` class in `instance.py` for clarity in comments and better representation of supported bounding box formats.
- Streamlined bounding boxes format conversion functions in `ops.py` with clearer documentation, assertions for input shape validations, and optimizations in cloning/copying arrays.
- Removal of dead code and comments for better code cleanliness.

### 🎯 Purpose & Impact
- 🔍 Provides a more robust download method by ensuring proper handling of progress bar formatting.
- 🧐 Enhances documentation, making the purpose and format of bounding boxes clearer to users and developers.
- 🚀 Improves efficiency and error handling in bounding box transformations, leading to potentially fewer bugs and better performance in machine learning tasks.
- 🧹 Reduces code complexity and clutter, making the codebase easier to maintain and understand.