### PR TITLE
Fix `*.txt` source inference dataloader

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -49,6 +49,16 @@ def test_predict_dir():
     model(source=ASSETS, imgsz=32)
 
 
+def test_predict_txt():
+    # Write a list of sources to a txt file
+    txt_file = TMP / 'sources.txt'
+    with open(txt_file, 'w') as f:
+        for x in [ASSETS / 'bus.jpg', ASSETS / 'zidane.jpg']:
+            f.write(f'{x}\n')
+    model = YOLO(MODEL)
+    model(source=txt_file, imgsz=640)
+
+
 def test_predict_img():
     model = YOLO(MODEL)
     seg_model = YOLO(WEIGHTS_DIR / 'yolov8n-seg.pt')

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -182,7 +182,8 @@ class LoadImages:
         parent = None
         if isinstance(path, str) and Path(path).suffix == '.txt':  # *.txt file with img/vid/dir on each line
             parent = Path(path).parent
-            path = Path(path).read_text().splitlines() # Instead of rsplit() -> splitlines() Split lines ("\n") instead of all spaces (" ")
+            path = Path(path).read_text().splitlines(
+            )  # Instead of rsplit() -> splitlines() Split lines ("\n") instead of all spaces (" ")
         files = []
         for p in sorted(path) if isinstance(path, (list, tuple)) else [path]:
             a = str(Path(p).absolute())  # do not use .resolve() https://github.com/ultralytics/ultralytics/issues/2912

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -182,7 +182,7 @@ class LoadImages:
         parent = None
         if isinstance(path, str) and Path(path).suffix == '.txt':  # *.txt file with img/vid/dir on each line
             parent = Path(path).parent
-            path = Path(path).read_text().rsplit()
+            path = Path(path).read_text().splitlines() # Instead of rsplit() -> splitlines() Split lines ("\n") instead of all spaces (" ")
         files = []
         for p in sorted(path) if isinstance(path, (list, tuple)) else [path]:
             a = str(Path(p).absolute())  # do not use .resolve() https://github.com/ultralytics/ultralytics/issues/2912

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -182,8 +182,7 @@ class LoadImages:
         parent = None
         if isinstance(path, str) and Path(path).suffix == '.txt':  # *.txt file with img/vid/dir on each line
             parent = Path(path).parent
-            path = Path(path).read_text().splitlines(
-            )  # Instead of rsplit() -> splitlines() Split lines ("\n") instead of all spaces (" ")
+            path = Path(path).read_text().splitlines()  # list of sources
         files = []
         for p in sorted(path) if isinstance(path, (list, tuple)) else [path]:
             a = str(Path(p).absolute())  # do not use .resolve() https://github.com/ultralytics/ultralytics/issues/2912


### PR DESCRIPTION
Instead of using rsplit(), use splitlines(): Split lines ("\n") instead of all spaces (" ").

In the model JSON, the format for TXT files requires each file to be on separate lines. When performing a prediction using one of those .txt files, if the file names contain spaces (" "), they were being treated as two different files. For example, "example (1).JPG" would be treated as two files: "example" and "(1).JPG," resulting in an error and preventing successful file load.

With this modification, files will be read line by line. Therefore, a file name can include a space character (" ").


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c21b0b3</samp>

### Summary
🐛📝🖼️

<!--
1.  🐛 - This emoji represents a bug or a bug fix, and can be used to indicate that the change is part of a bug fix pull request.
2.  📝 - This emoji represents a document or a text file, and can be used to indicate that the change involves manipulating a text file content.
3.  🖼️ - This emoji represents an image or a picture, and can be used to indicate that the change relates to loading images from a text file.
-->
Fix bug in loading images from text file by using `splitlines()` instead of `rsplit()` in `ultralytics/data/loaders.py`.

> _`splitlines` used_
> _to avoid whitespace issues_
> _a winter bug fixed_

### Walkthrough
*  Fix bug related to loading images from a text file by splitting the content by line breaks instead of by any whitespace ([link](https://github.com/ultralytics/ultralytics/pull/4468/files?diff=unified&w=0#diff-3687f61e2371eaae4d90d58bf3aa6be449b113677b3ce104fd0d868b7df441deL185-R185))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added functionality for model prediction using image paths listed in a `.txt` file.

### 📊 Key Changes
- New test function `test_predict_txt()` in `tests/test_python.py` for checking prediction functionality with text files.
- Modification in `loaders.py` to accept image paths from a `.txt` file, with a change from `.rsplit()` to `.splitlines()` for correct list generation.

### 🎯 Purpose & Impact
- 🎨 Improves flexibility, allowing users to supply a list of image file paths within a `.txt` file for batch processing.
- 📈 Enhances testing robustness for new input methods, ensuring the software handles text file inputs without issues.
- 🔄 This should have minimal impact on existing functionalities but expands the use cases for the model prediction feature.