### PR TITLE
Improve `check_imshow()` robustness

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -312,13 +312,14 @@ def test_utils_init():
 
 def test_utils_checks():
     from ultralytics.utils.checks import (check_imgsz, check_requirements, check_yolov5u_filename, git_describe,
-                                          print_args)
+                                          print_args, check_imshow)
 
     check_yolov5u_filename('yolov5n.pt')
     # check_imshow(warn=True)
     git_describe(ROOT)
     check_requirements()  # check requirements.txt
     check_imgsz([600, 600], max_dim=1)
+    check_imshow()
     print_args()
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -311,8 +311,8 @@ def test_utils_init():
 
 
 def test_utils_checks():
-    from ultralytics.utils.checks import (check_imgsz, check_requirements, check_yolov5u_filename, git_describe,
-                                          print_args, check_imshow)
+    from ultralytics.utils.checks import (check_imgsz, check_imshow, check_requirements, check_yolov5u_filename,
+                                          git_describe, print_args)
 
     check_yolov5u_filename('yolov5n.pt')
     # check_imshow(warn=True)

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -20,9 +20,9 @@ import requests
 import torch
 from matplotlib import font_manager
 
-from ultralytics.utils import (ASSETS, AUTOINSTALL, LOGGER, ONLINE, ROOT, USER_CONFIG_DIR, ThreadingLocked, TryExcept,
-                               clean_url, colorstr, downloads, emojis, is_colab, is_docker, is_jupyter, is_kaggle,
-                               is_online, is_pip_package, url2file)
+from ultralytics.utils import (ASSETS, AUTOINSTALL, LINUX, LOGGER, ONLINE, ROOT, USER_CONFIG_DIR, ThreadingLocked,
+                               TryExcept, clean_url, colorstr, downloads, emojis, is_colab, is_docker, is_jupyter,
+                               is_kaggle, is_online, is_pip_package, url2file)
 
 
 def is_ascii(s) -> bool:
@@ -389,8 +389,10 @@ def check_yaml(file, suffix=('.yaml', '.yml'), hard=True):
 def check_imshow(warn=False):
     """Check if environment supports image displays."""
     try:
-        assert not any((is_colab(), is_kaggle(), is_docker()))
-        cv2.imshow('test', np.zeros((1, 1, 3)))
+        if LINUX:
+            assert 'DISPLAY' == os.environ
+            assert not any((is_colab(), is_kaggle(), is_docker()))
+        cv2.imshow('test', np.zeros((8, 8, 3), dtype=np.uint8))  # show a small 8-pixel image
         cv2.waitKey(1)
         cv2.destroyAllWindows()
         cv2.waitKey(1)

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -390,8 +390,7 @@ def check_imshow(warn=False):
     """Check if environment supports image displays."""
     try:
         if LINUX:
-            assert 'DISPLAY' in os.environ
-            assert not any((is_colab(), is_kaggle(), is_docker()))
+            assert 'DISPLAY' in os.environ and not is_docker() and not is_colab() and not is_kaggle()
         cv2.imshow('test', np.zeros((8, 8, 3), dtype=np.uint8))  # show a small 8-pixel image
         cv2.waitKey(1)
         cv2.destroyAllWindows()

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -390,7 +390,7 @@ def check_imshow(warn=False):
     """Check if environment supports image displays."""
     try:
         if LINUX:
-            assert 'DISPLAY' == os.environ
+            assert 'DISPLAY' in os.environ
             assert not any((is_colab(), is_kaggle(), is_docker()))
         cv2.imshow('test', np.zeros((8, 8, 3), dtype=np.uint8))  # show a small 8-pixel image
         cv2.waitKey(1)


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f8c1d7c</samp>

### Summary
🖼️🐧🛠️

<!--
1.  🖼️ - This emoji represents an image or a picture, which is relevant to the test for image display support and the use of a test image.
2.  🐧 - This emoji represents a penguin, which is a common symbol for Linux systems, which are now handled better by the `check_imshow` function.
3.  🛠️ - This emoji represents a tool or a wrench, which is often used to indicate improvement or fixing of something, which is the case for the `check_imshow` function.
-->
Added and improved tests for image display functionality in `ultralytics` using `check_imshow`.

> _No matter where you run, you can't escape the doom_
> _We'll test your image display with `check_imshow`_
> _We'll use a better image, not some random noise_
> _We'll handle Linux systems without graphical toys_

### Walkthrough
*  Add and modify `check_imshow` function to test image display support ([link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-5b30bb601bc6484cdfcca11c382b45064aecc5b1024571f2984f6d4c74b89095L23-R25), [link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-5b30bb601bc6484cdfcca11c382b45064aecc5b1024571f2984f6d4c74b89095L392-R395), [link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-51deb1ccb3a8b618784df2e2abfbc3b056436f1db72d1896d5102f9906978492L315-R315), [link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-51deb1ccb3a8b618784df2e2abfbc3b056436f1db72d1896d5102f9906978492R322))
  - Import `LINUX` constant from `ultralytics.utils` in `ultralytics/utils/checks.py` ([link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-5b30bb601bc6484cdfcca11c382b45064aecc5b1024571f2984f6d4c74b89095L23-R25))
  - Check for `DISPLAY` environment variable on Linux systems in `check_imshow` function in `ultralytics/utils/checks.py` ([link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-5b30bb601bc6484cdfcca11c382b45064aecc5b1024571f2984f6d4c74b89095L392-R395))
  - Use a small 8-pixel image instead of a 1-pixel image for testing in `check_imshow` function in `ultralytics/utils/checks.py` ([link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-5b30bb601bc6484cdfcca11c382b45064aecc5b1024571f2984f6d4c74b89095L392-R395))
  - Import and call `check_imshow` function in `test_utils_checks` function in `tests/test_python.py` ([link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-51deb1ccb3a8b618784df2e2abfbc3b056436f1db72d1896d5102f9906978492L315-R315), [link](https://github.com/ultralytics/ultralytics/pull/4483/files?diff=unified&w=0#diff-51deb1ccb3a8b618784df2e2abfbc3b056436f1db72d1896d5102f9906978492R322))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `check_imshow` function for better environment compatibility checks.

### 📊 Key Changes
- 🆕 Added `check_imshow` validation in `test_utils_checks` to ensure the environment supports image displays.
- ✅ Added an `LINUX` import to the `checks.py` utilities, which is now used in `check_imshow`.
- 📸 Revised `check_imshow` to check for the `DISPLAY` environment variable on Linux and updated the image display check with an 8-pixel image.

### 🎯 Purpose & Impact
- 👀 The updates to `check_imshow` aim to prevent issues when trying to display images in environments like Docker containers, Colab, and Kaggle, where display capabilities may be limited or non-existent.
- 🔍 The added check for the `DISPLAY` environment variable on Linux ensures that image display capabilities are only expected when a display is actually available, reducing the risk of runtime errors.
- 🖼 By displaying a very small image (8x8), the function tests the imshow capability without unnecessary resource usage, ensuring it functions in a lightweight manner.
- ✨ Users will experience fewer errors when using Ultralytics tools in diverse environments, and developers can trust that this utility function provides a more reliable check for display capabilities.