### PR TITLE
Use 1-based indexing for `results.csv` epochs

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -554,7 +554,7 @@ class BaseTrainer:
         n = len(metrics) + 1  # number of cols
         s = '' if self.csv.exists() else (('%23s,' * n % tuple(['epoch'] + keys)).rstrip(',') + '\n')  # header
         with open(self.csv, 'a') as f:
-            f.write(s + ('%23.5g,' * n % tuple([self.epoch] + vals)).rstrip(',') + '\n')
+            f.write(s + ('%23.5g,' * n % tuple([self.epoch + 1] + vals)).rstrip(',') + '\n')
 
     def plot_metrics(self):
         """Plot and display metrics visually."""

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -536,6 +536,7 @@ def plot_results(file='path/to/results.csv', dir='', segment=False, pose=False, 
                 ax[i].plot(x, y, marker='.', label=f.stem, linewidth=2, markersize=8)  # actual results
                 ax[i].plot(x, gaussian_filter1d(y, sigma=3), ':', label='smooth', linewidth=2)  # smoothing line
                 ax[i].set_title(s[j], fontsize=12)
+                ax[i].set_xlim(min(x), max(x))
                 # if j in [8, 9, 10]:  # share train and val loss y axes
                 #     ax[i].get_shared_y_axes().join(ax[i], ax[i - 5])
         except Exception as e:

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -536,7 +536,6 @@ def plot_results(file='path/to/results.csv', dir='', segment=False, pose=False, 
                 ax[i].plot(x, y, marker='.', label=f.stem, linewidth=2, markersize=8)  # actual results
                 ax[i].plot(x, gaussian_filter1d(y, sigma=3), ':', label='smooth', linewidth=2)  # smoothing line
                 ax[i].set_title(s[j], fontsize=12)
-                ax[i].set_xlim(min(x), max(x))
                 # if j in [8, 9, 10]:  # share train and val loss y axes
                 #     ax[i].get_shared_y_axes().join(ax[i], ax[i - 5])
         except Exception as e:


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9a84a5f</samp>

### Summary
📝🐛📈

<!--
1.  📝 This emoji can be used to indicate that the code has been edited or updated, especially for documentation or comments. In this case, the `save_metrics` function has been modified to write a different value to the csv file, which is a form of documentation for the training metrics.
2.  🐛 This emoji can be used to indicate that a bug has been fixed or a problem has been resolved. In this case, the change is part of a pull request that fixes some issues with the epoch numbering and logging, which could be considered bugs or inconsistencies in the original code.
3.  📈 This emoji can be used to indicate that the code has improved or enhanced some aspect of the performance, functionality, or quality. In this case, the change makes the epoch numbering more consistent and aligned across the logs and plots, which could improve the user experience and the clarity of the results.
-->
Fix epoch numbering and logging inconsistencies in `ultralytics/engine/trainer.py`. Adjust the `save_metrics` function to write the correct epoch number to the csv file.

> _`save_metrics` shifts_
> _epoch number by one notch_
> _autumn leaves falling_

### Walkthrough
*  Align epoch number in csv file with logs and plots by adding one in `save_metrics` function ([link](https://github.com/ultralytics/ultralytics/pull/4491/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL557-R557))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjusted epoch value in training metrics to be 1-based numbering instead of 0-based.

### 📊 Key Changes
- The epoch number when saving metrics is now incremented by 1, changing from 0-index to 1-index.

### 🎯 Purpose & Impact
- This change ensures that the epoch displayed to the user starts at 1, which is generally more user-friendly and aligns with common standards where counting starts at 1. 🎉
- For users, it will be easier to understand at which stage of training they are, since epoch numbering now starts from 1, which is more intuitive than starting from 0. ✅
- It may require users to adjust if they have scripts or tools that expect 0-based epoch numbering. 🔧