### PR TITLE
Simplify postprocessing methods

### DIFF
--- a/ultralytics/models/fastsam/predict.py
+++ b/ultralytics/models/fastsam/predict.py
@@ -15,7 +15,6 @@ class FastSAMPredictor(DetectionPredictor):
         self.args.task = 'segment'
 
     def postprocess(self, preds, img, orig_imgs):
-        """TODO: filter by classes."""
         p = ops.non_max_suppression(preds[0],
                                     self.args.conf,
                                     self.args.iou,
@@ -32,22 +31,20 @@ class FastSAMPredictor(DetectionPredictor):
             full_box[0][6:] = p[0][critical_iou_index][:, 6:]
             p[0][critical_iou_index] = full_box
         results = []
+        is_list = isinstance(orig_imgs, list)  # input images are a list, not a torch.Tensor
         proto = preds[1][-1] if len(preds[1]) == 3 else preds[1]  # second output is len 3 if pt, but only 1 if exported
         for i, pred in enumerate(p):
-            orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs
-            path = self.batch[0]
-            img_path = path[i] if isinstance(path, list) else path
+            orig_img = orig_imgs[i] if is_list else orig_imgs
+            img_path = self.batch[0][i]
             if not len(pred):  # save empty boxes
-                results.append(Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred[:, :6]))
-                continue
-            if self.args.retina_masks:
-                if not isinstance(orig_imgs, torch.Tensor):
+                masks = None
+            elif self.args.retina_masks:
+                if is_list:
                     pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
                 masks = ops.process_mask_native(proto[i], pred[:, 6:], pred[:, :4], orig_img.shape[:2])  # HWC
             else:
                 masks = ops.process_mask(proto[i], pred[:, 6:], pred[:, :4], img.shape[2:], upsample=True)  # HWC
-                if not isinstance(orig_imgs, torch.Tensor):
+                if is_list:
                     pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
-            results.append(
-                Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred[:, :6], masks=masks))
+            results.append(Results(orig_img, path=img_path, names=self.model.names, boxes=pred[:, :6], masks=masks))
         return results

--- a/ultralytics/models/nas/predict.py
+++ b/ultralytics/models/nas/predict.py
@@ -24,11 +24,11 @@ class NASPredictor(BasePredictor):
                                         classes=self.args.classes)
 
         results = []
+        is_list = isinstance(orig_imgs, list)  # input images are a list, not a torch.Tensor
         for i, pred in enumerate(preds):
-            orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs
-            if not isinstance(orig_imgs, torch.Tensor):
+            orig_img = orig_imgs[i] if is_list else orig_imgs
+            if is_list:
                 pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
-            path = self.batch[0]
-            img_path = path[i] if isinstance(path, list) else path
-            results.append(Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred))
+            img_path = self.batch[0][i]
+            results.append(Results(orig_img, path=img_path, names=self.model.names, boxes=pred))
         return results

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -318,8 +318,9 @@ class Predictor(BasePredictor):
         pred_bboxes = preds[2] if self.segment_all else None
         names = dict(enumerate(str(i) for i in range(len(pred_masks))))
         results = []
+        is_list = isinstance(orig_imgs, list)  # input images are a list, not a torch.Tensor
         for i, masks in enumerate([pred_masks]):
-            orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs
+            orig_img = orig_imgs[i] if is_list else orig_imgs
             if pred_bboxes is not None:
                 pred_bboxes = ops.scale_boxes(img.shape[2:], pred_bboxes.float(), orig_img.shape, padding=False)
                 cls = torch.arange(len(pred_masks), dtype=torch.int32, device=pred_masks.device)
@@ -327,9 +328,8 @@ class Predictor(BasePredictor):
 
             masks = ops.scale_masks(masks[None].float(), orig_img.shape[:2], padding=False)[0]
             masks = masks > self.model.mask_threshold  # to bool
-            path = self.batch[0]
-            img_path = path[i] if isinstance(path, list) else path
-            results.append(Results(orig_img=orig_img, path=img_path, names=names, masks=masks, boxes=pred_bboxes))
+            img_path = self.batch[0][i]
+            results.append(Results(orig_img, path=img_path, names=names, masks=masks, boxes=pred_bboxes))
         # Reset segment-all mode.
         self.segment_all = False
         return results

--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -39,10 +39,9 @@ class ClassificationPredictor(BasePredictor):
     def postprocess(self, preds, img, orig_imgs):
         """Post-processes predictions to return Results objects."""
         results = []
+        is_list = isinstance(orig_imgs, list)  # input images are a list, not a torch.Tensor
         for i, pred in enumerate(preds):
-            orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs
-            path = self.batch[0]
-            img_path = path[i] if isinstance(path, list) else path
-            results.append(Results(orig_img=orig_img, path=img_path, names=self.model.names, probs=pred))
-
+            orig_img = orig_imgs[i] if is_list else orig_imgs
+            img_path = self.batch[0][i]
+            results.append(Results(orig_img, path=img_path, names=self.model.names, probs=pred))
         return results

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -1,7 +1,5 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-import torch
-
 from ultralytics.engine.predictor import BasePredictor
 from ultralytics.engine.results import Results
 from ultralytics.utils import ops
@@ -32,11 +30,11 @@ class DetectionPredictor(BasePredictor):
                                         classes=self.args.classes)
 
         results = []
+        is_list = isinstance(orig_imgs, list)  # input images are a list, not a torch.Tensor
         for i, pred in enumerate(preds):
-            orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs
-            if not isinstance(orig_imgs, torch.Tensor):
+            orig_img = orig_imgs[i] if is_list else orig_imgs
+            if is_list:
                 pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
-            path = self.batch[0]
-            img_path = path[i] if isinstance(path, list) else path
-            results.append(Results(orig_img=orig_img, path=img_path, names=self.model.names, boxes=pred))
+            img_path = self.batch[0][i]
+            results.append(Results(orig_img, path=img_path, names=self.model.names, boxes=pred))
         return results


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b9b7aa</samp>

### Summary
🧹,🚀,📝,

<!--
1.  🧹, which means cleaning or tidying up
2.  🚀, which means improving speed or performance
3.  📝, which means writing or documenting
-->
This pull request refactors and simplifies the code for various predictors in the `ultralytics/models` directory. It introduces a common variable `is_list` to handle different input types, and uses positional arguments for the `Results` class. It also removes unnecessary or outdated imports, comments, and branches.

> _We are the masters of the code_
> _We simplify and streamline the mode_
> _We use `is_list` to handle the input_
> _We create `Results` with no argument_

### Walkthrough
*  Simplify the code by using a variable `is_list` to check if the input images are a list or a torch.Tensor, and avoid repeating the same condition multiple times in all predictors ([link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-7c48ede77b870dae7664b49a45c6f9aa0c835fd37fa9e084e1e5bb05b4d27ed8L35-R49), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-cb0a8d6008c9163906be795736ce0434301c4228f770740e3fb91c9177c840c1L27-R33), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-752d7deb4a6279bd12373b285f7be5c587ca4805bd62976d0e0c577d6b0acf3aR31), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-752d7deb4a6279bd12373b285f7be5c587ca4805bd62976d0e0c577d6b0acf3aL38-R45), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-abae5c0cfe4087dc193f98a5d67d7c726ac769ae8a58b3abda232a7657c69edeL321-R323), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-abae5c0cfe4087dc193f98a5d67d7c726ac769ae8a58b3abda232a7657c69edeL330-R332), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-663b5aaaf7a04b1a7fe40326af039d2baf50df166e9738332eacbae9271ec55fL42-R46), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-9dded00f5e51a32b00c6266aa445990bae22fe6ea0bbb9d2c8898f4fcdb8cb23L35-R39), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-383afc92a2a66556c136cd357f28db596eed25b3472abe26b7e778208a365571L41-R49), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-a6dc03b08ac83fa9cfd1e48cbc1f4744b72e4fff1fe523df8936c0a144b50498L39-R51))
* Use positional arguments instead of keyword arguments for the `Results` class in all predictors, as they are more concise and consistent ([link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-7c48ede77b870dae7664b49a45c6f9aa0c835fd37fa9e084e1e5bb05b4d27ed8L35-R49), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-cb0a8d6008c9163906be795736ce0434301c4228f770740e3fb91c9177c840c1L27-R33), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-752d7deb4a6279bd12373b285f7be5c587ca4805bd62976d0e0c577d6b0acf3aL38-R45), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-abae5c0cfe4087dc193f98a5d67d7c726ac769ae8a58b3abda232a7657c69edeL330-R332), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-663b5aaaf7a04b1a7fe40326af039d2baf50df166e9738332eacbae9271ec55fL42-R46), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-9dded00f5e51a32b00c6266aa445990bae22fe6ea0bbb9d2c8898f4fcdb8cb23L35-R39), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-383afc92a2a66556c136cd357f28db596eed25b3472abe26b7e778208a365571L41-R49), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-a6dc03b08ac83fa9cfd1e48cbc1f4744b72e4fff1fe523df8936c0a144b50498L39-R51))
* Remove unused imports of torch in `yolo/detect/predict.py` and `yolo/segment/predict.py` ([link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-9dded00f5e51a32b00c6266aa445990bae22fe6ea0bbb9d2c8898f4fcdb8cb23L3-L4), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-a6dc03b08ac83fa9cfd1e48cbc1f4744b72e4fff1fe523df8936c0a144b50498L3-L4))
* Remove TODO comments that are no longer relevant in `fastsam/predict.py` and `yolo/segment/predict.py`, as the filtering by classes is implemented in the `nms` function ([link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-7c48ede77b870dae7664b49a45c6f9aa0c835fd37fa9e084e1e5bb05b4d27ed8L18), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-a6dc03b08ac83fa9cfd1e48cbc1f4744b72e4fff1fe523df8936c0a144b50498L30))
* Remove unnecessary `if not len(pred)` branches in `fastsam/predict.py` and `yolo/segment/predict.py`, as the `Results` class can handle empty boxes and masks ([link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-7c48ede77b870dae7664b49a45c6f9aa0c835fd37fa9e084e1e5bb05b4d27ed8L35-R49), [link](https://github.com/ultralytics/ultralytics/pull/4497/files?diff=unified&w=0#diff-a6dc03b08ac83fa9cfd1e48cbc1f4744b72e4fff1fe523df8936c0a144b50498L39-R51))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
PR implements code cleanup and reduces redundancy in postprocess methods across models.

### 📊 Key Changes
- Simplified image and path extraction by creating `is_list` flag to check if input images are in list format or not.
- Streamlined the `Results` object creation by removing redundant checks and direct assigning of values.
- Removed TODO comments related to filtering by classes as this seems to be already implemented or deferred.
- Enhanced consistency and readability of the post-processing steps for different models.

### 🎯 Purpose & Impact
- **Purpose**: The primary aim of these changes is to simplify the code for better maintainability and readability, enabling easier future updates and bug fixes.
- **Impact**: These changes should not affect any model functionality from a user perspective but will make the codebase cleaner and potentially decrease future development times for the Ultralytics team.