### PR TITLE
Fix pytest `world_size` environment bug

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -169,7 +169,7 @@ class BaseTrainer:
     def train(self):
         """Allow device='', device=None on Multi-GPU systems to default to device=0."""
         if isinstance(self.args.device, str) and len(self.args.device):  # i.e. device='0' or device='0,1,2,3'
-            world_size = len(self.args.device.split(","))
+            world_size = len(self.args.device.split(','))
         elif isinstance(self.args.device, tuple):  # multi devices from cli is tuple type
             world_size = len(self.args.device)
         elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -168,9 +168,11 @@ class BaseTrainer:
 
     def train(self):
         """Allow device='', device=None on Multi-GPU systems to default to device=0."""
-        if isinstance(self.args.device, int) or self.args.device:  # i.e. device=0 or device=[0,1,2,3]
-            world_size = torch.cuda.device_count()
-        elif torch.cuda.is_available():  # i.e. device=None or device=''
+        if isinstance(self.args.device, str) and len(self.args.device):  # i.e. device='0' or device='0,1,2,3'
+            world_size = len(self.args.device.split(","))
+        elif isinstance(self.args.device, tuple):  # multi devices from cli is tuple type
+            world_size = len(self.args.device)
+        elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number
             world_size = 1  # default to device 0
         else:  # i.e. device='cpu' or 'mps'
             world_size = 0


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d8a0fa3</samp>

### Summary
🛠️🚀🖥️

<!--
1.  🛠️ - This emoji represents a tool or a fix, which is suitable for the modification of the `train` function to handle different types of device arguments.
2.  🚀 - This emoji represents a rocket or a boost, which is suitable for the improvement of the flexibility and robustness of the device argument handling.
3.  🖥️ - This emoji represents a computer or a device, which is suitable for the topic of the device argument and the number of devices.
-->
Improved device argument handling in `train` function of `BaseTrainer` class. The function can now accept different types of device arguments and avoid errors or unexpected behavior.

> _`train` function changed_
> _device argument more flexible_
> _autumn leaves falling_

### Walkthrough
*  Modify `train` function to handle different types of device arguments ([link](https://github.com/ultralytics/ultralytics/pull/4590/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL171-R175))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved device selection logic for training in multi-GPU environments.

### 📊 Key Changes
- Altered condition to check for `self.args.device` being a non-empty string when determining world size.
- Added handling for `self.args.device` being a tuple, accommodating multiple devices specified through the command line interface (CLI).
- Clarified comment regarding defaulting to single device training when no specific GPU device is mentioned (`device=None` or `device=''`) and CUDA is available.

### 🎯 Purpose & Impact
- 🛠 Ensures correct parsing of device arguments, preventing potential errors in GPU device allocation.
- 🧩 Allows the training script to work seamlessly with different types of device specifications, enhancing usability.
- 🔍 Improves clarity in the codebase, making it easier to maintain and understand the logic for device selection. 

The impact will be most felt by users with multi-GPU setups who can now more reliably specify devices for training.