### PR TITLE
Add new StreamLoader `stream_buffer` argument

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -54,7 +54,7 @@ plots: True  # (bool) save plots during train/val
 # Prediction settings --------------------------------------------------------------------------------------------------
 source:  # (str, optional) source directory for images or videos
 show: False  # (bool) show results if possible
-stream_buffer: False # (bool) True/False : buffer every frame of stream/get most reacent frame 
+stream_buffer: False # (bool) True/False : buffer every frame of stream/get most reacent frame
 save_txt: False  # (bool) save results as .txt file
 save_conf: False  # (bool) save results with confidence scores
 save_crop: False  # (bool) save cropped images with results

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -54,6 +54,7 @@ plots: True  # (bool) save plots during train/val
 # Prediction settings --------------------------------------------------------------------------------------------------
 source:  # (str, optional) source directory for images or videos
 show: False  # (bool) show results if possible
+stream_buffer: False # (bool) True/False : buffer every frame of stream/get most reacent frame 
 save_txt: False  # (bool) save results as .txt file
 save_conf: False  # (bool) save results with confidence scores
 save_crop: False  # (bool) save cropped images with results

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -143,6 +143,7 @@ def load_inference_source(source=None, imgsz=640, vid_stride=1, stream_buffer=Fa
         source (str, Path, Tensor, PIL.Image, np.ndarray): The input source for inference.
         imgsz (int, optional): The size of the image for inference. Default is 640.
         vid_stride (int, optional): The frame interval for video sources. Default is 1.
+        stream_buffer (bool, optional): Determined whether stream frames will be buffered. Default is False.
 
     Returns:
         dataset (Dataset): A dataset object for the specified input source.

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -157,7 +157,7 @@ def load_inference_source(source=None, imgsz=640, vid_stride=1, stream_buffer=Fa
     elif in_memory:
         dataset = source
     elif webcam:
-        dataset = LoadStreams(source, imgsz=imgsz, vid_stride=vid_stride, stream_buffer=stream_buffer )
+        dataset = LoadStreams(source, imgsz=imgsz, vid_stride=vid_stride, stream_buffer=stream_buffer)
     elif screenshot:
         dataset = LoadScreenshots(source, imgsz=imgsz)
     elif from_img:

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -135,7 +135,7 @@ def check_source(source):
     return source, webcam, screenshot, from_img, in_memory, tensor
 
 
-def load_inference_source(source=None, imgsz=640, vid_stride=1):
+def load_inference_source(source=None, imgsz=640, vid_stride=1, stream_buffer=False):
     """
     Loads an inference source for object detection and applies necessary transformations.
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -156,7 +156,7 @@ def load_inference_source(source=None, imgsz=640, vid_stride=1, stream_buffer=Fa
     elif in_memory:
         dataset = source
     elif webcam:
-        dataset = LoadStreams(source, imgsz=imgsz, vid_stride=vid_stride)
+        dataset = LoadStreams(source, imgsz=imgsz, vid_stride=vid_stride, stream_buffer=stream_buffer )
     elif screenshot:
         dataset = LoadScreenshots(source, imgsz=imgsz)
     elif from_img:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -34,6 +34,7 @@ class LoadStreams:
     def __init__(self, sources='file.streams', imgsz=640, vid_stride=1, stream_buffer=False):
         """Initialize instance variables and check for consistent input stream shapes."""
         torch.backends.cudnn.benchmark = True  # faster for fixed-size inference
+        self.stream_buffer = stream_buffer
         self.running = True  # running flag for Thread
         self.mode = 'stream'
         self.imgsz = imgsz

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -82,7 +82,7 @@ class LoadStreams:
         n, f = 0, self.frames[i]  # frame number, frame array
         while self.running and cap.isOpened() and n < (f - 1):
             # Only read a new frame if the buffer is empty
-            if not self.imgs[i]:
+            if not self.imgs[i] or self.stream_buffer == False:
                 n += 1
                 cap.grab()  # .read() = .grab() followed by .retrieve()
                 if n % self.vid_stride == 0:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -125,7 +125,14 @@ class LoadStreams:
             time.sleep(1 / min(self.fps))
 
         # Get and remove the next frame from imgs buffer
-        return self.sources, [x.pop(0) for x in self.imgs], None, ''
+        if self.stream_buffer==True:
+            return self.sources, [x.pop(0) for x in self.imgs], None, ''
+        # Get the latest frame, and clear the rest from the imgs buffer
+        else:
+            last_elements = [x.pop(-1) if x else None for x in self.imgs]
+            for x in self.imgs:
+                x.clear()
+            return self.sources, last_elements, None, ''
 
     def __len__(self):
         """Return the length of the sources object."""

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -31,7 +31,7 @@ class SourceTypes:
 class LoadStreams:
     """YOLOv8 streamloader, i.e. `yolo predict source='rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP streams`."""
 
-    def __init__(self, sources='file.streams', imgsz=640, vid_stride=1):
+    def __init__(self, sources='file.streams', imgsz=640, vid_stride=1, stream_buffer=False):
         """Initialize instance variables and check for consistent input stream shapes."""
         torch.backends.cudnn.benchmark = True  # faster for fixed-size inference
         self.running = True  # running flag for Thread

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -125,7 +125,7 @@ class LoadStreams:
             time.sleep(1 / min(self.fps))
 
         # Get and remove the next frame from imgs buffer
-        if self.stream_buffer==True:
+        if self.stream_buffer == True:
             return self.sources, [x.pop(0) for x in self.imgs], None, ''
         # Get the latest frame, and clear the rest from the imgs buffer
         else:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -125,7 +125,7 @@ class LoadStreams:
             time.sleep(1 / min(self.fps))
 
         # Get and remove the next frame from imgs buffer
-        if self.stream_buffer == True:
+        if self.stream_buffer:
             return self.sources, [x.pop(0) for x in self.imgs], None, ''
         # Get the latest frame, and clear the rest from the imgs buffer
         else:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -82,7 +82,7 @@ class LoadStreams:
         n, f = 0, self.frames[i]  # frame number, frame array
         while self.running and cap.isOpened() and n < (f - 1):
             # Only read a new frame if the buffer is empty
-            if not self.imgs[i] or self.stream_buffer == False:
+            if not self.imgs[i] or not self.stream_buffer:
                 n += 1
                 cap.grab()  # .read() = .grab() followed by .retrieve()
                 if n % self.vid_stride == 0:

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -209,7 +209,10 @@ class BasePredictor:
         self.imgsz = check_imgsz(self.args.imgsz, stride=self.model.stride, min_dim=2)  # check image size
         self.transforms = getattr(self.model.model, 'transforms', classify_transforms(
             self.imgsz[0])) if self.args.task == 'classify' else None
-        self.dataset = load_inference_source(source=source, imgsz=self.imgsz, vid_stride=self.args.vid_stride,stream_buffer=self.args.stream_buffer)
+        self.dataset = load_inference_source(source=source,
+                                             imgsz=self.imgsz,
+                                             vid_stride=self.args.vid_stride,
+                                             stream_buffer=self.args.stream_buffer)
         self.source_type = self.dataset.source_type
         if not getattr(self, 'stream', True) and (self.dataset.mode == 'stream' or  # streams
                                                   len(self.dataset) > 1000 or  # images

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -209,7 +209,7 @@ class BasePredictor:
         self.imgsz = check_imgsz(self.args.imgsz, stride=self.model.stride, min_dim=2)  # check image size
         self.transforms = getattr(self.model.model, 'transforms', classify_transforms(
             self.imgsz[0])) if self.args.task == 'classify' else None
-        self.dataset = load_inference_source(source=source, imgsz=self.imgsz, vid_stride=self.args.vid_stride)
+        self.dataset = load_inference_source(source=source, imgsz=self.imgsz, vid_stride=self.args.vid_stride,stream_buffer=self.args.stream_buffer)
         self.source_type = self.dataset.source_type
         if not getattr(self, 'stream', True) and (self.dataset.mode == 'stream' or  # streams
                                                   len(self.dataset) > 1000 or  # images


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

Added stream_buffer (bool) inferencing arg, optional, default is False. If True streams will buffer, if False or undefined, stream will return the latest frame. 

Tested with:

```
for result in model.track(device = "mps",source='rtsp_url_to_CCTV_camera',stream = True,conf=0.5, iou =0.5, show=True,verbose = False, stream_buffer = True/False):
        time.sleep(0.5)
```



<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cbfe8ae</samp>

### Summary
🎥🚀🛠️

<!--
1.  🎥 - This emoji represents the video stream processing feature that is being added or modified by this change. It also conveys the idea of capturing and processing frames from a stream source.
2.  🚀 - This emoji represents the performance and speed improvement that can be achieved by using the `stream_buffer` option. It also conveys the idea of launching or accelerating a stream processing task.
3.  🛠️ - This emoji represents the configuration and customization aspect of this change. It also conveys the idea of building or fixing something with tools.
-->
This pull request adds a new option `stream_buffer` to the ultralytics framework, which allows users to control the buffering behavior of video streams for inference. It updates the data loading and processing modules, as well as the configuration file and the predictor class, to support this option.

> _`stream_buffer` is the key to your fate_
> _Choose wisely or you'll be too late_
> _Buffer every frame or get the latest one_
> _The stream of doom has just begun_

### Walkthrough
*  Add `stream_buffer` option to config file to control stream buffering behavior ([link](https://github.com/ultralytics/ultralytics/pull/4594/files?diff=unified&w=0#diff-732d61cb4969eff986cec58058000b2949ea3b429a97ca5a1045897e754145c5R57))
*  Modify `load_inference_source` function to accept `stream_buffer` argument and pass it to `LoadStreams` class ([link](https://github.com/ultralytics/ultralytics/pull/4594/files?diff=unified&w=0#diff-e8bb4966653e657a3bfc4a4c892ccdcf3c486a982016d2e51631b5b9393c2c5fL138-R138), [link](https://github.com/ultralytics/ultralytics/pull/4594/files?diff=unified&w=0#diff-e8bb4966653e657a3bfc4a4c892ccdcf3c486a982016d2e51631b5b9393c2c5fL159-R160))
*  Document `stream_buffer` argument in `load_inference_source` docstring ([link](https://github.com/ultralytics/ultralytics/pull/4594/files?diff=unified&w=0#diff-e8bb4966653e657a3bfc4a4c892ccdcf3c486a982016d2e51631b5b9393c2c5fR146))
*  Modify `LoadStreams` class to store and use `stream_buffer` flag in `update` and `__next__` methods ([link](https://github.com/ultralytics/ultralytics/pull/4594/files?diff=unified&w=0#diff-3687f61e2371eaae4d90d58bf3aa6be449b113677b3ce104fd0d868b7df441deL34-R37), [link](https://github.com/ultralytics/ultralytics/pull/4594/files?diff=unified&w=0#diff-3687f61e2371eaae4d90d58bf3aa6be449b113677b3ce104fd0d868b7df441deL84-R85), [link](https://github.com/ultralytics/ultralytics/pull/4594/files?diff=unified&w=0#diff-3687f61e2371eaae4d90d58bf3aa6be449b113677b3ce104fd0d868b7df441deL127-R135))
*  Modify `BasePredictor` class to pass `stream_buffer` argument to `load_inference_source` function when setting up dataset for inference ([link](https://github.com/ultralytics/ultralytics/pull/4594/files?diff=unified&w=0#diff-9fa2bf7f1273283680da3daeb8bae8e20cf8d477f838575796d2bf3b415bc534L212-R212))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduced stream buffering option for real-time video processing.

### 📊 Key Changes
- Added `stream_buffer` config option to determine frame buffering during stream processing.
- Modified `load_inference_source` function to accept the new `stream_buffer` parameter.
- Updated `LoadStreams` class to handle buffering logic based on `stream_buffer` status.
- Adjusted frame extraction in the `LoadStreams` iterator to support both buffered and latest-frame modes.

### 🎯 Purpose & Impact
- **Purpose**: To enable or disable frame buffering for real-time video streams, providing users with a choice between processing every frame or only the latest one.
- **Impact**: Users can now choose to buffer every frame for a stream (potentially reducing frame loss but increasing latency) or get the most recent frame (which could reduce latency but increase the chance of missing frames). This is particularly beneficial in applications like real-time monitoring, where either frame completeness or low latency might be preferred. 📹🚀