### PR TITLE
Fix DDP when device is a list

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -35,7 +35,7 @@ def test_train():
 def test_autobatch():
     from ultralytics.utils.autobatch import check_train_batch_size
 
-    check_train_batch_size(YOLO(MODEL).model, imgsz=128, amp=True)
+    check_train_batch_size(YOLO(MODEL).model.cuda(), imgsz=128, amp=True)
 
 
 @pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -28,7 +28,14 @@ def test_checks():
 @pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')
 def test_train():
     device = 0 if CUDA_DEVICE_COUNT == 1 else [0, 1]
-    YOLO(MODEL).train(data=DATA, imgsz=64, epochs=1, batch=-1, device=device)  # also test AutoBatch, requires imgsz>=64
+    YOLO(MODEL).train(data=DATA, imgsz=64, epochs=1, device=device)  # requires imgsz>=64
+
+
+@pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')
+def test_autobatch():
+    from ultralytics.utils.autobatch import check_train_batch_size
+
+    check_train_batch_size(YOLO(MODEL).model, imgsz=128, amp=True)
 
 
 @pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -28,7 +28,7 @@ def test_checks():
 @pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')
 def test_train():
     device = 0 if CUDA_DEVICE_COUNT == 1 else [0, 1]
-    YOLO(MODEL).train(data=DATA, imgsz=64, epochs=1, batch=-1, device=device)  # also test AutoBatch, requires imgsz>=64
+    YOLO(MODEL).train(data=DATA, imgsz=64, epochs=1, device=device)  # also test AutoBatch, requires imgsz>=64
 
 
 @pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -28,7 +28,7 @@ def test_checks():
 @pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')
 def test_train():
     device = 0 if CUDA_DEVICE_COUNT == 1 else [0, 1]
-    YOLO(MODEL).train(data=DATA, imgsz=64, epochs=1, device=device)  # also test AutoBatch, requires imgsz>=64
+    YOLO(MODEL).train(data=DATA, imgsz=64, epochs=1, batch=-1, device=device)  # also test AutoBatch, requires imgsz>=64
 
 
 @pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -170,7 +170,7 @@ class BaseTrainer:
         """Allow device='', device=None on Multi-GPU systems to default to device=0."""
         if isinstance(self.args.device, str) and len(self.args.device):  # i.e. device='0' or device='0,1,2,3'
             world_size = len(self.args.device.split(','))
-        elif isinstance(self.args.device, (tuple, list)):  # multi devices from cli is tuple type, or device=[0,1]
+        elif isinstance(self.args.device, (tuple, list)):  # i.e. device=[0, 1, 2, 3] (multi-GPU from CLI is list)
             world_size = len(self.args.device)
         elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number
             world_size = 1  # default to device 0

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -170,7 +170,7 @@ class BaseTrainer:
         """Allow device='', device=None on Multi-GPU systems to default to device=0."""
         if isinstance(self.args.device, str) and len(self.args.device):  # i.e. device='0' or device='0,1,2,3'
             world_size = len(self.args.device.split(','))
-        elif isinstance(self.args.device, tuple):  # multi devices from cli is tuple type
+        elif isinstance(self.args.device, (tuple, list)):  # multi devices from cli is tuple type, or device=[0,1]
             world_size = len(self.args.device)
         elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number
             world_size = 1  # default to device 0


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eaa309f</samp>

### Summary
🗑️🛠️📜

<!--
1.  🗑️ - This emoji represents the removal of the `batch` argument from the `YOLO.train` method call, as it indicates that the argument is no longer needed and can be discarded.
2.  🛠️ - This emoji represents the modification of the `isinstance` check for the `device` argument, as it indicates that the check was fixed or improved to handle different types of inputs.
3.  📜 - This emoji represents the consistency of the `device` argument with the PyTorch API and the `torch.device` class, as it indicates that the argument follows a standard or convention that is documented or expected by the users.
-->
This pull request simplifies the test code for the `YOLO.train` method and fixes a bug in the `device` argument handling. It also makes the `device` argument more flexible and consistent with PyTorch by allowing a list of device indices.

> _`train` method changed_
> _`batch` removed, `device` fixed_
> _autumn of refactoring_

### Walkthrough
*  Allow list of device indices in `train` method and fix bug for list input ([link](https://github.com/ultralytics/ultralytics/pull/4600/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL173-R173))
*  Remove `batch` argument from `YOLO.train` calls in tests, as it is no longer needed after `AutoBatch` refactoring ([link](https://github.com/ultralytics/ultralytics/pull/4600/files?diff=unified&w=0#diff-6deae64cdc8b70e42e1ad5f9605daac08ddd27153ddcba689b424cfc261f30caL31-R31))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements in CUDA testing and training device selection.

### 📊 Key Changes
- 🧪 Separated the AutoBatch test from the `test_train` function.
- 💻 Adjusted `trainer.py` to accept a device list for specifying multiple GPUs.
- 🚀 Introduced a new function `test_autobatch` with Automatic Mixed Precision (AMP) support for better performance.

### 🎯 Purpose & Impact
- 🛠️ Improves the modularity of tests, allowing for focused testing of AutoBatch functionality.
- ⚙️ Expands device compatibility, enabling developers to easily run models on multiple GPUs by passing a list.
- 📈 Optimizes model training by testing AutoBatch with AMP, potentially leading to faster training times and better resource utilization.
- 🤖 Benefits users with multi-GPU setups and those looking to take advantage of automatic optimization in training deep learning models.