### PR TITLE
Enable changing the Albumentation probability by overriding yaml

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -108,6 +108,7 @@ fliplr: 0.5  # (float) image flip left-right (probability)
 mosaic: 1.0  # (float) image mosaic (probability)
 mixup: 0.0  # (float) image mixup (probability)
 copy_paste: 0.0  # (float) segment copy-paste (probability)
+albumentations: 1.0 # (float) image albumentations (probability)
 
 # Custom config.yaml ---------------------------------------------------------------------------------------------------
 cfg:  # (str, optional) for overriding defaults.yaml

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -789,7 +789,7 @@ def v8_transforms(dataset, imgsz, hyp, stretch=False):
     return Compose([
         pre_transform,
         MixUp(dataset, pre_transform=pre_transform, p=hyp.mixup),
-        Albumentations(p=1.0),
+        Albumentations(p=hyp.albumentations),
         RandomHSV(hgain=hyp.hsv_h, sgain=hyp.hsv_s, vgain=hyp.hsv_v),
         RandomFlip(direction='vertical', p=hyp.flipud),
         RandomFlip(direction='horizontal', p=hyp.fliplr, flip_idx=flip_idx)])  # transforms


### PR DESCRIPTION
Enable changing the Albumentation probability by overriding yaml

During my research, I found that the albumentations augmentation is adopted fixed probability, and can not access or change from overriding yaml file... 

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 83a5dd3</samp>

### Summary
📸🎛️🛠️

<!--
1.  📸 - This emoji represents the image augmentations from the Albumentations library, which can enhance the quality and diversity of the input images for the model.
2.  🎛️ - This emoji represents the new hyperparameter `albumentations` that allows the user to control the probability of applying image augmentations from the Albumentations library.
3.  🛠️ - This emoji represents the modification of the `v8_transforms` function in the `augment.py` module, which implements the logic of using the `albumentations` hyperparameter.
-->
This pull request adds support for image augmentations from the Albumentations library as a configurable hyperparameter. It modifies the `ultralytics/cfg/default.yaml` and `ultralytics/data/augment.py` files to enable this feature.

> _`albumentations`_
> _Boosts model with more transforms_
> _A spring of learning_

### Walkthrough
* Add a new hyperparameter `albumentations` to control the probability of applying image augmentations from the Albumentations library ([link](https://github.com/ultralytics/ultralytics/pull/4604/files?diff=unified&w=0#diff-732d61cb4969eff986cec58058000b2949ea3b429a97ca5a1045897e754145c5R111))
* Use the `albumentations` hyperparameter in the `v8_transforms` function in `augment.py` to adjust the level of image augmentations ([link](https://github.com/ultralytics/ultralytics/pull/4604/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L792-R792))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced data augmentation with configurable Albumentations probability.

### 📊 Key Changes
- Added a new Albumentations toggle to the default configuration file (`default.yaml`).
- Enabled dynamic control of the Albumentations augmentation probability within the augmentation pipeline.

### 🎯 Purpose & Impact
- **Purpose:** To provide users the flexibility to adjust the probability of applying Albumentations, a library of data augmentation techniques for enhancing model training.
- **Impact:** Users can now experiment with Albumentations more easily, potentially improving model accuracy and robustness by tuning the augmentation strength to their dataset and use case.