### PR TITLE
add an option to disable integration callbacks and turn off tqdm when not verbose

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -65,7 +65,7 @@ from ultralytics.nn.autobackend import check_class_names
 from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder
 from ultralytics.nn.tasks import DetectionModel, SegmentationModel
 from ultralytics.utils import (ARM64, DEFAULT_CFG, LINUX, LOGGER, MACOS, ROOT, WINDOWS, __version__, callbacks,
-                               colorstr, get_default_args, yaml_save)
+                               colorstr, get_default_args, yaml_save, INTEGRATION_CALLBACKS)
 from ultralytics.utils.checks import check_imgsz, check_requirements, check_version
 from ultralytics.utils.downloads import attempt_download_asset, get_github_assets
 from ultralytics.utils.files import file_size, spaces_in_path
@@ -141,7 +141,8 @@ class Exporter:
         """
         self.args = get_cfg(cfg, overrides)
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        callbacks.add_integration_callbacks(self)
+        if INTEGRATION_CALLBACKS:
+            callbacks.add_integration_callbacks(self)
 
     @smart_inference_mode()
     def __call__(self, model=None):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -64,8 +64,8 @@ from ultralytics.cfg import get_cfg
 from ultralytics.nn.autobackend import check_class_names
 from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder
 from ultralytics.nn.tasks import DetectionModel, SegmentationModel
-from ultralytics.utils import (ARM64, DEFAULT_CFG, LINUX, LOGGER, MACOS, ROOT, WINDOWS, __version__, callbacks,
-                               colorstr, get_default_args, yaml_save, INTEGRATION_CALLBACKS)
+from ultralytics.utils import (ARM64, DEFAULT_CFG, INTEGRATION_CALLBACKS, LINUX, LOGGER, MACOS, ROOT, WINDOWS,
+                               __version__, callbacks, colorstr, get_default_args, yaml_save)
 from ultralytics.utils.checks import check_imgsz, check_requirements, check_version
 from ultralytics.utils.downloads import attempt_download_asset, get_github_assets
 from ultralytics.utils.files import file_size, spaces_in_path

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -38,7 +38,7 @@ from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data import load_inference_source
 from ultralytics.data.augment import LetterBox, classify_transforms
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import DEFAULT_CFG, LOGGER, MACOS, WINDOWS, callbacks, colorstr, ops, INTEGRATION_CALLBACKS
+from ultralytics.utils import DEFAULT_CFG, INTEGRATION_CALLBACKS, LOGGER, MACOS, WINDOWS, callbacks, colorstr, ops
 from ultralytics.utils.checks import check_imgsz, check_imshow
 from ultralytics.utils.files import increment_path
 from ultralytics.utils.torch_utils import select_device, smart_inference_mode

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -38,7 +38,7 @@ from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data import load_inference_source
 from ultralytics.data.augment import LetterBox, classify_transforms
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import DEFAULT_CFG, LOGGER, MACOS, WINDOWS, callbacks, colorstr, ops
+from ultralytics.utils import DEFAULT_CFG, LOGGER, MACOS, WINDOWS, callbacks, colorstr, ops, INTEGRATION_CALLBACKS
 from ultralytics.utils.checks import check_imgsz, check_imshow
 from ultralytics.utils.files import increment_path
 from ultralytics.utils.torch_utils import select_device, smart_inference_mode
@@ -106,7 +106,8 @@ class BasePredictor:
         self.transforms = None
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
         self.txt_path = None
-        callbacks.add_integration_callbacks(self)
+        if INTEGRATION_CALLBACKS:
+            callbacks.add_integration_callbacks(self)
 
     def preprocess(self, im):
         """Prepares input image before inference.

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -27,7 +27,7 @@ from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.tasks import attempt_load_one_weight, attempt_load_weights
 from ultralytics.utils import (DEFAULT_CFG, LOGGER, RANK, TQDM_BAR_FORMAT, __version__, callbacks, clean_url, colorstr,
-                               emojis, yaml_save, INTEGRATION_CALLBACKS)
+                               emojis, yaml_save, INTEGRATION_CALLBACKS, VERBOSE)
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, print_args
 from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command
@@ -324,7 +324,7 @@ class BaseTrainer:
 
             if RANK in (-1, 0):
                 LOGGER.info(self.progress_string())
-                pbar = tqdm(enumerate(self.train_loader), total=nb, bar_format=TQDM_BAR_FORMAT)
+                pbar = tqdm(enumerate(self.train_loader), total=nb, bar_format=TQDM_BAR_FORMAT, disable=not VERBOSE)
             self.tloss = None
             self.optimizer.zero_grad()
             for i, batch in pbar:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -27,7 +27,7 @@ from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.tasks import attempt_load_one_weight, attempt_load_weights
 from ultralytics.utils import (DEFAULT_CFG, LOGGER, RANK, TQDM_BAR_FORMAT, __version__, callbacks, clean_url, colorstr,
-                               emojis, yaml_save)
+                               emojis, yaml_save, INTEGRATION_CALLBACKS)
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, print_args
 from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command
@@ -140,7 +140,7 @@ class BaseTrainer:
 
         # Callbacks
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
-        if RANK in (-1, 0):
+        if RANK in (-1, 0) and INTEGRATION_CALLBACKS:
             callbacks.add_integration_callbacks(self)
 
     def add_callback(self, event: str, callback):

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -26,8 +26,8 @@ from tqdm import tqdm
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.tasks import attempt_load_one_weight, attempt_load_weights
-from ultralytics.utils import (DEFAULT_CFG, LOGGER, RANK, TQDM_BAR_FORMAT, __version__, callbacks, clean_url, colorstr,
-                               emojis, yaml_save, INTEGRATION_CALLBACKS, VERBOSE)
+from ultralytics.utils import (DEFAULT_CFG, INTEGRATION_CALLBACKS, LOGGER, RANK, TQDM_BAR_FORMAT, VERBOSE, __version__,
+                               callbacks, clean_url, colorstr, emojis, yaml_save)
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, print_args
 from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -29,7 +29,7 @@ from tqdm import tqdm
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis, INTEGRATION_CALLBACKS, VERBOSE
+from ultralytics.utils import INTEGRATION_CALLBACKS, LOGGER, TQDM_BAR_FORMAT, VERBOSE, callbacks, colorstr, emojis
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.torch_utils import de_parallel, select_device, smart_inference_mode

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -29,7 +29,7 @@ from tqdm import tqdm
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis, INTEGRATION_CALLBACKS
+from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis, INTEGRATION_CALLBACKS, VERBOSE
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.torch_utils import de_parallel, select_device, smart_inference_mode
@@ -160,7 +160,7 @@ class BaseValidator:
         # NOTE: keeping `not self.training` in tqdm will eliminate pbar after segmentation evaluation during training,
         # which may affect classification task since this arg is in yolov5/classify/val.py.
         # bar = tqdm(self.dataloader, desc, n_batches, not self.training, bar_format=TQDM_BAR_FORMAT)
-        bar = tqdm(self.dataloader, desc, n_batches, bar_format=TQDM_BAR_FORMAT)
+        bar = tqdm(self.dataloader, desc, n_batches, bar_format=TQDM_BAR_FORMAT, disable=not VERBOSE)
         self.init_metrics(de_parallel(model))
         self.jdict = []  # empty before each val
         for batch_i, batch in enumerate(bar):

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -29,7 +29,7 @@ from tqdm import tqdm
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis
+from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis, INTEGRATION_CALLBACKS
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.torch_utils import de_parallel, select_device, smart_inference_mode
@@ -119,7 +119,8 @@ class BaseValidator:
             self.args.plots = trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs - 1)
             model.eval()
         else:
-            callbacks.add_integration_callbacks(self)
+            if INTEGRATION_CALLBACKS:
+                callbacks.add_integration_callbacks(self)
             self.run_callbacks('on_val_start')
             model = AutoBackend(model or self.args.model,
                                 device=select_device(self.args.device, self.args.batch),

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -35,7 +35,7 @@ DEFAULT_CFG_PATH = ROOT / 'cfg/default.yaml'
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv5 multiprocessing threads
 AUTOINSTALL = str(os.getenv('YOLO_AUTOINSTALL', True)).lower() == 'true'  # global auto-install mode
 VERBOSE = str(os.getenv('YOLO_VERBOSE', True)).lower() == 'true'  # global verbose mode
-INTEGRATION_CALLBACKS = str(os.getenv("YOLO_INTEGRATION_CALLBACKS", True)).lower() == 'true'
+INTEGRATION_CALLBACKS = str(os.getenv('YOLO_INTEGRATION_CALLBACKS', True)).lower() == 'true'
 TQDM_BAR_FORMAT = '{l_bar}{bar:10}{r_bar}'  # tqdm bar format
 LOGGING_NAME = 'ultralytics'
 MACOS, LINUX, WINDOWS = (platform.system() == x for x in ['Darwin', 'Linux', 'Windows'])  # environment booleans

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -35,6 +35,7 @@ DEFAULT_CFG_PATH = ROOT / 'cfg/default.yaml'
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv5 multiprocessing threads
 AUTOINSTALL = str(os.getenv('YOLO_AUTOINSTALL', True)).lower() == 'true'  # global auto-install mode
 VERBOSE = str(os.getenv('YOLO_VERBOSE', True)).lower() == 'true'  # global verbose mode
+INTEGRATION_CALLBACKS = str(os.getenv("YOLO_INTEGRATION_CALLBACKS", True)).lower() == 'true'
 TQDM_BAR_FORMAT = '{l_bar}{bar:10}{r_bar}'  # tqdm bar format
 LOGGING_NAME = 'ultralytics'
 MACOS, LINUX, WINDOWS = (platform.system() == x for x in ['Darwin', 'Linux', 'Windows'])  # environment booleans


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8367011</samp>

### Summary
🎛️🔌🚀

<!--
1.  🎛️ - This emoji represents the addition of options or variables to control the integration callbacks and progress bars in different classes. It suggests the idea of adjusting or tuning the settings or parameters of the modules.
2.  🔌 - This emoji represents the integration callbacks themselves, which connect the ultralytics modules with external services or tools. It suggests the idea of plugging in or out the integration features.
3.  🚀 - This emoji represents the improvement of the flexibility and robustness of the exporter, predictor, trainer and validator classes. It suggests the idea of boosting or enhancing the performance or functionality of the modules.
-->
Added options to control integration callbacks and progress bars in the engine module. Integration callbacks are functions that integrate the engine classes with external services or tools. The `INTEGRATION_CALLBACKS` variable from `ultralytics.utils` can be used to enable or disable these features globally or per class.

> _`INTEGRATION_CALLBACKS` are the chains that bind us_
> _We break them with the power of `YOLO`_
> _We control our destiny with `VERBOSE` and `ultralytics`_
> _We are the masters of the exporter, predictor, trainer and validator_

### Walkthrough
*  Add `INTEGRATION_CALLBACKS` variable to control integration callbacks ([link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL68-R68), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-9fa2bf7f1273283680da3daeb8bae8e20cf8d477f838575796d2bf3b415bc534L41-R41), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL30-R30), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-01e0aaa194c770fed7f7a0cc941222f0acfa857d478bfeba933eed1bcb1f65e7L32-R32), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faR38))
*  Add `VERBOSE` variable to control progress bars ([link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-9fa2bf7f1273283680da3daeb8bae8e20cf8d477f838575796d2bf3b415bc534L41-R41), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL30-R30), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-01e0aaa194c770fed7f7a0cc941222f0acfa857d478bfeba933eed1bcb1f65e7L32-R32))
*  Call `callbacks.add_integration_callbacks` only if `INTEGRATION_CALLBACKS` is True in `Exporter`, `BasePredictor`, `BaseTrainer` and `BaseValidator` classes ([link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL144-R145), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-9fa2bf7f1273283680da3daeb8bae8e20cf8d477f838575796d2bf3b415bc534L109-R110), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL143-R143), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-01e0aaa194c770fed7f7a0cc941222f0acfa857d478bfeba933eed1bcb1f65e7L122-R123))
*  Add `disable=not VERBOSE` argument to `tqdm` calls in `BaseTrainer` and `BaseValidator` classes ([link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL327-R327), [link](https://github.com/ultralytics/ultralytics/pull/4609/files?diff=unified&w=0#diff-01e0aaa194c770fed7f7a0cc941222f0acfa857d478bfeba933eed1bcb1f65e7L162-R163))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduced environment variable control for integration callbacks and verbose logging in various components of Ultralytics software.

### 📊 Key Changes
- Added a new environment variable `INTEGRATION_CALLBACKS` to control the addition of integration callbacks.
- Modified the addition of integration callbacks in `exporter.py`, `predictor.py`, `trainer.py`, and `validator.py` to respect the `INTEGRATION_CALLBACKS` flag.
- Introduced the `VERBOSE` environment variable to toggle tqdm progress bar visibility in `trainer.py` and `validator.py`.

### 🎯 Purpose & Impact
- 🎛️ **Customization**: The `INTEGRATION_CALLBACKS` flag allows users to enable or disable integration callbacks, giving more control over the behavior of their software environment.
- 🔕 **Quieter Output**: The `VERBOSE` flag permits users to reduce output clutter by hiding progress bars if desired, which could be useful in logs or non-interactive scripts.
- 🚀 **User Experience**: These changes empower users and system administrators by providing more options to configure the Ultralytics software behavior to better fit their use case or preferences.