### PR TITLE
Warn on DDP AutoBatch and default to 16

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -181,8 +181,13 @@ class BaseTrainer:
         if world_size > 1 and 'LOCAL_RANK' not in os.environ:
             # Argument checks
             if self.args.rect:
-                LOGGER.warning("WARNING ⚠️ 'rect=True' is incompatible with Multi-GPU training, setting rect=False")
+                LOGGER.warning("WARNING ⚠️ 'rect=True' is incompatible with Multi-GPU training, setting 'rect=False'")
                 self.args.rect = False
+            if self.args.batch == -1:
+                LOGGER.warning("WARNING ⚠️ 'batch=-1' for AutoBatch is incompatible with Multi-GPU training, setting "
+                               "default 'batch=16'")
+                self.args.batch = 16
+
             # Command
             cmd, file = generate_ddp_command(world_size, self)
             try:
@@ -192,6 +197,7 @@ class BaseTrainer:
                 raise e
             finally:
                 ddp_cleanup(self, str(file))
+
         else:
             self._do_train(world_size)
 
@@ -254,9 +260,6 @@ class BaseTrainer:
         if self.batch_size == -1:
             if RANK == -1:  # single-GPU only, estimate best batch size
                 self.args.batch = self.batch_size = check_train_batch_size(self.model, self.args.imgsz, self.amp)
-            else:
-                SyntaxError('batch=-1 to use AutoBatch is only available in Single-GPU training. '
-                            'Please pass a valid batch size value for Multi-GPU DDP training, i.e. batch=16')
 
         # Dataloaders
         batch_size = self.batch_size // max(world_size, 1)


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8500cde</samp>

### Summary
🐛🚀⚠️

<!--
1.  🐛 for fixing a bug
2.  🚀 for improving performance or scalability
3.  ⚠️ for adding a warning
-->
This pull request improves the integration of AutoBatch and Multi-GPU training in `trainer.py`. It fixes a bug, adds a warning, and sets a reasonable default for the batch size.

> _Oh we're the coders of the sea, and we work on `trainer.py`_
> _We fix the bugs and make it run, with AutoBatch and Multi-GPU_
> _Heave away, me hearties, heave away_
> _We add a warning and a default, and remove a SyntaxError too_

### Walkthrough
*  Add warning and default value for `batch` argument when using Multi-GPU training with AutoBatch in `trainer.py` ([link](https://github.com/ultralytics/ultralytics/pull/4610/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL184-R190))
*  Remove invalid SyntaxError when using AutoBatch with Multi-GPU training in `trainer.py` ([link](https://github.com/ultralytics/ultralytics/pull/4610/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL257-L259))
*  Add empty line for code formatting in `trainer.py` ([link](https://github.com/ultralytics/ultralytics/pull/4610/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeR200))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved batch size handling and error reporting in multi-GPU training setups.

### 📊 Key Changes
- Removed the ability to set `batch=-1` for automatic batch size detection in multi-GPU (DDP) training.
- Added a default batch size of 16 when no batch size is specified in multi-GPU training environments.
- Cleaned up deprecated code that allowed `batch=-1` in distributed training contexts.

### 🎯 Purpose & Impact
- Ensures users are aware that automatic batch size detection is only available for single-GPU setups.
- Prevents potential confusion by setting a sensible default batch size when users don't specify one in a multi-GPU context.
- Clarifies trainer behavior and reduces errors by eliminating unsupported options in distributed training, leading to a smoother user experience.