### PR TITLE
removed unecessary duplicate computations

### DIFF
--- a/ultralytics/nn/modules/transformer.py
+++ b/ultralytics/nn/modules/transformer.py
@@ -358,15 +358,15 @@ class DeformableTransformerDecoder(nn.Module):
         for i, layer in enumerate(self.layers):
             output = layer(output, refer_bbox, feats, shapes, padding_mask, attn_mask, pos_mlp(refer_bbox))
 
-            # refine bboxes, (bs, num_queries+num_denoising, 4)
-            refined_bbox = torch.sigmoid(bbox_head[i](output) + inverse_sigmoid(refer_bbox))
+            bbox = bbox_head[i](output)
+            refined_bbox = torch.sigmoid(bbox + inverse_sigmoid(refer_bbox))
 
             if self.training:
                 dec_cls.append(score_head[i](output))
                 if i == 0:
                     dec_bboxes.append(refined_bbox)
                 else:
-                    dec_bboxes.append(torch.sigmoid(bbox_head[i](output) + inverse_sigmoid(last_refined_bbox)))
+                    dec_bboxes.append(torch.sigmoid(bbox + inverse_sigmoid(last_refined_bbox)))
             elif i == self.eval_idx:
                 dec_cls.append(score_head[i](output))
                 dec_bboxes.append(refined_bbox)


### PR DESCRIPTION
Same bounding box computation was executed twice.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8c5ff8a</samp>

### Summary
🔧🚀♻️

<!--
1.  🔧 (wrench) for refactoring and optimizing the code.
2.  🚀 (rocket) for improving the performance and efficiency of the module.
3.  ♻️ (recycling symbol) for reusing the `bbox` variable and avoiding redundancy.
-->
Refactor `transformer.py` to improve performance of deformable transformer decoder. Reuse `bbox` values instead of recomputing them.

> _`bbox` from sigmoid_
> _cuts redundant work in half_
> _a winter pruning_

### Walkthrough
* Extract and reuse `bbox` variable to avoid redundant computation in deformable transformer decoder ([link](https://github.com/ultralytics/ultralytics/pull/4611/files?diff=unified&w=0#diff-fc9bd8e217a8c71a55895011182403a8a55b9fe8751949a92dc3b9d75d45ce57L361-R362), [link](https://github.com/ultralytics/ultralytics/pull/4611/files?diff=unified&w=0#diff-fc9bd8e217a8c71a55895011182403a8a55b9fe8751949a92dc3b9d75d45ce57L369-R369)) in `transformer.py`




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of bounding box calculations in the transformer module.

### 📊 Key Changes
- Removed the direct addition of `inverse_sigmoid(refer_bbox)` to `bbox_head[i](output)` in the bounding box refinement step.
- Introduced an intermediate variable `bbox` to hold the output of `bbox_head[i](output)` before applying the sigmoid function.

### 🎯 Purpose & Impact
- The changes are intended for cleaner and possibly more efficient bounding box refinement during both training and inference.
- This can improve the readability of the code and may have minor performance implications due to reduced redundancy in calculations.
- Users may experience slight enhancements in the object detection tasks that rely on transformers, although the fundamental algorithm remains unchanged.