### PR TITLE
support FastSAM directory inference and plot

### DIFF
--- a/ultralytics/models/fastsam/prompt.py
+++ b/ultralytics/models/fastsam/prompt.py
@@ -1,32 +1,29 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 import os
-from pathlib import Path
 
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from PIL import Image
-
-from ultralytics.utils import LOGGER
+from tqdm import tqdm
+from ultralytics.utils import TQDM_BAR_FORMAT
 
 
 class FastSAMPrompt:
 
-    def __init__(self, img_path, results, device='cuda') -> None:
-        # self.img_path = img_path
+    def __init__(self, source, results, device='cuda') -> None:
         self.device = device
         self.results = results
-        self.img_path = str(img_path)
-        self.ori_img = cv2.imread(self.img_path)
+        self.source = source
 
         # Import and assign clip
         try:
             import clip  # for linear_assignment
         except ImportError:
             from ultralytics.utils.checks import check_requirements
-            check_requirements('git+https://github.com/openai/CLIP.git')
+            check_requirements('git+https://github.com/openai/CLIP.git')  # required before installing lap from source
             import clip
         self.clip = clip
 
@@ -51,15 +48,31 @@ class FastSAMPrompt:
         n = len(result.masks.data)
         for i in range(n):
             mask = result.masks.data[i] == 1.0
-            if torch.sum(mask) >= filter:
-                annotation = {
-                    'id': i,
-                    'segmentation': mask.cpu().numpy(),
-                    'bbox': result.boxes.data[i],
-                    'score': result.boxes.conf[i]}
-                annotation['area'] = annotation['segmentation'].sum()
-                annotations.append(annotation)
+
+            if torch.sum(mask) < filter:
+                continue
+            annotation = {
+                'id': i,
+                'segmentation': mask.cpu().numpy(),
+                'bbox': result.boxes.data[i],
+                'score': result.boxes.conf[i]}
+            annotation['area'] = annotation['segmentation'].sum()
+            annotations.append(annotation)
         return annotations
+
+    @staticmethod
+    def filter_masks(annotations):  # filter the overlap mask
+        annotations.sort(key=lambda x: x['area'], reverse=True)
+        to_remove = set()
+        for i in range(len(annotations)):
+            a = annotations[i]
+            for j in range(i + 1, len(annotations)):
+                b = annotations[j]
+                if i != j and j not in to_remove and b['area'] < a['area'] and \
+                        (a['segmentation'] & b['segmentation']).sum() / b['segmentation'].sum() > 0.8:
+                    to_remove.add(j)
+
+        return [a for i, a in enumerate(annotations) if i not in to_remove], to_remove
 
     @staticmethod
     def _get_bbox_from_mask(mask):
@@ -75,6 +88,8 @@ class FastSAMPrompt:
                 y1 = min(y1, y_t)
                 x2 = max(x2, x_t + w_t)
                 y2 = max(y2, y_t + h_t)
+            h = y2 - y1
+            w = x2 - x1
         return [x1, y1, x2, y2]
 
     def plot(self,
@@ -86,71 +101,82 @@ class FastSAMPrompt:
              mask_random_color=True,
              better_quality=True,
              retina=False,
-             with_countouers=True):
-        if isinstance(annotations[0], dict):
-            annotations = [annotation['segmentation'] for annotation in annotations]
-        if isinstance(annotations, torch.Tensor):
-            annotations = annotations.cpu().numpy()
-        result_name = os.path.basename(self.img_path)
-        image = self.ori_img
-        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        original_h = image.shape[0]
-        original_w = image.shape[1]
-        # for macOS only
-        # plt.switch_backend('TkAgg')
-        fig = plt.figure(figsize=(original_w / 100, original_h / 100))
-        # Add subplot with no margin.
-        plt.subplots_adjust(top=1, bottom=0, right=1, left=0, hspace=0, wspace=0)
-        plt.margins(0, 0)
-        plt.gca().xaxis.set_major_locator(plt.NullLocator())
-        plt.gca().yaxis.set_major_locator(plt.NullLocator())
+             withContours=True):
+        n = len(annotations)
+        pbar = tqdm(annotations, total=n, bar_format=TQDM_BAR_FORMAT)
+        for ann in pbar:
+            result_name = os.path.basename(ann.path)
+            image = ann.orig_img
+            original_h, original_w = ann.orig_shape
+            # for macOS only
+            # plt.switch_backend('TkAgg')
+            plt.figure(figsize=(original_w / 100, original_h / 100))
+            # Add subplot with no margin.
+            plt.subplots_adjust(top=1, bottom=0, right=1, left=0, hspace=0, wspace=0)
+            plt.margins(0, 0)
+            plt.gca().xaxis.set_major_locator(plt.NullLocator())
+            plt.gca().yaxis.set_major_locator(plt.NullLocator())
+            plt.imshow(image)
 
-        plt.imshow(image)
-        if better_quality:
-            for i, mask in enumerate(annotations):
-                mask = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))
-                annotations[i] = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_OPEN, np.ones((8, 8), np.uint8))
-        self.fast_show_mask(
-            annotations,
-            plt.gca(),
-            random_color=mask_random_color,
-            bbox=bbox,
-            points=points,
-            pointlabel=point_label,
-            retinamask=retina,
-            target_height=original_h,
-            target_width=original_w,
-        )
+            masks = ann.masks.data
+            if better_quality:
+                if isinstance(masks[0], torch.Tensor):
+                    masks = np.array(masks.cpu())
+                for i, mask in enumerate(masks):
+                    mask = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))
+                    masks[i] = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_OPEN, np.ones((8, 8), np.uint8))
+                    
+            if withContours:
+                contour_all = []
+                temp = np.zeros((original_h, original_w, 1))
+                for i, mask in enumerate(masks):
+                    mask = mask.astype(np.uint8)
+                    if not retina:
+                        mask = cv2.resize(
+                            mask,
+                            (original_w, original_h),
+                            interpolation=cv2.INTER_NEAREST,
+                        )
+                    contours, _ = cv2.findContours(mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+                    contour_all.extend(iter(contours))
+                cv2.drawContours(temp, contour_all, -1, (255, 255, 255), 2)
+                color = np.array([0 / 255, 0 / 255, 1.0, 0.8])
+                contour_mask = temp / 255 * color.reshape(1, 1, -1)
+                plt.imshow(contour_mask)
 
-        if with_countouers:
-            contour_all = []
-            temp = np.zeros((original_h, original_w, 1))
-            for i, mask in enumerate(annotations):
-                if isinstance(mask, dict):
-                    mask = mask['segmentation']
-                annotation = mask.astype(np.uint8)
-                if not retina:
-                    annotation = cv2.resize(
-                        annotation,
-                        (original_w, original_h),
-                        interpolation=cv2.INTER_NEAREST,
-                    )
-                contours, hierarchy = cv2.findContours(annotation, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
-                contour_all.extend(iter(contours))
-            cv2.drawContours(temp, contour_all, -1, (255, 255, 255), 2)
-            color = np.array([0 / 255, 0 / 255, 1.0, 0.8])
-            contour_mask = temp / 255 * color.reshape(1, 1, -1)
-            plt.imshow(contour_mask)
+            masks = torch.from_numpy(masks)
+            self.fast_show_mask(
+                masks,
+                plt.gca(),
+                random_color=mask_random_color,
+                bbox=bbox,
+                points=points,
+                pointlabel=point_label,
+                retinamask=retina,
+                target_height=original_h,
+                target_width=original_w,
+            )
 
-        save_path = Path(output) / result_name
-        save_path.parent.mkdir(exist_ok=True, parents=True)
-        plt.axis('off')
-        fig.savefig(save_path)
-        LOGGER.info(f'Saved to {save_path.absolute()}')
+            save_path = output
+            if not os.path.exists(save_path):
+                os.makedirs(save_path)
+            plt.axis('off')
+            fig = plt.gcf()
+            plt.draw()
 
-    #   CPU post process
-    @staticmethod
+            try:
+                buf = fig.canvas.tostring_rgb()
+            except AttributeError:
+                fig.canvas.draw()
+                buf = fig.canvas.tostring_rgb()
+            cols, rows = fig.canvas.get_width_height()
+            img_array = np.frombuffer(buf, dtype=np.uint8).reshape(rows, cols, 3)
+            cv2.imwrite(os.path.join(save_path, result_name), cv2.cvtColor(img_array, cv2.COLOR_RGB2BGR))
+            plt.close()
+            pbar.set_description("Saving {} to {}".format(result_name, os.path.join(save_path, result_name)))
+
     def fast_show_mask(
+        self,
         annotation,
         ax,
         random_color=False,
@@ -161,29 +187,33 @@ class FastSAMPrompt:
         target_height=960,
         target_width=960,
     ):
-        n, h, w = annotation.shape  # batch, height, width
-
-        areas = np.sum(annotation, axis=(1, 2))
-        annotation = annotation[np.argsort(areas)]
-
-        index = (annotation != 0).argmax(axis=0)
+        msak_sum = annotation.shape[0]
+        height = annotation.shape[1]
+        weight = annotation.shape[2]
+        areas = torch.sum(annotation, dim=(1, 2))
+        sorted_indices = torch.argsort(areas, descending=False)
+        annotation = annotation[sorted_indices]
+        # 找每个位置第一个非零值下标
+        index = (annotation != 0).to(torch.long).argmax(dim=0)
         if random_color:
-            color = np.random.random((n, 1, 1, 3))
+            color = torch.rand((msak_sum, 1, 1, 3)).to(annotation.device)
         else:
-            color = np.ones((n, 1, 1, 3)) * np.array([30 / 255, 144 / 255, 1.0])
-        transparency = np.ones((n, 1, 1, 1)) * 0.6
-        visual = np.concatenate([color, transparency], axis=-1)
-        mask_image = np.expand_dims(annotation, -1) * visual
-
-        show = np.zeros((h, w, 4))
-        h_indices, w_indices = np.meshgrid(np.arange(h), np.arange(w), indexing='ij')
+            color = torch.ones((msak_sum, 1, 1, 3)).to(annotation.device) * torch.tensor([30 / 255, 144 / 255, 1.0]).to(
+                annotation.device)
+        transparency = torch.ones((msak_sum, 1, 1, 1)).to(annotation.device) * 0.6
+        visual = torch.cat([color, transparency], dim=-1)
+        mask_image = torch.unsqueeze(annotation, -1) * visual
+        # 按index取数，index指每个位置选哪个batch的数，把mask_image转成一个batch的形式
+        show = torch.zeros((height, weight, 4)).to(annotation.device)
+        h_indices, w_indices = torch.meshgrid(torch.arange(height), torch.arange(weight), indexing='ij')
         indices = (index[h_indices, w_indices], h_indices, w_indices, slice(None))
-
+        # 使用向量化索引更新show的值
         show[h_indices, w_indices, :] = mask_image[indices]
+        show_cpu = show.cpu().numpy()
         if bbox is not None:
             x1, y1, x2, y2 = bbox
             ax.add_patch(plt.Rectangle((x1, y1), x2 - x1, y2 - y1, fill=False, edgecolor='b', linewidth=1))
-        # Draw point
+        # draw point
         if points is not None:
             plt.scatter(
                 [point[0] for i, point in enumerate(points) if pointlabel[i] == 1],
@@ -197,11 +227,11 @@ class FastSAMPrompt:
                 s=20,
                 c='m',
             )
-
         if not retinamask:
-            show = cv2.resize(show, (target_width, target_height), interpolation=cv2.INTER_NEAREST)
-        ax.imshow(show)
+            show_cpu = cv2.resize(show_cpu, (target_width, target_height), interpolation=cv2.INTER_NEAREST)
+        ax.imshow(show_cpu)
 
+    # clip
     @torch.no_grad()
     def retrieve(self, model, preprocess, elements, search_text: str, device) -> int:
         preprocessed_images = [preprocess(image).to(device) for image in elements]
@@ -215,8 +245,9 @@ class FastSAMPrompt:
         return probs[:, 0].softmax(dim=0)
 
     def _crop_image(self, format_results):
-
-        image = Image.fromarray(cv2.cvtColor(self.ori_img, cv2.COLOR_BGR2RGB))
+        if os.path.isdir(self.source):
+            raise ValueError(f"'{self.source}' is a directory, not a valid source for this function.")
+        image = Image.fromarray(cv2.cvtColor(self.results[0].orig_img, cv2.COLOR_BGR2RGB))
         ori_w, ori_h = image.size
         annotations = format_results
         mask_h, mask_w = annotations[0]['segmentation'].shape
@@ -226,22 +257,25 @@ class FastSAMPrompt:
         cropped_images = []
         not_crop = []
         filter_id = []
+        # annotations, _ = filter_masks(annotations)
+        # filter_id = list(_)
         for _, mask in enumerate(annotations):
             if np.sum(mask['segmentation']) <= 100:
                 filter_id.append(_)
                 continue
             bbox = self._get_bbox_from_mask(mask['segmentation'])  # mask 的 bbox
             cropped_boxes.append(self._segment_image(image, bbox))  # 保存裁剪的图片
+            # cropped_boxes.append(segment_image(image,mask["segmentation"]))
             cropped_images.append(bbox)  # 保存裁剪的图片的bbox
 
         return cropped_boxes, cropped_images, not_crop, filter_id, annotations
 
     def box_prompt(self, bbox):
-
         assert (bbox[2] != 0 and bbox[3] != 0)
+        if os.path.isdir(self.source):
+            raise ValueError(f"'{self.source}' is a directory, not a valid source for this function.")
         masks = self.results[0].masks.data
-        target_height = self.ori_img.shape[0]
-        target_width = self.ori_img.shape[1]
+        target_height, target_width = self.results[0].orig_shape
         h = masks.shape[1]
         w = masks.shape[2]
         if h != target_height or w != target_width:
@@ -265,13 +299,14 @@ class FastSAMPrompt:
         IoUs = masks_area / union
         max_iou_index = torch.argmax(IoUs)
 
-        return np.array([masks[max_iou_index].cpu().numpy()])
+        self.results[0].masks.data = torch.tensor(np.array([masks[max_iou_index].cpu().numpy()]))
+        return self.results
 
     def point_prompt(self, points, pointlabel):  # numpy 处理
-
+        if os.path.isdir(self.source):
+            raise ValueError(f"'{self.source}' is a directory, not a valid source for this function.")
         masks = self._format_results(self.results[0], 0)
-        target_height = self.ori_img.shape[0]
-        target_width = self.ori_img.shape[1]
+        target_height, target_width = self.results[0].orig_shape
         h = masks[0]['segmentation'].shape[0]
         w = masks[0]['segmentation'].shape[1]
         if h != target_height or w != target_width:
@@ -285,7 +320,8 @@ class FastSAMPrompt:
                 if mask[point[1], point[0]] == 1 and pointlabel[i] == 0:
                     onemask -= mask
         onemask = onemask >= 1
-        return np.array([onemask])
+        self.results[0].masks.data = torch.tensor(np.array([onemask]))
+        return self.results
 
     def text_prompt(self, text):
         format_results = self._format_results(self.results[0], 0)
@@ -295,7 +331,8 @@ class FastSAMPrompt:
         max_idx = scores.argsort()
         max_idx = max_idx[-1]
         max_idx += sum(np.array(filter_id) <= int(max_idx))
-        return np.array([annotations[max_idx]['segmentation']])
+        self.results[0].masks.data = torch.tensor(np.array([ann['segmentation'] for ann in annotations]))
+        return self.results
 
     def everything_prompt(self):
-        return self.results[0].masks.data
+        return self.results

--- a/ultralytics/models/fastsam/prompt.py
+++ b/ultralytics/models/fastsam/prompt.py
@@ -24,7 +24,7 @@ class FastSAMPrompt:
             import clip  # for linear_assignment
         except ImportError:
             from ultralytics.utils.checks import check_requirements
-            check_requirements('git+https://github.com/openai/CLIP.git')  # required before installing lap from source
+            check_requirements('git+https://github.com/openai/CLIP.git')
             import clip
         self.clip = clip
 

--- a/ultralytics/models/fastsam/prompt.py
+++ b/ultralytics/models/fastsam/prompt.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 from PIL import Image
 from tqdm import tqdm
+
 from ultralytics.utils import TQDM_BAR_FORMAT
 
 
@@ -125,7 +126,7 @@ class FastSAMPrompt:
                 for i, mask in enumerate(masks):
                     mask = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))
                     masks[i] = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_OPEN, np.ones((8, 8), np.uint8))
-                    
+
             if withContours:
                 contour_all = []
                 temp = np.zeros((original_h, original_w, 1))
@@ -173,7 +174,7 @@ class FastSAMPrompt:
             img_array = np.frombuffer(buf, dtype=np.uint8).reshape(rows, cols, 3)
             cv2.imwrite(os.path.join(save_path, result_name), cv2.cvtColor(img_array, cv2.COLOR_RGB2BGR))
             plt.close()
-            pbar.set_description("Saving {} to {}".format(result_name, os.path.join(save_path, result_name)))
+            pbar.set_description('Saving {} to {}'.format(result_name, os.path.join(save_path, result_name)))
 
     def fast_show_mask(
         self,

--- a/ultralytics/models/fastsam/prompt.py
+++ b/ultralytics/models/fastsam/prompt.py
@@ -124,7 +124,7 @@ class FastSAMPrompt:
                 target_height=original_h,
                 target_width=original_w,
             )
- 
+
             if withContours:
                 contour_all = []
                 temp = np.zeros((original_h, original_w, 1))


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1c43c07</samp>

### Summary
🔧🚀🎨

<!--
1.  🔧 - This emoji represents refactoring, fixing, or improving the code quality or functionality.
2.  🚀 - This emoji represents speeding up the performance, enhancing the efficiency, or optimizing the computation of the code.
3.  🎨 - This emoji represents adding, updating, or improving the visual aspects, such as images or plots, of the code.
-->
This pull request improves the `FastSAMPrompt` class for semantic image manipulation. It adds support for different source types, enhances the segmentation results, fixes bugs, and simplifies the code. It also uses `torch` for faster and more flexible image processing and plotting.

> _We face the doom of different sources_
> _We segment them with `FastSAMPrompt`_
> _We fix the bugs and simplify the code_
> _We torch the images and plot the results_

### Walkthrough
*  Modify `FastSAMPrompt` class to handle different sources and improve segmentation quality ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L11-R19), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L54-R77), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L89-R179), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L164-R216), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L200-R234), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L218-R250), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L240-R278), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L268-R309), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L288-R324), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L298-R338))
  * Add `source` argument to `__init__` method and use `results` attributes instead of `img_path` ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L11-R19))
  * Add `filter_masks` method to remove overlapping masks based on area and IoU ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L54-R77))
  * Iterate over `results` list and use `torch` for faster image processing in `plot` method ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L89-R179))
  * Use `torch` for faster computation and fix typo in `fast_show_mask` method ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L164-R216), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L200-R234))
  * Use `results` argument and raise error for invalid `source` in `_crop_image` method ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L218-R250))
  * Add optional calls to `filter_masks` and `segment_image` in `_crop_image` method ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438R260-R261), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438R268))
  * Use `results` argument and return modified `results` in `box_prompt`, `point_prompt`, `text_prompt`, and `everything_prompt` methods ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L240-R278), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L268-R309), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L288-R324), [link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L298-R338))
* Fix bug in `_get_bbox_from_mask` method by calculating bounding box dimensions from mask ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438R91-R92))
* Add comment to explain `check_requirements` call before importing `clip` ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L29-R26))
* Remove unused import of `pathlib.Path` ([link](https://github.com/ultralytics/ultralytics/pull/4621/files?diff=unified&w=0#diff-525486f27ba5eca08d7cfaca5bdb538fb7c4c7963005d75565cfd5912be42438L4))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved functionality and efficiency in FastSAMPrompt Class.

### 📊 Key Changes
- Replaced `img_path` with the more versatile `source` parameter in the `FastSAMPrompt` initializer.
- Refactored conditional statement that filters out masks below the size threshold to make code clearer.
- Added progress tracking with `tqdm` for plot generations.
- Changed contour visualization logic for better quality in plot outputs.
- Added error handling to prevent directories from being passed as invalid function sources.
- Code now saves plot images more robustly and closes figures to free memory.
- Enhanced box selection with `box_prompt` to consider object size.
- Masked image post-processing is now more consistent, and masks are stored efficiently.

### 🎯 Purpose & Impact
- 🔍 Generalize input source handling, improving the flexibility of the class.
- 📈 Enhance performance via cleaner code and progress bars for long-running tasks.
- 🖼️ Boost image plotting quality, leading to better output visuals for users.
- 🛠️ Ensure stable behavior by preventing unsupported input scenarios.
- 🧹 Improve memory management by closing unused figures, reducing the risk of resource depletion.
- 📐 Make box prompts smarter to improve mask selection based on size, impacting accuracy and usage.