### PR TITLE
Add NNCF support in OpenVINO export

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -367,13 +367,71 @@ class Exporter:
 
         LOGGER.info(f'\n{prefix} starting export with openvino {ov.__version__}...')
         f = str(self.file).replace(self.file.suffix, f'_openvino_model{os.sep}')
+        fq = str(self.file).replace(self.file.suffix, f'_int8_openvino_model{os.sep}')
         f_onnx = self.file.with_suffix('.onnx')
         f_ov = str(Path(f) / self.file.with_suffix('.xml').name)
+        fq_ov = str(Path(fq) / self.file.with_suffix('.xml').name)
 
         ov_model = mo.convert_model(f_onnx,
                                     model_name=self.pretty_name,
                                     framework='onnx',
                                     compress_to_fp16=self.args.half)  # export
+        if self.args.data and self.args.int8:
+            import numpy as np
+            import nncf
+            from ultralytics.data.dataset import YOLODataset
+            from ultralytics.data.utils import check_det_dataset
+            from ultralytics.data import build_dataloader
+
+            # Generate calibration data for integer quantization
+            LOGGER.info(f"{prefix} collecting INT8 calibration images from 'data={self.args.data}'")
+            data = check_det_dataset(self.args.data)
+            dataset = YOLODataset(data['val'], data=data, imgsz=self.imgsz[0], augment=False)
+            dl = build_dataloader(dataset, batch=1, workers=self.args.workers)
+
+            def prepare_input_tensor(image: np.ndarray):
+                input_tensor = image.astype(np.float32)  # uint8 to fp16/32
+                input_tensor /= 255.0  # 0 - 255 to 0.0 - 1.0
+
+                if input_tensor.ndim == 3:
+                    input_tensor = np.expand_dims(input_tensor, 0)
+                return input_tensor
+
+            def transform_fn(data_item):
+                """
+                Quantization transform function. Extracts and preprocess input data from dataloader item for quantization.
+                Parameters:
+                   data_item: Tuple with data item produced by DataLoader during iteration
+                Returns:
+                    input_tensor: Input data for quantization
+                """
+                img = data_item['img'].numpy()
+                input_tensor = prepare_input_tensor(img)
+                return input_tensor
+
+            quantization_dataset = nncf.Dataset(dl, transform_fn)
+            ignored_scope = nncf.IgnoredScope(
+                types=["Multiply", "Subtract", "Sigmoid"],  # ignore operation
+
+            )
+            # Detection model
+            quantized_ov_model = nncf.quantize(
+                ov_model,
+                quantization_dataset,
+                preset=nncf.QuantizationPreset.MIXED,
+               ignored_scope=ignored_scope
+            )
+            quantized_ov_model.set_rt_info('YOLOv8', ['model_info', 'model_type'])
+            quantized_ov_model.set_rt_info(True, ['model_info', 'reverse_input_channels'])
+            quantized_ov_model.set_rt_info(114, ['model_info', 'pad_value'])
+            quantized_ov_model.set_rt_info([255.0], ['model_info', 'scale_values'])
+            quantized_ov_model.set_rt_info(self.args.iou, ['model_info', 'iou_threshold'])
+            quantized_ov_model.set_rt_info([v.replace(' ', '_') for k, v in sorted(self.model.names.items())],
+                                 ['model_info', 'labels'])
+            if self.model.task != 'classify':
+                quantized_ov_model.set_rt_info('fit_to_window_letterbox', ['model_info', 'resize_type'])
+            ov.serialize(quantized_ov_model, fq_ov)
+            yaml_save(Path(fq) / 'metadata.yaml', self.metadata)  # add metadata.yaml
 
         # Set RT info
         ov_model.set_rt_info('YOLOv8', ['model_info', 'model_type'])

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -378,6 +378,7 @@ class Exporter:
                                     compress_to_fp16=self.args.half)  # export
         if self.args.data and self.args.int8:
             import numpy as np
+            check_requirements('nncf')
             import nncf
             from ultralytics.data.dataset import YOLODataset
             from ultralytics.data.utils import check_det_dataset


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->
Add NNCF support in OpenVINO export to improve predict performance on Intel GPU with int8 hardware support 

Calibration and It's data is necessary  (From OpenVINO's offical [doc ](https://docs.openvino.ai/2022.3/basic_qauntization_flow.html))
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 970f830</samp>

### Summary
🚀🔧📝

<!--
1.  🚀 for adding a new feature that can improve the model performance and efficiency
2.  🔧 for modifying the existing function to support a new option
3.  📝 for updating the documentation and examples to reflect the new option
-->
This pull request enhances the `export_openvino` function in `ultralytics/engine/exporter.py` to support quantization with the `nncf` library. This can enable faster and more efficient openvino models for some target devices.

> _Sing, O Muse, of the skillful engineers who devised_
> _A way to export a quantized openvino model, a marvel_
> _Of nncf, the library of compression, that enhances_
> _The performance and efficiency of the hardware, like Hermes_

### Walkthrough
* Add variables to store quantized openvino model paths ([link](https://github.com/ultralytics/ultralytics/pull/4660/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL370-R373))
* Implement optional integer quantization of openvino model using nncf library ([link](https://github.com/ultralytics/ultralytics/pull/4660/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cL377-R436))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added INT8 quantization support for OpenVINO model export.

### 📊 Key Changes
- 🧠 Introduced model conversion to INT8 using the Neural Network Compression Framework (NNCF) for OpenVINO exports.
- 📈 Added a calibration stage using validation data to produce a quantized model optimized for INT8 inference. 
- 🌐 Exported quantized models include runtime (RT) information like YOLO version, IOU threshold, model type, and labels.

### 🎯 Purpose & Impact
- 🚀 Improve inference speed: INT8 quantization can significantly increase the speed of model inference on compatible hardware.
- 💾 Reduce model size: Quantized models typically require less storage compared to FP32/FP16 models.
- 🛠️ Facilitate deployment: Provides better support for deploying models in edge computing scenarios where resources are constrained.