### PR TITLE
disable tqdm with YOLO_DISABLE_TQDM=True

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -27,7 +27,7 @@ from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.tasks import attempt_load_one_weight, attempt_load_weights
 from ultralytics.utils import (DEFAULT_CFG, LOGGER, RANK, TQDM_BAR_FORMAT, __version__, callbacks, clean_url, colorstr,
-                               emojis, yaml_save)
+                               emojis, yaml_save, DISABLE_TQDM)
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, print_args
 from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command
@@ -326,7 +326,7 @@ class BaseTrainer:
 
             if RANK in (-1, 0):
                 LOGGER.info(self.progress_string())
-                pbar = tqdm(enumerate(self.train_loader), total=nb, bar_format=TQDM_BAR_FORMAT)
+                pbar = tqdm(enumerate(self.train_loader), total=nb, bar_format=TQDM_BAR_FORMAT, disable=DISABLE_TQDM)
             self.tloss = None
             self.optimizer.zero_grad()
             for i, batch in pbar:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -26,8 +26,8 @@ from tqdm import tqdm
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.tasks import attempt_load_one_weight, attempt_load_weights
-from ultralytics.utils import (DEFAULT_CFG, LOGGER, RANK, TQDM_BAR_FORMAT, __version__, callbacks, clean_url, colorstr,
-                               emojis, yaml_save, DISABLE_TQDM)
+from ultralytics.utils import (DEFAULT_CFG, DISABLE_TQDM, LOGGER, RANK, TQDM_BAR_FORMAT, __version__, callbacks,
+                               clean_url, colorstr, emojis, yaml_save)
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, print_args
 from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -29,7 +29,7 @@ from tqdm import tqdm
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis, DISABLE_TQDM
+from ultralytics.utils import DISABLE_TQDM, LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.torch_utils import de_parallel, select_device, smart_inference_mode

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -29,7 +29,7 @@ from tqdm import tqdm
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis
+from ultralytics.utils import LOGGER, TQDM_BAR_FORMAT, callbacks, colorstr, emojis, DISABLE_TQDM
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.torch_utils import de_parallel, select_device, smart_inference_mode
@@ -159,7 +159,7 @@ class BaseValidator:
         # NOTE: keeping `not self.training` in tqdm will eliminate pbar after segmentation evaluation during training,
         # which may affect classification task since this arg is in yolov5/classify/val.py.
         # bar = tqdm(self.dataloader, desc, n_batches, not self.training, bar_format=TQDM_BAR_FORMAT)
-        bar = tqdm(self.dataloader, desc, n_batches, bar_format=TQDM_BAR_FORMAT)
+        bar = tqdm(self.dataloader, desc, n_batches, bar_format=TQDM_BAR_FORMAT, disable=DISABLE_TQDM)
         self.init_metrics(de_parallel(model))
         self.jdict = []  # empty before each val
         for batch_i, batch in enumerate(bar):

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -35,6 +35,7 @@ DEFAULT_CFG_PATH = ROOT / 'cfg/default.yaml'
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv5 multiprocessing threads
 AUTOINSTALL = str(os.getenv('YOLO_AUTOINSTALL', True)).lower() == 'true'  # global auto-install mode
 VERBOSE = str(os.getenv('YOLO_VERBOSE', True)).lower() == 'true'  # global verbose mode
+DISABLE_TQDM = str(os.getenv('YOLO_DISABLE_TQDM', False)).lower() == 'true'  # global disable tqdm mode
 TQDM_BAR_FORMAT = '{l_bar}{bar:10}{r_bar}'  # tqdm bar format
 LOGGING_NAME = 'ultralytics'
 MACOS, LINUX, WINDOWS = (platform.system() == x for x in ['Darwin', 'Linux', 'Windows'])  # environment booleans


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

Discussed this here #4609 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a59ee32</samp>

### Summary
🔇🚀🛠️

<!--
1.  🔇 - This emoji can represent the mute or silence feature, which is related to the idea of disabling the tqdm progress bars and reducing the output verbosity.
2.  🚀 - This emoji can represent the speed or performance improvement, which is related to the idea of disabling the tqdm progress bars and improving the performance in some scenarios.
3.  🛠️ - This emoji can represent the tool or fix feature, which is related to the idea of adding a global option to disable the tqdm progress bars and providing more flexibility and control to the users.
-->
Added a global option to disable tqdm progress bars in `ultralytics` modules. This can improve performance and reduce output verbosity when using the `YOLO_DISABLE_TQDM` environment variable.

> _Oh we are the coders of the YOLO crew_
> _And we like to make our code run fast and true_
> _So we set the `DISABLE_TQDM` to our liking_
> _And we heave away the progress bars with a hoo and a hikin'_

### Walkthrough
*  Add global option to disable tqdm progress bars ([link](https://github.com/ultralytics/ultralytics/pull/4668/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL30-R30), [link](https://github.com/ultralytics/ultralytics/pull/4668/files?diff=unified&w=0#diff-01e0aaa194c770fed7f7a0cc941222f0acfa857d478bfeba933eed1bcb1f65e7L32-R32), [link](https://github.com/ultralytics/ultralytics/pull/4668/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faR38))
  - Import `DISABLE_TQDM` variable from `ultralytics.utils` in `trainer.py` and `validator.py` ([link](https://github.com/ultralytics/ultralytics/pull/4668/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL30-R30), [link](https://github.com/ultralytics/ultralytics/pull/4668/files?diff=unified&w=0#diff-01e0aaa194c770fed7f7a0cc941222f0acfa857d478bfeba933eed1bcb1f65e7L32-R32))
  - Define `DISABLE_TQDM` variable in `ultralytics.utils` as the boolean value of the environment variable `YOLO_DISABLE_TQDM` ([link](https://github.com/ultralytics/ultralytics/pull/4668/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faR38))
  - Pass `disable=DISABLE_TQDM` argument to `tqdm` function calls in `_do_train` and `__call__` methods of `BaseTrainer` and `BaseValidator` classes ([link](https://github.com/ultralytics/ultralytics/pull/4668/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL329-R329), [link](https://github.com/ultralytics/ultralytics/pull/4668/files?diff=unified&w=0#diff-01e0aaa194c770fed7f7a0cc941222f0acfa857d478bfeba933eed1bcb1f65e7L162-R162))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduction of an environment variable to globally disable tqdm progress bars.

### 📊 Key Changes
- A new environment variable `DISABLE_TQDM` is added to allow the toggling of tqdm progress bars.
- The `trainer.py` and `validator.py` files are updated to make use of the `DISABLE_TQDM` variable.

### 🎯 Purpose & Impact
- **Purpose**: This change allows users with the `YOLO_DISABLE_TQDM` environment variable set to `true` to disable tqdm progress bars if they find them unnecessary or if they are running scripts in environments where progress bars can clutter the output (e.g., logging systems, CI environments).
- **Potential Impact**: Users who prefer a cleaner console or need to save log storage space can easily turn off progress bars. This will not affect the code's functionality or performance, only the user interface in the terminal. 🚀