### PR TITLE
`ultralytics 8.0.168` save `Tuner` results every iteration

### DIFF
--- a/docs/yolov5/tutorials/hyperparameter_evolution.md
+++ b/docs/yolov5/tutorials/hyperparameter_evolution.md
@@ -100,7 +100,6 @@ done
 ```
 
 The default evolution settings will run the base scenario 300 times, i.e. for 300 generations. You can modify generations via the `--evolve` argument, i.e. `python train.py --evolve 1000`.
-https://github.com/ultralytics/yolov5/blob/6a3ee7cf03efb17fbffde0e68b1a854e80fe3213/train.py#L608
 
 The main genetic operators are **crossover** and **mutation**. In this work mutation is used, with an 80% probability and a 0.04 variance to create new offspring based on a combination of the best parents from all previous generations. Results are logged to `runs/evolve/exp/evolve.csv`, and the highest fitness offspring is saved every generation as `runs/evolve/hyp_evolved.yaml`:
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.167'
+__version__ = '8.0.168'
 
 from ultralytics.models import RTDETR, SAM, YOLO
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -158,8 +158,8 @@ class Tuner:
            Ensure this path is set correctly in the Tuner instance.
         """
 
-        best_save_dir = None
         t0 = time.time()
+        best_save_dir, best_metrics = None, None
         self.tune_dir.mkdir(parents=True, exist_ok=True)
         for i in range(iterations):
             # Mutate hyperparameters
@@ -188,9 +188,11 @@ class Tuner:
             best_is_current = best_idx == i
             if best_is_current:
                 best_save_dir = results.save_dir
+                best_metrics = {k: round(v, 5) for k, v in results.results_dict.items()}
             header = (f'{prefix} {i + 1} iterations complete ✅ ({time.time() - t0:.2f}s)\n'
                       f'{prefix} Results saved to {colorstr("bold", self.tune_dir)}\n'
                       f'{prefix} Best fitness={fitness[best_idx]} observed at iteration {best_idx + 1}\n'
+                      f'{prefix} Best fitness metrics are {best_metrics}\n'
                       f'{prefix} Best fitness model is {best_save_dir}\n'
                       f'{prefix} Best fitness hyperparameters are printed below.\n')
 
@@ -198,6 +200,6 @@ class Tuner:
 
             # Save turning results
             data = {k: float(x[0, i + 1]) for i, k in enumerate(self.space.keys())}
-            header = header.replace(prefix, '#').replace('[1m/', '').replace('[0m', '')
+            header = header.replace(prefix, '#').replace('[1m/', '').replace('[0m', '') + '\n'
             yaml_save(self.tune_dir / 'best.yaml', data=data, header=header)
             yaml_print(self.tune_dir / 'best.yaml')

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -165,8 +165,8 @@ class Tuner:
             mutated_hyp = self._mutate()
             LOGGER.info(f'{prefix} Starting iteration {i + 1}/{iterations} with hyperparameters: {mutated_hyp}')
 
-            # Initialize and train YOLOv8 model
             try:
+                # Train YOLO model with mutated hyperparameters
                 train_args = {**vars(self.args), **mutated_hyp}
                 fitness = (deepcopy(model) or YOLO(self.args.model)).train(**train_args).fitness  # results.fitness
             except Exception as e:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -286,13 +286,14 @@ class ThreadingLocked:
         return decorated
 
 
-def yaml_save(file='data.yaml', data=None):
+def yaml_save(file='data.yaml', data=None, header=''):
     """
     Save YAML data to a file.
 
     Args:
         file (str, optional): File name. Default is 'data.yaml'.
         data (dict): Data to save in YAML format.
+        header (str, optional): YAML header to add.
 
     Returns:
         (None): Data is saved to the specified file.
@@ -311,6 +312,8 @@ def yaml_save(file='data.yaml', data=None):
 
     # Dump data to file in YAML format
     with open(file, 'w') as f:
+        if header:
+            f.write(header)
         yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
 
 

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -29,7 +29,7 @@ def check_train_batch_size(model, imgsz=640, amp=True):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
 
 
-def autobatch(model, imgsz=640, fraction=0.67, batch_size=DEFAULT_CFG.batch):
+def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
     """
     Automatically estimate the best YOLO batch size to use a fraction of the available CUDA memory.
 


### PR DESCRIPTION
Designed to partially address https://github.com/ultralytics/ultralytics/issues/4659#issuecomment-1700533483

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d67d134</samp>

### Summary
🗑️🌟📝

<!--
1.  🗑️ for removing the redundant link
2.  🌟 for enhancing the `Tuner` class and improving the code quality
3.  📝 for enhancing the `yaml_save` function and adding a docstring
-->
This pull request adds features and fixes to the `Tuner` class, the `yaml_save` function, and the hyperparameter evolution tutorial. It aims to improve the functionality and usability of hyperparameter tuning and saving for the YOLOv5 model.

> _To tune hyperparameters with ease_
> _We enhanced the `Tuner` class, please_
> _It saves the best model_
> _And makes the code less dull_
> _And we removed a redundant link tease_

### Walkthrough
*  Add and update logic for saving and printing the best model and hyperparameters during hyperparameter tuning ([link](https://github.com/ultralytics/ultralytics/pull/4680/files?diff=unified&w=0#diff-d42d1b8bc1c237d1e34d8da7ab7ab8130ad4eab91e795d5030271dafb52565d9R161), [link](https://github.com/ultralytics/ultralytics/pull/4680/files?diff=unified&w=0#diff-d42d1b8bc1c237d1e34d8da7ab7ab8130ad4eab91e795d5030271dafb52565d9L168-R173), [link](https://github.com/ultralytics/ultralytics/pull/4680/files?diff=unified&w=0#diff-d42d1b8bc1c237d1e34d8da7ab7ab8130ad4eab91e795d5030271dafb52565d9L182-R203), [link](https://github.com/ultralytics/ultralytics/pull/4680/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faL289-R289), [link](https://github.com/ultralytics/ultralytics/pull/4680/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faR296), [link](https://github.com/ultralytics/ultralytics/pull/4680/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faR315-R316))
* Remove a redundant link to the train.py file in the documentation of hyperparameter evolution ([link](https://github.com/ultralytics/ultralytics/pull/4680/files?diff=unified&w=0#diff-53d00a538b4685d53ec9a4e04a6495f83c61604e258a4d8bf648e5217c4e01eaL103))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates the hyperparameter tuner and improves configuration customization.

### 📊 Key Changes
- Removed a non-essential hyperlink from the hyperparameter evolution documentation.
- Incremented the package version in the `__init__.py` file.
- Modified the tuner's `__call__` function to better handle the printing of the best tuning results and the saving of the best hyperparameters.
- Introduced a header option to the `yaml_save` function to allow for additional context when saving YAML files.
- Adjusted the default memory fraction used to determine the optimal batch size from 0.67 to 0.60 in the autobatch utility function.

### 🎯 Purpose & Impact
- Enhanced clarity in the hyperparameter evolution tutorial to prevent confusion.
- Version bump to reflect new updates and fixes in the package 🆙.
- Improvements in the `tuner.py` code ensure more informative output and reliable saving of the best-performing hyperparameters, making the tuning process more transparent and user-friendly.
- Introduction of the header parameter to `yaml_save` allows developers to add a useful preamble to YAML files, which can be beneficial for documentation and context.
- The change in the autobatch's memory fraction aims to provide a safer default that reduces memory usage, potentially avoiding out-of-memory errors on different hardware setups 💾.