### PR TITLE
Fix the bug: orig_shape is wrong when input is BCHW tensor

### DIFF
--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -31,8 +31,9 @@ class DetectionPredictor(BasePredictor):
                                         classes=self.args.classes)
 
         results = []
-        if isinstance(orig_imgs, torch.Tensor) and orig_imgs.dim() == 4: # process for batch input
-            orig_imgs = (orig_imgs.permute(0, 2, 3, 1).contiguous() * 255).to(torch.uint8).numpy() # convert to [(HWC) x B]
+        if isinstance(orig_imgs, torch.Tensor) and orig_imgs.dim() == 4:  # process for batch input
+            orig_imgs = (orig_imgs.permute(0, 2, 3, 1).contiguous() * 255).to(
+                torch.uint8).numpy()  # convert to [(HWC) x B]
         for i, pred in enumerate(preds):
             orig_img = orig_imgs[i]
             pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -1,4 +1,5 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
+import torch
 
 from ultralytics.engine.predictor import BasePredictor
 from ultralytics.engine.results import Results
@@ -31,6 +32,9 @@ class DetectionPredictor(BasePredictor):
 
         results = []
         is_list = isinstance(orig_imgs, list)  # input images are a list, not a torch.Tensor
+        if isinstance(orig_imgs, torch.Tensor) and orig_imgs.dim() == 4: # process for batch input
+            is_list = True
+            orig_imgs = (orig_imgs.permute(0, 2, 3, 1).contiguous() * 255).to(torch.uint8).numpy() # convert to [(HWC) x B]
         for i, pred in enumerate(preds):
             orig_img = orig_imgs[i] if is_list else orig_imgs
             if is_list:

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -31,14 +31,11 @@ class DetectionPredictor(BasePredictor):
                                         classes=self.args.classes)
 
         results = []
-        is_list = isinstance(orig_imgs, list)  # input images are a list, not a torch.Tensor
         if isinstance(orig_imgs, torch.Tensor) and orig_imgs.dim() == 4: # process for batch input
-            is_list = True
             orig_imgs = (orig_imgs.permute(0, 2, 3, 1).contiguous() * 255).to(torch.uint8).numpy() # convert to [(HWC) x B]
         for i, pred in enumerate(preds):
-            orig_img = orig_imgs[i] if is_list else orig_imgs
-            if is_list:
-                pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
+            orig_img = orig_imgs[i]
+            pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
             img_path = self.batch[0][i]
             results.append(Results(orig_img, path=img_path, names=self.model.names, boxes=pred))
         return results


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 28442c8</samp>

### Summary
📦🔢🚀

<!--
1.  📦 - This emoji can represent the batch tensor input, as it suggests packing multiple items or tensors into one container or dimension.
2.  🔢 - This emoji can represent the scaling of the predicted boxes, as it suggests numerical operations or calculations involving ratios or proportions.
3.  🚀 - This emoji can represent the overall improvement of the `postprocess` function, as it suggests speed, efficiency, or performance enhancement.
-->
This pull request improves the `postprocess` function in `ultralytics/models/yolo/detect/predict.py` by enabling batch processing and streamlining the box scaling logic.

> _Oh we're the jolly coders of the `predict.py` file_
> _We scale and postprocess tensors with a smile_
> _We heave and ho and pull the code to make it versatile_
> _And we support the batch input for a little while_

### Walkthrough
* Import `torch` module to enable tensor operations and conversions ([link](https://github.com/ultralytics/ultralytics/pull/4712/files?diff=unified&w=0#diff-9dded00f5e51a32b00c6266aa445990bae22fe6ea0bbb9d2c8898f4fcdb8cb23R2))
* Modify `postprocess` function to handle batch input of images as a torch.Tensor, convert tensor to numpy array, and scale predicted boxes for all images ([link](https://github.com/ultralytics/ultralytics/pull/4712/files?diff=unified&w=0#diff-9dded00f5e51a32b00c6266aa445990bae22fe6ea0bbb9d2c8898f4fcdb8cb23L33-R38))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced YOLO model prediction handling for batch image inputs in Ultralytics AI software.

### 📊 Key Changes
- 🔍 Added `torch` import to utilize PyTorch functionalities.
- 📸 Modified image preprocessing to support batch input directly as torch tensors.
- ✂️ Removed the check for `orig_imgs` as a list and streamlined the code for scaling bounding boxes.

### 🎯 Purpose & Impact
- 🏗️ The purpose is to improve how the model processes a batch of images, making it more efficient.
- 💡 This impacts users by enabling smoother, optimized predictions for multiple images, likely resulting in faster inference times and reduced code complexity.