### PR TITLE
Fixed missing initialization for confidence threshold of ConfusionMatrix (during validation)

### DIFF
--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -68,7 +68,7 @@ class DetectionValidator(BaseValidator):
         self.nc = len(model.names)
         self.metrics.names = self.names
         self.metrics.plot = self.args.plots
-        self.confusion_matrix = ConfusionMatrix(nc=self.nc)
+        self.confusion_matrix = ConfusionMatrix(nc=self.nc, conf=self.args.conf)
         self.seen = 0
         self.jdict = []
         self.stats = []


### PR DESCRIPTION
Regardless of what confidence threshold user specifies when calling 'val' method of YOLO model, ConfusionMatrix applies 0.25 as confidence threshold (default value) since the value set by user does not get passed in.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5ffa596</samp>

### Summary
📊🔥🕵️

<!--
1.  📊 This emoji represents the confusion matrix, which is a common metric for evaluating the performance of a classifier. It also suggests the idea of data analysis and visualization, which are relevant for the validation script.
2.  🔥 This emoji represents the confidence threshold, which is a way of filtering out low-quality detections and increasing the precision of the model. It also suggests the idea of intensity and improvement, which are relevant for the pull request goal.
3.  🕵️ This emoji represents the object detection task, which involves finding and identifying objects in images. It also suggests the idea of investigation and discovery, which are relevant for the YOLOv5 model.
-->
Added `conf` argument to `DetectionValidator.confusion_matrix` to filter out low-confidence detections. This improves the validation metrics and plots for YOLOv5.

> _`conf` filters out_
> _low-confidence predictions_
> _autumn leaves falling_

### Walkthrough
*  Add `conf` argument to `DetectionValidator` class to filter detections by confidence threshold ([link](https://github.com/ultralytics/ultralytics/pull/4723/files?diff=unified&w=0#diff-023bb20ae0db3d69310690d02fbea0e2a6d57e5cf3878f00ea1cd097761fd7b5L71-R71))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced confusion matrix initialization in YOLO validation script.

### 📊 Key Changes
- The `ConfusionMatrix` class now receives an additional argument, `conf`, during initialization.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To customize the confusion matrix by incorporating a confidence threshold from command line arguments, enabling more flexible evaluation based on user preference.
- 🔍 **Impact**: Users can now tailor the strictness of their model evaluation by setting a desired confidence level, potentially leading to more relevant performance metrics for different use-cases.