### PR TITLE
Make OpenVINO device be configurable

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -152,7 +152,7 @@ class AutoBackend(nn.Module):
             batch_dim = get_batch(ov_model)
             if batch_dim.is_static:
                 batch_size = batch_dim.get_length()
-            ov_compiled_model = core.compile_model(ov_model, device_name='AUTO')  # AUTO selects best available device
+            ov_compiled_model = core.compile_model(ov_model, device_name=str(device).upper())
             metadata = w.parent / 'metadata.yaml'
         elif engine:  # TensorRT
             LOGGER.info(f'Loading {w} for TensorRT inference...')


### PR DESCRIPTION
OpenVINO AUTO device usually starts running on CPU and after the model is ready on another device (iGPU in my case), switches to it. It results in unstable predictions because implementation varies from device to device. The problem with the proposed solution is that `device` comes from `select_device()` which requires it to be one of the torch devices. That prohibits having AUTO.

Close https://github.com/ultralytics/ultralytics/issues/4721


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 29e9648</samp>

### Summary
:sparkles::wrench::recycle:

<!--
1.  :sparkles: This emoji is used to indicate new features or enhancements, such as adding support for different devices and engines.
2.  :wrench: This emoji is used to indicate tooling or configuration changes, such as changing the default argument of the `core.compile_model` function.
3.  :recycle: This emoji is used to indicate refactoring or code improvements, such as using the `str` and `upper` methods to format the device name.
-->
This file modifies the `core.compile_model` function to accept a user-defined device for the OpenVINO model. This is part of a pull request that enhances the AutoBackend class with more device and engine options.

> _`device_name` changed_
> _AutoBackend supports more_
> _Winter of options_

### Walkthrough
*  Add support for different devices and engines for the AutoBackend class ([link](https://github.com/ultralytics/ultralytics/pull/4724/files?diff=unified&w=0#diff-2e3ad5da4ba57eb68a9b5aaddf0c40c784d888b7619ed337ce31dfea4f6380f9L155-R155),                             F0L182




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced device selection during model compilation in Ultralytics neural network backend.

### 📊 Key Changes
- Modified device name parameter in the model compilation line to accept dynamic device input.

### 🎯 Purpose & Impact
- **Purpose:** This change enables more explicit control over which computing device is used when compiling a neural network model, rather than relying on the 'AUTO' setting.
- **Impact:** Users can now specify their preferred device (CPU, GPU, etc.) for model compilation, potentially improving compatibility and performance across different hardware setups. 🚀