### PR TITLE
Fixed missing initialization for confidence threshold of ConfusionMatrix

### DIFF
--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -68,7 +68,7 @@ class DetectionValidator(BaseValidator):
         self.nc = len(model.names)
         self.metrics.names = self.names
         self.metrics.plot = self.args.plots
-        self.confusion_matrix = ConfusionMatrix(nc=self.nc)
+        self.confusion_matrix = ConfusionMatrix(nc=self.nc, conf=self.args.conf)
         self.seen = 0
         self.jdict = []
         self.stats = []

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -68,7 +68,10 @@ class DetectionValidator(BaseValidator):
         self.nc = len(model.names)
         self.metrics.names = self.names
         self.metrics.plot = self.args.plots
-        self.confusion_matrix = ConfusionMatrix(nc=self.nc, conf=self.args.conf)
+        if isinstance(self.args.conf, (int, float)):
+            self.confusion_matrix = ConfusionMatrix(nc=self.nc, conf=self.args.conf)
+        else:
+            self.confusion_matrix = ConfusionMatrix(nc=self.nc)
         self.seen = 0
         self.jdict = []
         self.stats = []


### PR DESCRIPTION
Regardless of what confidence threshold user specifies when calling 'val' method of YOLO model, ConfusionMatrix applies 0.25 as confidence threshold (default value) since the value set by user does not get passed in.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c719f1a</samp>

### Summary
🚀🔧📊

<!--
1.  🚀 This emoji can be used to indicate a new feature or enhancement that adds value or functionality to the project.
2.  🔧 This emoji can be used to indicate a configuration or settings change that affects how the project runs or behaves.
3.  📊 This emoji can be used to indicate a change related to data analysis, metrics, or visualization.
-->
Added `conf` argument to `DetectionValidator.confusion_matrix` to adjust confidence threshold for predictions. This enhances the validation and testing of the YOLOv5 model.

> _`conf` sets the threshold_
> _trade precision for recall_
> _autumn of detection_

### Walkthrough
*  Add `conf` argument to `DetectionValidator` class to control confidence threshold for predictions ([link](https://github.com/ultralytics/ultralytics/pull/4725/files?diff=unified&w=0#diff-023bb20ae0db3d69310690d02fbea0e2a6d57e5cf3878f00ea1cd097761fd7b5L71-R71))
*  Pass `conf` value from `args` attribute of `DetectionValidator` class, which is set by command-line arguments or default values ([link](https://github.com/ultralytics/ultralytics/pull/4725/files?diff=unified&w=0#diff-023bb20ae0db3d69310690d02fbea0e2a6d57e5cf3878f00ea1cd097761fd7b5L71-R71))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility for setting the confidence threshold in the confusion matrix of YOLO detection validation.

### 📊 Key Changes
- Confusion matrix initialization now supports custom confidence thresholds.
- Accepts both integer and float values for defining the confidence level.

### 🎯 Purpose & Impact
- This change allows more precise control over the confidence threshold when analyzing model predictions.
- It could lead to better interpretation of the model's performance and assist in fine-tuning the model for improved accuracy.
- Users can now adjust the sensitivity of predictions included in the confusion matrix, potentially benefiting various scenarios where different confidence levels are optimal. 📈