### PR TITLE
🐞 fix add_integration_callbacks bug

### DIFF
--- a/ultralytics/utils/callbacks/base.py
+++ b/ultralytics/utils/callbacks/base.py
@@ -214,12 +214,14 @@ def add_integration_callbacks(instance):
         from .raytune import callbacks as tune_cb
         from .tensorboard import callbacks as tb_cb
         from .wb import callbacks as wb_cb
+
         # callbacks.update({**clear_cb, **comet_cb, **dvc_cb, **mlflow_cb, **neptune_cb, **tune_cb, **tb_cb, **wb_cb})
         callbacks_list.extend([clear_cb, comet_cb, dvc_cb, mlflow_cb, neptune_cb, tune_cb, tb_cb, wb_cb])
 
     # Load export callbacks (patch to avoid CoreML protobuf error)
     if 'Exporter' in instance.__class__.__name__:
         from .tensorboard import callbacks as tb_cb
+
         # callbacks.update(tb_cb)
         callbacks_list.append(tb_cb)
 

--- a/ultralytics/utils/callbacks/base.py
+++ b/ultralytics/utils/callbacks/base.py
@@ -197,8 +197,12 @@ def add_integration_callbacks(instance):
             of callback lists.
     """
 
+    # callbacks list
+    callbacks_list = []
+
     # Load HUB callbacks
-    from .hub import callbacks
+    from .hub import callbacks as hub_cb
+    callbacks_list.append(hub_cb)
 
     # Load training callbacks
     if 'Trainer' in instance.__class__.__name__:
@@ -210,13 +214,21 @@ def add_integration_callbacks(instance):
         from .raytune import callbacks as tune_cb
         from .tensorboard import callbacks as tb_cb
         from .wb import callbacks as wb_cb
-        callbacks.update({**clear_cb, **comet_cb, **dvc_cb, **mlflow_cb, **neptune_cb, **tune_cb, **tb_cb, **wb_cb})
+        # callbacks.update({**clear_cb, **comet_cb, **dvc_cb, **mlflow_cb, **neptune_cb, **tune_cb, **tb_cb, **wb_cb})
+        callbacks_list.extend([clear_cb, comet_cb, dvc_cb, mlflow_cb, neptune_cb, tune_cb, tb_cb, wb_cb])
 
     # Load export callbacks (patch to avoid CoreML protobuf error)
     if 'Exporter' in instance.__class__.__name__:
         from .tensorboard import callbacks as tb_cb
-        callbacks.update(tb_cb)
+        # callbacks.update(tb_cb)
+        callbacks_list.append(tb_cb)
 
-    for k, v in callbacks.items():
-        if v not in instance.callbacks[k]:  # prevent duplicate callbacks addition
-            instance.callbacks[k].append(v)  # callback[name].append(func)
+    # for k, v in callbacks.items():
+    #     if v not in instance.callbacks[k]:  # prevent duplicate callbacks addition
+    #         instance.callbacks[k].append(v)  # callback[name].append(func)
+
+    # add the callbacks to the callbacks dictionary
+    for callbacks in callbacks_list:
+        for k, v in callbacks.items():
+            if v not in instance.callbacks[k]:
+                instance.callbacks[k].append(v)

--- a/ultralytics/utils/callbacks/base.py
+++ b/ultralytics/utils/callbacks/base.py
@@ -197,12 +197,9 @@ def add_integration_callbacks(instance):
             of callback lists.
     """
 
-    # callbacks list
-    callbacks_list = []
-
     # Load HUB callbacks
     from .hub import callbacks as hub_cb
-    callbacks_list.append(hub_cb)
+    callbacks_list = [hub_cb]
 
     # Load training callbacks
     if 'Trainer' in instance.__class__.__name__:
@@ -214,22 +211,14 @@ def add_integration_callbacks(instance):
         from .raytune import callbacks as tune_cb
         from .tensorboard import callbacks as tb_cb
         from .wb import callbacks as wb_cb
-
-        # callbacks.update({**clear_cb, **comet_cb, **dvc_cb, **mlflow_cb, **neptune_cb, **tune_cb, **tb_cb, **wb_cb})
         callbacks_list.extend([clear_cb, comet_cb, dvc_cb, mlflow_cb, neptune_cb, tune_cb, tb_cb, wb_cb])
 
     # Load export callbacks (patch to avoid CoreML protobuf error)
     if 'Exporter' in instance.__class__.__name__:
         from .tensorboard import callbacks as tb_cb
-
-        # callbacks.update(tb_cb)
         callbacks_list.append(tb_cb)
 
-    # for k, v in callbacks.items():
-    #     if v not in instance.callbacks[k]:  # prevent duplicate callbacks addition
-    #         instance.callbacks[k].append(v)  # callback[name].append(func)
-
-    # add the callbacks to the callbacks dictionary
+    # Add the callbacks to the callbacks dictionary
     for callbacks in callbacks_list:
         for k, v in callbacks.items():
             if v not in instance.callbacks[k]:


### PR DESCRIPTION
… callbacks coverage

In the add_integration_callbacks, using the update method of a dictionary can cause callbacks to be overwritten. Such as the callbacks of tensorboard will overwrite the callbacks of comet. And the callbacks variable should be a dictionary with a list as its value. To fix this bug, use a callback_ list to temporarily save all callbacks, and update the instance's callbacks dictionary at the end.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d8e9f75</samp>

### Summary
🛠️📊🚀

<!--
1.  🛠️ - This emoji represents the refactoring aspect of the changes, as it implies fixing or improving something that already exists.
2.  📊 - This emoji represents the logging and tracking aspect of the changes, as it implies collecting and displaying data or metrics.
3.  🚀 - This emoji represents the flexibility and compatibility aspect of the changes, as it implies enhancing the performance or functionality of something.
-->
Refactored the callback system in `ultralytics/utils/callbacks/base.py` to allow for more customization and integration with various logging and tracking tools.

> _Oh we're the coders of the sea, and we work with skill and glee_
> _We refactor and we debug, and we make our code more snug_
> _We create and add callbacks, to the `BaseCallback` class_
> _Heave away, me hearties, heave away, on the count of three!_

### Walkthrough
* Create a list of callbacks from different modules and sources ([link](https://github.com/ultralytics/ultralytics/pull/4749/files?diff=unified&w=0#diff-c534c18744d055f2c63177a753a5661a07e0217ecaf9719f565f1296968ddb72L200-R205)) in `ultralytics/utils/callbacks/base.py` to allow for easier and more flexible management of the callbacks and avoid potential conflicts or overwriting of keys




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced callback integration in Ultralytics software.

### 📊 Key Changes
- Modified the way of importing and accumulating callbacks, now using lists for better organization.
- Switched from a dictionary update method to a list extension method to gather callbacks across different modules.
- Improved the addition of callbacks to the instance's callback dictionary to prevent duplicates.

### 🎯 Purpose & Impact
- **Purpose**: To streamline the callback integration process in the codebase and reduce errors associated with duplicate callback registration.
- **Impact**: Provides a cleaner, more maintainable approach to handle various integration callbacks. This will likely lead to more stable and manageable code, benefiting both developers who maintain the software and users who rely on consistent behavior from the underlying systems. 👨‍💻🔧