### PR TITLE
Update YouTube URL https://youtu.be/LNwODJXcvt4

### DIFF
--- a/docs/datasets/track/index.md
+++ b/docs/datasets/track/index.md
@@ -21,10 +21,10 @@ Support for training trackers alone is coming soon
         from ultralytics import YOLO
 
         model = YOLO('yolov8n.pt')
-        results = model.track(source="https://youtu.be/Zgi9g1ksQHc", conf=0.3, iou=0.5, show=True)
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", conf=0.3, iou=0.5, show=True)
         ```
     === "CLI"
 
         ```bash
-        yolo track model=yolov8n.pt source="https://youtu.be/Zgi9g1ksQHc" conf=0.3, iou=0.5 show
+        yolo track model=yolov8n.pt source="https://youtu.be/LNwODJXcvt4" conf=0.3, iou=0.5 show
         ```

--- a/docs/modes/predict.md
+++ b/docs/modes/predict.md
@@ -67,7 +67,7 @@ YOLOv8 can process different types of input sources for inference, as shown in t
 | video ✅        | `'video.mp4'`                              | `str` or `Path` | Video file in formats like MP4, AVI, etc.                                                   |
 | directory ✅    | `'path/'`                                  | `str` or `Path` | Path to a directory containing images or videos.                                            |
 | glob ✅         | `'path/*.jpg'`                             | `str`           | Glob pattern to match multiple files. Use the `*` character as a wildcard.                  |
-| YouTube ✅      | `'https://youtu.be/Zgi9g1ksQHc'`           | `str`           | URL to a YouTube video.                                                                     |
+| YouTube ✅      | `'https://youtu.be/LNwODJXcvt4'`           | `str`           | URL to a YouTube video.                                                                     |
 | stream ✅       | `'rtsp://example.com/media.mp4'`           | `str`           | URL for streaming protocols such as RTSP, RTMP, or an IP address.                           |
 | multi-stream ✅ | `'list.streams'`                           | `str` or `Path` | `*.streams` text file with one stream URL per row, i.e. 8 streams will run at batch-size 8. |
 
@@ -257,7 +257,7 @@ Below are code examples for using each source type:
         model = YOLO('yolov8n.pt')
 
         # Define source as YouTube video URL
-        source = 'https://youtu.be/Zgi9g1ksQHc'
+        source = 'https://youtu.be/LNwODJXcvt4'
 
         # Run inference on the source
         results = model(source, stream=True)  # generator of Results objects

--- a/docs/modes/track.md
+++ b/docs/modes/track.md
@@ -37,18 +37,18 @@ To run the tracker on video streams, use a trained Detect, Segment or Pose model
         model = YOLO('path/to/best.pt')  # Load a custom trained model
 
         # Perform tracking with the model
-        results = model.track(source="https://youtu.be/Zgi9g1ksQHc", show=True)  # Tracking with default tracker
-        results = model.track(source="https://youtu.be/Zgi9g1ksQHc", show=True, tracker="bytetrack.yaml")  # Tracking with ByteTrack tracker
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", show=True)  # Tracking with default tracker
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", show=True, tracker="bytetrack.yaml")  # Tracking with ByteTrack tracker
         ```
 
     === "CLI"
 
         ```bash
         # Perform tracking with various models using the command line interface
-        yolo track model=yolov8n.pt source="https://youtu.be/Zgi9g1ksQHc"  # Official Detect model
-        yolo track model=yolov8n-seg.pt source="https://youtu.be/Zgi9g1ksQHc"  # Official Segment model
-        yolo track model=yolov8n-pose.pt source="https://youtu.be/Zgi9g1ksQHc"  # Official Pose model
-        yolo track model=path/to/best.pt source="https://youtu.be/Zgi9g1ksQHc"  # Custom trained model
+        yolo track model=yolov8n.pt source="https://youtu.be/LNwODJXcvt4"  # Official Detect model
+        yolo track model=yolov8n-seg.pt source="https://youtu.be/LNwODJXcvt4"  # Official Segment model
+        yolo track model=yolov8n-pose.pt source="https://youtu.be/LNwODJXcvt4"  # Official Pose model
+        yolo track model=path/to/best.pt source="https://youtu.be/LNwODJXcvt4"  # Custom trained model
 
         # Track using ByteTrack tracker
         yolo track model=path/to/best.pt tracker="bytetrack.yaml" 
@@ -71,14 +71,14 @@ Tracking configuration shares properties with Predict mode, such as `conf`, `iou
 
         # Configure the tracking parameters and run the tracker
         model = YOLO('yolov8n.pt')
-        results = model.track(source="https://youtu.be/Zgi9g1ksQHc", conf=0.3, iou=0.5, show=True)
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", conf=0.3, iou=0.5, show=True)
         ```
 
     === "CLI"
 
         ```bash
         # Configure tracking parameters and run the tracker using the command line interface
-        yolo track model=yolov8n.pt source="https://youtu.be/Zgi9g1ksQHc" conf=0.3, iou=0.5 show
+        yolo track model=yolov8n.pt source="https://youtu.be/LNwODJXcvt4" conf=0.3, iou=0.5 show
         ```
 
 ### Tracker Selection
@@ -94,14 +94,14 @@ Ultralytics also allows you to use a modified tracker configuration file. To do 
 
         # Load the model and run the tracker with a custom configuration file
         model = YOLO('yolov8n.pt')
-        results = model.track(source="https://youtu.be/Zgi9g1ksQHc", tracker='custom_tracker.yaml')
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", tracker='custom_tracker.yaml')
         ```
 
     === "CLI"
 
         ```bash
         # Load the model and run the tracker with a custom configuration file using the command line interface
-        yolo track model=yolov8n.pt source="https://youtu.be/Zgi9g1ksQHc" tracker='custom_tracker.yaml'
+        yolo track model=yolov8n.pt source="https://youtu.be/LNwODJXcvt4" tracker='custom_tracker.yaml'
         ```
 
 For a comprehensive list of tracking arguments, refer to the [ultralytics/cfg/trackers](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/trackers) page.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -153,7 +153,7 @@ The Ultralytics command line interface (CLI) allows for simple single-line comma
 
         Predict a YouTube video using a pretrained segmentation model at image size 320:
         ```bash
-        yolo predict model=yolov8n-seg.pt source='https://youtu.be/Zgi9g1ksQHc' imgsz=320
+        yolo predict model=yolov8n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
         ```
 
     === "Val"

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -34,7 +34,7 @@ CLI requires no customization or Python code. You can simply run all tasks from 
 
         Predict a YouTube video using a pretrained segmentation model at image size 320:
         ```bash
-        yolo predict model=yolov8n-seg.pt source='https://youtu.be/Zgi9g1ksQHc' imgsz=320
+        yolo predict model=yolov8n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
         ```
 
     === "Val"
@@ -196,7 +196,7 @@ Default arguments can be overridden by simply passing them as arguments in the C
     === "Predict"
         Predict a YouTube video using a pretrained segmentation model at image size 320:
         ```bash
-        yolo segment predict model=yolov8n-seg.pt source='https://youtu.be/Zgi9g1ksQHc' imgsz=320
+        yolo segment predict model=yolov8n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
         ```
 
     === "Val"

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -220,8 +220,8 @@ for applications such as surveillance systems or self-driving cars.
         model = YOLO('path/to/best.pt')  # load a custom model
 
         # Track with the model
-        results = model.track(source="https://youtu.be/Zgi9g1ksQHc", show=True)
-        results = model.track(source="https://youtu.be/Zgi9g1ksQHc", show=True, tracker="bytetrack.yaml")
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", show=True)
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", show=True, tracker="bytetrack.yaml")
         ```
 
 [Track Examples](../modes/track.md){ .md-button .md-button--primary}

--- a/docs/yolov5/quickstart_tutorial.md
+++ b/docs/yolov5/quickstart_tutorial.md
@@ -55,7 +55,7 @@ python detect.py --weights yolov5s.pt --source 0                               #
                                                list.txt                        # list of images
                                                list.streams                    # list of streams
                                                'path/*.jpg'                    # glob
-                                               'https://youtu.be/Zgi9g1ksQHc'  # YouTube
+                                               'https://youtu.be/LNwODJXcvt4'  # YouTube
                                                'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream
 ```
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -42,7 +42,7 @@ CLI_HELP_MSG = \
         yolo train data=coco128.yaml model=yolov8n.pt epochs=10 lr0=0.01
 
     2. Predict a YouTube video using a pretrained segmentation model at image size 320:
-        yolo predict model=yolov8n-seg.pt source='https://youtu.be/Zgi9g1ksQHc' imgsz=320
+        yolo predict model=yolov8n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
 
     3. Val a pretrained detection model at batch-size 1 and image size 640:
         yolo val model=yolov8n.pt data=coco128.yaml batch=1 imgsz=640

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -48,7 +48,7 @@ class LoadStreams:
             # Start thread to read frames from video stream
             st = f'{i + 1}/{n}: {s}... '
             if urlparse(s).hostname in ('www.youtube.com', 'youtube.com', 'youtu.be'):  # if source is YouTube video
-                # YouTube format i.e. 'https://www.youtube.com/watch?v=Zgi9g1ksQHc' or 'https://youtu.be/Zgi9g1ksQHc'
+                # YouTube format i.e. 'https://www.youtube.com/watch?v=Zgi9g1ksQHc' or 'https://youtu.be/LNwODJXcvt4'
                 s = get_best_youtube_url(s)
             s = eval(s) if s.isnumeric() else s  # i.e. s = '0' local webcam
             if s == 0 and (is_colab() or is_kaggle()):

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -11,7 +11,7 @@ Usage - sources:
                                                 list.txt                        # list of images
                                                 list.streams                    # list of streams
                                                 'path/*.jpg'                    # glob
-                                                'https://youtu.be/Zgi9g1ksQHc'  # YouTube
+                                                'https://youtu.be/LNwODJXcvt4'  # YouTube
                                                 'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream
 
 Usage - formats:

--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -117,7 +117,8 @@ class HUBTrainingSession:
 
             if data['status'] == 'new':  # new model to start training
                 self.train_args = {
-                    'batch': data['batch'],
+                    # TODO deprecate before 8.1.0
+                    'batch': data['batch' if 'batch' in data else 'batch_size'],
                     'epochs': data['epochs'],
                     'imgsz': data['imgsz'],
                     'patience': data['patience'],

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -77,7 +77,7 @@ HELP_MSG = \
             yolo detect train data=coco128.yaml model=yolov8n.pt epochs=10 lr0=0.01
 
         - Predict a YouTube video using a pretrained segmentation model at image size 320:
-            yolo segment predict model=yolov8n-seg.pt source='https://youtu.be/Zgi9g1ksQHc' imgsz=320
+            yolo segment predict model=yolov8n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
 
         - Val a pretrained detection model at batch-size 1 and image size 640:
             yolo detect val model=yolov8n.pt data=coco128.yaml batch=1 imgsz=640


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c41a6f1</samp>

### Summary
🎥🔄📝

<!--
1.  🎥 This emoji represents the change of the YouTube video URLs in various files and documents. It conveys the idea of video content and source.
2.  🔄 This emoji represents the change of the batch argument in the _get_model function of the HUBTrainingSession class. It conveys the idea of backward compatibility and updating.
3.  📝 This emoji represents the change of the documentation files for the predict and track modes. It conveys the idea of writing and editing.
-->
This pull request updates the YouTube video URLs in various documentation files and help messages to use a consistent and suitable video for demonstrating the track mode feature of the ultralytics library. It also adds a backward compatibility check for the batch argument in the hub training session class.

> _We are the ultralytics, we track the objects of doom_
> _We use the same video, to show our power and gloom_
> _We update the URLs, in docs and code and help_
> _We are the ultralytics, we make the weak ones yelp_

### Walkthrough
*  Update YouTube video URL to a more suitable one for tracking demonstration in various files and comments ([link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-6ef362428fdd19046ae5942ea342963c49876b29174b3c84c8169e3477235c10L24-R29), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-31a8e95fab032c4aff065cd0faacd330d81e4b154c017a7827c9f85d7f8dea49L70-R70), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-31a8e95fab032c4aff065cd0faacd330d81e4b154c017a7827c9f85d7f8dea49L260-R260), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-28a675294ad148751845f8d4fd08d1a73a30bde0bf27a269e7f8294d1537bbcfL40-R41), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-28a675294ad148751845f8d4fd08d1a73a30bde0bf27a269e7f8294d1537bbcfL48-R51), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-28a675294ad148751845f8d4fd08d1a73a30bde0bf27a269e7f8294d1537bbcfL74-R74), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-28a675294ad148751845f8d4fd08d1a73a30bde0bf27a269e7f8294d1537bbcfL81-R81), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-28a675294ad148751845f8d4fd08d1a73a30bde0bf27a269e7f8294d1537bbcfL97-R97), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-28a675294ad148751845f8d4fd08d1a73a30bde0bf27a269e7f8294d1537bbcfL104-R104), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL156-R156), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-663fe42f952ce882f90c216dced632218edb61e49e615b3245c701882ccce9cbL37-R37), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-663fe42f952ce882f90c216dced632218edb61e49e615b3245c701882ccce9cbL199-R199), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-c126129d1acbfd2e959449cfc21aa78cd3b1c64661368ca387341b3ee69b3520L223-R224), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-291fda406114bf9ac954dba00b435d62821878659cacbc228496209b7a45588cL58-R58), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-c02fb3f9e86e97bf85f07211aed56aa04774504a61eeff07a08471bbdea14556L45-R45), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-3687f61e2371eaae4d90d58bf3aa6be449b113677b3ce104fd0d868b7df441deL51-R51), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-9fa2bf7f1273283680da3daeb8bae8e20cf8d477f838575796d2bf3b415bc534L14-R14), [link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faL80-R80))
* Add backward compatibility check for batch argument in `HUBTrainingSession._get_model` function in `ultralytics/hub/session.py` file ([link](https://github.com/ultralytics/ultralytics/pull/4808/files?diff=unified&w=0#diff-9a8f35e10c3ac02a449639cf43585490df23cfd85ccf328635b79214fe710bfaL120-R121))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated YouTube video links in documentation and example code.

### 📊 Key Changes
- 🎬 Changed the YouTube video URLs used in example code throughout various documentation files.
- 🛠 Fixed deprecated `batch` argument in `ultralytics/hub/session.py` to support `batch_size`.

### 🎯 Purpose & Impact
- 📚 Provides users with updated example videos to illustrate how to use the software with different input sources.
- 📈 Enhances clarity in the documentation, ensuring users access updated resources and examples for learning.
- ⚙️ Improves code maintainability by addressing deprecations, thus preventing potential confusion or errors for developers integrating with Ultralytics AI models.