### PR TITLE
Apply default ConfusionMatrix `conf=0.25`

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -189,7 +189,7 @@ class ConfusionMatrix:
         self.task = task
         self.matrix = np.zeros((nc + 1, nc + 1)) if self.task == 'detect' else np.zeros((nc, nc))
         self.nc = nc  # number of classes
-        self.conf = 0.25 if conf is None else conf  # argument may be None from default cfg
+        self.conf = 0.25 if conf in (None, 0.001) else conf  # apply 0.25 if default val conf is passed
         self.iou_thres = iou_thres
 
     def process_cls_preds(self, preds, targets):


### PR DESCRIPTION
May resolve https://github.com/ultralytics/ultralytics/issues/4811

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 01b9bf9</samp>

### Summary
🐛🚀📈

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the `__init__` function. The bug fix emoji is usually used to indicate that a change resolves an issue or improves the functionality of the code.
2.  🚀 - This emoji represents a performance improvement, which is a possible outcome of the change to the `__init__` function. The performance improvement emoji is usually used to indicate that a change enhances the speed, efficiency, or quality of the code or the results.
3.  📈 - This emoji represents a metric improvement, which is another possible outcome of the change to the `__init__` function. The metric improvement emoji is usually used to indicate that a change improves the accuracy, precision, recall, or F1-score of the code or the results.
-->
Fixed a bug in `ConfusionMatrix` class that affected object detection metrics. Changed the default confidence threshold to 0.25 in `ultralytics/utils/metrics.py`.

> _`ConfusionMatrix`_
> _Fixes bug with threshold_
> _Autumn of errors_

### Walkthrough
*  Apply a default confidence threshold of 0.25 to the `ConfusionMatrix` class to fix a bug in confusion matrix calculations ([link](https://github.com/ultralytics/ultralytics/pull/4813/files?diff=unified&w=0#diff-fb567871ecb755681f83f6e1edeb903d3a5757316d9caa1a28bd2be993bf4fc8L192-R192))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved default confidence threshold handling in metrics utility.

### 📊 Key Changes
- Changed how the default confidence threshold is set in the metrics calculation.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To ensure the confidence threshold has a sensible default, avoiding potential issues with specific default configuration values.
- 💡 **Impact**: Users will experience more consistent behavior in metrics calculations, especially when not explicitly setting confidence values, leading to more reliable model evaluations.