### PR TITLE
fix: show upload progress

### DIFF
--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -159,6 +159,7 @@ class HUBTrainingSession:
         data = {'epoch': epoch}
         if final:
             data.update({'type': 'final', 'map': map})
+            filesize = Path(weights).stat().st_size
             smart_request('post',
                           url,
                           data=data,
@@ -167,7 +168,7 @@ class HUBTrainingSession:
                           retry=10,
                           timeout=3600,
                           thread=False,
-                          progress=True,
+                          progress=filesize,
                           code=4)
         else:
             data.update({'type': 'epoch', 'isBest': bool(is_best)})

--- a/ultralytics/hub/utils.py
+++ b/ultralytics/hub/utils.py
@@ -77,7 +77,7 @@ def requests_with_progress(method, url, **kwargs):
     if not progress:
         return requests.request(method, url, **kwargs)
     response = requests.request(method, url, stream=True, **kwargs)
-    total = int(response.headers.get('content-length', 0))  # total size
+    total = int(progress)  # total size
     try:
         pbar = TQDM(total=total, unit='B', unit_scale=True, unit_divisor=1024)
         for data in response.iter_content(chunk_size=1024):


### PR DESCRIPTION

@glenn-jocher This will allow the progress bar to work again on upload. As this code is being refactored in the SDK I did a quick fix.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model upload progress tracking in Ultralytics' hub module.

### 📊 Key Changes
- The `filesize` of the model is now calculated during the upload process.
- The `progress` parameter in the `smart_request` function within the `upload_model` method has been updated to use this `filesize`.
- Adjusted the `requests_with_progress` method to utilize the provided `filesize` for progress calculation rather than the `content-length` header from the response.

### 🎯 Purpose & Impact
- **Accurate Progress Indication:** Users will now see more accurate upload progress based on the actual file size, resulting in a better user experience.
- **Consistent Upload Feedback:** By calculating the `filesize` beforehand, users are given a consistent progress bar even if the `content-length` header is unavailable or incorrect.
- **Enhanced Reliability:** These updates improve the reliability of the upload process in the Ultralytics hub, ensuring that users have a clear indication of upload status.