### PR TITLE
Fix `pretrained` documentation default

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ include setup.py
 include ultralytics/assets/bus.jpg
 include ultralytics/assets/zidane.jpg
 recursive-include ultralytics *.yaml
+recursive-include ultralytics *__init__.py
 recursive-exclude __pycache__ *

--- a/docs/usage/cfg.md
+++ b/docs/usage/cfg.md
@@ -88,7 +88,7 @@ The training settings for YOLO models encompass various hyperparameters and conf
 | `project`         | `None`   | project name                                                                                   |
 | `name`            | `None`   | experiment name                                                                                |
 | `exist_ok`        | `False`  | whether to overwrite existing experiment                                                       |
-| `pretrained`      | `False`  | whether to use a pretrained model                                                              |
+| `pretrained`      | `True`   | whether to use a pretrained model                                                              |
 | `optimizer`       | `'auto'` | optimizer to use, choices=[SGD, Adam, Adamax, AdamW, NAdam, RAdam, RMSProp, auto]              |
 | `verbose`         | `False`  | whether to print verbose output                                                                |
 | `seed`            | `0`      | random seed for reproducibility                                                                |


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->
As I read the documentation on YOLOv8's training on the official [Ultralytics Documentation](https://docs.ultralytics.com/modes/train/#arguments). It caught my eye that the training argument `pretrained` defaults to `False`, whilst on the [default.yaml](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/default.yaml#L22) config file it defaults to `True`.

It seems to me that this is a mistake in the documentation. If so, I hope this PR helps!

I have read the CLA Document and I sign the CLA

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 77984c2</samp>

### Summary
🚀📚🎁

<!--
1.  🚀 - This emoji can be used to indicate a performance improvement or a feature enhancement, as using a pretrained model can speed up the training process and achieve better results.
2.  📚 - This emoji can be used to indicate a documentation improvement or a clarification, as the change was part of a pull request to improve the documentation and usability of the repository.
3.  🎁 - This emoji can be used to indicate a new feature or a gift, as using a pretrained model by default can be seen as a benefit or a convenience for the users of the repository.
-->
Enable pretrained model by default in `cfg.md`. Update documentation to reflect this change and improve usability.

> _Use `pretrained` model_
> _Faster and better vision_
> _Spring of improvement_

### Walkthrough
*  Enable pretrained model by default ([link](https://github.com/ultralytics/ultralytics/pull/4890/files?diff=unified&w=0#diff-a21b6f90c80bba2698f9a8e30b1a002078a425376e5eb2864f078e0a97d32a3bL91-R91)) in `cfg.md`, which can improve training performance and speed




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to package inclusion and documentation default settings. 

### 📊 Key Changes
- Added `__init__.py` inclusion in the package manifest for better module recognition.
- Updated the default value for `pretrained` in the configuration documentation from `False` to `True`.

### 🎯 Purpose & Impact
- 📦 The inclusion of `__init__.py` ensures that Python recognizes the directories as containing packages, potentially resolving module import issues for users.
- 📖 Changing the `pretrained` default value in the documentation reflects a more user-friendly setting, encouraging users to leverage pre-trained models for improved out-of-the-box performance and quicker start times for training custom models. This can amplify the efficiency and ease-of-use for new users getting started with Ultralytics' tools.