### PR TITLE
Fix Ray 2.7.0 breaking changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,7 +241,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   Conda:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.conda == 'true' || github.event_name == 'schedule')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -79,7 +79,6 @@ def test_predict_sam():
 
 
 @pytest.mark.skipif(not CUDA_IS_AVAILABLE, reason='CUDA is not available')
-@pytest.mark.skipif(True, reason="RayTune Error pyarrow.lib.ArrowInvalid: URI has empty scheme: './runs/tune'")
 def test_model_ray_tune():
     with contextlib.suppress(RuntimeError):  # RuntimeError may be caused by out-of-memory
         YOLO('yolov8n-cls.yaml').tune(use_ray=True,

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -41,7 +41,7 @@ def test_model_methods():
     model.to('cpu')
     model.fuse()
     model.clear_callback('on_train_start')
-    model._reset_callbacks()
+    model.reset_callbacks()
 
     # Model properties
     _ = model.names

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -392,16 +392,16 @@ class Model(nn.Module):
         """Clear all event callbacks."""
         self.callbacks[event] = []
 
+    def reset_callbacks(self):
+        """Reset all registered callbacks."""
+        for event in callbacks.default_callbacks.keys():
+            self.callbacks[event] = [callbacks.default_callbacks[event][0]]
+
     @staticmethod
     def _reset_ckpt_args(args):
         """Reset arguments when loading a PyTorch model."""
         include = {'imgsz', 'data', 'task', 'single_cls'}  # only remember these arguments when loading a PyTorch model
         return {k: v for k, v in args.items() if k in include}
-
-    def _reset_callbacks(self):
-        """Reset all registered callbacks."""
-        for event in callbacks.default_callbacks.keys():
-            self.callbacks[event] = [callbacks.default_callbacks[event][0]]
 
     # def __getattr__(self, attr):
     #    """Raises error if object has no requested attribute."""

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -2,8 +2,8 @@
 
 import subprocess
 
-from ultralytics.cfg import TASK2DATA, TASK2METRIC
-from ultralytics.utils import DEFAULT_CFG_DICT, LOGGER, NUM_THREADS
+from ultralytics.cfg import TASK2DATA, TASK2METRIC, get_save_dir
+from ultralytics.utils import DEFAULT_CFG, DEFAULT_CFG_DICT, LOGGER, NUM_THREADS
 
 
 def run_ray_tune(model,
@@ -93,7 +93,7 @@ def run_ray_tune(model,
         Returns:
             None.
         """
-        model._reset_callbacks()
+        model.reset_callbacks()
         config.update(train_args)
         model.train(**config)
 
@@ -123,10 +123,12 @@ def run_ray_tune(model,
     tuner_callbacks = [WandbLoggerCallback(project='YOLOv8-tune')] if wandb else []
 
     # Create the Ray Tune hyperparameter search tuner
+    tune_dir = get_save_dir(DEFAULT_CFG, name='tune')
+    tune_dir.mkdir(parents=True, exist_ok=True)
     tuner = tune.Tuner(trainable_with_resources,
                        param_space=space,
                        tune_config=tune.TuneConfig(scheduler=asha_scheduler, num_samples=max_samples),
-                       run_config=RunConfig(callbacks=tuner_callbacks, storage_path='./runs/tune'))
+                       run_config=RunConfig(callbacks=tuner_callbacks, storage_path=tune_dir))
 
     # Run the hyperparameter search
     tuner.fit()

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -95,7 +95,8 @@ def run_ray_tune(model,
         """
         model.reset_callbacks()
         config.update(train_args)
-        model.train(**config)
+        results = model.train(**config)
+        return results.results_dict
 
     # Get search space
     if not space:


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ed1eab0</samp>

### Summary
🐛🔧🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the case for the first change that removes the pytest decorator and fixes the storage path error.
2.  🔧 - This emoji represents a tool or improvement, which is the case for the second and third changes that rename and simplify the callback management for the `Model` class.
3.  🚀 - This emoji represents a feature or enhancement, which is the case for the fourth change that improves the integration of RayTune with the ultralytics framework.
-->
This pull request enhances the callback management and RayTune integration for the `Model` class and the `tuner` module. It also updates and fixes some tests related to these changes.

> _To tune models with RayTune and ultralytics_
> _We fixed some errors and improved the logic_
> _We added `reset_callbacks` to the `Model` class_
> _To simplify the callback management task_
> _And used `get_save_dir` to avoid storage conflicts_

### Walkthrough
*  Add `reset_callbacks` method to `Model` class to allow resetting callbacks for multiple training sessions ([link](https://github.com/ultralytics/ultralytics/pull/4964/files?diff=unified&w=0#diff-cb649199881b55cff01fb5d1a216adf39d007be25e815089340a5b4f074cba00R395-R399))
*  Remove `_reset_callbacks` method from `Model` class as it is replaced by the public method ([link](https://github.com/ultralytics/ultralytics/pull/4964/files?diff=unified&w=0#diff-cb649199881b55cff01fb5d1a216adf39d007be25e815089340a5b4f074cba00L401-L405))
*  Update call to `reset_callbacks` method in `tuner._tune` function to match the new name ([link](https://github.com/ultralytics/ultralytics/pull/4964/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659L96-R96))
*  Use `get_save_dir` function to create a valid URI for RayTune runs in `tuner.run_ray_tune` function and `tests/test_cuda.py` file ([link](https://github.com/ultralytics/ultralytics/pull/4964/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659L126-R131), [link](https://github.com/ultralytics/ultralytics/pull/4964/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659L5-R6))
*  Remove pytest decorator that was skipping a test function in `tests/test_cuda.py` file due to a fixed RayTune error ([link](https://github.com/ultralytics/ultralytics/pull/4964/files?diff=unified&w=0#diff-6deae64cdc8b70e42e1ad5f9605daac08ddd27153ddcba689b424cfc261f30caL82))
*  Rename `_reset_callbacks` method to `reset_callbacks` in `tests/test_python.py` file to match the public method in `Model` class ([link](https://github.com/ultralytics/ultralytics/pull/4964/files?diff=unified&w=0#diff-51deb1ccb3a8b618784df2e2abfbc3b056436f1db72d1896d5102f9906978492L44-R44))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced CI pipeline, refined hyperparameter tuning, and improved testing for Ultralytics AI models.

### 📊 Key Changes
- Updated conditions for the Conda job within CI to trigger only on schedule or if a specific input is set.
- Removed the skip condition for `test_model_ray_tune()` that was previously bypassing the test due to a RayTune-related error.
- Renamed a private method `_reset_callbacks()` to `reset_callbacks()` changing its scope to be publicly accessible.
- Adjusted the hyperparameter tuning process to store results and to ensure the save directory is created properly.

### 🎯 Purpose & Impact
- Streamlining the CI workflow to reduce unnecessary Conda job triggers, improving resource usage and efficiency. 🚀
- Restoring a test function for RayTune, ensuring that automated tests cover hyperparameter tuning features. 🧪
- Modifications in code methods to align with naming conventions and to grant easier access which leads to a clearer, more predictable workflow for developers. 👨‍💻
- Tuning process tweaks enable better management of results and storage, leading to a smoother hyperparameter optimization experience and better organization. 📈