### PR TITLE
Update matplotlib backend switching

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,8 +23,9 @@ RUN apt upgrade --no-install-recommends -y openssl tar
 WORKDIR /usr/src/ultralytics
 
 # Copy contents
+COPY . /usr/src/ultralytics
 # COPY . /usr/src/ultralytics  # git permission issues inside container
-RUN git clone https://github.com/ultralytics/ultralytics -b main /usr/src/ultralytics
+# RUN git clone https://github.com/ultralytics/ultralytics -b main /usr/src/ultralytics
 ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt /usr/src/ultralytics/
 
 # Install pip packages

--- a/ultralytics/models/fastsam/prompt.py
+++ b/ultralytics/models/fastsam/prompt.py
@@ -143,7 +143,7 @@ class FastSAMPrompt:
 
             save_path = Path(output) / result_name
             save_path.parent.mkdir(exist_ok=True, parents=True)
-            image = Image.frombytes('RGB', fig.canvas.get_width_height(), fig.canvas.buffer_rgba())
+            image = Image.frombytes('RGB', fig.canvas.get_width_height(), fig.canvas.tostring_rgb())
             image.save(save_path)
             plt.close()
             pbar.set_description(f'Saving {result_name} to {save_path}')

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -208,12 +208,16 @@ def plt_settings(rcparams=None, backend='Agg'):
         def wrapper(*args, **kwargs):
             """Sets rc parameters and backend, calls the original function, and restores the settings."""
             original_backend = plt.get_backend()
-            plt.switch_backend(backend)
+            if backend != original_backend:
+                plt.close('all')  # auto-close()ing of figures upon backend switching is deprecated since 3.8
+                plt.switch_backend(backend)
 
             with plt.rc_context(rcparams):
                 result = func(*args, **kwargs)
 
-            plt.switch_backend(original_backend)
+            if backend != original_backend:
+                plt.close('all')
+                plt.switch_backend(original_backend)
             return result
 
         return wrapper


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fa5a997</samp>

### Summary
🚫🔀📊

<!--
1.  🚫 This emoji can represent the deprecation warning that the change is trying to avoid, as well as the closing of the figures that are no longer needed.
2.  🔀 This emoji can represent the switching of the backend, which is the main action of the function.
3.  📊 This emoji can represent the plotting utilities that the change is part of, as well as the figures that are created and closed by the function.
-->
The change fixes a matplotlib deprecation warning by closing figures before and after switching the backend in `ultralytics/utils/__init__.py`. This improves the plotting utilities of the ultralytics package.

> _`backend` changes_
> _close figures to avoid warnings_
> _autumn leaves falling_

### Walkthrough
*  Add conditional statements to close figures before and after switching matplotlib backend to avoid deprecation warning ([link](https://github.com/ultralytics/ultralytics/pull/4987/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faL211-R220))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to Docker workflow and enhancements to image plotting functions in Ultralytics codebase.

### 📊 Key Changes
- Dockerfile now copies the repo's contents instead of cloning from GitHub, solving permissions issues.
- The image plotting function in `fastsam/prompt.py` is modified to use `tostring_rgb` instead of `buffer_rgba`, fixing image saving issues.
- Enhancements to backend switching logic in `utils/__init__.py` to avoid deprecated auto-closing of figures and potential errors when the backend is unchanged.

### 🎯 Purpose & Impact
- The Dockerfile change allows for easier and more reliable container setup for developers, improving the development environment setup. 🐳
- The image plotting update ensures that generated images are correctly saved, leading to a smoother user experience in visualizing results. 🖼️
- Improved plot backend management prevents unnecessary figure closures, which could impact memory usage and performance, leading to a more stable visualization experience. 📈