### PR TITLE
Update train.md

### DIFF
--- a/docs/modes/train.md
+++ b/docs/modes/train.md
@@ -189,7 +189,7 @@ Training settings for YOLO models refer to the various hyperparameters and confi
 | `project`         | `None`   | project name                                                                                   |
 | `name`            | `None`   | experiment name                                                                                |
 | `exist_ok`        | `False`  | whether to overwrite existing experiment                                                       |
-| `pretrained`      | `True`   | (bool | str) whether to use a pretrained model (bool) or a model to load weights from (str)    |
+| `pretrained`      | `True`   | (bool / str) whether to use a pretrained model (bool) or a model to load weights from (str)    |
 | `optimizer`       | `'auto'` | optimizer to use, choices=[SGD, Adam, Adamax, AdamW, NAdam, RAdam, RMSProp, auto]              |
 | `verbose`         | `False`  | whether to print verbose output                                                                |
 | `seed`            | `0`      | random seed for reproducibility                                                                |

--- a/docs/modes/train.md
+++ b/docs/modes/train.md
@@ -189,7 +189,7 @@ Training settings for YOLO models refer to the various hyperparameters and confi
 | `project`         | `None`   | project name                                                                                   |
 | `name`            | `None`   | experiment name                                                                                |
 | `exist_ok`        | `False`  | whether to overwrite existing experiment                                                       |
-| `pretrained`      | `True`   | (bool / str) whether to use a pretrained model (bool) or a model to load weights from (str)    |
+| `pretrained`      | `True`   | (bool \| str) whether to use a pretrained model (bool) or a model to load weights from (str)    |
 | `optimizer`       | `'auto'` | optimizer to use, choices=[SGD, Adam, Adamax, AdamW, NAdam, RAdam, RMSProp, auto]              |
 | `verbose`         | `False`  | whether to print verbose output                                                                |
 | `seed`            | `0`      | random seed for reproducibility                                                                |


### PR DESCRIPTION
Fix for `pretrained` parameter in train arguments for not showing the whole description


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 587157d</samp>

### Summary
📝🚚🌟

<!--
1.  📝 This emoji represents a documentation change, as the argument description was modified in the docstring.
2.  🚚 This emoji represents a relocation or renaming change, as the pipe (|) character was replaced by a slash (/) character in the argument description.
3.  🌟 This emoji represents an improvement or enhancement change, as the readability and consistency of the documentation was improved by the change.
-->
Updated the documentation of the `pretrained` argument in `docs/modes/train.md` to use slashes instead of pipes for clarity and consistency.

> _`pretrained` docs_
> _Slash replaces pipe symbol_
> _Clearer in winter_

### Walkthrough
*  Replace pipe (|) with slash (/) in `pretrained` argument description to avoid Markdown confusion and improve readability ([link](https://github.com/ultralytics/ultralytics/pull/4999/files?diff=unified&w=0#diff-4a4a3691b08dc4cb045c88d4405e25fe3e154c35ddf71370e94e336b5f3b417dL192-R192))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced documentation clarity for the `pretrained` parameter.

### 📊 Key Changes
- Corrected the display of the `pretrained` parameter type in the training settings table to properly show the `bool or str` options.

### 🎯 Purpose & Impact
- 📝 Provides clearer guidance for users on how to use the `pretrained` parameter.
- ✅ Ensures developers and users understand the flexibility in specifying a pretrained model or a path to load weights.
- ⚙ Fosters easier adoption and fewer errors for new users setting up their training configurations.