### PR TITLE
Remove unused values

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -264,8 +264,7 @@ class Model(nn.Module):
             validator (BaseValidator): Customized validator.
             **kwargs : Any other args accepted by the validators. To see all args check 'configuration' section in docs
         """
-        custom = {'rect': True}  # method defaults
-        args = {**self.overrides, **custom, **kwargs, 'mode': 'val'}  # highest priority args on the right
+        args = {**self.overrides, **kwargs}  # highest priority args on the right
         args['imgsz'] = check_imgsz(args['imgsz'], max_dim=1)
 
         validator = (validator or self._smart_load('validator'))(args=args, _callbacks=self.callbacks)

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -145,8 +145,6 @@ class BaseValidator:
 
             if self.device.type in ('cpu', 'mps'):
                 self.args.workers = 0  # faster CPU val as time dominated by inference, not dataloading
-            if not pt:
-                self.args.rect = False
             self.dataloader = self.dataloader or self.get_dataloader(self.data.get(self.args.split), self.args.batch)
 
             model.eval()


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b456192</samp>

### Summary
:wrench::sparkles::memo:

<!--
1.  :wrench: This emoji represents the idea of adjusting or fixing something, which is relevant for the changes that modify the default or conditional settings of the `rect` argument in the validation methods.
2.  :sparkles: This emoji represents the idea of adding or enhancing something, which is relevant for the changes that enable more flexibility and control over the validation settings for different models and datasets.
3.  :memo: This emoji represents the idea of documenting or explaining something, which is relevant for the changes that ensure consistency and transparency in the validation settings for different models and datasets.
-->
This pull request removes the hard-coded `rect` argument values in the `val` method of the `Model` class and the `__call__` method of the `BaseValidator` class. This allows the user to control the `rect` argument in the `kwargs` or the `overrides` when validating different models and datasets with `ultralytics/engine/model.py` and `ultralytics/engine/validator.py`.

> _`rect` is now free_
> _user can choose validation_
> _autumn of options_

### Walkthrough
*  Remove default `rect` settings in `Model.val` and `BaseValidator.__call__` methods to allow user-specified `rect` argument ([link](https://github.com/ultralytics/ultralytics/pull/5056/files?diff=unified&w=0#diff-cb649199881b55cff01fb5d1a216adf39d007be25e815089340a5b4f074cba00L267-R267), [link](https://github.com/ultralytics/ultralytics/pull/5056/files?diff=unified&w=0#diff-01e0aaa194c770fed7f7a0cc941222f0acfa857d478bfeba933eed1bcb1f65e7L148-L149))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlined model validation arguments management for increased configurability.

### 📊 Key Changes
- Removed hardcoded default `rect` argument from validation method in `model.py`.
- Eliminated the conditional disabling of `rect` in the absence of `'pt'` in `validator.py`.

### 🎯 Purpose & Impact
- Gives users more control over the validation process by not enforcing a default value for the `rect` argument.
- Ensures consistent handling of the `rect` argument across different computing backends and irrespective of the training format (i.e., `'pt'`).
- Potential increase in user satisfaction due to more flexible and predictable validation configuration, thereby improving overall user experience with the library. 🔄