### PR TITLE
Fix `ratio_pad`

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -571,8 +571,6 @@ class LetterBox:
         if self.center:
             dw /= 2  # divide padding into 2 sides
             dh /= 2
-        if labels.get('ratio_pad'):
-            labels['ratio_pad'] = (labels['ratio_pad'], (dw, dh))  # for evaluation
 
         if shape[::-1] != new_unpad:  # resize
             img = cv2.resize(img, new_unpad, interpolation=cv2.INTER_LINEAR)
@@ -580,6 +578,8 @@ class LetterBox:
         left, right = int(round(dw - 0.1)) if self.center else 0, int(round(dw + 0.1))
         img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT,
                                  value=(114, 114, 114))  # add border
+        if labels.get('ratio_pad'):
+            labels['ratio_pad'] = (labels['ratio_pad'], (left, top))  # for evaluation
 
         if len(labels):
             labels = self._update_labels(labels, ratio, dw, dh)


### PR DESCRIPTION
`dw` and `dh` may have `*.5` value, but padding is discrete. `print(ultralytics.models.yolo.detect.DetectionValidator(args={"data": "coco.yaml", "device": "cpu"})(model="yolov8n.pt")["metrics/mAP50-95(B)"])` now gives

`0.3703562587540393` instead of

`0.370353195723441`


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fe77eb4</samp>

### Summary
🐛🔄📦

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request.
2.  🔄 - This emoji represents a rotation, which is the operation that affects the letterbox padding for the bounding boxes.
3.  📦 - This emoji represents a box or a padding, which is the attribute that is modified by this pull request.
-->
Fix letterbox padding bug for rotated bounding boxes in `ultralytics/data/augment.py`. Use rotated image dimensions and offset to calculate correct padding values for `labels['ratio_pad']`.

> _There once was a bug in `ratio_pad`_
> _That made the bounding boxes look bad_
> _They removed `(dw, dh)`_
> _And added `(left, top)`_
> _And now the letterbox padding is rad_

### Walkthrough
*  Fix bug in evaluation of letterbox padding for rotated bounding boxes in `augment.py` ([link](https://github.com/ultralytics/ultralytics/pull/5064/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L574-L575), [link](https://github.com/ultralytics/ultralytics/pull/5064/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528R581-R582))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image padding process in data augmentation.

### 📊 Key Changes
- Removed initial setting of the `ratio_pad` label before the conditional image resizing.
- Added setting of the `ratio_pad` label after the conditional image resizing and border addition, with updated padding values reflecting the final image padding.

### 🎯 Purpose & Impact
- This change ensures that the `ratio_pad` label accurately represents the padding after the image has been resized and the border has been added, rather than before these operations.
- It impacts users by providing more precise label adjustments for images that have undergone padding, particularly important for image evaluation and training processes where exact spatial correspondence between the original and augmented image is necessary. 🖼️✨