### PR TITLE
Test coco128-seg.yaml

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -15,7 +15,7 @@ from ultralytics.utils import (ASSETS, DEFAULT_CFG, DEFAULT_CFG_DICT, DEFAULT_CF
 # Define valid tasks and modes
 MODES = 'train', 'val', 'predict', 'export', 'track', 'benchmark'
 TASKS = 'detect', 'segment', 'classify', 'pose'
-TASK2DATA = {'detect': 'coco8.yaml', 'segment': 'coco8-seg.yaml', 'classify': 'imagenet10', 'pose': 'coco8-pose.yaml'}
+TASK2DATA = {'detect': 'coco8.yaml', 'segment': 'coco128-seg.yaml', 'classify': 'imagenet10', 'pose': 'coco8-pose.yaml'}
 TASK2MODEL = {
     'detect': 'yolov8n.pt',
     'segment': 'yolov8n-seg.pt',

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -286,4 +286,6 @@ class BaseDataset(Dataset):
             )
         """
         raise NotImplementedError
+
+
 # Test

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -286,3 +286,4 @@ class BaseDataset(Dataset):
             )
         """
         raise NotImplementedError
+# Test

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -795,4 +795,6 @@ def clean_str(s):
         (str): a string with special characters replaced by an underscore _
     """
     return re.sub(pattern='[|@#!¡·$€%&()=?¿^*;:,¨´><+]', repl='_', string=s)
+
+
 #Test

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -795,3 +795,4 @@ def clean_str(s):
         (str): a string with special characters replaced by an underscore _
     """
     return re.sub(pattern='[|@#!¡·$€%&()=?¿^*;:,¨´><+]', repl='_', string=s)
+#Test


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0202520</samp>

### Summary
📈🤷🙄

<!--
1.  📈 This emoji could represent the improvement or enhancement of using a larger and more diverse dataset for the segmentation task, which could potentially lead to better performance and generalization of the models.
2.  🤷 This emoji could represent the uncertainty or confusion of why the comment `# Test` was added to `ultralytics/data/base.py`, as it does not seem to provide any useful information or explanation of the code.
3.  🙄 This emoji could represent the annoyance or frustration of seeing another comment `#Test` added to `ultralytics/utils/ops.py`, as it also does not seem to provide any useful information or explanation of the code.
-->
The pull request updates the dataset configuration for the segmentation task in `ultralytics/cfg/__init__.py` to use `coco128-seg.yaml`. It also adds two unnecessary comments `# Test` to `ultralytics/data/base.py` and `ultralytics/utils/ops.py` that could be removed.

> _`TASK2DATA` changed_
> _`coco128-seg` for segments_
> _Fall leaves more colors_

### Walkthrough
*  Update the dataset for the segmentation task to `coco128-seg.yaml` in `TASK2DATA` ([link](https://github.com/ultralytics/ultralytics/pull/5075/files?diff=unified&w=0#diff-c02fb3f9e86e97bf85f07211aed56aa04774504a61eeff07a08471bbdea14556L18-R18))
*  Add unnecessary comments `# Test` and `#Test` to `ultralytics/data/base.py` and `ultralytics/utils/ops.py` respectively ([link](https://github.com/ultralytics/ultralytics/pull/5075/files?diff=unified&w=0#diff-0b2d0be08e156856d63e748af252444d26d092bf1ca32e56c4a25074efccc4c9R289), [link](https://github.com/ultralytics/ultralytics/pull/5075/files?diff=unified&w=0#diff-4c045e45231b1287ae6222068d75c8a96d1e2bf450c5ecf9dc0959eaec04dfe6R798))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated configuration for segmentation tasks and added placeholder test annotations.

### 📊 Key Changes
- The dataset file for the segmentation task in `TASK2DATA` mapping has been updated from `coco8-seg.yaml` to `coco128-seg.yaml`.
- Placeholder comments for tests have been added at the end of `data/base.py` and `utils/ops.py` files.

### 🎯 Purpose & Impact
- The change in the dataset file ensures the segmentation tasks use a more comprehensive dataset (`coco128-seg.yaml`), which may lead to improved model performance and versatility.
- Placeholder comments suggest that future test cases may be planned, which would strengthen the codebase reliability upon implementation.
- For users, these changes indicate active development and potential enhancements in segmentation model accuracy and software robustness. 🔄