### PR TITLE
Update __init__.py. Missing assignment of re.sub result to pair

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -291,7 +291,7 @@ def handle_yolo_settings(args: List[str]) -> None:
 
 def parse_key_value_pair(pair):
     """Parse one 'key=value' pair and return key and value."""
-    re.sub(r' *= *', '=', pair)  # remove spaces around equals sign
+    pair = re.sub(r' *= *', '=', pair)  # remove spaces around equals sign
     k, v = pair.split('=', 1)  # split on first '=' sign
     assert v, f"missing '{k}' value"
     return k, smart_value(v)


### PR DESCRIPTION
Missing assignment of re.sub result to pair in function parse_key_value_pair

The pull request addresses issue #5080.

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3d72bc6</samp>

### Summary
🐛🛠️✅

<!--
1.  🐛 - This emoji represents a bug or an error that needs to be fixed. In this case, the original code did not remove the spaces around the equals sign as intended, which could cause problems when parsing the input.
2.  🛠️ - This emoji represents a tool or a fix that solves a problem or improves something. In this case, the `re.sub` function is a tool that performs the desired replacement of spaces with an empty string.
3.  ✅ - This emoji represents a check mark or a confirmation that something is done or correct. In this case, the reassignment of the `pair` variable ensures that the removal of spaces is actually applied and the parsing can proceed as expected.
-->
Fixed a bug in `ultralytics/cfg/__init__.py` that could cause incorrect parsing of configuration files. Applied a regular expression to remove spaces around the equals sign in key-value pairs.

> _`pair` gets new value_
> _re.sub removes spaces well_
> _parsing bug is gone_

### Walkthrough
* Fix bug in parsing key-value pairs with spaces by applying `re.sub` to `pair` variable ([link](https://github.com/ultralytics/ultralytics/pull/5082/files?diff=unified&w=0#diff-c02fb3f9e86e97bf85f07211aed56aa04774504a61eeff07a08471bbdea14556L294-R294))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixed a regex replacement bug in configuration parsing.

### 📊 Key Changes
- Addressed an issue where spaces around the equals sign were not properly being removed during the parsing of key-value pairs in configurations.
- Ensured the regex substitution result is correctly assigned back to the `pair` variable.

### 🎯 Purpose & Impact
- **Purpose:** To ensure that key-value pairs in configuration files are parsed accurately, without errors due to formatting inconsistencies like spaces.
- **Impact:** This fix allows both developers and users to write more flexible and forgiving configuration files, improving user experience and reducing configuration-related errors. 🛠️✨