### PR TITLE
PyTorch: "please use 'torch.backends.mps.is_built()'"

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -135,7 +135,7 @@ def select_device(device='', batch=0, newline=False, verbose=True):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
         arg = 'cuda:0'
-    elif TORCH_2_0 and mps and torch.backends.mps.is_built() and torch.backends.mps.is_available():
+    elif mps and TORCH_2_0 and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f'MPS ({get_cpu_info()})\n'
         arg = 'mps'

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -135,7 +135,7 @@ def select_device(device='', batch=0, newline=False, verbose=True):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
         arg = 'cuda:0'
-    elif mps and getattr(torch, 'has_mps', False) and torch.backends.mps.is_available() and TORCH_2_0:
+    elif TORCH_2_0 and mps and torch.backends.mps.is_built() and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f'MPS ({get_cpu_info()})\n'
         arg = 'mps'


### PR DESCRIPTION
- Remove deprecated usage
- I'm guessing python short circuits, might as well check the constant first


I have read the CLA Document and I sign the CLA

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1d43329</samp>

### Summary
🔧🆙🚀

<!--
1.  🔧 (wrench) - This emoji can be used to indicate a bug fix or a configuration change, which are both applicable to updating the condition for using MPS.
2.  🆙 (up) - This emoji can be used to indicate an upgrade or an improvement, which are both applicable to enhancing compatibility and avoiding errors.
3.  🚀 (rocket) - This emoji can be used to indicate a performance boost or a feature launch, which are both applicable to using MPS more effectively and efficiently.
-->
Updated the MPS detection logic in `ultralytics/utils/torch_utils.py` to use a more reliable and compatible method. This improves the performance and stability of the ultralytics library with newer PyTorch versions.

> _`torch.has_mps` gone_
> _MPS check is updated_
> _Winter of errors_

### Walkthrough
* Update the condition for using MPS ([link](https://github.com/ultralytics/ultralytics/pull/5125/files?diff=unified&w=0#diff-9bd07d929cb8522458c879bd81a82d9af468ffbc215e762f39b2a50a601758d7L138-R138)) to check if MPS is built and available, instead of using a deprecated attribute `torch.has_mps`. This improves compatibility with newer versions of PyTorch and avoids potential errors in `torch_utils.py`.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of device selection logic for PyTorch operations.

### 📊 Key Changes
- Simplified the MPS (Apple Silicon GPU) availability check within the `select_device` function.

### 🎯 Purpose & Impact
- 🏃‍♂️ Streamlines the process of checking whether the MPS backend is available for use, ensuring better code readability and possibly minor performance improvements.
- 🍏 Enhances the user experience for those running PyTorch on Apple Silicon Macs by potentially selecting the MPS device more efficiently.
- 👨‍💻 Provides cleaner code for developers to understand and maintain in the future.