### PR TITLE
fix: wandb run finish()

### DIFF
--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -56,8 +56,14 @@ def on_train_end(trainer):
         wb.run.log_artifact(art, aliases=['best'])
 
 
+def teardown(*args, **kwargs):
+    """Ends the W&B run."""
+    wb.run.finish()
+
+
 callbacks = {
     'on_pretrain_routine_start': on_pretrain_routine_start,
     'on_train_epoch_end': on_train_epoch_end,
     'on_fit_epoch_end': on_fit_epoch_end,
-    'on_train_end': on_train_end} if wb else {}
+    'on_train_end': on_train_end,
+    'teardown': teardown} if wb else {}


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

This PR adds a `wb.run.finish()` call to the W&B callback. This solves the issue mentioned in https://github.com/ultralytics/ultralytics/issues/5141

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2bc0e35</samp>

### Summary
🐛🏁⏯️

<!--
1.  🐛 - This emoji represents a bug fix, as the change addresses a problem that prevented the W&B run from ending correctly.
2.  🏁 - This emoji represents a finish line, as the change calls the `wb.run.finish()` method to end the run gracefully.
3.  ⏯️ - This emoji represents a play/pause button, as the change relates to the `--resume` flag that allows pausing and resuming a run from a checkpoint.
-->
Added a `teardown` callback to end W&B runs gracefully when resuming from a checkpoint. This fixes a bug in `ultralytics/utils/callbacks/wb.py`.

> _`teardown` callback_
> _resumes and ends W&B run_
> _a graceful autumn_

### Walkthrough
*  Add `teardown` function to callbacks dictionary to end W&B run gracefully ([link](https://github.com/ultralytics/ultralytics/pull/5144/files?diff=unified&w=0#diff-3c04fc6482220c244e06a4f4923dede32f280698f563ccc10c9ecda3cdb873a6L59-R69)). This fixes a bug where the W&B run would not end properly when using the `--resume` flag. The `teardown` function calls `wb.run.finish()` which is the recommended way to end a W&B run. The file `ultralytics/utils/callbacks/wb.py` contains the W&B callback class that integrates W&B logging with the ultralytics framework.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Weights & Biases integration with a new teardown callback.

### 📊 Key Changes
- A new `teardown` function has been added to the `utils/callbacks/wb.py` file.
- The `teardown` function is responsible for ending a Weights & Biases run when called.

### 🎯 Purpose & Impact
- **Purpose**: To ensure that Weights & Biases runs are properly closed after training, to avoid any potential issues with incomplete or ongoing runs. This helps in managing the runs more effectively and keeping the experiment tracking clean.
- **Impact**: Users who utilize Weights & Biases for tracking their experiments will now have a more robust and reliable system. Their experiment tracking will now automatically end runs, potentially making the tool easier to use and reducing manual intervention. 🛠️📈