### PR TITLE
Add support for rectangular images when training a classifier

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -791,14 +791,22 @@ def v8_transforms(dataset, imgsz, hyp, stretch=False):
 
 
 # Classification augmentations -----------------------------------------------------------------------------------------
-def classify_transforms(size=224, mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0)):  # IMAGENET_MEAN, IMAGENET_STD
+def classify_transforms(size=224, rect=False, mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0)):  # IMAGENET_MEAN, IMAGENET_STD
     # Transforms to apply if albumentations not installed
     if not isinstance(size, int):
         raise TypeError(f'classify_transforms() size {size} must be integer, not (list, tuple)')
-    if any(mean) or any(std):
-        return T.Compose([CenterCrop(size), ToTensor(), T.Normalize(mean, std, inplace=True)])
+
+    transforms = []
+    if rect:
+        transforms.append(ClassifyLetterBox(size, auto=True))
     else:
-        return T.Compose([CenterCrop(size), ToTensor()])
+        transforms.append(CenterCrop(size))
+    transforms.append(ToTensor())
+
+    if any(mean) or any(std):
+        transforms.append(T.Normalize(mean, std, inplace=True))
+
+    return T.Compose(transforms)
 
 
 def hsv2colorjitter(h, s, v):
@@ -864,9 +872,9 @@ class ClassifyLetterBox:
         imh, imw = im.shape[:2]
         r = min(self.h / imh, self.w / imw)  # ratio of new/old
         h, w = round(imh * r), round(imw * r)  # resized image
-        hs, ws = (math.ceil(x / self.stride) * self.stride for x in (h, w)) if self.auto else self.h, self.w
+        hs, ws = [math.ceil(x / self.stride) * self.stride for x in (h, w)] if self.auto else [self.h, self.w]
         top, left = round((hs - h) / 2 - 0.1), round((ws - w) / 2 - 0.1)
-        im_out = np.full((self.h, self.w, 3), 114, dtype=im.dtype)
+        im_out = np.full((hs, ws, 3), 114, dtype=im.dtype)
         im_out[top:top + h, left:left + w] = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)
         return im_out
 

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -792,20 +792,12 @@ def v8_transforms(dataset, imgsz, hyp, stretch=False):
 
 # Classification augmentations -----------------------------------------------------------------------------------------
 def classify_transforms(size=224, rect=False, mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0)):  # IMAGENET_MEAN, IMAGENET_STD
-    # Transforms to apply if albumentations not installed
+    """Transforms to apply if albumentations not installed."""
     if not isinstance(size, int):
         raise TypeError(f'classify_transforms() size {size} must be integer, not (list, tuple)')
-
-    transforms = []
-    if rect:
-        transforms.append(ClassifyLetterBox(size, auto=True))
-    else:
-        transforms.append(CenterCrop(size))
-    transforms.append(ToTensor())
-
+    transforms = [ClassifyLetterBox(size, auto=True) if rect else CenterCrop(size), ToTensor()]
     if any(mean) or any(std):
         transforms.append(T.Normalize(mean, std, inplace=True))
-
     return T.Compose(transforms)
 
 
@@ -872,7 +864,7 @@ class ClassifyLetterBox:
         imh, imw = im.shape[:2]
         r = min(self.h / imh, self.w / imw)  # ratio of new/old
         h, w = round(imh * r), round(imw * r)  # resized image
-        hs, ws = [math.ceil(x / self.stride) * self.stride for x in (h, w)] if self.auto else [self.h, self.w]
+        hs, ws = (math.ceil(x / self.stride) * self.stride for x in (h, w)) if self.auto else (self.h, self.w)
         top, left = round((hs - h) / 2 - 0.1), round((ws - w) / 2 - 0.1)
         im_out = np.full((hs, ws, 3), 114, dtype=im.dtype)
         im_out[top:top + h, left:left + w] = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -222,7 +222,7 @@ class ClassificationDataset(torchvision.datasets.ImageFolder):
         self.cache_disk = cache == 'disk'
         self.samples = self.verify_images()  # filter out bad images
         self.samples = [list(x) + [Path(x[0]).with_suffix('.npy'), None] for x in self.samples]  # file, index, npy, im
-        self.torch_transforms = classify_transforms(args.imgsz)
+        self.torch_transforms = classify_transforms(args.imgsz, rect=args.rect)
         self.album_transforms = classify_albumentations(
             augment=augment,
             size=args.imgsz,


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e53ae6</samp>

### Summary
:sparkles::bug::wrench:

<!--
1.  :sparkles: This emoji is often used to indicate a new feature or enhancement. In this case, the feature is the option to choose between rectangular or square images for classification tasks.
2.  :bug: This emoji is often used to indicate a bug fix or improvement. In this case, the bug fixes are related to the `ClassifyLetterBox` transform, which had some issues with padding and resizing the images.
3.  :wrench: This emoji is often used to indicate a tool or configuration change. In this case, the change is related to the `rect` argument, which is a configuration option that affects how the images are cropped and transformed.
-->
This pull request adds a feature to enable rectangular or square cropping of images for classification tasks, and fixes some bugs in the `ClassifyLetterBox` transform. It affects the `classify_transforms` function and the `ClassifyLetterBox` class in `ultralytics/data/augment.py`, and the `ClassificationDataset` class in `ultralytics/data/dataset.py`.

> _To classify images with ease_
> _We can crop them as squares or as `rect`s_
> _But the `ClassifyLetterBox` had some bugs_
> _That messed up the aspect and the flux_
> _So we fixed them and passed `rect` to `classify_transforms`_

### Walkthrough
*  Add `rect` argument to `classify_transforms` function to choose between rectangular or square cropping for classification tasks ([link](https://github.com/ultralytics/ultralytics/pull/5145/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L794-R811))
*  Modify `ClassifyLetterBox` transform to resize and pad the image to a multiple of a given stride, preserving the aspect ratio ([link](https://github.com/ultralytics/ultralytics/pull/5145/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L794-R811), [link](https://github.com/ultralytics/ultralytics/pull/5145/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L867-R877))
*  Modify `ClassificationDataset` class to use the same `rect` argument as `classify_transforms` function ([link](https://github.com/ultralytics/ultralytics/pull/5145/files?diff=unified&w=0#diff-0834dc62a5ebc93f43947ef49530b3e973013f844888646e5fb9962bfefecd90L225-R225))
*  Use list comprehensions instead of generators for `hs` and `ws` variables in `ClassifyLetterBox` transform to avoid potential issues with arithmetic operations ([link](https://github.com/ultralytics/ultralytics/pull/5145/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L867-R877))
*  Use `hs` and `ws` instead of `self.h` and `self.w` for `im_out` variable in `ClassifyLetterBox` transform to ensure consistent output shape ([link](https://github.com/ultralytics/ultralytics/pull/5145/files?diff=unified&w=0#diff-8945a175b39a1efcabd4d2fb09b583d2f25409f05038ca9a0f1165e39ee48528L867-R877))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image preprocessing for classification tasks in Ultralytics library.

### 📊 Key Changes
- Added a `rect` parameter to `classify_transforms` to toggle between rectangular and square letterboxing.
- Comment improved to better explain the purpose of `classify_transforms`.
- Modified the `ClassifyLetterBox` and `CenterCrop` usage based on the `rect` parameter.
- Updated normalization to be included in the transforms sequence as a conditional step.
- Fixed the resizing output dimensions to match the intended padded resolution.
- Integrated the new `rect` parameter within `dataset.py`, aligning dataset transformations with the updated `classify_transforms`.

### 🎯 Purpose & Impact
- The introduction of the `rect` parameter allows more flexibility in image preprocessing, accommodating non-square input sizes for classification models.
- Cleaner code documentation will help developers understand the intended use and behavior of the `classify_transforms`.
- The adjustment in the augmented image size ensures that the aspect ratio is maintained after letterboxing, which could improve model accuracy when dealing with various image dimensions.
- These changes could potentially lead to better performance of classification models and offer users greater customization for their specific use cases. 🖼️✨