### PR TITLE
[yolo export] Delete model and clear GPU vRAM to avoid out of memory errors during TensorRT export

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -627,6 +627,9 @@ class Exporter:
         if builder.platform_has_fast_fp16 and self.args.half:
             config.set_flag(trt.BuilderFlag.FP16)
 
+        del self.model
+        torch.cuda.empty_cache()
+
         # Write file
         with builder.build_engine(network, config) as engine, open(f, 'wb') as t:
             # Metadata


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ad052b1</samp>

### Summary
🗑️🧹🐛

<!--
1.  🗑️ - This emoji represents deleting or removing something, such as the model attribute. It can also convey a sense of cleaning up or getting rid of unwanted or unnecessary things.
2.  🧹 - This emoji represents sweeping or clearing something, such as the CUDA memory cache. It can also convey a sense of tidying up or making space for something new.
3.  🐛 - This emoji represents a bug or an error, such as the one related to exporting engines with different input sizes. It can also convey a sense of fixing or resolving a problem or issue.
-->
Fix memory leak bug in engine exporting. Clear CUDA cache and remove model attribute in `ultralytics/engine/exporter.py` after exporting.

> _`model` is no more_
> _Clear the CUDA cache now_
> _Memory leaks, gone_

### Walkthrough
* Free GPU memory and prevent memory leaks after exporting engine ([link](https://github.com/ultralytics/ultralytics/pull/5149/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cR630-R632))



## Description

I was trying to convert a YoloV8-generated PyTorch model to TensorRT on a Jetson Nano 2GB. The conversion to ONNX succeeded, but it later failed on TRT.

`yolo export model=model.pt format=engine device=0 verbose=True` produced the following OOM error:

```
[TensorRT] ERROR: Tactic Device request: 52MB Available: 42MB. Device memory is insufficient to use tactic.
[TensorRT] WARNING: Skipping tactic 8 due to oom error on requested size of 52 detected for tactic -2409163523992614473.
```

After noticing that exporting using `trtexec` directly worked flawlessly, I wanted to find out what the reason behind this sudden difference in memory consumption was. I noticed that the `.pt` model supplied during `yolo export` is loaded by `ultralytics` to extract information from it, but it is not unloaded afterwards from the memory, leaving less resources available for TRT. This PR aims to improve that and shows that unloading the model from memory right before running TensorRT helps me to avoid my OOM problem.

This PR is probably not ready to be merged, as it is not a universal fix for all export formats. It is merely a suggestion currently. As I don't really see how to implement unloading best for all export formats, I'm asking for **your tips in how I can make this more universal**. Thanks for YoloV8!

## Steps to reproduce:

- Obtain a larger model (for a low-memory device like the Jetson Nano 2GB), with a bigger imgsz like 1280
- Run `yolo export model=model.pt format=engine device=0 verbose=True` on low-end hardware with little GPU memory.
- Observe that the TensorRT export goes OOM without this PR
- Observe that the TensorRT export no longer goes OOM with this PR

## Related issues:

- https://github.com/ultralytics/ultralytics/issues/3713
- https://github.com/ultralytics/ultralytics/issues/4597
- https://github.com/ultralytics/ultralytics/issues/3176
- https://github.com/ultralytics/ultralytics/issues/1225

These issues are indirectly related, they all used trtexec directly, however trtexec's output file is not encoded correctly for usage in YoloV8. They may be using trtexec to work around this OOM problem.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in memory management during TensorRT engine export.

### 📊 Key Changes
- Added deletion of the `self.model` attribute within the export process.
- Included a call to `torch.cuda.empty_cache()` to clear the CUDA memory cache.

### 🎯 Purpose & Impact
- 🔍 **Purpose**: These changes are likely introduced to reduce memory usage and avoid out-of-memory errors during the export of a model to TensorRT format.
- 💻 **Impact**: Users may experience smoother exports with reduced memory overhead, especially beneficial for machines with limited GPU memory. This can also help in environments where multiple models or processes are running concurrently. 🚀