### PR TITLE
[BUG #5128] allow users to supply save_dir override...

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -108,8 +108,6 @@ def get_cfg(cfg: Union[str, Path, Dict, SimpleNamespace] = DEFAULT_CFG_DICT, ove
     # Merge overrides
     if overrides:
         overrides = cfg2dict(overrides)
-        if 'save_dir' not in cfg:
-            overrides.pop('save_dir', None)  # special override keys to ignore
         check_dict_alignment(cfg, overrides)
         cfg = {**cfg, **overrides}  # merge cfg and overrides dicts (prefer overrides)
 


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->
https://github.com/ultralytics/ultralytics/issues/5128
don't assume users are making a mistake when supplying the save_dir override:
 ```python
#ultralytics.cfg.__init__.py
def get_cfg(cfg: Union[str, Path, Dict, SimpleNamespace] = DEFAULT_CFG_DICT, overrides: Dict = None):
    ...
    # Merge overrides
    if overrides:
        overrides = cfg2dict(overrides)
        # fix -- why so special?
        # if 'save_dir' not in cfg:
            # overrides.pop('save_dir', None)  # special override keys to ignore
        check_dict_alignment(cfg, overrides)
        cfg = {**cfg, **overrides}  # merge cfg and overrides dicts (prefer overrides)
    ...
```

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dddc8a6</samp>

### Summary
🗑️🛠️💾

<!--
1.  🗑️ - This emoji represents the removal or deletion of code, such as the check and pop for the `save_dir` key.
2.  🛠️ - This emoji represents the improvement or simplification of code, such as the new configuration system that handles the `save_dir` key more elegantly.
3.  💾 - This emoji represents the saving or storing of data, such as the `save_dir` key that specifies where to save the model outputs.
-->
Simplify configuration system and remove override keys. Move `save_dir` handling from `cfg` to `setup_run`.

> _`save_dir` is gone_
> _config system simplified_
> _autumn leaves fall fast_

### Walkthrough
*  Simplify configuration system and remove override keys ([link](https://github.com/ultralytics/ultralytics/pull/5168/files?diff=unified&w=0#diff-c02fb3f9e86e97bf85f07211aed56aa04774504a61eeff07a08471bbdea14556L111-L112),                              F




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated configuration handling to accept `save_dir` override.

### 📊 Key Changes
- Removed code that prevented `save_dir` from being overwritten in the configuration.

### 🎯 Purpose & Impact
- Allows developers to set a custom `save_dir` through config overrides, providing more flexibility in specifying where to save outputs.
- Potentially impacts existing workflows that relied on the inability to override `save_dir`, as they may now need to account for this change.