### PR TITLE
Set invisible Pose points to 0.0

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -489,6 +489,9 @@ class Keypoints(BaseTensor):
         """Initializes the Keypoints object with detection keypoints and original image size."""
         if keypoints.ndim == 2:
             keypoints = keypoints[None, :]
+        if keypoints.shape[2] == 3:  # x, y, conf
+            mask = keypoints[..., 2] < 0.5  # points with conf < 0.5 (not visible)
+            keypoints[..., :2][mask] = 0
         super().__init__(keypoints, orig_shape)
         self.has_visible = self.data.shape[-1] == 3
 

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -15,6 +15,7 @@ import torch
 from ultralytics.data.augment import LetterBox
 from ultralytics.utils import LOGGER, SimpleClass, ops
 from ultralytics.utils.plotting import Annotator, colors, save_one_box
+from ultralytics.utils.torch_utils import smart_inference_mode
 
 
 class BaseTensor(SimpleClass):
@@ -485,6 +486,7 @@ class Keypoints(BaseTensor):
         to(device, dtype): Returns a copy of the keypoints tensor with the specified device and dtype.
     """
 
+    @smart_inference_mode()  # avoid keypoints < conf in-place error
     def __init__(self, keypoints, orig_shape) -> None:
         """Initializes the Keypoints object with detection keypoints and original image size."""
         if keypoints.ndim == 2:


### PR DESCRIPTION
Test with

```python
from ultralytics import YOLO

# Load a model
model = YOLO('yolov8n-pose.pt')

# Predict with the model
results = model()

# Show raw results
results[0].keypoints.data
```


<img width="624" alt="Screenshot 2023-10-03 at 21 04 33" src="https://github.com/ultralytics/ultralytics/assets/26833433/7bccc1a9-38e7-4755-866f-bc49238b5ff4">



<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e1909d4</samp>

### Summary
🕵️‍♂️🎭🚫

<!--
1.  🕵️‍♂️ - This emoji represents the condition that inspects the shape of the keypoints array and verifies that it has three dimensions.
2.  🎭 - This emoji represents the mask that filters out the low-confidence keypoints by setting their coordinates to zero, creating a contrast between the visible and invisible keypoints.
3.  🚫 - This emoji represents the effect of the mask, which eliminates the unwanted keypoints from the output.
-->
This pull request improves the filtering of keypoints with low confidence in `ultralytics/engine/results.py`. It adds a check for the keypoints array shape and a mask to zero out the coordinates of the keypoints with confidence below 0.5.

> _`keypoints` array_
> _filter by confidence mask_
> _zero out the rest_

### Walkthrough
*  Filter out low-confidence keypoints by masking their coordinates ([link](https://github.com/ultralytics/ultralytics/pull/5212/files?diff=unified&w=0#diff-24af401e53ffc5ce49197395e1e3d7111344ad31b08cbb2bee9377614da98955R492-R494)) in `results.py`




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced keypoints initialisation with smart inference and visibility check in Ultralytics engine.

### 📊 Key Changes
- Introduced `smart_inference_mode` decorator to optimize the keypoints initialization.
- Added a condition to zero out (x, y) coordinates of keypoints with a confidence score less than 0.5, indicating non-visible points.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: The update seeks to improve performance during the keypoints object initialization and ensure that non-visible points do not affect downstream processing.
- ✅ **Impact**: Users can expect more efficient and reliable keypoints handling, especially when dealing with occluded or partially visible points in images, leading to better detection accuracy.