### PR TITLE
Remove rank confusion for multinode

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -24,9 +24,15 @@ from tqdm import tqdm as tqdm_original
 
 from ultralytics import __version__
 
+import socket
+hostname = socket.gethostname()
+
 # PyTorch Multi-GPU DDP Constants
 RANK = int(os.getenv('RANK', -1))
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
+WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))
+
+print(f'DDP info: HOSTNAME : {hostname}, LOCAL_RANK {LOCAL_RANK}, RANK {RANK}, WORLD_SIZE {WORLD_SIZE}')
 
 # Other Constants
 FILE = Path(__file__).resolve()

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -6,6 +6,7 @@ import logging.config
 import os
 import platform
 import re
+import socket
 import subprocess
 import sys
 import threading
@@ -24,7 +25,6 @@ from tqdm import tqdm as tqdm_original
 
 from ultralytics import __version__
 
-import socket
 hostname = socket.gethostname()
 
 # PyTorch Multi-GPU DDP Constants


### PR DESCRIPTION
As promised here : https://github.com/ultralytics/ultralytics/issues/3428

I updated the code to remove ranks confusions while training on multinode. I took inspiration from yolov5 code. 
I successfully ran training on 2 nodes with 3 GPU each on a SLURM cluster with pytorch 2.1.0

Ping me if you need anything else

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to distributed training setup in Ultralytics' software.

### 📊 Key Changes
- Added socket import to retrieve hostname information.
- Introduced a `@record` decorator to provide additional logging around training functions.
- Adjusted configuration to support improved device handling and environment setup in distributed data parallel (DDP) training.
- Made changes to identify the world size not only from device specifications but also from environment variables in a DDP scenario.
- Setup DDP now initializes with the correct backend, ranks, and timeout settings.
- LOGGER now includes hostname information to assist in debugging multi-node training environments.
- Updated device and rank settings during the setup of DDP and data loaders to align with the latest improvements.
- Added a WORLD_SIZE environment variable to assist with simpler DDP configuration.

### 🎯 Purpose & Impact
- These changes aim to improve the ease of setting up distributed training, making it more robust and clearer for users.
- Reducing the complexity and potential errors when configuring distributed training will benefit users running training jobs across multiple GPUs or nodes.
- The additional logging and environment variable usage can ease the debugging and management of distributed training sessions, potentially leading to better resource utilization and efficiency in training large-scale models. 🔄 
- Users should experience smoother distributed training sessions with more informative logs, which is especially valuable in multi-node or complex setups. 🚀