### PR TITLE
RayTune fix for larger YOLO models

### DIFF
--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -85,7 +85,7 @@ def run_ray_tune(model,
 
     # put the model in ray store
     model_in_store = ray.put(model)
-                   
+
     def _tune(config):
         """
         Trains the YOLO model with the specified hyperparameters and additional arguments.

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -1,7 +1,8 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 import subprocess
-import ray 
+
+import ray
 
 from ultralytics.cfg import TASK2DATA, TASK2METRIC, get_save_dir
 from ultralytics.utils import DEFAULT_CFG, DEFAULT_CFG_DICT, LOGGER, NUM_THREADS

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -1,6 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 import subprocess
+import ray 
 
 from ultralytics.cfg import TASK2DATA, TASK2METRIC, get_save_dir
 from ultralytics.utils import DEFAULT_CFG, DEFAULT_CFG_DICT, LOGGER, NUM_THREADS


### PR DESCRIPTION
…er models

Hello! :) 

Here I utilized ray.put() so that model passed inside a trainable is inside ray store. That way, the problem, as indicated by the error "ValueError: The actor ImplicitFunc is too large", and which occurs for models other than "nano", is solved.

In by putting the larger models in ray store and "unpacking" via ray.get() inside the trainable function, the hyperparameter search can take place for larger models.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 02664c6</samp>

### Summary
🚀🛠️🧠

<!--
1.  🚀 This emoji represents the speed and efficiency gains from using the ray store instead of serializing and deserializing the model object for each trial.
2.  🛠️ This emoji represents the reliability and robustness improvements from avoiding potential errors or inconsistencies that could arise from serializing and deserializing the model object.
3.  🧠 This emoji represents the intelligence and sophistication of the hyperparameter tuning process, which can leverage the ray store to share information and resources across trials.
-->
This pull request enhances the hyperparameter tuning module by using `ray` to share the model object across trials. This avoids redundant loading and saving of the model in `./ultralytics/utils/tuner.py`.

> _`ray store` helps tune_
> _model across many trials_
> _faster and better_

### Walkthrough
*  Store and retrieve the model object in the ray store to avoid serialization overhead and ensure consistency across trials ([link](https://github.com/ultralytics/ultralytics/pull/5348/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659R86-R88), [link](https://github.com/ultralytics/ultralytics/pull/5348/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659R99-R100), [link](https://github.com/ultralytics/ultralytics/pull/5348/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659L107-R112), [link](https://github.com/ultralytics/ultralytics/pull/5348/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659L117-R122))
*  Use the correct metric for the ASHA scheduler based on the model's task attribute, which is obtained from the ray store ([link](https://github.com/ultralytics/ultralytics/pull/5348/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659L107-R112), [link](https://github.com/ultralytics/ultralytics/pull/5348/files?diff=unified&w=0#diff-808b0cbadac7ae9f2d294182a82b86697eac40526ac60febe55c7cb18c114659L117-R122))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced robustness of hyperparameter tuning with Ray integration in Ultralytics' optimizer.

### 📊 Key Changes
- Introduced a direct import statement for the `ray` library for improved clarity in the code.
- Enabled storing and retrieving the model using Ray's object store, ensuring a clean session each time a model is trained during hyperparameter tuning.
- Made the retrieval of default dataset and metric names more consistent by using the `task` variable.

### 🎯 Purpose & Impact
- Ensuring that the `ray` library is explicitly imported improves code maintainability and decreases the chance of runtime errors due to missing dependencies.
- Storing the model in Ray's object store makes each tuning iteration more independent and reduces the risk of side-effects between training runs.
- The consistent approach to fetching dataset and metric information based on the model's task improves the reliability and readability of the code.
- Overall, these changes can potentially lead to more efficient hyperparameter tuning with fewer bugs and better performance of machine learning models developed using Ultralytics' tools. 🔄👌