### PR TITLE
Onnxruntime CPP FP16 Inference Postprocess Bug Fix

### DIFF
--- a/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
+++ b/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
@@ -175,10 +175,18 @@ char *DCSP_CORE::TensorProcess(clock_t &starttime_1, cv::Mat &iImg, N &blob, std
             std::vector<int> class_ids;
             std::vector<float> confidences;
             std::vector<cv::Rect> boxes;
-            cv::Mat rowData(signalResultNum, strideNum, CV_32F, output);
-            rowData = rowData.t();
 
-            float *data = (float *) rowData.data;
+            cv::Mat rawData;
+            if (modelType == 1) {
+                // FP32
+                rawData = cv::Mat(signalResultNum, strideNum, CV_32F, output);
+            } else {
+                // FP16
+                rawData = cv::Mat(signalResultNum, strideNum, CV_16F, output);
+                rawData.convertTo(rawData, CV_32F);
+            }
+            rawData = rawData.t();
+            float *data = (float *) rawData.data;
 
             float x_factor = iImg.cols / 640.;
             float y_factor = iImg.rows / 640.;


### PR DESCRIPTION
The onnxruntime cpp example does not work properly with the fp16 model. The results are not correct.

In function TensorProcess, inference.cpp
```cpp
/* ... */
auto output = outputTensor.front().GetTensorMutableData<typename std::remove_pointer<N>::type>();
switch (modelType) {
    case 1://V8_ORIGIN_FP32
    case 4://V8_ORIGIN_FP16
    {
        /* ... */
        cv::Mat rowData(signalResultNum, strideNum, CV_32F, output);
        rowData = rowData.t();

        float *data = (float *) rowData.data;
        /* ... */
```
The output tensor is converted to a CV_32F Mat but when fp16 model is used, the data type of output tensor is ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 which can not be used for creating a CV_32F Mat directly.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7756209</samp>

### Summary
🧠🔄🕵️‍♂️

<!--
1.  🧠 - This emoji represents the inference or reasoning process that the `E` class performs on the input image using the ONNX model. It also suggests the intelligence or smartness of the model and the class.
2.  🔄 - This emoji represents the conversion or transformation of the output data from the model to a 32-bit floating point matrix, regardless of the model type. It also suggests the flexibility or adaptability of the class to handle different model types.
3.  🕵️‍♂️ - This emoji represents the detection or identification of the objects and their confidences and bounding boxes in the output matrix. It also suggests the accuracy or precision of the model and the class.
-->
Support FP16 ONNX models in `inference.cpp`. Add logic to convert output data to FP32 matrix based on model type.

> _`E` class adapts_
> _to FP16 models now_
> _autumn of inference_

### Walkthrough
*  Support FP16 models by converting output data to 32-bit floating point matrix ([link](https://github.com/ultralytics/ultralytics/pull/5760/files?diff=unified&w=0#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8L178-R189))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ONNXRuntime C++ example with FP16 support.

### 📊 Key Changes
- Added a conditional block to handle both FP32 (single precision floating-point) and FP16 (half precision floating-point) model types.
- Introduced a `modelType` variable to switch between data types.
- Applied a matrix transpose operation to the `rawData` for both FP32 and FP16.
- Performed data type conversion from FP16 to FP32 to maintain compatibility with further processing steps.

### 🎯 Purpose & Impact
- 🎨 Enabling FP16 support allows for using models that are optimized for speed and memory usage, especially beneficial for devices with limited resources.
- 🚀 Potential speed improvements due to reduced precision computations in inference.
- 🔧 Provides flexibility to developers and users by accommodating different ONNX model types without compromising the code structure.
- 💻 Ultimately, users gain an opportunity to run faster, more efficient object detection models while developers maintain a clean and adaptable codebase.