### PR TITLE
half=True for onnx

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -313,6 +313,8 @@ class Exporter:
         requirements = ['onnx>=1.12.0']
         if self.args.simplify:
             requirements += ['onnxsim>=0.4.33', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime']
+        if self.args.half:
+            requirements += ['onnxconverter_common']
         check_requirements(requirements)
         import onnx  # noqa
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -361,11 +361,12 @@ class Exporter:
         if self.args.half:
             try:
                 import onnxconverter_common
-                LOGGER.info(f'{prefix} converting to float16 with onnxconverter_common {onnxconverter_common.__version__}...')
+                LOGGER.info(
+                    f'{prefix} converting to float16 with onnxconverter_common {onnxconverter_common.__version__}...')
                 model_onnx = onnxconverter_common.float16.convert_float_to_float16(model_onnx)
             except Exception as e:
                 LOGGER.info(f'{prefix} convert to float16 failure: {e}')
-        
+
         # Metadata
         for k, v in self.metadata.items():
             meta = model_onnx.metadata_props.add()

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -357,6 +357,15 @@ class Exporter:
             except Exception as e:
                 LOGGER.info(f'{prefix} simplifier failure: {e}')
 
+        # Convert to float16
+        if self.args.half:
+            try:
+                import onnxconverter_common
+                LOGGER.info(f'{prefix} converting to float16 with onnxconverter_common {onnxconverter_common.__version__}...')
+                model_onnx = onnxconverter_common.float16.convert_float_to_float16(model_onnx)
+            except Exception as e:
+                LOGGER.info(f'{prefix} convert to float16 failure: {e}')
+        
         # Metadata
         for k, v in self.metadata.items():
             meta = model_onnx.metadata_props.add()


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5a70c0a</samp>

### Summary
🚀🎛️📦

<!--
1.  🚀 This emoji can signify a performance improvement or a new feature that boosts the speed or efficiency of the engine.
2.  🎛️ This emoji can signify a new option or parameter that gives the user more control or flexibility over the engine's behavior or output.
3.  📦 This emoji can signify a dependency or package that is added or updated to support the new functionality or improvement.
-->
Add float16 conversion option for ONNX export. This change allows users to optionally reduce the size and increase the speed of their ONNX models using `onnxconverter_common`. The change affects `ultralytics/engine/exporter.py`.

> _`onnxconverter_common`_
> _Shrinks and speeds up ONNX models_
> _Fall leaves float lightly_

### Walkthrough
* Add an option to convert ONNX model to float16 precision ([link](https://github.com/ultralytics/ultralytics/pull/5763/files?diff=unified&w=0#diff-b9f4cf4260fabd8ffb31e9a85b332a63d39fb49829ce1d98d980b2ec3549322cR360-R368))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ONNX export functionality with half-precision (float16) support.

### 📊 Key Changes
- Added a new requirement for `onnxconverter_common` when the `--half` flag is used.
- Implemented conversion to float16 during the ONNX export process.

### 🎯 Purpose & Impact
- **Purpose**: To reduce the size and potentially increase the inference speed of ONNX models by supporting half-precision floats.
- **Impact**: Users who need smaller model sizes for deployment on platforms with limited resources or who want faster inference might benefit significantly from this update. 🚀