### PR TITLE
Account for machine epsilon in image _single_check

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -451,7 +451,11 @@ class LoadTensor:
             im = im.unsqueeze(0)
         if im.shape[2] % stride or im.shape[3] % stride:
             raise ValueError(s)
-        if im.max() > 1.0:
+
+        # Calculate machine epsilon for this image
+        # e.g. torch.float32 epsilon is 1.1920928955078125e-07
+        epsilon = torch.finfo(im.dtype).eps      
+        if im.max() - 1.0 > epsilon:
             LOGGER.warning(f'WARNING ⚠️ torch.Tensor inputs should be normalized 0.0-1.0 but max value is {im.max()}. '
                            f'Dividing input by 255.')
             im = im.float() / 255.0

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -451,11 +451,7 @@ class LoadTensor:
             im = im.unsqueeze(0)
         if im.shape[2] % stride or im.shape[3] % stride:
             raise ValueError(s)
-
-        # Calculate machine epsilon for this image
-        # e.g. torch.float32 epsilon is 1.1920928955078125e-07
-        epsilon = torch.finfo(im.dtype).eps
-        if im.max() - 1.0 > epsilon:
+        if im.max() > 1.0 + torch.finfo(im.dtype).eps:  # torch.float32 eps is 1.2e-07
             LOGGER.warning(f'WARNING ⚠️ torch.Tensor inputs should be normalized 0.0-1.0 but max value is {im.max()}. '
                            f'Dividing input by 255.')
             im = im.float() / 255.0

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -454,7 +454,7 @@ class LoadTensor:
 
         # Calculate machine epsilon for this image
         # e.g. torch.float32 epsilon is 1.1920928955078125e-07
-        epsilon = torch.finfo(im.dtype).eps      
+        epsilon = torch.finfo(im.dtype).eps
         if im.max() - 1.0 > epsilon:
             LOGGER.warning(f'WARNING ⚠️ torch.Tensor inputs should be normalized 0.0-1.0 but max value is {im.max()}. '
                            f'Dividing input by 255.')


### PR DESCRIPTION
The previous comparison, `im.max() > 1.0`, was failing on my image with the message:

```
WARNING  torch.Tensor inputs should be normalized 0.0-1.0 but max value is
1.0000001192092896. Dividing input by 255.
```

However, my image was fine; this number is actually 1, just within the machine epsilon of the `torch.float32` data type.

This new check accounts for that properly.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 518158b</samp>

### Summary
:mag::warning::chart_with_upwards_trend:

<!--
1.  :mag: This emoji represents the idea of finding or searching for something, which relates to the calculation of the machine epsilon and the comparison of the maximum value with 1.0.
2.  :warning: This emoji represents the idea of alerting or warning about something, which relates to the purpose of avoiding false warnings when the image is already normalized.
3.  :chart_with_upwards_trend: This emoji represents the idea of improving or optimizing something, which relates to the context of using the `_single_check` function for the `LoadTensor` class, which is a custom data loader for torch.Tensor inputs.
-->
Improved the normalization check for image tensors in `LoadTensor` data loader. Added a machine epsilon tolerance to avoid false warnings in `_single_check` function in `ultralytics/data/loaders.py`.

> _`_single_check` warns_
> _when image is not normalized_
> _epsilon fixes it_

### Walkthrough
*  Add machine epsilon comparison to avoid false warnings for normalized images ([link](https://github.com/ultralytics/ultralytics/pull/5898/files?diff=unified&w=0#diff-3687f61e2371eaae4d90d58bf3aa6be449b113677b3ce104fd0d868b7df441deL454-R458))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to image normalization check in data loader.

### 📊 Key Changes
- Updated the condition that checks if image pixel values are normalized.

### 🎯 Purpose & Impact
- **Purpose:** The modification ensures that the check for image normalization accounts for floating-point precision errors, making the condition more robust.
- **Impact:** The change reduces potential false-positive errors during image loading due to the finite precision of floating-point numbers, improving user experience especially when working with image data that is already close to the upper normalization bound. ✨🖼️