### PR TITLE
Limit setup.py for python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def parse_requirements(file_path: Path):
 setup(
     name='ultralytics',  # name of pypi package
     version=get_version(),  # version of pypi package
-    python_requires='>=3.8, !=3.12.*'
+    python_requires='>=3.8, !=3.12.*',
     license='AGPL-3.0',
     description=('Ultralytics YOLOv8 for SOTA object detection, multi-object tracking, instance segmentation, '
                  'pose estimation and image classification.'),

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def parse_requirements(file_path: Path):
 setup(
     name='ultralytics',  # name of pypi package
     version=get_version(),  # version of pypi package
-    python_requires='>=3.8',
+    python_requires='>=3.8', '!=3.12.*'
     license='AGPL-3.0',
     description=('Ultralytics YOLOv8 for SOTA object detection, multi-object tracking, instance segmentation, '
                  'pose estimation and image classification.'),

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def parse_requirements(file_path: Path):
 setup(
     name='ultralytics',  # name of pypi package
     version=get_version(),  # version of pypi package
-    python_requires='>=3.8, !=3.12.*',
+    python_requires='>=3.8,<3.12',
     license='AGPL-3.0',
     description=('Ultralytics YOLOv8 for SOTA object detection, multi-object tracking, instance segmentation, '
                  'pose estimation and image classification.'),

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def parse_requirements(file_path: Path):
 setup(
     name='ultralytics',  # name of pypi package
     version=get_version(),  # version of pypi package
-    python_requires='>=3.8', '!=3.12.*'
+    python_requires='>=3.8, !=3.12.*'
     license='AGPL-3.0',
     description=('Ultralytics YOLOv8 for SOTA object detection, multi-object tracking, instance segmentation, '
                  'pose estimation and image classification.'),


### PR DESCRIPTION
Restrict `setup.py` for installs on any `python 3.12` environments. Since PyTorch does not yet support python 3.12, adding upper bound `!=3.12.*` to prevent users from attempting installation when using python 3.12. Observed multiple users reporting issues in Discord related to attempted installation using python 3.12.

## Example of error shown during python 3.12 install
![image](https://github.com/ultralytics/ultralytics/assets/62214284/9bbd84e6-c829-41c7-ad85-54d477312566)

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8fe8c03</samp>

### Summary
:arrow_up::no_entry_sign::memo:

<!--
1.  :arrow_up: This emoji can be used to indicate that the package metadata was updated or upgraded, as well as to suggest that the change is related to versioning or dependencies.
2.  :no_entry_sign: This emoji can be used to indicate that something was excluded, blocked, or denied, as well as to suggest that the change is related to compatibility or restrictions.
3.  :memo: This emoji can be used to indicate that the documentation was updated or improved, as well as to suggest that the change is related to writing or communication.
-->
Updated package metadata and documentation to reflect current status and requirements. Restricted `python_requires` in `setup.py` to exclude future Python 3.12 version.

> _`python_requires`_
> _No future version for now_
> _Autumn leaves falling_

### Walkthrough
*  Exclude Python 3.12 from the supported versions ([link](https://github.com/ultralytics/ultralytics/pull/5899/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L48-R48)) to avoid potential compatibility issues with future releases




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upping the Python version compatibility for Ultralytics package.

### 📊 Key Changes
- The Python version requirement for the `ultralytics` package has been updated to support versions between 3.8 and before 3.12.

### 🎯 Purpose & Impact
- **Ensure Compatibility:** This change ensures that the Ultralytics package is compatible with a wider but specific range of Python versions, preventing potential issues with newer, yet unsupported Python versions.
- **Future-Proofing:** Helps in maintaining the library's functionality across various Python environments, ensuring users have a smooth experience without running into compatibility issues.
- **Impact to Users:** Users must now be mindful of the Python version they are using when installing the `ultralytics` package. It provides clarity on which versions are officially supported, reducing the chances of encountering unexpected bugs due to version incompatibilities. 🐍✨