### PR TITLE
Add reset function to trackers

### DIFF
--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -192,3 +192,9 @@ class BOTSORT(BYTETracker):
     def multi_predict(self, tracks):
         """Predict and track multiple objects with YOLOv8 model."""
         BOTrack.multi_predict(tracks)
+
+    def reset(self):
+        """Reset tracker."""
+        super().reset()
+        self.gmc.reset_params()
+

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -197,4 +197,3 @@ class BOTSORT(BYTETracker):
         """Reset tracker."""
         super().reset()
         self.gmc.reset_params()
-

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -374,6 +374,15 @@ class BYTETracker:
         """Resets the ID counter of STrack."""
         STrack.reset_id()
 
+    def reset(self):
+        """Reset tracker."""
+        self.tracked_stracks = []  # type: list[STrack]
+        self.lost_stracks = []  # type: list[STrack]
+        self.removed_stracks = []  # type: list[STrack]
+        self.frame_id = 0
+        self.kalman_filter = self.get_kalmanfilter()
+        self.reset_id()
+
     @staticmethod
     def joint_stracks(tlista, tlistb):
         """Combine two lists of stracks into a single one."""

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -1,6 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 from functools import partial
+from pathlib import Path
 
 import torch
 
@@ -40,8 +41,12 @@ def on_predict_start(predictor, persist=False):
 def on_predict_postprocess_end(predictor):
     """Postprocess detected boxes and update with object tracking."""
     bs = predictor.dataset.bs
-    im0s = predictor.batch[1]
+    path, im0s = predictor.batch[:2]
+
     for i in range(bs):
+        if predictor.vid_path[i] != str(predictor.save_dir / Path(path[i]).name):  # new video
+            predictor.trackers[i].reset()
+
         det = predictor.results[i].boxes.cpu().numpy()
         if len(det) == 0:
             continue

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -300,3 +300,10 @@ class GMC:
         self.prevKeyPoints = copy.copy(keypoints)
 
         return H
+
+    def reset_params(self):
+        """Reset parameters."""
+        self.prevFrame = None
+        self.prevKeyPoints = None
+        self.prevDescriptors = None
+        self.initializedFirstFrame = False


### PR DESCRIPTION
After this PR, trackers will be reset when inference on different videos in the same folder.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 94a5612</samp>

### Summary
🔄🎥🔧

<!--
1.  🔄 This emoji represents the idea of resetting or restarting something, which is the main functionality added by these changes. It also conveys a sense of circular motion, which is related to the global motion compensation algorithm.
2. 🎥 This emoji represents the idea of video processing, which is the context in which these changes are applied. It also conveys a sense of capturing and tracking motion, which is the goal of the tracker.
3. 🔧 This emoji represents the idea of adjusting or modifying something, which is what the `reset_params` and `reset` methods do to the tracker components. It also conveys a sense of fixing or improving something, which is the motivation for these changes.
-->
This pull request adds `reset` methods to the `Track`, `BOTSort`, and `BYTETracker` classes, and a `reset_params` method to the `GMC` class, to enable resetting the tracker state when switching to a new video. It also uses the `Path` class to handle file paths in the `Track` class.

> _We are the trackers of the night_
> _We follow every motion and every fight_
> _But when the video changes we must reset_
> _Or face the doom of losing our target_

### Walkthrough
*  Add `reset` methods to `BOTSort` and `BYTETracker` classes to clear their state when a new video is processed ([link](https://github.com/ultralytics/ultralytics/pull/5979/files?diff=unified&w=0#diff-f434469b0f2be3297026e1f42d92ad7237ce16a19b791f7a9c9f2762defb3f30R195-R200), [link](https://github.com/ultralytics/ultralytics/pull/5979/files?diff=unified&w=0#diff-73a5aa7f9038e6b81c75736b0c0e5ceb6ed922312774a6524dd2c857ff41d717R377-R385))
*  Modify `on_predict_postprocess_end` method in `Track` class to call `reset` methods of trackers and compare video paths using `Path` class ([link](https://github.com/ultralytics/ultralytics/pull/5979/files?diff=unified&w=0#diff-bdb6386c91992a2e78da487232bf0e4796032c2c3256bdb6a9c640951ef6415aR4), [link](https://github.com/ultralytics/ultralytics/pull/5979/files?diff=unified&w=0#diff-bdb6386c91992a2e78da487232bf0e4796032c2c3256bdb6a9c640951ef6415aL43-R49))
*  Add `reset_params` method to `GMC` class to reset its attributes when a new video is processed ([link](https://github.com/ultralytics/ultralytics/pull/5979/files?diff=unified&w=0#diff-7f45e5bf2640fef899a34a9b10eaae262e1afd6329687e77fa6f8548912d2b2dR303-R309))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to object tracking with reset capabilities for trackers in the Ultralytics library.

### 📊 Key Changes
- Implemented a `reset` method in `bot_sort.py` to reset the tracker to its initial state.
- Added a `reset` method in `byte_tracker.py`, clearing lists of tracked, lost, and removed objects and resetting frame ID and ID counters.
- Ensured trackers reset when a new video starts in `track.py` by comparing the video path.
- Introduced a `reset_params` method in `gmc.py` to reset frame details and foundational tracking parameters.

### 🎯 Purpose & Impact
- The new reset methods allow for better memory management and more consistent tracking between separate video feeds or tracking sessions.
- Should lead to improved tracking accuracy and reliability when processing multiple videos or reinitializing trackers in the same session.
- Tracker reset can help in scenarios where real-time systems handle multiple video sources, providing a clean state for each new video feed. 🔄