### PR TITLE
Allow for arguments to be passed to DDP processes.

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -15,6 +15,7 @@ save: True  # (bool) save train checkpoints and predict results
 save_period: -1 # (int) Save checkpoint every x epochs (disabled if < 1)
 cache: False  # (bool) True/ram, disk or False. Use cache for data loading
 device:  # (int | str | list, optional) device to run on, i.e. cuda device=0 or device=0,1,2,3 or device=cpu
+distributed_args: [] # Arguments to pass to script for each instance spawned with torch.distributed.run
 workers: 8  # (int) number of worker threads for data loading (per RANK if DDP)
 project:  # (str, optional) project name
 name:  # (str, optional) experiment name, results saved to 'project/name' directory

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -179,7 +179,7 @@ class BaseTrainer:
                 self.args.batch = 16
 
             # Command
-            cmd, file = generate_ddp_command(world_size, self)
+            cmd, file = generate_ddp_command(world_size, self.args.distributed_args, self)
             try:
                 LOGGER.info(f'{colorstr("DDP:")} debug command {" ".join(cmd)}')
                 subprocess.run(cmd, check=True)

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -58,8 +58,8 @@ def generate_ddp_command(world_size, distributed_args, trainer):
         file = generate_ddp_file(trainer)
     dist_cmd = 'torch.distributed.run' if TORCH_1_9 else 'torch.distributed.launch'
     port = find_free_network_port()
-    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file
-           ] + distributed_args
+    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file]
+    cmd.extend(distributed_args)
     return cmd, file
 
 

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -58,7 +58,8 @@ def generate_ddp_command(world_size, distributed_args, trainer):
         file = generate_ddp_file(trainer)
     dist_cmd = 'torch.distributed.run' if TORCH_1_9 else 'torch.distributed.launch'
     port = find_free_network_port()
-    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file] + distributed_args
+    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file
+           ] + distributed_args
     return cmd, file
 
 

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -47,7 +47,7 @@ def generate_ddp_file(trainer):
     return file.name
 
 
-def generate_ddp_command(world_size, trainer):
+def generate_ddp_command(world_size, distributed_args, trainer):
     """Generates and returns command for distributed training."""
     import __main__  # noqa local import to avoid https://github.com/Lightning-AI/lightning/issues/15218
     if not trainer.resume:
@@ -58,7 +58,7 @@ def generate_ddp_command(world_size, trainer):
         file = generate_ddp_file(trainer)
     dist_cmd = 'torch.distributed.run' if TORCH_1_9 else 'torch.distributed.launch'
     port = find_free_network_port()
-    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file]
+    cmd = [sys.executable, '-m', dist_cmd, '--nproc_per_node', f'{world_size}', '--master_port', f'{port}', file] + distributed_args
     return cmd, file
 
 


### PR DESCRIPTION
I have been running into issues with using DDP to perform multi-GPU training on a python script requiring command-line arguments, as described in #5989. This PR adds a new argument to the training function which is made use of in the trainer class. This argument is a list of strings which will simply be appended onto the command line when running the `torch.distributed.run` script.

A new default argument is made `distributed_args` which is defaulted to `[]` in the `default.yaml` file. The `train` function in the `BaseTrainer` now passes `self.args.distributed_args` to the `generate_ddp_command` function. The user-defined arguments specified in the `distributed_args` list are simply appended to the end of the returned list.

Please notify me if I have missed anything, as this is my first PR to a public repository so I am not 100% sure of the general process/etiquette involved here. I would be happy to answer any questions!

I have read the CLA Document and I sign the CLA

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3640ea3</samp>

### Summary
📝🚀🌐

<!--
1.  📝 - This emoji represents the addition of a new configuration option to the YAML file.
2.  🚀 - This emoji represents the modification of the `train` method to pass the extra arguments to the distributed training command.
3.  🌐 - This emoji represents the enhancement of the distributed mode to accept custom arguments for the script.
-->
This pull request enables passing custom arguments to the script that runs in distributed mode with `torch.distributed`. It adds a new configuration option `distributed_args` to the default YAML file and the `generate_ddp_command` function, and modifies the `BaseTrainer` class to use it.

> _If you want to train models with `torch`_
> _And use distributed mode as your approach_
> _You can now add some flags_
> _To your script or data bags_
> _With the new option `distributed_args`_

### Walkthrough
*  Add a new configuration option `distributed_args` to allow the user to specify extra arguments for distributed training ([link](https://github.com/ultralytics/ultralytics/pull/5990/files?diff=unified&w=0#diff-732d61cb4969eff986cec58058000b2949ea3b429a97ca5a1045897e754145c5R18))
*  Pass the `distributed_args` option to the `generate_ddp_command` function in the `train` method of the `BaseTrainer` class ([link](https://github.com/ultralytics/ultralytics/pull/5990/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL182-R182))
*  Modify the `generate_ddp_command` function in `dist.py` to accept and append the `distributed_args` parameter to the command list ([link](https://github.com/ultralytics/ultralytics/pull/5990/files?diff=unified&w=0#diff-6d6c6436fc82e51c808c2c794bc3f4f74c8d960fccb1157ea2899feeca50fd10L50-R50), [link](https://github.com/ultralytics/ultralytics/pull/5990/files?diff=unified&w=0#diff-6d6c6436fc82e51c808c2c794bc3f4f74c8d960fccb1157ea2899feeca50fd10L61-R61))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced distributed training configuration support in Ultralytics framework.

### 📊 Key Changes
- Added a new `distributed_args` configuration option in `default.yaml`.
- Updated `train` method in `trainer.py` to pass `distributed_args` to the distributed training command generator.
- Modified the `generate_ddp_command` function in `utils/dist.py` to include additional distributed training arguments.

### 🎯 Purpose & Impact
- Allows for more flexible distributed training setups by passing custom arguments to Torch's distributed training script.
- Users can now fine-tune distributed training behavior directly from the configuration file, improving ease of use and customization. 🛠️
- The change could potentially lead to more efficient training on distributed systems by allowing advanced users to optimize their setups. 🚀