### PR TITLE
[example] add yolov8 segmentation onnxruntime python demo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ This repository features a collection of real-world applications and walkthrough
 ### Ultralytics YOLO Example Applications
 
 | Title                                                                                                                                     | Format             | Contributor                                                                               |
-|-------------------------------------------------------------------------------------------------------------------------------------------|--------------------|-------------------------------------------------------------------------------------------|
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
 | [YOLO ONNX Detection Inference with C++](./YOLOv8-CPP-Inference)                                                                          | C++/ONNX           | [Justas Bartnykas](https://github.com/JustasBart)                                         |
 | [YOLO OpenCV ONNX Detection Python](./YOLOv8-OpenCV-ONNX-Python)                                                                          | OpenCV/Python/ONNX | [Farid Inawan](https://github.com/frdteknikelektro)                                       |
 | [YOLOv8 .NET ONNX ImageSharp](https://github.com/dme-compunet/YOLOv8)                                                                     | C#/ONNX/ImageSharp | [Compunet](https://github.com/dme-compunet)                                               |
@@ -23,10 +23,10 @@ This repository features a collection of real-world applications and walkthrough
 We welcome contributions from the community in the form of examples, applications, and guides. To contribute, please follow these steps:
 
 1. Create a pull request (PR) with the `[Example]` prefix in the title, adding your project folder to the `examples/` directory in the repository.
-2. Ensure that your project meets the following criteria:
-    - Utilizes the `ultralytics` package.
-    - Includes a `README.md` file with instructions on how to run the project.
-    - Avoids adding large assets or dependencies unless absolutely necessary.
-    - The contributor is expected to provide support for issues related to their examples.
+1. Ensure that your project meets the following criteria:
+   - Utilizes the `ultralytics` package.
+   - Includes a `README.md` file with instructions on how to run the project.
+   - Avoids adding large assets or dependencies unless absolutely necessary.
+   - The contributor is expected to provide support for issues related to their examples.
 
 If you have any questions or concerns about these requirements, please submit a PR, and we will be more than happy to guide you.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ This repository features a collection of real-world applications and walkthrough
 ### Ultralytics YOLO Example Applications
 
 | Title                                                                                                                                     | Format             | Contributor                                                                               |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
+|-------------------------------------------------------------------------------------------------------------------------------------------|--------------------|-------------------------------------------------------------------------------------------|
 | [YOLO ONNX Detection Inference with C++](./YOLOv8-CPP-Inference)                                                                          | C++/ONNX           | [Justas Bartnykas](https://github.com/JustasBart)                                         |
 | [YOLO OpenCV ONNX Detection Python](./YOLOv8-OpenCV-ONNX-Python)                                                                          | OpenCV/Python/ONNX | [Farid Inawan](https://github.com/frdteknikelektro)                                       |
 | [YOLOv8 .NET ONNX ImageSharp](https://github.com/dme-compunet/YOLOv8)                                                                     | C#/ONNX/ImageSharp | [Compunet](https://github.com/dme-compunet)                                               |
@@ -16,16 +16,17 @@ This repository features a collection of real-world applications and walkthrough
 | [RTDETR ONNXRuntime C#](https://github.com/Kayzwer/yolo-cs/blob/master/RTDETR.cs)                                                         | C#/ONNX            | [Kayzwer](https://github.com/Kayzwer)                                                     |
 | [YOLOv8 SAHI Video Inference](https://github.com/RizwanMunawar/ultralytics/blob/main/examples/YOLOv8-SAHI-Inference-Video/yolov8_sahi.py) | Python             | [Muhammad Rizwan Munawar](https://github.com/RizwanMunawar)                               |
 | [YOLOv8 Region Counter](https://github.com/RizwanMunawar/ultralytics/blob/main/examples/YOLOv8-Region-Counter/yolov8_region_counter.py)   | Python             | [Muhammad Rizwan Munawar](https://github.com/RizwanMunawar)                               |
+| [YOLOv8 Segmentation ONNXRuntime Python](./YOLOv8-Segmentation-ONNXRuntime-Python)                                                        | Python/ONNXRuntime | [jamjamjon](https://github.com/jamjamjon)                                                 |
 
 ### How to Contribute
 
 We welcome contributions from the community in the form of examples, applications, and guides. To contribute, please follow these steps:
 
 1. Create a pull request (PR) with the `[Example]` prefix in the title, adding your project folder to the `examples/` directory in the repository.
-1. Ensure that your project meets the following criteria:
-   - Utilizes the `ultralytics` package.
-   - Includes a `README.md` file with instructions on how to run the project.
-   - Avoids adding large assets or dependencies unless absolutely necessary.
-   - The contributor is expected to provide support for issues related to their examples.
+2. Ensure that your project meets the following criteria:
+    - Utilizes the `ultralytics` package.
+    - Includes a `README.md` file with instructions on how to run the project.
+    - Avoids adding large assets or dependencies unless absolutely necessary.
+    - The contributor is expected to provide support for issues related to their examples.
 
 If you have any questions or concerns about these requirements, please submit a PR, and we will be more than happy to guide you.

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,13 +20,15 @@ This repository features a collection of real-world applications and walkthrough
 
 ### How to Contribute
 
-We welcome contributions from the community in the form of examples, applications, and guides. To contribute, please follow these steps:
+We greatly appreciate contributions from the community, including examples, applications, and guides. If you'd like to contribute, please follow these guidelines:
 
-1. Create a pull request (PR) with the `[Example]` prefix in the title, adding your project folder to the `examples/` directory in the repository.
-1. Ensure that your project meets the following criteria:
-   - Utilizes the `ultralytics` package.
-   - Includes a `README.md` file with instructions on how to run the project.
-   - Avoids adding large assets or dependencies unless absolutely necessary.
-   - The contributor is expected to provide support for issues related to their examples.
+1. Create a pull request (PR) with the title prefix `[Example]`, adding your new example folder to the `examples/` directory within the repository.
+1. Make sure your project adheres to the following standards:
+   - Makes use of the `ultralytics` package.
+   - Includes a `README.md` with clear instructions for setting up and running the example.
+   - Refrains from adding large files or dependencies unless they are absolutely necessary for the example.
+   - Contributors should be willing to provide support for their examples and address related issues.
 
-If you have any questions or concerns about these requirements, please submit a PR, and we will be more than happy to guide you.
+For more detailed information and guidance on contributing, please visit our [contribution documentation](https://docs.ultralytics.com/help/contributing).
+
+If you encounter any questions or concerns regarding these guidelines, feel free to open a PR or an issue in the repository, and we will assist you in the contribution process.

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
@@ -1,0 +1,19 @@
+# YOLOv8-ONNXRuntime-Segmentation-Python Demo
+
+This project implements YOLOv8 segmentation using ONNX Runtime. No PyTorch code, just Numpy and OpenCV.
+
+## Installing Required Dependencies
+
+```bash
+pip install untralytics 
+pip install onnxruntime-gpu   
+# pip install onnxruntime  # No NVIDIA GPU
+pip install numpy
+pip install opencv
+```
+
+## Usage
+
+```bash
+python main.py --model yolov8s-seg.onnx --img IMAGE_PATH
+```

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
@@ -1,19 +1,35 @@
-# YOLOv8-ONNXRuntime-Segmentation-Python Demo
+# YOLOv8-Segmentation-ONNXRuntime-Python Demo
 
-This project implements YOLOv8 segmentation using ONNX Runtime. **No PyTorch code, just Numpy and OpenCV.**
+This project implements YOLOv8 segmentation using ONNX Runtime. 
 
-## Installing Required Dependencies
+ - No PyTorch imported! Just Numpy and OpenCV.
+ - Support both FP32 and FP16 ONNX model.
+
+
+
+## Installation 
 
 ```bash
-pip install untralytics
-pip install onnxruntime-gpu
-# pip install onnxruntime  # No NVIDIA GPU
+pip install untralytics  # for exporting YOLOv8-seg ONNX model and using some basic functions
+pip install onnxruntime-gpu   
+# pip install onnxruntime  # If has no NVIDIA GPU -> uncomment this line
 pip install numpy
 pip install opencv
 ```
 
-## Usage
 
+## 1. Get ONNX model first
 ```bash
-python main.py --model yolov8s-seg.onnx --img IMAGE_PATH
+yolo export model=yolov8s-seg.pt imgsz=640 format=onnx opset=12 simplify=true
+
 ```
+
+
+## 2. Run
+
+```python
+python main.py --model <MODEL_PATH> --source <IMAGE_PATH>
+```
+
+Then you will get the results like this:
+![demo](https://github.com/jamjamjon/ultralytics/assets/51357717/44759936-43d7-430b-89ea-c3af770c21c0)

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
@@ -1,6 +1,6 @@
 # YOLOv8-ONNXRuntime-Segmentation-Python Demo
 
-This project implements YOLOv8 segmentation using ONNX Runtime. No PyTorch code, just Numpy and OpenCV.
+This project implements YOLOv8 segmentation using ONNX Runtime. **No PyTorch code, just Numpy and OpenCV.**
 
 ## Installing Required Dependencies
 

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
@@ -5,8 +5,8 @@ This project implements YOLOv8 segmentation using ONNX Runtime. **No PyTorch cod
 ## Installing Required Dependencies
 
 ```bash
-pip install untralytics 
-pip install onnxruntime-gpu   
+pip install untralytics
+pip install onnxruntime-gpu
 # pip install onnxruntime  # No NVIDIA GPU
 pip install numpy
 pip install opencv

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
@@ -1,29 +1,26 @@
 # YOLOv8-Segmentation-ONNXRuntime-Python Demo
 
-This project implements YOLOv8 segmentation using ONNX Runtime. 
+This project implements YOLOv8 segmentation using ONNX Runtime.
 
- - No PyTorch imported! Just Numpy and OpenCV.
- - Support both FP32 and FP16 ONNX model.
+- No PyTorch imported! Just Numpy and OpenCV.
+- Support both FP32 and FP16 ONNX model.
 
-
-
-## Installation 
+## Installation
 
 ```bash
 pip install untralytics  # for exporting YOLOv8-seg ONNX model and using some basic functions
-pip install onnxruntime-gpu   
+pip install onnxruntime-gpu
 # pip install onnxruntime  # If has no NVIDIA GPU -> uncomment this line
 pip install numpy
 pip install opencv
 ```
 
-
 ## 1. Get ONNX model first
+
 ```bash
 yolo export model=yolov8s-seg.pt imgsz=640 format=onnx opset=12 simplify=true
 
 ```
-
 
 ## 2. Run
 

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/README.md
@@ -1,32 +1,63 @@
 # YOLOv8-Segmentation-ONNXRuntime-Python Demo
 
-This project implements YOLOv8 segmentation using ONNX Runtime.
+This repository provides a Python demo for performing segmentation with YOLOv8 using ONNX Runtime, highlighting the interoperability of YOLOv8 models without the need for the full PyTorch stack.
 
-- No PyTorch imported! Just Numpy and OpenCV.
-- Support both FP32 and FP16 ONNX model.
+## Features
+
+- **Framework Agnostic**: Runs segmentation inference purely on ONNX Runtime without importing PyTorch.
+- **Efficient Inference**: Supports both FP32 and FP16 precision for ONNX models, catering to different computational needs.
+- **Ease of Use**: Utilizes simple command-line arguments for model execution.
+- **Broad Compatibility**: Leverages Numpy and OpenCV for image processing, ensuring broad compatibility with various environments.
 
 ## Installation
 
+Install the required packages using pip. You will need `ultralytics` for exporting YOLOv8-seg ONNX model and using some utility functions, `onnxruntime-gpu` for GPU-accelerated inference, and `opencv-python` for image processing.
+
 ```bash
-pip install untralytics  # for exporting YOLOv8-seg ONNX model and using some basic functions
-pip install onnxruntime-gpu
-# pip install onnxruntime  # If has no NVIDIA GPU -> uncomment this line
+pip install ultralytics
+pip install onnxruntime-gpu  # For GPU support
+# pip install onnxruntime    # Use this instead if you don't have an NVIDIA GPU
 pip install numpy
-pip install opencv
+pip install opencv-python
 ```
 
-## 1. Get ONNX model first
+## Getting Started
+
+### 1. Export the YOLOv8 ONNX Model
+
+Export the YOLOv8 segmentation model to ONNX format using the provided `ultralytics` package.
 
 ```bash
-yolo export model=yolov8s-seg.pt imgsz=640 format=onnx opset=12 simplify=true
-
+yolo export model=yolov8s-seg.pt imgsz=640 format=onnx opset=12 simplify
 ```
 
-## 2. Run
+### 2. Run Inference
 
-```python
-python main.py --model <MODEL_PATH> --source <IMAGE_PATH>
+Perform inference with the exported ONNX model on your images.
+
+```bash
+python main.py --model-path <MODEL_PATH> --source <IMAGE_PATH>
 ```
 
-Then you will get the results like this:
-![demo](https://github.com/jamjamjon/ultralytics/assets/51357717/44759936-43d7-430b-89ea-c3af770c21c0)
+### Example Output
+
+After running the command, you should see segmentation results similar to this:
+
+<img src="https://user-images.githubusercontent.com/51357717/279988626-eb74823f-1563-4d58-a8e4-0494025b7c9a.jpg" alt="Segmentation Demo" width="800"/>
+
+## Advanced Usage
+
+For more advanced usage, including real-time video processing, please refer to the `main.py` script's command-line arguments.
+
+## Contributing
+
+We welcome contributions to improve this demo! Please submit issues and pull requests for bug reports, feature requests, or submitting a new algorithm enhancement.
+
+## License
+
+This project is licensed under the AGPL-3.0 License - see the [LICENSE](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) file for details.
+
+## Acknowledgments
+
+- The YOLOv8-Segmentation-ONNXRuntime-Python demo is contributed by GitHub user [jamjamjon](https://github.com/jamjamjon).
+- Thanks to the ONNX Runtime community for providing a robust and efficient inference engine.

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -42,7 +42,7 @@ class YOLOv8Seg:
         The whole pipeline: pre-process -> inference -> post-process.
 
         Args:
-            im0 (Numpy.ndarray): orginal input image.
+            im0 (Numpy.ndarray): original input image.
             conf_threshold (float): confidence threshold for filtering predictions.
             iou_threshold (float): iou threshold for NMS.
             nm (int): the number of masks.
@@ -85,7 +85,7 @@ class YOLOv8Seg:
         """
 
         # Resize and pad input image using letterbox() (Borrowed from Ultralytics)
-        shape = img.shape[:2]  # orginal image shape
+        shape = img.shape[:2]  # original image shape
         new_shape = (self.model_height, self.model_width)
         r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
         ratio = r, r
@@ -97,7 +97,7 @@ class YOLOv8Seg:
         left, right = int(round(pad_w - 0.1)), int(round(pad_w + 0.1))
         img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(114, 114, 114))
 
-        # Transfroms: HWC to CHW -> BGR to RGB -> div(255) -> contiguous -> add axis(optional)
+        # Transforms: HWC to CHW -> BGR to RGB -> div(255) -> contiguous -> add axis(optional)
         img = np.ascontiguousarray(np.einsum('HWC->CHW', img)[::-1], dtype=self.ndtype) / 255.0
         img_process = img[None] if len(img.shape) == 3 else img
         return img_process, ratio, (pad_w, pad_h)
@@ -108,7 +108,7 @@ class YOLOv8Seg:
 
         Args:
             preds (Numpy.ndarray): predictions come from ort.session.run().
-            im0 (Numpy.ndarray): [h, w, c] orginal input image.
+            im0 (Numpy.ndarray): [h, w, c] original input image.
             ratio (tuple): width, height ratios in letterbox.
             pad_w (float): width padding in letterbox.
             pad_h (float): height padding in letterbox.

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -1,89 +1,187 @@
 import argparse
-
 import cv2
 import numpy as np
 import onnxruntime as ort
 
 from ultralytics.utils import ASSETS, yaml_load
 from ultralytics.utils.checks import check_yaml
+from ultralytics.utils.plotting import Colors
 
 
-class Model:
+class YOLOv8Seg:
+    """YOLOv8 segmentation model"""
 
-    def __init__(self, *, p, **kwargs):
-        self.session = ort.InferenceSession(p,
+    def __init__(self, onnx_model):
+        """
+        Initialization.
+
+        Args:
+            onnx_model (str): Path to the ONNX model.
+        """
+
+        # Build Ort session
+        self.session = ort.InferenceSession(onnx_model,
                                             providers=['CUDAExecutionProvider', 'CPUExecutionProvider']
-                                            if ort.get_device() == 'GPU' else ['CPUExecutionProvider'])  # session
-        self.ndtype = np.half if self.session.get_inputs()[0].type == 'tensor(float16)' else np.single  # dtype
-        self.iShapes = [x.shape for x in self.session.get_inputs()]  # input shapes
-        self.im_meta = dict()
-        self.conf_threshold = kwargs.get('conf_threshold', 0.4)
-        self.iou_threshold = kwargs.get('iou_threshold', 0.45)
-        self.nm = kwargs.get('nms', 32)
-        self.classes = yaml_load(check_yaml('coco128.yaml'))['names']
-        self.palette = np.random.uniform(0, 255, size=(len(self.classes), 3))
+                                            if ort.get_device() == 'GPU' else ['CPUExecutionProvider'])
 
-    def __call__(self, x, **kwargs):
-        self._preprocess(x)
-        preds = self.session.run(None, {self.session.get_inputs()[0].name: self.im_meta['im']})
-        x, proto = np.einsum('bcn->bnc', preds[0]), preds[1][0]  # prediction, proto
-        x = x[np.amax(x[..., 4:-self.nm], axis=-1) > self.conf_threshold]  # filter by conf
-        x = np.c_[x[..., :4],
-                  np.amax(x[..., 4:-self.nm], axis=-1),
-                  np.argmax(x[..., 4:-self.nm], axis=-1), x[..., -self.nm:]]  # box, score, cls
-        x = x[cv2.dnn.NMSBoxes(x[:, :4], x[:, 4], self.conf_threshold, self.iou_threshold)]  # nms
-        if len(x) == 0:
-            return [], [], []
-        else:
-            # de-scale boxes
+        # Numpy dtype: support both FP32 and FP16 onnx model
+        self.ndtype = np.half if self.session.get_inputs()[0].type == 'tensor(float16)' else np.single
+
+        # Get model width and height(YOLOv8-seg only has one input)
+        self.model_height, self.model_width = [x.shape for x in self.session.get_inputs()][0][-2:]
+
+        # Load COCO class names
+        self.classes = yaml_load(check_yaml('coco128.yaml'))['names']
+
+        # Create color palette
+        self.color_palette = Colors()
+
+
+
+    def __call__(self, im0, conf_threshold=0.4, iou_threshold=0.45, nm=32):
+        """
+        The whole pipeline: pre-process -> inference -> post-process.
+
+        Args:
+            im0 (Numpy.ndarray): orginal input image.
+            conf_threshold (float): confidence threshold for filtering predictions.
+            iou_threshold (float): iou threshold for NMS.
+            nm (int): the number of masks.
+
+        Returns:
+            boxes (List): list of bounding boxes.
+            segments (List): list of segments.
+            masks (np.ndarray): [N, H, W], output masks.
+        """
+
+        # Pre-process
+        im, ratio, (pad_w, pad_h) = self.preprocess(im0)
+
+        # Ort inference
+        preds = self.session.run(None, {self.session.get_inputs()[0].name: im})
+
+        # Post-process
+        boxes, segments, masks = self.postprocess(
+            preds, 
+            im0=im0,
+            ratio=ratio, 
+            pad_w=pad_w, 
+            pad_h=pad_h, 
+            conf_threshold=conf_threshold, 
+            iou_threshold=iou_threshold, 
+            nm=nm
+        )
+        return boxes, segments, masks
+
+
+    def preprocess(self, img):
+        """
+        Pre-processes the input image.
+
+        Args:
+            img (Numpy.ndarray): image about to be processed.
+
+        Returns:
+            img_process (Numpy.ndarray): image preprocessed for inference.
+            ratio (tuple): width, height ratios in letterbox.
+            pad_w (float): width padding in letterbox.
+            pad_h (float): height padding in letterbox.
+        """
+
+        # Resize and pad input image using letterbox() (Borrowed from Ultralytics) 
+        shape = img.shape[:2]  # orginal image shape
+        new_shape = (self.model_height, self.model_width)
+        r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
+        ratio = r, r
+        new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
+        pad_w, pad_h = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] - new_unpad[1]) / 2  # wh padding
+        if shape[::-1] != new_unpad:  # resize
+            img = cv2.resize(img, new_unpad, interpolation=cv2.INTER_LINEAR)
+        top, bottom = int(round(pad_h - 0.1)), int(round(pad_h + 0.1))
+        left, right = int(round(pad_w - 0.1)), int(round(pad_w + 0.1))
+        img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(114, 114, 114))
+
+        # Transfroms: HWC to CHW -> BGR to RGB -> div(255) -> contiguous -> add axis(optional)
+        img = np.ascontiguousarray(np.einsum('HWC->CHW', img)[::-1], dtype=self.ndtype) / 255.0
+        img_process = img[None] if len(img.shape) == 3 else img
+        return img_process, ratio, (pad_w, pad_h)
+
+
+    def postprocess(self, preds, im0, ratio, pad_w, pad_h, conf_threshold, iou_threshold, nm=32):
+        """
+        Post-process the prediction.
+
+        Args:
+            preds (Numpy.ndarray): predictions come from ort.session.run().
+            im0 (Numpy.ndarray): [h, w, c] orginal input image.
+            ratio (tuple): width, height ratios in letterbox.
+            pad_w (float): width padding in letterbox.
+            pad_h (float): height padding in letterbox.
+            conf_threshold (float): conf threshold.
+            iou_threshold (float): iou threshold.
+            nm (int): the number of masks.
+
+        Returns:
+            boxes (List): list of bounding boxes.
+            segments (List): list of segments.
+            masks (np.ndarray): [N, H, W], output masks.
+        """
+        x, protos = preds[0], preds[1]  # Two outputs: predictions and protos
+
+        # Transpose the first output: (Batch_size, xywh_conf_cls_nm, Num_anchors) -> (Batch_size, Num_anchors, xywh_conf_cls_nm)
+        x = np.einsum('bcn->bnc', x)
+
+        # Predictions filtering by conf-threshold
+        x = x[np.amax(x[..., 4:-nm], axis=-1) > conf_threshold]
+
+        # Create a new matrix which merge these(box, score, cls, nm) into one
+        # For more details about `numpy.c_()`: https://numpy.org/doc/1.26/reference/generated/numpy.c_.html
+        x = np.c_[x[..., :4], np.amax(x[..., 4:-nm], axis=-1), np.argmax(x[..., 4:-nm], axis=-1), x[..., -nm:]]
+
+        # NMS filtering
+        x = x[cv2.dnn.NMSBoxes(x[:, :4], x[:, 4], conf_threshold, iou_threshold)]
+
+        # Decode and return
+        if len(x) > 0:
+
+            # Bounding boxes format change: cxcywh -> xyxy
             x[..., [0, 1]] -= x[..., [2, 3]] / 2
             x[..., [2, 3]] += x[..., [0, 1]]
-            x[..., :4] -= [self.im_meta['dw'], self.im_meta['dh'], self.im_meta['dw'], self.im_meta['dh']]
-            x[..., :4] /= min(self.im_meta['ratio'])
-            x[..., [0, 2]] = x[:, [0, 2]].clip(0, self.im_meta['im0'].shape[1])
-            x[..., [1, 3]] = x[:, [1, 3]].clip(0, self.im_meta['im0'].shape[0])
-            masks = self.process_mask_hq(proto, x[:, 6:], x[:, :4], self.im_meta['im0'].shape)
-            segments = self.mask2segs(masks)  # mask2segments
 
-            # visualize
-            for segment in segments:
-                cv2.polylines(self.im_meta['im0'], np.int32([segment]), True, (255, 255, 0), 2)
-                # cv2.fillPoly(self.im_meta['im0'], np.int32([segment]), (255, 255, 0))
-            for *box, conf, cls_ in x[..., :6]:
-                cv2.rectangle(self.im_meta['im0'], (int(box[0]), int(box[1])), (int(box[2]), int(box[3])),
-                              self.palette[int(cls_)], 0, cv2.LINE_AA)
-                cv2.putText(self.im_meta['im0'], f'{self.classes[cls_]}: {conf:.3f}', (int(box[0]), int(box[1] - 9)),
-                            cv2.FONT_HERSHEY_SIMPLEX, 0.7, self.palette[int(cls_)], 2, cv2.LINE_AA)
-            cv2.imshow('demo', self.im_meta['im0'])
-            cv2.waitKey(0)
-            cv2.destroyAllWindows()
-            # cv2.imwrite('demo.jpg', self.im_meta['im0'])
+            # Rescales bounding boxes from model shape(model_height, model_width) to the shape of original image
+            x[..., :4] -= [pad_w, pad_h, pad_w, pad_h]
+            x[..., :4] /= min(ratio)
 
-            return x[..., :6], segments, masks
+            # Bounding boxes boundary clamp
+            x[..., [0, 2]] = x[:, [0, 2]].clip(0, im0.shape[1])
+            x[..., [1, 3]] = x[:, [1, 3]].clip(0, im0.shape[0])
 
-    def _preprocess(self, x) -> dict:
-        self.im_meta['im0'] = x
-        shape = x.shape[:2]  # current shape
-        new_shape = self.iShapes[0][-2:]
-        r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
-        self.im_meta['ratio'] = r, r
-        new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
-        self.im_meta['dw'], self.im_meta['dh'] = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] -
-                                                                                     new_unpad[1]) / 2  # wh padding
-        if shape[::-1] != new_unpad:  # resize
-            x = cv2.resize(x, new_unpad, interpolation=cv2.INTER_LINEAR)
-        top, bottom = int(round(self.im_meta['dh'] - 0.1)), int(round(self.im_meta['dh'] + 0.1))
-        left, right = int(round(self.im_meta['dw'] - 0.1)), int(round(self.im_meta['dw'] + 0.1))
-        x = cv2.copyMakeBorder(x, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(114, 114, 114))  # add border
-        x = np.ascontiguousarray(np.einsum('asd->das', x)[::-1], dtype=self.ndtype) / 255.0  # transform
-        x = x[None] if len(x.shape) == 3 else x
-        self.im_meta['im'] = x
+            # Process masks
+            masks = self.process_mask(protos[0], x[:, 6:], x[:, :4], im0.shape)
+            
+            # Masks -> Segments(contours)
+            segments = self.masks2segments(masks)
+            return x[..., :6], segments, masks   # boxes, segments, masks
+        else:
+            return [], [], []
+
+
 
     @staticmethod
-    def mask2segs(masks):
+    def masks2segments(masks):
+        """
+        It takes a list of masks(n,h,w) and returns a list of segments(n,xy) (Borrowed from 
+        https://github.com/ultralytics/ultralytics/blob/465df3024f44fa97d4fad9986530d5a13cdabdca/ultralytics/utils/ops.py#L750)
+
+        Args:
+            masks (numpy.ndarray): the output of the model, which is a tensor of shape (batch_size, 160, 160).
+
+        Returns:
+            segments (List): list of segment masks.
+        """
         segments = []
         for x in masks.astype('uint8'):
-            c = cv2.findContours(x, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[0]  # CHAIN_APPROX_SIMPLE
+            c = cv2.findContours(x, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[0]  # CHAIN_APPROX_SIMPLE 
             if c:
                 c = np.array(c[np.array([len(x) for x in c]).argmax()]).reshape(-1, 2)
             else:
@@ -91,12 +189,19 @@ class Model:
             segments.append(c.astype('float32'))
         return segments
 
+
     @staticmethod
     def crop_mask(masks, boxes):
         """
+        It takes a mask and a bounding box, and returns a mask that is cropped to the bounding box. (Borrowed from 
+        https://github.com/ultralytics/ultralytics/blob/465df3024f44fa97d4fad9986530d5a13cdabdca/ultralytics/utils/ops.py#L599)
+
         Args:
-            - masks should be a size [h, w, n] tensor of masks
-            - boxes should be a size [n, 4] tensor of bbox coords in relative point form
+            masks (Numpy.ndarray): [n, h, w] tensor of masks.
+            boxes (Numpy.ndarray): [n, 4] tensor of bbox coordinates in relative point form.
+
+        Returns:
+            (Numpy.ndarray): The masks are being cropped to the bounding box.
         """
         n, h, w = masks.shape
         x1, y1, x2, y2 = np.split(boxes[:, :, None], 4, 1)
@@ -104,52 +209,137 @@ class Model:
         c = np.arange(h, dtype=x1.dtype)[None, :, None]
         return masks * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
 
-    def process_mask_hq(self, protos, masks_in, bboxes, im0shape):
+
+    def process_mask(self, protos, masks_in, bboxes, im0_shape):
+        """
+        Takes the output of the mask head, and applies the mask to the bounding boxes. This produces masks of higher quality
+        but is slower. (Borrowed from https://github.com/ultralytics/ultralytics/blob/465df3024f44fa97d4fad9986530d5a13cdabdca/ultralytics/utils/ops.py#L618)
+
+        Args:
+            protos (numpy.ndarray): [mask_dim, mask_h, mask_w].
+            masks_in (numpy.ndarray): [n, mask_dim], n is number of masks after nms.
+            bboxes (numpy.ndarray): bboxes re-scaled to original image shape.
+            im0_shape (tuple): the size of the input image (h,w,c).
+
+        Returns:
+            (numpy.ndarray): The upsampled masks.
+        """
         c, mh, mw = protos.shape
-        mask_protos = np.reshape(protos, (c, -1))
-        matmulres = np.matmul(masks_in, mask_protos)
-        masks = np.reshape(matmulres, (-1, mh, mw))
-        masks = np.ascontiguousarray(masks.transpose(1, 2, 0))
-        masks = self.scale_mask(masks.shape[:2], masks, im0shape)
-        masks = np.einsum('zxc->czx', masks)
-        masks = self.crop_mask(masks, bboxes.copy())
-        masks_gt = np.greater(masks, 0.5)
-        masks_gt = masks_gt.astype(float)
-        return masks_gt
+        masks = np.matmul(masks_in, protos.reshape((c, -1))).reshape((-1, mh, mw)).transpose(1, 2, 0)  # HWN
+        masks = np.ascontiguousarray(masks)
+        masks = self.scale_mask(masks, im0_shape)  # re-scale mask from P3 shape to original input image shape
+        masks = np.einsum('HWN -> NHW', masks)  # HWN -> NHW
+        masks = self.crop_mask(masks, bboxes)
+        return np.greater(masks, 0.5)
+
 
     @staticmethod
-    def scale_mask(im1_shape, masks, im0_shape, ratio_pad=None):
+    def scale_mask(masks, im0_shape, ratio_pad=None):
+        """
+        Takes a mask, and resizes it to the original image size. (Borrowed from  
+        https://github.com/ultralytics/ultralytics/blob/465df3024f44fa97d4fad9986530d5a13cdabdca/ultralytics/utils/ops.py#L305)
+
+        Args:
+            masks (np.ndarray): resized and padded masks/images, [h, w, num]/[h, w, 3].
+            im0_shape (tuple): the original image shape.
+            ratio_pad (tuple): the ratio of the padding to the original image.
+
+        Returns:
+            masks (np.ndarray): The masks that are being returned.
+        """
+        im1_shape = masks.shape[:2]
         if ratio_pad is None:  # calculate from im0_shape
             gain = min(im1_shape[0] / im0_shape[0], im1_shape[1] / im0_shape[1])  # gain  = old / new
             pad = (im1_shape[1] - im0_shape[1] * gain) / 2, (im1_shape[0] - im0_shape[0] * gain) / 2  # wh padding
         else:
             pad = ratio_pad[1]
-        top, left = int(pad[1]), int(pad[0])  # y, x
-        bottom, right = int(im1_shape[0] - pad[1]), int(im1_shape[1] - pad[0])
+
+        # calculate tlbr of mask
+        top, left = int(round(pad[1] - 0.1)), int(round(pad[0] - 0.1))  # y, x
+        bottom, right = int(round(im1_shape[0] - pad[1] + 0.1)), int(round(im1_shape[1] - pad[0] + 0.1))
         if len(masks.shape) < 2:
             raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
         masks = masks[top:bottom, left:right]
-        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_CUBIC)  #
+        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_LINEAR)  # INTER_CUBIC would be better
         if len(masks.shape) == 2:
             masks = masks[:, :, None]
         return masks
 
 
+    def draw_and_visualize(self, im, bboxes, segments, vis=False, save=True):
+        """
+        Draw and visualize results.
+
+        Args:
+            im (np.ndarray): original image, shape [h, w, c].
+            bboxes (numpy.ndarray): [n, 4], n is number of bboxes.
+            segments (List): list of segment masks.
+            vis (bool): imshow using OpenCV.
+            save (bool): save image annotated.
+
+        Returns:
+            None
+        """
+
+        # draw rectangles and polygons
+        im_canvas = im.copy()
+        for (*box, conf, cls_), segment in zip(bboxes, segments):
+            # draw contour and fill mask
+            cv2.polylines(im, np.int32([segment]), True, (255, 255, 255), 2)  # white borderline
+            cv2.fillPoly(im_canvas, np.int32([segment]), self.color_palette(int(cls_), bgr=True))
+
+            # draw bbox rectangle
+            cv2.rectangle(
+                im, 
+                (int(box[0]), int(box[1])), (int(box[2]), int(box[3])),
+                self.color_palette(int(cls_), bgr=True), 
+                1, 
+                cv2.LINE_AA
+            )
+            cv2.putText(
+                im, 
+                f'{self.classes[cls_]}: {conf:.3f}', 
+                (int(box[0]), int(box[1] - 9)),
+                cv2.FONT_HERSHEY_SIMPLEX, 
+                0.7, 
+                self.color_palette(int(cls_), bgr=True), 
+                2, 
+                cv2.LINE_AA
+            )
+
+        # mixup
+        im = cv2.addWeighted(im_canvas, 0.3, im, 0.7, 0)
+
+        # imshow
+        if vis:
+            cv2.imshow('demo', im)
+            cv2.waitKey(0)
+            cv2.destroyAllWindows()
+
+        # save image
+        if save:
+            cv2.imwrite('demo.jpg', im)
+
+
+
 if __name__ == '__main__':
     # Create an argument parser to handle command-line arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model', type=str, required=True, help='Path to ONNX model ')
+    parser.add_argument('--model', type=str, required=True, help='Path to ONNX model')
     parser.add_argument('--source', type=str, default=str(ASSETS / 'bus.jpg'), help='Path to input image')
-    parser.add_argument('--conf', type=float, default=0.3, help='Confidence threshold')
+    parser.add_argument('--conf', type=float, default=0.25, help='Confidence threshold')
     parser.add_argument('--iou', type=float, default=0.45, help='NMS IoU threshold')
     args = parser.parse_args()
 
-    # build model
-    model = Model(p=args.model, conf_threshold=args.conf, iou_threshold=args.iou)
+    # Build model
+    model = YOLOv8Seg(args.model)
 
-    # load image
+    # Read image by OpenCV
     img = cv2.imread(args.source)
 
-    # infer
-    y_bboxes, _, _ = model(img)
-    print(y_bboxes)
+    # Inference
+    boxes, segments, _ = model(img, conf_threshold=args.conf, iou_threshold=args.iou)
+
+    # Draw bboxes and polygons
+    if len(boxes) > 0:
+        model.draw_and_visualize(img, boxes, segments, vis=False, save=True)

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -1,19 +1,21 @@
 import argparse
+
 import cv2
 import numpy as np
 import onnxruntime as ort
+
 from ultralytics.utils import ASSETS, yaml_load
 from ultralytics.utils.checks import check_yaml
 
 
 class Model:
+
     def __init__(self, *, p, **kwargs):
-        self.session = ort.InferenceSession(
-            p, 
-            providers=['CUDAExecutionProvider', 'CPUExecutionProvider'] if ort.get_device() == 'GPU' else ['CPUExecutionProvider']
-        )  # session
+        self.session = ort.InferenceSession(p,
+                                            providers=['CUDAExecutionProvider', 'CPUExecutionProvider']
+                                            if ort.get_device() == 'GPU' else ['CPUExecutionProvider'])  # session
         self.ndtype = np.half if self.session.get_inputs()[0].type == 'tensor(float16)' else np.single  # dtype
-        self.iShapes = [x.shape for x in self.session.get_inputs()] # input shapes
+        self.iShapes = [x.shape for x in self.session.get_inputs()]  # input shapes
         self.im_meta = dict()
         self.conf_threshold = kwargs.get('conf_threshold', 0.4)
         self.iou_threshold = kwargs.get('iou_threshold', 0.45)
@@ -21,17 +23,18 @@ class Model:
         self.classes = yaml_load(check_yaml('coco128.yaml'))['names']
         self.palette = np.random.uniform(0, 255, size=(len(self.classes), 3))
 
-
     def __call__(self, x, **kwargs):
         self._preprocess(x)
         preds = self.session.run(None, {self.session.get_inputs()[0].name: self.im_meta['im']})
-        x, proto = np.einsum('bcn->bnc', preds[0]), preds[1][0]   # prediction, proto
-        x = x[np.amax(x[..., 4: -self.nm], axis=-1) > self.conf_threshold]  # filter by conf
-        x = np.c_[x[..., :4], np.amax(x[..., 4: -self.nm], axis=-1), np.argmax(x[..., 4: -self.nm], axis=-1), x[..., -self.nm: ]]  # box, score, cls
+        x, proto = np.einsum('bcn->bnc', preds[0]), preds[1][0]  # prediction, proto
+        x = x[np.amax(x[..., 4:-self.nm], axis=-1) > self.conf_threshold]  # filter by conf
+        x = np.c_[x[..., :4],
+                  np.amax(x[..., 4:-self.nm], axis=-1),
+                  np.argmax(x[..., 4:-self.nm], axis=-1), x[..., -self.nm:]]  # box, score, cls
         x = x[cv2.dnn.NMSBoxes(x[:, :4], x[:, 4], self.conf_threshold, self.iou_threshold)]  # nms
         if len(x) == 0:
             return [], [], []
-        else: 
+        else:
             # de-scale boxes
             x[..., [0, 1]] -= x[..., [2, 3]] / 2
             x[..., [2, 3]] += x[..., [0, 1]]
@@ -48,27 +51,16 @@ class Model:
                 cv2.polylines(self.im_meta['im0'], np.int32([segment]), True, (255, 255, 0), 2)
                 # cv2.fillPoly(self.im_meta['im0'], np.int32([segment]), (255, 255, 0))
             for *box, conf, cls_ in x[..., :6]:
-                cv2.rectangle(
-                    self.im_meta['im0'],
-                    (int(box[0]), int(box[1])), (int(box[2]), int(box[3])), 
-                    self.palette[int(cls_)], 0, cv2.LINE_AA
-                 )
-                cv2.putText(
-                    self.im_meta['im0'], 
-                    f'{self.classes[cls_]}: {conf:.3f}', 
-                    (int(box[0]), int(box[1] - 9)), 
-                    cv2.FONT_HERSHEY_SIMPLEX, 
-                    0.7, 
-                    self.palette[int(cls_)], 
-                    2, cv2.LINE_AA
-                )
+                cv2.rectangle(self.im_meta['im0'], (int(box[0]), int(box[1])), (int(box[2]), int(box[3])),
+                              self.palette[int(cls_)], 0, cv2.LINE_AA)
+                cv2.putText(self.im_meta['im0'], f'{self.classes[cls_]}: {conf:.3f}', (int(box[0]), int(box[1] - 9)),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.7, self.palette[int(cls_)], 2, cv2.LINE_AA)
             cv2.imshow('demo', self.im_meta['im0'])
             cv2.waitKey(0)
             cv2.destroyAllWindows()
             # cv2.imwrite('demo.jpg', self.im_meta['im0'])
 
             return x[..., :6], segments, masks
-
 
     def _preprocess(self, x) -> dict:
         self.im_meta['im0'] = x
@@ -77,7 +69,8 @@ class Model:
         r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
         self.im_meta['ratio'] = r, r
         new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
-        self.im_meta['dw'], self.im_meta['dh'] = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] - new_unpad[1]) / 2  # wh padding
+        self.im_meta['dw'], self.im_meta['dh'] = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] -
+                                                                                     new_unpad[1]) / 2  # wh padding
         if shape[::-1] != new_unpad:  # resize
             x = cv2.resize(x, new_unpad, interpolation=cv2.INTER_LINEAR)
         top, bottom = int(round(self.im_meta['dh'] - 0.1)), int(round(self.im_meta['dh'] + 0.1))
@@ -86,7 +79,6 @@ class Model:
         x = np.ascontiguousarray(np.einsum('asd->das', x)[::-1], dtype=self.ndtype) / 255.0  # transform
         x = x[None] if len(x.shape) == 3 else x
         self.im_meta['im'] = x
-
 
     @staticmethod
     def mask2segs(masks):
@@ -99,7 +91,6 @@ class Model:
                 c = np.zeros((0, 2))  # no segments found
             segments.append(c.astype('float32'))
         return segments
-
 
     @staticmethod
     def crop_mask(masks, boxes):
@@ -114,20 +105,18 @@ class Model:
         c = np.arange(h, dtype=x1.dtype)[None, :, None]
         return masks * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
 
-
     def process_mask_hq(self, protos, masks_in, bboxes, im0shape):
-        c, mh, mw = protos.shape  
+        c, mh, mw = protos.shape
         mask_protos = np.reshape(protos, (c, -1))
-        matmulres = np.matmul(masks_in, mask_protos) 
-        masks = np.reshape(matmulres, (-1, mh, mw))  
+        matmulres = np.matmul(masks_in, mask_protos)
+        masks = np.reshape(matmulres, (-1, mh, mw))
         masks = np.ascontiguousarray(masks.transpose(1, 2, 0))
-        masks = self.scale_mask(masks.shape[:2], masks, im0shape) 
+        masks = self.scale_mask(masks.shape[:2], masks, im0shape)
         masks = np.einsum('zxc->czx', masks)
-        masks = self.crop_mask(masks, bboxes.copy()) 
+        masks = self.crop_mask(masks, bboxes.copy())
         masks_gt = np.greater(masks, 0.5)
         masks_gt = masks_gt.astype(float)
         return masks_gt
-
 
     @staticmethod
     def scale_mask(im1_shape, masks, im0_shape, ratio_pad=None):
@@ -140,12 +129,11 @@ class Model:
         bottom, right = int(im1_shape[0] - pad[1]), int(im1_shape[1] - pad[0])
         if len(masks.shape) < 2:
             raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
-        masks = masks[top:bottom, left:right]   
-        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_CUBIC)  # 
+        masks = masks[top:bottom, left:right]
+        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_CUBIC)  #
         if len(masks.shape) == 2:
             masks = masks[:, :, None]
         return masks
-
 
 
 if __name__ == '__main__':
@@ -159,7 +147,7 @@ if __name__ == '__main__':
 
     # build model
     model = Model(p=args.model, conf_threshold=args.conf, iou_threshold=args.iou)
-    
+
     # load image
     img = cv2.imread(args.source)
 

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -42,7 +42,6 @@ class Model:
             x[..., :4] /= min(self.im_meta['ratio'])
             x[..., [0, 2]] = x[:, [0, 2]].clip(0, self.im_meta['im0'].shape[1])
             x[..., [1, 3]] = x[:, [1, 3]].clip(0, self.im_meta['im0'].shape[0])
-            y_segments, y_masks, y_boxes = list(), list(), list()
             masks = self.process_mask_hq(proto, x[:, 6:], x[:, :4], self.im_meta['im0'].shape)
             segments = self.mask2segs(masks)  # mask2segments
 

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -1,21 +1,19 @@
 import argparse
-
 import cv2
 import numpy as np
 import onnxruntime as ort
-
 from ultralytics.utils import ASSETS, yaml_load
-from ultralytics.utils.checks import check_requirements, check_yaml
+from ultralytics.utils.checks import check_yaml
 
 
 class Model:
-
     def __init__(self, *, p, **kwargs):
-        self.session = ort.InferenceSession(p,
-                                            providers=['CUDAExecutionProvider', 'CPUExecutionProvider']
-                                            if ort.get_device() == 'GPU' else ['CPUExecutionProvider'])  # session
+        self.session = ort.InferenceSession(
+            p, 
+            providers=['CUDAExecutionProvider', 'CPUExecutionProvider'] if ort.get_device() == 'GPU' else ['CPUExecutionProvider']
+        )  # session
         self.ndtype = np.half if self.session.get_inputs()[0].type == 'tensor(float16)' else np.single  # dtype
-        self.iShapes = [x.shape for x in self.session.get_inputs()]  # input shapes
+        self.iShapes = [x.shape for x in self.session.get_inputs()] # input shapes
         self.im_meta = dict()
         self.conf_threshold = kwargs.get('conf_threshold', 0.4)
         self.iou_threshold = kwargs.get('iou_threshold', 0.45)
@@ -23,18 +21,17 @@ class Model:
         self.classes = yaml_load(check_yaml('coco128.yaml'))['names']
         self.palette = np.random.uniform(0, 255, size=(len(self.classes), 3))
 
+
     def __call__(self, x, **kwargs):
         self._preprocess(x)
         preds = self.session.run(None, {self.session.get_inputs()[0].name: self.im_meta['im']})
-        x, proto = np.einsum('bcn->bnc', preds[0]), preds[1][0]  # prediction, proto
-        x = x[np.amax(x[..., 4:-self.nm], axis=-1) > self.conf_threshold]  # filter by conf
-        x = np.c_[x[..., :4],
-                  np.amax(x[..., 4:-self.nm], axis=-1),
-                  np.argmax(x[..., 4:-self.nm], axis=-1), x[..., -self.nm:]]  # box, score, cls
+        x, proto = np.einsum('bcn->bnc', preds[0]), preds[1][0]   # prediction, proto
+        x = x[np.amax(x[..., 4: -self.nm], axis=-1) > self.conf_threshold]  # filter by conf
+        x = np.c_[x[..., :4], np.amax(x[..., 4: -self.nm], axis=-1), np.argmax(x[..., 4: -self.nm], axis=-1), x[..., -self.nm: ]]  # box, score, cls
         x = x[cv2.dnn.NMSBoxes(x[:, :4], x[:, 4], self.conf_threshold, self.iou_threshold)]  # nms
         if len(x) == 0:
             return [], [], []
-        else:
+        else: 
             # de-scale boxes
             x[..., [0, 1]] -= x[..., [2, 3]] / 2
             x[..., [2, 3]] += x[..., [0, 1]]
@@ -51,16 +48,27 @@ class Model:
                 cv2.polylines(self.im_meta['im0'], np.int32([segment]), True, (255, 255, 0), 2)
                 # cv2.fillPoly(self.im_meta['im0'], np.int32([segment]), (255, 255, 0))
             for *box, conf, cls_ in x[..., :6]:
-                cv2.rectangle(self.im_meta['im0'], (int(box[0]), int(box[1])), (int(box[2]), int(box[3])),
-                              self.palette[int(cls_)], 0, cv2.LINE_AA)
-                cv2.putText(self.im_meta['im0'], f'{self.classes[cls_]}: {conf:.3f}', (int(box[0]), int(box[1] - 9)),
-                            cv2.FONT_HERSHEY_SIMPLEX, 0.7, self.palette[int(cls_)], 2, cv2.LINE_AA)
+                cv2.rectangle(
+                    self.im_meta['im0'],
+                    (int(box[0]), int(box[1])), (int(box[2]), int(box[3])), 
+                    self.palette[int(cls_)], 0, cv2.LINE_AA
+                 )
+                cv2.putText(
+                    self.im_meta['im0'], 
+                    f'{self.classes[cls_]}: {conf:.3f}', 
+                    (int(box[0]), int(box[1] - 9)), 
+                    cv2.FONT_HERSHEY_SIMPLEX, 
+                    0.7, 
+                    self.palette[int(cls_)], 
+                    2, cv2.LINE_AA
+                )
             cv2.imshow('demo', self.im_meta['im0'])
             cv2.waitKey(0)
             cv2.destroyAllWindows()
-            cv2.imwrite('demo.jpg', self.im_meta['im0'])
+            # cv2.imwrite('demo.jpg', self.im_meta['im0'])
 
             return x[..., :6], segments, masks
+
 
     def _preprocess(self, x) -> dict:
         self.im_meta['im0'] = x
@@ -69,16 +77,16 @@ class Model:
         r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
         self.im_meta['ratio'] = r, r
         new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
-        self.im_meta['dw'], self.im_meta['dh'] = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] -
-                                                                                     new_unpad[1]) / 2  # wh padding
+        self.im_meta['dw'], self.im_meta['dh'] = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] - new_unpad[1]) / 2  # wh padding
         if shape[::-1] != new_unpad:  # resize
             x = cv2.resize(x, new_unpad, interpolation=cv2.INTER_LINEAR)
         top, bottom = int(round(self.im_meta['dh'] - 0.1)), int(round(self.im_meta['dh'] + 0.1))
         left, right = int(round(self.im_meta['dw'] - 0.1)), int(round(self.im_meta['dw'] + 0.1))
         x = cv2.copyMakeBorder(x, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(114, 114, 114))  # add border
-        x = np.ascontiguousarray(np.einsum('asd->das', x)[::-1], dtype=self.ndtype) / 255.0  # tranform
+        x = np.ascontiguousarray(np.einsum('asd->das', x)[::-1], dtype=self.ndtype) / 255.0  # transform
         x = x[None] if len(x.shape) == 3 else x
         self.im_meta['im'] = x
+
 
     @staticmethod
     def mask2segs(masks):
@@ -91,6 +99,7 @@ class Model:
                 c = np.zeros((0, 2))  # no segments found
             segments.append(c.astype('float32'))
         return segments
+
 
     @staticmethod
     def crop_mask(masks, boxes):
@@ -105,18 +114,20 @@ class Model:
         c = np.arange(h, dtype=x1.dtype)[None, :, None]
         return masks * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
 
+
     def process_mask_hq(self, protos, masks_in, bboxes, im0shape):
-        c, mh, mw = protos.shape
+        c, mh, mw = protos.shape  
         mask_protos = np.reshape(protos, (c, -1))
-        matmulres = np.matmul(masks_in, mask_protos)
-        masks = np.reshape(matmulres, (-1, mh, mw))
+        matmulres = np.matmul(masks_in, mask_protos) 
+        masks = np.reshape(matmulres, (-1, mh, mw))  
         masks = np.ascontiguousarray(masks.transpose(1, 2, 0))
-        masks = self.scale_mask(masks.shape[:2], masks, im0shape)
+        masks = self.scale_mask(masks.shape[:2], masks, im0shape) 
         masks = np.einsum('zxc->czx', masks)
-        masks = self.crop_mask(masks, bboxes.copy())
+        masks = self.crop_mask(masks, bboxes.copy()) 
         masks_gt = np.greater(masks, 0.5)
         masks_gt = masks_gt.astype(float)
         return masks_gt
+
 
     @staticmethod
     def scale_mask(im1_shape, masks, im0_shape, ratio_pad=None):
@@ -129,28 +140,29 @@ class Model:
         bottom, right = int(im1_shape[0] - pad[1]), int(im1_shape[1] - pad[0])
         if len(masks.shape) < 2:
             raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
-        masks = masks[top:bottom, left:right]
-        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_CUBIC)  #
+        masks = masks[top:bottom, left:right]   
+        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_CUBIC)  # 
         if len(masks.shape) == 2:
             masks = masks[:, :, None]
         return masks
+
 
 
 if __name__ == '__main__':
     # Create an argument parser to handle command-line arguments
     parser = argparse.ArgumentParser()
     parser.add_argument('--model', type=str, required=True, help='Path to ONNX model ')
-    parser.add_argument('--source', type=str, required=True, help='Path to input image')
+    parser.add_argument('--source', type=str, default=str(ASSETS / 'bus.jpg'), help='Path to input image')
     parser.add_argument('--conf', type=float, default=0.3, help='Confidence threshold')
     parser.add_argument('--iou', type=float, default=0.45, help='NMS IoU threshold')
     args = parser.parse_args()
 
     # build model
     model = Model(p=args.model, conf_threshold=args.conf, iou_threshold=args.iou)
-
+    
     # load image
     img = cv2.imread(args.source)
 
     # infer
-    y_bboxes, y_segments, y_masks = model(img)
+    y_bboxes, _, _ = model(img)
     print(y_bboxes)

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -1,19 +1,21 @@
 import argparse
+
 import cv2
 import numpy as np
 import onnxruntime as ort
+
 from ultralytics.utils import ASSETS, yaml_load
 from ultralytics.utils.checks import check_requirements, check_yaml
 
 
 class Model:
+
     def __init__(self, *, p, **kwargs):
-        self.session = ort.InferenceSession(
-            p, 
-            providers=['CUDAExecutionProvider', 'CPUExecutionProvider'] if ort.get_device() == 'GPU' else ['CPUExecutionProvider']
-        )  # session
+        self.session = ort.InferenceSession(p,
+                                            providers=['CUDAExecutionProvider', 'CPUExecutionProvider']
+                                            if ort.get_device() == 'GPU' else ['CPUExecutionProvider'])  # session
         self.ndtype = np.half if self.session.get_inputs()[0].type == 'tensor(float16)' else np.single  # dtype
-        self.iShapes = [x.shape for x in self.session.get_inputs()] # input shapes
+        self.iShapes = [x.shape for x in self.session.get_inputs()]  # input shapes
         self.im_meta = dict()
         self.conf_threshold = kwargs.get('conf_threshold', 0.4)
         self.iou_threshold = kwargs.get('iou_threshold', 0.45)
@@ -21,17 +23,18 @@ class Model:
         self.classes = yaml_load(check_yaml('coco128.yaml'))['names']
         self.palette = np.random.uniform(0, 255, size=(len(self.classes), 3))
 
-
     def __call__(self, x, **kwargs):
         self._preprocess(x)
         preds = self.session.run(None, {self.session.get_inputs()[0].name: self.im_meta['im']})
-        x, proto = np.einsum('bcn->bnc', preds[0]), preds[1][0]   # prediction, proto
-        x = x[np.amax(x[..., 4: -self.nm], axis=-1) > self.conf_threshold]  # filter by conf
-        x = np.c_[x[..., :4], np.amax(x[..., 4: -self.nm], axis=-1), np.argmax(x[..., 4: -self.nm], axis=-1), x[..., -self.nm: ]]  # box, score, cls
+        x, proto = np.einsum('bcn->bnc', preds[0]), preds[1][0]  # prediction, proto
+        x = x[np.amax(x[..., 4:-self.nm], axis=-1) > self.conf_threshold]  # filter by conf
+        x = np.c_[x[..., :4],
+                  np.amax(x[..., 4:-self.nm], axis=-1),
+                  np.argmax(x[..., 4:-self.nm], axis=-1), x[..., -self.nm:]]  # box, score, cls
         x = x[cv2.dnn.NMSBoxes(x[:, :4], x[:, 4], self.conf_threshold, self.iou_threshold)]  # nms
         if len(x) == 0:
             return [], [], []
-        else: 
+        else:
             # de-scale boxes
             x[..., [0, 1]] -= x[..., [2, 3]] / 2
             x[..., [2, 3]] += x[..., [0, 1]]
@@ -48,27 +51,16 @@ class Model:
                 cv2.polylines(self.im_meta['im0'], np.int32([segment]), True, (255, 255, 0), 2)
                 # cv2.fillPoly(self.im_meta['im0'], np.int32([segment]), (255, 255, 0))
             for *box, conf, cls_ in x[..., :6]:
-                cv2.rectangle(
-                    self.im_meta['im0'],
-                    (int(box[0]), int(box[1])), (int(box[2]), int(box[3])), 
-                    self.palette[int(cls_)], 0, cv2.LINE_AA
-                 )
-                cv2.putText(
-                    self.im_meta['im0'], 
-                    f'{self.classes[cls_]}: {conf:.3f}', 
-                    (int(box[0]), int(box[1] - 9)), 
-                    cv2.FONT_HERSHEY_SIMPLEX, 
-                    0.7, 
-                    self.palette[int(cls_)], 
-                    2, cv2.LINE_AA
-                )
+                cv2.rectangle(self.im_meta['im0'], (int(box[0]), int(box[1])), (int(box[2]), int(box[3])),
+                              self.palette[int(cls_)], 0, cv2.LINE_AA)
+                cv2.putText(self.im_meta['im0'], f'{self.classes[cls_]}: {conf:.3f}', (int(box[0]), int(box[1] - 9)),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.7, self.palette[int(cls_)], 2, cv2.LINE_AA)
             cv2.imshow('demo', self.im_meta['im0'])
             cv2.waitKey(0)
             cv2.destroyAllWindows()
             cv2.imwrite('demo.jpg', self.im_meta['im0'])
 
             return x[..., :6], segments, masks
-
 
     def _preprocess(self, x) -> dict:
         self.im_meta['im0'] = x
@@ -77,7 +69,8 @@ class Model:
         r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
         self.im_meta['ratio'] = r, r
         new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
-        self.im_meta['dw'], self.im_meta['dh'] = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] - new_unpad[1]) / 2  # wh padding
+        self.im_meta['dw'], self.im_meta['dh'] = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] -
+                                                                                     new_unpad[1]) / 2  # wh padding
         if shape[::-1] != new_unpad:  # resize
             x = cv2.resize(x, new_unpad, interpolation=cv2.INTER_LINEAR)
         top, bottom = int(round(self.im_meta['dh'] - 0.1)), int(round(self.im_meta['dh'] + 0.1))
@@ -86,7 +79,6 @@ class Model:
         x = np.ascontiguousarray(np.einsum('asd->das', x)[::-1], dtype=self.ndtype) / 255.0  # tranform
         x = x[None] if len(x.shape) == 3 else x
         self.im_meta['im'] = x
-
 
     @staticmethod
     def mask2segs(masks):
@@ -99,7 +91,6 @@ class Model:
                 c = np.zeros((0, 2))  # no segments found
             segments.append(c.astype('float32'))
         return segments
-
 
     @staticmethod
     def crop_mask(masks, boxes):
@@ -114,20 +105,18 @@ class Model:
         c = np.arange(h, dtype=x1.dtype)[None, :, None]
         return masks * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
 
-
     def process_mask_hq(self, protos, masks_in, bboxes, im0shape):
-        c, mh, mw = protos.shape  
+        c, mh, mw = protos.shape
         mask_protos = np.reshape(protos, (c, -1))
-        matmulres = np.matmul(masks_in, mask_protos) 
-        masks = np.reshape(matmulres, (-1, mh, mw))  
+        matmulres = np.matmul(masks_in, mask_protos)
+        masks = np.reshape(matmulres, (-1, mh, mw))
         masks = np.ascontiguousarray(masks.transpose(1, 2, 0))
-        masks = self.scale_mask(masks.shape[:2], masks, im0shape) 
+        masks = self.scale_mask(masks.shape[:2], masks, im0shape)
         masks = np.einsum('zxc->czx', masks)
-        masks = self.crop_mask(masks, bboxes.copy()) 
+        masks = self.crop_mask(masks, bboxes.copy())
         masks_gt = np.greater(masks, 0.5)
         masks_gt = masks_gt.astype(float)
         return masks_gt
-
 
     @staticmethod
     def scale_mask(im1_shape, masks, im0_shape, ratio_pad=None):
@@ -140,12 +129,11 @@ class Model:
         bottom, right = int(im1_shape[0] - pad[1]), int(im1_shape[1] - pad[0])
         if len(masks.shape) < 2:
             raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
-        masks = masks[top:bottom, left:right]   
-        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_CUBIC)  # 
+        masks = masks[top:bottom, left:right]
+        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_CUBIC)  #
         if len(masks.shape) == 2:
             masks = masks[:, :, None]
         return masks
-
 
 
 if __name__ == '__main__':
@@ -159,7 +147,7 @@ if __name__ == '__main__':
 
     # build model
     model = Model(p=args.model, conf_threshold=args.conf, iou_threshold=args.iou)
-    
+
     # load image
     img = cv2.imread(args.source)
 

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -244,7 +244,7 @@ class YOLOv8Seg:
         else:
             pad = ratio_pad[1]
 
-        # calculate tlbr of mask
+        # Calculate tlbr of mask
         top, left = int(round(pad[1] - 0.1)), int(round(pad[0] - 0.1))  # y, x
         bottom, right = int(round(im1_shape[0] - pad[1] + 0.1)), int(round(im1_shape[1] - pad[0] + 0.1))
         if len(masks.shape) < 2:
@@ -271,7 +271,7 @@ class YOLOv8Seg:
             None
         """
 
-        # draw rectangles and polygons
+        # Draw rectangles and polygons
         im_canvas = im.copy()
         for (*box, conf, cls_), segment in zip(bboxes, segments):
             # draw contour and fill mask
@@ -284,16 +284,16 @@ class YOLOv8Seg:
             cv2.putText(im, f'{self.classes[cls_]}: {conf:.3f}', (int(box[0]), int(box[1] - 9)),
                         cv2.FONT_HERSHEY_SIMPLEX, 0.7, self.color_palette(int(cls_), bgr=True), 2, cv2.LINE_AA)
 
-        # mixup
+        # Mix image
         im = cv2.addWeighted(im_canvas, 0.3, im, 0.7, 0)
 
-        # imshow
+        # Show image
         if vis:
             cv2.imshow('demo', im)
             cv2.waitKey(0)
             cv2.destroyAllWindows()
 
-        # save image
+        # Save image
         if save:
             cv2.imwrite('demo.jpg', im)
 

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -1,0 +1,168 @@
+import argparse
+import cv2
+import numpy as np
+import onnxruntime as ort
+from ultralytics.utils import ASSETS, yaml_load
+from ultralytics.utils.checks import check_requirements, check_yaml
+
+
+class Model:
+    def __init__(self, *, p, **kwargs):
+        self.session = ort.InferenceSession(
+            p, 
+            providers=['CUDAExecutionProvider', 'CPUExecutionProvider'] if ort.get_device() == 'GPU' else ['CPUExecutionProvider']
+        )  # session
+        self.ndtype = np.half if self.session.get_inputs()[0].type == 'tensor(float16)' else np.single  # dtype
+        self.iShapes = [x.shape for x in self.session.get_inputs()] # input shapes
+        self.im_meta = dict()
+        self.conf_threshold = kwargs.get('conf_threshold', 0.4)
+        self.iou_threshold = kwargs.get('iou_threshold', 0.45)
+        self.nm = kwargs.get('nms', 32)
+        self.classes = yaml_load(check_yaml('coco128.yaml'))['names']
+        self.palette = np.random.uniform(0, 255, size=(len(self.classes), 3))
+
+
+    def __call__(self, x, **kwargs):
+        self._preprocess(x)
+        preds = self.session.run(None, {self.session.get_inputs()[0].name: self.im_meta['im']})
+        x, proto = np.einsum('bcn->bnc', preds[0]), preds[1][0]   # prediction, proto
+        x = x[np.amax(x[..., 4: -self.nm], axis=-1) > self.conf_threshold]  # filter by conf
+        x = np.c_[x[..., :4], np.amax(x[..., 4: -self.nm], axis=-1), np.argmax(x[..., 4: -self.nm], axis=-1), x[..., -self.nm: ]]  # box, score, cls
+        x = x[cv2.dnn.NMSBoxes(x[:, :4], x[:, 4], self.conf_threshold, self.iou_threshold)]  # nms
+        if len(x) == 0:
+            return [], [], []
+        else: 
+            # de-scale boxes
+            x[..., [0, 1]] -= x[..., [2, 3]] / 2
+            x[..., [2, 3]] += x[..., [0, 1]]
+            x[..., :4] -= [self.im_meta['dw'], self.im_meta['dh'], self.im_meta['dw'], self.im_meta['dh']]
+            x[..., :4] /= min(self.im_meta['ratio'])
+            x[..., [0, 2]] = x[:, [0, 2]].clip(0, self.im_meta['im0'].shape[1])
+            x[..., [1, 3]] = x[:, [1, 3]].clip(0, self.im_meta['im0'].shape[0])
+            y_segments, y_masks, y_boxes = list(), list(), list()
+            masks = self.process_mask_hq(proto, x[:, 6:], x[:, :4], self.im_meta['im0'].shape)
+            segments = self.mask2segs(masks)  # mask2segments
+
+            # visualize
+            for segment in segments:
+                cv2.polylines(self.im_meta['im0'], np.int32([segment]), True, (255, 255, 0), 2)
+                # cv2.fillPoly(self.im_meta['im0'], np.int32([segment]), (255, 255, 0))
+            for *box, conf, cls_ in x[..., :6]:
+                cv2.rectangle(
+                    self.im_meta['im0'],
+                    (int(box[0]), int(box[1])), (int(box[2]), int(box[3])), 
+                    self.palette[int(cls_)], 0, cv2.LINE_AA
+                 )
+                cv2.putText(
+                    self.im_meta['im0'], 
+                    f'{self.classes[cls_]}: {conf:.3f}', 
+                    (int(box[0]), int(box[1] - 9)), 
+                    cv2.FONT_HERSHEY_SIMPLEX, 
+                    0.7, 
+                    self.palette[int(cls_)], 
+                    2, cv2.LINE_AA
+                )
+            cv2.imshow('demo', self.im_meta['im0'])
+            cv2.waitKey(0)
+            cv2.destroyAllWindows()
+            cv2.imwrite('demo.jpg', self.im_meta['im0'])
+
+            return x[..., :6], segments, masks
+
+
+    def _preprocess(self, x) -> dict:
+        self.im_meta['im0'] = x
+        shape = x.shape[:2]  # current shape
+        new_shape = self.iShapes[0][-2:]
+        r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
+        self.im_meta['ratio'] = r, r
+        new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
+        self.im_meta['dw'], self.im_meta['dh'] = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] - new_unpad[1]) / 2  # wh padding
+        if shape[::-1] != new_unpad:  # resize
+            x = cv2.resize(x, new_unpad, interpolation=cv2.INTER_LINEAR)
+        top, bottom = int(round(self.im_meta['dh'] - 0.1)), int(round(self.im_meta['dh'] + 0.1))
+        left, right = int(round(self.im_meta['dw'] - 0.1)), int(round(self.im_meta['dw'] + 0.1))
+        x = cv2.copyMakeBorder(x, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(114, 114, 114))  # add border
+        x = np.ascontiguousarray(np.einsum('asd->das', x)[::-1], dtype=self.ndtype) / 255.0  # tranform
+        x = x[None] if len(x.shape) == 3 else x
+        self.im_meta['im'] = x
+
+
+    @staticmethod
+    def mask2segs(masks):
+        segments = []
+        for x in masks.astype('uint8'):
+            c = cv2.findContours(x, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[0]  # CHAIN_APPROX_SIMPLE
+            if c:
+                c = np.array(c[np.array([len(x) for x in c]).argmax()]).reshape(-1, 2)
+            else:
+                c = np.zeros((0, 2))  # no segments found
+            segments.append(c.astype('float32'))
+        return segments
+
+
+    @staticmethod
+    def crop_mask(masks, boxes):
+        """
+        Args:
+            - masks should be a size [h, w, n] tensor of masks
+            - boxes should be a size [n, 4] tensor of bbox coords in relative point form
+        """
+        n, h, w = masks.shape
+        x1, y1, x2, y2 = np.split(boxes[:, :, None], 4, 1)
+        r = np.arange(w, dtype=x1.dtype)[None, None, :]
+        c = np.arange(h, dtype=x1.dtype)[None, :, None]
+        return masks * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
+
+
+    def process_mask_hq(self, protos, masks_in, bboxes, im0shape):
+        c, mh, mw = protos.shape  
+        mask_protos = np.reshape(protos, (c, -1))
+        matmulres = np.matmul(masks_in, mask_protos) 
+        masks = np.reshape(matmulres, (-1, mh, mw))  
+        masks = np.ascontiguousarray(masks.transpose(1, 2, 0))
+        masks = self.scale_mask(masks.shape[:2], masks, im0shape) 
+        masks = np.einsum('zxc->czx', masks)
+        masks = self.crop_mask(masks, bboxes.copy()) 
+        masks_gt = np.greater(masks, 0.5)
+        masks_gt = masks_gt.astype(float)
+        return masks_gt
+
+
+    @staticmethod
+    def scale_mask(im1_shape, masks, im0_shape, ratio_pad=None):
+        if ratio_pad is None:  # calculate from im0_shape
+            gain = min(im1_shape[0] / im0_shape[0], im1_shape[1] / im0_shape[1])  # gain  = old / new
+            pad = (im1_shape[1] - im0_shape[1] * gain) / 2, (im1_shape[0] - im0_shape[0] * gain) / 2  # wh padding
+        else:
+            pad = ratio_pad[1]
+        top, left = int(pad[1]), int(pad[0])  # y, x
+        bottom, right = int(im1_shape[0] - pad[1]), int(im1_shape[1] - pad[0])
+        if len(masks.shape) < 2:
+            raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
+        masks = masks[top:bottom, left:right]   
+        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]), interpolation=cv2.INTER_CUBIC)  # 
+        if len(masks.shape) == 2:
+            masks = masks[:, :, None]
+        return masks
+
+
+
+if __name__ == '__main__':
+    # Create an argument parser to handle command-line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model', type=str, required=True, help='Path to ONNX model ')
+    parser.add_argument('--source', type=str, required=True, help='Path to input image')
+    parser.add_argument('--conf', type=float, default=0.3, help='Confidence threshold')
+    parser.add_argument('--iou', type=float, default=0.45, help='NMS IoU threshold')
+    args = parser.parse_args()
+
+    # build model
+    model = Model(p=args.model, conf_threshold=args.conf, iou_threshold=args.iou)
+    
+    # load image
+    img = cv2.imread(args.source)
+
+    # infer
+    y_bboxes, y_segments, y_masks = model(img)
+    print(y_bboxes)


### PR DESCRIPTION
I find no yolov8 segmentation demo provided in examples directory. Some people want to deploy yolov8-seg models with ONNXRuntime or other frameworks, while not importing PyTorch. So I write a simple segmentation demo using Numpy and OpenCV.

----------------------
# PR Update

## Summary
This pull request adds a new example project that implements ONNXRuntime-based YOLOv8 segmentation which not relying on PyTorch. Just Numpy and OpenCV. It includes a main.py file that implements the model and a README.md file that explains the project and how to run it.

## Walkthrough
 - Provide usage instructions
 - Add docstrings for class and methods
 - Support FP32 and FP16 model



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added YOLOv8 Segmentation with ONNXRuntime in Python example.

### 📊 Key Changes
- 🧩 New example directory `YOLOv8-Segmentation-ONNXRuntime-Python` with code and README.
- ✨ README.md details how to run segmentation with YOLOv8 using ONNX Runtime.
- 🛠 Main script `main.py` added for running segmentation in Python.
- 📝 Updated contribution guidelines in `examples/README.md`.

### 🎯 Purpose & Impact
- 🚀 Enables users to perform image segmentation without PyTorch, relying solely on ONNX Runtime.
- 🔍 Supports FP32 and FP16 precision, optimizing performance across devices.
- 🤝 Expanded community contribution guidelines streamline the process for contributors.
- 🌐 Promotes interoperability and easier setup, broadening access to machine learning applications.