### PR TITLE
convert cfg.get('model', '') to str

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -118,7 +118,7 @@ def get_cfg(cfg: Union[str, Path, Dict, SimpleNamespace] = DEFAULT_CFG_DICT, ove
         if k in cfg and isinstance(cfg[k], (int, float)):
             cfg[k] = str(cfg[k])
     if cfg.get('name') == 'model':  # assign model to 'name' arg
-        cfg['name'] = cfg.get('model', '').split('.')[0]
+        cfg['name'] = str(cfg.get('model', '')).split('.')[0]
         LOGGER.warning(f"WARNING ⚠️ 'name=model' automatically updated to 'name={cfg['name']}'.")
 
     # Type and Value checks


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d32bf93</samp>

### Summary
🐛🚑🎨

<!--
1.  🐛 - This emoji represents a bug fix, since the change was made to resolve an issue that caused an error in some cases.
2.  🚑 - This emoji represents a hotfix, since the change was made to patch a critical or urgent problem that affected the functionality of the code.
3.  🎨 - This emoji represents an improvement to the code format or structure, since the change was made to make the code more robust and readable by explicitly casting the value to a string.
-->
Fixed a bug in `cfg['name']` assignment that could cause an error if `model` was not a string. Updated `ultralytics/cfg/__init__.py` to handle different types of `model` values.

> _`cfg['name']` fixed_
> _Cast `model` to a string_
> _Winter bug no more_

### Walkthrough
*  Cast `cfg.get('model', '')` to string before splitting by dot to avoid error if `model` is not a string ([link](https://github.com/ultralytics/ultralytics/pull/6116/files?diff=unified&w=0#diff-c02fb3f9e86e97bf85f07211aed56aa04774504a61eeff07a08471bbdea14556L121-R121))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement in configuration name assignment logic.

### 📊 Key Changes
- Modified the assignment of the `name` configuration parameter to ensure it is always treated as a string before splitting.

### 🎯 Purpose & Impact
- 🛠️ **Enhances robustness**: by explicitly converting the model configuration name to a string, the risk of type errors from unexpected non-string inputs is reduced.
- 🏗️ **Improves consistency**: helps maintain a standard format for the `name` parameter, which may prevent errors in downstream code that relies on this configuration.
- 🚀 **Potential impact**: users can expect more reliable configuration parsing, leading to fewer crashes or issues related to model naming.