### PR TITLE
`ultralytics 8.0.207` fix `model.track(persist=True)` bug

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.206'
+__version__ = '8.0.207'
 
 from ultralytics.models import RTDETR, SAM, YOLO
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -38,13 +38,13 @@ def on_predict_start(predictor, persist=False):
     predictor.trackers = trackers
 
 
-def on_predict_postprocess_end(predictor):
+def on_predict_postprocess_end(predictor, persist=False):
     """Postprocess detected boxes and update with object tracking."""
     bs = predictor.dataset.bs
     path, im0s = predictor.batch[:2]
 
     for i in range(bs):
-        if predictor.vid_path[i] != str(predictor.save_dir / Path(path[i]).name):  # new video
+        if not persist and predictor.vid_path[i] != str(predictor.save_dir / Path(path[i]).name):  # new video
             predictor.trackers[i].reset()
 
         det = predictor.results[i].boxes.cpu().numpy()
@@ -67,4 +67,4 @@ def register_tracker(model, persist):
         persist (bool): Whether to persist the trackers if they already exist.
     """
     model.add_callback('on_predict_start', partial(on_predict_start, persist=persist))
-    model.add_callback('on_predict_postprocess_end', on_predict_postprocess_end)
+    model.add_callback('on_predict_postprocess_end', partial(on_predict_postprocess_end, persist=persist))


### PR DESCRIPTION
May resolve https://github.com/ultralytics/ultralytics/issues/6096


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7c9bf82</samp>

### Summary
🆕🔄🎞️

<!--
1.  🆕 - This emoji can be used to indicate that a new feature or option was added to the existing functionality of object tracking.
2.  🔄 - This emoji can be used to indicate that the behavior or logic of the `on_predict_postprocess_end` callback was modified or updated to handle the new feature or option.
3.  🎞️ - This emoji can be used to indicate that the object tracking feature now supports multiple videos or video changes, which might be relevant for users who want to apply it to different sources or scenarios.
-->
Added a feature to `track.py` to enable persistent object tracking across multiple videos. Updated the callback function to handle the new feature.

> _`persist` the trackers of your prey_
> _Across the videos of doom_
> _`on_predict_postprocess_end` is the gate_
> _To handle the changes of your gloom_

### Walkthrough
*  Add `persist` argument to enable or disable tracker persistence across videos ([link](https://github.com/ultralytics/ultralytics/pull/6145/files?diff=unified&w=0#diff-bdb6386c91992a2e78da487232bf0e4796032c2c3256bdb6a9c640951ef6415aL41-R41), [link](https://github.com/ultralytics/ultralytics/pull/6145/files?diff=unified&w=0#diff-bdb6386c91992a2e78da487232bf0e4796032c2c3256bdb6a9c640951ef6415aL47-R47), [link](https://github.com/ultralytics/ultralytics/pull/6145/files?diff=unified&w=0#diff-bdb6386c91992a2e78da487232bf0e4796032c2c3256bdb6a9c640951ef6415aL70-R70))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to Ultralytics package and enhancements to object tracking logic 🛠️

### 📊 Key Changes
- Bump in Ultralytics version number from `8.0.206` to `8.0.207`.
- Addition of a `persist` parameter to `on_predict_postprocess_end` function.
- Conditional tracker reset based on `persist` parameter and video path comparison.

### 🎯 Purpose & Impact
- **Version Update**: Maintains the progression of the software, possibly including minor fixes or improvements not explicitly detailed in the diff.
- **Tracking Enhancement**: The `persist` parameter allows better control over object trackers between video segments or batch processing, reducing potential tracking errors or enabling long-term continuity.
- **User Experience**: Improved object tracking may result in more accurate and reliable model predictions, beneficial for applications relying on video analysis or real-time object tracking. 🎥➡️👀