### PR TITLE
change brute-resize method to letterbox-resize

### DIFF
--- a/examples/YOLOv8-ONNXRuntime-CPP/inference.h
+++ b/examples/YOLOv8-ONNXRuntime-CPP/inference.h
@@ -81,4 +81,5 @@ private:
     std::vector<int> imgSize;
     float rectConfidenceThreshold;
     float iouThreshold;
+    float resizeScales;//letterbox scale
 };


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7959492</samp>

### Summary
:memo::sparkles::bug:

<!--
1.  :memo: This emoji represents documentation or code comments, since the pull request adds some comments to explain the letterbox resizing method and the bounding box calculations.
2.  :sparkles: This emoji represents a new feature or enhancement, since the pull request improves the accuracy of the YOLOv8 model by using letterbox resizing instead of simple resizing.
3.  :bug: This emoji represents a bug fix or a correction, since the pull request fixes the issue of distorted bounding boxes caused by simple resizing.
-->
The pull request improves the accuracy of the YOLOv8 model for object detection by using letterbox resizing for images and bounding boxes. It also declares `resizeScales` as a class member in `inference.h` to avoid redundant calculations.

> _To detect objects with YOLOv8_
> _We need to resize images great_
> _We use `resizeScales`_
> _In `E` class details_
> _And letterbox them to keep aspect rate_

### Walkthrough
*  Modify `PostProcess` function to use letterbox resizing for YOLOv8 model ([link](https://github.com/ultralytics/ultralytics/pull/6300/files?diff=unified&w=0#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8L43-R64))
*  Remove `x_factor` and `y_factor` variables from `E` constructor and add `resizeScales` variable to store scaling factor for each image ([link](https://github.com/ultralytics/ultralytics/pull/6300/files?diff=unified&w=0#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8L191-L192), [link](https://github.com/ultralytics/ultralytics/pull/6300/files?diff=unified&w=0#diff-f5d599dd06fc6fe16f8d0baa50c155992f0769af08495431ad265ad74dc4f90fR84))
*  Adjust bounding box coordinates and dimensions to use `resizeScales` variable instead of `x_factor` and `y_factor` variables ([link](https://github.com/ultralytics/ultralytics/pull/6300/files?diff=unified&w=0#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8L208-R226))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to the image preprocessing and bounding box scaling in the YOLOv8 ONNXRuntime C++ example.

### 📊 Key Changes
- Improved the image preprocessing logic to handle different image channel formats (grayscale vs RGB).
- Added conditional resizing based on the image's aspect ratio to maintain the scale while converting to the model's input size.
- Introduced a `resizeScales` variable to handle the scaling of bounding boxes accurately after detection.
- Removed hard-coded scaling factors, replacing them with the dynamic `resizeScales` for bounding box adjustments.

### 🎯 Purpose & Impact
- 🔍 The updated preprocessing ensures that all input images are correctly formatted for the model, potentially improving detection accuracy.
- 📐 By dynamically resizing images according to their aspect ratio, the model can better recognize objects without distortion.
- 🔧 The variable `resizeScales` provides accurate bounding box coordinates post-detection, which is crucial for applications that require precise object localization.
- 🌐 These changes are likely to boost the general performance and usability of the YOLOv8 ONNXRuntime C++ example, benefiting developers who rely on this example as a starting point for integration in their projects.