### PR TITLE
change resize method from brute to letterbox

### DIFF
--- a/examples/YOLOv8-ONNXRuntime-CPP/inference.h
+++ b/examples/YOLOv8-ONNXRuntime-CPP/inference.h
@@ -81,4 +81,5 @@ private:
     std::vector<int> imgSize;
     float rectConfidenceThreshold;
     float iouThreshold;
+    float resizeScales;//letterbox scale
 };


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bb923ee</samp>

### Summary
🔍📐🛠️

<!--
1.  🔍 This emoji can represent the improved accuracy and precision of the object detection model after using letterbox resizing, which preserves the aspect ratio of the input image and avoids distortion or cropping of the objects.
2.  📐 This emoji can represent the scaling and padding operations that are involved in letterbox resizing, which adjust the input image to fit the desired dimensions and fill the remaining space with black pixels.
3.  🛠️ This emoji can represent the modification of the code and the addition of the `resizeScales` variable, which is a tool for implementing the letterbox resizing method.
-->
The pull request improves the YOLOv8 object detection model by using letterbox resizing for the input and output images. It also declares `resizeScales` as a class member in `inference.h` to simplify the code.

> _To improve the YOLOv8 detection_
> _They changed the input's resizing section_
> _They used `resizeScales`_
> _In the `E` class details_
> _And applied letterbox for correction_

### Walkthrough
*  Modify `PostProcess` function to use letterbox resizing for input image ([link](https://github.com/ultralytics/ultralytics/pull/6304/files?diff=unified&w=0#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8L43-R64))
*  Remove `x_factor` and `y_factor` variables from `E` constructor and add `resizeScales` variable to store scaling factor for input image ([link](https://github.com/ultralytics/ultralytics/pull/6304/files?diff=unified&w=0#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8L191-L192), [link](https://github.com/ultralytics/ultralytics/pull/6304/files?diff=unified&w=0#diff-f5d599dd06fc6fe16f8d0baa50c155992f0769af08495431ad265ad74dc4f90fR84))
*  Adjust bounding box coordinates and dimensions to use `resizeScales` variable instead of `x_factor` and `y_factor` variables ([link](https://github.com/ultralytics/ultralytics/pull/6304/files?diff=unified&w=0#diff-8a52ad28c0e0fa1a4348a3b3d4380f9abafe6985bb935a1eec74d3b77b76fca8L208-R226))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved preprocessing and bounding box scaling in YOLOv8 ONNXRuntime C++ example.

### 📊 Key Changes
- Post-processing now maintains aspect ratio during image resizing using letterboxing.
- Removed redundant image color conversion when input has three channels.
- Adjusted bounding box scaling to use a new `resizeScales` variable calculated from aspect ratio.

### 🎯 Purpose & Impact
- **Purpose**: To ensure that the image preprocessing step retains the original aspect ratio and to improve the accuracy of bounding box coordinates after detection.
- **Impact**: Results in more accurate object detection in images with varying aspect ratios, enhancing overall performance and reliability of YOLOv8 C++ examples. Users will see better detection results without distorted images or bounding boxes. 📈👀