### PR TITLE
fix last.pt explanation as author-said

### DIFF
--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -188,7 +188,7 @@ This file contains scatter plots generated from `tune_results.csv`, helping you 
 
 This directory contains the saved PyTorch models for the last and the best iterations during the hyperparameter tuning process.
 
-- **`last.pt`**: The last.pt weights for the iteration that achieved the best fitness score.
+- **`last.pt`**: The last.pt are the weights from the last epoch of training.
 - **`best.pt`**: The best.pt weights for the iteration that achieved the best fitness score.
 
 Using these results, you can make more informed decisions for your future model trainings and analyses. Feel free to consult these artifacts to understand how well your model performed and how you might improve it further.


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

Hello, Thank you always.
I changed the explanation about last.pt.

**Before**
```
last.pt: The last.pt weights for the iteration that achieved the best fitness score.
```
**After**
```
last.pt: The last.pt are the weights from the last epoch of training.
```

[Document](https://docs.ultralytics.com/guides/hyperparameter-tuning/?h=best.pt#tune_scatter_plotspng) explains last.pt and best.pt.
But I think 2 different parameters are explained in the same sentence.
So, I changed the previous explanation to  [author-said definition](https://github.com/ultralytics/yolov5/issues/582).

cite
>weights/
This directory contains the saved PyTorch models for the last and the best iterations during the hyperparameter tuning process.
>last.pt: The last.pt weights for the iteration that achieved the best fitness score.
>best.pt: The best.pt weights for the iteration that achieved the best fitness score.

I have read the CLA Document and I sign the CLA

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3683575</samp>

### Summary
📝🐛🚀

<!--
1.  📝 This emoji can be used to indicate that a text or documentation was edited or updated.
2.  🐛 This emoji can be used to indicate that a bug or an error was fixed or resolved.
3.  🚀 This emoji can be used to indicate that a performance or efficiency improvement was made or a new feature was added.
-->
Updated the documentation of `last.pt` file in the hyperparameter tuning guide. Explained the difference between `last.pt` and `best.pt` files and how they are generated.

> _`last.pt` file_
> _not the same as `best.pt`_
> _autumn leaves falling_

### Walkthrough
*  Clarify the difference between `last.pt` and `best.pt` files in the hyperparameter tuning guide ([link](https://github.com/ultralytics/ultralytics/pull/6312/files?diff=unified&w=0#diff-55a4cc30df517e7a8d66696d04421b32daf5c3ad2741c227467730991ae85c61L191-R191))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved documentation clarity for model weight files in Ultralytics hyperparameter tuning guide.

### 📊 Key Changes
- Updated the description of `last.pt` to specify that it represents the weights from the last epoch of training.

### 🎯 Purpose & Impact
- 💡 **Clarity**: Ensures users understand exactly what `last.pt` represents, avoiding confusion between final epoch weights and best performance weights.
- 🚀 **User Guidance**: Improved documentation helps users make better-informed decisions when analyzing model performance and planning subsequent training sessions.