### PR TITLE
Include `int8` as arguments for export to OpenVINO and SavedModel

### DIFF
--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -96,10 +96,10 @@ Available YOLOv8 export formats are in the table below. You can export to any fo
 | [PyTorch](https://pytorch.org/)                                    | -                 | `yolov8n.pt`              | ✅        | -                                                   |
 | [TorchScript](https://pytorch.org/docs/stable/jit.html)            | `torchscript`     | `yolov8n.torchscript`     | ✅        | `imgsz`, `optimize`                                 |
 | [ONNX](https://onnx.ai/)                                           | `onnx`            | `yolov8n.onnx`            | ✅        | `imgsz`, `half`, `dynamic`, `simplify`, `opset`     |
-| [OpenVINO](https://docs.openvino.ai/latest/index.html)             | `openvino`        | `yolov8n_openvino_model/` | ✅        | `imgsz`, `half`                                     |
+| [OpenVINO](https://docs.openvino.ai/latest/index.html)             | `openvino`        | `yolov8n_openvino_model/` | ✅        | `imgsz`, `half`, `int8`                             |
 | [TensorRT](https://developer.nvidia.com/tensorrt)                  | `engine`          | `yolov8n.engine`          | ✅        | `imgsz`, `half`, `dynamic`, `simplify`, `workspace` |
 | [CoreML](https://github.com/apple/coremltools)                     | `coreml`          | `yolov8n.mlpackage`       | ✅        | `imgsz`, `half`, `int8`, `nms`                      |
-| [TF SavedModel](https://www.tensorflow.org/guide/saved_model)      | `saved_model`     | `yolov8n_saved_model/`    | ✅        | `imgsz`, `keras`                                    |
+| [TF SavedModel](https://www.tensorflow.org/guide/saved_model)      | `saved_model`     | `yolov8n_saved_model/`    | ✅        | `imgsz`, `keras`, `int8`                            |
 | [TF GraphDef](https://www.tensorflow.org/api_docs/python/tf/Graph) | `pb`              | `yolov8n.pb`              | ❌        | `imgsz`                                             |
 | [TF Lite](https://www.tensorflow.org/lite)                         | `tflite`          | `yolov8n.tflite`          | ✅        | `imgsz`, `half`, `int8`                             |
 | [TF Edge TPU](https://coral.ai/docs/edgetpu/models-intro/)         | `edgetpu`         | `yolov8n_edgetpu.tflite`  | ✅        | `imgsz`                                             |


### PR DESCRIPTION
This PR updates the documentation to include the `int8` argument for exporting to OpenVINO and SavedModel, aligning it with the current capabilities in the Ultralytics main branch.

References to the code implementations:

References:

- OpenVINO - https://github.com/ultralytics/ultralytics/blob/9a5891444ebd374b1aba4aa147c1f9e11a1db5d2/ultralytics/engine/exporter.py#L401

- SavedModel - https://github.com/ultralytics/ultralytics/blob/9a5891444ebd374b1aba4aa147c1f9e11a1db5d2/ultralytics/engine/exporter.py#L667



Docs page - https://docs.ultralytics.com/modes/export/#export-formats

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 15035ef</samp>

### Summary
🚀🗜️🌐

<!--
1.  🚀 This emoji conveys the idea of boosting performance and speed, which is one of the benefits of quantization-aware training and inference. It also suggests innovation and progress, which are relevant to the addition of a new option for the export formats.
2.  🗜️ This emoji represents compression and reduction, which are also outcomes of quantization-aware training and inference. It implies that the model size can be decreased and the memory footprint can be optimized by using the `int8` option.
3.  🌐 This emoji symbolizes the global and cross-platform nature of the export formats, which allow YOLOv5 models to be deployed on various devices and environments. It also reflects the diversity and compatibility of the ultralytics/ultralytics framework, which supports multiple formats and platforms.
-->
Added `int8` quantization option for OpenVINO and TF SavedModel export formats in `docs/en/modes/export.md`. This allows faster and smaller models for these platforms.

> _`int8` option_
> _quantizes models for speed_
> _autumn leaves falling_

### Walkthrough
* Add `int8` option to OpenVINO and TF SavedModel export formats to enable quantization-aware training and inference ([link](https://github.com/ultralytics/ultralytics/pull/6329/files?diff=unified&w=0#diff-039a49a0e1108cd98696a4fb610482afad76600040018008ef56968d08d2c956L99-R102))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

It appears you haven't provided the actual content changes from the `ultralytics/ultralytics` PR diff for the file `docs/en/modes/export.md`. Without the specific changes made to the document, I can't generate an accurate summary. Please provide the content changes that have been made so I can assist you with your request!