### PR TITLE
Let Triton model run via gRPC

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -509,6 +509,6 @@ class AutoBackend(nn.Module):
         else:
             from urllib.parse import urlsplit
             url = urlsplit(p)
-            triton = url.netloc and url.path and url.scheme in {'http', 'grfc'}
+            triton = url.netloc and url.path and url.scheme in {'http', 'grpc'}
 
         return types + [triton]

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -439,7 +439,8 @@ def check_file(file, suffix='', download=True, hard=True):
     check_suffix(file, suffix)  # optional
     file = str(file).strip()  # convert to string and strip spaces
     file = check_yolov5u_filename(file)  # yolov5n -> yolov5nu
-    if not file or ('://' not in file and Path(file).exists()) or file.lower().startswith('grpc://'):  # exists ('://' check required in Windows Python<3.10)
+    if not file or ('://' not in file and Path(file).exists()
+                    ) or file.lower().startswith('grpc://'):  # exists ('://' check required in Windows Python<3.10)
         return file
     elif download and file.lower().startswith(('https://', 'http://', 'rtsp://', 'rtmp://', 'tcp://')):  # download
         url = file  # warning: Pathlib turns :// -> :/

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -439,7 +439,7 @@ def check_file(file, suffix='', download=True, hard=True):
     check_suffix(file, suffix)  # optional
     file = str(file).strip()  # convert to string and strip spaces
     file = check_yolov5u_filename(file)  # yolov5n -> yolov5nu
-    if not file or ('://' not in file and Path(file).exists()):  # exists ('://' check required in Windows Python<3.10)
+    if not file or ('://' not in file and Path(file).exists()) or file.lower().startswith('grpc://'):  # exists ('://' check required in Windows Python<3.10)
         return file
     elif download and file.lower().startswith(('https://', 'http://', 'rtsp://', 'rtmp://', 'tcp://')):  # download
         url = file  # warning: Pathlib turns :// -> :/


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

This pull request is going to fix the error that arises while using the Triton gRPC client. Prior to this PR, I was encountering the following error: `FileNotFoundError: 'grpc://localhost:8001/yolo' does not exist` while I was using the example from documentation. After the changes, I'm able to send images to the Triton backend using gRPC.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9b20de6</samp>

### Summary
🐛🆕🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the case for the typo correction in the scheme name for the gRPC protocol.
2.  🆕 - This emoji represents a new feature, which is the case for the addition of the condition to accept files that start with 'grpc://'.
3.  🚀 - This emoji represents a performance improvement, which is the case for the support of models that use the gRPC protocol without downloading them.
-->
This pull request fixes a typo and adds a condition to support models that use the `gRPC` protocol in the `ultralytics` library. The changes affect the `AutoBackend` class and the `check_file` function in the `ultralytics/nn/autobackend.py` and `ultralytics/utils/checks.py` modules, respectively.

> _`gRPC` models work_
> _Fix typo and add check file_
> _Winter of bugs ends_

### Walkthrough
* Fix typo in gRPC scheme name in `_model_type` function ([link](https://github.com/ultralytics/ultralytics/pull/6442/files?diff=unified&w=0#diff-2e3ad5da4ba57eb68a9b5aaddf0c40c784d888b7619ed337ce31dfea4f6380f9L512-R512))
* Allow `check_file` function to accept files that start with 'grpc://' ([link](https://github.com/ultralytics/ultralytics/pull/6442/files?diff=unified&w=0#diff-5b30bb601bc6484cdfcca11c382b45064aecc5b1024571f2984f6d4c74b89095L442-R442))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in backend detection and file-checking protocols for Ultralytics AI models.

### 📊 Key Changes
- Corrected a typo in the autobackend script from 'grfc' to 'grpc'.
- Updated the file existence check to accept URLs starting with 'grpc://'.

### 🎯 Purpose & Impact
- Ensures proper identification of Triton servers by fixing the protocol name, which is critical for users working with remote AI models. 🛠️
- Allows gRPC protocol URLs to pass file existence checks, enabling seamless interaction with models served over gRPC. 🔄

The changes are likely to benefit developers and users by facilitating better integration with AI models hosted remotely, particularly through Triton and gRPC servers, enhancing the framework's flexibility and robustness. 🌐