### PR TITLE
`ultralytics 8.0.213` NVIDIA Triton gRPC fix

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.212'
+__version__ = '8.0.213'
 
 from ultralytics.models import RTDETR, SAM, YOLO
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -102,7 +102,7 @@ class Model(nn.Module):
         """Is model a Triton Server URL string, i.e. <scheme>://<netloc>/<endpoint>/<task_name>"""
         from urllib.parse import urlsplit
         url = urlsplit(model)
-        return url.netloc and url.path and url.scheme in {'http', 'grfc'}
+        return url.netloc and url.path and url.scheme in {'http', 'grpc'}
 
     @staticmethod
     def is_hub_model(model):

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -509,6 +509,6 @@ class AutoBackend(nn.Module):
         else:
             from urllib.parse import urlsplit
             url = urlsplit(p)
-            triton = url.netloc and url.path and url.scheme in {'http', 'grfc'}
+            triton = url.netloc and url.path and url.scheme in {'http', 'grpc'}
 
         return types + [triton]

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -439,7 +439,8 @@ def check_file(file, suffix='', download=True, hard=True):
     check_suffix(file, suffix)  # optional
     file = str(file).strip()  # convert to string and strip spaces
     file = check_yolov5u_filename(file)  # yolov5n -> yolov5nu
-    if not file or ('://' not in file and Path(file).exists()) or file.lower().startswith('grpc://'):  # exists ('://' check required in Windows Python<3.10)
+    if not file or ('://' not in file and Path(file).exists()
+                    ) or file.lower().startswith('grpc://'):  # exists ('://' check required in Windows Python<3.10)
         return file
     elif download and file.lower().startswith(('https://', 'http://', 'rtsp://', 'rtmp://', 'tcp://')):  # download
         url = file  # warning: Pathlib turns :// -> :/

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -439,8 +439,8 @@ def check_file(file, suffix='', download=True, hard=True):
     check_suffix(file, suffix)  # optional
     file = str(file).strip()  # convert to string and strip spaces
     file = check_yolov5u_filename(file)  # yolov5n -> yolov5nu
-    if not file or ('://' not in file and Path(file).exists()
-                    ) or file.lower().startswith('grpc://'):  # exists ('://' check required in Windows Python<3.10)
+    if (not file or ('://' not in file and Path(file).exists()) or  # '://' check required in Windows Python<3.10
+            file.lower().startswith('grpc://')):  # file exists or gRPC Triton images
         return file
     elif download and file.lower().startswith(('https://', 'http://', 'rtsp://', 'rtmp://', 'tcp://')):  # download
         url = file  # warning: Pathlib turns :// -> :/

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -439,7 +439,7 @@ def check_file(file, suffix='', download=True, hard=True):
     check_suffix(file, suffix)  # optional
     file = str(file).strip()  # convert to string and strip spaces
     file = check_yolov5u_filename(file)  # yolov5n -> yolov5nu
-    if not file or ('://' not in file and Path(file).exists()):  # exists ('://' check required in Windows Python<3.10)
+    if not file or ('://' not in file and Path(file).exists()) or file.lower().startswith('grpc://'):  # exists ('://' check required in Windows Python<3.10)
         return file
     elif download and file.lower().startswith(('https://', 'http://', 'rtsp://', 'rtmp://', 'tcp://')):  # download
         url = file  # warning: Pathlib turns :// -> :/


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

This pull request is going to fix the error that arises while using the Triton gRPC client. Prior to this PR, I was encountering the following error: `FileNotFoundError: grpc://localhost:8001/yolo does not exist` while I was using the example from documentation. After the changes, I'm able to send images to the Triton backend using gRPC.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a163886</samp>

### Summary
🐛🌐➕

<!--
1.  🐛 - This emoji represents a bug fix, which is what the typo correction is.
2.  🌐 - This emoji represents the internet or web, which is what the gRPC protocol is related to.
3.  ➕ - This emoji represents adding something new or enhancing something existing, which is what the condition for gRPC URLs does.
-->
This pull request fixes a typo in the gRPC scheme name and adds support for gRPC URLs as model paths in the `AutoBackend` class. These changes enable remote inference with Triton servers in the `ultralytics` library.

> _`gRPC` for Triton_
> _Remote inference with ease_
> _No need to download_

### Walkthrough
* Fix typo in gRPC scheme name for remote inference with Triton servers ([link](https://github.com/ultralytics/ultralytics/pull/6443/files?diff=unified&w=0#diff-2e3ad5da4ba57eb68a9b5aaddf0c40c784d888b7619ed337ce31dfea4f6380f9L512-R512))
* Add condition to return gRPC URLs as model paths without downloading or checking ([link](https://github.com/ultralytics/ultralytics/pull/6443/files?diff=unified&w=0#diff-5b30bb601bc6484cdfcca11c382b45064aecc5b1024571f2984f6d4c74b89095L442-R443))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to Ultralytics version 8.0.213 with a typo fix and improved file support

### 📊 Key Changes
- Bumped the Ultralytics version from `8.0.212` to `8.0.213`.
- Corrected a typo from `grfc` to `grpc` in the URL scheme checks.
- Extended the file existence check to support `grpc://` prefixed files.

### 🎯 Purpose & Impact
- 🆕 Version increment ensures that users can reference and use the newest set of features and bug fixes.
- ✅ Typo fix in URL scheme validation corrects the protocol specification, likely for communication with Triton inference servers, ensuring proper functionality.
- 🚀 Enhanced file check with gRPC support opens the door for Triton server users to work with models served via gRPC without encountering file-related errors.

These changes primarily impact developers integrating Triton server machine learning models with Ultralytics software and users who rely on the latest features and fixes.