### PR TITLE
fixing AttributeError: 'OutStream' object has no attribute 'reconfigure'

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.213'
+__version__ = '8.0.214'
 
 from ultralytics.models import RTDETR, SAM, YOLO
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -230,7 +230,10 @@ def set_logging(name=LOGGING_NAME, verbose=True):
 
     # Configure the console (stdout) encoding to UTF-8
     if WINDOWS:  # for Windows
-        sys.stdout.reconfigure(encoding='utf-8')
+        if hasattr(sys.stdout, 'reconfigure'):
+            sys.stdout.reconfigure(encoding='utf-8')
+        else:
+            sys.stdout.encoding = 'utf-8'
 
     # Create and configure the StreamHandler
     stream_handler = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
Fixing 
AttributeError: 'OutStream' object has no attribute 'reconfigure'

https://github.com/ultralytics/ultralytics/issues/6446#issue-2001267790



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Version bump and improved console encoding on Windows.

### 📊 Key Changes
- Updated Ultralytics package version from 8.0.213 to 8.0.214.
- Uncommented code to ensure UTF-8 encoding for console output on Windows systems.

### 🎯 Purpose & Impact
- Keeping the version updated helps users identify they are using the latest release.
- UTF-8 console encoding ensures that a wider range of characters are displayed correctly, especially beneficial for international users who may encounter issues with non-ASCII characters on Windows. This can lead to a better user experience and fewer encoding-related bugs. 💻🌍