### PR TITLE
`ultralytics 8.0.215` Windows UTF-8 fix 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ['3.11']
         torch: [latest]
         include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.11']
         torch: [latest]
         include:

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -24,9 +24,9 @@ Note:
 - This script is built to be run in an environment where Python and MkDocs are installed and properly configured.
 """
 
-import os
 import re
 import shutil
+import subprocess
 from pathlib import Path
 
 DOCS = Path(__file__).parent.resolve()
@@ -41,12 +41,12 @@ def build_docs():
 
     # Build the main documentation
     print(f'Building docs from {DOCS}')
-    os.system(f'mkdocs build -f {DOCS}/mkdocs.yml')
+    subprocess.run(f'mkdocs build -f {DOCS}/mkdocs.yml', check=True, shell=True)
 
     # Build other localized documentations
     for file in DOCS.glob('mkdocs_*.yml'):
         print(f'Building MkDocs site with configuration file: {file}')
-        os.system(f'mkdocs build -f {file}')
+        subprocess.run(f'mkdocs build -f {file}', check=True, shell=True)
     print(f'Site built at {SITE}')
 
 

--- a/docs/en/reference/utils/__init__.md
+++ b/docs/en/reference/utils/__init__.md
@@ -94,7 +94,8 @@ keywords: Ultralytics, Utils, utilitarian functions, colorstr, yaml_save, set_lo
 <br><br>
 
 ---
-## ::: ultralytics.utils.is_github_actions_ci
+
+## ::: ultralytics.utils.is_github_action_running
 <br><br>
 
 ---

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -379,10 +379,10 @@ def test_cfg_init():
 
 def test_utils_init():
     """Test initialization utilities."""
-    from ultralytics.utils import get_git_branch, get_git_origin_url, get_ubuntu_version, is_github_actions_ci
+    from ultralytics.utils import get_git_branch, get_git_origin_url, get_ubuntu_version, is_github_action_running
 
     get_ubuntu_version()
-    is_github_actions_ci()
+    is_github_action_running()
     get_git_origin_url()
     get_git_branch()
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -233,9 +233,11 @@ def set_logging(name=LOGGING_NAME, verbose=True):
         try:
             if hasattr(sys.stdout, 'reconfigure'):
                 sys.stdout.reconfigure(encoding='utf-8')
-            else:
+            elif hasattr(sys.stdout, 'buffer'):
                 import io
                 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+            else:
+                sys.stdout.encoding = 'utf-8'
         except Exception as e:
             print(f'ERROR setting UTF-8 encoding: {e}')
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -243,6 +243,7 @@ def set_logging(name=LOGGING_NAME, verbose=True):
             print(f'Creating custom formatter for non UTF-8 environments due to {e}')
 
             class CustomFormatter(logging.Formatter):
+
                 def format(self, record):
                     return emojis(super().format(record))
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -229,6 +229,7 @@ def set_logging(name=LOGGING_NAME, verbose=True):
     level = logging.INFO if verbose and RANK in {-1, 0} else logging.ERROR  # rank in world for Multi-GPU trainings
 
     # Configure the console (stdout) encoding to UTF-8
+    formatter = logging.Formatter('%(message)s')  # Default formatter
     if WINDOWS and sys.stdout.encoding != 'utf-8':
         try:
             if hasattr(sys.stdout, 'reconfigure'):
@@ -239,11 +240,17 @@ def set_logging(name=LOGGING_NAME, verbose=True):
             else:
                 sys.stdout.encoding = 'utf-8'
         except Exception as e:
-            print(f'ERROR setting UTF-8 encoding: {e}')
+            print(f'Creating custom formatter for non UTF-8 environments due to {e}')
+
+            class CustomFormatter(logging.Formatter):
+                def format(self, record):
+                    return emojis(super().format(record))
+
+            formatter = CustomFormatter('%(message)s')  # Use CustomFormatter to eliminate UTF-8 output as last recourse
 
     # Create and configure the StreamHandler
     stream_handler = logging.StreamHandler(sys.stdout)
-    stream_handler.setFormatter(logging.Formatter('%(message)s'))
+    stream_handler.setFormatter(formatter)
     stream_handler.setLevel(level)
 
     logger = logging.getLogger(name)
@@ -256,7 +263,7 @@ def set_logging(name=LOGGING_NAME, verbose=True):
 # Set logger
 LOGGER = set_logging(LOGGING_NAME, verbose=VERBOSE)  # define globally (used in train.py, val.py, predict.py, etc.)
 for logger in 'sentry_sdk', 'urllib3.connectionpool':
-    logging.getLogger(logger).setLevel(logging.CRITICAL)
+    logging.getLogger(logger).setLevel(logging.CRITICAL + 1)
 
 
 def emojis(string=''):


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7723a9a</samp>

### Summary
🔧🧪🌐

<!--
1.  🔧 for the function name change, which is a minor fix or improvement.
2.  🧪 for the test function update, which is related to testing or quality assurance.
3.  🌐 for the encoding handling improvement, which is related to internationalization or compatibility.
-->
This pull request renames a function in the `ultralytics.utils` module and updates the documentation and the test code accordingly. It also improves the logging utility to handle different cases of setting the UTF-8 encoding for the standard output stream.

> _`is_github_action`_
> _Better reflects env var_
> _Name change in code_

### Walkthrough
*  Rename function `is_github_actions_ci` to `is_github_action_running` to match environment variable `GITHUB_ACTION` ([link](https://github.com/ultralytics/ultralytics/pull/6463/files?diff=unified&w=0#diff-cab8ed793ce4a3c69644d5a9d8485b4e433dbab38fb50c8257eb523d3d0ae228L97-R98), [link](https://github.com/ultralytics/ultralytics/pull/6463/files?diff=unified&w=0#diff-51deb1ccb3a8b618784df2e2abfbc3b056436f1db72d1896d5102f9906978492L382-R385))
*  Improve `set_logging` function to handle different cases of setting UTF-8 encoding for `sys.stdout` ([link](https://github.com/ultralytics/ultralytics/pull/6463/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faL236-R240))
*  Update documentation and code references for `ultralytics.utils` module in `docs/en/reference/utils/__init__.md` and `ultralytics/utils/__init__.py` ([link](https://github.com/ultralytics/ultralytics/pull/6463/files?diff=unified&w=0#diff-cab8ed793ce4a3c69644d5a9d8485b4e433dbab38fb50c8257eb523d3d0ae228L97-R98), [link](https://github.com/ultralytics/ultralytics/pull/6463/files?diff=unified&w=0#diff-067b5aadc258357e37c686a1a9bd895fa0532dbaf436334af483acd57a6b07faL236-R240))
*  Update test function `test_utils_init` in `tests/test_python.py` to use new function name `is_github_action_running` ([link](https://github.com/ultralytics/ultralytics/pull/6463/files?diff=unified&w=0#diff-51deb1ccb3a8b618784df2e2abfbc3b056436f1db72d1896d5102f9906978492L382-R385))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved documentation build process and updated logging for better compatibility and error handling.

### 📊 Key Changes
- Replaced `os.system` with `subprocess.run` for building documentation to enable better error handling.
- Renamed `is_github_actions_ci` utility function to `is_github_action_running` for clarity.
- Enhanced logging configuration to handle UTF-8 encoding issues and use custom formatter as a fallback.

### 🎯 Purpose & Impact
- **Enhanced Build Script**: The switch to `subprocess.run` provides more robust error checking during the documentation build, leading to a more reliable and maintainable process. 🛠️
- **Clearer Utility Function Naming**: Renaming the function improves code readability and removes potential confusion about its purpose. 🤔➡️💡
- **Improved Logging**: The logging update ensures proper encoding across different environments, which is essential for consistent log output, and the custom formatter helps handle systems where UTF-8 is not natively supported. 📝🌐