### PR TITLE
Fix hardcoded `batch=64` Classify loss

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -523,6 +523,6 @@ class v8ClassificationLoss:
 
     def __call__(self, preds, batch):
         """Compute the classification loss between predictions and true labels."""
-        loss = torch.nn.functional.cross_entropy(preds, batch['cls'], reduction='sum') / 64
+        loss = torch.nn.functional.cross_entropy(preds, batch['cls'], reduction='mean')
         loss_items = loss.detach()
         return loss, loss_items


### PR DESCRIPTION
In class v8ClassificationLoss， the loss is calculated by hardcoding batchsize = 64. now change it to actual batchsize just use mean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of the classification loss calculation in Ultralytics' AI models.

### 📊 Key Changes
- Changed the classification loss calculation from a scaled sum (`reduction='sum'`) to an average (`reduction='mean'`).

### 🎯 Purpose & Impact
- 🔍 **Accuracy Improvement**: Transition to `mean` reduction ensures a more consistent loss value irrespective of batch size, likely improving the robustness of model training.
- 🔄 **Simplified Scaling**: Removes the hardcoded scaling factor of 64, simplifying the loss function and preventing potential errors from manual scaling.
- 🛠 **User Experience**: This change could lead to better out-of-the-box model performance, affecting users who rely on Ultralytics for accurate AI model predictions.