### PR TITLE
feat: added support for warmup when benchmarking

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -408,7 +408,7 @@ def test_utils_benchmarks():
 
 
 def test_utils_benchmark():
-    """Test benchmark method"""
+    """Test benchmark method."""
     from ultralytics.utils.benchmarks import benchmark
 
     benchmark(model='yolov8n.pt', data='coco8.yaml', imgsz=32, half=False, num_warmups=1, device='cpu')

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -407,6 +407,13 @@ def test_utils_benchmarks():
     ProfileModels(['yolov8n.yaml'], imgsz=32, min_time=1, num_timed_runs=3, num_warmup_runs=1).profile()
 
 
+def test_utils_benchmark():
+    """Test benchmark method"""
+    from ultralytics.utils.benchmarks import benchmark
+
+    benchmark(model='yolov8n.pt', data='coco8.yaml', imgsz=32, half=False, num_warmups=1, device='cpu')
+
+
 def test_utils_torchutils():
     """Test Torch utility functions."""
     from ultralytics.nn.modules.conv import Conv


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->
Added parameter "num_warmups" to benchmark method in order to be able to do several warm ups when benchmarking (necessary for better torchscript profiling).


<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5f0b572</samp>

### Summary
🔥📈📝

<!--
1.  🔥 for the warmup runs, since they are meant to heat up the model and prepare it for the actual benchmarking.
2.  📈 for the benchmarking itself, since it measures the model performance and produces a graph of the results.
3.  📝 for the documentation and the logging, since they explain how to use the new feature and provide feedback to the user.
-->
Add warmup option to `benchmark` function in `ultralytics/utils/benchmarks.py`. This improves the accuracy and consistency of the performance measurements.

> _Sing, O Muse, of the skillful coder who devised_
> _A new feature for the `benchmark` function, to test_
> _The speed of models with warmup runs, and revised_
> _The docs and logs with clear and eloquent zest._

### Walkthrough
*  Add `num_warmups` parameter to `benchmark` function to control warmup runs for each format and device ([link](https://github.com/ultralytics/ultralytics/pull/6627/files?diff=unified&w=0#diff-0aaacfa9e7ed54c1a6234cf053efec57da412817e8d8cf176f06e532359f06aaR51), [link](https://github.com/ultralytics/ultralytics/pull/6627/files?diff=unified&w=0#diff-0aaacfa9e7ed54c1a6234cf053efec57da412817e8d8cf176f06e532359f06aaR64))
*  Implement warmup runs logic and logging in the loop that calls `predict` method of the exported model in `ultralytics/utils/benchmarks.py` ([link](https://github.com/ultralytics/ultralytics/pull/6627/files?diff=unified&w=0#diff-0aaacfa9e7ed54c1a6234cf053efec57da412817e8d8cf176f06e532359f06aaL114-R118))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added support for configurable warmup runs in the YOLO model benchmarking process, improving test reliability and flexibility. 🏁

### 📊 Key Changes
- Introduced a `num_warmups` parameter to the `benchmark` function, allowing users to specify how many warmup runs to perform before actual benchmarking.
- Updated the benchmarking logic to execute the specified number of warmup runs.
- Enhanced logging to inform users about the number of warmup runs completed.
- Added a new test to verify the updated benchmarking functionality.

### 🎯 Purpose & Impact
- Helps ensure more accurate and stable benchmarking results by allowing warmup runs, which can reduce variability from initial model loading or device setup.
- Gives users and developers more control over the benchmarking process, making it easier to adapt to different hardware or testing scenarios.
- Improves test coverage and reliability for the benchmarking utility, benefiting both contributors and end users.