### PR TITLE
DO NOT MERGE - Changes related to compilation of rtdetr-l exported torchscript

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -326,7 +326,7 @@ class RTDETRDecoder(nn.Module):
             # [b, c, h, w] -> [b, h*w, c]
             feats.append(feat.flatten(2).permute(0, 2, 1))
             # [nl, 2]
-            shapes.append([h, w])
+            shapes.append([int(h), int(w)])
 
         # [b, h*w, c]
         feats = torch.cat(feats, 1)

--- a/ultralytics/nn/modules/transformer.py
+++ b/ultralytics/nn/modules/transformer.py
@@ -86,7 +86,7 @@ class AIFI(TransformerEncoderLayer):
         if not isinstance(c, torch.Tensor):
             c = torch.tensor(c)
         c = c.to(device=x.device)
-        print(f"{x.shape=}; {c=}; {type(c)=}")
+        print(f'{x.shape=}; {c=}; {type(c)=}')
         pos_embed = self.build_2d_sincos_position_embedding(w, h, c, device=x.device)
         # print(f"DEVICE: {x.device}")
         # flatten [B, C, H, W] to [B, HxW, C]
@@ -103,13 +103,13 @@ class AIFI(TransformerEncoderLayer):
             'Embed dimension must be divisible by 4 for 2D sin-cos position embedding'
         pos_dim = torch.floor_divide(embed_dim, 4).to(device)
         # pos_dim = torch.floor(embed_dim / torch.tensor(4).to(device)).to(device)
-        print(f"{pos_dim.device=}; {type(pos_dim)=}")
+        print(f'{pos_dim.device=}; {type(pos_dim)=}')
         omega = torch.arange(pos_dim, dtype=torch.float32, device=device) / pos_dim
-        print(f"{omega.device=}; {type(embed_dim)=}")
+        print(f'{omega.device=}; {type(embed_dim)=}')
         if isinstance(embed_dim, torch.Tensor):
-            print(f"{embed_dim.device=}")
+            print(f'{embed_dim.device=}')
         else:
-            print(f"{embed_dim=}")
+            print(f'{embed_dim=}')
 
         omega = omega.to(device)
         omega = 1. / (temperature ** omega)


### PR DESCRIPTION
This PR was made for future reference, and not to lose the effort. As described in the original issue, we opted to export directly to tensorrt (instead of exporting to torchscript and then compiling to tensorrt). Perhaps this information is still useful later for someone else. Original issue:
https://github.com/ultralytics/ultralytics/issues/6572

This PR demonstrates possible changes that eliminate certain error messages during compilation of the torchscript exported rtdetr-l model.

With these changes, the torch_tensorrt compilation process seems to proceed (takes several minutes and produces a lot of output). However, the following error message is produced:

```
  File "/usr/local/lib/python3.10/dist-packages/torch_tensorrt/_compile.py", line 133, in compile
    return torch_tensorrt.ts.compile(
  File "/usr/local/lib/python3.10/dist-packages/torch_tensorrt/ts/_compiler.py", line 139, in compile
    compiled_cpp_mod = _C.compile_graph(module._c, _parse_compile_spec(spec))
RuntimeError: [Error thrown at core/conversion/conversionctx/ConversionCtx.cpp:169] Building serialized network failed in TensorRT
```
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d779e06</samp>

### Summary
🐛✨🖨️

<!--
1.  🐛 for the bug fix
2.  ✨ for the new feature
3.  🖨️ for the print statements
-->
This pull request fixes a bug in `head.py` and adds a feature in `transformer.py` related to input shape handling. The bug fix prevents a type mismatch error and the feature supports different input formats.

> _Cast `height` and `width`_
> _To fix a bug in shapes list_
> _Winter of errors_

### Walkthrough
* Cast height and width to integers to fix bug in shapes list ([link](https://github.com/ultralytics/ultralytics/pull/6628/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L329-R329))
* Handle tensor input for channel variable and add print statements for new feature in `transformer.py` ([link](https://github.com/ultralytics/ultralytics/pull/6628/files?diff=unified&w=0#diff-fc9bd8e217a8c71a55895011182403a8a55b9fe8751949a92dc3b9d75d45ce57L86-R114))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR improves device compatibility and robustness in the transformer module by ensuring tensors are created on the correct device and input shapes are handled more reliably. 🛠️

### 📊 Key Changes
- Ensures tensor shapes and position embeddings are explicitly cast to integers for consistency.
- Updates the transformer module to create all tensors (like position embeddings) directly on the same device as the input, preventing device mismatch errors.
- Adds debug print statements to help track tensor shapes and devices during development.

### 🎯 Purpose & Impact
- Reduces the risk of runtime errors related to device mismatches (e.g., CPU vs. GPU), making the code more stable and easier to run on different hardware. 💻⚡
- Improves code clarity and maintainability by standardizing how tensor shapes and devices are handled.
- Debug print statements will help developers troubleshoot and verify correct tensor placement during ongoing development. 🐞

**Overall, these changes enhance reliability and developer experience, especially when working with custom hardware setups or debugging model internals.**