### PR TITLE
Fixed Open Image V7 caption typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ See [Detection Docs](https://docs.ultralytics.com/tasks/detect/) for usage examp
 
 - **mAP<sup>val</sup>** values are for single-model single-scale on [Open Image V7](https://docs.ultralytics.com/datasets/detect/open-images-v7/) dataset.
   <br>Reproduce by `yolo val detect data=open-images-v7.yaml device=0`
-- **Speed** averaged over COCO val images using an [Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instance.
+- **Speed** averaged over Open Image V7 val images using an [Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instance.
   <br>Reproduce by `yolo val detect data=open-images-v7.yaml batch=1 device=0|cpu`
 
 </details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -139,7 +139,7 @@ success = model.export(format="onnx")  # 将模型导出为 ONNX 格式
 
 - **mAP<sup>验证</sup>** 值适用于在[Open Image V7](https://docs.ultralytics.com/datasets/detect/open-images-v7/)数据集上的单模型单尺度。
   <br>通过 `yolo val detect data=open-images-v7.yaml device=0` 以复现。
-- **速度** 在使用[Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/)实例对COCO验证图像进行平均测算。
+- **速度** 在使用[Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/)实例对Open Image V7验证图像进行平均测算。
   <br>通过 `yolo val detect data=open-images-v7.yaml batch=1 device=0|cpu` 以复现。
 
 </details>


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->
I have read the CLA Document and I sign the CLA

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6e5b878</samp>

### Summary
🚀🔄🌐

<!--
1.  🚀 This emoji can be used to indicate that the speed metric was updated to use a more reliable and consistent dataset, which could improve the performance and efficiency of the model.
2.  🔄 This emoji can be used to indicate that the same change was applied to the Chinese version of the README file, which could enhance the readability and accessibility of the documentation for Chinese speakers.
3.  🌐 This emoji can be used to indicate that the change involved a translation from one language to another, which could reflect the diversity and inclusivity of the project.
-->
Updated the speed metric in the README files to use Open Image V7. This improves the consistency and accuracy of the performance comparison. The change affects both the English and Chinese versions of the README.

> _Metrics aligned now_
> _`README` files updated_
> _Autumn of changes_

### Walkthrough
* Update the speed metric to use Open Image V7 dataset for consistency and accuracy in both English and Chinese README files ([link](https://github.com/ultralytics/ultralytics/pull/6644/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R142), [link](https://github.com/ultralytics/ultralytics/pull/6644/files?diff=unified&w=0#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L142-R142))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated performance benchmarks in documentation.

### 📊 Key Changes
- Changed the dataset reference for speed benchmarks from COCO to Open Image V7.

### 🎯 Purpose & Impact
- Ensures accuracy by aligning speed benchmark data with the actual dataset used.
- Provides clarity for users on how to reproduce speed benchmarks.
- 🌍 Aids international understanding by updating Chinese README accordingly.