### PR TITLE
Fix `convert_coco()` box-segment discarding

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.220'
+__version__ = '8.0.221'
 
 from ultralytics.models import RTDETR, SAM, YOLO
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -118,22 +118,21 @@ def convert_coco(labels_dir='../coco/annotations/',
                 box = [cls] + box.tolist()
                 if box not in bboxes:
                     bboxes.append(box)
-                if use_segments and ann.get('segmentation') is not None:
-                    if len(ann['segmentation']) == 0:
-                        segments.append([])
-                        continue
-                    elif len(ann['segmentation']) > 1:
-                        s = merge_multi_segment(ann['segmentation'])
-                        s = (np.concatenate(s, axis=0) / np.array([w, h])).reshape(-1).tolist()
-                    else:
-                        s = [j for i in ann['segmentation'] for j in i]  # all segments concatenated
-                        s = (np.array(s).reshape(-1, 2) / np.array([w, h])).reshape(-1).tolist()
-                    s = [cls] + s
-                    if s not in segments:
+                    if use_segments and ann.get('segmentation') is not None:
+                        if len(ann['segmentation']) == 0:
+                            segments.append([])
+                            continue
+                        elif len(ann['segmentation']) > 1:
+                            s = merge_multi_segment(ann['segmentation'])
+                            s = (np.concatenate(s, axis=0) / np.array([w, h])).reshape(-1).tolist()
+                        else:
+                            s = [j for i in ann['segmentation'] for j in i]  # all segments concatenated
+                            s = (np.array(s).reshape(-1, 2) / np.array([w, h])).reshape(-1).tolist()
+                        s = [cls] + s
                         segments.append(s)
-                if use_keypoints and ann.get('keypoints') is not None:
-                    keypoints.append(box + (np.array(ann['keypoints']).reshape(-1, 3) /
-                                            np.array([w, h, 1])).reshape(-1).tolist())
+                    if use_keypoints and ann.get('keypoints') is not None:
+                        keypoints.append(box + (np.array(ann['keypoints']).reshape(-1, 3) /
+                                                np.array([w, h, 1])).reshape(-1).tolist())
 
             # Write
             with open((fn / f).with_suffix('.txt'), 'a') as file:


### PR DESCRIPTION
The previous code checked and discarded identical bboxes, but then continued processing the label and made the same check with the segmentation. This means that for some cases where the boxes are slightly different, but the segmentation coincides (due to auto-labelling or other reasons), the system discards the segment and ends up with N bboxes and N-1 segments. This generates an out-of-bounds error in line 144. This duplication check is not performed for keypoints. 

The code has been modified to make the discarding of the whole label (bbox, segment, and keypoint) only with the bbox duplication check. (another alternative is to check the duplicity of all the parts and then add them if non is duplicated)

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a61bb57</samp>

### Summary
🐛🚀✅

<!--
1.  🐛 - This emoji represents a bug fix, and can be used to indicate that the change fixes a bug that caused duplicate segments and keypoints.
2.  🚀 - This emoji represents a performance improvement, and can be used to indicate that the change improves the efficiency of the COCO conversion function by removing unnecessary checks.
3.  ✅ - This emoji represents a correctness improvement, and can be used to indicate that the change ensures the bounding box, segment, and keypoint are unique and consistent.
-->
Fix bug in `converter.py` that caused to drop duplicate segments while keeping the bounding boxes for COCO conversion. Ensure segments and keypoints are only written for unique bounding boxes.

> _`COCO` conversion_
> _bug fixed with fewer checks_
> _autumn leaves no trace_

### Walkthrough
* Fix a bug that caused duplicate segments and keypoints for the same bounding box in COCO conversion ([link](https://github.com/ultralytics/ultralytics/pull/6689/files?diff=unified&w=0#diff-75efef96e07c9d4ff2cd886cf936b1ee920f98058cf4abd2194a668f90d3655fL121-R135))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to Ultralytics library with minor version increment and improvements in COCO data conversion.

### 📊 Key Changes
- Incremented the library version from `8.0.220` to `8.0.221`.
- Refactored the `convert_coco` function in `converter.py` for better readability and potentially more efficient checks for the presence of segmentation and keypoints in annotation data.

### 🎯 Purpose & Impact
- The version increment signifies a new, albeit minor, update is rolled out, ensuring users are up-to-date with the latest iteration of the Ultralytics library.
- The changes to `convert_coco` aim to improve the code structure and may lead to fewer errors and better maintainability of the code which helps developers working with the Ultralytics platform.
- Users importing and converting COCO dataset annotations using this function may experience a more streamlined process with clearer code logic.