### PR TITLE
Update Tuner() attempt metrics save on crash

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -186,6 +186,12 @@ class Tuner:
             except Exception as e:
                 LOGGER.warning(f'WARNING ❌️ training failure for hyperparameter tuning iteration {i + 1}\n{e}')
 
+                # If training failed, the metrics could may still have been saved.
+                if ckpt_file.exists():
+                    ckpt = torch.load(ckpt_file)
+                    if 'train_metrics' in ckpt: # this check may not be necessary.
+                        metrics = ckpt['train_metrics']
+
             # Save results and mutated_hyp to CSV
             fitness = metrics.get('fitness', 0.0)
             log_row = [round(fitness, 5)] + [mutated_hyp[k] for k in self.space.keys()]

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -182,7 +182,7 @@ class Tuner:
                 cmd = ['yolo', 'train', *(f'{k}={v}' for k, v in train_args.items())]
                 return_code = subprocess.run(cmd, check=True).returncode
                 metrics = torch.load(ckpt_file)['train_metrics']
-                assert returncode == 0, 'training failed'
+                assert return_code == 0, 'training failed'
 
             except Exception as e:
                 LOGGER.warning(f'WARNING ❌️ training failure for hyperparameter tuning iteration {i + 1}\n{e}')

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -180,17 +180,12 @@ class Tuner:
             try:
                 # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
                 cmd = ['yolo', 'train', *(f'{k}={v}' for k, v in train_args.items())]
-                assert subprocess.run(cmd, check=True).returncode == 0, 'training failed'
+                return_code = subprocess.run(cmd, check=True).returncode
                 metrics = torch.load(ckpt_file)['train_metrics']
+                assert returncode == 0, 'training failed'
 
             except Exception as e:
                 LOGGER.warning(f'WARNING ❌️ training failure for hyperparameter tuning iteration {i + 1}\n{e}')
-
-                # If training failed, the metrics could may still have been saved.
-                if ckpt_file.exists():
-                    ckpt = torch.load(ckpt_file)
-                    if 'train_metrics' in ckpt:  # this check may not be necessary.
-                        metrics = ckpt['train_metrics']
 
             # Save results and mutated_hyp to CSV
             fitness = metrics.get('fitness', 0.0)

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -189,7 +189,7 @@ class Tuner:
                 # If training failed, the metrics could may still have been saved.
                 if ckpt_file.exists():
                     ckpt = torch.load(ckpt_file)
-                    if 'train_metrics' in ckpt: # this check may not be necessary.
+                    if 'train_metrics' in ckpt:  # this check may not be necessary.
                         metrics = ckpt['train_metrics']
 
             # Save results and mutated_hyp to CSV


### PR DESCRIPTION
Changes have been made to the Tuner class to check for any saved metrics during exception handling of a training run. This is useful if a training run throws an exception right at the end of the task, since there will be saved models which may have their metrics computed. Currently the code simply defaults to 0 fitness if a training run fails. This is a solution to #6710.

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e1a9310</samp>

### Summary
🚑📊💾

<!--
1.  🚑 This emoji can be used to indicate that the change is a bug fix or a recovery mechanism that helps to prevent or mitigate errors or failures.
2.  📊 This emoji can be used to indicate that the change is related to metrics, data analysis, or reporting, as it enables the tuner to load and display the training metrics from the checkpoint file.
3.  💾 This emoji can be used to indicate that the change involves loading or saving data from a file, as it uses the checkpoint file as a fallback source of metrics data.
-->
This change improves the tuner module by enabling it to recover the training metrics from the checkpoint file in case of a failure. This helps to preserve the progress and performance of the tuning process.

> _`tuner` module grows_
> _more resilient to failure_
> _load metrics from `ckpt`_

### Walkthrough
*  Add fallback mechanism to load training metrics from checkpoint file if training process failed ([link](https://github.com/ultralytics/ultralytics/pull/6711/files?diff=unified&w=0#diff-d42d1b8bc1c237d1e34d8da7ab7ab8130ad4eab91e795d5030271dafb52565d9R189-R194))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced error handling for YOLO model training subprocess within the tuner module.

### 📊 Key Changes
- The `return_code` from the YOLO model training subprocess is now stored in a variable.
- An `assert` statement checks the return code after metrics are loaded, improving error reporting.

### 🎯 Purpose & Impact
- 🛠️ **Better Error Diagnosis:** By capturing the return code, developers can better diagnose issues if the training subprocess fails.
- ⏱️ **More Efficient Debugging:** Loading metrics before the assert ensures that even when training fails, any gathered metrics are not lost, helping in debugging.
- 🔍 **Clearer Failures:** Users will get a more specific error message ("training failed") if something goes wrong, facilitating a smoother experience and quicker fixes.