### PR TITLE
Faster (optional) function for bbox annotations

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -695,7 +695,7 @@ def fast_bbox_draw(result,
              color_dict:dict=dict(), # indicies must match class names
              lwidth:int=None,
              font_size:int=None,
-             font:str|Path|None=USER_CONFIG_DIR / 'Arial.ttf',
+             font:Path=USER_CONFIG_DIR / 'Arial.ttf',
              ) -> torch.Tensor|np.ndarray:
     """
     Annotate using basic bounding boxes. Label positions are uncontrolled and may draw outside of image.

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -694,7 +694,7 @@ def fast_bbox_draw(
     w_name: bool = True,
     conf: bool = True,
     np_out: bool = False,
-    color_dict: dict = dict(),  # indicies must match class names
+    color_dict: dict = dict(),  # indices must match class names
     lwidth: int = None,
     font_size: int = None,
     font: Path = USER_CONFIG_DIR / 'Arial.ttf',
@@ -708,10 +708,10 @@ def fast_bbox_draw(
         result (ultralytics.engine.results.Results): Detection results (bounding boxes only)
         w_name (bool): Draw detection class names. Default is `True`.
         conf (bool): Draw confidence of detections. Default is `True`.
-        color_dict (dict): Custom color dictionary, integer keys corresponding to class indicies, any missing are filled automatically. Default is `{}`
+        color_dict (dict): Custom color dictionary, integer keys corresponding to class indices, any missing are filled automatically. Default is `{}`
         lwidth (int): Line width for drawn bounding boxes, otherwise calculated from image size. Default is `None`
-        font_size (int): Font size for labels (if any), otherwise cacluated from image size. Default is `None`.
-        font (str|Path): Location or name of font to use for any drawn text. Defualt is 'Arial' font or default PIL.ImageFont if `font=None`.
+        font_size (int): Font size for labels (if any), otherwise calculated from image size. Default is `None`.
+        font (str|Path): Location or name of font to use for any drawn text. Default is 'Arial' font or default PIL.ImageFont if `font=None`.
 
     Example:
         ```py

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -698,7 +698,7 @@ def fast_bbox_draw(
     lwidth: int = None,
     font_size: int = None,
     font: Path = USER_CONFIG_DIR / 'Arial.ttf',
-) -> torch.Tensor | np.ndarray:
+):
     """
     Annotate using basic bounding boxes. Label positions are uncontrolled and may draw outside of image. Fastest draw
     time with no names or confidence, including only confidence is faster than including only names. Defaults include

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -9,10 +9,11 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+from torchvision.utils import draw_bounding_boxes
 from PIL import Image, ImageDraw, ImageFont
 from PIL import __version__ as pil_version
 
-from ultralytics.utils import LOGGER, TryExcept, ops, plt_settings, threaded
+from ultralytics.utils import LOGGER, USER_CONFIG_DIR, TryExcept, ops, plt_settings, threaded
 
 from .checks import check_font, check_version, is_ascii
 from .files import increment_path
@@ -686,3 +687,81 @@ def feature_visualization(x, module_type, stage, n=32, save_dir=Path('runs/detec
         plt.savefig(f, dpi=300, bbox_inches='tight')
         plt.close()
         np.save(str(f.with_suffix('.npy')), x[0].cpu().numpy())  # npy save
+
+def fast_bbox_draw(result,
+             w_name:bool=True,
+             conf:bool=True,
+             np_out:bool=False,
+             color_dict:dict=dict(), # indicies must match class names
+             lwidth:int=None,
+             font_size:int=None,
+             font:str|Path|None=USER_CONFIG_DIR / 'Arial.ttf',
+             ) -> torch.Tensor|np.ndarray:
+    """
+    Annotate using basic bounding boxes. Label positions are uncontrolled and may draw outside of image.
+    Fastest draw time with no names or confidence, including only confidence is faster than including only names.
+    Defaults include names and confidences, process time ~100ms for 300 boxes on 'bus.jpg' test image.
+    
+    Args:
+        result (ultralytics.engine.results.Results): Detection results (bounding boxes only)
+        w_name (bool): Draw detection class names. Default is `True`.
+        conf (bool): Draw confidence of detections. Default is `True`.
+        color_dict (dict): Custom color dictionary, integer keys corresponding to class indicies, any missing are filled automatically. Default is `{}`
+        lwidth (int): Line width for drawn bounding boxes, otherwise calculated from image size. Default is `None`
+        font_size (int): Font size for labels (if any), otherwise cacluated from image size. Default is `None`.
+        font (str|Path): Location or name of font to use for any drawn text. Defualt is 'Arial' font or default PIL.ImageFont if `font=None`.
+    
+    Example:
+        ```py
+        from ultralytics import YOLO
+        from ultralytics.utils.plotting import gpu_draw
+
+        m = YOLO()
+        _ = m.to('cuda')
+
+        n_ims = 60
+        ims = ['ultralytics/assets/bus.jpg'] * n_ims
+        res = m.predict(source=ims, imgsz=1088, conf=0.0001, iou=0.99, verbose=False) # 300 detections
+        total = sum([int(r.boxes.cls.shape[0]) for r in res])
+
+        anno_ims = [d for d in map(gpu_draw, res)] # full annotations, ~100 ms/image when tested on 60 images
+        
+        from functools import partial
+
+        p_draw = partial(gpu_draw, w_name=False, conf=False)
+        box_only_ims = [d for d in map(p_draw, res)] # box only annotations, much faster ~7.5 ms/image when tested
+        ```
+    """
+    if isinstance(result.orig_img, np.ndarray): # otherwise assume Tensor has correct format
+        size = result.orig_img.shape[:2]
+        t_img = torch.from_numpy(result.orig_img).permute(2, 0, 1) # torch image with channel first
+    
+    if len(result) >=1:
+        lwidth = lwidth or max(round(sum(size) / 2 * 0.003), 2)
+        
+        idx = result.boxes.cls.to(int).tolist()
+        labels, names, confs = [''] * len(idx), [''] * len(idx), [''] * len(idx)
+        box_colors = [color_dict.get(i, colors(i)) for i in idx]
+        font = font if font and (w_name or conf) else None
+        
+        if w_name:
+            names = [result.names.get(c) for c in idx]
+            font = font if font or all([is_ascii(n) for n in names]) else check_font('Arial.Unicode.ttf')
+        
+        if conf:
+            confs = [round(c,2) for c in result.boxes.conf.tolist()]
+
+        font_size = font_size or max(round(sum(size) / 2 * 0.035), 12) if font else None
+        labels = [f'{n} {c}' for n,c in zip(names,confs)]
+        
+        drawn = draw_bounding_boxes(image=t_img,
+                                    boxes=result.boxes.xyxy,
+                                    labels=labels,
+                                    colors=box_colors,
+                                    width=lwidth,
+                                    font=str(font) if font is not None else font,
+                                    font_size=font_size)
+    else:
+        drawn = t_img
+    
+    return drawn.permute(1,2,0) if not np_out else drawn.permute(1,2,0).numpy()

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -9,9 +9,9 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from torchvision.utils import draw_bounding_boxes
 from PIL import Image, ImageDraw, ImageFont
 from PIL import __version__ as pil_version
+from torchvision.utils import draw_bounding_boxes
 
 from ultralytics.utils import LOGGER, USER_CONFIG_DIR, TryExcept, ops, plt_settings, threaded
 
@@ -688,20 +688,22 @@ def feature_visualization(x, module_type, stage, n=32, save_dir=Path('runs/detec
         plt.close()
         np.save(str(f.with_suffix('.npy')), x[0].cpu().numpy())  # npy save
 
-def fast_bbox_draw(result,
-             w_name:bool=True,
-             conf:bool=True,
-             np_out:bool=False,
-             color_dict:dict=dict(), # indicies must match class names
-             lwidth:int=None,
-             font_size:int=None,
-             font:str|Path|None=USER_CONFIG_DIR / 'Arial.ttf',
-             ) -> torch.Tensor|np.ndarray:
+
+def fast_bbox_draw(
+    result,
+    w_name: bool = True,
+    conf: bool = True,
+    np_out: bool = False,
+    color_dict: dict = dict(),  # indicies must match class names
+    lwidth: int = None,
+    font_size: int = None,
+    font: str | Path | None = USER_CONFIG_DIR / 'Arial.ttf',
+) -> torch.Tensor | np.ndarray:
     """
-    Annotate using basic bounding boxes. Label positions are uncontrolled and may draw outside of image.
-    Fastest draw time with no names or confidence, including only confidence is faster than including only names.
-    Defaults include names and confidences, process time ~100ms for 300 boxes on 'bus.jpg' test image.
-    
+    Annotate using basic bounding boxes. Label positions are uncontrolled and may draw outside of image. Fastest draw
+    time with no names or confidence, including only confidence is faster than including only names. Defaults include
+    names and confidences, process time ~100ms for 300 boxes on 'bus.jpg' test image.
+
     Args:
         result (ultralytics.engine.results.Results): Detection results (bounding boxes only)
         w_name (bool): Draw detection class names. Default is `True`.
@@ -710,7 +712,7 @@ def fast_bbox_draw(result,
         lwidth (int): Line width for drawn bounding boxes, otherwise calculated from image size. Default is `None`
         font_size (int): Font size for labels (if any), otherwise cacluated from image size. Default is `None`.
         font (str|Path): Location or name of font to use for any drawn text. Defualt is 'Arial' font or default PIL.ImageFont if `font=None`.
-    
+
     Example:
         ```py
         from ultralytics import YOLO
@@ -725,35 +727,35 @@ def fast_bbox_draw(result,
         total = sum([int(r.boxes.cls.shape[0]) for r in res])
 
         anno_ims = [d for d in map(gpu_draw, res)] # full annotations, ~100 ms/image when tested on 60 images
-        
+
         from functools import partial
 
         p_draw = partial(gpu_draw, w_name=False, conf=False)
         box_only_ims = [d for d in map(p_draw, res)] # box only annotations, much faster ~7.5 ms/image when tested
         ```
     """
-    if isinstance(result.orig_img, np.ndarray): # otherwise assume Tensor has correct format
+    if isinstance(result.orig_img, np.ndarray):  # otherwise assume Tensor has correct format
         size = result.orig_img.shape[:2]
-        t_img = torch.from_numpy(result.orig_img).permute(2, 0, 1) # torch image with channel first
-    
-    if len(result) >=1:
+        t_img = torch.from_numpy(result.orig_img).permute(2, 0, 1)  # torch image with channel first
+
+    if len(result) >= 1:
         lwidth = lwidth or max(round(sum(size) / 2 * 0.003), 2)
-        
+
         idx = result.boxes.cls.to(int).tolist()
         labels, names, confs = [''] * len(idx), [''] * len(idx), [''] * len(idx)
         box_colors = [color_dict.get(i, colors(i)) for i in idx]
         font = font if font and (w_name or conf) else None
-        
+
         if w_name:
             names = [result.names.get(c) for c in idx]
             font = font if font or all([is_ascii(n) for n in names]) else check_font('Arial.Unicode.ttf')
-        
+
         if conf:
-            confs = [round(c,2) for c in result.boxes.conf.tolist()]
+            confs = [round(c, 2) for c in result.boxes.conf.tolist()]
 
         font_size = font_size or max(round(sum(size) / 2 * 0.035), 12) if font else None
-        labels = [f'{n} {c}' for n,c in zip(names,confs)]
-        
+        labels = [f'{n} {c}' for n, c in zip(names, confs)]
+
         drawn = draw_bounding_boxes(image=t_img,
                                     boxes=result.boxes.xyxy,
                                     labels=labels,
@@ -763,5 +765,5 @@ def fast_bbox_draw(result,
                                     font_size=font_size)
     else:
         drawn = t_img
-    
-    return drawn.permute(1,2,0) if not np_out else drawn.permute(1,2,0).numpy()
+
+    return drawn.permute(1, 2, 0) if not np_out else drawn.permute(1, 2, 0).numpy()


### PR DESCRIPTION
# Description

Discord discussion about improving speed of bounding box annotations with results inspired addition of an optional function for users prioritizing speed of annotation. Function reuses many of the components from `Annotator` class in attempt to maintain consistency, however is an attempt to strip down to the barest of options.

# Example usage

## Option 1

Includes all labels and confidence values, but does not control label positions to keep within bounds of image.

```py
from ultralytics import YOLO
from ultralytics.utils.ops import Profile
from ultralytics.utils.plotting import fast_bbox_draw

m = YOLO()
_ = m.to('cuda')

n_ims = 60
ims = ['ultralytics/assets/bus.jpg'] * n_ims # built-in 'bus.jpg' image

# Artificially inflated detections
res = m.predict(source=ims, imgsz=1088, conf=0.0001, iou=0.99, verbose=False, max_det=1000)
total = sum([int(r.boxes.cls.shape[0]) for r in res])

# Timing with all annotation options
with Profile() as p:
    anno_ims = [d for d in map(fast_bbox_draw, res)]

# View results of processing example image(s)
f"""Total time {p.dt * 1E3} ms | time per image {(p.dt * 1E3) / n_ims} ms | time per 100 detections {(p.dt * 1E3) / (total / 100)} ms"""
```

## Option 2

No labels or confidence values, prioritize performance and only concern is viewing boxes with colors corresponding to matching classes.

```py
from functools import partial

from ultralytics import YOLO
from ultralytics.utils.ops import Profile
from ultralytics.utils.plotting import fast_bbox_draw

m = YOLO()
_ = m.to('cuda')

n_ims = 60
ims = ['ultralytics/assets/bus.jpg'] * n_ims # built-in 'bus.jpg' image

# Artificially inflated detections
res = m.predict(source=ims, imgsz=1088, conf=0.0001, iou=0.99, verbose=False, max_det=1000)
total = sum([int(r.boxes.cls.shape[0]) for r in res])

p_draw = partial(fast_bbox_draw, w_name=False, conf=False)

# Timing with limited annotation options (boxes only)
with Profile() as p:
    box_only_ims = [d for d in map(p_draw, res)]

# View results of processing example image(s)
f"""Total time {p.dt * 1E3} ms | time per image {(p.dt * 1E3) / n_ims} ms | time per 100 detections {(p.dt * 1E3) / (total / 100)} ms"""
```

## Results

<details>

<summary>System environment details used for testing</summary>

```
Ultralytics YOLOv8.0.221 🚀 Python-3.10.9 torch-2.1.1+cu121 CUDA:0 (NVIDIA GeForce RTX 3080, 12288MiB)        
Setup complete ✅ (12 CPUs, 31.9 GB RAM, 141.4/1863.0 GB disk)

OS                  Windows-10-10.0.19045-SP0       
Environment         Windows
Python              3.10.9
Install             git
RAM                 31.86 GB
CPU                 Intel Core(TM) i5-10600K 4.10GHz
CUDA                12.1

matplotlib          ✅ 3.8.1>=3.3.0   
numpy               ✅ 1.26.2>=1.22.2 
opencv-python       ✅ 4.8.1.78>=4.6.0
pillow              ✅ 10.1.0>=7.1.2  
pyyaml              ✅ 6.0.1>=5.3.1       
requests            ✅ 2.31.0>=2.23.0     
scipy               ✅ 1.11.3>=1.4.1      
torch               ✅ 2.1.1+cu121>=1.8.0 
torchvision         ✅ 0.16.1+cu121>=0.9.0
tqdm                ✅ 4.66.1>=4.64.0
pandas              ✅ 2.1.3>=1.1.4
seaborn             ✅ 0.13.0>=0.11.0
psutil              ✅ 5.9.6
py-cpuinfo          ✅ 9.0.0
thop                ✅ 0.1.1-2209072238>=0.1.1
```

</details>

| opt | n_images | detections | total (s) | time/image (ms) | time/100-detections (ms) |
|:----:|:----------:|:------------:|:---------:|:------------------:|:-----------------------------:|
|   1  |       60     |      1000     |   18.12   |         318.62         |                  31.86                 |
|   2  |       60     |      1000     |     8.41   |          14.02          |                    1.40                 |



<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 46512cd</samp>

### Summary
🖼️🚀🛠️

<!--
1.  🖼️ - This emoji represents the concept of bounding boxes and annotation of images, as well as the visual aspect of the function.
2.  🚀 - This emoji represents the speed and efficiency of the function, as well as the GPU acceleration feature.
3.  🛠️ - This emoji represents the utility and functionality of the function, as well as the customization options.
-->
Added a new function `fast_bbox_draw` to `ultralytics.utils.plotting` for faster and more flexible detection visualization. The function leverages GPU power and supports different styles and labels for bounding boxes.

> _`fast_bbox_draw`:_
> _GPU-accelerated plots_
> _for detection tasks._

### Walkthrough
*  Import `draw_bounding_boxes` function and `USER_CONFIG_DIR` constant to use for fast annotation of detection results ([link](https://github.com/ultralytics/ultralytics/pull/6713/files?diff=unified&w=0#diff-471dc6902e48f880561beca675bfee38e440de6cd49a3de9432de27305d3cc6bL12-R16))
*  Add `fast_bbox_draw` function to provide a faster and simpler alternative to `plot_results` for drawing bounding boxes on images ([link](https://github.com/ultralytics/ultralytics/pull/6713/files?diff=unified&w=0#diff-471dc6902e48f880561beca675bfee38e440de6cd49a3de9432de27305d3cc6bR690-R767))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing a new, faster method for drawing bounding boxes on images.

### 📊 Key Changes
- Added `fast_bbox_draw` function for quick bounding box visualization.
- Enhanced utility by including optional parameters for class names, confidence scores, colors, and font customization.
- Incorporated `torchvision.utils.draw_bounding_boxes` for the drawing process.

### 🎯 Purpose & Impact
- 🚀 Improves drawing performance, especially beneficial for large sets of detections, thus speeding up the visualization process.
- ✅ Offers flexibility with customizable options, allowing users to choose the level of detail to include on the bounding boxes.
- 💻 User-friendly for both existing and new users, simplifying the annotation of object detection results with minimal effort.

This update will be particularly helpful for those working on object detection tasks who need a quick and efficient way to visualize their results.