### PR TITLE
Fix selection of GPU

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -137,7 +137,7 @@ def select_device(device='', batch=0, newline=False, verbose=True):
         if n == 0:
             arg = 'cuda:0'
         else:
-            arg = f'cuda:{device[0]}'
+            arg = f'cuda:{devices[0]}'
     elif mps and TORCH_2_0 and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f'MPS ({get_cpu_info()})\n'

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -134,7 +134,10 @@ def select_device(device='', batch=0, newline=False, verbose=True):
         for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
-        arg = 'cuda:0'
+        if n == 0:
+            arg = 'cuda:0'
+        else:
+            arg = f'cuda:{device[0]}'
     elif mps and TORCH_2_0 and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f'MPS ({get_cpu_info()})\n'


### PR DESCRIPTION
For cuda, this always returns device 0, this change will have it return the first device selected. Since only one device is returned, only the first will be returned here.


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 20809a9</samp>

### Summary
🚀🔧🎛️

<!--
1.  🚀 This emoji conveys the idea of improving performance, speed, or efficiency, which are possible benefits of using a specific CUDA device instead of the default one.
2.  🔧 This emoji conveys the idea of fixing, adjusting, or tweaking something, which are actions that the change performs on the `select_device` function.
3.  🎛️ This emoji conveys the idea of controlling, configuring, or setting something, which are outcomes that the change enables for the user of the function.
-->
Allow specifying a specific CUDA device in `select_device` function. This improves device management and avoids potential conflicts or errors when multiple devices are available.

> _`select_device` changed_
> _No more `cuda:0` default_
> _Autumn of choices_

### Walkthrough
*  Enable specifying a specific CUDA device to use in `select_device` function ([link](https://github.com/ultralytics/ultralytics/pull/6731/files?diff=unified&w=0#diff-9bd07d929cb8522458c879bd81a82d9af468ffbc215e762f39b2a50a601758d7L137-R140))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved device selection logic in Ultralytics' PyTorch utility to better handle multiple CUDA devices.

### 📊 Key Changes
- Modified the `select_device` function in the `torch_utils.py` script to update the way CUDA devices are assigned.
- Introduced logic to dynamically select CUDA devices based on availability, switching from a fixed to a more flexible device assignment strategy.

### 🎯 Purpose & Impact
- **Enhanced Flexibility:** Automatically selects the first available CUDA device, which improves adaptability in environments with multiple GPUs.
- **Improved Resource Utilization:** Ensures optimized use of GPU resources by dynamically selecting devices, which can lead to better performance in multi-GPU systems.