### PR TITLE
Add train loss and lr to loggers

### DIFF
--- a/docs/en/reference/utils/callbacks/mlflow.md
+++ b/docs/en/reference/utils/callbacks/mlflow.md
@@ -15,6 +15,10 @@ keywords: Ultralytics, MLflow, Callbacks, on_pretrain_routine_end, on_train_end,
 
 <br><br>
 
+## ::: ultralytics.utils.callbacks.mlflow.on_train_epoch_end
+
+<br><br>
+
 ## ::: ultralytics.utils.callbacks.mlflow.on_fit_epoch_end
 
 <br><br>

--- a/docs/en/reference/utils/callbacks/tensorboard.md
+++ b/docs/en/reference/utils/callbacks/tensorboard.md
@@ -27,7 +27,7 @@ keywords: Ultralytics, YOLO, documentation, callback utilities, log_scalars, on_
 
 <br><br>
 
-## ::: ultralytics.utils.callbacks.tensorboard.on_batch_end
+## ::: ultralytics.utils.callbacks.tensorboard.on_train_epoch_end
 
 <br><br>
 

--- a/ultralytics/utils/callbacks/clearml.py
+++ b/ultralytics/utils/callbacks/clearml.py
@@ -102,6 +102,8 @@ def on_fit_epoch_end(trainer):
                                         series='Epoch Time',
                                         value=trainer.epoch_time,
                                         iteration=trainer.epoch)
+        for k, v in trainer.metrics.items():
+            task.get_logger().report_scalar('train', k, v, iteration=trainer.epoch)
         if trainer.epoch == 0:
             from ultralytics.utils.torch_utils import model_info_for_loggers
             for k, v in model_info_for_loggers(trainer).items():

--- a/ultralytics/utils/callbacks/clearml.py
+++ b/ultralytics/utils/callbacks/clearml.py
@@ -90,8 +90,10 @@ def on_train_epoch_end(trainer):
         if trainer.epoch == 1:
             _log_debug_samples(sorted(trainer.save_dir.glob('train_batch*.jpg')), 'Mosaic')
         # Report the current training progress
-        for k, v in trainer.validator.metrics.results_dict.items():
+        for k, v in trainer.label_loss_items(trainer.tloss, prefix='train').items():
             task.get_logger().report_scalar('train', k, v, iteration=trainer.epoch)
+        for k, v in trainer.lr.items():
+            task.get_logger().report_scalar('lr', k, v, iteration=trainer.epoch)
 
 
 def on_fit_epoch_end(trainer):
@@ -103,7 +105,7 @@ def on_fit_epoch_end(trainer):
                                         value=trainer.epoch_time,
                                         iteration=trainer.epoch)
         for k, v in trainer.metrics.items():
-            task.get_logger().report_scalar('train', k, v, iteration=trainer.epoch)
+            task.get_logger().report_scalar('val', k, v, iteration=trainer.epoch)
         if trainer.epoch == 0:
             from ultralytics.utils.torch_utils import model_info_for_loggers
             for k, v in model_info_for_loggers(trainer).items():

--- a/ultralytics/utils/callbacks/tensorboard.py
+++ b/ultralytics/utils/callbacks/tensorboard.py
@@ -58,9 +58,10 @@ def on_train_start(trainer):
         _log_tensorboard_graph(trainer)
 
 
-def on_batch_end(trainer):
-    """Logs scalar statistics at the end of a training batch."""
+def on_train_epoch_end(trainer):
+    """Logs scalar statistics at the end of a training epoch."""
     _log_scalars(trainer.label_loss_items(trainer.tloss, prefix='train'), trainer.epoch + 1)
+    _log_scalars(trainer.lr, trainer.epoch + 1)
 
 
 def on_fit_epoch_end(trainer):
@@ -72,4 +73,4 @@ callbacks = {
     'on_pretrain_routine_start': on_pretrain_routine_start,
     'on_train_start': on_train_start,
     'on_fit_epoch_end': on_fit_epoch_end,
-    'on_batch_end': on_batch_end} if SummaryWriter else {}
+    'on_train_epoch_end': on_train_epoch_end} if SummaryWriter else {}


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 927a13d</samp>

### Summary
📈🧹🕒

<!--
1.  📈 This emoji represents the improvement of the reporting methods and the addition of new functions for logging metrics to ClearML and MLflow.
2.  🧹 This emoji represents the sanitization of the metric names and values to avoid errors and ensure compatibility with the logging platforms.
3.  🕒 This emoji represents the change of the logging frequency from batch to epoch for the TensorBoard callback, which reduces the overhead and aligns with the other callbacks.
-->
This pull request improves the callback modules for ClearML, MLflow, and TensorBoard by using the latest methods, sanitizing metric names and values, and logging metrics at the end of each epoch. It also renames and updates some functions and variables for consistency.

> _Oh we're the coders of the sea, and we log our metrics well_
> _We use `clearml` and `mlflow` to track our models' spell_
> _We heave and ho on every epoch, and we sanitize our names_
> _We sing our shanty loud and proud, and we harmonize our games_

### Walkthrough
*  Rename `on_batch_end` to `on_train_epoch_end` and log scalar statistics at the end of each epoch instead of each batch in `tensorboard.py` ([link](https://github.com/ultralytics/ultralytics/pull/6732/files?diff=unified&w=0#diff-ff5a6a48d029d76ffd4eecab24a98ae15a8c4076641ce35c0a16137c11f0088eL61-R64), [link](https://github.com/ultralytics/ultralytics/pull/6732/files?diff=unified&w=0#diff-ff5a6a48d029d76ffd4eecab24a98ae15a8c4076641ce35c0a16137c11f0088eL75-R76))
*  Log training metrics and learning rates to ClearML and MLflow at the end of each epoch using `trainer.label_loss_items` and `SANITIZE` in `clearml.py` and `mlflow.py` ([link](https://github.com/ultralytics/ultralytics/pull/6732/files?diff=unified&w=0#diff-413a18cfdbf4840581d11447c399341f362b9fa9d703efbf0cde5924bb95c1eaL93-R96), [link](https://github.com/ultralytics/ultralytics/pull/6732/files?diff=unified&w=0#diff-413a18cfdbf4840581d11447c399341f362b9fa9d703efbf0cde5924bb95c1eaR107-R108), [link](https://github.com/ultralytics/ultralytics/pull/6732/files?diff=unified&w=0#diff-1d0709c6f7ef2e65b3174d19938d0feaa0c9f8445b82377265cb4c94b76a45fcL35-R37), [link](https://github.com/ultralytics/ultralytics/pull/6732/files?diff=unified&w=0#diff-1d0709c6f7ef2e65b3174d19938d0feaa0c9f8445b82377265cb4c94b76a45fcL84-R97))
*  Add `on_fit_epoch_end` function to log validation metrics to ClearML and MLflow at the end of each fit epoch using `trainer.metrics` in `clearml.py` and `mlflow.py` ([link](https://github.com/ultralytics/ultralytics/pull/6732/files?diff=unified&w=0#diff-413a18cfdbf4840581d11447c399341f362b9fa9d703efbf0cde5924bb95c1eaR107-R108), [link](https://github.com/ultralytics/ultralytics/pull/6732/files?diff=unified&w=0#diff-1d0709c6f7ef2e65b3174d19938d0feaa0c9f8445b82377265cb4c94b76a45fcL84-R97))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved logging and documentation for MLflow, TensorBoard, and ClearML callbacks in Ultralytics projects.

### 📊 Key Changes
- Updated MLflow documentation to include `on_train_epoch_end` callback.
- Replaced `on_batch_end` with `on_train_epoch_end` in the TensorBoard callback documentation to reflect more accurate logging.
- Enhanced the ClearML `on_train_epoch_end` and `on_fit_epoch_end` callbacks to log training and validation metrics, including learning rates at the end of each epoch.
- Introduced a SANITIZE function in the MLflow callback to clean metric names before logging them.
  
### 🎯 Purpose & Impact
- 🔄 Keep the documentation in sync with code updates, ensuring accurate information for developers.
- 📈 Provide detailed metrics tracking across various stages of model training and validation, helping users to monitor the learning process more effectively.
- 🌐 Improve integration with popular machine learning experiment tracking tools (MLflow, TensorBoard, and ClearML), giving users greater flexibility and better insights into their model performance.
- 🧹 Simplify the logging code for MLflow ensuring more consistent metric naming and logging.