### PR TITLE
adding index verifications

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -273,21 +273,22 @@ class BasePredictor:
                 n = len(im0s)
                 for i in range(n):
                     self.seen += 1
-                    self.results[i].speed = {
-                        'preprocess': profilers[0].dt * 1E3 / n,
-                        'inference': profilers[1].dt * 1E3 / n,
-                        'postprocess': profilers[2].dt * 1E3 / n}
-                    p, im0 = path[i], None if self.source_type.tensor else im0s[i].copy()
-                    p = Path(p)
+                    if i < len(self.results):
+                        self.results[i].speed = {
+                            'preprocess': profilers[0].dt * 1E3 / n,
+                            'inference': profilers[1].dt * 1E3 / n,
+                            'postprocess': profilers[2].dt * 1E3 / n}
+                        p, im0 = path[i], None if self.source_type.tensor else im0s[i].copy()
+                        p = Path(p)
 
-                    if self.args.verbose or self.args.save or self.args.save_txt or self.args.show:
-                        s += self.write_results(i, self.results, (p, im, im0))
-                    if self.args.save or self.args.save_txt:
-                        self.results[i].save_dir = self.save_dir.__str__()
-                    if self.args.show and self.plotted_img is not None:
-                        self.show(p)
-                    if self.args.save and self.plotted_img is not None:
-                        self.save_preds(vid_cap, i, str(self.save_dir / p.name))
+                        if self.args.verbose or self.args.save or self.args.save_txt or self.args.show:
+                            s += self.write_results(i, self.results, (p, im, im0))
+                        if self.args.save or self.args.save_txt:
+                            self.results[i].save_dir = self.save_dir.__str__()
+                        if self.args.show and self.plotted_img is not None:
+                            self.show(p)
+                        if self.args.save and self.plotted_img is not None:
+                            self.save_preds(vid_cap, i, str(self.save_dir / p.name))
 
                 self.run_callbacks('on_predict_batch_end')
                 yield from self.results

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -34,8 +34,9 @@ class DetectionPredictor(BasePredictor):
 
         results = []
         for i, pred in enumerate(preds):
-            orig_img = orig_imgs[i]
-            pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
-            img_path = self.batch[0][i]
-            results.append(Results(orig_img, path=img_path, names=self.model.names, boxes=pred))
+            if i < len(orig_imgs) and i < len(self.batch[0]):
+                orig_img = orig_imgs[i]
+                pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
+                img_path = self.batch[0][i]
+                results.append(Results(orig_img, path=img_path, names=self.model.names, boxes=pred))
         return results


### PR DESCRIPTION
I have read the CLA Document and I sign the CLA

In the same request I have always the same exception, so I start to suspicious about a Yolo internal file bug.
I have to use the traceback python bib to discover.
In these two files I add a index check and the exception stop to displays:
C:\Python310\lib\site-packages\ultralytics\engine\predictor.py -> line 264

```python:
276      if(i< len(self.results)):  # LINE I'VE ADDED
277          self.results[i].speed = { #the rest is equal but is idented      
````
C:\Python310\lib\site-packages\ultralytics\models\yolo\detect\predict.py -> 37
```python:
37            if i < len(orig_imgs) and i < len(self.batch[0]): # LINE I'VE ADDED
38               orig_img = orig_imgs[i] #the rest is equal but is idented    
```` 

Both cenarios, assumes that the two lists have the same size, but is not true.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update improves the reliability of prediction and post-processing steps in Ultralytics models by adding extra checks to prevent errors when handling batches of images. 🛡️✨

### 📊 Key Changes
- Added safeguards to ensure code only processes results when the expected data is available, preventing out-of-range errors.
- Updated both the prediction streaming and post-processing logic to check list lengths before accessing elements.

### 🎯 Purpose & Impact
- Prevents potential crashes or errors during batch inference, especially when batch sizes or result counts don't match perfectly.
- Makes the prediction process more robust and user-friendly, reducing unexpected interruptions for both developers and end users.
- Enhances stability for anyone running batch predictions, including those using Ultralytics HUB or custom pipelines. 🚀