### PR TITLE
Add a less conservative estimation mode to the Auto-batching trainer

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -246,7 +246,10 @@ class BaseTrainer:
         if self.batch_size == -1 and RANK == -1:  # single-GPU only, conservative 60% VRAM estimate of best batch size
             self.args.batch = self.batch_size = check_train_batch_size(self.model, self.args.imgsz, self.amp)
         if self.batch_size == -2 and RANK == -1:  # single-GPU only, optimistic 90% VRAM estimate of best batch size
-            self.args.batch = self.batch_size = check_train_batch_size(self.model, self.args.imgsz, self.amp, fraction=0.90)
+            self.args.batch = self.batch_size = check_train_batch_size(self.model,
+                                                                       self.args.imgsz,
+                                                                       self.amp,
+                                                                       fraction=0.90)
 
         # Dataloaders
         batch_size = self.batch_size // max(world_size, 1)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -243,8 +243,10 @@ class BaseTrainer:
         self.args.imgsz = check_imgsz(self.args.imgsz, stride=gs, floor=gs, max_dim=1)
 
         # Batch size
-        if self.batch_size == -1 and RANK == -1:  # single-GPU only, estimate best batch size
+        if self.batch_size == -1 and RANK == -1:  # single-GPU only, conservative 60% VRAM estimate of best batch size
             self.args.batch = self.batch_size = check_train_batch_size(self.model, self.args.imgsz, self.amp)
+        if self.batch_size == -2 and RANK == -1:  # single-GPU only, optimistic 90% VRAM estimate of best batch size
+            self.args.batch = self.batch_size = check_train_batch_size(self.model, self.args.imgsz, self.amp, fraction=0.90)
 
         # Dataloaders
         batch_size = self.batch_size // max(world_size, 1)

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -24,7 +24,7 @@ def check_train_batch_size(model, imgsz=640, amp=True, fraction=0.60):
     """
 
     with torch.cuda.amp.autocast(amp):
-        return autobatch(deepcopy(model).train(), imgsz,fraction=fraction)  # compute optimal batch size
+        return autobatch(deepcopy(model).train(), imgsz, fraction=fraction)  # compute optimal batch size
 
 
 def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
@@ -76,9 +76,11 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
             i = results.index(None)  # first fail index
             if b >= batch_sizes[i]:  # y intercept above failure point
                 b = batch_sizes[max(i - 1, 0)]  # select prior safe point
-        if b < 1 or (b > 1024 and fraction==0.6): # b outside of safe range - and conservative mode is on
+        if b < 1 or (b > 1024 and fraction == 0.6):  # b outside of safe range - and conservative mode is on
             b = batch_size
-            LOGGER.info(f'{prefix}WARNING ⚠️ CUDA anomaly detected: Batch size {b} was recommended when the maximum automatic size is 1024. using default batch-size {batch_size}.')
+            LOGGER.info(
+                f'{prefix}WARNING ⚠️ CUDA anomaly detected: Batch size {b} was recommended when the maximum automatic size is 1024. using default batch-size {batch_size}.'
+            )
 
         fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted
         LOGGER.info(f'{prefix}Using batch-size {b} for {d} {t * fraction:.2f}G/{t:.2f}G ({fraction * 100:.0f}%) ✅')

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -63,7 +63,7 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
     LOGGER.info(f'{prefix}{d} ({properties.name}) {t:.2f}G total, {r:.2f}G reserved, {a:.2f}G allocated, {f:.2f}G free')
 
     # Profile batch sizes
-    batch_sizes = [1, 2, 4, 8, 16]
+    batch_sizes = [1, 2, 4, 8, 16, 32]
     try:
         img = [torch.empty(b, 3, imgsz, imgsz) for b in batch_sizes]
         results = profile(img, model, n=3, device=device)
@@ -79,7 +79,7 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
         if b < 1 or (b > 1024 and fraction==0.6): # b outside of safe range - and conservative mode is on
             b = batch_size
             LOGGER.info(f"b is {b}. fraction is {fraction}.")
-            LOGGER.info(f'{prefix}WARNING ⚠️ CUDA anomaly detected, using default batch-size {batch_size}.')
+            LOGGER.info(f'{prefix} MARTIN EDITING THIS WARNING ⚠️ CUDA anomaly detected, using default batch-size {batch_size}.')
 
         fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted
         LOGGER.info(f'{prefix}Using batch-size {b} for {d} {t * fraction:.2f}G/{t:.2f}G ({fraction * 100:.0f}%) ✅')

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -78,7 +78,7 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
                 b = batch_sizes[max(i - 1, 0)]  # select prior safe point
         if b < 1 or (b > 1024 and fraction==0.6): # b outside of safe range - and conservative mode is on
             b = batch_size
-            LOGGER.info(f'{prefix}WARNING ⚠️ CUDA anomaly detected, using default batch-size {batch_size}.')
+            LOGGER.info(f'{prefix}WARNING ⚠️ CUDA anomaly detected: Batch size {b} was recommended when the maximum automatic size is 1024. using default batch-size {batch_size}.')
 
         fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted
         LOGGER.info(f'{prefix}Using batch-size {b} for {d} {t * fraction:.2f}G/{t:.2f}G ({fraction * 100:.0f}%) ✅')

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -63,7 +63,7 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
     LOGGER.info(f'{prefix}{d} ({properties.name}) {t:.2f}G total, {r:.2f}G reserved, {a:.2f}G allocated, {f:.2f}G free')
 
     # Profile batch sizes
-    batch_sizes = [1, 2, 4, 8, 16, 32]
+    batch_sizes = [1, 2, 4, 8, 16]
     try:
         img = [torch.empty(b, 3, imgsz, imgsz) for b in batch_sizes]
         results = profile(img, model, n=3, device=device)
@@ -79,7 +79,7 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
         if b < 1 or (b > 1024 and fraction==0.6): # b outside of safe range - and conservative mode is on
             b = batch_size
             LOGGER.info(f"b is {b}. fraction is {fraction}.")
-            LOGGER.info(f'{prefix} MARTIN EDITING THIS WARNING ⚠️ CUDA anomaly detected, using default batch-size {batch_size}.')
+            LOGGER.info(f'{prefix}WARNING ⚠️ CUDA anomaly detected, using default batch-size {batch_size}.')
 
         fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted
         LOGGER.info(f'{prefix}Using batch-size {b} for {d} {t * fraction:.2f}G/{t:.2f}G ({fraction * 100:.0f}%) ✅')

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -78,6 +78,7 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
                 b = batch_sizes[max(i - 1, 0)]  # select prior safe point
         if b < 1 or (b > 1024 and fraction==0.6): # b outside of safe range - and conservative mode is on
             b = batch_size
+            LOGGER.info(f"b is {b}. fraction is {fraction}.")
             LOGGER.info(f'{prefix}WARNING ⚠️ CUDA anomaly detected, using default batch-size {batch_size}.')
 
         fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -76,7 +76,7 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
             i = results.index(None)  # first fail index
             if b >= batch_sizes[i]:  # y intercept above failure point
                 b = batch_sizes[max(i - 1, 0)]  # select prior safe point
-        if b < 1 or b > 1024:  # b outside of safe range
+        if b < 1 or (b > 1024 and fraction==0.6): # b outside of safe range - and conservative mode is on
             b = batch_size
             LOGGER.info(f'{prefix}WARNING ⚠️ CUDA anomaly detected, using default batch-size {batch_size}.')
 

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -10,7 +10,7 @@ from ultralytics.utils import DEFAULT_CFG, LOGGER, colorstr
 from ultralytics.utils.torch_utils import profile
 
 
-def check_train_batch_size(model, imgsz=640, amp=True):
+def check_train_batch_size(model, imgsz=640, amp=True, fraction=0.60):
     """
     Check YOLO training batch size using the autobatch() function.
 
@@ -24,7 +24,7 @@ def check_train_batch_size(model, imgsz=640, amp=True):
     """
 
     with torch.cuda.amp.autocast(amp):
-        return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
+        return autobatch(deepcopy(model).train(), imgsz,fraction=fraction)  # compute optimal batch size
 
 
 def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -78,7 +78,6 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
                 b = batch_sizes[max(i - 1, 0)]  # select prior safe point
         if b < 1 or (b > 1024 and fraction==0.6): # b outside of safe range - and conservative mode is on
             b = batch_size
-            LOGGER.info(f"b is {b}. fraction is {fraction}.")
             LOGGER.info(f'{prefix}WARNING ⚠️ CUDA anomaly detected, using default batch-size {batch_size}.')
 
         fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted


### PR DESCRIPTION
This addresses the feature request I've raised [here](https://github.com/ultralytics/ultralytics/issues/6857), and implements an agressive or optimistic auto-batch mode wherein the batch is scaled to use 90% of VRAM.


<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 51296e5</samp>

### Summary
🚀🎛️🔎

<!--
1.  🚀 - This emoji conveys the idea of speeding up the training process by using more VRAM, and also suggests a potential trade-off between performance and stability.
2.  🎛️ - This emoji represents the new option to adjust the batch size parameter to -2, which gives the user more control and flexibility over the training settings.
3.  🔎 - This emoji indicates the change in the anomaly detection logic, which involves a closer inspection and comparison of the VRAM fractions.
-->
This pull request improves the `autobatch` utility and the single-GPU training mode by allowing more VRAM usage for estimating and setting the optimal batch size. It adds new options to `ultralytics/utils/autobatch.py` and `ultralytics/engine/trainer.py` to control the VRAM fraction and the batch size estimate.

> _`autobatch` option_
> _use more VRAM, train faster_
> _watch for memory - ah!_

### Walkthrough
*  Add option to use 90% of VRAM for single-GPU training by setting batch size to -2 ([link](https://github.com/ultralytics/ultralytics/pull/6858/files?diff=unified&w=0#diff-49b2ec280b0d3c7e2f0040660ce399d51e26311a122e7a8052ef0d57fc40aadeL246-R249), [link](https://github.com/ultralytics/ultralytics/pull/6858/files?diff=unified&w=0#diff-2bcc26483f2f89ee2c89065ebfe7cbdf5ea5c6c238a5a0a2b7551ce62b564ec5L13-R13), [link](https://github.com/ultralytics/ultralytics/pull/6858/files?diff=unified&w=0#diff-2bcc26483f2f89ee2c89065ebfe7cbdf5ea5c6c238a5a0a2b7551ce62b564ec5L27-R27), [link](https://github.com/ultralytics/ultralytics/pull/6858/files?diff=unified&w=0#diff-2bcc26483f2f89ee2c89065ebfe7cbdf5ea5c6c238a5a0a2b7551ce62b564ec5L79-R81))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 📊 Key Changes
- Implemented a new mode for estimating the best batch size for single-GPU training, with a more optimistic use of VRAM (90% instead of the previous conservative estimate of 60%).
- Adjusted the `check_train_batch_size` function to support a configurable fraction of VRAM usage when determining the batch size.

### 🎯 Purpose & Impact
The purpose of this change is to allow users with a single GPU to allocate more VRAM to their training batches if they choose to take a more aggressive approach. This could lead to faster training times and better resource utilization for those with high-performance setups. It provides users with the flexibility to balance between risk (of running out of memory) and the benefit of increased batch sizes for their models.

### 🌟 Summary
Enhanced the Auto-batching feature with an "optimistic mode" for better VRAM usage on single-GPU systems. 🚀