### PR TITLE
`ultralytics 8.0.225` multi-video tracker bug fix

### DIFF
--- a/docs/en/reference/nn/modules/block.md
+++ b/docs/en/reference/nn/modules/block.md
@@ -78,3 +78,11 @@ keywords: YOLO, Ultralytics, neural network, nn.modules.block, Proto, HGBlock, S
 ## ::: ultralytics.nn.modules.block.BottleneckCSP
 
 <br><br>
+
+## ::: ultralytics.nn.modules.block.ResNetBlock
+
+<br><br>
+
+## ::: ultralytics.nn.modules.block.ResNetLayer
+
+<br><br>

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.224'
+__version__ = '8.0.225'
 
 from ultralytics.models import RTDETR, SAM, YOLO
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -345,9 +345,9 @@ class BasePredictor:
         else:  # 'video' or 'stream'
             frames_path = f'{save_path.split(".", 1)[0]}_frames/'
             if self.vid_path[idx] != save_path:  # new video
+                self.vid_path[idx] = save_path
                 if self.args.save_frames:
                     Path(frames_path).mkdir(parents=True, exist_ok=True)
-                    self.vid_path[idx] = save_path
                     self.vid_frame[idx] = 0
                 if isinstance(self.vid_writer[idx], cv2.VideoWriter):
                     self.vid_writer[idx].release()  # release previous video writer

--- a/ultralytics/solutions/heatmap.py
+++ b/ultralytics/solutions/heatmap.py
@@ -20,16 +20,16 @@ class Heatmap:
     def __init__(self):
         """Initializes the heatmap class with default values for Visual, Image, track, count and heatmap parameters."""
 
-        # Visual Information
+        # Visual information
         self.annotator = None
         self.view_img = False
 
-        # Image Information
+        # Image information
         self.imw = None
         self.imh = None
         self.im0 = None
 
-        # Heatmap Colormap and heatmap np array
+        # Heatmap colormap and heatmap np array
         self.colormap = None
         self.heatmap = None
         self.heatmap_alpha = 0.5
@@ -40,7 +40,7 @@ class Heatmap:
         self.clss = None
         self.track_history = None
 
-        # Counting Info
+        # Counting info
         self.count_reg_pts = None
         self.count_region = None
         self.in_counts = 0
@@ -160,7 +160,8 @@ class Heatmap:
 
         return im0_with_heatmap
 
-    def display_frames(self, im0_with_heatmap):
+    @staticmethod
+    def display_frames(im0_with_heatmap):
         """
         Display heatmap.
 


### PR DESCRIPTION
Introduced by me in 8.0.223

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e32494</samp>

### Summary
:memo::bookmark::bug:

<!--
1.  :memo: for adding documentation
2.  :bookmark: for updating the version number
3.  :bug: for fixing a bug
-->
This pull request improves the documentation and code quality of the `ultralytics` package, fixes a bug in the `save_preds` method of the `BasePredictor` class, and updates the version number.

> _`ultralytics` grows_
> _docs, bug fixes, and features_
> _autumn of progress_

### Walkthrough
*  Add documentation for `ResNetBlock` and `ResNetLayer` classes ([link](https://github.com/ultralytics/ultralytics/pull/6862/files?diff=unified&w=0#diff-ab79474136e023226f670d46c40c631695d509d3bd6248092da1adbb9de10dc0R81-R88))
*  Fix bug that caused frames to be saved in wrong directory in `save_preds` method of `BasePredictor` class ([link](https://github.com/ultralytics/ultralytics/pull/6862/files?diff=unified&w=0#diff-9fa2bf7f1273283680da3daeb8bae8e20cf8d477f838575796d2bf3b415bc534L348-R350))
*  Update version number of `ultralytics` package in `__init__.py` ([link](https://github.com/ultralytics/ultralytics/pull/6862/files?diff=unified&w=0#diff-b6202fa6738a34b56894dce00b24b8a4e4d7f4b1cbf1b04db6860f6b0f9635ceL3-R3))
*  Improve documentation quality and style of `Heatmap` class in `ultralytics.solutions.heatmap` module ([link](https://github.com/ultralytics/ultralytics/pull/6862/files?diff=unified&w=0#diff-093586443f50bb4abd2f74c1cf06db0a8cd3e635f0ac9e4c3239c13146bdcccbL23-R32), [link](https://github.com/ultralytics/ultralytics/pull/6862/files?diff=unified&w=0#diff-093586443f50bb4abd2f74c1cf06db0a8cd3e635f0ac9e4c3239c13146bdcccbL43-R43))
*  Add `@staticmethod` decorator to `display_frames` method of `Heatmap` class ([link](https://github.com/ultralytics/ultralytics/pull/6862/files?diff=unified&w=0#diff-093586443f50bb4abd2f74c1cf06db0a8cd3e635f0ac9e4c3239c13146bdcccbL163-R164))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to Ultralytics documentation and minor codebase improvements.

### 📊 Key Changes
- Added documentation entries for `ResNetBlock` and `ResNetLayer` classes.
- Incremented the project version to '8.0.225'.
- Refactored the `Predictor.save_preds` method by rearranging code for setting the video path.
- Updated `Heatmap` class to contain more consistent and cleaner comments.
- Made the `display_frames` method in `Heatmap` class static.

### 🎯 Purpose & Impact
- 📚 **Documentation**: The new doc entries for ResNetBlock and ResNetLayer will help users better understand how to use these building blocks within the Ultralytics framework.
- 🔄 **Project Versioning**: Updating the version number helps users and developers track changes and updates within the software.
- 🛠 **Code Quality**: The minor refactoring and cleanup work in the `Predictor` and `Heatmap` classes result in more maintainable and readable code.
- 📈 **Static Method**: Turning `display_frames` into a static method removes unnecessary reliance on object instances, potentially simplifying the use of the Heatmap class in different scenarios.