### PR TITLE
add flexibility to class Tuner: now it's possible to create custom search space and pass it in __init__, without changing source code

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -65,8 +65,7 @@ class Tuner:
         Args:
             args (dict, optional): Configuration for hyperparameter evolution.
         """
-        self.args = get_cfg(overrides=args)
-        self.space = {  # key: (min, max, gain(optional))
+        self.space = args.pop('space', None) or {  # key: (min, max, gain(optional))
             # 'optimizer': tune.choice(['SGD', 'Adam', 'AdamW', 'NAdam', 'RAdam', 'RMSProp']),
             'lr0': (1e-5, 1e-1),
             'lrf': (0.0001, 0.1),  # final OneCycleLR learning rate (lr0 * lrf)
@@ -90,6 +89,7 @@ class Tuner:
             'mosaic': (0.0, 1.0),  # image mixup (probability)
             'mixup': (0.0, 1.0),  # image mixup (probability)
             'copy_paste': (0.0, 1.0)}  # segment copy-paste (probability)
+        self.args = get_cfg(overrides=args)
         self.tune_dir = get_save_dir(self.args, name='tune')
         self.tune_csv = self.tune_dir / 'tune_results.csv'
         self.callbacks = _callbacks or callbacks.get_default_callbacks()


### PR DESCRIPTION
This PR created, bases on issue: https://github.com/ultralytics/ultralytics/issues/6856

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6210796</samp>

### Summary
🛠️🚀🔧

<!--
1.  🛠️ - This emoji represents the tool or wrench, and it can be used to indicate that the tuner class was improved or enhanced with more features and options.
2.  🚀 - This emoji represents the rocket, and it can be used to indicate that the tuner class was made faster or more efficient with the hyperparameter search space and the configuration settings.
3.  🔧 - This emoji represents the nut or bolt, and it can be used to indicate that the tuner class was adjusted or fine-tuned with the `self.args` and `self.space` attributes.
-->
Updated the `tuner` class to enable more customization of hyperparameter optimization. Moved and changed the `self.args` and `self.space` attributes to use configuration dictionaries.

> _`Tuner` of the dark, unleash your power_
> _Search the `space` for the optimal solution_
> _`self.args` is your key, configure your destiny_
> _Break the limits of the default execution_

### Walkthrough
* Allow custom hyperparameter search space for tuner ([link](https://github.com/ultralytics/ultralytics/pull/6882/files?diff=unified&w=0#diff-d42d1b8bc1c237d1e34d8da7ab7ab8130ad4eab91e795d5030271dafb52565d9L68-R68))
* Use configuration dictionary for tuner arguments ([link](https://github.com/ultralytics/ultralytics/pull/6882/files?diff=unified&w=0#diff-d42d1b8bc1c237d1e34d8da7ab7ab8130ad4eab91e795d5030271dafb52565d9R92))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in hyperparameter space configuration for tuning.

### 📊 Key Changes
- Added the option to pass a custom hyperparameter space via the `args` dictionary.
- Prioritized 'space' in `args` if present, before falling back to the default hyperparameter space definition.

### 🎯 Purpose & Impact
- 🎨 Allows users to easily define or override the hyperparameter space for model tuning without modifying the codebase.
- 🚀 Potentially improves model performance by enabling finer control over the tuning process.
- 🛠 Simplifies the process of experimenting with different hyperparameters, leading to more efficient and targeted model optimization.