### PR TITLE
`ultralytics 8.0.227` respect `defaults.yaml` data

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.226'
+__version__ = '8.0.227'
 
 from ultralytics.models import RTDETR, SAM, YOLO
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -437,7 +437,7 @@ def entrypoint(debug=''):
         LOGGER.warning(f"WARNING ⚠️ 'source' is missing. Using default 'source={overrides['source']}'.")
     elif mode in ('train', 'val'):
         if 'data' not in overrides and 'resume' not in overrides:
-            overrides['data'] = TASK2DATA.get(task or DEFAULT_CFG.task, DEFAULT_CFG.data)
+            overrides['data'] = DEFAULT_CFG.data or TASK2DATA.get(task or DEFAULT_CFG.task, DEFAULT_CFG.data)
             LOGGER.warning(f"WARNING ⚠️ 'data' is missing. Using default 'data={overrides['data']}'.")
     elif mode == 'export':
         if 'format' not in overrides:

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -325,7 +325,7 @@ class Model(nn.Module):
         checks.check_pip_update_available()
 
         overrides = yaml_load(checks.check_yaml(kwargs['cfg'])) if kwargs.get('cfg') else self.overrides
-        custom = {'data': TASK2DATA[self.task]}  # method defaults
+        custom = {'data': DEFAULT_CFG_DICT['data'] or TASK2DATA[self.task]}  # method defaults
         args = {**overrides, **custom, **kwargs, 'mode': 'train'}  # highest priority args on the right
         if args.get('resume'):
             args['resume'] = self.ckpt_path


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 711901e</samp>

### Summary
🔄🗂️🛠️

<!--
1.  🔄 - This emoji represents the change of logic for setting the default data path, as it implies a switch or a rotation of options.
2.  🗂️ - This emoji represents the use of the DEFAULT_CFG file and the data attribute, as it implies a folder or a file system where the data is stored.
3.  🛠️ - This emoji represents the consistency and flexibility of the data path between the entrypoint and the model, as it implies a tool or a fix for potential issues.
-->
This pull request allows the user to specify a default data path for training and validation in the `DEFAULT_CFG` file, and makes the code more consistent and flexible in handling different data sources. It modifies the `ultralytics/cfg/__init__.py` and `ultralytics/engine/model.py` files to implement this feature.

> _`DEFAULT_CFG` sets_
> _data path for training, val_
> _fall back to `TASK2DATA`_

### Walkthrough
*  Modify the logic for setting the default data path for training and validation modes ([link](https://github.com/ultralytics/ultralytics/pull/6935/files?diff=unified&w=0#diff-c02fb3f9e86e97bf85f07211aed56aa04774504a61eeff07a08471bbdea14556L440-R440), [link](https://github.com/ultralytics/ultralytics/pull/6935/files?diff=unified&w=0#diff-cb649199881b55cff01fb5d1a216adf39d007be25e815089340a5b4f074cba00L328-R328))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to version 8.0.227 with enhancements in configuration defaults.

### 📊 Key Changes
- Bumped the library version from 8.0.226 to 8.0.227.
- Modified default data configurations to prioritize the `DEFAULT_CFG.data` value when specifying task data.
- Updated the `custom` dictionary in the training method to also prioritize `DEFAULT_CFG_DICT['data']` over `TASK2DATA`.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: These changes ensure that default configuration values are used more consistently across different parts of the library, which leads to a more predictable and controlled environment when starting training or validation tasks.
- 👥 **Impact to Users**: Users will experience more reliable and intuitive behavior regarding default data paths, reducing possible confusion or errors due to mismatched or unexpected data configurations.
- 🧰 **Developer Impact**: Developers benefit from clearer and more straightforward code when managing configuration defaults, potentially leading to easier maintenance and extension of the library in the future.