### PR TITLE
Add quantization support to TensorFlow.js converter

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -789,6 +789,12 @@ class Exporter:
         f = str(self.file).replace(self.file.suffix, '_web_model')  # js dir
         f_pb = str(self.file.with_suffix('.pb'))  # *.pb path
 
+        quantization = ''
+        if self.args.int8:
+            quantization = '--quantize_uint8'
+        elif self.args.half:
+            quantization = '--quantize_float16'
+
         gd = tf.Graph().as_graph_def()  # TF GraphDef
         with open(f_pb, 'rb') as file:
             gd.ParseFromString(file.read())
@@ -796,7 +802,7 @@ class Exporter:
         LOGGER.info(f'\n{prefix} output node names: {outputs}')
 
         with spaces_in_path(f_pb) as fpb_, spaces_in_path(f) as f_:  # exporter can not handle spaces in path
-            cmd = f'tensorflowjs_converter --input_format=tf_frozen_model --output_node_names={outputs} "{fpb_}" "{f_}"'
+            cmd = f'tensorflowjs_converter --input_format=tf_frozen_model {quantization} --output_node_names={outputs} "{fpb_}" "{f_}"'
             LOGGER.info(f"{prefix} running '{cmd}'")
             subprocess.run(cmd, shell=True)
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -790,18 +790,13 @@ class Exporter:
         f = str(self.file).replace(self.file.suffix, '_web_model')  # js dir
         f_pb = str(self.file.with_suffix('.pb'))  # *.pb path
 
-        quantization = ''
-        if self.args.int8:
-            quantization = '--quantize_uint8'
-        elif self.args.half:
-            quantization = '--quantize_float16'
-
         gd = tf.Graph().as_graph_def()  # TF GraphDef
         with open(f_pb, 'rb') as file:
             gd.ParseFromString(file.read())
         outputs = ','.join(gd_outputs(gd))
         LOGGER.info(f'\n{prefix} output node names: {outputs}')
 
+        quantization = '--quantize_float16' if self.args.half else '--quantize_uint8' if self.args.int8 else ''
         with spaces_in_path(f_pb) as fpb_, spaces_in_path(f) as f_:  # exporter can not handle spaces in path
             cmd = f'tensorflowjs_converter --input_format=tf_frozen_model {quantization} --output_node_names={outputs} "{fpb_}" "{f_}"'
             LOGGER.info(f"{prefix} running '{cmd}'")


### PR DESCRIPTION
check existing PR and open issues ✅ 

summary: the quantization option was not passed to the tensorflowjs_converter

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow.js export with model quantization options.

### 📊 Key Changes
- Introduced a new line to add quantization parameters based on command line arguments (`--half` for float16 and `--int8` for uint8).
- Modified the TensorFlow.js converter command to include conditional quantization flags.

### 🎯 Purpose & Impact
- 🚀 The purpose of these changes is to enable quantization during the TensorFlow.js model export, reducing model size and potentially improving execution speed on web platforms.
- 📉 Potential impact includes faster inference times and lower memory usage for web-deployed models, making machine learning models more accessible and efficient in a browser environment.