### PR TITLE
fix dataset loader handle invalid image

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -250,6 +250,10 @@ class ClassificationDataset(torchvision.datasets.ImageFolder):
             im = np.load(fn)
         else:  # read image
             im = cv2.imread(f)  # BGR
+        if not im:
+            print("Error: The item is null. Skipping item...")
+            del self.samples[i]
+            return None
         if self.album_transforms:
             sample = self.album_transforms(image=cv2.cvtColor(im, cv2.COLOR_BGR2RGB))['image']
         else:

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -251,7 +251,7 @@ class ClassificationDataset(torchvision.datasets.ImageFolder):
         else:  # read image
             im = cv2.imread(f)  # BGR
         if not im:
-            print("Error: The item is null. Skipping item...")
+            print('Error: The item is null. Skipping item...')
             del self.samples[i]
             return None
         if self.album_transforms:


### PR DESCRIPTION
Fix the report bug here: https://github.com/ultralytics/ultralytics/issues/7018

I just skip the invalid item from self.samples

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in dataset handling by skipping null/invalid images.

### 📊 Key Changes
- Added a check to verify if an image is successfully loaded.
- If an image is not loaded (null), a error message is printed.
- The invalid image entry is removed from the dataset's samples.

### 🎯 Purpose & Impact
- **Purpose**: To ensure the dataset does not contain null images that would cause errors during training or evaluation.
- **Impact**: Provides a more robust and error-resistant dataset loading process, improving user experience by preventing crashes due to invalid image data. 🛠️📈