### PR TITLE
Fix PNNX `ubuntu` -> `linux` bug

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -464,7 +464,7 @@ class Exporter:
                 _, assets = get_github_assets(repo='pnnx/pnnx', retry=True)
                 url = [x for x in assets if any(s in x for s in system)][0]
             except Exception as e:
-                url = f'https://github.com/pnnx/pnnx/releases/download/20230816/pnnx-20231127-{system[0]}.zip'
+                url = f'https://github.com/pnnx/pnnx/releases/download/20231127/pnnx-20231127-{system[0]}.zip'
                 LOGGER.warning(f'{prefix} WARNING ⚠️ PNNX GitHub assets not found: {e}, using default {url}')
             asset = attempt_download_asset(url, repo='pnnx/pnnx', release='latest')
             if check_is_path_safe(Path.cwd(), asset):  # avoid path traversal security vulnerability

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -459,11 +459,14 @@ class Exporter:
                 f'{prefix} WARNING ⚠️ PNNX not found. Attempting to download binary file from '
                 'https://github.com/pnnx/pnnx/.\nNote PNNX Binary file must be placed in current working directory '
                 f'or in {ROOT}. See PNNX repo for full installation instructions.')
-            _, assets = get_github_assets(repo='pnnx/pnnx', retry=True)
-            system = 'macos' if MACOS else 'ubuntu' if LINUX else 'windows'  # operating system
-            asset = [x for x in assets if system in x][0] if assets else \
-                f'https://github.com/pnnx/pnnx/releases/download/20230816/pnnx-20230816-{system}.zip'  # fallback
-            asset = attempt_download_asset(asset, repo='pnnx/pnnx', release='latest')
+            system = ['macos'] if MACOS else ['windows'] if WINDOWS else ['ubuntu', 'linux']  # operating system
+            try:
+                _, assets = get_github_assets(repo='pnnx/pnnx', retry=True)
+                url = [x for x in assets if any(s in x for s in system)][0]
+            except Exception as e:
+                url = f'https://github.com/pnnx/pnnx/releases/download/20230816/pnnx-20231127-{system[0]}.zip'
+                LOGGER.warning(f'{prefix} WARNING ⚠️ PNNX GitHub assets not found: {e}, using default {url}')
+            asset = attempt_download_asset(url, repo='pnnx/pnnx', release='latest')
             if check_is_path_safe(Path.cwd(), asset):  # avoid path traversal security vulnerability
                 unzip_dir = Path(asset).with_suffix('')
                 (unzip_dir / name).rename(pnnx)  # move binary to ROOT


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced reliability for downloading `pnnx` binaries in NCNN export process.

### 📊 Key Changes
- Improved OS detection logic to include both 'ubuntu' and 'linux' for Linux systems.
- Wrapped asset retrieval in a `try-except` block to handle exceptions gracefully.
- Specified a fallback URL with an explicit date for the `pnnx` binary if asset retrieval fails.

### 🎯 Purpose & Impact
- Ensures compatibility with a wider range of Linux distributions.
- Increases robustness of the code by handling potential errors during the download process.
- Provides a clearer fallback mechanism, ensuring that users can still access the required `pnnx` binary even if the primary method fails, maintaining ease of use and stability of the export function.