### PR TITLE
Build with `opencv-python` in headless version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Base ----------------------------------------
 matplotlib>=3.3.0
 numpy>=1.22.2 # pinned by Snyk to avoid a vulnerability
-opencv-python>=4.6.0
+opencv-python-headless>=4.6.0
 pillow>=7.1.2
 pyyaml>=5.3.1
 requests>=2.23.0

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -149,7 +149,7 @@ class AutoBackend(nn.Module):
                 metadata = json.loads(extra_files['config.txt'], object_hook=lambda x: dict(x.items()))
         elif dnn:  # ONNX OpenCV DNN
             LOGGER.info(f'Loading {w} for ONNX OpenCV DNN inference...')
-            check_requirements('opencv-python>=4.5.4')
+            check_requirements('opencv-python-headless>=4.5.4')
             net = cv2.dnn.readNetFromONNX(w)
         elif onnx:  # ONNX Runtime
             LOGGER.info(f'Loading {w} for ONNX Runtime inference...')


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->
Resolves #7056 #4422 

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switch to OpenCV headless for reduced package size and dependencies.

### 📊 Key Changes
- Changed the OpenCV dependency to `opencv-python-headless` instead of `opencv-python`.
- Updated the version pinning to require at least version 4.6.0 of `opencv-python-headless`.

### 🎯 Purpose & Impact
- The purpose of this change is to reduce the size and number of dependencies required by replacing the full OpenCV package with a headless version that doesn't include any GUI functionality or unnecessary bloat.
- This could potentially lower the installation time and the space required for projects using this repository.
- The impact on end-users is likely to be minimal, as long as they don't depend on OpenCV's GUI features within this project, further contributing to a leaner project footprint. 📦