### PR TITLE
Remove YT video demo from VisionEye docs page

### DIFF
--- a/docs/en/guides/vision-eye.md
+++ b/docs/en/guides/vision-eye.md
@@ -10,17 +10,6 @@ keywords: Ultralytics, YOLOv8, Object Detection, Object Tracking, IDetection, Vi
 
 [Ultralytics YOLOv8](https://github.com/ultralytics/ultralytics/) VisionEye offers the capability for computers to identify and pinpoint objects, simulating the observational precision of the human eye. This functionality enables computers to discern and focus on specific objects, much like the way the human eye observes details from a particular viewpoint.
 
-<p align="center">
-  <br>
-  <iframe width="720" height="405" src="https://www.youtube.com/embed/in6xF7KgF7Q"
-    title="YouTube video player" frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    allowfullscreen>
-  </iframe>
-  <br>
-  <strong>Watch:</strong> VisionEye Mapping using Ultralytics YOLOv8
-</p>
-
 ## Samples
 
 |                                                                        VisionEye View                                                                        |                                                                        VisionEye View With Object Tracking                                                                        |


### PR DESCRIPTION
@glenn-jocher 

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removed YouTube video embed from VisionEye documentation.

### 📊 Key Changes
- Deleted an embedded YouTube video from the VisionEye guide in the documentation.

### 🎯 Purpose & Impact
- The removal may be aimed at streamlining the documentation page or because the video is no longer relevant.
- Readers will no longer have direct video insight into VisionEye capabilities on that page, possibly reducing the immediate visual understanding of the feature.