### PR TITLE
`ultralytics 8.0.230` TensorRT export hang fix

### DIFF
--- a/docs/en/integrations/roboflow.md
+++ b/docs/en/integrations/roboflow.md
@@ -8,9 +8,9 @@ keywords: Ultralytics, YOLOv8, Roboflow, vector analysis, confusion matrix, data
 
 [Roboflow](https://roboflow.com/?ref=ultralytics) has everything you need to build and deploy computer vision models. Connect Roboflow at any step in your pipeline with APIs and SDKs, or use the end-to-end interface to automate the entire process from image to inference. Whether you’re in need of [data labeling](https://roboflow.com/annotate?ref=ultralytics), [model training](https://roboflow.com/train?ref=ultralytics), or [model deployment](https://roboflow.com/deploy?ref=ultralytics), Roboflow gives you building blocks to bring custom computer vision solutions to your project.
 
-!!! Warning
+!!! Note
 
-    Roboflow users can use Ultralytics under the [AGPL license](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) or procure an [Enterprise license](https://ultralytics.com/license) directly from Ultralytics. Be aware that Roboflow does **not** provide Ultralytics licenses, and it is the responsibility of the user to ensure appropriate licensing.
+    Ultralytics offers two licensing options: the [AGPL-3.0 License](https://github.com/ultralytics/ultralytics/blob/main/LICENSE), an OSI-approved open-source license ideal for students and enthusiasts, and the [Enterprise License](https://ultralytics.com/license) for businesses seeking to incorporate our AI models into their products and services. More details are available via [Ultralytics Licensing](https://ultralytics.com/license).
 
 In this guide, we are going to showcase how to find, label, and organize data for use in training a custom Ultralytics YOLOv8 model. Use the table of contents below to jump directly to a specific section:
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -579,10 +579,10 @@ class Exporter:
     def export_engine(self, prefix=colorstr('TensorRT:')):
         """YOLOv8 TensorRT export https://developer.nvidia.com/tensorrt."""
         assert self.im.device.type != 'cpu', "export running on CPU but must be on GPU, i.e. use 'device=0'"
-        
+
         # fix TRT export bug
         f_onnx, _ = self.export_onnx()
-        
+
         try:
             import tensorrt as trt  # noqa
         except ImportError:
@@ -591,7 +591,7 @@ class Exporter:
             import tensorrt as trt  # noqa
 
         check_version(trt.__version__, '7.0.0', hard=True)  # require tensorrt>=7.0.0
-        
+
         self.args.simplify = True
 
         LOGGER.info(f'\n{prefix} starting export with TensorRT {trt.__version__}...')

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -579,6 +579,10 @@ class Exporter:
     def export_engine(self, prefix=colorstr('TensorRT:')):
         """YOLOv8 TensorRT export https://developer.nvidia.com/tensorrt."""
         assert self.im.device.type != 'cpu', "export running on CPU but must be on GPU, i.e. use 'device=0'"
+        
+        # fix TRT export bug
+        f_onnx, _ = self.export_onnx()
+        
         try:
             import tensorrt as trt  # noqa
         except ImportError:
@@ -587,8 +591,8 @@ class Exporter:
             import tensorrt as trt  # noqa
 
         check_version(trt.__version__, '7.0.0', hard=True)  # require tensorrt>=7.0.0
+        
         self.args.simplify = True
-        f_onnx, _ = self.export_onnx()
 
         LOGGER.info(f'\n{prefix} starting export with TensorRT {trt.__version__}...')
         assert Path(f_onnx).exists(), f'failed to export ONNX file: {f_onnx}'

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -579,9 +579,7 @@ class Exporter:
     def export_engine(self, prefix=colorstr('TensorRT:')):
         """YOLOv8 TensorRT export https://developer.nvidia.com/tensorrt."""
         assert self.im.device.type != 'cpu', "export running on CPU but must be on GPU, i.e. use 'device=0'"
-
-        # fix TRT export bug
-        f_onnx, _ = self.export_onnx()
+        f_onnx, _ = self.export_onnx()  # run before trt import https://github.com/ultralytics/ultralytics/issues/7016
 
         try:
             import tensorrt as trt  # noqa


### PR DESCRIPTION
This change should fix TensorRT model exports (.engine) for anyone who was previously having trouble with YOLO not reading model metadata (UTF-8 error). When exporting a model in the TRT .engine format, the previous code used to hang at converting the model to ONNX format, and then the program exits without any errors, while no file is created. Now, a file is created, TRT is correctly invoked, and the program completes. We can now use the .engine file as our model file when loading through either the CLI executable or the Python SDK. 

#866 #7016 

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved clarity on licensing options and streamlined model export process to TensorRT.

### 📊 Key Changes
- Updated the licensing information in the documentation to better reflect the options available.
- Adjusted the model export sequence for TensorRT to ensure ONNX export occurs beforehand.

### 🎯 Purpose & Impact
- **Clarity on Licensing**: Ensures that users clearly understand the two types of licenses offered by Ultralytics - for hobbyists and for enterprise use.
- **Model Export Efficiency**: The change in export order resolves an issue and streamlines the process for converting models to TensorRT, particularly beneficial for developers working on NVIDIA platforms.