### PR TITLE
Dockerfile-jetson `pyproject.toml` OpenCV fix

### DIFF
--- a/docker/Dockerfile-jetson
+++ b/docker/Dockerfile-jetson
@@ -21,8 +21,8 @@ WORKDIR /usr/src/ultralytics
 RUN git clone https://github.com/ultralytics/ultralytics -b main /usr/src/ultralytics
 ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt /usr/src/ultralytics/
 
-# Remove opencv-python from requirements.txt as it conflicts with opencv-python installed in base image
-RUN grep -v '^opencv-python' requirements.txt > tmp.txt && mv tmp.txt requirements.txt
+# Remove opencv-python from Ultralytics dependencies as it conflicts with opencv-python installed in base image
+RUN grep -v "opencv-python" pyproject.toml > temp.toml && mv temp.toml pyproject.toml
 
 # Install pip packages manually for TensorRT compatibility https://github.com/NVIDIA/TensorRT/issues/2567
 RUN python3 -m pip install --upgrade pip wheel


### PR DESCRIPTION
May resolve failing Dockerfile-jetson build


<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Dockerfile for Jetson compatibility with Ultralytics software.

### 📊 Key Changes
- 🔧 Modified the Dockerfile used for Nvidia Jetson devices.
- 🔍 Updated the script to remove `opencv-python` entry from `pyproject.toml` instead of `requirements.txt`.

### 🎯 Purpose & Impact
- 🎨 Prevents conflicts with `opencv-python` versions that might arise due to pre-installed packages in the base image, ensuring smoother installations.
- 🚀 Users working on Nvidia Jetson will have fewer issues when using Ultralytics software, potentially leading to a more stable experience.