### PR TITLE
fix `show_conf` argument 

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -244,7 +244,8 @@ class Results(SimpleClass):
             for d in reversed(pred_boxes):
                 c, conf, id = int(d.cls), float(d.conf) if conf else None, None if d.id is None else int(d.id.item())
                 name = ('' if id is None else f'id:{id} ') + names[c]
-                label = f'{name} {conf:.2f}' if labels and confs else (f'{name}' if labels else (f'{conf:.2f}' if confs else None))
+                label = f'{name} {conf:.2f}' if labels and confs else (f'{name}' if labels else
+                                                                       (f'{conf:.2f}' if confs else None))
                 annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
 
         # Plot Classify results

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -238,12 +238,13 @@ class Results(SimpleClass):
             idx = pred_boxes.cls if pred_boxes else range(len(pred_masks))
             annotator.masks(pred_masks.data, colors=[colors(x, True) for x in idx], im_gpu=im_gpu)
 
+        confs = conf  # flag to plot the detection confidence score.
         # Plot Detect results
         if pred_boxes and show_boxes:
             for d in reversed(pred_boxes):
                 c, conf, id = int(d.cls), float(d.conf) if conf else None, None if d.id is None else int(d.id.item())
                 name = ('' if id is None else f'id:{id} ') + names[c]
-                label = (f'{name} {conf:.2f}' if conf else name) if labels else None
+                label = f'{name} {conf:.2f}' if labels and confs else (f'{name}' if labels else (f'{conf:.2f}' if confs else None))
                 annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
 
         # Plot Classify results


### PR DESCRIPTION
### Highlights

- If a user wishes to show labels using `show_labels=True`, it functions correctly. However, if the user intends to display only the confidence of labels with `show_conf`, they need to set `show_labels=False`. This currently results in no labels and no confidence being displayed, whereas the expected behavior is to show the confidence score only. This PR will hopefully resolve this issue.

#7229 

@glenn-jocher 



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced label and confidence display in detection visualizations.

### 📊 Key Changes
- Added control over whether detection confidence scores are displayed alongside labels in visualizations.
- Adjusted the label formatting logic to include optional display of confidence levels.

### 🎯 Purpose & Impact
- **Purpose**: To give users more flexibility in how detection results are presented, by allowing the option to display confidence scores with detection labels.
- **Impact**: Users will now be able to see the confidence level of each detection directly on the image, which can be useful for understanding model performance and for debugging purposes. This optional feature adds clarity to results without overwhelming users who may prefer simpler visualizations. 🎨✨