### PR TITLE
Fix RTDETR generate anchor grid out of boundary

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -303,7 +303,7 @@ class RTDETRDecoder(nn.Module):
             grid_y, grid_x = torch.meshgrid(sy, sx, indexing='ij') if TORCH_1_10 else torch.meshgrid(sy, sx)
             grid_xy = torch.stack([grid_x, grid_y], -1)  # (h, w, 2)
 
-            valid_WH = torch.tensor([h, w], dtype=dtype, device=device)
+            valid_WH = torch.tensor([w, h], dtype=dtype, device=device)
             grid_xy = (grid_xy.unsqueeze(0) + 0.5) / valid_WH  # (1, h, w, 2)
             wh = torch.ones_like(grid_xy, dtype=dtype, device=device) * grid_size * (2.0 ** i)
             anchors.append(torch.cat([grid_xy, wh], -1).view(-1, h * w, 4))  # (1, h*w, 4)


### PR DESCRIPTION

In the process of generating anchors in the _generate_anchors function, the order of the valid_hw is [h,w], which does not match the dimension order of the grid_xy, and if the width and height of the feature map are not equal, the generated result will be out of bounds on the short side and small on the long side.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixed anchor generation aspect ratio in detection model.

### 📊 Key Changes
- Corrected the order of height and width parameters in the anchor tensor creation.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To ensure that the anchor boxes generated by the neural network have accurate aspect ratios.
- 💥 **Impact**: This correction will improve object detection accuracy, particularly for objects whose aspect ratio is critical for identification. Users can expect more reliable detection results after this fix.