### PR TITLE
fix: rename ModelPath to modelPath

### DIFF
--- a/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
+++ b/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
@@ -127,7 +127,7 @@ char* YOLO_V8::CreateSession(DL_INIT_PARAM& iParams) {
         wide_cstr[ModelPathSize] = L'\0';
         const wchar_t* modelPath = wide_cstr;
 #else
-        const char* modelPath = iParams.ModelPath.c_str();
+        const char* modelPath = iParams.modelPath.c_str();
 #endif // _WIN32
 
         session = new Ort::Session(env, modelPath, sessionOption);


### PR DESCRIPTION
inference.cpp:130:41: error: ‘DL_INIT_PARAM’ {aka ‘struct _DL_INIT_PARAM’} has no member named ‘ModelPath’; did you mean ‘modelPath’

Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.

2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.

3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.

4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updating ONNXRuntime C++ example to fix a variable naming issue.

### 📊 Key Changes
- Corrected the case of a variable from `ModelPath` to `modelPath` in the C++ ONNXRuntime example.

### 🎯 Purpose & Impact
- 🎨 Enhances code consistency and prevents potential bugs related to case sensitivity.
- 🔍 Aids developers in following best practices for variable naming conventions.
- 💼 This minor change does not directly impact users but helps maintain code quality and readability.