### PR TITLE
`ultralytics 8.0.234` VOC `exist_ok=True` unzip fix

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = '8.0.233'
+__version__ = '8.0.234'
 
 from ultralytics.models import RTDETR, SAM, YOLO
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/cfg/datasets/VOC.yaml
+++ b/ultralytics/cfg/datasets/VOC.yaml
@@ -81,7 +81,7 @@ download: |
   urls = [f'{url}VOCtrainval_06-Nov-2007.zip',  # 446MB, 5012 images
           f'{url}VOCtest_06-Nov-2007.zip',  # 438MB, 4953 images
           f'{url}VOCtrainval_11-May-2012.zip']  # 1.95GB, 17126 images
-  download(urls, dir=dir / 'images', curl=True, threads=3)
+  download(urls, dir=dir / 'images', curl=True, threads=3, exist_ok=True)  # download and unzip over existing paths (required)
 
   # Convert
   path = dir / 'images/VOCdevkit'

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -266,6 +266,7 @@ def safe_download(url,
                   curl=False,
                   retry=3,
                   min_bytes=1E0,
+                  exist_ok=False,
                   progress=True):
     """
     Downloads files from a URL, with options for retrying, unzipping, and deleting the downloaded file.
@@ -282,6 +283,7 @@ def safe_download(url,
         retry (int, optional): The number of times to retry the download in case of failure. Default: 3.
         min_bytes (float, optional): The minimum number of bytes that the downloaded file should have, to be considered
             a successful download. Default: 1E0.
+        exist_ok (bool, optional): Whether to overwrite existing contents during unzipping. Defaults to False.
         progress (bool, optional): Whether to display a progress bar during the download. Default: True.
 
     Example:
@@ -342,7 +344,7 @@ def safe_download(url,
 
         unzip_dir = (dir or f.parent).resolve()  # unzip to dir if provided else unzip in place
         if is_zipfile(f):
-            unzip_dir = unzip_file(file=f, path=unzip_dir, progress=progress)  # unzip
+            unzip_dir = unzip_file(file=f, path=unzip_dir, exist_ok=exist_ok, progress=progress)  # unzip
         elif f.suffix in ('.tar', '.gz'):
             LOGGER.info(f'Unzipping {f} to {unzip_dir}...')
             subprocess.run(['tar', 'xf' if f.suffix == '.tar' else 'xfz', f, '--directory', unzip_dir], check=True)
@@ -437,7 +439,7 @@ def attempt_download_asset(file, repo='ultralytics/assets', release='v0.0.0', **
         return str(file)
 
 
-def download(url, dir=Path.cwd(), unzip=True, delete=False, curl=False, threads=1, retry=3):
+def download(url, dir=Path.cwd(), unzip=True, delete=False, curl=False, threads=1, retry=3, exist_ok=False):
     """
     Downloads files from specified URLs to a given directory. Supports concurrent downloads if multiple threads are
     specified.
@@ -450,6 +452,7 @@ def download(url, dir=Path.cwd(), unzip=True, delete=False, curl=False, threads=
         curl (bool, optional): Flag to use curl for downloading. Defaults to False.
         threads (int, optional): Number of threads to use for concurrent downloads. Defaults to 1.
         retry (int, optional): Number of retries in case of download failure. Defaults to 3.
+        exist_ok (bool, optional): Whether to overwrite existing contents during unzipping. Defaults to False.
 
     Example:
         ```python
@@ -461,11 +464,16 @@ def download(url, dir=Path.cwd(), unzip=True, delete=False, curl=False, threads=
     if threads > 1:
         with ThreadPool(threads) as pool:
             pool.map(
-                lambda x: safe_download(
-                    url=x[0], dir=x[1], unzip=unzip, delete=delete, curl=curl, retry=retry, progress=threads <= 1),
-                zip(url, repeat(dir)))
+                lambda x: safe_download(url=x[0],
+                                        dir=x[1],
+                                        unzip=unzip,
+                                        delete=delete,
+                                        curl=curl,
+                                        retry=retry,
+                                        exist_ok=exist_ok,
+                                        progress=threads <= 1), zip(url, repeat(dir)))
             pool.close()
             pool.join()
     else:
         for u in [url] if isinstance(url, (str, Path)) else url:
-            safe_download(url=u, dir=dir, unzip=unzip, delete=delete, curl=curl, retry=retry)
+            safe_download(url=u, dir=dir, unzip=unzip, delete=delete, curl=curl, retry=retry, exist_ok=exist_ok)


### PR DESCRIPTION
@AyushExel this should solve our VOC bug

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced downloading logic with overwrite support for existing files.

### 📊 Key Changes
- Bumped the package version from `8.0.233` to `8.0.234`.
- Updated `VOC.yaml` to support downloading over existing paths.
- Added an `exist_ok` parameter to the `safe_download` and `download` functions, defaulting to `False`.
- Included logic to overwrite existing contents during unzipping if `exist_ok` is set to `True`.

### 🎯 Purpose & Impact
- 🔄 Ensures more robust data management by allowing downloads to write over already existing files, preventing potential conflicts or errors during dataset preparation.
- ⚙️ Improves user experience by supporting use cases where redownloading and overwriting existing files is necessary, which may help in scenarios involving corrupt data or updates.
- 🔃 Users can now rerun scripts without manually handling existing files, streamlining the setup and update process for datasets or other downloaded content.