### PR TITLE
Disable mosaic buffer if batch size is too low

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -161,7 +161,8 @@ class Mosaic(BaseMixTransform):
         # disable mosaic buffer if batch size is lower than n
         self.use_buffer = len(dataset.buffer) >= n
         if self.use_buffer is False:
-            LOGGER.warning(f"WARNING ⚠️ Mosaic buffer disabled because batch size is too low ({len(dataset.buffer)} < {n}).")
+            LOGGER.warning(
+                f'WARNING ⚠️ Mosaic buffer disabled because batch size is too low ({len(dataset.buffer)} < {n}).')
 
     def get_indexes(self):
         """Return a list of random indexes from the dataset."""


### PR DESCRIPTION
When using a very low batch size (contrained by available VRAM), mosaic will become useless because it will just keep using the same image again and again in the mosaic, which reduces the final model performance.

Auto disabling the buffer allows to get a better sample on each sent batch.

Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.

2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.

3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.

4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

   _I have read the CLA Document and I hereby sign the CLA_




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to Mosaic Data Augmentation Handling in Batch Processing.

### 📊 Key Changes
- Added a condition to disable the mosaic augmentation buffer if the batch size is smaller than the expected number of images (`n`) for creating a mosaic.
- Removed the `buffer` parameter from the `get_indexes` method and instead used the new `use_buffer` attribute to determine whether to select images from the buffer.
- A warning is now logged if the mosaic buffer is not used due to the batch size being too small.

### 🎯 Purpose & Impact
- ⚙️ **Enhanced Efficiency**: The update avoids the unnecessary use of mosaic buffers for small batch sizes, streamlining the processing.
- 🚀 **Better Resource Use**: This change ensures the augmentation process is more appropriate for the available data, preventing the wasteful recycling of images in mosaics.
- 📢 **Improved User Awareness**: By warning users when the buffer isn't used, they will be aware of potential suboptimal training conditions.