### PR TITLE
fix: handle failed creation gracefully

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
     "thop>=0.1.1", # FLOPs computation
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
+    "hub-sdk @ git+https://github.com/ultralytics/hub-sdk.git@develop", # hub integration
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -87,7 +87,7 @@ class Model(nn.Module):
             self.session = get_hub_session(model)
             model = self.session.model_file
 
-        elif SETTINGS['hub'] is True and task == 'train':
+        elif SETTINGS['hub'] is True:
             # Create a model in HUB
             try:
                 self.session = get_hub_session(model)
@@ -96,7 +96,7 @@ class Model(nn.Module):
                 pass
 
         # Check if Triton Server model
-        elif self.is_triton_model(model):
+        if self.is_triton_model(model):
             self.model = model
             self.task = task
             return
@@ -371,9 +371,13 @@ class Model(nn.Module):
             self.trainer.model = self.trainer.get_model(weights=self.model if self.ckpt else None, cfg=self.model.yaml)
             self.model = self.trainer.model
 
-            # Create HUB model
+            # Create HUB
             if self.session and not self.session.model.id:
                 self.session.create_model(args)
+
+                # HUB model could not be created
+                if not self.session.model.id:
+                    self.session = None
 
         self.trainer.hub_session = self.session  # attach optional HUB session
         self.trainer.train()

--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -103,6 +103,12 @@ class HUBTrainingSession:
             payload['lineage']['parent']['name'] = self.filename
 
         self.model.create_model(payload)
+
+        # Model could not be created
+        # TODO: improve error handling
+        if not self.model.id:
+            return
+
         self.model_url = f'{HUB_WEB_ROOT}/models/{self.model.id}'
 
         # Start heartbeats for HUB to monitor agent


### PR DESCRIPTION
This PR fixes the HUB model creation code. We no longer check based on task and handle failure gracefully.

It also temporarily includes the hub-sdk as a dependency via git. Before merge this will be updated to the PyPi package.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Integration of Ultralytics Hub SDK for enhanced model management and analytics within the project ecosystem.

### 📊 Key Changes
- Added Ultralytics Hub SDK dependency in `pyproject.toml`.
- Modified condition to allow Hub integration for tasks beyond just training.
- Placed a conditional check that only proceeds if a Hub model ID exists after attempting to create a Hub model.
- Adjusted logic to handle Triton Server models independently of the Hub integration condition.

### 🎯 Purpose & Impact
- 🤝 Provides a streamlined way for users to integrate with Ultralytics Hub, offering a platform for model versioning, collaboration, and potentially metrics tracking.
- 🔀 Enhances the platform's ability to manage various model sources and training configurations, by allowing integration with the Hub API during various tasks, not limited to training.
- 🛑 Ensures that the system does not continue with Hub-related processes if a model could not be created in the Hub, preventing potential errors or confusion.
- 👁️‍🗨️ Makes the codebase more robust by better error handling related to Hub integration and model management, potentially improving user experience and operational efficiency.