### PR TITLE
Fix Multi-GPU resume bug

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -121,7 +121,6 @@ class BaseTrainer:
 
         self.trainset, self.testset = self.get_dataset(self.data)
         self.ema = None
-        self.resume = False
 
         # Optimization utils init
         self.lf = None


### PR DESCRIPTION
Fix [#7219](https://github.com/ultralytics/ultralytics/issues/7219)

I have successfully tested the system with the CPU, a single GPU, and multiple GPUs.


I have read the CLA Document and I sign the CLA



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated training initialization in Ultralytics' codebase.

### 📊 Key Changes
- Removed the `resume` attribute from the Trainer class initializer.

### 🎯 Purpose & Impact
- The change simplifies the Trainer class by removing potentially unused or redundant code, leading to cleaner, more maintainable code.
- Users working with the Trainer may experience a more streamlined initialization, with less confusion since `resume` functionality might be handled elsewhere or might not be needed in this context.