### PR TITLE
Add OBB models to `GITHUB_ASSET_NAMES`

### DIFF
--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -16,15 +16,14 @@ from ultralytics.utils import LOGGER, TQDM, checks, clean_url, emojis, is_online
 
 # Define Ultralytics GitHub assets maintained at https://github.com/ultralytics/assets
 GITHUB_ASSETS_REPO = 'ultralytics/assets'
-GITHUB_ASSETS_NAMES = (
-        [f'yolov8{k}{suffix}.pt' for k in 'nsmlx' for suffix in ('', '-cls', '-seg', '-pose', '-obb')] +
-        [f'yolov5{k}{resolution}u.pt' for k in 'nsmlx' for resolution in ('', '6')] +
-        [f'yolov3{k}u.pt' for k in ('', '-spp', '-tiny')] +
-        [f'yolo_nas_{k}.pt' for k in 'sml'] +
-        [f'sam_{k}.pt' for k in 'bl'] +
-        [f'FastSAM-{k}.pt' for k in 'sx'] +
-        [f'rtdetr-{k}.pt' for k in 'lx'] +
-        ['mobile_sam.pt'])
+GITHUB_ASSETS_NAMES = ([f'yolov8{k}{suffix}.pt' for k in 'nsmlx' for suffix in ('', '-cls', '-seg', '-pose', '-obb')] +
+                       [f'yolov5{k}{resolution}u.pt' for k in 'nsmlx'
+                        for resolution in ('', '6')] + [f'yolov3{k}u.pt' for k in ('', '-spp', '-tiny')] +
+                       [f'yolo_nas_{k}.pt'
+                        for k in 'sml'] + [f'sam_{k}.pt'
+                                           for k in 'bl'] + [f'FastSAM-{k}.pt'
+                                                             for k in 'sx'] + [f'rtdetr-{k}.pt'
+                                                                               for k in 'lx'] + ['mobile_sam.pt'])
 GITHUB_ASSETS_STEMS = [Path(k).stem for k in GITHUB_ASSETS_NAMES]
 
 

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -16,14 +16,15 @@ from ultralytics.utils import LOGGER, TQDM, checks, clean_url, emojis, is_online
 
 # Define Ultralytics GitHub assets maintained at https://github.com/ultralytics/assets
 GITHUB_ASSETS_REPO = 'ultralytics/assets'
-GITHUB_ASSETS_NAMES = [f'yolov8{k}{suffix}.pt' for k in 'nsmlx' for suffix in ('', '-cls', '-seg', '-pose')] + \
-                      [f'yolov5{k}{resolution}u.pt' for k in 'nsmlx' for resolution in ('', '6')] + \
-                      [f'yolov3{k}u.pt' for k in ('', '-spp', '-tiny')] + \
-                      [f'yolo_nas_{k}.pt' for k in 'sml'] + \
-                      [f'sam_{k}.pt' for k in 'bl'] + \
-                      [f'FastSAM-{k}.pt' for k in 'sx'] + \
-                      [f'rtdetr-{k}.pt' for k in 'lx'] + \
-                      ['mobile_sam.pt']
+GITHUB_ASSETS_NAMES = (
+        [f'yolov8{k}{suffix}.pt' for k in 'nsmlx' for suffix in ('', '-cls', '-seg', '-pose', '-obb')] +
+        [f'yolov5{k}{resolution}u.pt' for k in 'nsmlx' for resolution in ('', '6')] +
+        [f'yolov3{k}u.pt' for k in ('', '-spp', '-tiny')] +
+        [f'yolo_nas_{k}.pt' for k in 'sml'] +
+        [f'sam_{k}.pt' for k in 'bl'] +
+        [f'FastSAM-{k}.pt' for k in 'sx'] +
+        [f'rtdetr-{k}.pt' for k in 'lx'] +
+        ['mobile_sam.pt'])
 GITHUB_ASSETS_STEMS = [Path(k).stem for k in GITHUB_ASSETS_NAMES]
 
 

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -16,14 +16,14 @@ from ultralytics.utils import LOGGER, TQDM, checks, clean_url, emojis, is_online
 
 # Define Ultralytics GitHub assets maintained at https://github.com/ultralytics/assets
 GITHUB_ASSETS_REPO = 'ultralytics/assets'
-GITHUB_ASSETS_NAMES = ([f'yolov8{k}{suffix}.pt' for k in 'nsmlx' for suffix in ('', '-cls', '-seg', '-pose', '-obb')] +
-                       [f'yolov5{k}{resolution}u.pt' for k in 'nsmlx'
-                        for resolution in ('', '6')] + [f'yolov3{k}u.pt' for k in ('', '-spp', '-tiny')] +
-                       [f'yolo_nas_{k}.pt'
-                        for k in 'sml'] + [f'sam_{k}.pt'
-                                           for k in 'bl'] + [f'FastSAM-{k}.pt'
-                                                             for k in 'sx'] + [f'rtdetr-{k}.pt'
-                                                                               for k in 'lx'] + ['mobile_sam.pt'])
+GITHUB_ASSETS_NAMES = [f'yolov8{k}{suffix}.pt' for k in 'nsmlx' for suffix in ('', '-cls', '-seg', '-pose', '-obb')] + \
+                      [f'yolov5{k}{resolution}u.pt' for k in 'nsmlx' for resolution in ('', '6')] + \
+                      [f'yolov3{k}u.pt' for k in ('', '-spp', '-tiny')] + \
+                      [f'yolo_nas_{k}.pt' for k in 'sml'] + \
+                      [f'sam_{k}.pt' for k in 'bl'] + \
+                      [f'FastSAM-{k}.pt' for k in 'sx'] + \
+                      [f'rtdetr-{k}.pt' for k in 'lx'] + \
+                      ['mobile_sam.pt']
 GITHUB_ASSETS_STEMS = [Path(k).stem for k in GITHUB_ASSETS_NAMES]
 
 


### PR DESCRIPTION
Avoid rate limit errors showing in CI:

⚠️ GitHub assets check failure for https://api.github.com/repos/ultralytics/assets/releases/tags/v0.0.0: 403 rate limit exceeded
⚠️ GitHub assets check failure for https://api.github.com/repos/ultralytics/assets/releases/latest: 403 rate limit exceeded

@Laughing-q

<img width="2100" alt="Screenshot 2024-01-09 at 12 34 44" src="https://github.com/ultralytics/ultralytics/assets/26833433/433c685e-ea46-4126-98c5-3aad49a69fc4">


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of model asset variety in Ultralytics repository.

### 📊 Key Changes
- Added a new model variant with an OBB (oriented bounding box) suffix to the list of Ultralytics GitHub assets.

### 🎯 Purpose & Impact
- **Purpose:** This change aims to expand the range of pre-trained models available for download, specifically adding support for models that utilize oriented bounding boxes.
- **Impact:** Users can now access a wider variety of models, which may enhance object detection capabilities, especially in scenarios where objects are rotated or skewed, and traditional axis-aligned bounding boxes are not as effective. This can be particularly useful in fields such as satellite and aerial imagery analysis. 🛰️🖼️