### PR TITLE
Compute the available space for the current path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.11']
         torch: [latest]
         include:

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import re
-import os
 import shutil
 import subprocess
 from itertools import repeat
@@ -207,7 +206,7 @@ def check_disk_space(url='https://ultralytics.com/assets/coco128.zip', sf=1.5, h
     # Check file size
     gib = 1 << 30  # bytes per GiB
     data = int(r.headers.get('Content-Length', 0)) / gib  # file size (GB)
-    total, used, free = (x / gib for x in shutil.disk_usage(os.getcwd()))  # bytes
+    total, used, free = (x / gib for x in shutil.disk_usage(Path.cwd()))  # bytes
     if data * sf < free:
         return True  # sufficient space
 

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import re
+import os
 import shutil
 import subprocess
 from itertools import repeat
@@ -206,7 +207,7 @@ def check_disk_space(url='https://ultralytics.com/assets/coco128.zip', sf=1.5, h
     # Check file size
     gib = 1 << 30  # bytes per GiB
     data = int(r.headers.get('Content-Length', 0)) / gib  # file size (GB)
-    total, used, free = (x / gib for x in shutil.disk_usage('/'))  # bytes
+    total, used, free = (x / gib for x in shutil.disk_usage(os.getcwd()))  # bytes
     if data * sf < free:
         return True  # sufficient space
 


### PR DESCRIPTION
When downloading a file, we need to check for the available space for the current working drive.

The thing is on windows the current drive is not '/' but 'C:\\' which with the previous version generates the following error:

```bash
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect
```



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Expanding Continuous Integration (CI) to include more operating systems and refining disk space check logic.

### 📊 Key Changes
- Updated the CI configuration to run tests on multiple operating systems: Ubuntu, macOS, and Windows.
- Modified the disk space check to use the current working directory instead of the root directory.

### 🎯 Purpose & Impact
- **Broader Compatibility Testing:** Including macOS and Windows in the CI process ensures that the codebase is tested across different environments, catching OS-specific issues early.
- **Improved Disk Space Validation:** Calculating disk space based on the current working directory provides a more accurate measure of available space for the user's project, reducing the likelihood of insufficient space errors during downloads or operations.