### PR TITLE
Small OpenVINO INT8 quantization fixes

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -402,7 +402,7 @@ class Exporter:
 
         if self.args.int8:
             if not self.args.data:
-                self.args.data = DEFAULT_CFG.data or 'coco8.yaml'
+                self.args.data = DEFAULT_CFG.data or 'coco128.yaml'
                 LOGGER.warning(f"{prefix} WARNING ⚠️ INT8 export requires a missing 'data' arg for calibration. "
                                f"Using default 'data={self.args.data}'.")
             check_requirements('nncf>=2.5.0')
@@ -410,6 +410,7 @@ class Exporter:
 
             def transform_fn(data_item):
                 """Quantization transform function."""
+                assert data_item['img'].dtype == torch.uint8, 'input image must be uint8 for the quantization preprocessing'
                 im = data_item['img'].numpy().astype(np.float32) / 255.0  # uint8 to fp16/32 and 0 - 255 to 0.0 - 1.0
                 return np.expand_dims(im, 0) if im.ndim == 3 else im
 


### PR DESCRIPTION
Fix for #6947

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced validation and defaults in the model exporting process.

### 📊 Key Changes
- Changed the default dataset configuration file for INT8 quantization from `coco8.yaml` to `coco128.yaml`.
- Added an assertion to ensure the input image is in `uint8` format during the quantization preprocessing.

### 🎯 Purpose & Impact
- 👍 **Consistency Improvement**: By moving to `coco128.yaml` as the default, users benefit from a more standard and possibly more accurate dataset configuration during INT8 quantization.
- 🔒 **Input Validation**: The added assertion helps to prevent errors early by checking the image data type, ensuring that the quantization input is correct and potentially saving time troubleshooting.
- 🚀 **Optimization Readiness**: These changes pave the way for more effective and efficient INT8 model quantization, crucial for deployment on resource-constrained environments.