### PR TITLE
Adds back-off retry attempts when saving model

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -463,6 +463,20 @@ def test_utils_files():
         print(new_path)
 
 
+def test_utils_patches_torch_save():
+    """Test torch_save backoff when _torch_save throws RuntimeError."""
+    from unittest.mock import patch, MagicMock
+    from ultralytics.utils.patches import torch_save
+
+    mock = MagicMock(side_effect=RuntimeError)
+
+    with patch('ultralytics.utils.patches._torch_save', new=mock):
+        with pytest.raises(RuntimeError):
+            torch_save(torch.zeros(1), TMP / 'test.pt')
+
+    assert mock.call_count == 5, "torch_save was not attempted the expected number of times"
+
+
 def test_nn_modules_conv():
     """Test Convolutional Neural Network modules."""
     from ultralytics.nn.modules.conv import CBAM, Conv2, ConvTranspose, DWConvTranspose2d, Focus

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -474,7 +474,7 @@ def test_utils_patches_torch_save():
         with pytest.raises(RuntimeError):
             torch_save(torch.zeros(1), TMP / 'test.pt')
 
-    assert mock.call_count == 5, "torch_save was not attempted the expected number of times"
+    assert mock.call_count == 4, "torch_save was not attempted the expected number of times"
 
 
 def test_nn_modules_conv():

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -62,7 +62,7 @@ _torch_save = torch.save  # copy to avoid recursion errors
 
 def torch_save(*args, **kwargs):
     """
-    Use dill (if exists) to serialize the lambda functions where pickle does not do this. Also adds 3 retries with 
+    Use dill (if exists) to serialize the lambda functions where pickle does not do this. Also adds 3 retries with
     exponential standoff in case of save failure to improve robustness to transient issues.
 
     Args:
@@ -80,7 +80,7 @@ def torch_save(*args, **kwargs):
     for i in range(4):  # 3 retries
         try:
             return _torch_save(*args, **kwargs)
-        except RuntimeError: # unable to save, possibly waiting for device to flush or anti-virus to finish scanning
+        except RuntimeError:  # unable to save, possibly waiting for device to flush or anti-virus to finish scanning
             if i == 3:
                 raise
-            time.sleep((2 ** i) / 2)  # exponential standoff 0.5s, 1.0s, 2.0s
+            time.sleep((2**i) / 2)  # exponential standoff 0.5s, 1.0s, 2.0s

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import cv2
 import numpy as np
+import time
 import torch
 
 # OpenCV Multilanguage-friendly functions ------------------------------------------------------------------------------
@@ -74,4 +75,17 @@ def torch_save(*args, **kwargs):
 
     if "pickle_module" not in kwargs:
         kwargs["pickle_module"] = pickle  # noqa
-    return _torch_save(*args, **kwargs)
+
+    num_retries = 5
+    delay = 1
+
+    while True:
+        try:
+            return _torch_save(*args, **kwargs)
+        except RuntimeError:  # Unable to save, possibly waiting for device to flush or anti-virus to finish scanning
+            num_retries -= 1
+            if num_retries <= 0:
+                raise
+
+            time.sleep(delay)
+            delay *= 2

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -1,11 +1,11 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 """Monkey patches to update/extend functionality of existing functions."""
 
+import time
 from pathlib import Path
 
 import cv2
 import numpy as np
-import time
 import torch
 
 # OpenCV Multilanguage-friendly functions ------------------------------------------------------------------------------
@@ -62,7 +62,8 @@ _torch_save = torch.save  # copy to avoid recursion errors
 
 def torch_save(*args, **kwargs):
     """
-    Use dill (if exists) to serialize the lambda functions where pickle does not do this.
+    Use dill (if exists) to serialize the lambda functions where pickle does not do this. Also adds 3 retries with 
+    exponential standoff in case of save failure to improve robustness to transient issues.
 
     Args:
         *args (tuple): Positional arguments to pass to torch.save.
@@ -76,16 +77,10 @@ def torch_save(*args, **kwargs):
     if "pickle_module" not in kwargs:
         kwargs["pickle_module"] = pickle  # noqa
 
-    num_retries = 5
-    delay = 1
-
-    while True:
+    for i in range(4):  # 3 retries
         try:
             return _torch_save(*args, **kwargs)
-        except RuntimeError:  # Unable to save, possibly waiting for device to flush or anti-virus to finish scanning
-            num_retries -= 1
-            if num_retries <= 0:
+        except RuntimeError: # unable to save, possibly waiting for device to flush or anti-virus to finish scanning
+            if i == 3:
                 raise
-
-            time.sleep(delay)
-            delay *= 2
+            time.sleep((2 ** i) / 2)  # exponential standoff 0.5s, 1.0s, 2.0s


### PR DESCRIPTION
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.

2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.

3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.

4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.

This works around the #7087. The cause I've observed is that the previous file is still open by my anti-virus software when yolo attempts to write the next _last.pt_ file. I often encounter this issue when training a small model (yolov8n) against a small dataset with many epochs. I am able to resume the previous training, but there is a large amount of additional delay each time I need to restart. Setting `save_periods` to a larger value does not resolve the issue entirely as the CLI still writes _last.pt_ for each epoch.

This PR introduces a basic back-off loop to re-attempt the save up to 5 times after a short delay.


** Ultralytics Contributor License Agreement:** _I have read the CLA Document and I hereby sign the CLA_

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved reliability for saving models.

### 📊 Key Changes
- Added a test to ensure `torch_save` handles `RuntimeError` correctly.
- Enhanced `torch_save` to retry saving up to 3 times with exponential backoff.

### 🎯 Purpose & Impact
- The changes aim to make saving models with `torch.save` more robust, particularly when encountering transient save-related errors.
- Users benefit from reduced failure rates when saving models, especially in environments with possible file-system delays or security software interactions. ⏳💾