### PR TITLE
Add docstrings to new HUB functions

### DIFF
--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -68,7 +68,7 @@ class HUBTrainingSession:
             self.model = self.client.model()  # load empty model
 
     def load_model(self, model_id):
-        # Initialize model
+        """Loads an existing model from Ultralytics HUB using the provided model identifier."""
         self.model = self.client.model(model_id)
         if not self.model.data:  # then model model does not exist
             raise ValueError(emojis(f"❌ The specified HUB model does not exist"))  # TODO: improve error handling
@@ -82,7 +82,7 @@ class HUBTrainingSession:
         LOGGER.info(f"{PREFIX}View model at {self.model_url} 🚀")
 
     def create_model(self, model_args):
-        # Initialize model
+        """Initializes a HUB training session with the specified model identifier."""
         payload = {
             "config": {
                 "batchSize": model_args.get("batch", -1),
@@ -168,6 +168,7 @@ class HUBTrainingSession:
         return api_key, model_id, filename
 
     def _set_train_args(self, **kwargs):
+        """Initializes training arguments and creates a model entry on the Ultralytics HUB."""
         if self.model.is_trained():
             # Model is already trained
             raise ValueError(emojis(f"Model is already trained and uploaded to {self.model_url} 🚀"))
@@ -179,6 +180,7 @@ class HUBTrainingSession:
         else:
             # Model has no saved weights
             def get_train_args(config):
+                """Parses an identifier to extract API key, model ID, and filename if applicable."""
                 return {
                     "batch": config["batchSize"],
                     "epochs": config["epochs"],
@@ -213,6 +215,7 @@ class HUBTrainingSession:
         **kwargs,
     ):
         def retry_request():
+            """Attempts to call `request_func` with retries, timeout, and optional threading."""
             t0 = time.time()  # Record the start time for the timeout
             for i in range(retry + 1):
                 if (time.time() - t0) > timeout:
@@ -254,7 +257,7 @@ class HUBTrainingSession:
             return retry_request()
 
     def _should_retry(self, status_code):
-        # Status codes that trigger retries
+        """Determines if a request should be retried based on the HTTP status code."""
         retry_codes = {
             HTTPStatus.REQUEST_TIMEOUT,
             HTTPStatus.BAD_GATEWAY,


### PR DESCRIPTION
@kalenmike @hassaanfarooq01 this PR adds single-line docstrings to the newly introduced functions that are lacking them.

Every function within our open-source repositories must be accompanied by at least a single-line docstring. These will also render within the Docs reference section in addition to the code.

EDIT: Also note that a lines that start with `#` are not actually docstrings and will be ignored by MkDocs and other tools. Instead the docstring, even if it's single-line, must start and end with `"""`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving documentation and code clarity for model handling in the Ultralytics Hub.

### 📊 Key Changes
- Updated documentation strings for `load_model`, `create_model`, `_set_train_args`, `_parse_identifier`, `retry_request`, and `_should_retry` functions.
- Clarified the purpose of methods with more descriptive docstrings.

### 🎯 Purpose & Impact
- 📖 Improves code readability and documentation, making it easier for developers to understand the functionality of methods.
- 🛠️ Enhances maintainability of the codebase, as better commented code aids future updates and bug fixes.
- ☑️ Assists new developers or users in usability by clearly explaining what each function does and when it's called, potentially attracting a wider user base.