### PR TITLE
Fixed dataloader CPU bottleneck for small batch sizes

### DIFF
--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -107,7 +107,7 @@ def build_dataloader(dataset, batch, workers, shuffle=True, rank=-1):
     """Return an InfiniteDataLoader or DataLoader for training or validation set."""
     batch = min(batch, len(dataset))
     nd = torch.cuda.device_count()  # number of CUDA devices
-    nw = min([os.cpu_count() // max(nd, 1), batch, workers])  # number of workers
+    nw = min([os.cpu_count() // max(nd, 1), workers])  # number of workers
     sampler = None if rank == -1 else distributed.DistributedSampler(dataset, shuffle=shuffle)
     generator = torch.Generator()
     generator.manual_seed(6148914691236517205 + RANK)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -332,10 +332,7 @@ class BaseTrainer:
             f'Image sizes {self.args.imgsz} train, {self.args.imgsz} val\n'
             f'Using {self.train_loader.num_workers * (world_size or 1)} dataloader workers\n'
             f"Logging results to {colorstr('bold', self.save_dir)}\n"
-            f'Starting training for '
-            f'{self.args.time} hours...'
-            if self.args.time
-            else f"{self.epochs} epochs..."
+            f'Starting training for ' + (f"{self.args.time} hours..." if self.args.time else f"{self.epochs} epochs...")
         )
         if self.args.close_mosaic:
             base_idx = (self.epochs - self.args.close_mosaic) * nb


### PR DESCRIPTION




When the batch size is lower than the cpu count, the training will be slowed down because of slow "image feeding".

This will be even more visible when training on high resolution images where augmentations and loading takes a lot of CPU time,

GPU usage will be low, CPU usage (total, not on the X used cores which is capped by batch size) will be low as well.


Removing the batch size cap greatly increases training speed : 

Before the change : 
(please notice the "asked for 14 workers, got 3" and the estimated ETA of this epoch)

![image](https://github.com/ultralytics/ultralytics/assets/3909752/33d75ea3-263b-4c1b-b368-0e3187aef177)


After the changes  :  

![image](https://github.com/ultralytics/ultralytics/assets/3909752/c1af725f-cf8d-450e-96e5-4f01006fda07)



Please also notice high CPU and GPU usage : 

![image](https://github.com/ultralytics/ultralytics/assets/3909752/c661f96e-f221-4f33-b0fc-aa53253c747d)


This PR doesn't fix the albumentation slowdown with huges resolutions.

_I have read the CLA Document and I hereby sign the CLA_


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data loader worker configuration and code cleanup in training logic.

### 📊 Key Changes
- Updated the calculation for the number of workers in the data loader to exclude the batch size.
- Simplified the logging statement for training start, combining lines for clarity.

### 🎯 Purpose & Impact
- The change in worker calculation 🧮 ensures that the number of data loader workers is no longer unnecessarily limited by the batch size, potentially improving data loading efficiency.
- The logging statement cleanup ✂️ makes the code easier to read and maintains the training start message's information in a more concise format. 

Both changes aim to enhance the codebase for better performance and maintainability, with minimal direct impact on end-users, barring a potential indirect impact on performance due to the dataloader worker adjustment.