### PR TITLE
Handle upload_model response

### DIFF
--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -225,13 +225,13 @@ class HUBTrainingSession:
                     break  # Timeout reached, exit loop
 
                 response = request_func(*args, **kwargs)
-                if progress_total:
-                    self._show_upload_progress(progress_total, response)
-
                 if response is None:
                     LOGGER.warning(f"{PREFIX}Received no response from the request. {HELP_MSG}")
                     time.sleep(2**i)  # Exponential backoff before retrying
                     continue  # Skip further processing and retry
+
+                if progress_total:
+                    self._show_upload_progress(progress_total, response)
 
                 if HTTPStatus.OK <= response.status_code < HTTPStatus.MULTIPLE_CHOICES:
                     return response  # Success, no need to retry

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -46,7 +46,7 @@ def on_model_save(trainer):
         # Upload checkpoints with rate limiting
         is_best = trainer.best_fitness == trainer.fitness
         if time() - session.timers["ckpt"] > session.rate_limits["ckpt"]:
-            LOGGER.info(f"{PREFIX}Uploading checkpoint {HUB_WEB_ROOT}/models/{session.model_file}")
+            LOGGER.info(f"{PREFIX}Uploading checkpoint {HUB_WEB_ROOT}/models/{session.model_id}")
             session.upload_model(trainer.epoch, trainer.last, is_best)
             session.timers["ckpt"] = time()  # reset timer
 


### PR DESCRIPTION

"Issue:" `upload_model` none response handled after `_show_upload_progress`.
"Fix:" It should be after that because the response can be None and `_show_upload_progress` will fail.

**Issue:** Uploading checkpoint  Hub web url `<host>/models/model_file`, it runs to 404 page.
**Fix:** Change url with model_id instead of model_file `<host>/models/model_id`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved upload feedback and fixed model identifier in checkpoint logs.

### 📊 Key Changes
- Upload progress is now shown only after verifying the server's response.
- Model checkpoints logs now correctly display the model's unique identifier instead of the file name.

### 🎯 Purpose & Impact
- The change in upload progress ensures users are only informed about upload progress if there's a valid server response, reducing confusion in case of errors or no response.
- Logging the model's unique identifier instead of the file name provides clarity and helps in tracking and referencing the correct model, improving user experience.