### PR TITLE
Fix track mode

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -259,8 +259,8 @@ class Model(nn.Module):
             x in sys.argv for x in ("predict", "track", "mode=predict", "mode=track")
         )
 
-        custom = {"conf": 0.25, "save": is_cli}  # method defaults
-        args = {**self.overrides, **custom, **kwargs, "mode": "predict"}  # highest priority args on the right
+        custom = {"conf": 0.25, "save": is_cli, "mode": "predict"}  # method defaults
+        args = {**self.overrides, **custom, **kwargs}  # highest priority args on the right
         prompts = args.pop("prompts", None)  # for SAM-type models
 
         if not self.predictor:


### PR DESCRIPTION
allows `mode` be modified by `kwargs`, so that tracking results could be saved into `detect/track` folder by default.
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of prediction configuration defaults in Ultralytics AI model settings.

### 📊 Key Changes
- Simplified the setting of default arguments for predictions by merging "mode" into the `custom` dictionary.
- Removed the redundancy of specifying the "mode" in two separate places within the argument dictionary.

### 🎯 Purpose & Impact
- 🎨 This change streamlines the argument setup, making the code cleaner and more maintainable.
- 🛠 It reduces the likelihood of errors by having a single point of definition for the prediction mode.
- 👥 Users might experience more transparent and predictable behavior when utilizing the Ultralytics AI for predictions, as the mode is now explicitly set with other defaults.