### PR TITLE
Fix bbox2segment converter

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -515,6 +515,8 @@ def yolo_bbox2segment(im_dir, save_dir=None, sam_model="sam_b.pt"):
     for l in tqdm(dataset.labels, total=len(dataset.labels), desc="Generating segment labels"):
         h, w = l["shape"]
         boxes = l["bboxes"]
+        if len(boxes) == 0:  # skip empty labels
+            continue
         boxes[:, [0, 2]] *= w
         boxes[:, [1, 3]] *= h
         im = cv2.imread(l["im_file"])


### PR DESCRIPTION
should resolve https://github.com/ultralytics/ultralytics/pull/7572#issuecomment-1908024602
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in data conversion script by handling empty labels.

### 📊 Key Changes
- Added a check to skip over images with empty labels during the conversion from bounding boxes to segmentation labels.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: To prevent errors or unnecessary processing when there are images without associated bounding boxes.
- 💡 **Impact**: Ensures smoother data conversion for YOLO users and might improve the user experience by reducing potential for crashes or incorrect label outputs.