### PR TITLE
Fix TFLite INT8 for OBB

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -68,7 +68,7 @@ class Detect(nn.Module):
             img_size = torch.tensor([img_w, img_h, img_w, img_h], device=box.device).reshape(1, 4, 1)
             norm = self.strides / (self.stride[0] * img_size)
             dbox = self.decode_bboxes(self.dfl(box) * norm, self.anchors.unsqueeze(0) * norm[:, :2])
-        else:       
+        else:
             dbox = self.decode_bboxes(self.dfl(box), self.anchors.unsqueeze(0)) * self.strides
 
         y = torch.cat((dbox, cls.sigmoid()), 1)

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -63,10 +63,10 @@ class Detect(nn.Module):
         if self.export and self.format in ("tflite", "edgetpu"):
             # Precompute normalization factor to increase numerical stability
             # See https://github.com/ultralytics/ultralytics/issues/7371
-            img_h = shape[2]
-            img_w = shape[3]
-            img_size = torch.tensor([img_w, img_h, img_w, img_h], device=box.device).reshape(1, 4, 1)
-            norm = self.strides / (self.stride[0] * img_size)
+            grid_h = shape[2]
+            grid_w = shape[3]
+            grid_size = torch.tensor([grid_w, grid_h, grid_w, grid_h], device=box.device).reshape(1, 4, 1)
+            norm = self.strides / (self.stride[0] * grid_size)
             dbox = self.decode_bboxes(self.dfl(box) * norm, self.anchors.unsqueeze(0) * norm[:, :2])
         else:
             dbox = self.decode_bboxes(self.dfl(box), self.anchors.unsqueeze(0)) * self.strides

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -59,7 +59,6 @@ class Detect(nn.Module):
             cls = x_cat[:, self.reg_max * 4 :]
         else:
             box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
-        dbox = self.decode_bboxes(box)
 
         if self.export and self.format in ("tflite", "edgetpu"):
             # Precompute normalization factor to increase numerical stability
@@ -68,7 +67,9 @@ class Detect(nn.Module):
             img_w = shape[3]
             img_size = torch.tensor([img_w, img_h, img_w, img_h], device=box.device).reshape(1, 4, 1)
             norm = self.strides / (self.stride[0] * img_size)
-            dbox = dist2bbox(self.dfl(box) * norm, self.anchors.unsqueeze(0) * norm[:, :2], xywh=True, dim=1)
+            dbox = self.decode_bboxes(self.dfl(box) * norm, self.anchors.unsqueeze(0) * norm[:, :2])
+        else:       
+            dbox = self.decode_bboxes(self.dfl(box), self.anchors.unsqueeze(0)) * self.strides
 
         y = torch.cat((dbox, cls.sigmoid()), 1)
         return y if self.export else (y, x)
@@ -82,9 +83,9 @@ class Detect(nn.Module):
             a[-1].bias.data[:] = 1.0  # box
             b[-1].bias.data[: m.nc] = math.log(5 / m.nc / (640 / s) ** 2)  # cls (.01 objects, 80 classes, 640 img)
 
-    def decode_bboxes(self, bboxes):
+    def decode_bboxes(self, bboxes, anchors):
         """Decode bounding boxes."""
-        return dist2bbox(self.dfl(bboxes), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
+        return dist2bbox(bboxes, anchors, xywh=True, dim=1)
 
 
 class Segment(Detect):
@@ -139,9 +140,9 @@ class OBB(Detect):
             return x, angle
         return torch.cat([x, angle], 1) if self.export else (torch.cat([x[0], angle], 1), (x[1], angle))
 
-    def decode_bboxes(self, bboxes):
+    def decode_bboxes(self, bboxes, anchors):
         """Decode rotated bounding boxes."""
-        return dist2rbox(self.dfl(bboxes), self.angle, self.anchors.unsqueeze(0), dim=1) * self.strides
+        return dist2rbox(bboxes, self.angle, anchors, dim=1)
 
 
 class Pose(Detect):


### PR DESCRIPTION
This PR fixes the bug when exporting OBB model for TFLite with INT8 quantization. During normalization dist2bbox is used instead of dist2rbox.

NOTE: tests have been executed using the validation set. The test set is missing the labels. TFLite quantization was set to per-channel.

|Model|mAP50|mAP50:95|Note|
|--|--|--|--|
|Before yolov8n-obb.pt| 0.468 | 0.283||
|Before yolov8n-obb.TFLite INT8| 0.375 | 0.245||
|Before yolov8n-obb.TFLite Full INT| 0.305|0.175||
|After yolov8n-obb.pt| 0.468 | 0.283| |
|After yolov8n-obb.TFLite INT8| 0.496|0.355| How? |
|After yolov8n-obb.TFLite Full INT| 0.394|0.244||

Reproduce tests:
```
yolo export model=yolov8n-obb.pt data=coco128.yaml imgsz=640 format=tflite int8
yolo val obb model=yolov8n-obb.pt data=DOTAv1.yaml device=0 imgsz=640 batch=4 split=val
yolo val obb model=yolov8n-obb_saved_model/yolov8n-obb_int8.tflite data=DOTAv1.yaml device=0 imgsz=640 int8 split=val
yolo val obb model=yolov8n-obb_saved_model/yolov8n-obb_full_integer_quant.tflite data=DOTAv1.yaml device=0 imgsz=640 int8 split=val
```

It is surprising to observe that the TFLite INT8, where only weights are INT8 and inference is in FP32, is performing better than the original PyTorch model. This should be further tested, but I am not familiar with the OBB neither with DOTA dataset. Theoretically the only difference is that the bbox coordinates are normalized. Could it have an influence on the bbox rotations?


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactor of bounding box decoding in neural network heads to improve flexibility.

### 📊 Key Changes
- `decode_bboxes` method now takes `anchors` as an argument instead of using `self.anchors`.
- Bounding box decoding operation has been updated within the `forward` method of the network to better handle different conditions, such as when exporting models to TensorFlow Lite or Edge TPU.
- Calls to `dist2bbox` and `dist2rbox` now directly pass calculated bounding boxes and anchors.

### 🎯 Purpose & Impact
- 💡 **Purpose**: The changes aim to improve the stability and flexibility of bounding box decoding across different network heads and export formats.
- 🔍 **Impact**: Developers will have an easier time adapting and maintaining the bounding box decoding logic for different use cases, potentially resulting in better model compatibility and performance when exporting to various platforms.
- 🚀 **To users**: These updates might lead to more accurate object detections and support for broader deployment scenarios, especially for edge computing devices.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimized bounding box decoding for model export compatibility.

### 📊 Key Changes
- Modified decoding of bounding boxes in the `forward` function based on export conditions.
- Added `anchors` as an argument to both `decode_bboxes` and `decode_bboxes` methods to clarify input requirements.
- Applied stride normalization directly within the `decode_bboxes` method when not exporting.
- Renamed variables (`img_h -> grid_h`, `img_w -> grid_w`, `img_size -> grid_size`) for clarity in the context of grid dimensions.

### 🎯 Purpose & Impact
- The update aims to improve numerical stability for exported models, particularly those targeting platforms like TFLite and Edge TPU. 🤖
- Enhances code readability and maintainability through clearer naming conventions and streamlined decoding logic. 📖
- Users targeting different deployment environments can expect more reliable model performance and easier integration with hardware accelerators. 🚀