### PR TITLE
`ultralytics 8.1.10` MLFlow, OBB, TFLite and INT8 fixes

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.1.9"
+__version__ = "8.1.10"
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import RTDETR, SAM, YOLO

--- a/ultralytics/utils/callbacks/mlflow.py
+++ b/ultralytics/utils/callbacks/mlflow.py
@@ -86,9 +86,12 @@ def on_train_epoch_end(trainer):
     """Log training metrics at the end of each train epoch to MLflow."""
     if mlflow:
         mlflow.log_metrics(
-            metrics=SANITIZE(trainer.label_loss_items(trainer.tloss, prefix="train")), step=trainer.epoch
+            metrics={
+                **SANITIZE(trainer.lr),
+                **SANITIZE(trainer.label_loss_items(trainer.tloss, prefix="train")),
+            },
+            step=trainer.epoch
         )
-        mlflow.log_metrics(metrics=SANITIZE(trainer.lr), step=trainer.epoch)
 
 
 def on_fit_epoch_end(trainer):
@@ -115,6 +118,7 @@ def on_train_end(trainer):
 callbacks = (
     {
         "on_pretrain_routine_end": on_pretrain_routine_end,
+        "on_train_epoch_end": on_train_epoch_end,
         "on_fit_epoch_end": on_fit_epoch_end,
         "on_train_end": on_train_end,
     }

--- a/ultralytics/utils/callbacks/mlflow.py
+++ b/ultralytics/utils/callbacks/mlflow.py
@@ -90,7 +90,7 @@ def on_train_epoch_end(trainer):
                 **SANITIZE(trainer.lr),
                 **SANITIZE(trainer.label_loss_items(trainer.tloss, prefix="train")),
             },
-            step=trainer.epoch
+            step=trainer.epoch,
         )
 
 


### PR DESCRIPTION
Final fix for #6706 issue

Fix mlflow callback
Enable the MLFLOW logging of train losses, and learning rates

Activation of on_train_epoch_end
on_train_epoch_end refactor

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ultralytics software advances with version bump and MLflow logging improvements.

### 📊 Key Changes
- Updated Ultralytics package version from 8.1.9 to 8.1.10.
- Enhanced MLflow logging by combining loss and learning rate metrics into a single logging step during training epochs.

### 🎯 Purpose & Impact
- **Version Update:** Keeps users up-to-date with the latest software version, indicating minor improvements or bug fixes.
- **Improved MLflow Logging:** Provides a more streamlined and efficient logging experience during training, which can help users better track and analyze their model's performance over time. This may be particularly beneficial for users involved in machine learning operations (MLOps) who require detailed training logs for workflow optimizations. 📈🤖