### PR TITLE
Retry once for Docker CI failures

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -113,7 +113,7 @@ jobs:
         with:
           timeout_minutes: 60
           retry_wait_seconds: 0
-          max_attempts: 1
+          max_attempts: 2  # retry once
           command: |
             docker build \
             --platform ${{ matrix.platforms }} \


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Docker build resilience in CI workflow.

### 📊 Key Changes
- Increased `max_attempts` for Docker build from 1 to 2.

### 🎯 Purpose & Impact
- **Purpose:** To provide a fail-safe by allowing the Docker build process to retry once if it fails initially during continuous integration (CI).
- **Impact:** Reduces the likelihood of CI failures due to temporary issues with Docker builds, leading to smoother development and deployment pipelines. 🔄 Users can expect a more robust CI process with fewer interruptions.