### PR TITLE
Pin `duckdb<=0.9.2` to avoid 0.10.0 errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,12 +104,11 @@ export = [
 ]
 explorer = [
     "lancedb", # vector search
-    "duckdb==0.9.2", # SQL queries, supports lancedb tables
+    "duckdb<=0.9.2", # SQL queries, supports lancedb tables
     "streamlit", # visualizing with GUI
 ]
 # tensorflow>=2.4.1,<=2.13.1  # TF exports (-cpu, -aarch64, -macos)
 # tflite-support  # for TFLite model metadata
-# scikit-learn==0.19.2  # CoreML quantization
 # nvidia-pyindex  # TensorRT export
 # nvidia-tensorrt  # TensorRT export
 logging = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ export = [
 ]
 explorer = [
     "lancedb", # vector search
-    "duckdb<=0.9.2", # SQL queries, supports lancedb tables
+    "duckdb<=0.9.2", # SQL queries, duckdb==0.10.0 bug https://github.com/ultralytics/ultralytics/pull/8181
     "streamlit", # visualizing with GUI
 ]
 # tensorflow>=2.4.1,<=2.13.1  # TF exports (-cpu, -aarch64, -macos)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ export = [
 ]
 explorer = [
     "lancedb", # vector search
-    "duckdb", # SQL queries, supports lancedb tables
+    "duckdb==0.9.2", # SQL queries, supports lancedb tables
     "streamlit", # visualizing with GUI
 ]
 # tensorflow>=2.4.1,<=2.13.1  # TF exports (-cpu, -aarch64, -macos)

--- a/ultralytics/data/explorer/explorer.py
+++ b/ultralytics/data/explorer/explorer.py
@@ -59,7 +59,8 @@ class Explorer:
         model: str = "yolov8n.pt",
         uri: str = USER_CONFIG_DIR / "explorer",
     ) -> None:
-        checks.check_requirements(["lancedb>=0.4.3", "duckdb==0.9.2"])
+        # Note duckdb==0.10.0 bug https://github.com/ultralytics/ultralytics/pull/8181
+        checks.check_requirements(["lancedb>=0.4.3", "duckdb<=0.9.2"])
         import lancedb
 
         self.connection = lancedb.connect(uri)

--- a/ultralytics/data/explorer/explorer.py
+++ b/ultralytics/data/explorer/explorer.py
@@ -59,7 +59,7 @@ class Explorer:
         model: str = "yolov8n.pt",
         uri: str = USER_CONFIG_DIR / "explorer",
     ) -> None:
-        checks.check_requirements(["lancedb>=0.4.3", "duckdb"])
+        checks.check_requirements(["lancedb>=0.4.3", "duckdb==0.9.2"])
         import lancedb
 
         self.connection = lancedb.connect(uri)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjusting database dependencies to prevent bugs.

### 📊 Key Changes
- Specified a maximum version (`<=0.9.2`) for the `duckdb` dependency.
- Removed a commented-out dependency `scikit-learn==0.19.2`.

### 🎯 Purpose & Impact
- 🛠️ **Bug prevention**: The change guards against a known bug in `duckdb` version `0.10.0`, ensuring stability.
- 🔄 **Current compatibility**: Users' projects will not accidentally upgrade to a buggy version of `duckdb`, preserving the integrity of their data operations.
- 🧹 **Clean-up**: Eliminating the commented-out dependency makes the configuration cleaner and more maintainable.