### PR TITLE
Fix xyxyxyxyn calculation, swap axis

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -710,8 +710,8 @@ class OBB(BaseTensor):
     def xyxyxyxyn(self):
         """Return the boxes in xyxyxyxy format, (N, 4, 2)."""
         xyxyxyxyn = self.xyxyxyxy.clone() if isinstance(self.xyxyxyxy, torch.Tensor) else np.copy(self.xyxyxyxy)
-        xyxyxyxyn[..., 0] /= self.orig_shape[0]
-        xyxyxyxyn[..., 1] /= self.orig_shape[1]
+        xyxyxyxyn[..., 0] /= self.orig_shape[1]
+        xyxyxyxyn[..., 1] /= self.orig_shape[0]
         return xyxyxyxyn
 
     @property


### PR DESCRIPTION
This is a second fix to #8188

Instead of

```python
xyxyxyxyn[..., 0] /= self.orig_shape[0]
xyxyxyxyn[..., 1] /= self.orig_shape[1]
```

the image axes have been swapped to

```python
xyxyxyxyn[..., 0] /= self.orig_shape[1]
xyxyxyxyn[..., 1] /= self.orig_shape[0]
```

This should fix the scaling issue in #8149

    _I have read the CLA Document and I hereby sign the CLA_

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of coordinate normalization in bounding box transformation logic.

### 📊 Key Changes
- Fixed an issue in the `xyxyxyxyn` method of the `results.py` file where the normalization of bounding box coordinates was incorrect.
- The horizontal (x) coordinates of the bounding boxes are now correctly normalized by the width of the original image instead of its height, and vice versa for the vertical (y) coordinates.

### 🎯 Purpose & Impact
- **Purpose**: To correct the normalization process of bounding box coordinates, ensuring they are scaled accurately relative to the original image dimensions.
- **Impact**: This change ensures that any functionality depending on correctly normalized bounding box coordinates, such as visualization of results or post-processing analysis, is now more accurate and reliable. Users can expect improvements in tasks where precise object localization is crucial. 📏🖼️