### PR TITLE
Fix an issue with flatbuffer version for Raspberry Pi

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -722,9 +722,7 @@ class Exporter:
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
                 "tflite_support",
-                "flatbuffers>=23.5.26",
-                # if ARM64
-                # else "",  # Fix an issue with flatbuffer version included inside tensorflow package
+                "flatbuffers>=23.5.26",  # update old 'flatbuffers' included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),
             cmds="--extra-index-url https://pypi.ngc.nvidia.com",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -722,9 +722,9 @@ class Exporter:
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
                 "tflite_support",
-                "flatbuffers==23.5.26"
-                if ARM64
-                else "",  # Fix an issue with flatbuffer version included inside tensorflow package
+                "flatbuffers==23.5.26",
+                # if ARM64
+                # else "",  # Fix an issue with flatbuffer version included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),
             cmds="--extra-index-url https://pypi.ngc.nvidia.com",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -722,7 +722,7 @@ class Exporter:
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
                 "tflite_support",
-                "flatbuffers==23.5.26",
+                "flatbuffers>=23.5.26",
                 # if ARM64
                 # else "",  # Fix an issue with flatbuffer version included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -722,6 +722,7 @@ class Exporter:
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
                 "tflite_support",
+                "flatbuffers==23.5.26" if ARM64 else "",  # Fix an issue with flatbuffer version included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),
             cmds="--extra-index-url https://pypi.ngc.nvidia.com",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -722,7 +722,9 @@ class Exporter:
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
                 "tflite_support",
-                "flatbuffers==23.5.26" if ARM64 else "",  # Fix an issue with flatbuffer version included inside tensorflow package
+                "flatbuffers==23.5.26"
+                if ARM64
+                else "",  # Fix an issue with flatbuffer version included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),
             cmds="--extra-index-url https://pypi.ngc.nvidia.com",


### PR DESCRIPTION
When exporting to tflite on Raspberry Pi Bookworm OS, tensorflow package will be installed along with flatbuffer package. However, this flatbuffer version will result in failed tflite exports.

This is the specific version that gets installed automatically:

```
pi@raspberrypi:~ $ pip list | grep flat
flatbuffers                        20181003210633
```

And the error when exporting is as follows:

```
Traceback (most recent call last):
  File "/home/pi/.local/bin/onnx2tf", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/pi/.local/lib/python3.11/site-packages/onnx2tf/onnx2tf.py", line 2291, in main
    model = convert(
            ^^^^^^^^
  File "/home/pi/.local/lib/python3.11/site-packages/onnx2tf/onnx2tf.py", line 1229, in convert
    tflite_model = converter.convert()
                   ^^^^^^^^^^^^^^^^^^^
  File "/home/pi/.local/lib/python3.11/site-packages/tensorflow/lite/python/lite.py", line 2185, in convert
    return super(TFLiteConverterV2, self).convert()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/.local/lib/python3.11/site-packages/tensorflow/lite/python/lite.py", line 1139, in wrapper
    return self._convert_and_export_metrics(convert_func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/.local/lib/python3.11/site-packages/tensorflow/lite/python/lite.py", line 1111, in _convert_and_export_metrics
    return flatbuffer_utils.convert_object_to_bytearray(model_object)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/.local/lib/python3.11/site-packages/tensorflow/lite/tools/flatbuffer_utils.py", line 93, in convert_object_to_bytearray
    model_offset = model_object.Pack(builder)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/.local/lib/python3.11/site-packages/tensorflow/lite/python/schema_py_generated.py", line 18101, in Pack
    operatorCodes = builder.EndVector()
                    ^^^^^^^^^^^^^^^^^^^
TypeError: Builder.EndVector() missing 1 required positional argument: 'vectorNumElems'
```

Instead, I have included the latest version of the flatbuffer package (as a condition just for ARM64) which I have tested and verified on Raspberry Pi 5 Bookworm OS (TFlite exports work after this).

I have read the CLA Document and I hereby sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added `flatbuffers` version constraint to exporter dependencies.

### 📊 Key Changes
- Included `flatbuffers>=23.5.26` in the exporter's dependency list.

### 🎯 Purpose & Impact
- **Purpose:** Ensures that a newer version of `flatbuffers` is used, rather than relying on an outdated version bundled with TensorFlow.
- **Impact:** Users can expect more reliable export functionality with better compatibility and possibly performance improvements.