### PR TITLE
Added check of parameter type before setting `required_grad=True` for frozen layers

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -252,7 +252,7 @@ class BaseTrainer:
             if any(x in k for x in freeze_layer_names):
                 LOGGER.info(f"Freezing layer '{k}'")
                 v.requires_grad = False
-            elif not v.requires_grad:
+            elif not v.requires_grad and torch.is_floating_point(v):
                 LOGGER.info(
                     f"WARNING ⚠️ setting 'requires_grad=True' for frozen layer '{k}'. "
                     "See ultralytics.engine.trainer for customization of frozen layers."

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -252,7 +252,7 @@ class BaseTrainer:
             if any(x in k for x in freeze_layer_names):
                 LOGGER.info(f"Freezing layer '{k}'")
                 v.requires_grad = False
-            elif not v.requires_grad and torch.is_floating_point(v):
+            elif not v.requires_grad and v.dtype.is_floating_point:
                 LOGGER.info(
                     f"WARNING ⚠️ setting 'requires_grad=True' for frozen layer '{k}'. "
                     "See ultralytics.engine.trainer for customization of frozen layers."

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -252,7 +252,7 @@ class BaseTrainer:
             if any(x in k for x in freeze_layer_names):
                 LOGGER.info(f"Freezing layer '{k}'")
                 v.requires_grad = False
-            elif not v.requires_grad and v.dtype.is_floating_point:
+            elif not v.requires_grad and v.dtype.is_floating_point:  # only floating point Tensor can require gradients
                 LOGGER.info(
                     f"WARNING ⚠️ setting 'requires_grad=True' for frozen layer '{k}'. "
                     "See ultralytics.engine.trainer for customization of frozen layers."


### PR DESCRIPTION
PyTorch raise runtime error during setting `required_grad=True` for non-floating tensors:
```
RuntimeError: only Tensors of floating point and complex dtype can require gradients
```

The check of parameter type before setting `required_grad=True` for frozen layers was added in this PR to make more robust behavior of the trainer. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to layer freezing logic in the training engine.

### 📊 Key Changes
- Updated the condition for enabling gradients to account only for floating point tensors.

### 🎯 Purpose & Impact
- 🎨 Improves model training customizability by ensuring that only layers with floating point tensors have gradients enabled.
- 🛠️ Helps prevent potential user errors where gradients might be mistakenly required for non-floating-point layers.
- 🏃‍♂️ Users can expect more robust and error-proof model training, especially when customizing which layers to freeze.