### PR TITLE
Update tensorflow versions according to architecture

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -712,7 +712,7 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            check_requirements(f"tensorflow{'-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'}")
+            check_requirements("tensorflow")
             import tensorflow as tf  # noqa
         check_requirements(
             (

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -712,8 +712,8 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            suffix = '-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'
-            version = '' if ARM64 else '<=12.13.1'
+            suffix = "-macos" if MACOS else "-aarch64" if ARM64 else "" if cuda else "-cpu"
+            version = "" if ARM64 else "<=12.13.1"
             check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
         check_requirements(

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -712,7 +712,7 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            check_requirements("tensorflow")
+            check_requirements(f"tensorflow{'<=2.13.1' if cuda else '-cpu<=2.13.1' if not ARM64 else ''}")
             import tensorflow as tf  # noqa
         check_requirements(
             (
@@ -722,7 +722,7 @@ class Exporter:
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
                 "tflite_support",
-                "flatbuffers>=23.5.26",  # update old 'flatbuffers' included inside tensorflow package
+                "flatbuffers>=23.5.26,<100",  # update old 'flatbuffers' included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),
             cmds="--extra-index-url https://pypi.ngc.nvidia.com",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -712,7 +712,9 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            check_requirements(f"tensorflow{'<=2.13.1' if cuda else '-cpu<=2.13.1' if not ARM64 else ''}")
+            suffix = '-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'
+            version = '' if ARM64 else '<=12.13.1'
+            check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
         check_requirements(
             (


### PR DESCRIPTION
Currently tensorflow PyPI includes pre-build binaries for all architectures. Therefore, there is no need to specify different architectures. https://pypi.org/project/tensorflow/2.15.0/#files

I have read the CLA Document and I hereby sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow exporting compatibility for Ultralytics models.

### 📊 Key Changes
- Introduced version restriction for TensorFlow dependency on non-ARM64 systems (now capped at `12.13.1`).
- Limited the maximum version of `flatbuffers` now to be less than `100` during requirement checks.

### 🎯 Purpose & Impact
- 🎯 Ensuring compatibility by preventing installation of incompatible TensorFlow versions on certain platforms, potentially avoiding runtime errors.
- 🔧 Addressing future-proofing of dependency `flatbuffers` by setting a maximum version threshold, thereby preventing unforeseen issues with future breaking changes in the `flatbuffers` library.