### PR TITLE
Add Non-Maximum Suppression (NMS) `inplace` flag

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -173,6 +173,7 @@ def non_max_suppression(
     max_time_img=0.05,
     max_nms=30000,
     max_wh=7680,
+    in_place=True,
     rotated=False,
 ):
     """
@@ -197,7 +198,8 @@ def non_max_suppression(
         nc (int, optional): The number of classes output by the model. Any indices after this will be considered masks.
         max_time_img (float): The maximum time (seconds) for processing one image.
         max_nms (int): The maximum number of boxes into torchvision.ops.nms().
-        max_wh (int): The maximum box width and height in pixels
+        max_wh (int): The maximum box width and height in pixels.
+        in_place (bool): If True, the input prediction tensor will be modified in place.
 
     Returns:
         (List[torch.Tensor]): A list of length batch_size, where each element is a tensor of
@@ -224,7 +226,10 @@ def non_max_suppression(
 
     prediction = prediction.transpose(-1, -2)  # shape(1,84,6300) to shape(1,6300,84)
     if not rotated:
-        prediction = torch.cat((xywh2xyxy(prediction[..., :4]), prediction[..., 4:]), dim=-1)  # xywh to xyxy
+        if in_place:
+            prediction[..., :4] = xywh2xyxy(prediction[..., :4])  # xywh to xyxy
+        else:
+            prediction = torch.cat((xywh2xyxy(prediction[..., :4]), prediction[..., 4:]), dim=-1)  # xywh to xyxy
 
     t = time.time()
     output = [torch.zeros((0, 6 + nm), device=prediction.device)] * bs

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -224,7 +224,7 @@ def non_max_suppression(
 
     prediction = prediction.transpose(-1, -2)  # shape(1,84,6300) to shape(1,6300,84)
     if not rotated:
-        prediction[..., :4] = xywh2xyxy(prediction[..., :4])  # xywh to xyxy
+        prediction = torch.cat((xywh2xyxy(prediction[..., :4]), prediction[..., 4:]), dim=-1)  # xywh to xyxy
 
     t = time.time()
     output = [torch.zeros((0, 6 + nm), device=prediction.device)] * bs


### PR DESCRIPTION
**Summary**
This PR aims to handle the `prediction` input argument differently to prevent in-place modifications.

**Key Changes**
The code responsible for converting the bounding boxes contained in the prediction has been rewritten to avoid in-place modifications.

**Purpose and Impact**
This change prevents the input argument `prediction` from being modified in-place without explicit indication in the function definition. For example, it allows the `non_max_suppression` function to be called multiple times with decreasing confidence values without overwriting the input prediction. Without this adjustment, the format of `prediction` would be converted from `xywh` to `xyxy` in-place, potentially leading to unintended consequences.

<!-- _I have read the CLA Document and I hereby sign the CLA_ --->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in Non-Max Suppression Function with In-Place Option 🚀

### 📊 Key Changes
- Added a new parameter `in_place` to the `non_max_suppression` function.
- Added a conditional block to modify the input prediction tensor either in-place or by creating a new tensor, depending on the `in_place` flag.

### 🎯 Purpose & Impact
- 💪 **Flexibility:** The in-place operation option allows users to control memory usage. This can be crucial for low-memory environments or when working with very large datasets.
- ⚡ **Efficiency:** In-place modification can lead to performance improvements by avoiding the creation of additional data structures.
- 🔄 **Backward Compatibility:** The change is made to preserve existing functionality by default, with in-place alterations being optional, thus preventing disruptions to current user workflows.