### PR TITLE
`ultralytics 8.1.18` add cmake for building onnxsim on aarch64

### DIFF
--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -15,7 +15,7 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
 # g++ required to build 'tflite_support' and 'lap' packages, libusb-1.0-0 required for 'tflite_support' package
 # cmake and build-essential is needed to build onnxsim when exporting to tflite
 RUN apt update \
-    && apt install --no-install-recommends -y python3-pip git zip curl htop gcc libgl1 libglib2.0-0 libpython3-dev gnupg g++ libusb-1.0-0 cmake build-essential
+    && apt install --no-install-recommends -y python3-pip git zip curl htop gcc libgl1 libglib2.0-0 libpython3-dev gnupg g++ libusb-1.0-0 build-essential
 
 # Create working directory
 WORKDIR /usr/src/ultralytics

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.1.17"
+__version__ = "8.1.18"
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import RTDETR, SAM, YOLO, YOLOWorld

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -343,7 +343,8 @@ class Exporter:
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
             requirements += ["onnxsim>=0.4.33", "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"]
-        check_requirements("cmake" if ARM64 else "")  # 'cmake' is needed to build onnxsim on aarch64
+        if ARM64:
+            check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(requirements)
         import onnx  # noqa
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -714,7 +714,9 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            check_requirements(f"tensorflow{'<=2.13.1' if cuda else '-cpu<=2.13.1' if not ARM64 else ''}")
+            suffix = '-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'
+            version = '' if ARM64 else '<=12.13.1'
+            check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
         check_requirements("cmake" if ARM64 else "")  # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -714,8 +714,8 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            suffix = '-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'
-            version = '' if ARM64 else '<=12.13.1'
+            suffix = "-macos" if MACOS else "-aarch64" if ARM64 else "" if cuda else "-cpu"
+            version = "" if ARM64 else "<=12.13.1"
             check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
         check_requirements("cmake" if ARM64 else "")  # 'cmake' is needed to build onnxsim on aarch64

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -343,6 +343,7 @@ class Exporter:
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
             requirements += ["onnxsim>=0.4.33", "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"]
+        check_requirements("cmake" if ARM64 else '') # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(requirements)
         import onnx  # noqa
 
@@ -714,6 +715,7 @@ class Exporter:
         except ImportError:
             check_requirements(f"tensorflow{'<=2.13.1' if cuda else '-cpu<=2.13.1' if not ARM64 else ''}")
             import tensorflow as tf  # noqa
+        check_requirements("cmake" if ARM64 else '') # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(
             (
                 "onnx>=1.12.0",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -343,7 +343,7 @@ class Exporter:
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
             requirements += ["onnxsim>=0.4.33", "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"]
-        check_requirements("cmake" if ARM64 else '') # 'cmake' is needed to build onnxsim on aarch64
+        check_requirements("cmake" if ARM64 else "")  # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(requirements)
         import onnx  # noqa
 
@@ -715,7 +715,7 @@ class Exporter:
         except ImportError:
             check_requirements(f"tensorflow{'<=2.13.1' if cuda else '-cpu<=2.13.1' if not ARM64 else ''}")
             import tensorflow as tf  # noqa
-        check_requirements("cmake" if ARM64 else '') # 'cmake' is needed to build onnxsim on aarch64
+        check_requirements("cmake" if ARM64 else "")  # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(
             (
                 "onnx>=1.12.0",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -718,7 +718,8 @@ class Exporter:
             version = "" if ARM64 else "<=12.13.1"
             check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
-        check_requirements("cmake" if ARM64 else "")  # 'cmake' is needed to build onnxsim on aarch64
+        if ARM64:
+            check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(
             (
                 "onnx>=1.12.0",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -715,7 +715,7 @@ class Exporter:
             import tensorflow as tf  # noqa
         except ImportError:
             suffix = "-macos" if MACOS else "-aarch64" if ARM64 else "" if cuda else "-cpu"
-            version = "" if ARM64 else "<=12.13.1"
+            version = "" if ARM64 else "<=2.13.1"
             check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
         if ARM64:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -712,7 +712,7 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            check_requirements(f"tensorflow{'-macos' if MACOS else '-aarch64' if ARM64 else '' if cuda else '-cpu'}")
+            check_requirements("tensorflow")
             import tensorflow as tf  # noqa
         check_requirements(
             (

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -712,7 +712,7 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            check_requirements("tensorflow")
+            check_requirements(f"tensorflow{'<=2.13.1' if cuda else '-cpu<=2.13.1' if not ARM64 else ''}")
             import tensorflow as tf  # noqa
         check_requirements(
             (
@@ -722,7 +722,7 @@ class Exporter:
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
                 "tflite_support",
-                "flatbuffers>=23.5.26",  # update old 'flatbuffers' included inside tensorflow package
+                "flatbuffers>=23.5.26,<100",  # update old 'flatbuffers' included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),
             cmds="--extra-index-url https://pypi.ngc.nvidia.com",


### PR DESCRIPTION
onnxsim does not have pre-built binaries for aarch64.
https://pypi.org/project/onnxsim/#files

When exporting to tflite and exporting to onnx with simplify on aarch64 devices, it will try to download the tar.gz (20.1MB) file and compile onnxsim on the device. However, this needs `cmake` for the build process. All the other architectures have pre-built binaries and have no problem.

So I have included cmake inside onnx export with simplify and tflite exports. The reason I included cmake separately without combining it with other packages is that if cmake is included together with onnxsim inside `check_requirements()`, it will have the following error:

```
pi@raspberrypi:~ $ yolo export model=yolov8n.pt format=onnx simplify
Ultralytics YOLOv8.1.16 🚀 Python-3.11.2 torch-2.2.0 CPU (Cortex-A76)
YOLOv8n summary (fused): 168 layers, 3151904 parameters, 0 gradients, 8.7 GFLOPs

PyTorch: starting from 'yolov8n.pt' with input shape (1, 3, 640, 640) BCHW and output shape(s) (1, 84, 8400) (6.2 MB)
requirements: Ultralytics requirements ['cmake', 'onnxsim>=0.4.33'] not found, attempting AutoUpdate...
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      fatal: not a git repository (or any of the parent directories): .git
      fatal: not a git repository (or any of the parent directories): .git
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-6er09w5u/onnxsim_9b0aac316a144e64a73932b33fa051c1/setup.py", line 67, in <module>
          assert CMAKE, 'Could not find "cmake" executable!'
      AssertionError: Could not find "cmake" executable!
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
requirements: ❌ Command 'pip install --no-cache "cmake" "onnxsim>=0.4.33" ' returned non-zero exit status 1.
```

So `cmake` need to be installed separately at first.

I have read the CLA Document and I hereby sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved ARM64 Dockerfile and package requirements management.

### 📊 Key Changes
- Removed `cmake` from Dockerfile for ARM64 builds, optimizing the installation layer.
- Updated the Ultralytics package version from 8.1.17 to 8.1.18.
- Added conditional checks to install `cmake` if exporting to ONNX on an ARM64 system.
- Adjusted TensorFlow package requirement logic to handle ARM64 architecture and restricted versioning for non-ARM64 systems.
- Restricted `flatbuffers` version to below 100 to avoid potential future conflicts.

### 🎯 Purpose & Impact
- **Purpose:** These changes streamline the Docker build process for ARM64 and ensure compatibility and stability when exporting models using different platforms.
- **Impact:** Users benefit from a smoother experience with Docker on ARM64, and developers gain clarity on package dependencies during model exporting, particularly with TensorFlow and ONNX. This may also enhance overall performance and maintainability of the Ultralytics codebase. 🚀