### PR TITLE
Add plot_images `conf_thresh` parameter

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -713,6 +713,7 @@ def plot_images(
     on_plot=None,
     max_subplots=16,
     save=True,
+    conf_thres=0.25
 ):
     """Plot image grid with labels."""
     if isinstance(images, torch.Tensor):
@@ -778,7 +779,7 @@ def plot_images(
                     c = classes[j]
                     color = colors(c)
                     c = names.get(c, c) if names else c
-                    if labels or conf[j] > 0.25:  # 0.25 conf thresh
+                    if labels or conf[j] > conf_thres:
                         label = f"{c}" if labels else f"{c} {conf[j]:.1f}"
                         annotator.box_label(box, label, color=color, rotated=is_obb)
 
@@ -800,7 +801,7 @@ def plot_images(
                 kpts_[..., 0] += x
                 kpts_[..., 1] += y
                 for j in range(len(kpts_)):
-                    if labels or conf[j] > 0.25:  # 0.25 conf thresh
+                    if labels or conf[j] > conf_thres:
                         annotator.kpts(kpts_[j])
 
             # Plot masks
@@ -816,7 +817,7 @@ def plot_images(
 
                 im = np.asarray(annotator.im).copy()
                 for j in range(len(image_masks)):
-                    if labels or conf[j] > 0.25:  # 0.25 conf thresh
+                    if labels or conf[j] > conf_thres:
                         color = colors(classes[j])
                         mh, mw = image_masks[j].shape
                         if mh != h or mw != w:

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -713,7 +713,7 @@ def plot_images(
     on_plot=None,
     max_subplots=16,
     save=True,
-    conf_thres=0.25
+    conf_thres=0.25,
 ):
     """Plot image grid with labels."""
     if isinstance(images, torch.Tensor):


### PR DESCRIPTION
Add `conf_thresh` param to plot_images function, allowing user customization.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved customization of confidence threshold in image plotting.

### 📊 Key Changes
- Added a new parameter `conf_thres` to `plot_images` function to set a custom confidence threshold for annotations.
- Modified the condition check to use the new `conf_thres` parameter instead of the hardcoded value of `0.25`.

### 🎯 Purpose & Impact
- 🎨 **Enhanced Flexibility**: Users can now customize the confidence level required for annotations to be displayed on plotted images, which is particularly beneficial for fine-tuning visualization during model evaluations.
- 🔍 **Improved Usability**: Allows for more accurate and meaningful visual interpretations of model results, since users can adjust the threshold to exclude lower-confidence predictions.
- 📈 **Potential Impact**: This change can lead to better insights during model debugging and presentations, as users tailor the confidence threshold to their specific needs and use-cases.