### PR TITLE
Hold failed upload metrics and upload with next upload metrics

### DIFF
--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -33,6 +33,11 @@ def on_fit_epoch_end(trainer):
             all_plots = {**all_plots, **model_info_for_loggers(trainer)}
 
         session.metrics_queue[trainer.epoch] = json.dumps(all_plots)
+
+        # If any metrics fail to upload, add them to the queue to attempt uploading again.
+        if session.metrics_upload_failed_queue:
+            session.metrics_queue.update(session.metrics_upload_failed_queue)
+
         if time() - session.timers["metrics"] > session.rate_limits["metrics"]:
             session.upload_metrics()
             session.timers["metrics"] = time()  # reset timer


### PR DESCRIPTION
The task involves the upload_metrics function, which is executed on a separate thread. If the function exceeds the maximum number of retry attempts, the metrics_queue is intended to retain the metrics data. However, the main thread inadvertently removes this data. To address this, I have added a new variable, **session.metrics_upload_failed_queue**, to store the failed metrics. This allows for the failed metrics to be checked and updated before attempting to upload the metrics again. If the upload is successful, the **metrics_upload_failed_queue** is reset within the thread function.

However, there are some drawbacks or corner cases to consider. First, using **session.metrics_upload_failed_queue** to hold failed metrics can consume a significant amount of memory if failures continue to occur. Second, if the upload fails at the very end, the last set of metrics will not be pushed, I think which is an issue that cannot be avoided.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in handling failed metric uploads during model training sessions.

### 📊 Key Changes
- Added `metrics_upload_failed_queue` to store metrics when an upload fails during the training session.
- `retry_request` method in `session.py` clears `metrics_upload_failed_queue` upon a successful upload.
- If all retries fail, `retry_request` updates `metrics_upload_failed_queue` with the failed metrics.
- During `on_fit_epoch_end` in `callbacks/hub.py`, metrics from `metrics_upload_failed_queue` are re-added to the main `metrics_queue` for re-upload attempts.

### 🎯 Purpose & Impact
- **Robustness**: Ensures metrics are not lost due to intermittent network or service issues during a training session. 🛡️
- **Data Integrity**: Provides a way to retain important training progress data, improving result analysis and reproducibility. 📈
- **User Experience**: Streamlines the training process by quietly handling temporary upload issues, making the tool more reliable for users. 👩‍💻👨‍💻