### PR TITLE
Do RTDETR file suffix check using pathlib instead of string manipulations

### DIFF
--- a/ultralytics/models/rtdetr/model.py
+++ b/ultralytics/models/rtdetr/model.py
@@ -6,6 +6,7 @@ hybrid encoder and IoU-aware query selection for enhanced detection accuracy.
 
 For more information on RT-DETR, visit: https://arxiv.org/pdf/2304.08069.pdf
 """
+from pathlib import Path
 
 from ultralytics.engine.model import Model
 from ultralytics.nn.tasks import RTDETRDetectionModel
@@ -34,7 +35,7 @@ class RTDETR(Model):
         Raises:
             NotImplementedError: If the model file extension is not 'pt', 'yaml', or 'yml'.
         """
-        if model and model.split(".")[-1] not in ("pt", "yaml", "yml"):
+        if model and Path(model).suffix not in (".pt", ".yaml", ".yml"):
             raise NotImplementedError("RT-DETR only supports creating from *.pt, *.yaml, or *.yml files.")
         super().__init__(model=model, task="detect")
 


### PR DESCRIPTION
As written currently, the `RTDETR` model specifically can't accept a `Path` object because it checks the file extension using string methods. This PR brings it into line with the other models, which happily do so.

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced RT-DETR model initialization with improved file extension handling.

### 📊 Key Changes
- Imported `Path` from the `pathlib` module for file path manipulations.
- Refined model file extension check using `Path.suffix`.

### 🎯 Purpose & Impact
- 🧰 **Purpose:** To ensure that RT-DETR model initialization reliably checks supported file extensions, preventing user errors and improving the robustness of the implementation.
- 🔍 **Impact:** Users will experience more consistent validation of file types when initializing RT-DETR models, with potentially fewer errors and clearer restrictions on acceptable file formats (`.pt`, `.yaml`, `.yml`).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced file extension validation for RT-DETR model initialization in Ultralytics' repository.

### 📊 Key Changes
- Imported `Path` from the `pathlib` library.
- Updated file extension check using `Path.suffix` for better file extension handling.

### 🎯 Purpose & Impact
- The purpose of the update is to improve the reliability of file extension checking during model initialization.
- This change benefits users by providing a more robust and error-resistant method of verifying whether a valid model file has been provided.
- Impact on end-users includes reduced potential for issues related to file extension misinterpretation, particularly in different operating system environments where case sensitivity can vary. 🔄