### PR TITLE
Fix undefined ‘im_array’ bug in predict.md

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -683,7 +683,7 @@ The `plot()` method in `Results` objects facilitates visualization of prediction
     for i, r in enumerate(results):
         # Plot results image
         im_bgr = r.plot()  # BGR-order numpy array
-        im_rgb = Image.fromarray(im_array[..., ::-1])  # RGB-order PIL image
+        im_rgb = Image.fromarray(im_bgr[..., ::-1])  # RGB-order PIL image
         
         # Show results to screen (in supported environments)
         r.show()


### PR DESCRIPTION
This PR fixes a bug in predict.md of YOLOv8 project where ‘im_array’ was undefined in Plotting Results and replaces it with ‘im_bgr’, the image array in BGR format. This resolves the error and enables the users to run the code without issues. The code was tested on a sample image and verified the output.

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image plotting functionality in prediction documentation.

### 📊 Key Changes
- Fixed an incorrect variable reference in the documentation for converting BGR to RGB images.

### 🎯 Purpose & Impact
- 🛠 Ensures developers are using the correct code example to display images properly.
- 🔍 Enhances the clarity for new users following the prediction mode documentation.
- 👁‍🗨 Prevents potential confusion and errors when visualizing model predictions.