### PR TITLE
Fix cmake requirements for ARM64

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -344,8 +344,8 @@ class Exporter:
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
             requirements += ["onnxsim>=0.4.33", "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"]
-        if ARM64:
-            check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64
+            if ARM64:
+                check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(requirements)
         import onnx  # noqa
 


### PR DESCRIPTION
`cmake` is only needed when using ONNX export together with `simplify`. Because it is a requirement for `onnxsim` building. It is not needed for only ONNX exports.

I have read the CLA Document and I hereby sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary

Improved dependency checks for ONNX export functionality.

### 📊 Key Changes

- Modified the check for the `cmake` dependency to only occur on ARM64 platforms.

### 🎯 Purpose & Impact

- 🛠️ **Purpose**: To ensure `cmake` is verified as a requirement only when necessary, specifically for building `onnxsim` on ARM64 (aarch64) architecture.
- 💻 **Impact**: Users on ARM64 machines will experience a streamlined setup process, as the check for `cmake` will now only be relevant to them, reducing unnecessary checks for other users. This makes the ONNX export process more efficient on different platforms.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved dependency handling in ONNX export functionality 🔄

### 📊 Key Changes
- Modified requirement checks for better platform compatibility.
- `cmake` is now conditionally checked based on ARM64 platform detection, streamlining the installation process.

### 🎯 Purpose & Impact
- 🛠 The main purpose is to ensure that `cmake` is only checked and installed when needed, which is when exporting models to ONNX on an ARM64 architecture.
- 🚀 For users, this change results in a smoother setup experience and potentially quicker installation times on certain hardware platforms, minimising unnecessary dependency installations.