### PR TITLE
Simplify `cmake` installation for `onnxsim`

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -344,9 +344,9 @@ class Exporter:
         """YOLOv8 ONNX export."""
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
-            requirements += ["onnxsim>=0.4.33", "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"]
             if ARM64:
-                check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64
+                requirements += ["cmake"]  # 'cmake' is needed to build onnxsim on aarch64
+            requirements += ["onnxsim>=0.4.33", "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"]
         check_requirements(requirements)
         import onnx  # noqa
 


### PR DESCRIPTION
@lakshanthad can you test this PR to see if this works?

This removes 1 call to `check_requirements` and should result in faster and more streamlined export, assuming that the cmake install is available for the onnxsim install. 

If it doesn't work then we can close and leave as-is. Thanks!

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in dependency management for ONNX export functionality in the Ultralytics framework.

### 📊 Key Changes
- Moved the addition of `"cmake"` to the `requirements` list when exporting ONNX files on ARM64 architecture.
- Ensured that other dependencies such as `"onnxsim"` and the appropriate version of `"onnxruntime"` are checked and added after the `"cmake"` dependency.

### 🎯 Purpose & Impact
- 🎭 Ensures that necessary build tools (`"cmake"`) are included in the requirements list before building `onnxsim` on ARM64 machines, improving the export process on these systems.
- 🚀 This change streamlines the export process for different architectures and possibly fixes related bugs, leading to a more reliable and user-friendly experience when working with ONNX models.