### PR TITLE
Support OpenVINO>=2023.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ dev = [
 export = [
     "onnx>=1.12.0", # ONNX export
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
-    "openvino-dev>=2023.0; python_version <= '3.11'", # OpenVINO export
+    "openvino>=2023.0; python_version <= '3.11'", # OpenVINO export
     "tensorflow<=2.13.1; python_version <= '3.11'", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0; python_version <= '3.11'", # TF.js export, automatically installs tensorflow
 ]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -481,13 +481,13 @@ class Exporter:
 
                 ignored_scope = nncf.IgnoredScope(  # ignore operations
                     patterns=[
-                        f"/{head_module_name}/Add",
-                        f"/{head_module_name}/Sub",
-                        f"/{head_module_name}/Mul",
-                        f"/{head_module_name}/Div",
-                        f"/{head_module_name}/dfl",
+                        f"__module.{head_module_name}.*Add",
+                        f"__module.{head_module_name}.*Sub",
+                        f"__module.{head_module_name}.*Mul",
+                        f"__module.{head_module_name}.*Div",
+                        f"__module.{head_module_name}.*dfl",
                     ],
-                    names=[f"/{head_module_name}/Sigmoid"],
+                    names=[f"__module.{head_module_name}/aten::sigmoid/Sigmoid"],
                 )
             quantized_ov_model = nncf.quantize(
                 ov_model, quantization_dataset, preset=nncf.QuantizationPreset.MIXED, ignored_scope=ignored_scope

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -418,7 +418,7 @@ class Exporter:
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")
         f = str(self.file).replace(self.file.suffix, f"_openvino_model{os.sep}")
         fq = str(self.file).replace(self.file.suffix, f"_int8_openvino_model{os.sep}")
-        f_ov = str(Path(f) / self.file.with_suffix('.xml').name)
+        f_ov = str(Path(f) / self.file.with_suffix(".xml").name)
         fq_ov = str(Path(fq) / self.file.with_suffix(".xml").name)
 
         def serialize(ov_model, file, compress_to_fp16):
@@ -438,14 +438,11 @@ class Exporter:
         dynamic = self.args.dynamic
         if dynamic:
             ov_model = ov.convert_model(
-                self.model,
-                example_input=torch.ones(self.im.shape, dtype=torch.float32)
+                self.model, example_input=torch.ones(self.im.shape, dtype=torch.float32)
             )  # export
         else:
             ov_model = ov.convert_model(
-                self.model,
-                example_input=torch.ones(self.im.shape, dtype=torch.float32),
-                input=self.im.shape
+                self.model, example_input=torch.ones(self.im.shape, dtype=torch.float32), input=self.im.shape
             )  # export
 
         if self.args.int8:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -180,7 +180,7 @@ class AutoBackend(nn.Module):
             metadata = session.get_modelmeta().custom_metadata_map  # metadata
         elif xml:  # OpenVINO
             LOGGER.info(f"Loading {w} for OpenVINO inference...")
-            check_requirements("openvino>=2023.0")  # requires openvino-dev: https://pypi.org/project/openvino-dev/
+            check_requirements("openvino>=2023.0")  # requires openvino: https://pypi.org/project/openvino/
             from openvino.runtime import Core, Layout, get_batch  # noqa
 
             core = Core()


### PR DESCRIPTION
Support openvino>=2023.0. 
ONNX is not longer required for convertation into openvino format.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded OpenVINO dependency and refined OpenVINO export functionality for enhanced model deployment.

### 📊 Key Changes
- Updated the OpenVINO package requirement from `openvino-dev` to `openvino`.
- Simplified the OpenVINO export process in the codebase, tightening integration and improving the export workflow.
- Adjusted the model serialization for OpenVINO to include float16 compression support explicitly, aligning with export options.
- Enhanced the naming conventions and pattern matching within the INT8 quantization process for better clarity and maintainability.

### 🎯 Purpose & Impact
- **Smoother Integration and Setup**: By switching to `openvino` from `openvino-dev`, users can expect a more streamlined setup process, reducing compatibility issues. 🛠️
- **Improved Export Workflows**: These changes make exporting models to OpenVINO format more intuitive and flexible, particularly with options like FP16 compression, which can reduce model size and potentially improve performance on compatible hardware. 💨
- **Enhanced Quantization Support**: The updates in pattern matching and naming conventions during INT8 quantization aim to improve the reliability of quantized models, ensuring that they maintain high accuracy while benefiting from reduced computational resources. 🎛️
- **Overall, users can expect improved performance and ease of use when deploying models to environments that leverage OpenVINO for inference**, making this update particularly impactful for developers working in Edge computing or IoT devices where resource efficiency is key. 🚀