### PR TITLE
Add Ultralytics HUB Cloud Training banner to Docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -4,9 +4,9 @@
 
 {% block announce %}
    <div style="text-align: center;">
-       <a href="https://www.ultralytics.com/blog/ultralytics-yolov8-turns-one-a-year-of-breakthroughs-and-innovations"
+       <a href="https://hub.ultralytics.com/signup?utm_source=docs&utm_medium=banner&utm_campaign=cloud_training_release"
           target="_blank" style="color: #FFFFFF;">
-        Ultralytics YOLOv8 Turns One! 🎉 A Year of Breakthroughs and Innovations &nbsp; ➜
+          Introducing HUB Cloud Training! ☁️ Scalable. Simple. Smart. &nbsp; ➜
       </a>
    </div>
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -6,7 +6,7 @@
    <div style="text-align: center;">
        <a href="https://hub.ultralytics.com/signup?utm_source=docs&utm_medium=banner&utm_campaign=cloud_training_release"
           target="_blank" style="color: #FFFFFF;">
-          Introducing HUB Cloud Training! ☁️ Scalable. Simple. Smart. &nbsp; ➜
+          Introducing Ultralytics HUB Cloud Training! ☁️ Scalable. Simple. Smart. &nbsp; ➜
       </a>
    </div>
 {% endblock %}

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -51,7 +51,7 @@ div.highlight {
 
 /* Update the background of the banner (same as the one on the Ultralytics website) */
 .md-banner {
-  background-image: url(https://assets-global.website-files.com/646dd1f1a3703e451ba81ecc/659fc4f4163e480e7ec280d0_banner.webp);
+  background-image: url(https://uploads-ssl.webflow.com/646dd1f1a3703e451ba81ecc/65e60cd6a4080bba757850a3_banner_ct.webp);
   background-size: cover;
   background-position: center;
 }


### PR DESCRIPTION
This PR updates the [Ultralytics Docs](https://docs.ultralytics.com) banner, highlighting the new [Ultralytics HUB Cloud Training](https://hub.ultralytics.com/signup?utm_source=github&utm_medium=pr&utm_campaign=cloud_training_release) feature.

![banner_ct](https://github.com/ultralytics/ultralytics/assets/47978446/f7368a77-8768-4fcd-8b26-edd96a0c1e00)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing Ultralytics Cloud Training on the HUB platform!

### 📊 Key Changes
- Updated the announcement banner link in the main documentation page.
- Changed the banner background image to match the new cloud training theme.

### 🎯 Purpose & Impact
- **Purpose:** To promote the new Ultralytics HUB Cloud Training, which provides a scalable, simple, and smart way to train AI models.
- **Impact:** Users will be informed about the latest cloud training offering directly through the documentation site, potentially leading to increased usage and engagement with the Ultralytics platform. ☁️🚀