### PR TITLE
Typo in coco.md doc

### DIFF
--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -10,7 +10,7 @@ The [COCO-Seg](https://cocodataset.org/#home) dataset, an extension of the COCO 
 
 ## Key Features
 
-- COCO-Seg retains the original 330K images from COCO.
+- COCO-Seg retains the original 133K images from COCO.
 - The dataset consists of the same 80 object categories found in the original COCO dataset.
 - Annotations now include more detailed instance segmentation masks for each object in the images.
 - COCO-Seg provides standardized evaluation metrics like mean Average Precision (mAP) for object detection, and mean Average Recall (mAR) for instance segmentation tasks, enabling effective comparison of model performance.


### PR DESCRIPTION
Typo in coco.md regarding the total images.
Before: 330k total images
Right: 133k total images


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to COCO-Seg dataset image count documentation.

### 📊 Key Changes
- Corrected the number of images in COCO-Seg from "330K" to "133K."

### 🎯 Purpose & Impact
- **Accuracy:** Ensures users have the correct information regarding the dataset size.
- **Clarity:** Prevents confusion about dataset specifications, allowing better planning for resource allocation and training times.
- **Reliability:** Contributes to the trustworthiness of the documentation as a resource for researchers and developers.