### PR TITLE
OpenVino 2024.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ dev = [
 export = [
     "onnx>=1.12.0", # ONNX export
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
-    "openvino>=2023.3; python_version <= '3.11'", # OpenVINO export
+    "openvino>=2024.0.0", # OpenVINO export
     "tensorflow<=2.13.1; python_version <= '3.11'", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0; python_version <= '3.11'", # TF.js export, automatically installs tensorflow
 ]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -411,7 +411,7 @@ class Exporter:
     @try_export
     def export_openvino(self, prefix=colorstr("OpenVINO:")):
         """YOLOv8 OpenVINO export."""
-        check_requirements("openvino>=2023.3")  # requires openvino: https://pypi.org/project/openvino/
+        check_requirements("openvino>=2024.0.0")  # requires openvino: https://pypi.org/project/openvino/
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -190,7 +190,7 @@ class AutoBackend(nn.Module):
         # OpenVINO
         elif xml:
             LOGGER.info(f"Loading {w} for OpenVINO inference...")
-            check_requirements("openvino>=2023.3")
+            check_requirements("openvino>=2024.0.0")
             import openvino as ov
 
             core = ov.Core()


### PR DESCRIPTION
#8723 compatible with python 3.12

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded OpenVINO requirement for better model export capabilities 🚀

### 📊 Key Changes
- Updated the OpenVINO version requirement from `>=2023.3` to `>=2024.0.0` across various files including `pyproject.toml`, `exporter.py`, and `autobackend.py`.
 
### 🎯 Purpose & Impact
- **Ensures Compatibility:** Keeps the codebase up-to-date with the latest OpenVINO version, ensuring compatibility and leveraging new features.
- **Enhances Export Functionality:** Potentially unlocks improvements in exporting models to the OpenVINO format, which could mean better performance or more features for users exporting YOLOv8 models.
- **Broader Support:** This move can prepare users for future advancements in OpenVINO, possibly offering a broader range of model support or efficiency gains in model inference on various platforms.