### PR TITLE
Modify tuner best.pt logic to train first

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -188,11 +188,11 @@ class Tuner:
             train_args = {**vars(self.args), **mutated_hyp}
             save_dir = get_save_dir(get_cfg(train_args))
             weights_dir = save_dir / "weights"
-            ckpt_file = weights_dir / ("best.pt" if (weights_dir / "best.pt").exists() else "last.pt")
             try:
                 # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
                 cmd = ["yolo", "train", *(f"{k}={v}" for k, v in train_args.items())]
                 return_code = subprocess.run(cmd, check=True).returncode
+                ckpt_file = weights_dir / ("best.pt" if (weights_dir / "best.pt").exists() else "last.pt")
                 metrics = torch.load(ckpt_file)["train_metrics"]
                 assert return_code == 0, "training failed"
 


### PR DESCRIPTION
Changed the check for the checkpoint file in `tuner.py` to occur after the training subprocess is run, since `best.pt` will not exist before the training run is started. Closes #8791.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refined tuning process for YOLO model hyperparameters.

### 📊 Key Changes
- 👨‍💻 Moved the checkpoint file (`ckpt_file`) discovery step post-training to ensure it captures the most recent and relevant model weights.

### 🎯 Purpose & Impact
- 🚀 **Enhancement in Model Performance**: Ensures the tuner always evaluates the model using the very latest trained weights, potentially leading to more accurate performance assessments and improvements.
- 🛠️ **Streamlined Process**: By locating the best or last checkpoint after training completes, the change could prevent errors or confusion related to file availability or timing, resulting in a smoother tuning operation.
- 📈 **Potential Impact to Users**: Users may experience more reliable and potentially improved outcomes from the tuning process, leading to better model performance with less manual oversight.