### PR TITLE
New `MLFLOW_KEEP_RUN_ACTIVE` flag for enhanced MLflow run management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+mlruns/
 
 # Translations
 *.mo

--- a/ultralytics/utils/callbacks/mlflow.py
+++ b/ultralytics/utils/callbacks/mlflow.py
@@ -108,15 +108,17 @@ def on_train_end(trainer):
         for f in trainer.save_dir.glob("*"):  # log all other files in save_dir
             if f.suffix in {".png", ".jpg", ".csv", ".pt", ".yaml"}:
                 mlflow.log_artifact(str(f))
-        keep_run_active = os.environ.get('MLFLOW_KEEP_RUN_ACTIVE', 'False').lower() in ('true')
+        keep_run_active = os.environ.get("MLFLOW_KEEP_RUN_ACTIVE", "False").lower() in ("true")
         if not keep_run_active:
             mlflow.end_run()
-            LOGGER.debug(f'{PREFIX}mlflow run ended')
+            LOGGER.debug(f"{PREFIX}mlflow run ended")
         else:
-            LOGGER.info(f'{PREFIX}mlflow run still alive, remember to close it using mlflow.end_run()')
+            LOGGER.info(f"{PREFIX}mlflow run still alive, remember to close it using mlflow.end_run()")
 
-        LOGGER.info(f"{PREFIX}results logged to {mlflow.get_tracking_uri()}\n"
-                    f"{PREFIX}disable with 'yolo settings mlflow=False'")
+        LOGGER.info(
+            f"{PREFIX}results logged to {mlflow.get_tracking_uri()}\n"
+            f"{PREFIX}disable with 'yolo settings mlflow=False'"
+        )
 
 
 callbacks = (

--- a/ultralytics/utils/callbacks/mlflow.py
+++ b/ultralytics/utils/callbacks/mlflow.py
@@ -109,11 +109,11 @@ def on_train_end(trainer):
             if f.suffix in {".png", ".jpg", ".csv", ".pt", ".yaml"}:
                 mlflow.log_artifact(str(f))
         keep_run_active = os.environ.get("MLFLOW_KEEP_RUN_ACTIVE", "False").lower() in ("true")
-        if not keep_run_active:
+        if keep_run_active:
+            LOGGER.info(f"{PREFIX}mlflow run still alive, remember to close it using mlflow.end_run()")
+        else:
             mlflow.end_run()
             LOGGER.debug(f"{PREFIX}mlflow run ended")
-        else:
-            LOGGER.info(f"{PREFIX}mlflow run still alive, remember to close it using mlflow.end_run()")
 
         LOGGER.info(
             f"{PREFIX}results logged to {mlflow.get_tracking_uri()}\n"

--- a/ultralytics/utils/callbacks/mlflow.py
+++ b/ultralytics/utils/callbacks/mlflow.py
@@ -58,6 +58,7 @@ def on_pretrain_routine_end(trainer):
         MLFLOW_TRACKING_URI: The URI for MLflow tracking. If not set, defaults to 'runs/mlflow'.
         MLFLOW_EXPERIMENT_NAME: The name of the MLflow experiment. If not set, defaults to trainer.args.project.
         MLFLOW_RUN: The name of the MLflow run. If not set, defaults to trainer.args.name.
+        MLFLOW_KEEP_RUN_ACTIVE: Boolean indicating whether to keep the MLflow run active after the end of the training phase.
     """
     global mlflow
 
@@ -107,12 +108,15 @@ def on_train_end(trainer):
         for f in trainer.save_dir.glob("*"):  # log all other files in save_dir
             if f.suffix in {".png", ".jpg", ".csv", ".pt", ".yaml"}:
                 mlflow.log_artifact(str(f))
+        keep_run_active = os.environ.get('MLFLOW_KEEP_RUN_ACTIVE', 'False').lower() in ('true')
+        if not keep_run_active:
+            mlflow.end_run()
+            LOGGER.debug(f'{PREFIX}mlflow run ended')
+        else:
+            LOGGER.info(f'{PREFIX}mlflow run still alive, remember to close it using mlflow.end_run()')
 
-        mlflow.end_run()
-        LOGGER.info(
-            f"{PREFIX}results logged to {mlflow.get_tracking_uri()}\n"
-            f"{PREFIX}disable with 'yolo settings mlflow=False'"
-        )
+        LOGGER.info(f"{PREFIX}results logged to {mlflow.get_tracking_uri()}\n"
+                    f"{PREFIX}disable with 'yolo settings mlflow=False'")
 
 
 callbacks = (


### PR DESCRIPTION
This commit introduces a new configuration option, `MLFLOW_KEEP_RUN_ACTIVE`, aimed at providing users with greater flexibility in managing MLflow runs. The `MLFLOW_KEEP_RUN_ACTIVE` flag is a boolean variable that determines whether to keep the MLflow run active after the completion of the training phase.

Here's a brief overview of the changes:
- The commit introduces the `keep_run_active` variable, which is derived from the `MLFLOW_KEEP_RUN_ACTIVE` environment variable. The default value is set to `False`, but users can customize it by setting the environment variable to 'True'.
- If `keep_run_active` is set to `False`, the MLflow run is automatically ended using `mlflow.end_run()`. The system logs a debug message confirming the closure.
- If `keep_run_active` is set to `True`, a notification is logged, reminding users to manually close the MLflow run using `mlflow.end_run()` when appropriate.


This enhancement provides users with more control over their MLflow runs and ensures a seamless integration of MLflow into their workflow. Upgrade your system today to take advantage of this new functionality and optimize your MLflow run management experience.

Usage example:

```
import mlflow
os.environ['MLFLOW_KEEP_RUN_ACTIVE'] = 'True'
YOLO('yolov8n-cls.yaml').train(data='imagenet10', imgsz=32, epochs=1, plots=False, device='cpu')
mlflow.log_image(custome_metric, "custom_metric_img.png")
mlflow.end_run()
```

In this example, the image "custom_metric_image.png" is logged within the same Yolov8 artifacts run.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced MLflow integration with option to keep runs active post-training.

### 📊 Key Changes
- Added `mlruns/` to `.gitignore` to avoid tracking MLflow run files.
- Introduced a new test to verify MLflow run status based on the environment variable `MLFLOW_KEEP_RUN_ACTIVE`.
- Implemented the handling for `MLFLOW_KEEP_RUN_ACTIVE` in MLflow callback, enabling users to control whether an MLflow run should remain active after training completion.

### 🎯 Purpose & Impact
- **Improved Flexibility**: Allows users more control over their MLflow runs, specifically enabling runs to remain active for additional logging or analysis after the initial training phase ends.
- **Enhanced Workflow**: Facilitates deeper integration with MLflow for more complex machine learning workflows, potentially improving experiment tracking and reproducibility.
- **User Experience**: With clear logging about the status of MLflow runs, users can better manage their experiment tracking and ensure clean run state management.