### PR TITLE
Add local CI of RPi5 Bookworm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,8 @@ jobs:
         model: [yolov8n]
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Python
+      if: matrix.os != 'rpi5-bookworm'
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, rpi5-bookworm]
         python-version: ["3.11"]
         model: [yolov8n]
     steps:
@@ -155,7 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, rpi5-bookworm]
         python-version: ["3.11"]
         torch: [latest]
         include:


### PR DESCRIPTION
This PR is only to test the functionality

I have read the CLA Document and I hereby sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of CI workflow with Raspberry Pi 5 Bookworm support 🎉

### 📊 Key Changes
- Added `rpi5-bookworm` as a new operating system option in the CI (Continuous Integration) testing matrix.
- Modified Python setup process to exclude it when running on `rpi5-bookworm`.

### 🎯 Purpose & Impact
- **Broader Compatibility:** Including `rpi5-bookworm` ensures that the software is compatible with more environments, specifically targeting Raspberry Pi users. 🖥️🍓
- **Efficient Testing:** By adjusting the Python setup for `rpi5-bookworm`, the CI process is more streamlined and tailored for that environment, improving the reliability of testing across different systems. 🛠️✔️
- **User Benefit:** Raspberry Pi users will experience better support and performance, making the Ultralytics library more accessible and usable in diverse hardware setups. 🌍👩‍💻

This update highlights Ultralytics' commitment to supporting a wide range of environments, ensuring that users on even more platforms can benefit from the library's capabilities.