### PR TITLE
Add local CI of RPi5 Bookworm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,8 @@ jobs:
         model: [yolov8n]
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Python
+      if: matrix.os != 'rpi5-bookworm'
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,6 @@ jobs:
         model: [yolov8n]
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Python
       if: matrix.os != 'rpi5-bookworm'
       - uses: actions/setup-python@v5
         with:
@@ -166,6 +165,7 @@ jobs:
             torch: "1.8.0" # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v4
+      if: matrix.os != 'rpi5-bookworm'
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, rpi5-bookworm]
         python-version: ["3.11"]
         model: [yolov8n]
     steps:
@@ -155,7 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, rpi5-bookworm]
         python-version: ["3.11"]
         torch: [latest]
         include:


### PR DESCRIPTION
This PR is only to test the functionality

I have read the CLA Document and I hereby sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Expanding CI Testing to Include Raspberry Pi 5 on Bookworm 🍓

### 📊 Key Changes
- Added `rpi5-bookworm` as an operating system option in the continuous integration (CI) workflow.
- Modified conditions to skip certain setup steps when running on `rpi5-bookworm`.

### 🎯 Purpose & Impact
- **Purpose:** The inclusion of `rpi5-bookworm` aims to ensure that Ultralytics software runs smoothly on Raspberry Pi 5 with the Bookworm OS, expanding compatibility and operational reliability.
- **Impact:** Users leveraging Raspberry Pi 5 devices for their projects will benefit from validated support and stability. This update fosters a wider adoption and versatility of Ultralytics projects across various platforms.

🔧🍇 This move showcases a commitment to supporting a broad spectrum of hardware and operating systems, allowing more users to confidently integrate and use Ultralytics technology in their bespoke environments.