### PR TITLE
Fix `names` bug when exporting YOLOv8-World to ONNX

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -71,8 +71,9 @@ class YOLOWorld(Model):
         """
         super().__init__(model=model, task="detect")
 
-        # Assign default COCO class names
-        self.model.names = yaml_load(ROOT / "cfg/datasets/coco8.yaml").get("names")
+        # Assign default COCO class names when there is no customization
+        if not hasattr(self.model, "names"):
+            setattr(self.model, "names", yaml_load(ROOT / "cfg/datasets/coco8.yaml").get("names"))
 
     @property
     def task_map(self):

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -71,9 +71,9 @@ class YOLOWorld(Model):
         """
         super().__init__(model=model, task="detect")
 
-        # Assign default COCO class names when there is no customization
+        # Assign default COCO class names when there are no custom names
         if not hasattr(self.model, "names"):
-            setattr(self.model, "names", yaml_load(ROOT / "cfg/datasets/coco8.yaml").get("names"))
+            self.model.names = yaml_load(ROOT / "cfg/datasets/coco8.yaml").get("names")
 
     @property
     def task_map(self):


### PR DESCRIPTION
A PR for #8940 

This modification will export YOLOv8-World to ONNX model with correct class `names` metadata.


![image](https://github.com/ultralytics/ultralytics/assets/51357717/0d484797-5797-4bf3-9bef-e95aca2fa76d)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved handling of default class names in YOLO models.

### 📊 Key Changes
- Added a check to only assign default COCO class names if the model doesn't already have custom names set.

### 🎯 Purpose & Impact
- **Purpose:** This change ensures that YOLO models can use custom class names if provided, instead of always overwriting them with the default COCO names. This allows for greater flexibility and customization.
- **Impact:** Users employing custom classes for their detection tasks will find this update particularly useful, as it respects their custom settings and enhances the model's adaptability to various detection scenarios. 🚀

This change enriches the user experience by acknowledging and preserving user customizations, making the model more versatile for a range of applications.