### PR TITLE
Optimize TFJS export on ARM64

### DIFF
--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -32,11 +32,6 @@ RUN rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED
 RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache -e ".[export]"
 
-# Fix error: `np.object` was a deprecated alias for the builtin `object` when exporting to TensorFlow.js
-# Here onnxruntime is installed first because in tflite and onnx simplify exports, it will install latest numpy version as a dependency and we need to downgrade it
-RUN pip install --no-cache onnxruntime
-RUN pip install --no-cache numpy==1.23.5
-
 # Creates a symbolic link to make 'python' point to 'python3'
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -887,9 +887,8 @@ class Exporter:
         """YOLOv8 TensorFlow.js export."""
         check_requirements("tensorflowjs")
         if ARM64:
-            check_requirements(
-                "numpy==1.23.5"
-            )  # Fix error: `np.object` was a deprecated alias for the builtin `object` when exporting to TensorFlow.js on ARM64
+            # Fix error: `np.object` was a deprecated alias for the builtin `object` when exporting to TF.js on ARM64
+            check_requirements("numpy==1.23.5")  
         import tensorflow as tf
         import tensorflowjs as tfjs  # noqa
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -887,7 +887,9 @@ class Exporter:
         """YOLOv8 TensorFlow.js export."""
         check_requirements("tensorflowjs")
         if ARM64:
-            check_requirements("numpy==1.23.5")  # Fix error: `np.object` was a deprecated alias for the builtin `object` when exporting to TensorFlow.js on ARM64
+            check_requirements(
+                "numpy==1.23.5"
+            )  # Fix error: `np.object` was a deprecated alias for the builtin `object` when exporting to TensorFlow.js on ARM64
         import tensorflow as tf
         import tensorflowjs as tfjs  # noqa
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -886,6 +886,8 @@ class Exporter:
     def export_tfjs(self, prefix=colorstr("TensorFlow.js:")):
         """YOLOv8 TensorFlow.js export."""
         check_requirements("tensorflowjs")
+        if ARM64:
+            check_requirements("numpy==1.23.5")  # Fix error: `np.object` was a deprecated alias for the builtin `object` when exporting to TensorFlow.js on ARM64
         import tensorflow as tf
         import tensorflowjs as tfjs  # noqa
 


### PR DESCRIPTION
I have removed the fix from `dockerfile` and moved to `exporter.py` for a global-level fix.

I have read the CLA Document and I hereby sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in Docker and TensorFlow.js Export Compatibility for ARM64 Devices.

### 📊 Key Changes
- Removed explicit `numpy` and `onnxruntime` installations from ARM64 Dockerfile.
- Introduced conditional `numpy` version check in TensorFlow.js export function specifically for ARM64 architecture.

### 🎯 Purpose & Impact
- **Simplifies Docker Setup:** Removing specific `numpy` and `onnxruntime` installation steps makes the Dockerfile cleaner and more maintainable. 🧹
- **Enhances Export Functionality:** Ensuring a specific `numpy` version during TensorFlow.js export on ARM64 addresses compatibility issues, enhancing reliability. 🛠️
- **Broadens Compatibility:** These updates aim to improve the experience for users on ARM64 devices, facilitating smoother workflows and broader support. 🌍