### PR TITLE
fix yolo classify model loading error

### DIFF
--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -73,7 +73,7 @@ class ClassificationTrainer(BaseTrainer):
         elif model in torchvision.models.__dict__:
             self.model = torchvision.models.__dict__[model](weights="IMAGENET1K_V1" if self.args.pretrained else None)
         else:
-            FileNotFoundError(f"ERROR: model={model} not found locally or online. Please check model name.")
+            raise FileNotFoundError(f"ERROR: model={model} not found locally or online. Please check model name.")
         ClassificationModel.reshape_outputs(self.model, self.data["nc"])
 
         return ckpt


### PR DESCRIPTION
During the process of multi-GPU training, I encountered an issue related to the model loading mechanism in the ultralytics project. Specifically, when attempting to load a classification model, if the model file is not found, the code creates a FileNotFoundError exception object but does not throw it. This leads to a subtle error: the program continues execution without immediately notifying the user of the error when the specified model file does not exist. This behavior could result in users wasting significant time troubleshooting, especially in complex multi-GPU training scenarios.

To address this issue, I have submitted a fix. The modification involves the ultralytics/models/yolo/classify/train.py file, where I ensured that when the model file cannot be found, a FileNotFoundError is thrown using the raise keyword to promptly notify the user. This change makes error handling more transparent and helps users quickly identify and resolve configuration issues during the training process.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced error handling when a model isn't found in YOLO classification training.

### 📊 Key Changes
- Improved the error message to actively raise a `FileNotFoundError` when a specified model is not found either locally or online.

### 🎯 Purpose & Impact
- **Purpose**: To make error messages more informative and actionable for users trying to train classification models with YOLO. Previously, if the model wasn't found, the script did not raise an explicit exception, which could lead to confusion about what went wrong.
- **Impact**: Users will now receive a clear error message indicating that the model can't be located, guiding them to check the model name they've provided. This change improves user experience by helping diagnose issues faster and more accurately. 🔍💡