### PR TITLE
Fix TypeError in check_cfg()

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -245,7 +245,9 @@ def check_cfg(cfg, hard=True):
                         )
                     cfg[k] = float(v)
                 if not (0.0 <= cfg[k] <= 1.0):
-                    raise ValueError(f"'{k}={cfg[k]}' is an invalid value. " f"Valid '{k}' values are between 0.0 and 1.0.")
+                    raise ValueError(
+                        f"'{k}={cfg[k]}' is an invalid value. " f"Valid '{k}' values are between 0.0 and 1.0."
+                    )
             elif k in CFG_INT_KEYS and not isinstance(v, int):
                 if hard:
                     raise TypeError(

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -244,8 +244,8 @@ def check_cfg(cfg, hard=True):
                             f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
                         )
                     cfg[k] = float(v)
-                if not (0.0 <= v <= 1.0):
-                    raise ValueError(f"'{k}={v}' is an invalid value. " f"Valid '{k}' values are between 0.0 and 1.0.")
+                if not (0.0 <= cfg[k] <= 1.0):
+                    raise ValueError(f"'{k}={cfg[k]}' is an invalid value. " f"Valid '{k}' values are between 0.0 and 1.0.")
             elif k in CFG_INT_KEYS and not isinstance(v, int):
                 if hard:
                     raise TypeError(

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -243,11 +243,9 @@ def check_cfg(cfg, hard=True):
                             f"'{k}={v}' is of invalid type {type(v).__name__}. "
                             f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
                         )
-                    cfg[k] = float(v)
-                if not (0.0 <= cfg[k] <= 1.0):
-                    raise ValueError(
-                        f"'{k}={cfg[k]}' is an invalid value. " f"Valid '{k}' values are between 0.0 and 1.0."
-                    )
+                    cfg[k] = v = float(v)
+                if not (0.0 <= v <= 1.0):
+                    raise ValueError(f"'{k}={v}' is an invalid value. " f"Valid '{k}' values are between 0.0 and 1.0.")
             elif k in CFG_INT_KEYS and not isinstance(v, int):
                 if hard:
                     raise TypeError(


### PR DESCRIPTION
The value check shall use the type casted value, or it will raise TypeError.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved configuration value handling for better accuracy and flexibility.

### 📊 Key Changes
- Updated the handling of numerical configuration values to ensure they're properly converted to floats.
- Added validation to ensure numerical values are within the acceptable range (0.0 to 1.0) for certain keys.

### 🎯 Purpose & Impact
- **Ensures Accuracy:** By explicitly converting values to floats, we eliminate errors related to type mismatches. This change helps in situations where values might be input as strings but are expected to be numerical.
- **Improves Flexibility:** Users can input numerical values in a format that's most convenient for them (e.g., as integers, floats, or even strings), and the system will handle these correctly.
- **Prevents Misconfigurations:** By checking that values are within a specified range, the update prevents users from setting configurations that could lead to errors or suboptimal performance. This is particularly important for parameters that influence the algorithm's behavior, ensuring that users don't unintentionally set values that could degrade the system's functionality.

Overall, these changes help make Ultralytics' software more robust, user-friendly, and error-resistant. 🚀