### PR TITLE
`ultralytics 8.1.32` fix CLIP backwards compatibility

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ def test_rtdetr(task="detect", model="yolov8n-rtdetr.yaml", data="coco8.yaml"):
     run(f"yolo predict {task} model={model} source={ASSETS / 'bus.jpg'} imgsz=160 save save_crop save_txt")
 
 
-@pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="MobileSAM Clip is not supported in Python 3.12")
+@pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="MobileSAM with CLIP is not supported in Python 3.12")
 def test_fastsam(task="segment", model=WEIGHTS_DIR / "FastSAM-s.pt", data="coco8-seg.yaml"):
     """Test FastSAM segmentation functionality within Ultralytics."""
     source = ASSETS / "bus.jpg"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -636,3 +636,10 @@ def test_model_embeddings():
     for batch in [SOURCE], [SOURCE, SOURCE]:  # test batch size 1 and 2
         assert len(model_detect.embed(source=batch, imgsz=32)) == len(batch)
         assert len(model_segment.embed(source=batch, imgsz=32)) == len(batch)
+
+
+@pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="YOLOWorld with CLIP is not supported in Python 3.12")
+def test_yolo_world():
+    model = YOLO("yolov8s-world.pt")  # no YOLOv8n-world model yet
+    model.set_classes(["tree", "window"])
+    model(ASSETS / "bus.jpg", conf=0.01)

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.1.31"
+__version__ = "8.1.32"
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import RTDETR, SAM, YOLO, YOLOWorld

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -48,6 +48,7 @@ from ultralytics.nn.modules import (
     SPPELAN,
     CBFuse,
     CBLinear,
+    Silence,
 )
 from ultralytics.utils import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER, colorstr, emojis, yaml_load
 from ultralytics.utils.checks import check_requirements, check_suffix, check_yaml

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -48,7 +48,6 @@ from ultralytics.nn.modules import (
     SPPELAN,
     CBFuse,
     CBLinear,
-    Silence,
 )
 from ultralytics.utils import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER, colorstr, emojis, yaml_load
 from ultralytics.utils.checks import check_requirements, check_suffix, check_yaml
@@ -572,7 +571,7 @@ class WorldModel(DetectionModel):
             check_requirements("git+https://github.com/openai/CLIP.git")
             import clip
 
-        if not self.clip_model:
+        if not getattr(self, "clip_model"):  # for backwards compatibility of models lacking clip_model attribute
             self.clip_model = clip.load("ViT-B/32")[0]
         device = next(self.clip_model.parameters()).device
         text_token = clip.tokenize(text).to(device)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -572,7 +572,7 @@ class WorldModel(DetectionModel):
             check_requirements("git+https://github.com/openai/CLIP.git")
             import clip
 
-        if not getattr(self, "clip_model"):  # for backwards compatibility of models lacking clip_model attribute
+        if not getattr(self, "clip_model", None):  # for backwards compatibility of models lacking clip_model attribute
             self.clip_model = clip.load("ViT-B/32")[0]
         device = next(self.clip_model.parameters()).device
         text_token = clip.tokenize(text).to(device)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update in Ultralytics testing and compatibility, version bump to 8.1.32. 🚀

### 📊 Key Changes
- Adjusted a test description to accurately reflect the functionality being tested. 🧪
- Added a new test checking compatibility of "YOLOWorld with CLIP" with Python versions. 🐍
- Updated the Ultralytics package version to 8.1.32. 🆕
- Enhanced backwards compatibility in `nn/tasks.py` for models without a `clip_model` attribute. 🔧

### 🎯 Purpose & Impact
- These changes ensure clear communication in tests and maintain compatibility for users across different Python versions. 📝
- The version bump signifies ongoing improvements and bug fixes, providing users with the latest stable features. 🛠️
- Enhancing backwards compatibility means users with older models can still benefit from new updates without breaking their current implementations. 🔄
- Overall, these changes contribute to a smoother, more reliable experience for developers and users alike, fostering trust in Ultralytics software. 👥