### PR TITLE
Fix `None` `prevKeyPoints` for multi-object tracking

### DIFF
--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -324,7 +324,7 @@ class GMC:
             self.prevKeyPoints = copy.copy(keypoints)
             self.initializedFirstFrame = True
             return H
-        
+
         # Handle no prev keypoints case
         if self.prevKeyPoints is None:
             self.prevFrame = frame.copy()

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -324,6 +324,12 @@ class GMC:
             self.prevKeyPoints = copy.copy(keypoints)
             self.initializedFirstFrame = True
             return H
+        
+        # Handle no prev keypoints case
+        if self.prevKeyPoints is None:
+            self.prevFrame = frame.copy()
+            self.prevKeyPoints = copy.copy(keypoints)
+            return H
 
         # Find correspondences
         matchedKeypoints, status, _ = cv2.calcOpticalFlowPyrLK(self.prevFrame, frame, self.prevKeyPoints, None)

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -319,16 +319,10 @@ class GMC:
         keypoints = cv2.goodFeaturesToTrack(frame, mask=None, **self.feature_params)
 
         # Handle first frame
-        if not self.initializedFirstFrame:
+        if not self.initializedFirstFrame or self.prevKeyPoints is None:
             self.prevFrame = frame.copy()
             self.prevKeyPoints = copy.copy(keypoints)
             self.initializedFirstFrame = True
-            return H
-
-        # Handle no prev keypoints case
-        if self.prevKeyPoints is None:
-            self.prevFrame = frame.copy()
-            self.prevKeyPoints = copy.copy(keypoints)
             return H
 
         # Find correspondences


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->

This PR addresses [an existing issue posted on StackOverflow](https://stackoverflow.com/questions/77324377/when-using-yolov8-detector-with-bot-sort-i-see-warning-related-to-optical-flow) (not by me) with the `applySparseOptFlow` method in `gmc.py`.

`applySparseOptFlow` assumes that there will be valid detections after the first frame, and does not handle the case when the first 1+n frames do not contain detections. This could be caused by any number of reasons, including a high confidence threshold setting for the tracker, a poorly trained detection model, or an input video with blank intro frames.

My fix checks that `prevKeypoints` is not none before making the call to `cv2.calcOpticalFlowPyrLK`, [which expects `prevPoints` to be a non-empty array](https://docs.opencv.org/4.x/dc/d6b/group__video__track.html#ga473e4b886d0bcc6b65831eb88ed93323).

Steps to reproduce:
```
from ultralytics import YOLO

model = YOLO('yolov8n.pt')  # Load an official Detect model

# Tracking with default tracker on video with all black intro frames
# NOTE: the low confidence score
model.track(source="https://youtu.be/e2kDphvRM1g", show=True, conf=0.001)  
```
In this particular case, by setting the confidence score of the model very low, the following happens:
1. Detections exist during blank frames at the beginning of the video
2. `gmc.apply` is called for the first frame, but there are no valid detections above the tracker confidence threshold of 0.1. Thus `prevKeypoints` is set to `None`, _**despite the code's assumption that this will never be the case**_.
3. The subsequent call to `gmc.apply` passes `None` as the `prevKeypoints` argument to cv2.calcOpticalFlowPyrLK raising the following error:

```
cv2.error: OpenCV(4.9.0) /Users/xperience/GHA-OpenCV-Python2/_work/opencv-python/opencv-python/opencv/modules/video/src/lkpyramid.cpp:1260: error: (-215:Assertion failed) (npoints = prevPtsMat.checkVector(2, CV_32F, true)) >= 0 in function 'calc'
```

_I have read the CLA Document and I hereby sign the CLA_




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in handling optical flow initialization for object tracking.

### 📊 Key Changes
- Modified condition to better handle the initial frame and keypoint setup for optical flow tracking.

### 🎯 Purpose & Impact
- **Purpose:** Ensures more reliable tracking startup by accounting for scenarios where previous keypoints might be `None`.
- **Impact:** Enhances the stability and accuracy of object tracking, especially at the commencement of tracking, benefiting users with smoother and more consistent performance.🚀