### PR TITLE
Favor EMA over `model` in train checkpoints

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -521,7 +521,7 @@ class BaseTrainer:
         ckpt = None
         if str(model).endswith(".pt"):
             weights, ckpt = attempt_load_one_weight(model)
-            cfg = ckpt["model"].yaml
+            cfg = weights.yaml
         else:
             cfg = model
         self.model = self.get_model(cfg=cfg, weights=weights, verbose=RANK == -1)  # calls Model(cfg, weights)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -42,7 +42,6 @@ from ultralytics.utils.files import get_latest_run
 from ultralytics.utils.torch_utils import (
     EarlyStopping,
     ModelEMA,
-    de_parallel,
     init_seeds,
     one_cycle,
     select_device,
@@ -484,7 +483,7 @@ class BaseTrainer:
         ckpt = {
             "epoch": self.epoch,
             "best_fitness": self.best_fitness,
-            "model": deepcopy(de_parallel(self.model)).half(),
+            "model": None,
             "ema": deepcopy(self.ema.ema).half(),
             "updates": self.ema.updates,
             "optimizer": self.optimizer.state_dict(),

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -483,7 +483,7 @@ class BaseTrainer:
         ckpt = {
             "epoch": self.epoch,
             "best_fitness": self.best_fitness,
-            "model": None,
+            "model": None,  # resume and final checkpoints derive from EMA, deepcopy(de_parallel(self.model)).half()
             "ema": deepcopy(self.ema.ema).half(),
             "updates": self.ema.updates,
             "optimizer": self.optimizer.state_dict(),


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in model saving and configuration handling in Ultralytics training engine.

### 📊 Key Changes
- Removed `de_parallel` utility from imports, streamlining the library's dependencies.
- Changed how models are saved: now explicitly sets `"model"` to `None` in the checkpoint, emphasizing reliance on EMA (Exponential Moving Average) for model restoration.
- Adjusted model setup to derive configuration directly from weights rather than through checkpoint dictionary, simplifying the configuration process.

### 🎯 Purpose & Impact
- **Efficiency Boost:** Removing unnecessary utilities and streamlining saving processes makes the code cleaner and potentially faster. 🚀
- **Simplification:** By directly linking model configuration to weights and emphasizing EMA for checkpoints, this update simplifies the model restoration process for users, making it more intuitive. 🌐
- **User Experience:** These changes enhance user experience by making model saving and loading both more straightforward and more reliable, likely reducing common issues or confusion during these critical steps. 🛠️

This update is part of ongoing efforts to refine and optimize the Ultralytics framework, ensuring it remains at the forefront of efficiency, usability, and reliability in the AI and machine learning community. 🌟