### PR TITLE
Save optimizer as FP16 for smaller checkpoints

### DIFF
--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -115,6 +115,10 @@ keywords: Ultralytics, Torch Utils, Model EMA, Early Stopping, Smart Inference, 
 
 <br><br>
 
+## ::: ultralytics.utils.torch_utils.convert_optimizer_state_dict_to_fp16
+
+<br><br>
+
 ## ::: ultralytics.utils.torch_utils.profile
 
 <br><br>

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -521,7 +521,7 @@ class BaseTrainer:
         ckpt = None
         if str(model).endswith(".pt"):
             weights, ckpt = attempt_load_one_weight(model)
-            cfg = ckpt["model"].yaml
+            cfg = weights.yaml
         else:
             cfg = model
         self.model = self.get_model(cfg=cfg, weights=weights, verbose=RANK == -1)  # calls Model(cfg, weights)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -42,7 +42,6 @@ from ultralytics.utils.files import get_latest_run
 from ultralytics.utils.torch_utils import (
     EarlyStopping,
     ModelEMA,
-    de_parallel,
     init_seeds,
     one_cycle,
     select_device,
@@ -484,7 +483,7 @@ class BaseTrainer:
         ckpt = {
             "epoch": self.epoch,
             "best_fitness": self.best_fitness,
-            "model": deepcopy(de_parallel(self.model)).half(),
+            "model": None,
             "ema": deepcopy(self.ema.ema).half(),
             "updates": self.ema.updates,
             "optimizer": self.optimizer.state_dict(),

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -46,6 +46,7 @@ from ultralytics.utils.torch_utils import (
     one_cycle,
     select_device,
     strip_optimizer,
+    convert_optimizer_state_dict_to_fp16,
 )
 
 
@@ -486,7 +487,7 @@ class BaseTrainer:
             "model": None,  # resume and final checkpoints derive from EMA, deepcopy(de_parallel(self.model)).half()
             "ema": deepcopy(self.ema.ema).half(),
             "updates": self.ema.updates,
-            "optimizer": self.optimizer.state_dict(),
+            "optimizer": convert_optimizer_state_dict_to_fp16(deepcopy(self.optimizer.state_dict())),
             "train_args": vars(self.args),  # save as dict
             "train_metrics": metrics,
             "train_results": results,

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -483,7 +483,7 @@ class BaseTrainer:
         ckpt = {
             "epoch": self.epoch,
             "best_fitness": self.best_fitness,
-            "model": None,
+            "model": None,  # resume and final checkpoints derive from EMA, deepcopy(de_parallel(self.model)).half()
             "ema": deepcopy(self.ema.ema).half(),
             "updates": self.ema.updates,
             "optimizer": self.optimizer.state_dict(),

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -42,11 +42,11 @@ from ultralytics.utils.files import get_latest_run
 from ultralytics.utils.torch_utils import (
     EarlyStopping,
     ModelEMA,
+    convert_optimizer_state_dict_to_fp16,
     init_seeds,
     one_cycle,
     select_device,
     strip_optimizer,
-    convert_optimizer_state_dict_to_fp16,
 )
 
 
@@ -477,32 +477,37 @@ class BaseTrainer:
 
     def save_model(self):
         """Save model training checkpoints with additional metadata."""
+        import io
         import pandas as pd  # scope for faster startup
 
-        metrics = {**self.metrics, **{"fitness": self.fitness}}
-        results = {k.strip(): v for k, v in pd.read_csv(self.csv).to_dict(orient="list").items()}
-        ckpt = {
-            "epoch": self.epoch,
-            "best_fitness": self.best_fitness,
-            "model": None,  # resume and final checkpoints derive from EMA, deepcopy(de_parallel(self.model)).half()
-            "ema": deepcopy(self.ema.ema).half(),
-            "updates": self.ema.updates,
-            "optimizer": convert_optimizer_state_dict_to_fp16(deepcopy(self.optimizer.state_dict())),
-            "train_args": vars(self.args),  # save as dict
-            "train_metrics": metrics,
-            "train_results": results,
-            "date": datetime.now().isoformat(),
-            "version": __version__,
-            "license": "AGPL-3.0 (https://ultralytics.com/license)",
-            "docs": "https://docs.ultralytics.com",
-        }
+        # Serialize ckpt to a byte buffer once (faster than repeated torch.save() calls)
+        buffer = io.BytesIO()
+        torch.save(
+            {
+                "epoch": self.epoch,
+                "best_fitness": self.best_fitness,
+                "model": None,  # resume and final checkpoints derive from EMA
+                "ema": deepcopy(self.ema.ema).half(),
+                "updates": self.ema.updates,
+                "optimizer": convert_optimizer_state_dict_to_fp16(deepcopy(self.optimizer.state_dict())),
+                "train_args": vars(self.args),  # save as dict
+                "train_metrics": {**self.metrics, **{"fitness": self.fitness}},
+                "train_results": {k.strip(): v for k, v in pd.read_csv(self.csv).to_dict(orient="list").items()},
+                "date": datetime.now().isoformat(),
+                "version": __version__,
+                "license": "AGPL-3.0 (https://ultralytics.com/license)",
+                "docs": "https://docs.ultralytics.com",
+            },
+            buffer,
+        )
+        serialized_ckpt = buffer.getvalue()  # get the serialized content to save
 
-        # Save last and best
-        torch.save(ckpt, self.last)
+        # Save checkpoints
+        self.last.write_bytes(serialized_ckpt)  # save last.pt
         if self.best_fitness == self.fitness:
-            self.best.write_bytes(self.last.read_bytes())  # copy last.pt to best.pt
+            self.best.write_bytes(serialized_ckpt)  # save best.pt
         if (self.save_period > 0) and (self.epoch > 0) and (self.epoch % self.save_period == 0):
-            (self.wdir / f"epoch{self.epoch}.pt").write_bytes(self.last.read_bytes())  # copy last.pt to i.e. epoch3.pt
+            (self.wdir / f"epoch{self.epoch}.pt").write_bytes(serialized_ckpt)  # save epoch, i.e. 'epoch3.pt'
 
     @staticmethod
     def get_dataset(data):

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -507,8 +507,9 @@ def strip_optimizer(f: Union[str, Path] = "best.pt", s: str = "") -> None:
 
 def convert_optimizer_state_dict_to_fp16(state_dict):
     """
-    Converts the state_dict of a given optimizer to FP16, focusing on the 'state' key for tensor conversions. This
-    method aims to reduce storage size without altering 'param_groups' as they contain non-tensor data.
+    Converts the state_dict of a given optimizer to FP16, focusing on the 'state' key for tensor conversions.
+
+    This method aims to reduce storage size without altering 'param_groups' as they contain non-tensor data.
     """
     for state in state_dict["state"].values():
         for k, v in state.items():

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -509,11 +509,7 @@ def convert_optimizer_state_dict_to_fp16(state_dict):
     """
     Converts the state_dict of a given optimizer to FP16, focusing on the 'state' key for tensor conversions. This
     method aims to reduce storage size without altering 'param_groups' as they contain non-tensor data.
-
-    Note:
-        Key 'param_groups' contains hyperparameters and metadata which do not need conversion.
     """
-    # Convert all float tensors in the 'state' to FP16
     for state in state_dict["state"].values():
         for k, v in state.items():
             if isinstance(v, torch.Tensor) and v.dtype is torch.float32:

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -505,6 +505,23 @@ def strip_optimizer(f: Union[str, Path] = "best.pt", s: str = "") -> None:
     LOGGER.info(f"Optimizer stripped from {f},{f' saved as {s},' if s else ''} {mb:.1f}MB")
 
 
+def convert_optimizer_state_dict_to_fp16(state_dict):
+    """
+    Converts the state_dict of a given optimizer to FP16, focusing on the 'state' key for tensor conversions.
+    This method aims to reduce storage size without altering 'param_groups' as they contain non-tensor data.
+
+    Note:
+        Key 'param_groups' contains hyperparameters and metadata which do not need conversion.
+    """
+    # Convert all float tensors in the 'state' to FP16
+    for state in state_dict["state"].values():
+        for k, v in state.items():
+            if isinstance(v, torch.Tensor) and v.dtype is torch.float32:
+                state[k] = v.half()
+
+    return state_dict
+
+
 def profile(input, ops, n=10, device=None):
     """
     Ultralytics speed, memory and FLOPs profiler.

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -507,8 +507,8 @@ def strip_optimizer(f: Union[str, Path] = "best.pt", s: str = "") -> None:
 
 def convert_optimizer_state_dict_to_fp16(state_dict):
     """
-    Converts the state_dict of a given optimizer to FP16, focusing on the 'state' key for tensor conversions.
-    This method aims to reduce storage size without altering 'param_groups' as they contain non-tensor data.
+    Converts the state_dict of a given optimizer to FP16, focusing on the 'state' key for tensor conversions. This
+    method aims to reduce storage size without altering 'param_groups' as they contain non-tensor data.
 
     Note:
         Key 'param_groups' contains hyperparameters and metadata which do not need conversion.


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
A new feature for converting optimizer states to FP16 has been introduced, potentially reducing memory usage during model training.

### 📊 Key Changes
- **Documentation Update**: Added documentation for `convert_optimizer_state_dict_to_fp16` in the Torch Utilities section.
- **Code Enhancement**: Integrated `convert_optimizer_state_dict_to_fp16` into the model saving process in `trainer.py`, ensuring that the optimizer state is saved in FP16 format.
- **Function Implementation**: Introduced a new function `convert_optimizer_state_dict_to_fp16` in `torch_utils.py` to convert tensors within the optimizer state to FP16, aiming to reduce storage size without affecting the model's parameters.

### 🎯 Purpose & Impact
- **Reduced Model Checkpoint Size**: The conversion of optimizer state to FP16 helps in reducing the storage size of model checkpoints, making model management more efficient.
- **Efficient Training Process**: By storing optimizer states in FP16, memory usage during training could potentially be reduced, allowing for more efficient use of computational resources.
- **Maintained Training Precision**: The conversion focuses on optimizer states and preserves the precision of model parameters and training dynamics, ensuring that model performance is not compromised.

🔍 This update is crucial for developers and practitioners looking to optimize their training workflows, particularly those working with limited storage or memory capabilities.