### PR TITLE
Fix TensorRT inference issue on NVIDIA Jetson

### DIFF
--- a/docker/Dockerfile-jetson
+++ b/docker/Dockerfile-jetson
@@ -28,7 +28,7 @@ RUN grep -v "opencv-python" pyproject.toml > temp.toml && mv temp.toml pyproject
 
 # Install pip packages manually for TensorRT compatibility https://github.com/NVIDIA/TensorRT/issues/2567
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache tqdm matplotlib pyyaml psutil pandas onnx "numpy==1.23"
+RUN pip install --no-cache tqdm matplotlib pyyaml psutil pandas onnx
 RUN pip install --no-cache -e .
 
 # Set environment variables

--- a/docker/Dockerfile-jetson
+++ b/docker/Dockerfile-jetson
@@ -29,7 +29,7 @@ RUN grep -v "opencv-python" pyproject.toml > temp.toml && mv temp.toml pyproject
 # Install pip packages manually for TensorRT compatibility https://github.com/NVIDIA/TensorRT/issues/2567
 RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache tqdm matplotlib pyyaml psutil pandas onnx
-RUN pip install --no-cache -e .
+RUN pip install --no-cache -e ".[export]"
 
 # Set environment variables
 ENV OMP_NUM_THREADS=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ export = [
     "openvino>=2024.0.0", # OpenVINO export
     "tensorflow<=2.13.1; python_version <= '3.11'", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0; python_version <= '3.11'", # TF.js export, automatically installs tensorflow
+    "numpy==1.23.5; platform_machine == 'aarch64'", # Fix error: `np.bool` was a deprecated alias for the builtin `bool` when using TensorRT models on NVIDIA Jetson
 ]
 explorer = [
     "lancedb", # vector search


### PR DESCRIPTION
We need to downgrade numpy to v1.23.5 to fix a potential issue when inferencing TensorRT exported models on NVIDIA Jetson platform. I have applied the fix globally.

```sh
nvidia@nvidia-desktop:~$ yolo detect predict model=yolov8l.engine source="0"
Ultralytics YOLOv8.1.40 🚀 Python-3.8.10 torch-2.1.0a0+41361538.nv23.06 CUDA:0 (Orin, 15503MiB)
Loading yolov8l.engine for TensorRT inference...
[04/02/2024-00:13:14] [TRT] [I] Loaded engine size: 168 MiB
[04/02/2024-00:13:15] [TRT] [I] [MemUsageChange] Init cuDNN: CPU +616, GPU +584, now: CPU 1164, GPU 5393 (MiB)
[04/02/2024-00:13:15] [TRT] [I] [MemUsageChange] TensorRT-managed allocation in engine deserialization: CPU +0, GPU +167, now: CPU 0, GPU 167 (MiB)
[04/02/2024-00:13:15] [TRT] [I] [MemUsageChange] Init cuDNN: CPU +1, GPU +0, now: CPU 997, GPU 5236 (MiB)
[04/02/2024-00:13:15] [TRT] [I] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +93, now: CPU 0, GPU 260 (MiB)
/usr/lib/python3.8/dist-packages/tensorrt/__init__.py:166: FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.
  bool: np.bool,
Traceback (most recent call last):
  File "/home/nvidia/.local/bin/yolo", line 8, in <module>
    sys.exit(entrypoint())
  File "/home/nvidia/ultralytics/ultralytics/cfg/__init__.py", line 582, in entrypoint
    getattr(model, mode)(**overrides)  # default args from model
  File "/home/nvidia/ultralytics/ultralytics/engine/model.py", line 444, in predict
    self.predictor.setup_model(model=self.model, verbose=is_cli)
  File "/home/nvidia/ultralytics/ultralytics/engine/predictor.py", line 297, in setup_model
    self.model = AutoBackend(
  File "/home/nvidia/.local/lib/python3.8/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/nvidia/ultralytics/ultralytics/nn/autobackend.py", line 244, in __init__
    dtype = trt.nptype(model.get_binding_dtype(i))
  File "/usr/lib/python3.8/dist-packages/tensorrt/__init__.py", line 166, in nptype
    bool: np.bool,
  File "/home/nvidia/.local/lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

```

_I have read the CLA Document and I hereby sign the CLA_


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of NVIDIA Jetson compatibility and streamlined installation for deep learning dependencies.

### 📊 Key Changes
- **Updated Dockerfile for NVIDIA Jetson:** Specific versions of numpy are now only enforced for Jetson devices to ensure compatibility with TensorRT.
- **Refined Installation Requirements:** The installation process within the Dockerfile has been streamlined by grouping additional dependencies under the ".[export]" tag.
- **PyProject.toml Adjustments:** Added a numpy version specification for aarch64 platforms, directly addressing a known compatibility issue with TensorRT on Jetson devices.

### 🎯 Purpose & Impact
- 🚀 **Enhanced Compatibility**: Ensures that deep learning models run smoothly on NVIDIA Jetson devices by fixing a known numpy issue.
- 🛠 **Simplified Setup**: Streamlines the setup process for developers, making it easier to get started with deploying models on various platforms.
- 💾 **Future-Proofing**: By specifying dependency versions, the PR aims to minimize future compatibility issues, enhancing the user experience for both developers and end-users deploying AI models on NVIDIA's Jetson platform.