### PR TITLE
fix AttributeError: 'NoneType' object has no attribute 'encoding' error from ultralytics\utils_init_.py line 238, in set_logging

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -236,7 +236,7 @@ def set_logging(name=LOGGING_NAME, verbose=True):
 
     # Configure the console (stdout) encoding to UTF-8
     formatter = logging.Formatter("%(message)s")  # Default formatter
-    if WINDOWS and sys.stdout.encoding != "utf-8":
+    if WINDOWS and sys.stdout and sys.stdout.encoding != "utf-8":
         try:
             if hasattr(sys.stdout, "reconfigure"):
                 sys.stdout.reconfigure(encoding="utf-8")


### PR DESCRIPTION
it will throw error when there is no stdout console ,
File "ultralytics\utils_init_.py", line 238, in set_logging
AttributeError: 'NoneType' object has no attribute 'encoding'

_I have read the CLA Document and I hereby sign the CLA_


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced console logging compatibility for Windows environments. 🖥️✨

### 📊 Key Changes
- Added a check to ensure `sys.stdout` exists before assessing its encoding, specifically targeting Windows systems.

### 🎯 Purpose & Impact
- **Purpose:** Prevents potential errors in Windows by adding a safety check before attempting to reconfigure console encoding to UTF-8. This change ensures that operations involving console outputs work more reliably on Windows platforms.
- **Impact:** Users running Ultralytics software on Windows should experience fewer issues related to character encoding in console outputs, leading to a smoother and more consistent experience across different operating systems. 🌍🔄🛠️