### PR TITLE
Fix proc_device_model name for NVIDIA Jetson

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -498,7 +498,7 @@ def is_jetson() -> bool:
     Returns:
         (bool): True if running on a Jetson Nano or Jetson Orin, False otherwise.
     """
-    return "Jetson" in PROC_DEVICE_MODEL  # i.e. "Jetson Nano" or "Jetson Orin"
+    return "NVIDIA" in PROC_DEVICE_MODEL  # i.e. "NVIDIA Jetson Nano" or "NVIDIA Jetson Orin"
 
 
 def is_online() -> bool:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -498,7 +498,7 @@ def is_jetson() -> bool:
     Returns:
         (bool): True if running on a Jetson Nano or Jetson Orin, False otherwise.
     """
-    return "NVIDIA" in PROC_DEVICE_MODEL  # i.e. "NVIDIA Jetson Nano" or "NVIDIA Jetson Orin"
+    return "NVIDIA" in PROC_DEVICE_MODEL  # i.e. "NVIDIA Jetson Nano" or "NVIDIA Orin NX"
 
 
 def is_online() -> bool:


### PR DESCRIPTION
The output of `cat /proc/device-tree/model` in Jetson Nano will be `NVIDIA Jetson Nano Developer Kit`. However, for Jetson Orin such as the Orin NX I have here, the output will be as follows:

```sh
nvidia@nvidia-desktop:~$ cat /proc/device-tree/model
NVIDIA Orin NX Developer Kit
```

So we will need to change `Jetson` to `NVIDIA`. Eventhough we change this to NVIDIA, this will not affect the X86-based PC with NVIDIA GPUs because they do not have this  `/proc/device-tree/model` to begin with.

_I have read the CLA Document and I sign the CLA_

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced device recognition for NVIDIA Jetson platforms in Ultralytics software.

### 📊 Key Changes
- Updated the device detection logic to recognize NVIDIA Jetson devices by searching for "NVIDIA" in the device model name instead of "Jetson".

### 🎯 Purpose & Impact
- **Improved Accuracy**: Ensures more accurate detection of NVIDIA Jetson Nano and NVIDIA Orin NX devices. This change reflects the full device model names, enhancing compatibility.
- **Wider Reach**: By aligning with actual device model names including "NVIDIA," this update potentially supports a broader range of NVIDIA devices, not just the Jetson series, improving the utility and versatility of the Ultralytics software on NVIDIA hardware.
- **User Experience**: For users running Ultralytics software on NVIDIA hardware, this update ensures smoother setup and operation by accurately recognizing their devices, leading to optimized performance and fewer configuration issues.