### PR TITLE
Attempt PNNX pin to resolve NCNN bug

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -530,11 +530,12 @@ class Exporter:
             )
             system = "macos" if MACOS else "windows" if WINDOWS else "linux-aarch64" if ARM64 else "linux"
             try:
+                assert False  # bug in latest PNNX/NCNN release
                 _, assets = get_github_assets(repo="pnnx/pnnx", retry=True)
                 url = [x for x in assets if f"{system}.zip" in x][0]
             except Exception as e:
                 url = f"https://github.com/pnnx/pnnx/releases/download/20240226/pnnx-20240226-{system}.zip"
-                LOGGER.warning(f"{prefix} WARNING ⚠️ PNNX GitHub assets not found: {e}, using default {url}")
+                # LOGGER.warning(f"{prefix} WARNING ⚠️ PNNX GitHub assets not found: {e}, using default {url}")
             asset = attempt_download_asset(url, repo="pnnx/pnnx", release="latest")
             if check_is_path_safe(Path.cwd(), asset):  # avoid path traversal security vulnerability
                 unzip_dir = Path(asset).with_suffix("")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment in model exporting to NCNN due to a bug in the latest PNNX/NCNN release.

### 📊 Key Changes
- Inserted an assertion to deliberately fail the export process because of a known bug in the latest PNNX/NCNN release.
- Commented out a previously active warning about missing GitHub assets for PNNX, likely because the bug renders this step irrelevant for now.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: The changes aim to temporarily avoid an issue with the latest version of PNNX/NCNN by preventing the export process from proceeding under conditions known to currently fail.
- 🚀 **Impact**: Users trying to export models to NCNN will face an explicit block due to this newly inserted assertion. This is intended to prevent potential errors or issues stemming from the known bug in the latest PNNX/NCNN release until a fix is provided.
- 🛠 **Developer Insight**: Developers and users are temporarily directed away from using a possibly flawed export process, ensuring stability and reliability in the face of external library issues.