### PR TITLE
Fix increment `+=2` bug in object_counter.py

### DIFF
--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -224,7 +224,7 @@ class ObjectCounter:
 
                             if (box[0] - prev_position[0]) * (self.counting_region.centroid.x - prev_position[0]) > 0:
                                 self.in_counts += 1
-                                self.class_wise_count[self.names[cls]]["in"] += 2
+                                self.class_wise_count[self.names[cls]]["in"] += 1
                             else:
                                 self.out_counts += 1
                                 self.class_wise_count[self.names[cls]]["out"] += 1


### PR DESCRIPTION
In case of count by "line points" its adding 2 in counter by each passing object instead of adding 1 in value. Updated to resolve the issue. Issue raised on docs page as well. Video Reference for false output:- https://bit.ly/obj_count_wrong

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced accuracy in object counting within counting regions.

### 📊 Key Changes
- Corrected the increment of `in` count in the class-wise count from 2 to 1 for object tracking.

### 🎯 Purpose & Impact
- **Purpose:** This change aims to fix an error in the counting logic where objects entering a specified region were being counted twice instead of just once. By adjusting the increment from 2 to 1, the counting now accurately reflects the number of objects entering the region.
- **Impact:** Users deploying object counting solutions will experience more precise and reliable count metrics, leading to improved analytics and decision-making based on the count data. This can significantly enhance the utility of applications in various sectors, including retail, transportation, and surveillance, by providing more accurate people or object flow statistics. 📈