### PR TITLE
Fix `overrides` training cfg bug

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -647,7 +647,7 @@ class Model(nn.Module):
             else self.overrides
         )
         # NOTE: handle the case when 'cfg' includes 'data'.
-        overrides["data"] = overrides["data"] or DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task] 
+        overrides["data"] = overrides["data"] or DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task]
         args = {**overrides, **kwargs, "mode": "train"}  # highest priority args on the right
         if args.get("resume"):
             args["resume"] = self.ckpt_path

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -640,15 +640,14 @@ class Model(nn.Module):
 
         checks.check_pip_update_available()
 
-        overrides = (
-            # 'model' and 'task' from model loading/creating have higher priority
-            {**yaml_load(checks.check_yaml(kwargs["cfg"])), "model": self.overrides["model"], "task": self.task}
-            if kwargs.get("cfg")
-            else self.overrides
-        )
-        # NOTE: handle the case when 'cfg' includes 'data'.
-        overrides["data"] = overrides.get("data") or DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task]
-        args = {**overrides, **kwargs, "mode": "train"}  # highest priority args on the right
+        overrides = yaml_load(checks.check_yaml(kwargs["cfg"])) if kwargs.get("cfg") else self.overrides
+        custom = {
+            # NOTE: handle the case when 'cfg' includes 'data'.
+            "data": overrides.get("data") or DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task],
+            "model": self.overrides["model"],
+            "task": self.task,
+        }
+        args = {**overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
         if args.get("resume"):
             args["resume"] = self.ckpt_path
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -646,7 +646,7 @@ class Model(nn.Module):
             "data": overrides.get("data") or DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task],
             "model": self.overrides["model"],
             "task": self.task,
-        }
+        }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
         if args.get("resume"):
             args["resume"] = self.ckpt_path

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -647,7 +647,7 @@ class Model(nn.Module):
             else self.overrides
         )
         # NOTE: handle the case when 'cfg' includes 'data'.
-        overrides["data"] = overrides["data"] or DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task]
+        overrides["data"] = overrides.get("data") or DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task]
         args = {**overrides, **kwargs, "mode": "train"}  # highest priority args on the right
         if args.get("resume"):
             args["resume"] = self.ckpt_path

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -639,8 +639,18 @@ class Model(nn.Module):
             kwargs = self.session.train_args  # overwrite kwargs
 
         checks.check_pip_update_available()
-
-        overrides = yaml_load(checks.check_yaml(kwargs["cfg"])) if kwargs.get("cfg") else self.overrides
+        # Check if a new cfg is provided, if so, load and merge it
+        if 'cfg' in kwargs and kwargs['cfg']:
+            new_config_path = kwargs['cfg']
+            # Use the check_yaml function to ensure the configuration file is valid
+            new_overrides = yaml_load(checks.check_yaml(new_config_path))
+            # Merge configurations: first copy the old ones, then update with the new ones
+            merged_overrides = {**self.overrides, **new_overrides}
+            self.overrides = merged_overrides
+        else:
+            # If no new cfg is provided, retain the current overrides
+            self.overrides = self.overrides
+        overrides = self.overrides
         custom = {"data": DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task]}  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
         if args.get("resume"):

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -640,8 +640,8 @@ class Model(nn.Module):
 
         checks.check_pip_update_available()
         # Check if a new cfg is provided, if so, load and merge it
-        if 'cfg' in kwargs and kwargs['cfg']:
-            new_config_path = kwargs['cfg']
+        if "cfg" in kwargs and kwargs["cfg"]:
+            new_config_path = kwargs["cfg"]
             # Use the check_yaml function to ensure the configuration file is valid
             new_overrides = yaml_load(checks.check_yaml(new_config_path))
             # Merge configurations: first copy the old ones, then update with the new ones


### PR DESCRIPTION
## Pull Request Overview

This PR addresses a bug related to configuration overrides in the training code of the YOLO model within the `ultralytics` framework. The issue was identified during routine training operations and stems from the improper handling of the `overrides` dictionary, which could potentially lead to missing critical model parameters during training sessions.

### Background

While working with the YOLO model, instantiated from the `ultralytics.engine.model` class, I observed that model parameters could be lost during the configuration merging process. This realization came about during a deep dive into how the `ultralytics.engine.model` module initializes and loads models.

### Issue Description

Here is a succinct breakdown of the problematic behavior observed:

1. **Model Initialization**:
   - Models are typically loaded using `model = YOLO('models/pretrained/yolov8s-cls.pt')`, which relies on the underlying mechanism provided by `ultralytics.engine.model.py`.
   - The model initialization either loads a new YOLO model if the file extension is `.yaml` or `.yml` or proceeds to load an existing model with methods like `_load`.

2. **Model Configuration Handling**:
   - During the initialization (`_load`), `overrides` which include important model parameters like model path and task, are set.
   - However, if a new configuration is supplied (`cfg` parameter), the existing `overrides` dictionary is completely replaced by the new configuration without merging the important existing parameters.

3. **Consequences**:
   - This replacement causes the loss of crucial model parameters, such as the model path (`model`) and the task type (`task`), which are vital for the model’s training operations.
   - As a result, subsequent training operations do not have access to these essential parameters, leading to potential failures or incorrect behaviors.

### Solution

The proposed fix involves modifying the configuration merging process to ensure that any new configurations are merged with existing ones rather than replacing them outright. This preserves all necessary parameters and ensures stable and reliable model training operations.

### Technical Details

```markdown
My training code is as follows:

```python
new_config_path = create_new_config_file(args.config_dir, config)
if args.resume:
    model = YOLO(args.resume)
else:
    model = YOLO('models/pretrained/yolov8s-cls.pt')
model.train(
    data=args.dataset_dir,
    epochs=1000,
    # freeze=5,
    batch=256,
    device=[0, 1, 2, 3],
    # device=[1],
    imgsz=224,
    cache='disk',
    val=False,
    workers=5,
    cfg=new_config_path,
    name=args.timestamp,
)
```

In this code, I first load the model using `model = YOLO('models/pretrained/yolov8s-cls.pt')`. At this point, the `model` object is actually a class `YOLO(Model)`, which inherits from `from ultralytics.engine.model import Model`.

Then, I explored the `ultralytics.engine.model`, which certainly requires initialization. I found that it initializes here in `ultralytics/engine/model.py` with the following content:

```python
# Load or create new YOLO model
if Path(model).suffix in {".yaml", ".yml"}:
    self._new(model, task=task, verbose=verbose)
else:
    self._load(model, task=task)
```

Specifically, this line: `self._load(model, task=task)`.

The initialization process of the `load` method is detailed in `ultralytics/engine/model.py` as follows:
`weights` here is actully something like `models/pretrained/yolov8s-cls.pt`
```python
def _load(self, weights: str, task=None) -> None:
    """
    Initializes a new model and infers the task type from the model head.

    Args:
        weights (str): model checkpoint to be loaded
        task (str | None): model task
    """
    if weights.lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")):
        weights = checks.check_file(weights)  # automatically download and return local filename
    weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolov8n -> yolov8n.pt

    if Path(weights).suffix == ".pt":
        print(Path(weights))
        self.model, self.ckpt = attempt_load_one_weight(weights)
        self.task = self.model.args["task"]
        self.overrides = self.model.args = self._reset_ckpt_args(self.model.args)
        self.ckpt_path = self.model.pt_path
        
    else:
        weights = checks.check_file(weights)  # runs in all cases, not redundant with above call
        self.model, self.ckpt = weights, None
        self.task = task or guess_model_task(weights)
        self.ckpt_path = weights
    self.overrides["model"] = weights
    self.overrides["task"] = self.task
    self.model_name = weights
```

As you can see, this process updates the `overrides` dictionary and includes the `model` parameter, which is actually the path `models/pretrained/yolov8s-cls.pt` from `model = YOLO('models/pretrained/yolov8s-cls.pt')`. However, following the original code in `ultralytics/engine/model.py`:

```python
overrides = yaml_load(checks.check_yaml(kwargs["cfg"])) if kwargs.get("cfg") else self.overrides
```

Replacing it directly like this would lead to the loss of parameters, specifically the recently created `self.overrides["model"]` and `self.overrides["task"]`. This would cause issues when calling the trainer later on:

```python
custom = {"data": DEFAULT_CFG_DICT["data"] or TASK2DATA[self.task]}  # method defaults
args = {**overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
if args.get("resume"):
    args["resume"] = self.ckpt_path

self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
```

This results in the loss of the model's name, ultimately causing an issue where `str(self.model)` unexpectedly becomes `None`. Therefore, I have fixed this bug.
`ultralytics/models/yolo/classify/train.py`
```python
def setup_model(self):
    """Load, create or download model for any task."""
    import torchvision  # scope for faster 'import ultralytics'

    if isinstance(self.model, torch.nn.Module):  # if model is loaded beforehand. No setup needed
        return
    model, ckpt = str(self.model), None
    print(model, ckpt)
    # HERE WILL ALWAYS BE (None, None)!!! 
    if model.endswith(".pt"):
        self.model, ckpt = attempt_load_one_weight(model, device="cpu")
        for p in self.model.parameters():
            p.requires_grad = True  # for training
    elif model.split(".")[-1] in {"yaml", "yml"}:
        self.model = self.get_model(cfg=model)
    elif model in torchvision.models.__dict__:
        self.model = torchvision.models.__dict__[model](weights="IMAGENET1K_V1" if self.args.pretrained else None)
    else:
        raise FileNotFoundError(f"ERROR: model={model} not found locally or online. Please check model name.")
    ClassificationModel.reshape_outputs(self.model, self.data["nc"])

    return ckpt
```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced configuration handling in training method.

### 📊 Key Changes
- The training method now efficiently manages configurations sourced from multiple inputs (e.g., default settings, task-specifications, and direct user inputs).
- Introduction of a more comprehensive handling of the `data`, `model`, and `task` configuration parameters, ensuring that user-defined settings (`cfg`) take precedence if provided.

### 🎯 Purpose & Impact
- **Purpose**: To streamline the process of configuring model training, making it more intuitive and flexible for the users. These changes aim to minimize configuration errors and make the codebase more adaptable to different scenarios.
- **Impact**: Users will experience a more seamless and error-resistant setup process for training their models. This update ensures that training configurations are more predictable and user-friendly, potentially leading to improved user satisfaction and better model performance outcomes. 🚀