### PR TITLE
Allow TensorRT inference without metadata

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -234,8 +234,11 @@ class AutoBackend(nn.Module):
             logger = trt.Logger(trt.Logger.INFO)
             # Read file
             with open(w, "rb") as f, trt.Runtime(logger) as runtime:
-                meta_len = int.from_bytes(f.read(4), byteorder="little")  # read metadata length
-                metadata = json.loads(f.read(meta_len).decode("utf-8"))  # read metadata
+                try:
+                    meta_len = int.from_bytes(f.read(4), byteorder="little")  # read metadata length
+                    metadata = json.loads(f.read(meta_len).decode("utf-8"))  # read metadata
+                except UnicodeDecodeError:
+                    f.seek(0)
                 model = runtime.deserialize_cuda_engine(f.read())  # read engine
 
             # Model context

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -238,7 +238,7 @@ class AutoBackend(nn.Module):
                     meta_len = int.from_bytes(f.read(4), byteorder="little")  # read metadata length
                     metadata = json.loads(f.read(meta_len).decode("utf-8"))  # read metadata
                 except UnicodeDecodeError:
-                    f.seek(0)
+                    f.seek(0)  # engine file may lack embedded Ultralytics metadata
                 model = runtime.deserialize_cuda_engine(f.read())  # read engine
 
             # Model context


### PR DESCRIPTION
Allow manually exported tensorrt engine to run with python inference code.


Exporting to engine format without yolo export command cause the inference mode to fail.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling for metadata decoding in AI model loading 🛠️✨

### 📊 Key Changes
- Added exception handling for `UnicodeDecodeError` when reading metadata from a model file.
- In cases where metadata cannot be decoded, the reading process is reset to start, allowing the model to load without metadata.

### 🎯 Purpose & Impact
- **Enhances Robustness:** Prevents crashes due to decoding errors when loading models, especially when metadata is absent or corrupted. 🚫💥
- **Improves Compatibility:** Allows the loading of model files even if they lack Ultralytics-specific metadata, broadening the range of models that can be used without modification. 🔄↔️
- **User Experience:** Users will experience fewer interruptions due to loading errors, making model deployment smoother and more reliable. 🚀👨‍💻👩‍💻

This update makes the model loading process more forgiving and versatile, ensuring that a wider variety of models can be used seamlessly within the Ultralytics framework.