### PR TITLE
Reboot RPi CI to fix an issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -236,20 +236,20 @@ jobs:
           python3.11 -m venv env
           source env/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
-      - name: Install requirements
-        run: |
-          python -m pip install --upgrade pip wheel
-          pip install -e . pytest mlflow pycocotools "ray[tune]<=2.9.3" --extra-index-url https://download.pytorch.org/whl/cpu
-      - name: Check environment
-        run: |
-          yolo checks
-          pip list
+      # - name: Install requirements
+      #   run: |
+      #     python -m pip install --upgrade pip wheel
+      #     pip install -e . pytest mlflow pycocotools "ray[tune]<=2.9.3" --extra-index-url https://download.pytorch.org/whl/cpu
+      # - name: Check environment
+      #   run: |
+      #     yolo checks
+      #     pip list
       # - name: Pytest tests
       #   run: |
       #     pytest --slow tests/
       - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
         run: |
-          (sleep 10 ; sudo reboot) &
+          sudo bash -c "sleep 10; reboot" &
 
   Conda:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,7 +249,7 @@ jobs:
           pytest --slow tests/
       - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
         run: |
-          (sleep 10 && sudo reboot) &
+          (sleep 10 ; sudo reboot) &
 
   Conda:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -236,17 +236,17 @@ jobs:
           python3.11 -m venv env
           source env/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
-      # - name: Install requirements
-      #   run: |
-      #     python -m pip install --upgrade pip wheel
-      #     pip install -e . pytest mlflow pycocotools "ray[tune]<=2.9.3" --extra-index-url https://download.pytorch.org/whl/cpu
-      # - name: Check environment
-      #   run: |
-      #     yolo checks
-      #     pip list
-      # - name: Pytest tests
-      #   run: |
-      #     pytest --slow tests/
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -e . pytest mlflow pycocotools "ray[tune]<=2.9.3" --extra-index-url https://download.pytorch.org/whl/cpu
+      - name: Check environment
+        run: |
+          yolo checks
+          pip list
+      - name: Pytest tests
+        run: |
+          pytest --slow tests/
       - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
         run: |
           sudo bash -c "sleep 10; reboot" &

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,6 +247,9 @@ jobs:
       - name: Pytest tests
         run: |
           pytest --slow tests/
+      - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
+        run: |
+          sudo reboot
 
   Conda:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,7 +249,7 @@ jobs:
           pytest --slow tests/
       - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
         run: |
-          sudo reboot
+          (sleep 10 && sudo reboot) &
 
   Conda:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,9 +244,9 @@ jobs:
         run: |
           yolo checks
           pip list
-      - name: Pytest tests
-        run: |
-          pytest --slow tests/
+      # - name: Pytest tests
+      #   run: |
+      #     pytest --slow tests/
       - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
         run: |
           sudo bash -c "sleep 10; reboot" &

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,7 +226,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 60
     runs-on: raspberry-pi
     steps:
@@ -249,7 +249,9 @@ jobs:
           pytest --slow tests/
       - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
         run: |
-          sudo bash -c "sleep 10; reboot" &
+          # sudo bash -c "sleep 10; reboot" &
+          sleep 10
+          sudo reboot
 
   Conda:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,9 +244,9 @@ jobs:
         run: |
           yolo checks
           pip list
-      # - name: Pytest tests
-      #   run: |
-      #     pytest --slow tests/
+      - name: Pytest tests
+        run: |
+          pytest --slow tests/
       - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
         run: |
           sudo bash -c "sleep 10; reboot" &

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,9 +244,9 @@ jobs:
         run: |
           yolo checks
           pip list
-      - name: Pytest tests
-        run: |
-          pytest --slow tests/
+      # - name: Pytest tests
+      #   run: |
+      #     pytest --slow tests/
       - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
         run: |
           (sleep 10 ; sudo reboot) &

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,7 +226,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 60
     runs-on: raspberry-pi
     steps:
@@ -247,11 +247,8 @@ jobs:
       - name: Pytest tests
         run: |
           pytest --slow tests/
-      - name: Reboot # this is needed to clear hardware resources in the next run or else CI will hault in the middle
-        run: |
-          # sudo bash -c "sleep 10; reboot" &
-          sleep 10
-          sudo reboot
+      - name: Reboot # run a reboot command in the background to free resources for next run and not crash main thread
+        run: sudo bash -c "sleep 10; reboot" &
 
   Conda:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')


### PR DESCRIPTION
We need to reboot the RPi CI after doing Tests to clear up the hardware resources or otherwise Tests will hault in the middle in the next run

I have added a sleep or else Post Run Checkout will cancel if we do a normal reboot.

@glenn-jocher 



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CI Pipeline Stability with Scheduled Reboots 🔄

### 📊 Key Changes
- **Reboot Step Added:** A new step in the Continuous Integration (CI) pipeline to execute a reboot command after running Pytest tests.

### 🎯 Purpose & Impact
- **Purpose:** To clear hardware resources effectively before the next run, addressing issues where the CI could halt mid-process due to exhausted resources.
- **Impact:** Should improve the reliability and performance of the CI pipeline, ensuring smoother development workflows and faster integration times for developers and contributors to the Ultralytics project. Expect a more stable testing environment with less downtime.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in GitHub Actions workflow for resource management 🔄

### 📊 Key Changes
- Added a command to reboot the system after the Pytest tests are complete in the CI workflow.

### 🎯 Purpose & Impact
- **Purpose:** The main goal of adding a reboot command is to free up resources after tests are run. This helps in ensuring that the system is fresh for the next round of tests, preventing potential crashes due to resource exhaustion.
- **Impact:** Users can expect more stable and reliable test runs in the CI pipeline, leading to faster integration and fewer delays due to system instability. This tweak benefits both developers, by making CI processes smoother, and users, by potentially speeding up the cadence of stable releases.