### PR TITLE
Update Tests for `coremltools==7.2`

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -222,6 +222,7 @@ def test_export_openvino():
     YOLO(f)(SOURCE)  # exported model inference
 
 
+@pytest.mark.skipif(not TORCH_1_9, reason="CoreML>=7.2 not supported on PyTorch<=1.8")
 @pytest.mark.skipif(WINDOWS, reason="CoreML not supported on Windows")  # RuntimeError: BlobWriter not loaded
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="CoreML not supported on Raspberry Pi")
 @pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="CoreML not supported in Python 3.12")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -222,7 +222,7 @@ def test_export_openvino():
     YOLO(f)(SOURCE)  # exported model inference
 
 
-@pytest.mark.skipif(not TORCH_1_9, reason="CoreML>=7.2 not supported on PyTorch<=1.8")
+@pytest.mark.skipif(not TORCH_1_9, reason="CoreML>=7.2 not supported with PyTorch<=1.8")
 @pytest.mark.skipif(WINDOWS, reason="CoreML not supported on Windows")  # RuntimeError: BlobWriter not loaded
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="CoreML not supported on Raspberry Pi")
 @pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="CoreML not supported in Python 3.12")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved test compatibility for CoreML export with specific PyTorch versions.

### 📊 Key Changes
- Added a condition to skip CoreML export tests if PyTorch version is ≤1.8.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: Ensures that the test suite does not fail for users with PyTorch versions that are not compatible with CoreML≥7.2, improving the testing process's overall reliability.
- 🛠 **Impact**: Developers working with PyTorch ≤1.8 will see these tests skipped, preventing unnecessary test failures and making it clearer which environments are supported for CoreML exports. This helps in focusing on compatibility and support for the most relevant and up-to-date technology stacks.