### PR TITLE
Revert flatbuffers in [export]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ export = [
     "openvino>=2024.0.0", # OpenVINO export
     "tensorflow<=2.13.1; python_version <= '3.11'", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0; python_version <= '3.11'", # TF.js export, automatically installs tensorflow
-    # "flatbuffers>=23.5.26,<100", # update old 'flatbuffers' included inside tensorflow package: WARNING Dockerfile error https://github.com/ultralytics/ultralytics/actions/runs/8715942435/job/23908971614
+    "flatbuffers>=23.5.26,<100", # update old 'flatbuffers' included inside tensorflow package: WARNING Dockerfile error https://github.com/ultralytics/ultralytics/actions/runs/8715942435/job/23908971614
     "numpy==1.23.5; platform_machine == 'aarch64'", # fix error: `np.bool` was a deprecated alias for the builtin `bool` when using TensorRT models on NVIDIA Jetson
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ export = [
     "openvino>=2024.0.0", # OpenVINO export
     "tensorflow<=2.13.1; python_version <= '3.11'", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0; python_version <= '3.11'", # TF.js export, automatically installs tensorflow
-    "flatbuffers>=23.5.26,<100", # update old 'flatbuffers' included inside tensorflow package: WARNING Dockerfile error https://github.com/ultralytics/ultralytics/actions/runs/8715942435/job/23908971614
+    "flatbuffers>=23.5.26,<100", # update old 'flatbuffers' included inside tensorflow package
     "numpy==1.23.5; platform_machine == 'aarch64'", # fix error: `np.bool` was a deprecated alias for the builtin `bool` when using TensorRT models on NVIDIA Jetson
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
 ]


### PR DESCRIPTION
I have tested running only Push (Dockerfile, latest, linux/amd64) and it works now.
@glenn-jocher 

https://github.com/ultralytics/ultralytics/actions/runs/8803839325

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Integration of newer `flatbuffers` package version support in dependency management.

### 📊 Key Changes
- Uncomments and thus re-enables the previously commented line concerning the `flatbuffers` version constraint. 
- Ensures the `flatbuffers` package is set to versions between 23.5.26 and anything less than 100. 

### 🎯 Purpose & Impact
- 🚀 **Purpose**: The change aims to update the `flatbuffers` dependency to avoid conflicts and issues with TensorFlow packaging related to `flatbuffers`. By doing so, it ensures compatibility and stability in TensorFlow exports.
- ⚙️ **Impact**: Users might experience improved performance and fewer errors when working with TensorFlow exports. This change mainly affects developers relying on TensorFlow or TensorFlow.js for their projects, especially when exporting models.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded dependencies in the Ultralytics project for better performance and compatibility.

### 📊 Key Changes
- Re-enabled the use of `flatbuffers>=23.5.26,<100` to fix issues with outdated dependencies within the TensorFlow package.
- Maintained specific versions of `numpy` and `h5py` for `aarch64` platforms to address compatibility and build issues.

### 🎯 Purpose & Impact
- **Enhancing Compatibility:** By updating `flatbuffers`, the project aims to mitigate any potential issues caused by outdated dependencies, ensuring smoother operation and compatibility with TensorFlow. This could lead to more stable model exports and fewer errors for users exporting models to different formats.
- **Targeted Platform Support:** The explicit mention of versions for `numpy` and `h5py` on `aarch64` platforms (like NVIDIA Jetson) is designed to prevent common errors encountered in these environments. This ensures that developers working on these platforms experience fewer obstacles, promoting a more inclusive and accessible tool for a wider range of hardware.
  
Overall, these changes are expected to improve the reliability and user experience of the Ultralytics platform, particularly for those involved in model exportation and deployment on diverse platforms. 💪🚀