### PR TITLE
Update predict.md to add .obb result prop

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -69,6 +69,7 @@ Ultralytics YOLO models return either a Python list of `Results` objects, or a m
             masks = result.masks  # Masks object for segmentation masks outputs
             keypoints = result.keypoints  # Keypoints object for pose outputs
             probs = result.probs  # Probs object for classification outputs
+            obb = result.obb  # Oriented boxes object for OBB outputs
             result.show()  # display to screen
             result.save(filename='result.jpg')  # save to disk
         ```
@@ -87,10 +88,10 @@ Ultralytics YOLO models return either a Python list of `Results` objects, or a m
         # Process results generator
         for result in results:
             boxes = result.boxes  # Boxes object for bounding box outputs
-            obb = result.obb  # Oriented boxes object for obb outputs
             masks = result.masks  # Masks object for segmentation masks outputs
             keypoints = result.keypoints  # Keypoints object for pose outputs
             probs = result.probs  # Probs object for classification outputs
+            obb = result.obb  # Oriented boxes object for OBB outputs
             result.show()  # display to screen
             result.save(filename='result.jpg')  # save to disk
         ```

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -87,6 +87,7 @@ Ultralytics YOLO models return either a Python list of `Results` objects, or a m
         # Process results generator
         for result in results:
             boxes = result.boxes  # Boxes object for bounding box outputs
+            obb = result.obb  # Oriented boxes object for obb outputs
             masks = result.masks  # Masks object for segmentation masks outputs
             keypoints = result.keypoints  # Keypoints object for pose outputs
             probs = result.probs  # Probs object for classification outputs


### PR DESCRIPTION
Was confused why the `result.boxes` was empty on my working model and it took discord help to figure out the `.obb` prop, might be worth it to document it there as well. Thanks for the great lib!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing Oriented Bounding Boxes (OBB) in prediction results!

### 📊 Key Changes
- Added support for Oriented Bounding Boxes (OBB) alongside existing detection outputs like bounding boxes, segmentation masks, and keypoints.

### 🎯 Purpose & Impact
- **Enhanced Detection**: This update allows for more precise localization of objects, especially in images where objects are closely packed or overlap, enhancing overall detection accuracy. 🎯
- **Improved Usability**: Developers working with complex scenes or requiring detailed spatial recognition will find this feature particularly useful. 🛠️
- **Broader Applications**: The inclusion of OBBs opens up new possibilities for applications in fields requiring detailed object orientation, such as satellite imagery analysis, autonomous driving, and robotic manipulation. 🌍🚗🤖