### PR TITLE
Fix TFLite export for NVIDIA Jetson

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -750,9 +750,7 @@ class Exporter:
                 "sng4onnx>=1.0.1",
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
-                "tflite_support<=0.4.3"
-                if IS_JETSON
-                else "tflite_support",  # fix ImportError `GLIBCXX_3.4.29' not found for Jetson
+                "tflite_support<=0.4.3" if IS_JETSON else "tflite_support",  # fix ImportError `GLIBCXX_3.4.29'
                 "flatbuffers>=23.5.26,<100",  # update old 'flatbuffers' included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -750,7 +750,7 @@ class Exporter:
                 "sng4onnx>=1.0.1",
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
-                "tflite_support<=0.4.3" if IS_JETSON else "tflite_support",  # fix ImportError `GLIBCXX_3.4.29'
+                "tflite_support<=0.4.3" if IS_JETSON else "tflite_support",  # fix ImportError 'GLIBCXX_3.4.29'
                 "flatbuffers>=23.5.26,<100",  # update old 'flatbuffers' included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -72,8 +72,8 @@ from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder
 from ultralytics.nn.tasks import DetectionModel, SegmentationModel, WorldModel
 from ultralytics.utils import (
     ARM64,
-    IS_JETSON,
     DEFAULT_CFG,
+    IS_JETSON,
     LINUX,
     LOGGER,
     MACOS,
@@ -750,7 +750,9 @@ class Exporter:
                 "sng4onnx>=1.0.1",
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
-                "tflite_support<=0.4.3" if IS_JETSON else "tflite_support", # fix ImportError `GLIBCXX_3.4.29' not found for Jetson
+                "tflite_support<=0.4.3"
+                if IS_JETSON
+                else "tflite_support",  # fix ImportError `GLIBCXX_3.4.29' not found for Jetson
                 "flatbuffers>=23.5.26,<100",  # update old 'flatbuffers' included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -72,6 +72,7 @@ from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder
 from ultralytics.nn.tasks import DetectionModel, SegmentationModel, WorldModel
 from ultralytics.utils import (
     ARM64,
+    IS_JETSON,
     DEFAULT_CFG,
     LINUX,
     LOGGER,
@@ -749,7 +750,7 @@ class Exporter:
                 "sng4onnx>=1.0.1",
                 "onnxsim>=0.4.33",
                 "onnx_graphsurgeon>=0.3.26",
-                "tflite_support",
+                "tflite_support<=0.4.3" if IS_JETSON else "tflite_support", # fix ImportError `GLIBCXX_3.4.29' not found for Jetson
                 "flatbuffers>=23.5.26,<100",  # update old 'flatbuffers' included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
             ),


### PR DESCRIPTION
@glenn-jocher 

This fix is needed for NVIDIA Jetson or else, the following error can be seen.

```
(yolov8) nvidia@nvidia-desktop:~/YOLOv8-CPU$ yolo export model=yolov8n.pt format=tflite
Ultralytics YOLOv8.2.2 🚀 Python-3.8.10 torch-2.1.2 CPU (ARMv8 Processor rev 1 (v8l))
YOLOv8n summary (fused): 168 layers, 3151904 parameters, 0 gradients, 8.7 GFLOPs

PyTorch: starting from 'yolov8n.pt' with input shape (1, 3, 640, 640) BCHW and output shape(s) (1, 84, 8400) (6.2 MB)

TensorFlow SavedModel: starting export with tensorflow 2.13.1...

ONNX: starting export with onnx 1.16.0 opset 17...
ONNX: simplifying with onnxsim 0.4.36...
ONNX: export success ✅ 1.5s, saved as 'yolov8n.onnx' (12.3 MB)
TensorFlow SavedModel: starting TFLite export with onnx2tf 1.17.5...
TensorFlow SavedModel: export failure ❌ 35.3s: /lib/aarch64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/tensorflow_lite_support/metadata/cc/python/_pywrap_metadata_version.so)
Traceback (most recent call last):
  File "/home/nvidia/YOLOv8-CPU/yolov8/bin/yolo", line 8, in <module>
    sys.exit(entrypoint())
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/ultralytics/cfg/__init__.py", line 582, in entrypoint
    getattr(model, mode)(**overrides)  # default args from model
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/ultralytics/engine/model.py", line 601, in export
    return Exporter(overrides=args, _callbacks=self.callbacks)(model=self.model)
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/ultralytics/engine/exporter.py", line 296, in __call__
    f[5], keras_model = self.export_saved_model()
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/ultralytics/engine/exporter.py", line 140, in outer_func
    raise e
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/ultralytics/engine/exporter.py", line 135, in outer_func
    f, model = inner_func(*args, **kwargs)
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/ultralytics/engine/exporter.py", line 829, in export_saved_model
    f.unlink() if "quant_with_int16_act.tflite" in str(f) else self._add_tflite_metadata(file)
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/ultralytics/engine/exporter.py", line 945, in _add_tflite_metadata
    from tflite_support import flatbuffers  # noqa
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/tflite_support/__init__.py", line 48, in <module>
    from tensorflow_lite_support.metadata.python import metadata
  File "/home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/tensorflow_lite_support/metadata/python/metadata.py", line 30, in <module>
    from tensorflow_lite_support.metadata.cc.python import _pywrap_metadata_version
ImportError: /lib/aarch64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/nvidia/YOLOv8-CPU/yolov8/lib/python3.8/site-packages/tensorflow_lite_support/metadata/cc/python/_pywrap_metadata_version.so)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved support for exporting models on NVIDIA Jetson devices.

### 📊 Key Changes
- Added a check to use a specific version of `tflite_support` for Jetson devices to avoid compatibility issues.
- Updated dependencies for model exporting, ensuring better stability and performance.

### 🎯 Purpose & Impact
- **Purpose:** The update aims to fix an import error specifically encountered on NVIDIA Jetson devices due to a version incompatibility of the `tflite_support` library. By specifying a compatible version only for Jetson devices, this PR effectively resolves the issue, leading to smoother operations on these platforms.
- **Impact:** Users working on Jetson devices will experience no import errors when exporting models, enhancing the usability of Ultralytics software on these systems. This change improves support for edge computing applications, making it easier for developers to deploy AI models on Jetson hardware. 🚀