### PR TITLE
Fix `instance` area method format-change bug

### DIFF
--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -70,13 +70,15 @@ class Bboxes:
         self.bboxes = func(self.bboxes)
         self.format = format
 
-    def areas(self, revert_format=True):
-        """Return box areas, optionally reverting to original format."""
-        original_format = self.format
-        self.convert("xyxy")
-        areas = (self.bboxes[:, 2] - self.bboxes[:, 0]) * (self.bboxes[:, 3] - self.bboxes[:, 1])
-        if revert_format:
-            self.convert(original_format)
+    def areas(self):
+        """Return box areas."""
+        if self.format == "xyxy":
+            areas = (self.bboxes[:, 2] - self.bboxes[:, 0]) * (self.bboxes[:, 3] - self.bboxes[:, 1])
+        else:
+            # make a copy to avoid modifying the original data
+            bboxes = self.bboxes.copy()
+            bboxes.convert("xyxy")
+            areas = (bboxes[:, 2] - bboxes[:, 0]) * (bboxes[:, 3] - bboxes[:, 1])
         return areas
 
     # def denormalize(self, w, h):

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -72,14 +72,11 @@ class Bboxes:
 
     def areas(self):
         """Return box areas."""
-        if self.format == "xyxy":
-            areas = (self.bboxes[:, 2] - self.bboxes[:, 0]) * (self.bboxes[:, 3] - self.bboxes[:, 1])
-        else:
-            # make a copy to avoid modifying the original data
-            bboxes = self.bboxes.copy()
-            bboxes.convert("xyxy")
-            areas = (bboxes[:, 2] - bboxes[:, 0]) * (bboxes[:, 3] - bboxes[:, 1])
-        return areas
+        return (
+            (self.bboxes[:, 2] - self.bboxes[:, 0]) * (self.bboxes[:, 3] - self.bboxes[:, 1])  # format xyxy
+            if self.format == "xyxy"
+            else self.bboxes[:, 3] * self.bboxes[:, 2]  # format xywh or ltwh
+        )
 
     # def denormalize(self, w, h):
     #    if not self.normalized:

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -70,10 +70,14 @@ class Bboxes:
         self.bboxes = func(self.bboxes)
         self.format = format
 
-    def areas(self):
-        """Return box areas."""
+    def areas(self, revert_format=True):
+        """Return box areas, optionally reverting to original format."""
+        original_format = self.format
         self.convert("xyxy")
-        return (self.bboxes[:, 2] - self.bboxes[:, 0]) * (self.bboxes[:, 3] - self.bboxes[:, 1])
+        areas = (self.bboxes[:, 2] - self.bboxes[:, 0]) * (self.bboxes[:, 3] - self.bboxes[:, 1])
+        if revert_format:
+            self.convert(original_format)
+        return areas
 
     # def denormalize(self, w, h):
     #    if not self.normalized:


### PR DESCRIPTION
- Updated areas method to optionally revert format after calculation.
https://github.com/ultralytics/ultralytics/issues/10418


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in calculating box areas for different formats.

### 📊 Key Changes
- Removed the forced conversion to "xyxy" format when calculating box areas.
- Added direct area calculation support for different bbox formats: "xyxy" and "xywh" or "ltwh".

### 🎯 Purpose & Impact
- **Purpose:** To streamline area calculation by supporting direct calculations in both "xyxy" (corner points) and "xywh" or "ltwh" (width-height formats) without needing to convert between formats.
- **Impact:** Users benefit from more efficient computations and code simplicity, improving performance and usability across various applications involving bounding box operations. 🚀