### PR TITLE
fix double zero_grad call messing up gradient accumulation

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -349,7 +349,6 @@ class BaseTrainer:
                 LOGGER.info(self.progress_string())
                 pbar = TQDM(enumerate(self.train_loader), total=nb)
             self.tloss = None
-            self.optimizer.zero_grad()
             for i, batch in pbar:
                 self.run_callbacks("on_train_batch_start")
                 # Warmup

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -329,6 +329,7 @@ class BaseTrainer:
             base_idx = (self.epochs - self.args.close_mosaic) * nb
             self.plot_idx.extend([base_idx, base_idx + 1, base_idx + 2])
         epoch = self.start_epoch
+        self.optimizer.zero_grad()  # zero any resumed gradients to ensure stability on train start
         while True:
             self.epoch = epoch
             self.run_callbacks("on_train_epoch_start")


### PR DESCRIPTION
`optimizer.zero_grad` is called at two separate locations at the moment, and unless I'm mistaken about the code flow there seems to be a bug where the gradients of the last batches of each epoch may be discarded if `self.accumulate` is larger than 1.

`optimizer.zero_grad` is called both at the start of an epoch and in `self.optimizer_step`. Since `optimizer.step` is only called when `ni - last_opt_step >= self.accumulate`, the `optimizer.zero_grad` at the start of the epoch will throw away all gradients of batches at the end of each epoch if `self.accumulate` was not reached.

For example, if we have the situation:
- `self.accumulate = 32` (gradient accumulation steps)
- `nb = len(dataloader) = 120` (number of batches in one epoch)
- then the last `120 % 32 == 24` batches will not be backpropagated each epoch, because `optimizer.zero_grad` is called before `optimizer.step`.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->

 _I have read the CLA Document and I sign the CLA_

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization step moved for efficiency in training loop.

### 📊 Key Changes
- The line `self.optimizer.zero_grad()` is removed from the training loop.

### 🎯 Purpose & Impact
- **Purpose:** This change likely aims to optimize the training process by adjusting when the gradients are reset. By moving the gradient reset (`zero_grad()`) outside of the loop, it could be part of streamlining or restructuring the training steps for better efficiency or clarity in the code.
- **Impact:** Users could see improvements in training performance or clarity in how training steps are executed. The precise impact can vary depending on how the removed line is restructured elsewhere in the training process. For general users, this means potentially faster or more efficient training of models. For developers, understanding the training loop might become slightly more straightforward, assuming the gradient resetting is handled in a more logical or efficient part of the process now.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved training stability in Ultralytics' machine learning training routines.

### 📊 Key Changes
- Re-positioned `self.optimizer.zero_grad()` to the beginning of the training loop.
- Removed the redundant `self.optimizer.zero_grad()` call within the loop.

### 🎯 Purpose & Impact
- **Consistency Across Restarts**: Ensures gradients are reset to zero at the start of training, particularly helpful when resuming interrupted training sessions. 🔄
- **Stability and Performance**: Helps maintain the stability and efficiency of the training process, potentially leading to better model performance. 🚀
- **Impact**: Users can expect more reliable training sessions, especially when needing to pause and resume. This change benefits all levels of users by enhancing the training process's robustness and potentially improving the final model quality. 🛠️