### PR TITLE
YOLO-World: Fix verbose

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -15,7 +15,7 @@ class YOLO(Model):
         """Initialize YOLO model, switching to YOLOWorld if model filename contains '-world'."""
         path = Path(model)
         if "-world" in path.stem and path.suffix in {".pt", ".yaml", ".yml"}:  # if YOLOWorld PyTorch model
-            new_instance = YOLOWorld(path)
+            new_instance = YOLOWorld(path, verbose=verbose)
             self.__class__ = type(new_instance)
             self.__dict__ = new_instance.__dict__
         else:
@@ -62,14 +62,14 @@ class YOLO(Model):
 class YOLOWorld(Model):
     """YOLO-World object detection model."""
 
-    def __init__(self, model="yolov8s-world.pt") -> None:
+    def __init__(self, model="yolov8s-world.pt", verbose=False) -> None:
         """
         Initializes the YOLOv8-World model with the given pre-trained model file. Supports *.pt and *.yaml formats.
 
         Args:
             model (str | Path): Path to the pre-trained model. Defaults to 'yolov8s-world.pt'.
         """
-        super().__init__(model=model, task="detect")
+        super().__init__(model=model, task="detect", verbose=verbose)
 
         # Assign default COCO class names when there are no custom names
         if not hasattr(self.model, "names"):


### PR DESCRIPTION
verbose option for regular yolov8 model, works very well:
![pic-240506-1829-51](https://github.com/ultralytics/ultralytics/assets/61612323/a87cdf19-80c8-4a70-8597-0669dc232ec9)
For yolo-world:
before, nothing output:
![pic-240506-1828-48](https://github.com/ultralytics/ultralytics/assets/61612323/f85b343f-3e6b-4fd4-bd26-c2ffe38b32d2)
after, behaves like other detection models i.e yolov8:
![pic-240506-1828-56](https://github.com/ultralytics/ultralytics/assets/61612323/4d5d5f76-6779-47dc-853c-741ed7047600)



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced verbosity settings for YOLO model initialization 📢

### 📊 Key Changes
- Added `verbose` parameter to the `YOLOWorld` class constructor. 🛠
- Passed the `verbose` flag from the main YOLO model initializer to the `YOLOWorld` initializer. 🔧

### 🎯 Purpose & Impact
- **Purpose**: To allow users to specify whether they want detailed initialization logs when working with YOLO-World models. This helps in debugging and understanding model loading processes. 🕵️‍♂️
- **Impact**: Users now have better control over the verbosity of their model's initialization process, potentially making it easier for developers to identify issues or understand how their model is being set up. This should improve the user experience for both developers and researchers working with YOLO models. 🚀