### PR TITLE
Enforce `dynamic=True` for TensorRT and OpenVINO INT8

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -200,7 +200,7 @@ class Exporter:
             self.args.half = False
             assert not self.args.dynamic, "half=True not compatible with dynamic=True, i.e. use only one."
         self.imgsz = check_imgsz(self.args.imgsz, stride=model.stride, min_dim=2)  # check image size
-        if self.args.int8 and (engine | xml):
+        if self.args.int8 and (engine or xml):
             self.args.dynamic = True  # enforce dynamic to export TensorRT INT8; ensures ONNX is dynamic
         if self.args.optimize:
             assert not ncnn, "optimize=True not compatible with format='ncnn', i.e. use optimize=False"

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -200,7 +200,7 @@ class Exporter:
             self.args.half = False
             assert not self.args.dynamic, "half=True not compatible with dynamic=True, i.e. use only one."
         self.imgsz = check_imgsz(self.args.imgsz, stride=model.stride, min_dim=2)  # check image size
-        if self.args.int8 and engine:
+        if self.args.int8 and (engine | xml):
             self.args.dynamic = True  # enforce dynamic to export TensorRT INT8; ensures ONNX is dynamic
         if self.args.optimize:
             assert not ncnn, "optimize=True not compatible with format='ncnn', i.e. use optimize=False"


### PR DESCRIPTION
This should fix issues with failing export tests. All tests are failing specifically when `dynamic=False` (default) and `int8=True` during OpenVino export since the batch size is automatically being scaled 2× for calibration.

<details><summary>Failing export tests from 2024-05-08</summary>
<p>

```bash
=========================== short test summary info ===========================
FAILED tests/test_exports.py::test_export_openvino_matrix[obb-False-True-False-1] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[1,3,32,32]) and the tensor (shape=(2.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[obb-False-True-False-2] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[2,3,32,32]) and the tensor (shape=(4.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[classify-False-True-False-1] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[1,3,32,32]) and the tensor (shape=(2.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[classify-False-True-False-2] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[2,3,32,32]) and the tensor (shape=(4.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[segment-False-True-False-1] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[1,3,32,32]) and the tensor (shape=(2.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[segment-False-True-False-2] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[2,3,32,32]) and the tensor (shape=(4.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[pose-False-True-False-1] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[1,3,32,32]) and the tensor (shape=(2.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[pose-False-True-False-2] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[2,3,32,32]) and the tensor (shape=(4.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[detect-False-True-False-1] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[1,3,32,32]) and the tensor (shape=(2.3.32.32)) are incompatible
FAILED tests/test_exports.py::test_export_openvino_matrix[detect-False-True-False-2] - RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:121:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:382:
Can't set the input tensor with index: 0, because the model input (shape=[2,3,32,32]) and the tensor (shape=(4.3.32.32)) are incompatible
===== 10 failed, 165 passed, 40 skipped, 4 warnings in 1698.34s (0:28:18) =====
```

</p>
</details> 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model exporting logic to support INT8 quantization across more formats.

### 📊 Key Changes
- Added support for INT8 quantization with XML format.
- Enforced dynamic model exporting when using INT8 to ensure compatibility.

### 🎯 Purpose & Impact
- **Enhances Compatibility**: By introducing the option for INT8 with XML format, users have more flexibility in how they can export their models, optimizing for performance and resource usage.
- **Ensures Consistency**: Automatically enabling dynamic exporting for INT8 models streamlines the process, avoiding potential conflicts and making sure exports are properly optimized.

This update broadens the applicability of exported models, allowing for more efficient deployment across different platforms. 🚀

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in model export logic for greater flexibility and compatibility.

### 📊 Key Changes
- Modifications in the condition to enforce dynamic export when using INT8 precision, now also considers the presence of `xml` alongside `engine`.
- Added a check to ensure compatibility between optimization settings and export formats.

### 🎯 Purpose & Impact
- **Greater Flexibility**: The updated logic allows for the dynamic export setting to be enforced not only with `engine` but also when an `xml` is present, making INT8 model exports more adaptable. 🔄
- **Enhanced Compatibility**: Ensures that users are aware of incompatibilities between certain export formats and optimization settings, preventing potential errors during the model export process. ⚙️
- **User Experience Improvement**: These changes aim to minimize potential confusion and errors, leading to a smoother experience for developers working on model exports. 😊