### PR TITLE
Fix Python 3.8 `List[Results]` compatibility

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -2,7 +2,7 @@
 
 import inspect
 from pathlib import Path
-from typing import Union
+from typing import Union, List
 
 import numpy as np
 import torch
@@ -400,7 +400,7 @@ class Model(nn.Module):
         stream: bool = False,
         predictor=None,
         **kwargs,
-    ) -> list[Results]:
+    ) -> List[Results]:
         """
         Performs predictions on the given image source using the YOLO model.
 
@@ -458,7 +458,7 @@ class Model(nn.Module):
         stream: bool = False,
         persist: bool = False,
         **kwargs,
-    ) -> list[Results]:
+    ) -> List[Results]:
         """
         Conducts object tracking on the specified input source using the registered trackers.
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -2,7 +2,7 @@
 
 import inspect
 from pathlib import Path
-from typing import Union, List
+from typing import List, Union
 
 import numpy as np
 import torch


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved type annotations in model methods for Ultralytics software.

### 📊 Key Changes
- Changed the use of a generic `list` type annotation to the more specific `List` from the `typing` module.
- Made the return types of `predict` and `track` methods clearer by specifying `List[Results]`.

### 🎯 Purpose & Impact
- **Clarity and Type Safety:** This update makes the code more understandable and type-safe, which is particularly beneficial for developers using type checkers or IDEs that leverage type hints for autocompletion and error detection.
- **Improved Documentation:** Clearer type annotations serve as an effective form of documentation, helping developers understand what type of data they can expect as input and output when using these methods.
- **Potential Impact:** Users integrating Ultralytics models into their projects will benefit from reduced ambiguity, leading to fewer runtime errors related to type mismatches. Developers contributing to the project will have an easier time understanding the intended use of these methods, facilitating smoother development and maintenance work.

🔍 This change enhances code readability and maintainability without altering the core functionality or performance of Ultralytics models. It's a solid move towards more robust and error-resistant code!