### PR TITLE
`ultralytics 8.2.15` get_latest_opset() compat for `torch<1.13.0`

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.2.14"
+__version__ = "8.2.15"
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import RTDETR, SAM, YOLO, YOLOWorld

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -418,7 +418,7 @@ def get_latest_opset():
     elif check_version(current_version, "1.8.0"):
         return 12
     else:
-        return 9  # default opset of all torch version
+        return max(int(k[14:]) for k in vars(torch.onnx) if "symbolic_opset" in k) - 1  # opset
 
 
 def intersect_dicts(da, db, exclude=()):

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -405,7 +405,7 @@ def get_latest_opset():
     Because "torch.onnx" import symbolic_opset after torch1.13,can't get latest opset by "vars" before it.
     """
     current_version: str = torch.onnx.producer_version
-    if check_version(current_version, "1.13.0"):
+    if TORCH_1_13:
         return max(int(k[14:]) for k in vars(torch.onnx) if "symbolic_opset" in k) - 1  # opset
     elif check_version(current_version, "1.12.0"):
         return 15

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -390,7 +390,9 @@ def copy_attr(a, b, include=(), exclude=()):
 
 
 def get_latest_opset():
-    """Return second-most (for maturity) recently supported ONNX opset by this version of torch.
+    """
+    Return second-most (for maturity) recently supported ONNX opset by this version of torch.
+
     Because "torch.onnx" import symbolic_opset after torch1.13,can't get latest opset by "vars" before it.
     """
     current_version: str = torch.onnx.producer_version

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -390,8 +390,22 @@ def copy_attr(a, b, include=(), exclude=()):
 
 
 def get_latest_opset():
-    """Return second-most (for maturity) recently supported ONNX opset by this version of torch."""
-    return max(int(k[14:]) for k in vars(torch.onnx) if "symbolic_opset" in k) - 1  # opset
+    """Return second-most (for maturity) recently supported ONNX opset by this version of torch.
+    Because "torch.onnx" import symbolic_opset after torch1.13,can't get latest opset by "vars" before it.
+    """
+    current_version: str = torch.onnx.producer_version
+    if check_version(current_version, "1.13.0"):
+        return max(int(k[14:]) for k in vars(torch.onnx) if "symbolic_opset" in k) - 1  # opset
+    elif check_version(current_version, "1.12.0"):
+        return 15
+    elif check_version(current_version, "1.11.0"):
+        return 14
+    elif check_version(current_version, "1.10.0"):
+        return 13
+    elif check_version(current_version, "1.9.0"):
+        return 12
+    elif check_version(current_version, "1.8.0"):
+        return 12
 
 
 def intersect_dicts(da, db, exclude=()):

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -406,6 +406,8 @@ def get_latest_opset():
         return 12
     elif check_version(current_version, "1.8.0"):
         return 12
+    else:
+        return 9  # default opset of all torch version
 
 
 def intersect_dicts(da, db, exclude=()):

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -399,26 +399,13 @@ def copy_attr(a, b, include=(), exclude=()):
 
 
 def get_latest_opset():
-    """
-    Return second-most (for maturity) recently supported ONNX opset by this version of torch.
-
-    Because "torch.onnx" import symbolic_opset after torch1.13,can't get latest opset by "vars" before it.
-    """
-    current_version: str = torch.onnx.producer_version
+    """Return the second-most recent ONNX opset version supported by this version of PyTorch, adjusted for maturity."""
     if TORCH_1_13:
-        return max(int(k[14:]) for k in vars(torch.onnx) if "symbolic_opset" in k) - 1  # opset
-    elif check_version(current_version, "1.12.0"):
-        return 15
-    elif check_version(current_version, "1.11.0"):
-        return 14
-    elif check_version(current_version, "1.10.0"):
-        return 13
-    elif check_version(current_version, "1.9.0"):
-        return 12
-    elif check_version(current_version, "1.8.0"):
-        return 12
-    else:
-        return max(int(k[14:]) for k in vars(torch.onnx) if "symbolic_opset" in k) - 1  # opset
+        # If the PyTorch>=1.13, dynamically compute the latest opset minus one using 'symbolic_opset'
+        return max(int(k[14:]) for k in vars(torch.onnx) if "symbolic_opset" in k) - 1
+    # Otherwise for PyTorch<=1.12 return the corresponding predefined opset
+    version = torch.onnx.producer_version.rsplit(".", 1)[0]  # i.e. '2.3'
+    return {"1.12": 15, "1.11": 14, "1.10": 13, "1.9": 12, "1.8": 12}.get(version, 12)
 
 
 def intersect_dicts(da, db, exclude=()):


### PR DESCRIPTION
Fixes #9835 

Torch 1.13 introduced significant changes in onnx/init.py. In earlier Torch versions, it is not possible to directly retrieve the available opset. By examining the source code, it was determined that the maximum opset supported by PyTorch versions 1.8 to 1.12. The opset is directly specified as the highest version minus 1 in the code now.

1.12
-----
```python

    from typing import Dict
    
    import torch._C as _C
    
    TensorProtoDataType = _C._onnx.TensorProtoDataType
    OperatorExportTypes = _C._onnx.OperatorExportTypes
    TrainingMode = _C._onnx.TrainingMode
    _CAFFE2_ATEN_FALLBACK = _C._onnx._CAFFE2_ATEN_FALLBACK
    
    ONNX_ARCHIVE_MODEL_PROTO_NAME = "__MODEL_PROTO"
    
    producer_name = "pytorch"
    producer_version = _C._onnx.PRODUCER_VERSION
    ...
```
1.13
-----
```python
    from torch import _C
    from torch._C import _onnx as _C_onnx
    from torch._C._onnx import (
        _CAFFE2_ATEN_FALLBACK,
        OperatorExportTypes,
        TensorProtoDataType,
        TrainingMode,
    )
    
    from . import (  # usort:skip. Keep the order instead of sorting lexicographically
        _deprecation,
        errors,
        symbolic_caffe2,
        symbolic_helper,
        symbolic_opset7,
        symbolic_opset8,
        symbolic_opset9,
        symbolic_opset10,
        symbolic_opset11,
        symbolic_opset12,
        symbolic_opset13,
        symbolic_opset14,
        symbolic_opset15,
        symbolic_opset16,
        symbolic_opset17,
        utils,
    )
    ...
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgrade and Enhanced ONNX Support 🚀

### 📊 Key Changes
- **Version Bumped:** The Ultralytics package version has been increased from 8.2.14 to 8.2.15.
- **Improved ONNX Opset Determination:** There are significant enhancements in how the latest ONNX opset version supported by the current PyTorch version is determined, especially important for ensuring compatibility and leveraging new features.

### 🎯 Purpose & Impact
- **Streamlining Upgrades:** The version bump indicates a new release with improvements, signaling users to update for better performance and new features.
- **Enhanced Export Compatibility:** The changes in `torch_utils.py` aim to better support ONNX model export by dynamically selecting the most appropriate opset. This ensures:
  - For PyTorch 1.13 and above, the latest ONNX opset is automatically chosen based on current compatibility, minus one to ensure maturity.
  - For PyTorch 1.12 and below, a predefined opset is selected, maintaining compatibility with the most recent features available to those versions.
- **Overall Impact:** Users can expect smoother transitions when exporting their models to ONNX format, potentially reducing errors and improving compatibility with downstream tools and frameworks.