### PR TITLE
Update pip install arg `--no-cache-dir`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 # Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch or nvcr.io/nvidia/pytorch:23.03-py3
 FROM pytorch/pytorch:2.2.2-cuda12.1-cudnn8-runtime
-RUN pip install --no-cache nvidia-tensorrt --index-url https://pypi.ngc.nvidia.com
+RUN pip install --no-cache-dir nvidia-tensorrt --index-url https://pypi.ngc.nvidia.com
 
 # Downloads to user config dir
 ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
@@ -30,16 +30,16 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt /u
 
 # Install pip packages
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache -e ".[export]" "albumentations>=1.4.6" comet pycocotools
+RUN pip install --no-cache-dir -e ".[export]" "albumentations>=1.4.6" comet pycocotools
 
 # Run exports to AutoInstall packages
 # Edge TPU export fails the first time so is run twice here
 RUN yolo export model=tmp/yolov8n.pt format=edgetpu imgsz=32 || yolo export model=tmp/yolov8n.pt format=edgetpu imgsz=32
 RUN yolo export model=tmp/yolov8n.pt format=ncnn imgsz=32
 # Requires <= Python 3.10, bug with paddlepaddle==2.5.0 https://github.com/PaddlePaddle/X2Paddle/issues/991
-RUN pip install --no-cache paddlepaddle>=2.6.0 x2paddle
+RUN pip install --no-cache-dir paddlepaddle>=2.6.0 x2paddle
 # Fix error: `np.bool` was a deprecated alias for the builtin `bool` segmentation error in Tests
-RUN pip install --no-cache numpy==1.23.5
+RUN pip install --no-cache-dir numpy==1.23.5
 # Remove exported models
 RUN rm -rf tmp
 

--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -31,7 +31,7 @@ RUN rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED
 
 # Install pip packages
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache -e ".[export]"
+RUN pip install --no-cache-dir -e ".[export]"
 
 # Creates a symbolic link to make 'python' point to 'python3'
 RUN ln -sf /usr/bin/python3 /usr/bin/python

--- a/docker/Dockerfile-cpu
+++ b/docker/Dockerfile-cpu
@@ -28,13 +28,13 @@ RUN rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED
 
 # Install pip packages
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache -e ".[export]" --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir -e ".[export]" --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Run exports to AutoInstall packages
 RUN yolo export model=tmp/yolov8n.pt format=edgetpu imgsz=32
 RUN yolo export model=tmp/yolov8n.pt format=ncnn imgsz=32
 # Requires <= Python 3.10, bug with paddlepaddle==2.5.0 https://github.com/PaddlePaddle/X2Paddle/issues/991
-# RUN pip install --no-cache paddlepaddle>=2.6.0 x2paddle
+# RUN pip install --no-cache-dir paddlepaddle>=2.6.0 x2paddle
 # Remove exported models
 RUN rm -rf tmp
 

--- a/docker/Dockerfile-jetson
+++ b/docker/Dockerfile-jetson
@@ -34,8 +34,8 @@ RUN wget https://nvidia.box.com/shared/static/mvdcltm9ewdy2d5nurkiqorofz1s53ww.w
 # Install pip packages manually for TensorRT compatibility https://github.com/NVIDIA/TensorRT/issues/2567
 RUN python3 -m pip install --upgrade pip wheel
 RUN pip install onnxruntime_gpu-1.15.1-cp38-cp38-linux_aarch64.whl
-RUN pip install --no-cache tqdm matplotlib pyyaml psutil pandas onnx
-RUN pip install --no-cache -e ".[export]"
+RUN pip install --no-cache-dir tqdm matplotlib pyyaml psutil pandas onnx
+RUN pip install --no-cache-dir -e ".[export]"
 
 # Set environment variables
 ENV OMP_NUM_THREADS=1

--- a/docker/Dockerfile-python
+++ b/docker/Dockerfile-python
@@ -28,13 +28,13 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt /u
 
 # Install pip packages
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache -e ".[export]" --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir -e ".[export]" --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Run exports to AutoInstall packages
 RUN yolo export model=tmp/yolov8n.pt format=edgetpu imgsz=32
 RUN yolo export model=tmp/yolov8n.pt format=ncnn imgsz=32
 # Requires <= Python 3.10, bug with paddlepaddle==2.5.0 https://github.com/PaddlePaddle/X2Paddle/issues/991
-RUN pip install --no-cache paddlepaddle>=2.6.0 x2paddle
+RUN pip install --no-cache-dir paddlepaddle>=2.6.0 x2paddle
 # Remove exported models
 RUN rm -rf tmp
 

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -391,7 +391,7 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
                 t = time.time()
                 assert ONLINE, "AutoUpdate skipped (offline)"
                 with Retry(times=2, delay=1):  # run up to 2 times with 1-second retry delay
-                    LOGGER.info(subprocess.check_output(f"pip install --no-cache {s} {cmds}", shell=True).decode())
+                    LOGGER.info(subprocess.check_output(f"pip install --no-cache-dir {s} {cmds}", shell=True).decode())
                 dt = time.time() - t
                 LOGGER.info(
                     f"{prefix} AutoUpdate success ✅ {dt:.1f}s, installed {n} package{'s' * (n > 1)}: {pkgs}\n"


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the Dockerfile configurations across various platforms for improved package installation handling.

### 📊 Key Changes
- Changed `pip install --no-cache` to `pip install --no-cache-dir` in all Dockerfile variations to enforce correct usage of the no-cache-dir option across different environments.
- Adjustments to the installation of specific Python packages (`nvidia-tensorrt`, `albumentations`, `comet`, `pycocotools`, `paddlepaddle`, and `numpy`) to use the corrected no-cache-dir option.
- In `ultralytics/utils/checks.py`, updated the subprocess command to use `--no-cache-dir` correctly when auto-installing packages.

### 🎯 Purpose & Impact
- **Ensures consistency:** These changes aim to make sure that Dockerfiles across different architectures (standard, ARM64, CPU, Jetson, Python environments) use consistent flags for pip installations.
- **Improves performance and reliability:** Using `--no-cache-dir` correctly can help in reducing disk space usage by avoiding cache storage of the packages and dependencies. This can be particularly beneficial in environments with limited storage resources.
- **Potential reduction in build times:** By avoiding unnecessary caching, the changes could potentially speed up builds and installations in CI/CD pipelines and when deploying Docker containers.
- **Future-proofing:** Adjusting the Dockerfiles to use best practices for package installation ensures smoother future updates and compatibility with newer package versions and dependencies.

Overall, these modifications contribute to more efficient, reliable, and consistent Dockerfile configurations for the Ultralytics projects, impacting developers and users by streamlining deployments and development workflows. 🚀