### PR TITLE
Added `macos-latest` to test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-latest]
         python-version: ["3.11"]
         torch: [latest]
         include:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1012,7 +1012,7 @@ class Exporter:
         """Add metadata to *.tflite models per https://www.tensorflow.org/lite/models/convert/metadata."""
         import flatbuffers
 
-        if MACOS or IS_RASPBERRYPI:  # TODO: should this be 'if ARM64:'?
+        if ARM64:  # TODO: should this be 'if ARM64:'?
             from tflite_support import metadata  # noqa
             from tflite_support import metadata_schema_py_generated as schema  # noqa
         else:


### PR DESCRIPTION
Testing CI with `macos-latest` to investigate [this](https://github.com/ultralytics/ultralytics/pull/13088/files#r1612822575)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced workflow and refined model export on diverse platforms 🚀

### 📊 Key Changes
- Expanded Continuous Integration (CI) testing environments to include `macos-latest` alongside existing platforms.
- Streamlined the condition for adding metadata to TensorFlow Lite models to solely rely on whether the system is ARM64 architecture.

### 🎯 Purpose & Impact
- **Broader Test Coverage**: By adding `macos-latest` to the CI matrix, the change ensures that the software is tested across a wider range of environments, improving reliability and user confidence across different operating systems. 🧪
- **Better Performance and Compatibility**: Updating the condition for adding metadata to TFLite models specifically targets ARM64 systems, optimizing compatibility and potentially enhancing performance on a broader set of devices including newer Macs and high-end smartphones. 📱💻
  
These updates aim to make the Ultralytics framework more robust and easier to use across different platforms, ensuring users have a seamless experience regardless of their hardware choice.