### PR TITLE
`ultralytics 8.2.24` set ENV `OMP_NUM_THREADS=1`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip" # caching pip dependencies
+          # cache: "pip" # caching pip dependencies
       - name: Install requirements
         shell: bash # for Windows compatibility
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,8 +146,7 @@ jobs:
         shell: bash # for Windows compatibility
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -e ".[export]" "coverage[toml]" --extra-index-url https://download.pytorch.org/whl/cpu
-          # yolo export format=tflite imgsz=32 || true
+          pip install --no-cache-dir -e ".[export]" "coverage[toml]" --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Check environment
         run: |
           yolo checks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,12 +141,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          # cache: "pip" # caching pip dependencies
+          cache: "pip" # caching pip dependencies
       - name: Install requirements
         shell: bash # for Windows compatibility
         run: |
           python -m pip install --upgrade pip wheel
-          pip install --no-cache-dir -e ".[export]" "coverage[toml]" --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[export]" "coverage[toml]" --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Check environment
         run: |
           yolo checks

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,10 +1,11 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.2.23"
+__version__ = "8.2.24"
 
 import os
 
-os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training (place before imports)
+# Set ENV Variables (place before imports)
+os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import NAS, RTDETR, SAM, YOLO, FastSAM, YOLOWorld

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -7,9 +7,7 @@ import os
 os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training
 
 from ultralytics.data.explorer.explorer import Explorer
-from ultralytics.models import RTDETR, SAM, YOLO, YOLOWorld
-from ultralytics.models.fastsam import FastSAM
-from ultralytics.models.nas import NAS
+from ultralytics.models import RTDETR, SAM, YOLO, YOLOWorld, FastSAM, NAS
 from ultralytics.utils import ASSETS, SETTINGS
 from ultralytics.utils.checks import check_yolo as checks
 from ultralytics.utils.downloads import download

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -4,7 +4,7 @@ __version__ = "8.2.23"
 
 import os
 
-os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training
+os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training (place before imports)
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import NAS, RTDETR, SAM, YOLO, FastSAM, YOLOWorld

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -2,6 +2,10 @@
 
 __version__ = "8.2.23"
 
+import os
+
+os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training
+
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import RTDETR, SAM, YOLO, YOLOWorld
 from ultralytics.models.fastsam import FastSAM

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -7,7 +7,7 @@ import os
 os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training
 
 from ultralytics.data.explorer.explorer import Explorer
-from ultralytics.models import RTDETR, SAM, YOLO, YOLOWorld, FastSAM, NAS
+from ultralytics.models import NAS, RTDETR, SAM, YOLO, FastSAM, YOLOWorld
 from ultralytics.utils import ASSETS, SETTINGS
 from ultralytics.utils.checks import check_yolo as checks
 from ultralytics.utils.downloads import download

--- a/ultralytics/data/explorer/explorer.py
+++ b/ultralytics/data/explorer/explorer.py
@@ -7,8 +7,8 @@ from typing import Any, List, Tuple, Union
 import cv2
 import numpy as np
 import torch
-from PIL import Image
 from matplotlib import pyplot as plt
+from PIL import Image
 from tqdm import tqdm
 
 from ultralytics.data.augment import Format
@@ -16,6 +16,7 @@ from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.models.yolo.model import YOLO
 from ultralytics.utils import LOGGER, USER_CONFIG_DIR, IterableSimpleNamespace, checks
+
 from .utils import get_sim_index_schema, get_table_schema, plot_query_result, prompt_sql_query, sanitize_batch
 
 

--- a/ultralytics/data/explorer/explorer.py
+++ b/ultralytics/data/explorer/explorer.py
@@ -7,8 +7,8 @@ from typing import Any, List, Tuple, Union
 import cv2
 import numpy as np
 import torch
-from matplotlib import pyplot as plt
 from PIL import Image
+from matplotlib import pyplot as plt
 from tqdm import tqdm
 
 from ultralytics.data.augment import Format
@@ -16,7 +16,6 @@ from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.models.yolo.model import YOLO
 from ultralytics.utils import LOGGER, USER_CONFIG_DIR, IterableSimpleNamespace, checks
-
 from .utils import get_sim_index_schema, get_table_schema, plot_query_result, prompt_sql_query, sanitize_batch
 
 
@@ -64,7 +63,7 @@ class Explorer:
         import lancedb
 
         self.connection = lancedb.connect(uri)
-        self.table_name = Path(data).name.lower() + "_" + model.lower()
+        self.table_name = f"{Path(data).name.lower()}_{model.lower()}"
         self.sim_idx_base_name = (
             f"{self.table_name}_sim_idx".lower()
         )  # Use this name and append thres and top_k to reuse the table
@@ -268,10 +267,7 @@ class Explorer:
             similar = exp.get_similar(img='https://ultralytics.com/images/zidane.jpg')
             ```
         """
-        assert return_type in {
-            "pandas",
-            "arrow",
-        }, f"Return type should be either `pandas` or `arrow`, but got {return_type}"
+        assert return_type in {"pandas", "arrow"}, f"Return type should be `pandas` or `arrow`, but got {return_type}"
         img = self._check_imgs_or_idxs(img, idx)
         similar = self.query(img, limit=limit)
 

--- a/ultralytics/data/explorer/gui/dash.py
+++ b/ultralytics/data/explorer/gui/dash.py
@@ -197,12 +197,11 @@ def layout():
     imgs = []
     if st.session_state.get("error"):
         st.error(st.session_state["error"])
+    elif st.session_state.get("imgs"):
+        imgs = st.session_state.get("imgs")
     else:
-        if st.session_state.get("imgs"):
-            imgs = st.session_state.get("imgs")
-        else:
-            imgs = exp.table.to_lance().to_table(columns=["im_file"]).to_pydict()["im_file"]
-            st.session_state["res"] = exp.table.to_arrow()
+        imgs = exp.table.to_lance().to_table(columns=["im_file"]).to_pydict()["im_file"]
+        st.session_state["res"] = exp.table.to_arrow()
     total_imgs, selected_imgs = len(imgs), []
     with col1:
         subcol1, subcol2, subcol3, subcol4, subcol5 = st.columns(5)

--- a/ultralytics/models/__init__.py
+++ b/ultralytics/models/__init__.py
@@ -3,5 +3,7 @@
 from .rtdetr import RTDETR
 from .sam import SAM
 from .yolo import YOLO, YOLOWorld
+from .nas import NAS
+from .fastsam import FastSAM
 
-__all__ = "YOLO", "RTDETR", "SAM", "YOLOWorld"  # allow simpler import
+__all__ = "YOLO", "RTDETR", "SAM", "FastSAM", "NAS", "YOLOWorld"  # allow simpler import

--- a/ultralytics/models/__init__.py
+++ b/ultralytics/models/__init__.py
@@ -1,9 +1,9 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
+from .fastsam import FastSAM
+from .nas import NAS
 from .rtdetr import RTDETR
 from .sam import SAM
 from .yolo import YOLO, YOLOWorld
-from .nas import NAS
-from .fastsam import FastSAM
 
 __all__ = "YOLO", "RTDETR", "SAM", "FastSAM", "NAS", "YOLOWorld"  # allow simpler import

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -17,14 +17,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Union
 
-# Environment Variables (must be set early before other imports)
-NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLO multiprocessing threads
-os.environ["NUMEXPR_MAX_THREADS"] = str(NUM_THREADS)  # NumExpr max threads
-os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # for deterministic training
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress verbose TF compiler warnings in Colab
-os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not initialize NNPACK" warnings
-os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output when computing FLOPs
-
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
@@ -44,6 +36,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLO
 ASSETS = ROOT / "assets"  # default images
 DEFAULT_CFG_PATH = ROOT / "cfg/default.yaml"
+NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLO multiprocessing threads
 AUTOINSTALL = str(os.getenv("YOLO_AUTOINSTALL", True)).lower() == "true"  # global auto-install mode
 VERBOSE = str(os.getenv("YOLO_VERBOSE", True)).lower() == "true"  # global verbose mode
 TQDM_BAR_FORMAT = "{l_bar}{bar:10}{r_bar}" if VERBOSE else None  # tqdm bar format
@@ -109,10 +102,15 @@ HELP_MSG = """
     GitHub: https://github.com/ultralytics/ultralytics
     """
 
-# Settings
+# Settings and Environment Variables
 torch.set_printoptions(linewidth=320, precision=4, profile="default")
 np.set_printoptions(linewidth=320, formatter={"float_kind": "{:11.5g}".format})  # format short g, %precision=5
 cv2.setNumThreads(0)  # prevent OpenCV from multithreading (incompatible with PyTorch DataLoader)
+os.environ["NUMEXPR_MAX_THREADS"] = str(NUM_THREADS)  # NumExpr max threads
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # for deterministic training
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress verbose TF compiler warnings in Colab
+os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not initialize NNPACK" warnings
+os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output when computing FLOPs
 
 
 class TQDM(tqdm_original):

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -20,7 +20,6 @@ from typing import Union
 # Environment Variables (must be set early before other imports)
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLO multiprocessing threads
 os.environ["NUMEXPR_MAX_THREADS"] = str(NUM_THREADS)  # NumExpr max threads
-os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # for deterministic training
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress verbose TF compiler warnings in Colab
 os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not initialize NNPACK" warnings

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -17,6 +17,15 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Union
 
+# Environment Variables (must be set early before other imports)
+NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLO multiprocessing threads
+os.environ["NUMEXPR_MAX_THREADS"] = str(NUM_THREADS)  # NumExpr max threads
+os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # for deterministic training
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress verbose TF compiler warnings in Colab
+os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not initialize NNPACK" warnings
+os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output when computing FLOPs
+
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
@@ -36,7 +45,6 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLO
 ASSETS = ROOT / "assets"  # default images
 DEFAULT_CFG_PATH = ROOT / "cfg/default.yaml"
-NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLO multiprocessing threads
 AUTOINSTALL = str(os.getenv("YOLO_AUTOINSTALL", True)).lower() == "true"  # global auto-install mode
 VERBOSE = str(os.getenv("YOLO_VERBOSE", True)).lower() == "true"  # global verbose mode
 TQDM_BAR_FORMAT = "{l_bar}{bar:10}{r_bar}" if VERBOSE else None  # tqdm bar format
@@ -102,15 +110,10 @@ HELP_MSG = """
     GitHub: https://github.com/ultralytics/ultralytics
     """
 
-# Settings and Environment Variables
+# Settings
 torch.set_printoptions(linewidth=320, precision=4, profile="default")
 np.set_printoptions(linewidth=320, formatter={"float_kind": "{:11.5g}".format})  # format short g, %precision=5
 cv2.setNumThreads(0)  # prevent OpenCV from multithreading (incompatible with PyTorch DataLoader)
-os.environ["NUMEXPR_MAX_THREADS"] = str(NUM_THREADS)  # NumExpr max threads
-os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # for deterministic training
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress verbose TF compiler warnings in Colab
-os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not initialize NNPACK" warnings
-os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output when computing FLOPs
 
 
 class TQDM(tqdm_original):


### PR DESCRIPTION
@Laughing-q can you test this PR to see if moving the ENV definitions earlier in the imports fixes the high CPU-usage problem?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements in Ultralytics software improve efficiency and organization.

### 📊 Key Changes
- Removed a line of code testing YOLO export to TFLite format in CI workflow.
- Updated the software version to 8.2.24.
- Set environment variable to reduce CPU usage during training.
- Reorganized model imports for cleaner code structure.
- Improved the string formatting for table names in the data explorer.
- Simplified assertion for return types to cleaner syntax.
- Streamlined the GUI layout logic for displaying images.
- Made `FastSAM` and `NAS` models explicitly available for import.

### 🎯 Purpose & Impact
- **Efficiency Boost:** Setting `OMP_NUM_THREADS` reduces CPU overload during training, potentially speeding up the process for users. 🚀
- **Code Cleanliness:** Reorganizing imports and streamlining assertions and layout logic makes the codebase more maintainable and understandable. ✔️
- **User Access:** Explicitly including `FastSAM` and `NAS` in the package's `__all__` list makes these models easier to access and work with, broadening the toolbox for developers and researchers. 🛠️
- **Streamlined Development:** Removal of TFLite format export test and version bump facilitate smoother development and deployment processes, ensuring users get the latest, most efficient version. 🔄