### PR TITLE
120 Minute Docker Publish Action

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -114,7 +114,7 @@ jobs:
         if: github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true'
         uses: nick-invision/retry@v3
         with:
-          timeout_minutes: 60
+          timeout_minutes: 120
           retry_wait_seconds: 30
           max_attempts: 2 # retry once
           command: |

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -33,6 +33,7 @@ from ultralytics.utils import (
     ROOT,
     TORCHVISION_VERSION,
     USER_CONFIG_DIR,
+    Retry,
     SimpleNamespace,
     ThreadingLocked,
     TryExcept,
@@ -42,7 +43,6 @@ from ultralytics.utils import (
     emojis,
     is_github_action_running,
     url2file,
-    Retry,
 )
 
 

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -42,6 +42,7 @@ from ultralytics.utils import (
     emojis,
     is_github_action_running,
     url2file,
+    Retry,
 )
 
 
@@ -381,6 +382,11 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         except (AssertionError, metadata.PackageNotFoundError):
             pkgs.append(r)
 
+    @Retry(times=2, delay=1)
+    def attempt_install(s, cmds):
+        """Attempt pip install command with retries on failure."""
+        return subprocess.check_output(f"pip install --no-cache-dir {s} {cmds}", shell=True).decode()
+
     s = " ".join(f'"{x}"' for x in pkgs)  # console string
     if s:
         if install and AUTOINSTALL:  # check environment variable
@@ -389,7 +395,7 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
             try:
                 t = time.time()
                 assert ONLINE, "AutoUpdate skipped (offline)"
-                LOGGER.info(subprocess.check_output(f"pip install --no-cache-dir {s} {cmds}", shell=True).decode())
+                LOGGER.info(attempt_install(s, cmds))
                 dt = time.time() - t
                 LOGGER.info(
                     f"{prefix} AutoUpdate success ✅ {dt:.1f}s, installed {n} package{'s' * (n > 1)}: {pkgs}\n"

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -383,9 +383,9 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
             pkgs.append(r)
 
     @Retry(times=2, delay=1)
-    def attempt_install(s, cmds):
+    def attempt_install(packages, commands):
         """Attempt pip install command with retries on failure."""
-        return subprocess.check_output(f"pip install --no-cache-dir {s} {cmds}", shell=True).decode()
+        return subprocess.check_output(f"pip install --no-cache-dir {packages} {commands}", shell=True).decode()
 
     s = " ".join(f'"{x}"' for x in pkgs)  # console string
     if s:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements in Docker workflow and package installation reliability.

### 📊 Key Changes
- 🕒 Increased Docker workflow's timeout from 60 minutes to 120 minutes.
- ➕ Added a retry mechanism for package installation failures in the utilities.

### 🎯 Purpose & Impact
- 🕐 The increased timeout in the Docker workflow aims to provide ample time for processes to complete, reducing the chances of timeouts for longer tasks. This can lead to more successful builds and less frustration for developers.
- 🔄 The new retry mechanism for package installations seeks to improve reliability. If package installation fails (due to network issues or temporary PyPI server issues), the system will automatically retry. This reduces manual intervention and improves the overall setup experience for users. It’s particularly beneficial for ensuring that dependencies are consistently and successfully installed.

🚀 These changes aim to enhance the stability and efficiency of the development process, leading to a smoother experience for developers and users alike.