### PR TITLE
Install `cmake` with `onnxsim`

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -384,7 +384,7 @@ class Exporter:
         """YOLOv8 ONNX export."""
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
-            requirements += ["cmake", "onnxsim>=0.4.33", "onnxruntime" + "-gpu" if torch.cuda.is_available() else ""]
+            requirements += ["cmake", "onnxsim>=0.4.33", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
         import onnx  # noqa
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -384,9 +384,7 @@ class Exporter:
         """YOLOv8 ONNX export."""
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
-            requirements += ["onnxsim>=0.4.33", "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"]
-            if ARM64:
-                check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64
+            requirements += ["cmake", "onnxsim>=0.4.33", "onnxruntime" + "-gpu" if torch.cuda.is_available() else ""]
         check_requirements(requirements)
         import onnx  # noqa
 
@@ -815,10 +813,9 @@ class Exporter:
             version = ">=2.0.0"
             check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
-        if ARM64:
-            check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64
         check_requirements(
             (
+                "cmake",  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
                 "keras",
                 "onnx>=1.12.0",
                 "onnx2tf>1.17.5,<=1.22.3",


### PR DESCRIPTION
@lakshanthad I noticed that we are getting missing cmake errors from pip install onnxsum in our Conda tests in https://github.com/conda-forge/ultralytics-feedstock/pull/170 so trying this.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplification and broad compatibility enhancements in exporting models.

### 📊 Key Changes
- **Requirements Update**: For ONNX exports, the process now universally includes `cmake` in the requirements list, alongside `onnxsim` and `onnxruntime` (with GPU support conditional on CUDA availability).
- **Simplification in Dependencies**: The condition for checking ARM64 architecture before installing `cmake` is removed, making `cmake` a standard requirement for all environments in both ONNX and TensorFlow SavedModel exports.
- **Streamlined Code**: Removal of architecture-specific conditions for installing `cmake`, aiming for a more streamlined and less error-prone setup.

### 🎯 Purpose & Impact
- **Easier Setup**: These changes are intended to simplify the setup process for exporting models, making it more straightforward for users across different systems and architectures.
- **Broader Compatibility**: Including `cmake` by default addresses the need for its presence in various environments, notably ARM64 and Conda runners, thus ensuring broader compatibility and reducing the chance of errors during the export process.
- **Impact to Users**: Users can expect a smoother experience when exporting models to ONNX and TensorFlow formats, with fewer manual steps and less troubleshooting required. This makes the tool more accessible, especially to those without deep technical backgrounds or those working on diverse platforms.