### PR TITLE
`cmake` ARM64 fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,7 +262,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -812,10 +812,8 @@ class Exporter:
         except ImportError:
             suffix = "-macos" if MACOS else "-aarch64" if ARM64 else "" if cuda else "-cpu"
             version = ">=2.0.0"
-            check_requirements(
-                f"tensorflow{suffix}{version}", "cmake"
-            )  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
-            import tensorflow as tf  # noqa
+            check_requirements(f"tensorflow{suffix}{version}","cmake") # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
+            import tensorflow as tf  # noqa 
         check_requirements(
             (
                 "keras",  # required by onnx2tf package

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -812,8 +812,10 @@ class Exporter:
         except ImportError:
             suffix = "-macos" if MACOS else "-aarch64" if ARM64 else "" if cuda else "-cpu"
             version = ">=2.0.0"
-            check_requirements(f"tensorflow{suffix}{version}","cmake") # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
-            import tensorflow as tf  # noqa 
+            check_requirements(
+                f"tensorflow{suffix}{version}", "cmake"
+            )  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
+            import tensorflow as tf  # noqa
         check_requirements(
             (
                 "keras",  # required by onnx2tf package

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -808,12 +808,13 @@ class Exporter:
         cuda = torch.cuda.is_available()
         try:
             import tensorflow as tf  # noqa
-            import cmake
         except ImportError:
             suffix = "-macos" if MACOS else "-aarch64" if ARM64 else "" if cuda else "-cpu"
             version = ">=2.0.0"
-            check_requirements(f"tensorflow{suffix}{version}","cmake") # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
-            import tensorflow as tf  # noqa 
+            check_requirements(f"tensorflow{suffix}{version}")
+            import tensorflow as tf  # noqa
+        if ARM64:
+            check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
         check_requirements(
             (
                 "keras",  # required by onnx2tf package

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -813,9 +813,10 @@ class Exporter:
             version = ">=2.0.0"
             check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
+        if ARM64:
+            check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
         check_requirements(
             (
-                "cmake",  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
                 "keras",  # required by onnx2tf package
                 "tf_keras",  # required by onnx2tf package
                 "onnx>=1.12.0",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -813,8 +813,7 @@ class Exporter:
             version = ">=2.0.0"
             check_requirements(f"tensorflow{suffix}{version}")
             import tensorflow as tf  # noqa
-        if ARM64:
-            check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
+        check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
         check_requirements(
             (
                 "keras",  # required by onnx2tf package

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -808,13 +808,12 @@ class Exporter:
         cuda = torch.cuda.is_available()
         try:
             import tensorflow as tf  # noqa
+            import cmake
         except ImportError:
             suffix = "-macos" if MACOS else "-aarch64" if ARM64 else "" if cuda else "-cpu"
             version = ">=2.0.0"
-            check_requirements(f"tensorflow{suffix}{version}")
-            import tensorflow as tf  # noqa
-        if ARM64:
-            check_requirements("cmake")  # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
+            check_requirements(f"tensorflow{suffix}{version}","cmake") # 'cmake' is needed to build onnxsim on aarch64 and Conda runners
+            import tensorflow as tf  # noqa 
         check_requirements(
             (
                 "keras",  # required by onnx2tf package


### PR DESCRIPTION
@glenn-jocher 

`cmake` is needed to install first before installing others. It cannot be installed together with other packages. This is the same I did before and the reason why it was formatted like that before:
https://github.com/ultralytics/ultralytics/pull/8395

This is from today's failed CI runner:
https://github.com/ultralytics/ultralytics/actions/runs/9310874211/job/25629095032
![image](https://github.com/ultralytics/ultralytics/assets/20147381/e11c38ae-787a-4047-9589-23a550866142)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving Continuous Integration and Export Functionality in Ultralytics 🚀

### 📊 Key Changes
- **Continuous Integration Update**: Temporarily commented out the conditional for running tests on Raspberry Pi, potentially pausing these specialized tests.
- **Export Functionality Enhancement**: Adjusted package dependencies for TensorFlow exporting, making 'cmake' a prerequisite to enhance compatibility with aarch64 and Conda environments.

### 🎯 Purpose & Impact
- **CI Pipeline Efficiency**: The modification in the CI configuration may be aimed at streamlining test runs or addressing issues with Raspberry Pi tests. While this could mean fewer platform-specific checks in the short term, it signifies adjustments for more efficient or targeted testing strategies.
- **Export Feature Robustness**: By requiring 'cmake' before other dependencies during TensorFlow model export, the change ensures that necessary build tools are in place, specifically benefiting users on aarch64 architectures and Conda environments. This leads to smoother operation and fewer hiccups when exporting models to TensorFlow formats, enhancing the user experience and support for diverse development environments.

🛠️ Both changes indicate an ongoing effort to refine the development and deployment processes, ensuring the Ultralytics framework remains compatible, efficient, and user-friendly across a wide range of platforms and scenarios.