### PR TITLE
Patch Conda tests missing `thop` package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,7 +332,7 @@ jobs:
       - name: Install pip packages
         run: |
           # CoreML must be installed before export due to protobuf error from AutoInstall
-          pip install pytest "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'"
+          pip install pytest ultralytics-thop "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'"
       - name: Check environment
         run: |
           conda list


### PR DESCRIPTION
Closes #13287

[Error](https://github.com/ultralytics/ultralytics/actions/runs/9325883530/job/25673605755#step:10:26) due to missing install for `ultralytics-thop` during Conda scheduled `pytests`. Perhaps there's a better alternative to ensure the package is installed, but it seemed like that _might_ require publishing `ultralytics-thop` to `conda` which could be quite the maintenance a hassle.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Continuous Integration Workflow with an Updated Python Package Dependency

### 📊 Key Changes
- Added `ultralytics-thop` to the pip install command within the CI workflow.

### 🎯 Purpose & Impact
- **Purpose**: This update aims to incorporate `ultralytics-thop` directly into the continuous integration (CI) process, ensuring that the package's presence is verified across all testing environments.
- **Impact**: By integrating `ultralytics-thop` into the CI workflow, developers will benefit from more robust testing environments that reflect the actual package dependencies used in production. This addition could lead to more stable releases and potentially enhance the performance or functionality of Ultralytics projects. Users might not see an immediate difference, but it contributes to the overall improvement in software quality and reliability.