### PR TITLE
Revert `ultralytics-thop` to optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,9 @@ dependencies = [
     "tqdm>=4.64.0", # progress bars
     "psutil", # system utilization
     "py-cpuinfo", # display CPU info
-    "thop>=0.1.1", # FLOPs computation
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
+    "ultralytics-thop>=0.2.4", # FLOPs computation https://github.com/ultralytics/thop
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ dev = [
     "mkdocstrings[python]",
     "mkdocs-jupyter", # for notebooks
     "mkdocs-redirects", # for 301 redirects
-    "mkdocs-ultralytics-plugin>=0.0.44", # for meta descriptions and images, dates and authors
+    "mkdocs-ultralytics-plugin>=0.0.45", # for meta descriptions and images, dates and authors
 ]
 export = [
     "onnx>=1.12.0", # ONNX export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "py-cpuinfo", # display CPU info
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
-    "ultralytics-thop>=0.2.4", # FLOPs computation https://github.com/ultralytics/thop
+    "ultralytics-thop>=0.2.5", # FLOPs computation https://github.com/ultralytics/thop
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,9 @@ dependencies = [
     "tqdm>=4.64.0", # progress bars
     "psutil", # system utilization
     "py-cpuinfo", # display CPU info
+    "thop>=0.1.1", # FLOPs computation
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
-    "ultralytics-thop>=0.2.4", # FLOPs computation https://github.com/ultralytics/thop
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ dev = [
     "mkdocstrings[python]",
     "mkdocs-jupyter", # for notebooks
     "mkdocs-redirects", # for 301 redirects
-    "mkdocs-ultralytics-plugin>=0.0.45", # for meta descriptions and images, dates and authors
+    "mkdocs-ultralytics-plugin>=0.0.44", # for meta descriptions and images, dates and authors
 ]
 export = [
     "onnx>=1.12.0", # ONNX export

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -157,7 +157,7 @@ class BaseModel(nn.Module):
             None
         """
         c = m == self.model[-1] and isinstance(x, list)  # is final layer list, copy input as inplace fix
-        flops = thop.profile(m, inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2 if thop else 0  # FLOPs
+        flops = thop.profile(m, inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2 if thop else 0  # GFLOPs
         t = time_sync()
         for _ in range(10):
             m(x.copy() if c else x)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -4,7 +4,6 @@ import contextlib
 from copy import deepcopy
 from pathlib import Path
 
-import thop
 import torch
 import torch.nn as nn
 
@@ -65,6 +64,11 @@ from ultralytics.utils.torch_utils import (
     scale_img,
     time_sync,
 )
+
+try:
+    import thop
+except ImportError:
+    thop = None
 
 
 class BaseModel(nn.Module):
@@ -153,7 +157,7 @@ class BaseModel(nn.Module):
             None
         """
         c = m == self.model[-1] and isinstance(x, list)  # is final layer list, copy input as inplace fix
-        flops = thop.profile(m, inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2  # GFLOPs
+        flops = thop.profile(m, inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2 if thop else 0  # FLOPs
         t = time_sync()
         for _ in range(10):
             m(x.copy() if c else x)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
-import thop
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -27,6 +26,11 @@ from ultralytics.utils import (
     colorstr,
 )
 from ultralytics.utils.checks import check_version
+
+try:
+    import thop
+except ImportError:
+    thop = None
 
 # Version checks (all default to version>=min_version)
 TORCH_1_9 = check_version(torch.__version__, "1.9.0")
@@ -304,6 +308,9 @@ def model_info_for_loggers(trainer):
 
 def get_flops(model, imgsz=640):
     """Return a YOLO model's FLOPs."""
+    if not thop:
+        return 0.0  # if not installed return 0.0 GFLOPs
+
     try:
         model = de_parallel(model)
         p = next(model.parameters())
@@ -564,7 +571,7 @@ def profile(input, ops, n=10, device=None):
             m = m.half() if hasattr(m, "half") and isinstance(x, torch.Tensor) and x.dtype is torch.float16 else m
             tf, tb, t = 0, 0, [0, 0, 0]  # dt forward, backward
             try:
-                flops = thop.profile(m, inputs=[x], verbose=False)[0] / 1e9 * 2  # GFLOPs
+                flops = thop.profile(m, inputs=[x], verbose=False)[0] / 1e9 * 2 if thop else 0  # GFLOPs
             except Exception:
                 flops = 0
 


### PR DESCRIPTION
Reverts ultralytics/ultralytics#13282

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated dependency for FLOPs calculation and refined handling when the `thop` library is missing.

### 📊 Key Changes
- Updated the `ultralytics-thop` package from version `0.2.4` to `0.2.5`.
- Modified code to conditionally import `thop`. If `thop` is not installed, the import will fail gracefully without crashing.
- Adjusted functions that calculate the Floating Point Operations Per Second (FLOPs) to return `0` if `thop` is unavailable, ensuring the program can still run.

### 🎯 Purpose & Impact
- **More Accurate FLOPs Calculation:** The update to `ultralytics-thop` ensures users benefit from the latest improvements and fixes related to the calculation of FLOPs, providing more accurate performance metrics.
- **Increased Robustness:** By handling the absence of `thop` gracefully, the software becomes more robust and user-friendly, preventing crashes due to missing dependencies.
- **Broader Accessibility:** These changes make the software more accessible to users who might not have `thop` installed, enabling them to use the software without needing to calculate FLOPs.

This PR enhances the usability and stability of the software, ensuring it works smoothly even in environments where certain optional dependencies are not installed.