### PR TITLE
Fix for ValueError (expected type INT8)

### DIFF
--- a/examples/YOLOv8-OpenCV-int8-tflite-Python/main.py
+++ b/examples/YOLOv8-OpenCV-int8-tflite-Python/main.py
@@ -258,7 +258,8 @@ class Yolov8TFLite:
         img_data = img_data.transpose((0, 2, 3, 1))
 
         scale, zero_point = input_details[0]["quantization"]
-        interpreter.set_tensor(input_details[0]["index"], img_data)
+        img_data_int8 = (img_data / scale + zero_point).astype(np.int8)
+        interpreter.set_tensor(input_details[0]["index"], img_data_int8)
 
         # Run inference
         interpreter.invoke()


### PR DESCRIPTION
when running this example with the default model = yolov8n_full_integer_quant.tflite, a ValueError occurs at line 260/261 because the quantized tflite model only accepts INT8 inputs, but the image is still FLOAT32:

"ValueError: Cannot set tensor: Got value of type FLOAT32 but expected type INT8 for input 0, name: serving_default_images:0"

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving YOLOv8 model inference on OpenCV with INT8 quantization.

### 📊 Key Changes
- Added a step to quantize input images to INT8 format before feeding them into the model for inference.

### 🎯 Purpose & Impact
- **Enhance Performance:** This change aims to speed up inference by using INT8 quantized inputs, which are computationally less intensive than floating-point formats.
- **Broad Compatibility:** Makes the model more compatible with a wider range of hardware, especially devices that are optimized for INT8 operations, potentially increasing accessibility and efficiency.
- **Energy Efficiency:** INT8 operations generally consume less power, contributing to more energy-efficient model deployments, especially in mobile and embedded devices.

This update offers a notable improvement in performance and efficiency for applications utilizing the YOLOv8 model with OpenCV in Python, potentially broadening the model's usability across different platforms and devices. 🚀💻📱