### PR TITLE
Fix `jp` to `jetpack`

### DIFF
--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -68,7 +68,7 @@ The fastest way to get started with Ultralytics YOLOv8 on NVIDIA Jetson is to ru
 Execute the below command to pull the Docker container and run on Jetson. This is based on [l4t-pytorch](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-pytorch) docker image which contains PyTorch and Torchvision in a Python3 environment.
 
 ```bash
-t=ultralytics/ultralytics:latest-jetson-jp5 && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t
+t=ultralytics/ultralytics:latest-jetson-jetpack5 && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t
 ```
 
 After this is done, skip to [Use TensorRT on NVIDIA Jetson section](#use-tensorrt-on-nvidia-jetson).
@@ -153,7 +153,7 @@ Here we support to run Ultralytics on legacy hardware such as the Jetson Nano. C
 Execute the below command to pull the Docker container and run on Jetson. This is based on [l4t-cuda](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-cuda) docker image which contains CUDA in a L4T environment.
 
 ```bash
-t=ultralytics/ultralytics:jetson-jp4 && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t
+t=ultralytics/ultralytics:latest-jetson-jetpack4 && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t
 ```
 
 ## Use TensorRT on NVIDIA Jetson


### PR DESCRIPTION
@glenn-jocher This is a typo I missed in my last PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated Docker image tags for NVIDIA Jetson setup instructions.

### 📊 Key Changes
- Changed Docker image tags from `latest-jetson-jp5` to `latest-jetson-jetpack5`.
- Changed Docker image tags from `jetson-jp4` to `latest-jetson-jetpack4`.

### 🎯 Purpose & Impact
- **Clarity**: Using more descriptive and consistent naming conventions for Docker images.
- **Ease of Use**: Simplified instructions for pulling and running Docker containers on NVIDIA Jetson devices, making it easier for users to get started.
- **Compatibility**: Ensures that users are pulling the latest images specific to the JetPack versions for optimal performance and compatibility.