### PR TITLE
`ultralytics 8.2.32` Apple MPS device Autobatch handling

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.2.31"
+__version__ = "8.2.32"
 
 import os
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -395,7 +395,7 @@ def yaml_print(yaml_file: Union[str, Path, dict]) -> None:
         (None)
     """
     yaml_dict = yaml_load(yaml_file) if isinstance(yaml_file, (str, Path)) else yaml_file
-    dump = yaml.dump(yaml_dict, sort_keys=False, allow_unicode=True)
+    dump = yaml.dump(yaml_dict, sort_keys=False, allow_unicode=True, width=float("inf"))
     LOGGER.info(f"Printing '{colorstr('bold', 'black', yaml_file)}'\n\n{dump}")
 
 

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -48,6 +48,9 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
     if device.type == "cpu":
         LOGGER.info(f"{prefix}CUDA not detected, using default CPU batch-size {batch_size}")
         return batch_size
+    if device.type == "mps":
+        LOGGER.info(f"{prefix} ⚠️ Requires torch.device('cuda'), using default batch-size {batch_size}")
+        return batch_size
     if torch.backends.cudnn.benchmark:
         LOGGER.info(f"{prefix} ⚠️ Requires torch.backends.cudnn.benchmark=False, using default batch-size {batch_size}")
         return batch_size

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -45,11 +45,8 @@ def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
     prefix = colorstr("AutoBatch: ")
     LOGGER.info(f"{prefix}Computing optimal batch size for imgsz={imgsz} at {fraction * 100}% CUDA memory utilization.")
     device = next(model.parameters()).device  # get model device
-    if device.type == "cpu":
-        LOGGER.info(f"{prefix}CUDA not detected, using default CPU batch-size {batch_size}")
-        return batch_size
-    if device.type == "mps":
-        LOGGER.info(f"{prefix} ⚠️ Requires torch.device('cuda'), using default batch-size {batch_size}")
+    if device.type in {"cpu", "mps"}:
+        LOGGER.info(f"{prefix} ⚠️ intended for CUDA devices, using default batch-size {batch_size}")
         return batch_size
     if torch.backends.cudnn.benchmark:
         LOGGER.info(f"{prefix} ⚠️ Requires torch.backends.cudnn.benchmark=False, using default batch-size {batch_size}")


### PR DESCRIPTION
When training yolov8 model with autobatch and device = "mps" 

AssertionError("Torch not compiled with CUDA enabled")

**Possible related issues**
#8319 (closed)
![image](https://github.com/ultralytics/ultralytics/assets/10879551/df5cfbc5-15e3-4819-b3bb-a36d9cbd6087)


**Changes**
Add check if device is mps before trying to run CUDA batch sizes

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved handling for different device types in the batch size optimization process.

### 📊 Key Changes
- Added a check for `mps` device type.
- Implemented a log message for `mps` devices.
- Ensured default batch size is used for `mps` devices.

### 🎯 Purpose & Impact
- ⚡ Ensures compatibility with `mps` devices (like Apple's M1 chips).
- 🛠️ Prevents potential issues by defaulting to a safe batch size for unsupported devices.
- 🔍 Provides clearer information through log messages, helping users understand device-specific limitations and adjustments.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR makes a minor version update and includes small changes to logging and batch size selection.

### 📊 Key Changes
- **Version Update**: Incremented version number from 8.2.31 to 8.2.32.
- **YAML Logger**: Adjusted YAML print function to handle very wide data without line breaks.
- **Autobatch Logging**: Improved logging for autobatch functionality, especially when not using CUDA devices.

### 🎯 Purpose & Impact
- **YAML Logger Improvement**: Ensures better readability of YAML content in logs, accommodating large data structures more gracefully.
- **Enhanced Autobatch Messaging**: Provides clearer warnings when running on non-CUDA devices (CPU or MPS), helping users understand performance expectations and default behaviors.