### PR TITLE
Fix TensorRT Doc Overview URL

### DIFF
--- a/docs/en/integrations/tensorrt.md
+++ b/docs/en/integrations/tensorrt.md
@@ -13,7 +13,7 @@ By using the TensorRT export format, you can enhance your [Ultralytics YOLOv8](h
 ## TensorRT
 
 <p align="center">
-  <img width="100%" src="https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-601/tensorrt-developer-guide/graphics/whatistrt2.png" alt="TensorRT Overview">
+  <img width="100%" src="https://github.com/ultralytics/yolov5/releases/download/v1.0/tensorrt-overview.jpg" alt="TensorRT Overview">
 </p>
 
 [TensorRT](https://developer.nvidia.com/tensorrt), developed by NVIDIA, is an advanced software development kit (SDK) designed for high-speed deep learning inference. It's well-suited for real-time applications like object detection.


### PR DESCRIPTION
@glenn-jocher This is a fix for a broken link.

Don't we have any bots to check for broken links inside docs?

EDIT: It seems that the original URL redirects to a webpage. That's why maybe the bot doesn't catch it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the TensorRT integration documentation with a new image link.

### 📊 Key Changes
- Replaced the TensorRT overview image URL.

### 🎯 Purpose & Impact
- 🖼️ Updated the image source to ensure it is hosted on a reliable and consistent platform.
- 📈 Improves the reliability and accessibility of the documentation, providing a better user experience.