### PR TITLE
Move setup_hub to pretrain callback

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -7,7 +7,6 @@ Usage:
 """
 
 
-import contextlib
 import gc
 import math
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -6,6 +6,8 @@ Usage:
     $ yolo mode=train model=yolov8n.pt data=coco8.yaml imgsz=640 epochs=100 batch=16
 """
 
+
+import contextlib
 import gc
 import math
 import os
@@ -317,8 +319,6 @@ class BaseTrainer:
 
     def _do_train(self, world_size=1):
         """Train completed, evaluate and plot if specified by arguments."""
-        if RANK in {-1, 0}:
-            self._setup_hub()
         if world_size > 1:
             self._setup_ddp(world_size)
         self._setup_train(world_size)
@@ -773,25 +773,3 @@ class BaseTrainer:
             f'{len(g[1])} weight(decay=0.0), {len(g[0])} weight(decay={decay}), {len(g[2])} bias(decay=0.0)'
         )
         return optimizer
-
-    def _setup_hub(self):
-        """Setup session for Hub Training."""
-        from ultralytics.utils import SETTINGS
-
-        if SETTINGS["hub"] is False or self.hub_session is not None:
-            return
-
-        # Create a model in HUB
-        try:
-            from ultralytics.hub.session import HUBTrainingSession
-
-            session = HUBTrainingSession(self.hub_model_url or self.args.model)
-            self.hub_session = session if session.client.authenticated else None
-            if self.hub_session and self.hub_model_url == "":
-                self.hub_session.create_model(self.args)
-                # Check model was created
-                if not getattr(self.hub_session.model, "id", None):
-                    self.hub_session = None
-        except (PermissionError, ModuleNotFoundError):
-            # Ignore PermissionError and ModuleNotFoundError which indicates hub-sdk not installed
-            pass

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -1,10 +1,31 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
-
+import contextlib
 import json
 from time import time
 
 from ultralytics.hub.utils import HUB_WEB_ROOT, PREFIX, events
-from ultralytics.utils import LOGGER, SETTINGS
+from ultralytics.utils import LOGGER, SETTINGS, RANK
+
+
+def on_pretrain_routine_start(trainer):
+    """Setup session for HUB Training."""
+    if RANK not in {-1, 0}:
+        return
+    if SETTINGS["hub"] is False or trainer.hub_session is not None:
+        return
+
+    # Create a model in HUB
+    with contextlib.suppress(PermissionError, ModuleNotFoundError):
+        # Ignore PermissionError and ModuleNotFoundError which indicates hub-sdk not installed
+        from ultralytics.hub.session import HUBTrainingSession
+
+        session = HUBTrainingSession(trainer.hub_model_url or trainer.args.model)
+        trainer.hub_session = session if session.client.authenticated else None
+        if trainer.hub_session and trainer.hub_model_url == "":
+            trainer.hub_session.create_model(trainer.args)
+            # Check model was created
+            if not getattr(trainer.hub_session.model, "id", None):
+                trainer.hub_session = None
 
 
 def on_pretrain_routine_end(trainer):
@@ -91,6 +112,7 @@ def on_export_start(exporter):
 
 callbacks = (
     {
+        "on_pretrain_routine_start": on_pretrain_routine_start,
         "on_pretrain_routine_end": on_pretrain_routine_end,
         "on_fit_epoch_end": on_fit_epoch_end,
         "on_model_save": on_model_save,


### PR DESCRIPTION
@Laughing-q this PR moves some of the HUB session logic into the callbacks. I'd like to move as much HUB-special treatment as we can out of the engine classes.

Other loggers like W&B are completely enclosed within their own callbacks and operate correctly for single and multi-GPU training, so we should try to follow the same philosophy as them.
