### PR TITLE
DDP autodownload fix attempt

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -47,7 +47,8 @@ from ultralytics.utils.torch_utils import (
     init_seeds,
     one_cycle,
     select_device,
-    strip_optimizer, torch_distributed_zero_first,
+    strip_optimizer,
+    torch_distributed_zero_first,
 )
 
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -47,7 +47,7 @@ from ultralytics.utils.torch_utils import (
     init_seeds,
     one_cycle,
     select_device,
-    strip_optimizer,
+    strip_optimizer, torch_distributed_zero_first,
 )
 
 
@@ -127,7 +127,8 @@ class BaseTrainer:
 
         # Model and Dataset
         self.model = check_model_file_from_stem(self.args.model)  # add suffix, i.e. yolov8n -> yolov8n.pt
-        self.trainset, self.testset = self.get_dataset()
+        with torch_distributed_zero_first(RANK):  # avoid auto-downloading dataset multiple times
+            self.trainset, self.testset = self.get_dataset()
         self.ema = None
 
         # Optimization utils init

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -43,8 +43,8 @@ TORCHVISION_0_13 = check_version(TORCHVISION_VERSION, "0.13.0")
 
 @contextmanager
 def torch_distributed_zero_first(local_rank: int):
-    """Decorator to make all processes in distributed training wait for each local_master to do something."""
-    initialized = torch.distributed.is_available() and torch.distributed.is_initialized()
+    """Ensures all processes in distributed training wait for the local master (rank 0) to complete a task first."""
+    initialized = dist.is_available() and dist.is_initialized()
     if initialized and local_rank not in {-1, 0}:
         dist.barrier(device_ids=[local_rank])
     yield


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR improves distributed training efficiency by avoiding redundant dataset downloads.

### 📊 Key Changes
- Added `torch_distributed_zero_first` decorator to ensure all processes wait for dataset download to complete before proceeding.
- Modified dataset initialization to use the decorator, preventing multiple downloads in distributed environments.

### 🎯 Purpose & Impact
- **Efficiency Boost**: Ensures that datasets are only downloaded once, reducing redundant operations and saving bandwidth 💾.
- **Smooth Distributed Training**: Improves coordination among processes during distributed training, leading to more stable and faster training sessions 🚀.