### PR TITLE
Fix Annotator PIL Image size (width, height) order

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -298,7 +298,7 @@ class Annotator:
             if label:
                 w, h = self.font.getsize(label)  # text width, height
                 outside = p1[1] >= h  # label fits outside box
-                if p1[0] > self.im.size[0] - w:  # check if label extend beyond right side of image
+                if p1[0] > self.im.size[0] - w:  # size is (w, h), check if label extend beyond right side of image
                     p1 = self.im.size[0] - w, p1[1]
                 self.draw.rectangle(
                     (p1[0], p1[1] - h if outside else p1[1], p1[0] + w + 1, p1[1] + 1 if outside else p1[1] + h + 1),
@@ -317,7 +317,7 @@ class Annotator:
                 w, h = cv2.getTextSize(label, 0, fontScale=self.sf, thickness=self.tf)[0]  # text width, height
                 h += 3  # add pixels to pad text
                 outside = p1[1] >= h  # label fits outside box
-                if p1[0] > self.im.shape[1] - w:  # check if label extend beyond right side of image
+                if p1[0] > self.im.shape[1] - w:  # shape is (h, w), check if label extend beyond right side of image
                     p1 = self.im.shape[1] - w, p1[1]
                 p2 = p1[0] + w, p1[1] - h if outside else p1[1] + h
                 cv2.rectangle(self.im, p1, p2, color, -1, cv2.LINE_AA)  # filled

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -298,8 +298,8 @@ class Annotator:
             if label:
                 w, h = self.font.getsize(label)  # text width, height
                 outside = p1[1] >= h  # label fits outside box
-                if p1[0] > self.im.size[1] - w:  # check if label extend beyond right side of image
-                    p1 = self.im.size[1] - w, p1[1]
+                if p1[0] > self.im.size[0] - w:  # check if label extend beyond right side of image
+                    p1 = self.im.size[0] - w, p1[1]
                 self.draw.rectangle(
                     (p1[0], p1[1] - h if outside else p1[1], p1[0] + w + 1, p1[1] + 1 if outside else p1[1] + h + 1),
                     fill=color,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->
As described in #14225 , the labels' width ware set to a wrong value when they near the right side of the image, cause they ware compared and set to a wrong image width
```py
if p1[0] > self.im.size[1] - w:  # check if label extend beyond right side of image
    p1 = self.im.size[1] - w, p1[1]
```
the `size[1]` is not the whole image's width, we should use `im.width` instead of `im.size[1]`. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR corrects references to the width of an image in the plotting utilities.

### 📊 Key Changes
- Adjusted the way the image width is referenced in the box labeling code from `self.im.size[1]` and `self.im.shape[1]` to `self.im.width`.

### 🎯 Purpose & Impact
- **Precision Enhancement**: These changes ensure the code accurately references image width, preventing potential errors or misplacements of labels outside the image bounds.
- **User Experience**: Improves the reliability of visualizations, ensuring labels are correctly positioned within the image frame, which is crucial for clarity in data interpretation.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes an issue with label placement logic in image plotting to ensure labels are rendered correctly.

### 📊 Key Changes
- Corrected the condition checking the image dimensions:
  - Changed from checking image height to checking image width when ensuring labels fit within the image boundaries.
  - Adjusted index access for both `self.im.size` and `self.im.shape` attributes to properly fit labels.

### 🎯 Purpose & Impact
- **Purpose**: Ensure that labels are placed correctly on the right side of the images, preventing them from extending beyond image boundaries.
- **Impact**: Improves the visual accuracy and aesthetics of plotted images, making sure labels are always fully visible and properly aligned, enhancing user experience and reducing confusion.