### PR TITLE
Refactor/simplify probabilistic IoU calculation to avoid NaNs during OBB training

### DIFF
--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -65,7 +65,7 @@ class OBBValidator(DetectionValidator):
             (torch.Tensor): Correct prediction matrix of shape [N, 10] for 10 IoU levels.
         """
         iou = probiou(
-            gt_bboxes[:, None], 
+            gt_bboxes[:, None],
             torch.cat([detections[:, :4], detections[:, -1:]], dim=-1)[None],
         )
         return self.match_predictions(detections[:, 5], gt_cls, iou)

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -6,7 +6,7 @@ import torch
 
 from ultralytics.models.yolo.detect import DetectionValidator
 from ultralytics.utils import LOGGER, ops
-from ultralytics.utils.metrics import OBBMetrics, batch_probiou
+from ultralytics.utils.metrics import OBBMetrics, probiou
 from ultralytics.utils.plotting import output_to_rotated_target, plot_images
 
 
@@ -64,7 +64,10 @@ class OBBValidator(DetectionValidator):
         Returns:
             (torch.Tensor): Correct prediction matrix of shape [N, 10] for 10 IoU levels.
         """
-        iou = batch_probiou(gt_bboxes, torch.cat([detections[:, :4], detections[:, -1:]], dim=-1))
+        iou = probiou(
+            gt_bboxes[:, None], 
+            torch.cat([detections[:, :4], detections[:, -1:]], dim=-1)[None],
+        )
         return self.match_predictions(detections[:, 5], gt_cls, iou)
 
     def _prepare_batch(self, si, batch):

--- a/ultralytics/trackers/utils/matching.py
+++ b/ultralytics/trackers/utils/matching.py
@@ -4,8 +4,9 @@ import numpy as np
 import scipy
 from scipy.spatial.distance import cdist
 
-from ultralytics.utils.metrics import probiou, bbox_ioa
-#from ultralytics.utils.metrics import batch_probiou, bbox_ioa
+from ultralytics.utils.metrics import bbox_ioa, probiou
+
+# from ultralytics.utils.metrics import batch_probiou, bbox_ioa
 
 try:
     import lap  # for linear_assignment
@@ -81,9 +82,9 @@ def iou_distance(atracks: list, btracks: list) -> np.ndarray:
     ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float32)
     if len(atlbrs) and len(btlbrs):
         if len(atlbrs[0]) == 5 and len(btlbrs[0]) == 5:
-            #ious = batch_probiou(
+            # ious = batch_probiou(
             ious = probiou(
-                np.ascontiguousarray(atlbrs, dtype=np.float32)[:,None],
+                np.ascontiguousarray(atlbrs, dtype=np.float32)[:, None],
                 np.ascontiguousarray(btlbrs, dtype=np.float32)[None],
             ).numpy()
         else:

--- a/ultralytics/trackers/utils/matching.py
+++ b/ultralytics/trackers/utils/matching.py
@@ -4,7 +4,8 @@ import numpy as np
 import scipy
 from scipy.spatial.distance import cdist
 
-from ultralytics.utils.metrics import batch_probiou, bbox_ioa
+from ultralytics.utils.metrics import probiou, bbox_ioa
+#from ultralytics.utils.metrics import batch_probiou, bbox_ioa
 
 try:
     import lap  # for linear_assignment
@@ -80,9 +81,10 @@ def iou_distance(atracks: list, btracks: list) -> np.ndarray:
     ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float32)
     if len(atlbrs) and len(btlbrs):
         if len(atlbrs[0]) == 5 and len(btlbrs[0]) == 5:
-            ious = batch_probiou(
-                np.ascontiguousarray(atlbrs, dtype=np.float32),
-                np.ascontiguousarray(btlbrs, dtype=np.float32),
+            #ious = batch_probiou(
+            ious = probiou(
+                np.ascontiguousarray(atlbrs, dtype=np.float32)[:,None],
+                np.ascontiguousarray(btlbrs, dtype=np.float32)[None],
             ).numpy()
         else:
             ious = bbox_ioa(

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -122,18 +122,20 @@ class RotatedBboxLoss(BboxLoss):
     def forward(self, pred_dist, pred_bboxes, anchor_points, target_bboxes, target_scores, target_scores_sum, fg_mask):
         """IoU loss."""
         weight = target_scores.sum(-1)[fg_mask]
-        #weight = target_scores.sum(-1)[fg_mask].unsqueeze(-1)
+        # weight = target_scores.sum(-1)[fg_mask].unsqueeze(-1)
         iou = probiou(pred_bboxes[fg_mask], target_bboxes[fg_mask])
-        #print('weight shape:',weight.shape)
-        #print('probiou shape:',iou.shape)
-        #print('iou max:', iou.max())
-        #print('iou min:', iou.min())
+        # print('weight shape:',weight.shape)
+        # print('probiou shape:',iou.shape)
+        # print('iou max:', iou.max())
+        # print('iou min:', iou.min())
         loss_iou = ((1.0 - iou) * weight).sum() / target_scores_sum
 
         # DFL loss
         if self.dfl_loss:
             target_ltrb = bbox2dist(anchor_points, xywh2xyxy(target_bboxes[..., :4]), self.dfl_loss.reg_max - 1)
-            loss_dfl = self.dfl_loss(pred_dist[fg_mask].view(-1, self.dfl_loss.reg_max), target_ltrb[fg_mask]) * weight.unsqueeze(-1)
+            loss_dfl = self.dfl_loss(
+                pred_dist[fg_mask].view(-1, self.dfl_loss.reg_max), target_ltrb[fg_mask]
+            ) * weight.unsqueeze(-1)
             loss_dfl = loss_dfl.sum() / target_scores_sum
         else:
             loss_dfl = torch.tensor(0.0).to(pred_dist.device)

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -122,12 +122,7 @@ class RotatedBboxLoss(BboxLoss):
     def forward(self, pred_dist, pred_bboxes, anchor_points, target_bboxes, target_scores, target_scores_sum, fg_mask):
         """IoU loss."""
         weight = target_scores.sum(-1)[fg_mask]
-        # weight = target_scores.sum(-1)[fg_mask].unsqueeze(-1)
         iou = probiou(pred_bboxes[fg_mask], target_bboxes[fg_mask])
-        # print('weight shape:',weight.shape)
-        # print('probiou shape:',iou.shape)
-        # print('iou max:', iou.max())
-        # print('iou min:', iou.min())
         loss_iou = ((1.0 - iou) * weight).sum() / target_scores_sum
 
         # DFL loss

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -121,14 +121,19 @@ class RotatedBboxLoss(BboxLoss):
 
     def forward(self, pred_dist, pred_bboxes, anchor_points, target_bboxes, target_scores, target_scores_sum, fg_mask):
         """IoU loss."""
-        weight = target_scores.sum(-1)[fg_mask].unsqueeze(-1)
+        weight = target_scores.sum(-1)[fg_mask]
+        #weight = target_scores.sum(-1)[fg_mask].unsqueeze(-1)
         iou = probiou(pred_bboxes[fg_mask], target_bboxes[fg_mask])
+        #print('weight shape:',weight.shape)
+        #print('probiou shape:',iou.shape)
+        #print('iou max:', iou.max())
+        #print('iou min:', iou.min())
         loss_iou = ((1.0 - iou) * weight).sum() / target_scores_sum
 
         # DFL loss
         if self.dfl_loss:
             target_ltrb = bbox2dist(anchor_points, xywh2xyxy(target_bboxes[..., :4]), self.dfl_loss.reg_max - 1)
-            loss_dfl = self.dfl_loss(pred_dist[fg_mask].view(-1, self.dfl_loss.reg_max), target_ltrb[fg_mask]) * weight
+            loss_dfl = self.dfl_loss(pred_dist[fg_mask].view(-1, self.dfl_loss.reg_max), target_ltrb[fg_mask]) * weight.unsqueeze(-1)
             loss_dfl = loss_dfl.sum() / target_scores_sum
         else:
             loss_dfl = torch.tensor(0.0).to(pred_dist.device)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -205,26 +205,32 @@ def probiou(obb1, obb2, CIoU=False, eps=1e-7):
     Returns:
         (torch.Tensor): A tensor of shape (N, ) representing obb similarities.
     """
-    x1, y1 = obb1[..., :2].split(1, dim=-1)
-    x2, y2 = obb2[..., :2].split(1, dim=-1)
+    x1, y1, w1, h1, theta1 = obb1.split(1, dim=-1)
+    x2, y2, w2, h2, theta2 = obb2.split(1, dim=-1)
     a1, b1, c1 = _get_covariance_matrix(obb1)
     a2, b2, c2 = _get_covariance_matrix(obb2)
 
+    sqrt_det1 = w1 * h1 / 12
+    sqrt_det2 = w2 * h2 / 12
+
+    det_sum = (
+        sqrt_det1.pow(2) + sqrt_det2.pow(2)
+        + (w1.pow(2) * h2.pow(2) + w2.pow(2) * h1.pow(2)) * torch.cos(theta2 - theta1).pow(2) / 144
+        + (w1.pow(2) * h1.pow(2) + w2.pow(2) * h2.pow(2))  * torch.sin(theta2 - theta1).pow(2) / 144
+    )
     t1 = (
-        ((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / ((a1 + a2) * (b1 + b2) - (c1 + c2).pow(2) + eps)
+        ((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / (det_sum + eps)
     ) * 0.25
-    t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2)) / ((a1 + a2) * (b1 + b2) - (c1 + c2).pow(2) + eps)) * 0.5
+    t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2)) / (det_sum + eps)) * 0.5
     t3 = (
-        ((a1 + a2) * (b1 + b2) - (c1 + c2).pow(2))
-        / (4 * ((a1 * b1 - c1.pow(2)).clamp_(0) * (a2 * b2 - c2.pow(2)).clamp_(0)).sqrt() + eps)
+        det_sum
+        / (4 * sqrt_det1 * sqrt_det2 + eps)
         + eps
     ).log() * 0.5
     bd = (t1 + t2 + t3).clamp(eps, 100.0)
     hd = (1.0 - (-bd).exp() + eps).sqrt()
     iou = 1 - hd
     if CIoU:  # only include the wh aspect ratio part
-        w1, h1 = obb1[..., 2:4].split(1, dim=-1)
-        w2, h2 = obb2[..., 2:4].split(1, dim=-1)
         v = (4 / math.pi**2) * ((w2 / h2).atan() - (w1 / h1).atan()).pow(2)
         with torch.no_grad():
             alpha = v / (v - iou + (1 + eps))
@@ -247,18 +253,27 @@ def batch_probiou(obb1, obb2, eps=1e-7):
     obb1 = torch.from_numpy(obb1) if isinstance(obb1, np.ndarray) else obb1
     obb2 = torch.from_numpy(obb2) if isinstance(obb2, np.ndarray) else obb2
 
-    x1, y1 = obb1[..., :2].split(1, dim=-1)
-    x2, y2 = (x.squeeze(-1)[None] for x in obb2[..., :2].split(1, dim=-1))
+    x1, y1, w1, h1, theta1 = obb1.split(1, dim=-1)
+    x2, y2, w2, h2, theta2 = (x.squeeze(-1)[None] for x in obb2.split(1, dim=-1))
     a1, b1, c1 = _get_covariance_matrix(obb1)
     a2, b2, c2 = (x.squeeze(-1)[None] for x in _get_covariance_matrix(obb2))
 
+    sqrt_det1 = w1 * h1 / 12
+    sqrt_det2 = w2 * h2 / 12
+
+    det_sum = (
+        sqrt_det1.pow(2) + sqrt_det2.pow(2)
+        + (w1.pow(2) * h2.pow(2) + w2.pow(2) * h1.pow(2)) * torch.cos(theta2 - theta1).pow(2) / 144
+        + (w1.pow(2) * h1.pow(2) + w2.pow(2) * h2.pow(2))  * torch.sin(theta2 - theta1).pow(2) / 144
+    )
+
     t1 = (
-        ((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / ((a1 + a2) * (b1 + b2) - (c1 + c2).pow(2) + eps)
+        ((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / (det_sum + eps)
     ) * 0.25
-    t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2)) / ((a1 + a2) * (b1 + b2) - (c1 + c2).pow(2) + eps)) * 0.5
+    t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2)) / (det_sum + eps)) * 0.5
     t3 = (
-        ((a1 + a2) * (b1 + b2) - (c1 + c2).pow(2))
-        / (4 * ((a1 * b1 - c1.pow(2)).clamp_(0) * (a2 * b2 - c2.pow(2)).clamp_(0)).sqrt() + eps)
+        det_sum
+        / (4 * sqrt_det1 * sqrt_det2 + eps)
         + eps
     ).log() * 0.5
     bd = (t1 + t2 + t3).clamp(eps, 100.0)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -245,7 +245,7 @@ def probiou(obb1, obb2, CIoU=False, eps=1e-7):
         v = (4 / math.pi**2) * ((w2 / h2).atan() - (w1 / h1).atan()).pow(2)
         with torch.no_grad():
             alpha = v / (v - iou + (1 + eps))
-        return iou - v * alpha  # CIoU
+        return (iou - v * alpha).squeeze(-1)  # CIoU
     return iou.squeeze(-1)
 
 

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -178,13 +178,14 @@ def _get_covariance_matrix(boxes):
     Generating covariance matrix from obbs.
 
     Args:
-        boxes (torch.Tensor): A tensor of shape (N, 5) representing rotated bounding boxes, with xywhr format.
+        boxes (torch.Tensor): A tensor of shape (..., 5) representing rotated bounding boxes, with xywhr format.
 
     Returns:
-        (torch.Tensor): Covariance metrixs corresponding to original rotated bounding boxes.
+        (Tuple[torch.Tensor, torch.Tensor, torch.Tensor]): Covariance matrices corresponding 
+            to original rotated bounding boxes.
     """
     # Gaussian bounding boxes, ignore the center points (the first two columns) because they are not needed here.
-    gbbs = torch.cat((boxes[:, 2:4].pow(2) / 12, boxes[:, 4:]), dim=-1)
+    gbbs = torch.cat((boxes[..., 2:4].pow(2) / 12, boxes[..., 4:]), dim=-1)
     a, b, c = gbbs.split(1, dim=-1)
     cos = c.cos()
     sin = c.sin()
@@ -198,12 +199,13 @@ def probiou(obb1, obb2, CIoU=False, eps=1e-7):
     Calculate the prob IoU between oriented bounding boxes, https://arxiv.org/pdf/2106.06072v1.pdf.
 
     Args:
-        obb1 (torch.Tensor): A tensor of shape (N, 5) representing ground truth obbs, with xywhr format.
-        obb2 (torch.Tensor): A tensor of shape (N, 5) representing predicted obbs, with xywhr format.
+        obb1 (torch.Tensor): A tensor of shape (..., 5) representing ground truth obbs, with xywhr format.
+        obb2 (torch.Tensor): A tensor of shape (..., 5) representing predicted obbs, with xywhr format.
         eps (float, optional): A small value to avoid division by zero. Defaults to 1e-7.
 
     Returns:
-        (torch.Tensor): A tensor of shape (N, ) representing obb similarities.
+        (torch.Tensor): A tensor representing obb similarities. Its shape is obtained by
+            broadcasting obb1 and obb2, and excluding the last dimension.
     """
     x1, y1, w1, h1, theta1 = obb1.split(1, dim=-1)
     x2, y2, w2, h2, theta2 = obb2.split(1, dim=-1)
@@ -221,7 +223,7 @@ def probiou(obb1, obb2, CIoU=False, eps=1e-7):
     t1 = (
         ((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / (det_sum + eps)
     ) * 0.25
-    t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2)) / (det_sum + eps)) * 0.5
+    t2 = (c1 + c2) * (x2 - x1) * (y1 - y2) / (det_sum + eps) * 0.5
     t3 = (
         det_sum
         / (4 * sqrt_det1 * sqrt_det2 + eps)
@@ -235,51 +237,7 @@ def probiou(obb1, obb2, CIoU=False, eps=1e-7):
         with torch.no_grad():
             alpha = v / (v - iou + (1 + eps))
         return iou - v * alpha  # CIoU
-    return iou
-
-
-def batch_probiou(obb1, obb2, eps=1e-7):
-    """
-    Calculate the prob IoU between oriented bounding boxes, https://arxiv.org/pdf/2106.06072v1.pdf.
-
-    Args:
-        obb1 (torch.Tensor | np.ndarray): A tensor of shape (N, 5) representing ground truth obbs, with xywhr format.
-        obb2 (torch.Tensor | np.ndarray): A tensor of shape (M, 5) representing predicted obbs, with xywhr format.
-        eps (float, optional): A small value to avoid division by zero. Defaults to 1e-7.
-
-    Returns:
-        (torch.Tensor): A tensor of shape (N, M) representing obb similarities.
-    """
-    obb1 = torch.from_numpy(obb1) if isinstance(obb1, np.ndarray) else obb1
-    obb2 = torch.from_numpy(obb2) if isinstance(obb2, np.ndarray) else obb2
-
-    x1, y1, w1, h1, theta1 = obb1.split(1, dim=-1)
-    x2, y2, w2, h2, theta2 = (x.squeeze(-1)[None] for x in obb2.split(1, dim=-1))
-    a1, b1, c1 = _get_covariance_matrix(obb1)
-    a2, b2, c2 = (x.squeeze(-1)[None] for x in _get_covariance_matrix(obb2))
-
-    sqrt_det1 = w1 * h1 / 12
-    sqrt_det2 = w2 * h2 / 12
-
-    det_sum = (
-        sqrt_det1.pow(2) + sqrt_det2.pow(2)
-        + (w1.pow(2) * h2.pow(2) + w2.pow(2) * h1.pow(2)) * torch.cos(theta2 - theta1).pow(2) / 144
-        + (w1.pow(2) * h1.pow(2) + w2.pow(2) * h2.pow(2))  * torch.sin(theta2 - theta1).pow(2) / 144
-    )
-
-    t1 = (
-        ((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / (det_sum + eps)
-    ) * 0.25
-    t2 = (((c1 + c2) * (x2 - x1) * (y1 - y2)) / (det_sum + eps)) * 0.5
-    t3 = (
-        det_sum
-        / (4 * sqrt_det1 * sqrt_det2 + eps)
-        + eps
-    ).log() * 0.5
-    bd = (t1 + t2 + t3).clamp(eps, 100.0)
-    hd = (1.0 - (-bd).exp() + eps).sqrt()
-    return 1 - hd
-
+    return iou.squeeze(-1)
 
 def smooth_BCE(eps=0.1):
     """
@@ -358,7 +316,10 @@ class ConfusionMatrix:
         detection_classes = detections[:, 5].int()
         is_obb = detections.shape[1] == 7 and gt_bboxes.shape[1] == 5  # with additional `angle` dimension
         iou = (
-            batch_probiou(gt_bboxes, torch.cat([detections[:, :4], detections[:, -1:]], dim=-1))
+            probiou(
+                gt_bboxes[:,None], 
+                torch.cat([detections[:, :4], detections[:, -1:]], dim=-1)[None],
+            )
             if is_obb
             else box_iou(gt_bboxes, detections[:, :4])
         )

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -226,27 +226,16 @@ def probiou(obb1, obb2, CIoU=False, eps=1e-7):
     cosdtheta_sq = (cos1 * cos2 + sin1 * sin2).pow(2)
 
     det_sum = (
-<<<<<<< HEAD
-        sqrt_det1.pow(2)
-        + sqrt_det2.pow(2)
-        + (w1.pow(2) * h2.pow(2) + w2.pow(2) * h1.pow(2)) * torch.cos(theta2 - theta1).pow(2) / 144
-        + (w1.pow(2) * h1.pow(2) + w2.pow(2) * h2.pow(2)) * torch.sin(theta2 - theta1).pow(2) / 144
-=======
-        (det1 + det2) * (2-c2)
+        (det1 + det2) * (2 - cosdtheta_sq)
         + (w1_term * h2_term + w2_term * h1_term) * cosdtheta_sq
->>>>>>> d0b9ba06 (Speed up probiou)
     )
     t1 = (((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / (det_sum + eps)) * 0.25
     t2 = (c1 + c2) * (x2 - x1) * (y1 - y2) / (det_sum + eps) * 0.5
-<<<<<<< HEAD
-    t3 = (det_sum / (4 * sqrt_det1 * sqrt_det2 + eps) + eps).log() * 0.5
-=======
     t3 = (
         det_sum
         / (4 * (det1 * det2).sqrt() + eps)
         + eps
     ).log() * 0.5
->>>>>>> d0b9ba06 (Speed up probiou)
     bd = (t1 + t2 + t3).clamp(eps, 100.0)
     hd = (1.0 - (-bd).exp() + eps).sqrt()
     iou = 1 - hd

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -207,10 +207,12 @@ def probiou(obb1, obb2, CIoU=False, eps=1e-7):
         (torch.Tensor): A tensor representing obb similarities. Its shape is obtained by
             broadcasting obb1 and obb2, and excluding the last dimension.
     """
+
     def _get_covariance_matrix(w_term, h_term, cos, sin):
         return w_term * cos**2 + h_term * sin**2, w_term * sin**2 + h_term * cos**2, (w_term - h_term) * cos * sin
-    x1, y1, wh1, theta1 = obb1.split((1,1,2,1), dim=-1)
-    x2, y2, wh2, theta2 = obb2.split((1,1,2,1), dim=-1)
+
+    x1, y1, wh1, theta1 = obb1.split((1, 1, 2, 1), dim=-1)
+    x2, y2, wh2, theta2 = obb2.split((1, 1, 2, 1), dim=-1)
 
     w1_term, h1_term = (wh1.pow(2) / 12).split(1, dim=-1)
     w2_term, h2_term = (wh2.pow(2) / 12).split(1, dim=-1)
@@ -225,17 +227,10 @@ def probiou(obb1, obb2, CIoU=False, eps=1e-7):
     det2 = w2_term * h2_term
     cosdtheta_sq = (cos1 * cos2 + sin1 * sin2).pow(2)
 
-    det_sum = (
-        (det1 + det2) * (2 - cosdtheta_sq)
-        + (w1_term * h2_term + w2_term * h1_term) * cosdtheta_sq
-    )
+    det_sum = (det1 + det2) * (2 - cosdtheta_sq) + (w1_term * h2_term + w2_term * h1_term) * cosdtheta_sq
     t1 = (((a1 + a2) * (y1 - y2).pow(2) + (b1 + b2) * (x1 - x2).pow(2)) / (det_sum + eps)) * 0.25
     t2 = (c1 + c2) * (x2 - x1) * (y1 - y2) / (det_sum + eps) * 0.5
-    t3 = (
-        det_sum
-        / (4 * (det1 * det2).sqrt() + eps)
-        + eps
-    ).log() * 0.5
+    t3 = (det_sum / (4 * (det1 * det2).sqrt() + eps) + eps).log() * 0.5
     bd = (t1 + t2 + t3).clamp(eps, 100.0)
     hd = (1.0 - (-bd).exp() + eps).sqrt()
     iou = 1 - hd

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -173,27 +173,6 @@ def kpt_iou(kpt1, kpt2, area, sigma, eps=1e-7):
     return ((-e).exp() * kpt_mask[:, None]).sum(-1) / (kpt_mask.sum(-1)[:, None] + eps)
 
 
-def _get_covariance_matrix(boxes):
-    """
-    Generating covariance matrix from obbs.
-
-    Args:
-        boxes (torch.Tensor): A tensor of shape (..., 5) representing rotated bounding boxes, with xywhr format.
-
-    Returns:
-        (Tuple[torch.Tensor, torch.Tensor, torch.Tensor]): Covariance matrices corresponding
-            to original rotated bounding boxes.
-    """
-    # Gaussian bounding boxes, ignore the center points (the first two columns) because they are not needed here.
-    gbbs = torch.cat((boxes[..., 2:4].pow(2) / 12, boxes[..., 4:]), dim=-1)
-    a, b, c = gbbs.split(1, dim=-1)
-    cos = c.cos()
-    sin = c.sin()
-    cos2 = cos.pow(2)
-    sin2 = sin.pow(2)
-    return a * cos2 + b * sin2, a * sin2 + b * cos2, (a - b) * cos * sin
-
-
 def probiou(obb1, obb2, CIoU=False, eps=1e-7):
     """
     Calculate the prob IoU between oriented bounding boxes, https://arxiv.org/pdf/2106.06072v1.pdf.

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn.functional as F
 
 from ultralytics.utils import LOGGER
-from ultralytics.utils.metrics import batch_probiou
+from ultralytics.utils.metrics import probiou
 
 
 class Profile(contextlib.ContextDecorator):
@@ -154,7 +154,7 @@ def nms_rotated(boxes, scores, threshold=0.45):
         return np.empty((0,), dtype=np.int8)
     sorted_idx = torch.argsort(scores, descending=True)
     boxes = boxes[sorted_idx]
-    ious = batch_probiou(boxes, boxes).triu_(diagonal=1)
+    ious = probiou(boxes[:, None], boxes[None]).triu_(diagonal=1)
     pick = torch.nonzero(ious.max(dim=0)[0] < threshold).squeeze_(-1)
     return sorted_idx[pick]
 


### PR DESCRIPTION
### Avoiding NaNs in calculating probabilistic IoU
In Issue #13310, @QuantumForgeEngineer ran into NaN losses during training, and traced the problem back to covariance matrices which were not necessarily positive definite (`a*b-c^2 > 0` was not necessarily true for `obb1` or `obb2`.) In response, @glenn-jocher suggested artificially adding a small value `eps` to make sure that `a*b-c^2>0`. Although this is reasonable, there is a simpler solution which avoids this unfortunate rounding error.

For any oriented bounding box `obb`, one can show that $ab-c^2 = (hw/12)^2$, which is always positive. This follows from combining Eq. (1) and (3) of the [original paper](https://arxiv.org/abs/2106.06072) (recall that orthonormal changes of basis as in Eq. (1) don't change the determinant of a matrix.) Therefore, we can replace `(a * b - c^2).sqrt()` with `h*w/12` for `obb1` and `obb2`. This simplification avoids unnecessary calculation, reduces rounding error (which could affect automatic mixed precision training), and ensures that `t3` is positive.

I also did some algebra to also significantly simplify the determinant of the sum of the covariance matrices (see the denominator of `t1` and `t2`, and the numerator of `t3` in `probiou()`.

### Refactoring probiou code to remove the code duplication in the batch_probiou function
I noticed almost identical code in `probiou()` and `batch_probiou()`, so I refactored `probiou()` to automatically broadcast tensor dimensions appropriately, so it can take the place of `batch_probiou()`. For example, if `obb1` has shape (N,) and `obb2` has shape (N,) `probiou(obb1,obb2)` has shape (N,). If instead, `obb1` has shape (M,1) and `obb2` has shape (1,N), then `probiou(obb1,obb2)` will have shape (M,N) instead.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR refactors how oriented bounding box (OBB) similarity is calculated by replacing the `batch_probiou` function with a more flexible `probiou` function across the codebase, simplifying and improving OBB operations. 🚀

### 📊 Key Changes
- Replaces all uses of `batch_probiou` with the new `probiou` function in validation, tracking, loss calculation, and NMS for rotated boxes.
- Refactors the `probiou` implementation for better clarity, efficiency, and broadcasting support.
- Removes the now-unnecessary `batch_probiou` function.
- Updates related code to use the new function signature and broadcasting style.

### 🎯 Purpose & Impact
- **Simplifies the codebase** by consolidating OBB IoU calculations into a single, more versatile function.
- **Improves maintainability** and reduces potential bugs by having one clear implementation.
- **Enhances performance and flexibility** for OBB operations, supporting both single and batched comparisons more efficiently.
- **No changes to user-facing APIs**—existing workflows for OBB detection, tracking, and evaluation remain the same, but benefit from improved backend logic.

Overall, this update makes OBB handling in Ultralytics models cleaner, faster, and easier to maintain! 🧹✨