### PR TITLE
`ultralytics 8.2.52` fix CenterCrop transforms for PIL Image inputs

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.2.51"
+__version__ = "8.2.52"
 
 import os
 

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1401,6 +1401,10 @@ class CenterCrop:
         Returns:
             (numpy.ndarray): The center-cropped and resized image as a numpy array.
         """
+        
+        if isinstance(im, Image.Image):
+            im = np.asarray(im)
+        
         imh, imw = im.shape[:2]
         m = min(imh, imw)  # min dimension
         top, left = (imh - m) // 2, (imw - m) // 2

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1401,10 +1401,8 @@ class CenterCrop:
         Returns:
             (numpy.ndarray): The center-cropped and resized image as a numpy array.
         """
-
-        if isinstance(im, Image.Image):
+        if isinstance(im, Image.Image):  # convert from PIL to numpy array if required
             im = np.asarray(im)
-
         imh, imw = im.shape[:2]
         m = min(imh, imw)  # min dimension
         top, left = (imh - m) // 2, (imw - m) // 2

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1401,10 +1401,10 @@ class CenterCrop:
         Returns:
             (numpy.ndarray): The center-cropped and resized image as a numpy array.
         """
-        
+
         if isinstance(im, Image.Image):
             im = np.asarray(im)
-        
+
         imh, imw = im.shape[:2]
         m = min(imh, imw)  # min dimension
         top, left = (imh - m) // 2, (imw - m) // 2


### PR DESCRIPTION
There's scenarios where im type is an Image instance, raising an error when trying to get im shape, this solution just correct its type on those scenarios.

This may occur because of the [line 46 on predict.py](github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/classify/predict.py#L46) that convert the array to Image, but this happens because of the torchvision.transforms.Resize that expects PIL Image type and its called before center crop on [augment.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/augment.py#L1221).

Fixing this way would have minimum impact and solve this error.

_I have read the CLA Document and I sign the CLA_ 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the `__call__` method in `augment.py` to handle PIL images by converting them to numpy arrays before processing.

### 📊 Key Changes
- 🖼️ Added code to check if input is a PIL image.
- ✨ If the image is a PIL image, convert it to a numpy array for further processing.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: Ensures compatibility with PIL images, allowing for more flexible image input types.
- 🌐 **Impact**: Users can now seamlessly use PIL images without manually converting them to numpy arrays, improving ease of use and reducing potential errors in preprocessing steps.