### PR TITLE
Fixing xyxy2xywh bug

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -387,6 +387,7 @@ def scale_image(masks, im0_shape, ratio_pad=None):
 
     return masks
 
+
 def xyxy2xywh(x):
     """
     Convert bounding box coordinates from (x1, y1, x2, y2) format to (x, y, width, height) format where (x1, y1) is the
@@ -405,6 +406,7 @@ def xyxy2xywh(x):
     y[..., 2] = x[..., 2] - x[..., 0]  # width
     y[..., 3] = x[..., 3] - x[..., 1]  # height
     return y
+
 
 def xywh2xyxy(x):
     """

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -387,7 +387,6 @@ def scale_image(masks, im0_shape, ratio_pad=None):
 
     return masks
 
-
 def xyxy2xywh(x):
     """
     Convert bounding box coordinates from (x1, y1, x2, y2) format to (x, y, width, height) format where (x1, y1) is the
@@ -401,12 +400,11 @@ def xyxy2xywh(x):
     """
     assert x.shape[-1] == 4, f"input shape last dimension expected 4 but input shape is {x.shape}"
     y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)  # faster than clone/copy
-    y[..., 0] = (x[..., 0] + x[..., 2]) / 2  # x center
-    y[..., 1] = (x[..., 1] + x[..., 3]) / 2  # y center
+    y[..., 0] = x[..., 0]  # x (top-left corner)
+    y[..., 1] = x[..., 1]  # y (top-left corner)
     y[..., 2] = x[..., 2] - x[..., 0]  # width
     y[..., 3] = x[..., 3] - x[..., 1]  # height
     return y
-
 
 def xywh2xyxy(x):
     """


### PR DESCRIPTION
### Description

This PR addresses a bug in the `xyxy2xywh` function, which converts bounding box coordinates from `(x1, y1, x2, y2)` format to `(x, y, width, height)` format. The original implementation incorrectly calculated the `x` and `y` coordinates as the center of the bounding box. This PR corrects the calculation to use the top-left corner for `x` and `y`.

### Related Issues

This PR does not currently address any open issues.

### Changes

- Corrected the `xyxy2xywh` function to properly convert bounding box coordinates by using the top-left corner for `x` and `y`.
- Ensured the width and height calculations remain correct.

### Confirmation

_I have read the CLA Document and I sign the CLA_


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to `xyxy2xywh` function to change coordinate system interpretation.

### 📊 Key Changes
- Adjusted the calculation for `x` and `y` coordinates from center to top-left corner in the `xyxy2xywh` function.

### 🎯 Purpose & Impact
- **Improved Clarity:** Simplifies the coordinate system by using the more intuitive top-left origin.
- **Uniformity:** Makes coordinate handling consistent across various sections of the code.
- **User Convenience:** Easier for users to interpret bounding box coordinates mapped to the image's edges.