### PR TITLE
Fix `model.save()` method to FP16

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -312,10 +312,12 @@ class Model(nn.Module):
         """
         self._check_is_pytorch_model()
         from datetime import datetime
+        from copy import deepcopy
 
         from ultralytics import __version__
 
         updates = {
+            "model": deepcopy(self.model).half() if isinstance(self.model, nn.Module) else self.model,
             "date": datetime.now().isoformat(),
             "version": __version__,
             "license": "AGPL-3.0 License (https://ultralytics.com/license)",

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -311,8 +311,8 @@ class Model(nn.Module):
             AssertionError: If the model is not a PyTorch model.
         """
         self._check_is_pytorch_model()
-        from datetime import datetime
         from copy import deepcopy
+        from datetime import datetime
 
         from ultralytics import __version__
 


### PR DESCRIPTION
Resolves Slack discussion @Laughing-q @Burhan-Q @RizwanMunawar

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhances the model-saving mechanism with improved model serialization.

### 📊 Key Changes
- Added `deepcopy` to ensure a complete, independent copy of the model is saved.
- Applied `.half()` to convert the model to half-precision if it is a PyTorch `nn.Module`.

### 🎯 Purpose & Impact
- **Improved Reliability**: Ensures the saved model is an independent copy, reducing the risk of accidental modifications. 🛡️
- **Efficiency Gains**: Saving the model in half-precision reduces the file size and memory usage, offering better performance during deployment. 🚀