### PR TITLE
validator: Add incorrect validation metrics warning with `save_hybrid` flag.

### DIFF
--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -138,7 +138,7 @@ class BaseValidator:
             elif not pt and not jit:
                 self.args.batch = 1  # export.py models default to batch-size 1
                 LOGGER.info(f"Forcing batch=1 square inference (1,3,{imgsz},{imgsz}) for non-PyTorch models")
-            
+
             if self.args.save_hybrid:
                 LOGGER.warning("WARNING ⚠️ Validation metrics will be incorrect due to `save_hybrid`")
 

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -138,6 +138,9 @@ class BaseValidator:
             elif not pt and not jit:
                 self.args.batch = 1  # export.py models default to batch-size 1
                 LOGGER.info(f"Forcing batch=1 square inference (1,3,{imgsz},{imgsz}) for non-PyTorch models")
+            
+            if self.args.save_hybrid:
+                LOGGER.warning("WARNING ⚠️ Validation metrics will be incorrect due to `save_hybrid`")
 
             if str(self.args.data).split(".")[-1] in {"yaml", "yml"}:
                 self.data = check_det_dataset(self.args.data)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Add warning for potential inaccuracies in validation metrics when using `save_hybrid`.

### 📊 Key Changes
- Introduced a warning message when `save_hybrid` option is enabled during validation.

### 🎯 Purpose & Impact
- **Purpose:** Alerts users that activating `save_hybrid` may lead to inaccurate validation metrics.
- **Impact:** Ensures users are aware of potential discrepancies, leading to more informed decision-making and troubleshooting. 🔍