### PR TITLE
Fix `model` parameter in Pose, Segment dataset train examples

### DIFF
--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -71,7 +71,7 @@ To train a YOLOv8n-pose model on the COCO-Pose dataset for 100 epochs with an im
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco-pose.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo detect train data=coco-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations

--- a/docs/en/datasets/pose/coco8-pose.md
+++ b/docs/en/datasets/pose/coco8-pose.md
@@ -44,7 +44,7 @@ To train a YOLOv8n-pose model on the COCO8-Pose dataset for 100 epochs with an i
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco8-pose.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo detect train data=coco8-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations

--- a/docs/en/datasets/pose/tiger-pose.md
+++ b/docs/en/datasets/pose/tiger-pose.md
@@ -57,7 +57,7 @@ To train a YOLOv8n-pose model on the Tiger-Pose dataset for 100 epochs with an i
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo task=pose mode=train data=tiger-pose.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo task=pose mode=train data=tiger-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -69,7 +69,7 @@ To train a YOLOv8n-seg model on the COCO-Seg dataset for 100 epochs with an imag
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco-seg.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo detect train data=coco-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations

--- a/docs/en/datasets/segment/coco8-seg.md
+++ b/docs/en/datasets/segment/coco8-seg.md
@@ -44,7 +44,7 @@ To train a YOLOv8n-seg model on the COCO8-Seg dataset for 100 epochs with an ima
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco8-seg.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo detect train data=coco8-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations


### PR DESCRIPTION
Hi! I am following the [training yolov8-pose models on COCO8-Pose dataset](https://docs.ultralytics.com/datasets/pose/coco8-pose/#usage) guide, it seems like in the "usage" section, the pre-trained model used in shell command differed from the one used in python script. The shell command will start a training session using `yolov8n.pt`, instead of `yolov8n-pose.pt`:

## Python
```python
...
model = YOLO("yolov8n-pose.pt")  # load a pretrained model (recommended for training)
...
```

## CLI
```
yolo detect train data=coco8-pose.yaml model=yolov8n.pt epochs=100 imgsz=640
```

I have found the same situation in some of the other dataset examples, please have a look of the commit. Are these errors?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated documentation to correctly reference specific pretrained models for different tasks.

### 📊 Key Changes
- **COCO-Pose Documentation**: Changed model reference from `yolov8n.pt` to `yolov8n-pose.pt`.
- **COCO8-Pose Documentation**: Changed model reference from `yolov8n.pt` to `yolov8n-pose.pt`.
- **Tiger-Pose Documentation**: Changed model reference from `yolov8n.pt` to `yolov8n-pose.pt`.
- **COCO-Seg Documentation**: Changed model reference from `yolov8n.pt` to `yolov8n-seg.pt`.
- **COCO8-Seg Documentation**: Changed model reference from `yolov8n.pt` to `yolov8n-seg.pt`.

### 🎯 Purpose & Impact
- **Clarity**: Ensures that users are training with the correct YOLOv8 models specific to pose and segmentation tasks, improving their experience and results. 🚀
- **Accuracy**: Reduces confusion and potential errors in model training by clearly specifying the appropriate pretrained models. 👍