### PR TITLE
feat: Add Custom Clip Model Download Path

### DIFF
--- a/ultralytics/models/fastsam/prompt.py
+++ b/ultralytics/models/fastsam/prompt.py
@@ -335,7 +335,7 @@ class FastSAMPrompt:
             self.results[0].masks.data = torch.tensor(np.array([onemask]))
         return self.results
 
-    def text_prompt(self, text,clip_model_path=None):
+    def text_prompt(self, text, clip_model_path=None):
         """Processes a text prompt, applies it to existing results and returns the updated results."""
         if self.results[0].masks is not None:
             format_results = self._format_results(self.results[0], 0)

--- a/ultralytics/models/fastsam/prompt.py
+++ b/ultralytics/models/fastsam/prompt.py
@@ -335,12 +335,12 @@ class FastSAMPrompt:
             self.results[0].masks.data = torch.tensor(np.array([onemask]))
         return self.results
 
-    def text_prompt(self, text):
+    def text_prompt(self, text,clip_model_path=None):
         """Processes a text prompt, applies it to existing results and returns the updated results."""
         if self.results[0].masks is not None:
             format_results = self._format_results(self.results[0], 0)
             cropped_images, filter_id, annotations = self._crop_image(format_results)
-            clip_model, preprocess = self.clip.load("ViT-B/32", device=self.device)
+            clip_model, preprocess = self.clip.load("ViT-B/32", download_root=clip_model_path, device=self.device)
             scores = self.retrieve(clip_model, preprocess, cropped_images, text, device=self.device)
             max_idx = torch.argmax(scores)
             max_idx += sum(np.array(filter_id) <= int(max_idx))


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced text prompt function in `prompt.py` to support custom model paths for better flexibility.

### 📊 Key Changes
- Updated `text_prompt` method to accept an optional `clip_model_path` parameter.
- Modified loading of CLIP model to use the provided `clip_model_path` if available.

### 🎯 Purpose & Impact
- **Flexibility**: Users can now specify a custom path for the CLIP model, which can be useful for using different model versions or local paths 🚀.
- **Convenience**: Simplifies workflows where different models or specific versions are needed, saving time and reducing potential errors 🛠️.
- **Backward Compatibility**: Default behavior remains unchanged when `clip_model_path` is not provided, ensuring existing functionality is uninterrupted 🔄.