### PR TITLE
Fix XPU from `bfloat16` to `float16` in `check_amp function()`

### DIFF
--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -650,7 +650,7 @@ def check_amp(model):
         """All close FP32 vs AMP results."""
         a = m(im, device=device, verbose=False)[0].boxes.data  # FP32 inference
         _amp = torch.cuda.amp if dev_type == "cuda" else torch.xpu.amp
-        with _amp.autocast(enabled=True, dtype=torch.bfloat16 if dev_type == "xpu" else torch.float16):
+        with _amp.autocast(enabled=True, dtype=torch.float16):
             b = m(im, device=device, verbose=False)[0].boxes.data  # AMP inference
         del m
         return a.shape == b.shape and torch.allclose(a, b.float(), atol=0.5)  # close to 0.5 absolute tolerance


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->

While doing checks for [_Automatic Mixed Precision_](https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html) on Intel XPU, the dtype is set as **bfloat16** which can be less accurate for higher precision arithmetic.

**Changing it to float16 which passes AMP checks for better performance.**