### PR TITLE
Add Streamlit Inference Python `model` arg

### DIFF
--- a/docs/en/guides/streamlit-live-inference.md
+++ b/docs/en/guides/streamlit-live-inference.md
@@ -47,9 +47,9 @@ Streamlit makes it simple to build and deploy interactive web applications. Comb
 
 This will launch the Streamlit application in your default web browser. You will see the main title, subtitle, and the sidebar with configuration options. Select your desired YOLOv8 model, set the confidence and NMS thresholds, and click the "Start" button to begin the real-time object detection.
 
-You can optionally supply a specific model to add to the list of models:
+You can optionally supply a specific model in Python:
 
-!!! Example "Streamlit Application with custom models"
+!!! Example "Streamlit Application with a custom model"
 
     === "Python"
 
@@ -60,12 +60,6 @@ You can optionally supply a specific model to add to the list of models:
         solutions.inference(model="path/to/model.pt")
 
         ### Make sure to run the file using command `streamlit run <file-name.py>`
-        ```
-
-    === "CLI"
-
-        ```bash
-        yolo streamlit-predict
         ```
 
 ## Conclusion

--- a/docs/en/guides/streamlit-live-inference.md
+++ b/docs/en/guides/streamlit-live-inference.md
@@ -31,7 +31,7 @@ Streamlit makes it simple to build and deploy interactive web applications. Comb
 
     === "Python"
 
-        ```Python
+        ```python
         from ultralytics import solutions
 
         solutions.inference()
@@ -53,7 +53,7 @@ You can optionally supply a specific model in Python:
 
     === "Python"
 
-        ```Python
+        ```python
         from ultralytics import solutions
 
         # Pass a model as an argument

--- a/docs/en/guides/streamlit-live-inference.md
+++ b/docs/en/guides/streamlit-live-inference.md
@@ -70,7 +70,6 @@ You can optionally add your custom models to the list of available models:
         yolo streamlit-predict
         ```
 
-
 ## Conclusion
 
 By following this guide, you have successfully created a real-time object detection application using Streamlit and Ultralytics YOLOv8. This application allows you to experience the power of YOLOv8 in detecting objects through your webcam, with a user-friendly interface and the ability to stop the video stream at any time.

--- a/docs/en/guides/streamlit-live-inference.md
+++ b/docs/en/guides/streamlit-live-inference.md
@@ -99,6 +99,7 @@ Then, you can create a basic Streamlit application to run live inference:
 
     ```python
     from ultralytics import solutions
+
     solutions.inference()
 
     ### Make sure to run the file using command `streamlit run <file-name.py>`

--- a/docs/en/guides/streamlit-live-inference.md
+++ b/docs/en/guides/streamlit-live-inference.md
@@ -47,6 +47,30 @@ Streamlit makes it simple to build and deploy interactive web applications. Comb
 
 This will launch the Streamlit application in your default web browser. You will see the main title, subtitle, and the sidebar with configuration options. Select your desired YOLOv8 model, set the confidence and NMS thresholds, and click the "Start" button to begin the real-time object detection.
 
+You can optionally add your custom models to the list of available models:
+
+!!! Example "Streamlit Application with custom models"
+
+    === "Python"
+
+        ```Python
+        from ultralytics import solutions
+
+        # Files 'custommodel1.pt' and 'custom_model_2.pt' must be in the same folder
+        custom_models = ['CustomModel1', 'Custom_Model_2']
+
+        solutions.inference(custom_models)
+
+        ### Make sure to run the file using command `streamlit run <file-name.py>`
+        ```
+
+    === "CLI"
+
+        ```bash
+        yolo streamlit-predict
+        ```
+
+
 ## Conclusion
 
 By following this guide, you have successfully created a real-time object detection application using Streamlit and Ultralytics YOLOv8. This application allows you to experience the power of YOLOv8 in detecting objects through your webcam, with a user-friendly interface and the ability to stop the video stream at any time.

--- a/docs/en/guides/streamlit-live-inference.md
+++ b/docs/en/guides/streamlit-live-inference.md
@@ -47,7 +47,7 @@ Streamlit makes it simple to build and deploy interactive web applications. Comb
 
 This will launch the Streamlit application in your default web browser. You will see the main title, subtitle, and the sidebar with configuration options. Select your desired YOLOv8 model, set the confidence and NMS thresholds, and click the "Start" button to begin the real-time object detection.
 
-You can optionally add your custom models to the list of available models:
+You can optionally supply a specific model to add to the list of models:
 
 !!! Example "Streamlit Application with custom models"
 
@@ -56,10 +56,8 @@ You can optionally add your custom models to the list of available models:
         ```Python
         from ultralytics import solutions
 
-        # Files 'custommodel1.pt' and 'custom_model_2.pt' must be in the same folder
-        custom_models = ['CustomModel1', 'Custom_Model_2']
-
-        solutions.inference(custom_models)
+        # Pass a model as an argument
+        solutions.inference(model="path/to/model.pt")
 
         ### Make sure to run the file using command `streamlit run <file-name.py>`
         ```

--- a/docs/en/guides/streamlit-live-inference.md
+++ b/docs/en/guides/streamlit-live-inference.md
@@ -97,7 +97,7 @@ Then, you can create a basic Streamlit application to run live inference:
 
     === "Python"
 
-    ```Python
+    ```python
     from ultralytics import solutions
     solutions.inference()
 

--- a/ultralytics/solutions/streamlit_inference.py
+++ b/ultralytics/solutions/streamlit_inference.py
@@ -10,7 +10,7 @@ from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.downloads import GITHUB_ASSETS_STEMS
 
 
-def inference():
+def inference(custom_models=None):
     """Runs real-time object detection on video input using Ultralytics YOLOv8 in a Streamlit application."""
     check_requirements("streamlit>=1.29.0")  # scope imports for faster ultralytics package load speeds
     import streamlit as st
@@ -67,7 +67,12 @@ def inference():
         vid_file_name = 0
 
     # Add dropdown menu for model selection
-    available_models = (x.replace("yolo", "YOLO") for x in GITHUB_ASSETS_STEMS if x.startswith("yolov8"))
+    available_models = [x.replace("yolo", "YOLO") for x in GITHUB_ASSETS_STEMS if x.startswith("yolov8")]
+
+    # Add custom models if provided
+    if custom_models:
+        available_models.extend(custom_models)    
+     
     selected_model = st.sidebar.selectbox("Model", available_models)
     with st.spinner("Model is downloading..."):
         model = YOLO(f"{selected_model.lower()}.pt")  # Load the YOLO model

--- a/ultralytics/solutions/streamlit_inference.py
+++ b/ultralytics/solutions/streamlit_inference.py
@@ -10,7 +10,7 @@ from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.downloads import GITHUB_ASSETS_STEMS
 
 
-def inference(custom_models=None):
+def inference(model=None):
     """Runs real-time object detection on video input using Ultralytics YOLOv8 in a Streamlit application."""
     check_requirements("streamlit>=1.29.0")  # scope imports for faster ultralytics package load speeds
     import streamlit as st
@@ -68,10 +68,8 @@ def inference(custom_models=None):
 
     # Add dropdown menu for model selection
     available_models = [x.replace("yolo", "YOLO") for x in GITHUB_ASSETS_STEMS if x.startswith("yolov8")]
-
-    # Add custom models if provided
-    if custom_models:
-        available_models.extend(custom_models)
+    if model:
+        available_models.insert(0, model)
 
     selected_model = st.sidebar.selectbox("Model", available_models)
     with st.spinner("Model is downloading..."):

--- a/ultralytics/solutions/streamlit_inference.py
+++ b/ultralytics/solutions/streamlit_inference.py
@@ -71,8 +71,8 @@ def inference(custom_models=None):
 
     # Add custom models if provided
     if custom_models:
-        available_models.extend(custom_models)    
-     
+        available_models.extend(custom_models)
+
     selected_model = st.sidebar.selectbox("Model", available_models)
     with st.spinner("Model is downloading..."):
         model = YOLO(f"{selected_model.lower()}.pt")  # Load the YOLO model


### PR DESCRIPTION
The change allows the user to include custom models in the streamlit selectbox when using solution.inference()

I have to add an optional parameter so the user can include the models form the user's script.

The use is documented in the 'guides' file.

This PR was requested by Muhammad Rizwan Munawar in this post: 
https://www.linkedin.com/feed/update/urn:li:activity:7220221349149999105/

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR introduces the ability to specify a custom YOLOv8 model for Streamlit live inference applications.

### 📊 Key Changes
- Updated documentation to include instructions for using a custom model in Streamlit.
- Modified `inference` function to accept an optional `model` parameter.
- Adjusted Streamlit sidebar to prioritize and display the custom model if provided.

### 🎯 Purpose & Impact
- **Customization**: Enables users to specify and use their own YOLOv8 model for inference, enhancing flexibility.
- **User Experience**: Improves the documentation with clear examples, making it easier for users to implement their custom models.
- **Functionality**: The dropdown menu in the Streamlit app now lists the custom model first, streamlining the selection process. This update allows for a more tailored and efficient setup for specific user needs.