### PR TITLE
`ultralytics 8.2.64` YOLOv10 SavedModel, TFlite, and GraphDef export

### DIFF
--- a/docs/en/models/yolov10.md
+++ b/docs/en/models/yolov10.md
@@ -198,9 +198,9 @@ Due to the new operations introduced with YOLOv10, not all export formats provid
 | [OpenVINO](../integrations/openvino.md)           | ✅        |
 | [TensorRT](../integrations/tensorrt.md)           | ✅        |
 | [CoreML](../integrations/coreml.md)               | ❌        |
-| [TF SavedModel](../integrations/tf-savedmodel.md) | ❌        |
-| [TF GraphDef](../integrations/tf-graphdef.md)     | ❌        |
-| [TF Lite](../integrations/tflite.md)              | ❌        |
+| [TF SavedModel](../integrations/tf-savedmodel.md) | ✅        |
+| [TF GraphDef](../integrations/tf-graphdef.md)     | ✅        |
+| [TF Lite](../integrations/tflite.md)              | ✅        |
 | [TF Edge TPU](../integrations/edge-tpu.md)        | ❌        |
 | [TF.js](../integrations/tfjs.md)                  | ❌        |
 | [PaddlePaddle](../integrations/paddlepaddle.md)   | ❌        |

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.2.63"
+__version__ = "8.2.64"
 
 import os
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -885,6 +885,7 @@ class Exporter:
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)
             custom_input_op_name_np_data_path=np_data,
+            disable_group_convolution = True
         )
         yaml_save(f / "metadata.yaml", self.metadata)  # add metadata.yaml
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -886,7 +886,7 @@ class Exporter:
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)
             custom_input_op_name_np_data_path=np_data,
             disable_group_convolution=True,
-            enable_batchmatmul_unfold=True
+            enable_batchmatmul_unfold=True,
         )
         yaml_save(f / "metadata.yaml", self.metadata)  # add metadata.yaml
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -885,8 +885,8 @@ class Exporter:
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)
             custom_input_op_name_np_data_path=np_data,
-            disable_group_convolution=True,
-            enable_batchmatmul_unfold=True,
+            disable_group_convolution=True,  # for end-to-end model compatibility
+            enable_batchmatmul_unfold=True,  # for end-to-end model compatibility
         )
         yaml_save(f / "metadata.yaml", self.metadata)  # add metadata.yaml
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -885,7 +885,7 @@ class Exporter:
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)
             custom_input_op_name_np_data_path=np_data,
-            disable_group_convolution = True
+            disable_group_convolution=True,
         )
         yaml_save(f / "metadata.yaml", self.metadata)  # add metadata.yaml
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -886,6 +886,7 @@ class Exporter:
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)
             custom_input_op_name_np_data_path=np_data,
             disable_group_convolution=True,
+            enable_batchmatmul_unfold=True
         )
         yaml_save(f / "metadata.yaml", self.metadata)  # add metadata.yaml
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -589,7 +589,7 @@ class AutoBackend(nn.Module):
                         # xywh are normalized in TFLite/EdgeTPU to mitigate quantization error of integer models
                         if x.shape[-1] == 6:  # end-to-end model
                             x[:, :, [0, 2]] *= w
-                            x[:, :, [1, 3]] *= h   
+                            x[:, :, [1, 3]] *= h
                         else:
                             x[:, [0, 2]] *= w
                             x[:, [1, 3]] *= h
@@ -598,7 +598,7 @@ class AutoBackend(nn.Module):
             if len(y) == 2:  # segment with (det, proto) output order reversed
                 if len(y[1].shape) != 4:
                     y = list(reversed(y))  # should be y = (1, 116, 8400), (1, 160, 160, 32)
-                if y[1].shape[-1] == 6: # end-to-end model
+                if y[1].shape[-1] == 6:  # end-to-end model
                     y = [y[1]]
                 else:
                     y[1] = np.transpose(y[1], (0, 3, 1, 2))  # should be y = (1, 116, 8400), (1, 32, 160, 160)

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -587,16 +587,22 @@ class AutoBackend(nn.Module):
                     if x.ndim == 3:  # if task is not classification, excluding masks (ndim=4) as well
                         # Denormalize xywh by image size. See https://github.com/ultralytics/ultralytics/pull/1695
                         # xywh are normalized in TFLite/EdgeTPU to mitigate quantization error of integer models
-                        x[:, [0, 2]] *= w
-                        x[:, [1, 3]] *= h
+                        if x.shape[-1] == 6:  # end-to-end model
+                            x[:, :, [0, 2]] *= w
+                            x[:, :, [1, 3]] *= h   
+                        else:
+                            x[:, [0, 2]] *= w
+                            x[:, [1, 3]] *= h
                     y.append(x)
             # TF segment fixes: export is reversed vs ONNX export and protos are transposed
             if len(y) == 2:  # segment with (det, proto) output order reversed
                 if len(y[1].shape) != 4:
                     y = list(reversed(y))  # should be y = (1, 116, 8400), (1, 160, 160, 32)
-                y[1] = np.transpose(y[1], (0, 3, 1, 2))  # should be y = (1, 116, 8400), (1, 32, 160, 160)
+                if y[1].shape[-1] == 6: # end-to-end model
+                    y = [y[1]]
+                else:
+                    y[1] = np.transpose(y[1], (0, 3, 1, 2))  # should be y = (1, 116, 8400), (1, 32, 160, 160)
             y = [x if isinstance(x, np.ndarray) else x.numpy() for x in y]
-
         # for x in y:
         #     print(type(x), len(x)) if isinstance(x, (list, tuple)) else print(type(x), x.shape)  # debug shapes
         if isinstance(y, (list, tuple)):

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -603,6 +603,7 @@ class AutoBackend(nn.Module):
                 else:
                     y[1] = np.transpose(y[1], (0, 3, 1, 2))  # should be y = (1, 116, 8400), (1, 32, 160, 160)
             y = [x if isinstance(x, np.ndarray) else x.numpy() for x in y]
+
         # for x in y:
         #     print(type(x), len(x)) if isinstance(x, (list, tuple)) else print(type(x), x.shape)  # debug shapes
         if isinstance(y, (list, tuple)):

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -130,7 +130,9 @@ def benchmark(
             assert model.task != "pose" or i != 7, "GraphDef Pose inference is not supported"
             assert i not in {9, 10}, "inference not supported"  # Edge TPU and TF.js are unsupported
             assert i != 5 or platform.system() == "Darwin", "inference only supported on macOS>=10.13"  # CoreML
-            assert i not in {8} or not is_end2end or not MACOS, "TFLite is not supported for end-to-end models on MacOS" # TFLite in MacOS for end-to-end models
+            assert (
+                i not in {8} or not is_end2end or not MACOS
+            ), "TFLite is not supported for end-to-end models on MacOS"  # TFLite in MacOS for end-to-end models
             exported_model.predict(ASSETS / "bus.jpg", imgsz=imgsz, device=device, half=half)
 
             # Validate

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -104,7 +104,7 @@ def benchmark(
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 TensorFlow exports not supported by onnx2tf yet"
             if i in {9, 10}:  # TF EdgeTPU and TF.js
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 TensorFlow exports not supported by onnx2tf yet"
-                assert not is_end2end, "End-to-end models not supported by TF EdgeTPU and TF.js yet"                
+                assert not is_end2end, "End-to-end models not supported by TF EdgeTPU and TF.js yet"
             if i in {11}:  # Paddle
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 Paddle exports not supported yet"
                 assert not is_end2end, "End-to-end models not supported by PaddlePaddle yet"

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -130,9 +130,7 @@ def benchmark(
             assert model.task != "pose" or i != 7, "GraphDef Pose inference is not supported"
             assert i not in {9, 10}, "inference not supported"  # Edge TPU and TF.js are unsupported
             assert i != 5 or platform.system() == "Darwin", "inference only supported on macOS>=10.13"  # CoreML
-            assert (
-                i not in {8} or not is_end2end or not MACOS
-            ), "TFLite is not supported for end-to-end models on MacOS"  # TFLite in MacOS for end-to-end models
+            assert i != 8 or not is_end2end or not MACOS, "TFLite is not supported for end-to-end models on MacOS"
             exported_model.predict(ASSETS / "bus.jpg", imgsz=imgsz, device=device, half=half)
 
             # Validate

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -100,9 +100,11 @@ def benchmark(
                 assert not is_end2end, "End-to-end models not supported by CoreML and TF.js yet"
             if i in {3, 5}:  # CoreML and OpenVINO
                 assert not IS_PYTHON_3_12, "CoreML and OpenVINO not supported on Python 3.12"
-            if i in {6, 7, 8, 9, 10}:  # All TF formats
+            if i in {6, 7, 8}:  # TF SavedModel, TF GraphDef, and TFLite
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 TensorFlow exports not supported by onnx2tf yet"
-                assert not is_end2end, "End-to-end models not supported by onnx2tf yet"
+            if i in {9, 10}:  # TF EdgeTPU and TF.js
+                assert not isinstance(model, YOLOWorld), "YOLOWorldv2 TensorFlow exports not supported by onnx2tf yet"
+                assert not is_end2end, "End-to-end models not supported by TF EdgeTPU and TF.js yet"                
             if i in {11}:  # Paddle
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 Paddle exports not supported yet"
                 assert not is_end2end, "End-to-end models not supported by PaddlePaddle yet"

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -130,7 +130,6 @@ def benchmark(
             assert model.task != "pose" or i != 7, "GraphDef Pose inference is not supported"
             assert i not in {9, 10}, "inference not supported"  # Edge TPU and TF.js are unsupported
             assert i != 5 or platform.system() == "Darwin", "inference only supported on macOS>=10.13"  # CoreML
-            assert i != 8 or not is_end2end or not MACOS, "TFLite is not supported for end-to-end models on MacOS"
             exported_model.predict(ASSETS / "bus.jpg", imgsz=imgsz, device=device, half=half)
 
             # Validate

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -130,6 +130,7 @@ def benchmark(
             assert model.task != "pose" or i != 7, "GraphDef Pose inference is not supported"
             assert i not in {9, 10}, "inference not supported"  # Edge TPU and TF.js are unsupported
             assert i != 5 or platform.system() == "Darwin", "inference only supported on macOS>=10.13"  # CoreML
+            assert i not in {8} or not is_end2end or not MACOS, "TFLite is not supported for end-to-end models on MacOS" # TFLite in MacOS for end-to-end models
             exported_model.predict(ASSETS / "bus.jpg", imgsz=imgsz, device=device, half=half)
 
             # Validate


### PR DESCRIPTION
Hello,

Currently, some of the export formats (**TF SavedModel**, **TF Lite**, and **TF GraphDef**) are not supported for YOLOv10 due to an operation, grouped convolutions, used in YOLOv10.

Let's look at how this problem can be found and resolved. Model conversion from `.onnx` to `SavedModel`, `.tflite`, and `.pb` formats are done by onnx2tf package by function `onnx2tf.convert()`. First, let's try to convert YOLOv10 into `SavedModel` as it is now. To see any warning message, it needs to set the `verbosity` argument in `onnx2tf.convert() `to `'info'` in `exporter.py`. During model conversion, this warning is raised:

> This model contains GroupConvolution and is automatically optimized for TFLite, but is not output because saved_model does not support GroupConvolution. If saved_model is needed, specify --disable_group_convolution to retransform the model.

Setting optional argument `'disable_group_convolution' `in `onnx2tf.convert(),` replaces _GroupConvolution_ with _SeparableConvolution_, which resembles the function of grouped convolutions [see](https://github.com/PINTO0309/onnx2tf/blob/1.22.3/onnx2tf/onnx2tf.py#L1212). It is applied only to models using grouped convolutions (like YOLOv10). The owner of onnx2tf [mentioned](https://github.com/PINTO0309/onnx2tf/pull/361). this issue as TensorFlow bug that does not allow GroupConvolution to be output to `saved_model`. This change can be run under the current erequriement `onnx2tf>1.17.5,<=1.22.3`.

Also, minimum modifications are applied to the inference pipeline in TensorFlow inference section to be workable for YOLOv10 as an end-to-end NMS-free model. Finally, these changes are tested not to intervene for exporting other models like YOLOv8 at different sizes and tasks as well as YOLOv5.

I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved TensorFlow export compatibility and enhanced handling for end-to-end models.

### 📊 Key Changes
- Added `disable_group_convolution=True` to TensorFlow SavedModel export options.
- Adjusted denormalization logic for tensor shapes, especially for end-to-end models.
- Fixed segment output handling by conditionally reversing and transposing outputs.

### 🎯 Purpose & Impact
- **Enhanced Export Compatibility**: Disabling group convolution helps ensure the exported TensorFlow models work more smoothly with a wider variety of applications.
- **Improved Model Handling**: Better handling and formatting of tensor shapes enhance the reliability of end-to-end models and segmentation tasks, reducing errors and improving model performance during deployment.
- **User-Friendly Tweaks**: These refinements ensure that exported models are more robust and easier to use, contributing to a smoother user experience.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements in YOLOv10's compatibility with various TensorFlow export formats and optimized end-to-end model support.

### 📊 Key Changes
- 📝 Documentation update: YOLOv10 now supports more TensorFlow export formats including TF SavedModel, TF GraphDef, and TF Lite.
- 📈 Exporter improvements: Added support for `disable_group_convolution` and `enable_batchmatmul_unfold` to improve end-to-end model compatibility.
- 🔄 Adjustment in auto-backend logic: Updated tensor resizing logic for better compatibility with end-to-end models.
- 🚫 Limitations clarified: CoreML and TF.js do not yet support Python 3.12 or end-to-end models.

### 🎯 Purpose & Impact
- ✅ **Greater compatibility**: Enables the usage of YOLOv10 with a wider range of TensorFlow-based formats, expanding its utility.
- 🔧 **Improved model performance**: Enhancements in export and backend logic result in better end-to-end model support and performance.
- ⚠️ **Clearer limitations**: Documentation clarifies which export formats are supported and specific limitations, helping users avoid compatibility issues.