### PR TITLE
Fix OBB Docs page commas error

### DIFF
--- a/docs/en/datasets/obb/index.md
+++ b/docs/en/datasets/obb/index.md
@@ -15,7 +15,7 @@ Training a precise object detection model with oriented bounding boxes (OBB) req
 The YOLO OBB format designates bounding boxes by their four corner points with coordinates normalized between 0 and 1. It follows this format:
 
 ```bash
-class_index, x1, y1, x2, y2, x3, y3, x4, y4
+class_index x1 y1 x2 y2 x3 y3 x4 y4
 ```
 
 Internally, YOLO processes losses and outputs in the `xywhr` format, which represents the bounding box's center point (xy), width, height, and rotation.


### PR DESCRIPTION
May resolve https://github.com/ultralytics/ultralytics/issues/14606

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated documentation for the YOLO Oriented Bounding Box (OBB) format.

### 📊 Key Changes
- Modified the OBB format specification in documentation to use spaces instead of commas between coordinates.

### 🎯 Purpose & Impact
- 📝 **Clarification**: Simplifies the format explanation, making it easier to read and implement.
- 🚀 **User-Friendliness**: Improves the user experience by providing a clearer example, potentially reducing errors during model training and implementation.