### PR TITLE
Attempt to fix NAS models inference

### DIFF
--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -17,7 +17,7 @@ import torch
 
 from ultralytics.engine.model import Model
 from ultralytics.utils.downloads import attempt_download_asset
-from ultralytics.utils.torch_utils import model_info, smart_inference_mode
+from ultralytics.utils.torch_utils import model_info
 from .predict import NASPredictor
 from .val import NASValidator
 
@@ -49,8 +49,7 @@ class NAS(Model):
         assert Path(model).suffix not in {".yaml", ".yml"}, "YOLO-NAS models only support pre-trained models."
         super().__init__(model, task="detect")
 
-    @smart_inference_mode()
-    def _load(self, weights: str, task: str):
+    def _load(self, weights: str, task=None) -> None:
         """Loads an existing NAS model weights or creates a new NAS model with pretrained weights if not provided."""
         import super_gradients
 

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -63,13 +63,13 @@ class NAS(Model):
 
         torch.save(self.model, str(Path().cwd() / Path(weights).name))
 
-        # # Override the forward method to ignore additional arguments
-        # def new_forward(x, *args, **kwargs):
-        #     """Ignore additional __call__ arguments."""
-        #     return self.model._original_forward(x)
-        #
-        # self.model._original_forward = self.model.forward
-        # self.model.forward = new_forward
+        # Override the forward method to ignore additional arguments
+        def new_forward(x, *args, **kwargs):
+            """Ignore additional __call__ arguments."""
+            return self.model._original_forward(x)
+
+        self.model._original_forward = self.model.forward
+        self.model.forward = new_forward
 
         # Standardize model
         self.model.fuse = lambda verbose=True: self.model

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -65,6 +65,14 @@ class NAS(Model):
             self.model._original_call = self.model.__call__
             self.model.__call__ = new_call
 
+            # Override the __call__ method to ignore additional arguments
+            def new_forward(x, *args, **kwargs):
+                """Ignore additional __call__ arguments."""
+                return self.model._original_forward(x)
+
+            self.model._original_forward = self.model.forward
+            self.model.forward = new_forward
+
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
 

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -18,6 +18,7 @@ import torch
 from ultralytics.engine.model import Model
 from ultralytics.utils.downloads import attempt_download_asset
 from ultralytics.utils.torch_utils import model_info, smart_inference_mode
+
 from .predict import NASPredictor
 from .val import NASValidator
 

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -56,10 +56,10 @@ class NAS(Model):
 
         suffix = Path(weights).suffix
         if suffix == ".pt":
-            self.model_inner = torch.load(attempt_download_asset(weights))
+            self.model_single_arg = torch.load(attempt_download_asset(weights))
 
             def model_wrapper(arg1, *args, **kwargs):  # ignore additional Ultralytics args like 'augment', etc.
-                return self.model_inner(arg1)
+                return self.model_single_arg(arg1)
 
             self.model = model_wrapper
 

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -18,7 +18,6 @@ import torch
 from ultralytics.engine.model import Model
 from ultralytics.utils.downloads import attempt_download_asset
 from ultralytics.utils.torch_utils import model_info, smart_inference_mode
-
 from .predict import NASPredictor
 from .val import NASValidator
 
@@ -57,7 +56,13 @@ class NAS(Model):
 
         suffix = Path(weights).suffix
         if suffix == ".pt":
-            self.model = torch.load(attempt_download_asset(weights))
+            self.model_inner = torch.load(attempt_download_asset(weights))
+
+            def model_wrapper(arg1, *args, **kwargs):  # ignore additional Ultralytics args like 'augment', etc.
+                return self.model_inner(arg1)
+
+            self.model = model_wrapper
+
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
         # Standardize model

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -18,7 +18,6 @@ import torch
 from ultralytics.engine.model import Model
 from ultralytics.utils.downloads import attempt_download_asset
 from ultralytics.utils.torch_utils import model_info, smart_inference_mode
-
 from .predict import NASPredictor
 from .val import NASValidator
 
@@ -58,6 +57,15 @@ class NAS(Model):
         suffix = Path(weights).suffix
         if suffix == ".pt":
             self.model = torch.load(attempt_download_asset(weights))
+
+            # Override the __call__ method to ignore additional arguments
+            def new_call(x, *args, **kwargs):
+                """Ignore additional __call__ arguments."""
+                return self.model._original_call(x)
+
+            self.model._original_call = self.model.__call__
+            self.model.__call__ = new_call
+
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
 

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -61,13 +61,13 @@ class NAS(Model):
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
 
-        # Override the forward method to ignore additional arguments
-        def new_forward(x, *args, **kwargs):
-            """Ignore additional __call__ arguments."""
-            return self.model._original_forward(x)
-
-        self.model._original_forward = self.model.forward
-        self.model.forward = new_forward
+        # # Override the forward method to ignore additional arguments
+        # def new_forward(x, *args, **kwargs):
+        #     """Ignore additional __call__ arguments."""
+        #     return self.model._original_forward(x)
+        #
+        # self.model._original_forward = self.model.forward
+        # self.model.forward = new_forward
 
         # Standardize model
         self.model.fuse = lambda verbose=True: self.model

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -18,7 +18,6 @@ import torch
 from ultralytics.engine.model import Model
 from ultralytics.utils.downloads import attempt_download_asset
 from ultralytics.utils.torch_utils import model_info
-
 from .predict import NASPredictor
 from .val import NASValidator
 
@@ -60,6 +59,8 @@ class NAS(Model):
 
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
+
+        torch.save(self.model, str(Path().cwd() / Path(weights.name)))
 
         # # Override the forward method to ignore additional arguments
         # def new_forward(x, *args, **kwargs):

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -58,24 +58,16 @@ class NAS(Model):
         if suffix == ".pt":
             self.model = torch.load(attempt_download_asset(weights))
 
-            # Override the __call__ method to ignore additional arguments
-            def new_call(x, *args, **kwargs):
-                """Ignore additional __call__ arguments."""
-                return self.model._original_call(x)
-
-            self.model._original_call = self.model.__call__
-            self.model.__call__ = new_call
-
-            # Override the __call__ method to ignore additional arguments
-            def new_forward(x, *args, **kwargs):
-                """Ignore additional __call__ arguments."""
-                return self.model._original_forward(x)
-
-            self.model._original_forward = self.model.forward
-            self.model.forward = new_forward
-
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
+
+        # Override the forward method to ignore additional arguments
+        def new_forward(x, *args, **kwargs):
+            """Ignore additional __call__ arguments."""
+            return self.model._original_forward(x)
+
+        self.model._original_forward = self.model.forward
+        self.model.forward = new_forward
 
         # Standardize model
         self.model.fuse = lambda verbose=True: self.model

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -61,7 +61,7 @@ class NAS(Model):
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
 
-        torch.save(self.model, str(Path().cwd() / Path(weights.name)))
+        torch.save(self.model, str(Path().cwd() / Path(weights).name))
 
         # # Override the forward method to ignore additional arguments
         # def new_forward(x, *args, **kwargs):

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -12,7 +12,6 @@ Example:
 """
 
 from pathlib import Path
-from types import MethodType
 
 import torch
 
@@ -59,15 +58,6 @@ class NAS(Model):
         suffix = Path(weights).suffix
         if suffix == ".pt":
             self.model = torch.load(attempt_download_asset(weights))
-
-            # Override the __call__ method to ignore additional arguments
-            def new_call(model, x, *args, **kwargs):
-                """Ignore additional __call__ arguments."""
-                return model._original_call(x)
-
-            self.model._original_call = self.model.__call__
-            self.model.__call__ = MethodType(new_call, self.model)
-
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
 

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -18,6 +18,7 @@ import torch
 from ultralytics.engine.model import Model
 from ultralytics.utils.downloads import attempt_download_asset
 from ultralytics.utils.torch_utils import model_info
+
 from .predict import NASPredictor
 from .val import NASValidator
 

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -18,7 +18,6 @@ import torch
 from ultralytics.engine.model import Model
 from ultralytics.utils.downloads import attempt_download_asset
 from ultralytics.utils.torch_utils import model_info
-
 from .predict import NASPredictor
 from .val import NASValidator
 
@@ -60,8 +59,6 @@ class NAS(Model):
 
         elif suffix == "":
             self.model = super_gradients.training.models.get(weights, pretrained_weights="coco")
-
-        torch.save(self.model, str(Path().cwd() / Path(weights).name))
 
         # Override the forward method to ignore additional arguments
         def new_forward(x, *args, **kwargs):

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -453,11 +453,12 @@ class AutoBackend(nn.Module):
 
         # PyTorch
         if self.pt or self.nn_module:
-            y = (
-                self.model(im)
-                if "yolonas" in self.model.__class__.__name__.lower()
-                else self.model(im, augment=augment, visualize=visualize, embed=embed)
-            )
+            y = self.model(im)
+            #y = (
+            #    self.model(im)
+            #    if "yolonas" in self.model.__class__.__name__.lower()
+            #    else self.model(im, augment=augment, visualize=visualize, embed=embed)
+            #)
 
         # TorchScript
         elif self.jit:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -453,12 +453,11 @@ class AutoBackend(nn.Module):
 
         # PyTorch
         if self.pt or self.nn_module:
-            y = self.model(im)
-            # y = (
-            #    self.model(im)
-            #    if "yolonas" in self.model.__class__.__name__.lower()
-            #    else self.model(im, augment=augment, visualize=visualize, embed=embed)
-            # )
+            y = (
+               self.model(im)
+               if "yolonas" in self.model.__class__.__name__.lower()
+               else self.model(im, augment=augment, visualize=visualize, embed=embed)
+            )
 
         # TorchScript
         elif self.jit:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -454,9 +454,9 @@ class AutoBackend(nn.Module):
         # PyTorch
         if self.pt or self.nn_module:
             y = (
-               self.model(im)
-               if "yolonas" in self.model.__class__.__name__.lower()
-               else self.model(im, augment=augment, visualize=visualize, embed=embed)
+                self.model(im)
+                if "yolonas" in self.model.__class__.__name__.lower()
+                else self.model(im, augment=augment, visualize=visualize, embed=embed)
             )
 
         # TorchScript

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -454,11 +454,11 @@ class AutoBackend(nn.Module):
         # PyTorch
         if self.pt or self.nn_module:
             y = self.model(im)
-            #y = (
+            # y = (
             #    self.model(im)
             #    if "yolonas" in self.model.__class__.__name__.lower()
             #    else self.model(im, augment=augment, visualize=visualize, embed=embed)
-            #)
+            # )
 
         # TorchScript
         elif self.jit:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -453,11 +453,7 @@ class AutoBackend(nn.Module):
 
         # PyTorch
         if self.pt or self.nn_module:
-            y = (
-                self.model(im)
-                if "yolonas" in self.model.__class__.__name__.lower()
-                else self.model(im, augment=augment, visualize=visualize, embed=embed)
-            )
+            self.model(im, augment=augment, visualize=visualize, embed=embed)
 
         # TorchScript
         elif self.jit:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -453,7 +453,7 @@ class AutoBackend(nn.Module):
 
         # PyTorch
         if self.pt or self.nn_module:
-            self.model(im, augment=augment, visualize=visualize, embed=embed)
+            y = self.model(im, augment=augment, visualize=visualize, embed=embed)
 
         # TorchScript
         elif self.jit:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -453,7 +453,11 @@ class AutoBackend(nn.Module):
 
         # PyTorch
         if self.pt or self.nn_module:
-            y = self.model(im, augment=augment, visualize=visualize, embed=embed)
+            y = (
+                self.model(im)
+                if "yolonas" in self.model.__class__.__name__.lower()
+                else self.model(im, augment=augment, visualize=visualize, embed=embed)
+            )
 
         # TorchScript
         elif self.jit:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved handling of YOLO-NAS model loading and inference.

### 📊 Key Changes
- 🚫 Removed `smart_inference_mode` decorator from the `_load` method.
- 📂 Added new logic to override the `forward` method to ignore extra arguments.

### 🎯 Purpose & Impact
- 🔄 **More Robust Model Loading**: Provides flexibility by removing strict inference mode constraints, making the code easier to extend and debug.
- 👍 **Enhanced Forward Method**: The updated method ensures the main model’s `forward` function can handle unexpected arguments gracefully, improving overall robustness and reducing potential errors during inference.