### PR TITLE
Fix crash due to overflow

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -186,7 +186,8 @@ class v8DetectionLoss:
             i = targets[:, 0]  # image index
             _, counts = i.unique(return_counts=True)
             counts = counts.to(dtype=torch.int32)
-            max_count = counts.max().item() if counts.numel() > 0 else 0
+            max_count = counts.max().item()
+            max_count = 0 if max_count < 0 else max_count
             out = torch.zeros(batch_size, max_count, ne - 1, device=self.device)
             for j in range(batch_size):
                 matches = i == j

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -186,7 +186,8 @@ class v8DetectionLoss:
             i = targets[:, 0]  # image index
             _, counts = i.unique(return_counts=True)
             counts = counts.to(dtype=torch.int32)
-            out = torch.zeros(batch_size, counts.max(), ne - 1, device=self.device)
+            max_count = counts.max().item() if counts.numel() > 0 else 0
+            out = torch.zeros(batch_size, max_count, ne - 1, device=self.device)
             for j in range(batch_size):
                 matches = i == j
                 n = matches.sum()

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -186,8 +186,7 @@ class v8DetectionLoss:
             i = targets[:, 0]  # image index
             _, counts = i.unique(return_counts=True)
             counts = counts.to(dtype=torch.int32)
-            max_count = counts.max().item()
-            max_count = 0 if max_count < 0 else max_count
+            max_count = max(counts.max().item(), 0)
             out = torch.zeros(batch_size, max_count, ne - 1, device=self.device)
             for j in range(batch_size):
                 matches = i == j


### PR DESCRIPTION
The returned count will be negative when there are no targets. Add check to ensure non-negative counts.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes an issue in the loss computation by ensuring tensor initialization accounts for edge cases where count is zero.

### 📊 Key Changes
- Modified tensor initialization to utilize `max(counts.max().item(), 0)` instead of `counts.max()`.
  
### 🎯 Purpose & Impact
- 🐛 **Bug Fix**: Prevents errors when the count of unique target indices is zero.
- ✅ **Improved Stability**: Ensures the loss computation runs smoothly without unexpected crashes.
- 🌐 **Broader Compatibility**: Better handling of edge cases improves the robustness of the model training process.