### PR TITLE
Add compatible `tensorstore` versions for `aarch64`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,7 +280,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,7 +280,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:

--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -32,9 +32,8 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt $A
 RUN rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED
 
 # Install pip packages
-# Install tensorstore from .whl because PyPI does not include aarch64 binaries
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache-dir https://github.com/ultralytics/assets/releases/download/v0.0.0/tensorstore-0.1.59-cp311-cp311-linux_aarch64.whl -e ".[export]"
+RUN pip install --no-cache-dir -e ".[export]"
 
 # Creates a symbolic link to make 'python' point to 'python3'
 RUN ln -sf /usr/bin/python3 /usr/bin/python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ export = [
     "openvino>=2024.0.0", # OpenVINO export
     "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow
+    "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'",
     "keras",  # not installed automatically by tensorflow>=2.16
     "flatbuffers>=23.5.26,<100; platform_machine == 'aarch64'", # update old 'flatbuffers' included inside tensorflow package
     "numpy==1.23.5; platform_machine == 'aarch64'", # fix error: `np.bool` was a deprecated alias for the builtin `bool` when using TensorRT models on NVIDIA Jetson

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ export = [
     "openvino>=2024.0.0", # OpenVINO export
     "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow
-    "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'",
+    "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'",  # for TF Raspberry Pi exports
     "keras",  # not installed automatically by tensorflow>=2.16
     "flatbuffers>=23.5.26,<100; platform_machine == 'aarch64'", # update old 'flatbuffers' included inside tensorflow package
     "numpy==1.23.5; platform_machine == 'aarch64'", # fix error: `np.bool` was a deprecated alias for the builtin `bool` when using TensorRT models on NVIDIA Jetson


### PR DESCRIPTION
Adding `tensorstore>=0.1.63` which now supports `aarch64`
https://pypi.org/project/tensorstore/#files

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified the installation process for Tensorstore in the ARM64 Dockerfile and updated dependency management for ARM64 platforms in `pyproject.toml`.

### 📊 Key Changes
- Removed the manual installation of Tensorstore from a `.whl` file in the ARM64 Dockerfile.
- Updated `pyproject.toml` to include conditional installation of Tensorstore for ARM64 and Python 3.9 or above.

### 🎯 Purpose & Impact
- 📦 **Streamlined Dependency Management**: Makes maintaining dependencies easier by leveraging `pyproject.toml` for specific platform conditions.
- 🐍 **Compatibility**: Ensures Tensorstore is correctly installed on ARM64 systems with Python 3.9 or newer, supporting TensorFlow exports on devices like Raspberry Pi.
- 🔧 **Ease of Use**: Simplifies Dockerfile, reducing potential points of failure and manual intervention, which can save developers time and effort.

These changes enhance the reliability and simplicity of the setup process for users on ARM64 platforms.