### PR TITLE
Add JetPack6 Docker for NVIDIA Jetson Orin Series

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,6 +23,10 @@ on:
         type: boolean
         description: Use Dockerfile-arm64
         default: true
+      Dockerfile-jetson-jetpack6:
+        type: boolean
+        description: Use Dockerfile-jetson-jetpack6
+        default: true
       Dockerfile-jetson-jetpack5:
         type: boolean
         description: Use Dockerfile-jetson-jetpack5
@@ -61,6 +65,9 @@ jobs:
             platforms: "linux/amd64"
           - dockerfile: "Dockerfile-arm64"
             tags: "latest-arm64"
+            platforms: "linux/arm64"
+          - dockerfile: "Dockerfile-jetson-jetpack6"
+            tags: "latest-jetson-jetpack6"
             platforms: "linux/arm64"
           - dockerfile: "Dockerfile-jetson-jetpack5"
             tags: "latest-jetson-jetpack5"

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -34,15 +34,20 @@ COPY . $APP_HOME
 RUN chown -R root:root $APP_HOME
 ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt $APP_HOME
 
-# Download onnxruntime-gpu 1.8.0, tensorrt 8.2.0.6, torch 1.11.0a0 and torchvision 0.12.0a0
+# Download onnxruntime-gpu 1.8.0 and tensorrt 8.2.0.6
 # Other versions can be seen in https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
+ADD https://nvidia.box.com/shared/static/gjqofg7rkg97z3gc8jeyup6t8n9j8xjw.whl onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl
+ADD https://forums.developer.nvidia.com/uploads/short-url/hASzFOm9YsJx6VVFrDW1g44CMmv.whl tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl
+
+# Install pip packages
 RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache-dir \
-    https://nvidia.box.com/shared/static/gjqofg7rkg97z3gc8jeyup6t8n9j8xjw.whl \
-    https://forums.developer.nvidia.com/uploads/short-url/hASzFOm9YsJx6VVFrDW1g44CMmv.whl \
+    onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl \
+    tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl \
 RUN pip install --no-cache-dir -e ".[export]"
+RUN rm *.whl
 
 # Usage Examples -------------------------------------------------------------------------------------------------------
 

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -45,7 +45,7 @@ RUN pip install --no-cache-dir \
     onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl \
     tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
-    https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl
 RUN pip install --no-cache-dir -e ".[export]"
 RUN rm *.whl
 

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -34,19 +34,14 @@ COPY . $APP_HOME
 RUN chown -R root:root $APP_HOME
 ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt $APP_HOME
 
-# Download onnxruntime-gpu, TensorRT, PyTorch and Torchvision
+# Download onnxruntime-gpu 1.8.0, tensorrt 8.2.0.6, torch 1.11.0a0 and torchvision 0.12.0a0
 # Other versions can be seen in https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
-ADD https://nvidia.box.com/shared/static/gjqofg7rkg97z3gc8jeyup6t8n9j8xjw.whl onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl
-ADD https://forums.developer.nvidia.com/uploads/short-url/hASzFOm9YsJx6VVFrDW1g44CMmv.whl tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl
-ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
-    torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl
-ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl \
-    torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl
-
-# Install pip packages
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
-    torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl
+RUN pip install --no-cache-dir \
+    https://nvidia.box.com/shared/static/gjqofg7rkg97z3gc8jeyup6t8n9j8xjw.whl \
+    https://forums.developer.nvidia.com/uploads/short-url/hASzFOm9YsJx6VVFrDW1g44CMmv.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl \
 RUN pip install --no-cache-dir -e ".[export]"
 
 # Usage Examples -------------------------------------------------------------------------------------------------------

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -32,11 +32,13 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt $A
 RUN grep -v "opencv-python" pyproject.toml > temp.toml && mv temp.toml pyproject.toml
 
 # Download onnxruntime-gpu 1.15.1 for Jetson Linux 35.2.1 (JetPack 5.1). Other versions can be seen in https://elinux.org/Jetson_Zoo#ONNX_Runtime
+ADD https://nvidia.box.com/shared/static/mvdcltm9ewdy2d5nurkiqorofz1s53ww.whl onnxruntime_gpu-1.15.1-cp38-cp38-linux_aarch64.whl
+
 # Install pip packages manually for TensorRT compatibility https://github.com/NVIDIA/TensorRT/issues/2567
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install --no-cache-dir \
-    https://nvidia.box.com/shared/static/mvdcltm9ewdy2d5nurkiqorofz1s53ww.whl
+RUN pip install onnxruntime_gpu-1.15.1-cp38-cp38-linux_aarch64.whl
 RUN pip install --no-cache-dir -e ".[export]"
+RUN rm *.whl
 
 
 # Usage Examples -------------------------------------------------------------------------------------------------------

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -32,11 +32,10 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt $A
 RUN grep -v "opencv-python" pyproject.toml > temp.toml && mv temp.toml pyproject.toml
 
 # Download onnxruntime-gpu 1.15.1 for Jetson Linux 35.2.1 (JetPack 5.1). Other versions can be seen in https://elinux.org/Jetson_Zoo#ONNX_Runtime
-ADD https://nvidia.box.com/shared/static/mvdcltm9ewdy2d5nurkiqorofz1s53ww.whl onnxruntime_gpu-1.15.1-cp38-cp38-linux_aarch64.whl
-
 # Install pip packages manually for TensorRT compatibility https://github.com/NVIDIA/TensorRT/issues/2567
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install onnxruntime_gpu-1.15.1-cp38-cp38-linux_aarch64.whl
+RUN pip install --no-cache-dir \
+    https://nvidia.box.com/shared/static/mvdcltm9ewdy2d5nurkiqorofz1s53ww.whl
 RUN pip install --no-cache-dir -e ".[export]"
 
 

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -25,13 +25,17 @@ COPY . $APP_HOME
 RUN chown -R root:root $APP_HOME
 ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt $APP_HOME
 
+# Download onnxruntime-gpu 1.18.0 from https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
+ADD https://nvidia.box.com/shared/static/48dtuob7meiw6ebgfsfqakc9vse62sg4.whl onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl
+
 # Pip install onnxruntime-gpu, torch, torchvision and ultralytics
 RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache-dir \
-    https://nvidia.box.com/shared/static/48dtuob7meiw6ebgfsfqakc9vse62sg4.whl \
+    onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.3.0-cp310-cp310-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl
 RUN pip install --no-cache-dir -e ".[export]"
+RUN rm *.whl
 
 # Usage Examples -------------------------------------------------------------------------------------------------------
 

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -1,0 +1,54 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Builds ultralytics/ultralytics:jetson-jetpack6 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
+# Supports JetPack6.x for YOLOv8 on Jetson AGX Orin, Orin NX and Orin Nano Series
+
+# Start FROM https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-jetpack
+FROM nvcr.io/nvidia/l4t-jetpack:r36.3.0
+
+# Set environment variables
+ENV APP_HOME /usr/src/ultralytics
+
+# Downloads to user config dir
+ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.Unicode.ttf \
+    /root/.config/Ultralytics/
+
+# Install dependencies
+RUN apt update && \
+    apt install --no-install-recommends -y git python3-pip libopenmpi-dev libopenblas-base libomp-dev
+
+# Create working directory
+WORKDIR $APP_HOME
+
+# Copy contents and assign permissions
+COPY . $APP_HOME
+RUN chown -R root:root $APP_HOME
+ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt $APP_HOME
+
+# Download onnxruntime-gpu, PyTorch and Torchvision
+# Other versions can be seen in https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
+ADD https://nvidia.box.com/shared/static/48dtuob7meiw6ebgfsfqakc9vse62sg4.whl onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl
+ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.3.0-cp310-cp310-linux_aarch64.whl \
+    torch-2.3.0-cp310-cp310-linux_aarch64.whl
+ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl \
+    torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl
+
+# Install pip packages
+RUN python3 -m pip install --upgrade pip wheel
+RUN pip install onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl \
+    torch-2.3.0-cp310-cp310-linux_aarch64.whl torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl
+RUN pip install --no-cache-dir -e ".[export]"
+
+# Usage Examples -------------------------------------------------------------------------------------------------------
+
+# Build and Push
+# t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker build --platform linux/arm64 -f docker/Dockerfile-jetson-jetpack6 -t $t . && sudo docker push $t
+
+# Run
+# t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker run -it --ipc=host $t
+
+# Pull and Run
+# t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker pull $t && sudo docker run -it --ipc=host $t
+
+# Pull and Run with NVIDIA runtime
+# t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -25,18 +25,12 @@ COPY . $APP_HOME
 RUN chown -R root:root $APP_HOME
 ADD https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt $APP_HOME
 
-# Download onnxruntime-gpu, PyTorch and Torchvision
-# Other versions can be seen in https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
-ADD https://nvidia.box.com/shared/static/48dtuob7meiw6ebgfsfqakc9vse62sg4.whl onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl
-ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.3.0-cp310-cp310-linux_aarch64.whl \
-    torch-2.3.0-cp310-cp310-linux_aarch64.whl
-ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl \
-    torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl
-
-# Install pip packages
+# Pip install onnxruntime-gpu, torch, torchvision and ultralytics
 RUN python3 -m pip install --upgrade pip wheel
-RUN pip install onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl \
-    torch-2.3.0-cp310-cp310-linux_aarch64.whl torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl
+RUN pip install --no-cache-dir \
+    https://nvidia.box.com/shared/static/48dtuob7meiw6ebgfsfqakc9vse62sg4.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.3.0-cp310-cp310-linux_aarch64.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl
 RUN pip install --no-cache-dir -e ".[export]"
 
 # Usage Examples -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
@glenn-jocher FYI
This Docker is based on the latest JetPack6 version which supports all Jetson Orin devices. 
It is tested on [this workflow run](https://github.com/ultralytics/ultralytics/actions/runs/10104244796/job/27942907227) and builds successfully.

Just to give an overview, based on the JetPack versions, these are the supported devices.
JP4 - Jetson Nano, TX2, Xavier NX, AGX Xavier
JP5 - Jetson Xavier NX, AGX Xavier, AGX Orin, Orin NX and Orin Nano
JP6 - Jetson AGX Orin, Orin NX and Orin Nano Series

I understand that having 3 Docker containers for Jetson is a little too much, but according to the feedback from NVIDIA Jetson team, it seems that Xavier NX, AGX Xavier users still need JP5 and Orin users need the latest JP6.

Once this PR is approved, I can update the docs accordingly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added support for Jetson JetPack 6.x Docker images in the GitHub Actions workflow and created a corresponding Dockerfile.

### 📊 Key Changes
- **GitHub Actions Workflow Update**:
  - Introduced a new option `Dockerfile-jetson-jetpack6` with a default value set to `true`.
  - Added steps to build and tag Docker images using `Dockerfile-jetson-jetpack6`.
  
- **New Dockerfile**:
  - Created `Dockerfile-jetson-jetpack6` to support JetPack 6.x series on various NVIDIA Jetson devices like AGX Orin, Orin NX, and Orin Nano.

### 🎯 Purpose & Impact
- **Purpose**:
  - Enhance the Ultralytics setup to support the latest Jetson hardware using JetPack 6.x.
  
- **Impact**:
  - Users with newer Jetson devices will benefit from out-of-the-box support, enabling smoother deployment of YOLO models.
  - It expands the versatility of Ultralytics software for various edge AI applications on NVIDIA hardware. 🚀

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR adds support for Docker images tailored to Jetson JetPack 6, enhancing compatibility for NVIDIA Jetson devices 🖥️💪.

### 📊 Key Changes
- **New Workflow Configuration:**
  - Added an option to use `Dockerfile-jetson-jetpack6`.
  - Updated Docker build tags and platforms.

- **New Dockerfile:**
  - Introduced `Dockerfile-jetson-jetpack6` for building an image supporting JetPack6.x environments.
  - Configured dependencies and environment for Jetson AGX Orin, Orin NX, and Orin Nano Series.

- **Updates in Existing Dockerfiles:**
  - Added a `RUN rm *.whl` command to clean up wheel files post-installation in `Dockerfile-jetson-jetpack4` and `Dockerfile-jetson-jetpack5`.

### 🎯 Purpose & Impact
- **Broadened Hardware Support:** 
  - Enables the use of YOLOv8 on the latest NVIDIA Jetson hardware, improving performance and capabilities for edge AI applications 🚀.
- **Cleaner Docker Images:** 
  - Removing unnecessary files post-installation reduces image size, leading to faster deployment and less storage usage 📦.
- **Improved Configuration Flexibility:** 
  - The ability to select JetPack versions in the GitHub Actions workflow simplifies CI/CD processes and enhances development efficiency 🔧.