### PR TITLE
Using a zero tensor to run warmup instead of empty tensor

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -634,7 +634,7 @@ class AutoBackend(nn.Module):
 
         warmup_types = self.pt, self.jit, self.onnx, self.engine, self.saved_model, self.pb, self.triton, self.nn_module
         if any(warmup_types) and (self.device.type != "cpu" or self.triton):
-            im = torch.empty(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
+            im = torch.zeros(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
             for _ in range(2 if self.jit else 1):
                 self.forward(im)  # warmup
 


### PR DESCRIPTION
## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Stabilizes the warmup process by changing the tensor initialization method.

### 📊 Key Changes
- Replaces `torch.empty` with `torch.zeros` for initializing tensors during the warmup phase.

### 🎯 Purpose & Impact
When disabling fusing of the BatchNorm to the Conv layers, I observed signficant drops in the metrics after the final training epoch due to the effect described below.

Though there is nothing wrong with pushing an empty tensor through the network, there are failure cases or cases with unwanted side-effects associated with it. The torch.empty() call does not necessarily initialize the tensor, see
https://pytorch.org/docs/stable/generated/torch.empty.html

An unwanted side-effect can occur if the values that are found in the tensor are wildly out of range of the usual values for an image or are NaN in the worst-case scenario. Normally, the output of the warmup runs are irrelevant and pushing NaNs is fine, however in cases were _stateful_ layers like BatchNorm are used, this will destroy the running statistics and cause unexpected results in subsequent (validation) runs, where the outputs are important. Pushing a zero tensor here has negligible impact on the running statistics of BatchNorm layers and will maintain the accuracy of the previously trained model.

### Notes
There are a few other instances in the code base that use empty tensors (autobatch.py and torch_utils.py) but those runs are used for either training batch-size determination prior to training or to compute model FLOPs. For good measure, I recommend setting the tensors to zero tensors on those files too or make sure that those runs are not run prior to any evaluation that requires a (non-fused) BatchNorm to be well-adjusted.

### CLA

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
A minor update in the `autobackend.py` script modifies the initialization of input tensors during the warmup phase.

### 📊 Key Changes
- Changed the warmup tensor initialization from `torch.empty` to `torch.zeros`.

### 🎯 Purpose & Impact
- **Purpose**: Ensure that the input tensor used during the warmup phase is filled with zeros instead of arbitrary values.
- **Impact**: This change may help avoid potential issues or inconsistencies during warmup by providing a more predictable input, thereby promoting stability and reliability in the warmup process.