### PR TITLE
Exported model batch size validation fix

### DIFF
--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -136,8 +136,12 @@ class BaseValidator:
             if engine:
                 self.args.batch = model.batch_size
             elif not pt and not jit:
-                self.args.batch = 1  # export.py models default to batch-size 1
-                LOGGER.info(f"Forcing batch=1 square inference (1,3,{imgsz},{imgsz}) for non-PyTorch models")
+                if "batch" in model.metadata:
+                    self.args.batch = model.metadata["batch"]
+                    LOGGER.warning(f"Batch size found in metadata forcing batch={self.args.batch}")
+                else:
+                    self.args.batch = 1  # export.py models default to batch-size=1 if not specified in metadata
+                    LOGGER.warning(f"Forcing batch=1 square inference (1,3,{imgsz},{imgsz}) for non-PyTorch models")
 
             if str(self.args.data).split(".")[-1] in {"yaml", "yml"}:
                 self.data = check_det_dataset(self.args.data)

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -136,12 +136,8 @@ class BaseValidator:
             if engine:
                 self.args.batch = model.batch_size
             elif not pt and not jit:
-                if "batch" in model.metadata:
-                    self.args.batch = model.metadata["batch"]
-                    LOGGER.warning(f"Batch size found in metadata forcing batch={self.args.batch}")
-                else:
-                    self.args.batch = 1  # export.py models default to batch-size=1 if not specified in metadata
-                    LOGGER.warning(f"Forcing batch=1 square inference (1,3,{imgsz},{imgsz}) for non-PyTorch models")
+                self.args.batch = model.metadata.get("batch", 1)  # export.py models default to batch-size 1
+                LOGGER.info(f"Setting batch={self.args.batch} input of shape ({self.args.batch}, 3, {imgsz}, {imgsz})")
 
             if str(self.args.data).split(".")[-1] in {"yaml", "yml"}:
                 self.data = check_det_dataset(self.args.data)


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced the model batch size setting in the validator to be more adaptive based on model metadata.

### 📊 Key Changes
- Changed the default batch size handling.
- Instead of always setting the batch size to 1 for non-PyTorch models, it now uses `model.metadata.get("batch", 1)`.
- Adjusted logging to reflect the new dynamic batch size setting.

### 🎯 Purpose & Impact
- **Flexibility**: Models can now specify their desired batch size through metadata, allowing for customized and potentially more efficient processing.
- **Clarity**: Logging provides clearer information about the batch size being used, improving transparency and debugging capability.