### PR TITLE
Fix `model` in Pose, Segment datasets train FAQ sections

### DIFF
--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -133,7 +133,7 @@ Training a YOLOv8 model on the COCO-Pose dataset can be accomplished using eithe
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco-pose.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo detect train data=coco-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 For more details on the training process and available arguments, check the [training page](../../modes/train.md).

--- a/docs/en/datasets/pose/coco8-pose.md
+++ b/docs/en/datasets/pose/coco8-pose.md
@@ -105,7 +105,7 @@ To train a YOLOv8n-pose model on the COCO8-Pose dataset for 100 epochs with an i
     === "CLI"
     
         ```bash
-        yolo detect train data=coco8-pose.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo detect train data=coco8-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 For a comprehensive list of training arguments, refer to the model [Training](../../modes/train.md) page.

--- a/docs/en/datasets/pose/tiger-pose.md
+++ b/docs/en/datasets/pose/tiger-pose.md
@@ -126,7 +126,7 @@ To train a YOLOv8n-pose model on the Tiger-Pose dataset for 100 epochs with an i
     
         ```bash
         # Start training from a pretrained *.pt model
-        yolo task=pose mode=train data=tiger-pose.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo task=pose mode=train data=tiger-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 ### What configurations does the `tiger-pose.yaml` file include?

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -131,7 +131,7 @@ To train a YOLOv8n-seg model on the COCO-Seg dataset for 100 epochs with an imag
     
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco-seg.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo detect train data=coco-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 ### What are the key features of the COCO-Seg dataset?

--- a/docs/en/datasets/segment/coco8-seg.md
+++ b/docs/en/datasets/segment/coco8-seg.md
@@ -106,7 +106,7 @@ To train a **YOLOv8n-seg** model on the COCO8-Seg dataset for 100 epochs with an
     
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco8-seg.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo detect train data=coco8-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 For a thorough explanation of available arguments and configuration options, you can check the [Training](../../modes/train.md) documentation.


### PR DESCRIPTION
Fix the missing correct `model` parameter for the datasets train examples in Pose and Segmentation in the FAQ section for CLI usage. This PR is related to #14505.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates multiple training commands in the documentation to use specific pretrained models tailored for different tasks like pose detection and segmentation.

### 📊 Key Changes
- Updated training commands in various documentation files to:
  - Use `yolov8n-pose.pt` for pose datasets (COCO-Pose, COCO8-Pose, Tiger-Pose)
  - Use `yolov8n-seg.pt` for segmentation datasets (COCO-Seg, COCO8-Seg)

### 🎯 Purpose & Impact
- **Purpose:** 
  - Ensure users train models using the most appropriate pretrained weights for their specific tasks.
- **Impact:**
  - Users may experience improved model performance and training efficiency since the correct pretrained models for pose and segmentation tasks are utilized. 💪
  - Documentation now provides clearer and more accurate guidance, enhancing user experience and reducing chances of errors. 📚