### PR TITLE
Add missing CLI `yolo` commands for `TASK` and `MODE` in Docs - Quickstart and CLI Guide

### DIFF
--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -162,8 +162,8 @@ The Ultralytics command line interface (CLI) allows for simple single-line comma
         yolo TASK MODE ARGS
         ```
 
-        - `TASK` (optional) is one of ([detect](tasks/detect.md), [segment](tasks/segment.md), [classify](tasks/classify.md), [pose](tasks/pose.md))
-        - `MODE` (required) is one of ([train](modes/train.md), [val](modes/val.md), [predict](modes/predict.md), [export](modes/export.md), [track](modes/track.md))
+        - `TASK` (optional) is one of ([detect](tasks/detect.md), [segment](tasks/segment.md), [classify](tasks/classify.md), [pose](tasks/pose.md), [obb](tasks/obb.md))
+        - `MODE` (required) is one of ([train](modes/train.md), [val](modes/val.md), [predict](modes/predict.md), [export](modes/export.md), [track](modes/track.md), , [benchmark](modes/benchmark.md))
         - `ARGS` (optional) are `arg=value` pairs like `imgsz=640` that override defaults.
 
         See all `ARGS` in the full [Configuration Guide](usage/cfg.md) or with the `yolo cfg` CLI command.

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -163,7 +163,7 @@ The Ultralytics command line interface (CLI) allows for simple single-line comma
         ```
 
         - `TASK` (optional) is one of ([detect](tasks/detect.md), [segment](tasks/segment.md), [classify](tasks/classify.md), [pose](tasks/pose.md), [obb](tasks/obb.md))
-        - `MODE` (required) is one of ([train](modes/train.md), [val](modes/val.md), [predict](modes/predict.md), [export](modes/export.md), [track](modes/track.md), , [benchmark](modes/benchmark.md))
+        - `MODE` (required) is one of ([train](modes/train.md), [val](modes/val.md), [predict](modes/predict.md), [export](modes/export.md), [track](modes/track.md), [benchmark](modes/benchmark.md))
         - `ARGS` (optional) are `arg=value` pairs like `imgsz=640` that override defaults.
 
         See all `ARGS` in the full [Configuration Guide](usage/cfg.md) or with the `yolo cfg` CLI command.

--- a/docs/en/usage/cli.md
+++ b/docs/en/usage/cli.md
@@ -27,8 +27,8 @@ The YOLO command line interface (CLI) allows for simple single-line commands wit
         ```bash
         yolo TASK MODE ARGS
 
-        Where   TASK (optional) is one of [detect, segment, classify]
-                MODE (required) is one of [train, val, predict, export, track]
+        Where   TASK (optional) is one of [detect, segment, classify, pose, obb]
+                MODE (required) is one of [train, val, predict, export, track, benchmark]
                 ARGS (optional) are any number of custom 'arg=value' pairs like 'imgsz=320' that override defaults.
         ```
         See all ARGS in the full [Configuration Guide](cfg.md) or with `yolo cfg`
@@ -75,8 +75,8 @@ The YOLO command line interface (CLI) allows for simple single-line commands wit
 
 Where:
 
-- `TASK` (optional) is one of `[detect, segment, classify]`. If it is not passed explicitly YOLOv8 will try to guess the `TASK` from the model type.
-- `MODE` (required) is one of `[train, val, predict, export, track]`
+- `TASK` (optional) is one of `[detect, segment, classify, pose, obb]`. If it is not passed explicitly YOLOv8 will try to guess the `TASK` from the model type.
+- `MODE` (required) is one of `[train, val, predict, export, track, benchmark]`
 - `ARGS` (optional) are any number of custom `arg=value` pairs like `imgsz=320` that override defaults. For a full list of available `ARGS` see the [Configuration](cfg.md) page and `defaults.yaml`
 
 !!! Warning "Warning"

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -73,8 +73,8 @@ HELP_MSG = """
 
             yolo TASK MODE ARGS
 
-            Where   TASK (optional) is one of [detect, segment, classify]
-                    MODE (required) is one of [train, val, predict, export]
+            Where   TASK (optional) is one of [detect, segment, classify, pose, obb]
+                    MODE (required) is one of [train, val, predict, export, benchmark]
                     ARGS (optional) are any number of custom 'arg=value' pairs like 'imgsz=320' that override defaults.
                         See all ARGS at https://docs.ultralytics.com/usage/cfg or with 'yolo cfg'
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -47,7 +47,7 @@ PYTHON_VERSION = platform.python_version()
 TORCH_VERSION = torch.__version__
 TORCHVISION_VERSION = importlib.metadata.version("torchvision")  # faster than importing torchvision
 HELP_MSG = """
-    Usage examples for running YOLOv8:
+    Usage examples for running Ultralytics YOLO:
 
     1. Install the ultralytics package:
 
@@ -58,25 +58,25 @@ HELP_MSG = """
         from ultralytics import YOLO
 
         # Load a model
-        model = YOLO('yolov8n.yaml')  # build a new model from scratch
+        model = YOLO("yolov8n.yaml")  # build a new model from scratch
         model = YOLO("yolov8n.pt")  # load a pretrained model (recommended for training)
 
         # Use the model
         results = model.train(data="coco8.yaml", epochs=3)  # train the model
         results = model.val()  # evaluate model performance on the validation set
-        results = model('https://ultralytics.com/images/bus.jpg')  # predict on an image
-        success = model.export(format='onnx')  # export the model to ONNX format
+        results = model("https://ultralytics.com/images/bus.jpg")  # predict on an image
+        success = model.export(format="onnx")  # export the model to ONNX format
 
     3. Use the command line interface (CLI):
 
-        YOLOv8 'yolo' CLI commands use the following syntax:
+        Ultralytics 'yolo' CLI commands use the following syntax:
 
             yolo TASK MODE ARGS
 
             Where   TASK (optional) is one of [detect, segment, classify, pose, obb]
                     MODE (required) is one of [train, val, predict, export, benchmark]
-                    ARGS (optional) are any number of custom 'arg=value' pairs like 'imgsz=320' that override defaults.
-                        See all ARGS at https://docs.ultralytics.com/usage/cfg or with 'yolo cfg'
+                    ARGS (optional) are any number of custom "arg=value" pairs like "imgsz=320" that override defaults.
+                        See all ARGS at https://docs.ultralytics.com/usage/cfg or with "yolo cfg"
 
         - Train a detection model for 10 epochs with an initial learning_rate of 0.01
             yolo detect train data=coco8.yaml model=yolov8n.pt epochs=10 lr0=0.01


### PR DESCRIPTION
Add missing but available CLI `yolo` commands `pose`, `obb`, `benchmark` for `TASK` and `MODE` to the Quickstart CLI section and the CLI Guide in the Documentation.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated documentation and example code to include new 'obb' task and 'benchmark' mode for the YOLO command line interface and model usage.

### 📊 Key Changes
- Added `obb` (oriented bounding box) task to CLI and documentation.
- Introduced `benchmark` mode in CLI commands and documentation.
- General updates and clarifications in example usage syntax and help messages.

### 🎯 Purpose & Impact
- **Enhanced Capabilities**: Expanding the CLI and model functionality with `obb` task and `benchmark` mode allows users to perform more specialized tasks and measure performance accurately.
- **Improved Usability**: Clearer documentation helps both new and experienced users understand and leverage the full suite of tools and options available in Ultralytics YOLO.