### PR TITLE
Fix incorrect CLI commands in Datasets Docs

### DIFF
--- a/docs/en/datasets/classify/caltech101.md
+++ b/docs/en/datasets/classify/caltech101.md
@@ -46,7 +46,7 @@ To train a YOLO model on the Caltech-101 dataset for 100 epochs, you can use the
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=caltech101 model=yolov8n-cls.pt epochs=100 imgsz=416
+        yolo classify train data=caltech101 model=yolov8n-cls.pt epochs=100 imgsz=416
         ```
 
 ## Sample Images and Annotations
@@ -108,7 +108,7 @@ To train an Ultralytics YOLO model on the Caltech-101 dataset, you can use the p
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=caltech101 model=yolov8n-cls.pt epochs=100 imgsz=416
+        yolo classify train data=caltech101 model=yolov8n-cls.pt epochs=100 imgsz=416
         ```
 For more detailed arguments and options, refer to the model [Training](../../modes/train.md) page.
 

--- a/docs/en/datasets/classify/caltech256.md
+++ b/docs/en/datasets/classify/caltech256.md
@@ -57,7 +57,7 @@ To train a YOLO model on the Caltech-256 dataset for 100 epochs, you can use the
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=caltech256 model=yolov8n-cls.pt epochs=100 imgsz=416
+        yolo classify train data=caltech256 model=yolov8n-cls.pt epochs=100 imgsz=416
         ```
 
 ## Sample Images and Annotations
@@ -116,7 +116,7 @@ To train a YOLO model on the Caltech-256 dataset for 100 epochs, you can use the
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=caltech256 model=yolov8n-cls.pt epochs=100 imgsz=416
+        yolo classify train data=caltech256 model=yolov8n-cls.pt epochs=100 imgsz=416
         ```
 
 ### What are the most common use cases for the Caltech-256 dataset?

--- a/docs/en/datasets/classify/cifar10.md
+++ b/docs/en/datasets/classify/cifar10.md
@@ -60,7 +60,7 @@ To train a YOLO model on the CIFAR-10 dataset for 100 epochs with an image size 
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=cifar10 model=yolov8n-cls.pt epochs=100 imgsz=32
+        yolo classify train data=cifar10 model=yolov8n-cls.pt epochs=100 imgsz=32
         ```
 
 ## Sample Images and Annotations
@@ -114,7 +114,7 @@ To train a YOLO model on the CIFAR-10 dataset using Ultralytics, you can follow 
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=cifar10 model=yolov8n-cls.pt epochs=100 imgsz=32
+        yolo classify train data=cifar10 model=yolov8n-cls.pt epochs=100 imgsz=32
         ```
 
 For more details, refer to the model [Training](../../modes/train.md) page.

--- a/docs/en/datasets/classify/cifar100.md
+++ b/docs/en/datasets/classify/cifar100.md
@@ -49,7 +49,7 @@ To train a YOLO model on the CIFAR-100 dataset for 100 epochs with an image size
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=cifar100 model=yolov8n-cls.pt epochs=100 imgsz=32
+        yolo classify train data=cifar100 model=yolov8n-cls.pt epochs=100 imgsz=32
         ```
 
 ## Sample Images and Annotations
@@ -107,7 +107,7 @@ You can train a YOLO model on the CIFAR-100 dataset using either Python or CLI c
         
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=cifar100 model=yolov8n-cls.pt epochs=100 imgsz=32
+        yolo classify train data=cifar100 model=yolov8n-cls.pt epochs=100 imgsz=32
         ```
 
 For a comprehensive list of available arguments, please refer to the model [Training](../../modes/train.md) page.

--- a/docs/en/datasets/classify/fashion-mnist.md
+++ b/docs/en/datasets/classify/fashion-mnist.md
@@ -74,7 +74,7 @@ To train a CNN model on the Fashion-MNIST dataset for 100 epochs with an image s
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=fashion-mnist model=yolov8n-cls.pt epochs=100 imgsz=28
+        yolo classify train data=fashion-mnist model=yolov8n-cls.pt epochs=100 imgsz=28
         ```
 
 ## Sample Images and Annotations
@@ -117,7 +117,7 @@ To train an Ultralytics YOLO model on the Fashion-MNIST dataset, you can use bot
     === "CLI"
     
         ```bash
-        yolo detect train data=fashion-mnist model=yolov8n-cls.pt epochs=100 imgsz=28
+        yolo classify train data=fashion-mnist model=yolov8n-cls.pt epochs=100 imgsz=28
         ```
 
 For more detailed training parameters, refer to the [Training page](../../modes/train.md).

--- a/docs/en/datasets/classify/imagenet.md
+++ b/docs/en/datasets/classify/imagenet.md
@@ -59,7 +59,7 @@ To train a deep learning model on the ImageNet dataset for 100 epochs with an im
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo train data=imagenet model=yolov8n-cls.pt epochs=100 imgsz=224
+        yolo classify train data=imagenet model=yolov8n-cls.pt epochs=100 imgsz=224
         ```
 
 ## Sample Images and Annotations
@@ -120,7 +120,7 @@ To use a pretrained Ultralytics YOLO model for image classification on the Image
     
         ```bash
         # Start training from a pretrained *.pt model
-        yolo train data=imagenet model=yolov8n-cls.pt epochs=100 imgsz=224
+        yolo classify train data=imagenet model=yolov8n-cls.pt epochs=100 imgsz=224
         ```
 
 For more in-depth training instruction, refer to our [Training page](../../modes/train.md).

--- a/docs/en/datasets/classify/imagenet10.md
+++ b/docs/en/datasets/classify/imagenet10.md
@@ -45,7 +45,7 @@ To test a deep learning model on the ImageNet10 dataset with an image size of 22
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo train data=imagenet10 model=yolov8n-cls.pt epochs=5 imgsz=224
+        yolo classify train data=imagenet10 model=yolov8n-cls.pt epochs=5 imgsz=224
         ```
 
 ## Sample Images and Annotations
@@ -104,7 +104,7 @@ To test your deep learning model on the ImageNet10 dataset with an image size of
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo train data=imagenet10 model=yolov8n-cls.pt epochs=5 imgsz=224
+        yolo classify train data=imagenet10 model=yolov8n-cls.pt epochs=5 imgsz=224
         ```
 
 Refer to the [Training](../../modes/train.md) page for a comprehensive list of available arguments.

--- a/docs/en/datasets/classify/imagenette.md
+++ b/docs/en/datasets/classify/imagenette.md
@@ -47,7 +47,7 @@ To train a model on the ImageNette dataset for 100 epochs with a standard image 
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=imagenette model=yolov8n-cls.pt epochs=100 imgsz=224
+        yolo classify train data=imagenette model=yolov8n-cls.pt epochs=100 imgsz=224
         ```
 
 ## Sample Images and Annotations
@@ -82,7 +82,7 @@ To use these datasets, simply replace 'imagenette' with 'imagenette160' or 'imag
 
         ```bash
         # Start training from a pretrained *.pt model with ImageNette160
-        yolo detect train data=imagenette160 model=yolov8n-cls.pt epochs=100 imgsz=160
+        yolo classify train data=imagenette160 model=yolov8n-cls.pt epochs=100 imgsz=160
         ```
 
 !!! Example "Train Example with ImageNette320"
@@ -103,7 +103,7 @@ To use these datasets, simply replace 'imagenette' with 'imagenette160' or 'imag
 
         ```bash
         # Start training from a pretrained *.pt model with ImageNette320
-        yolo detect train data=imagenette320 model=yolov8n-cls.pt epochs=100 imgsz=320
+        yolo classify train data=imagenette320 model=yolov8n-cls.pt epochs=100 imgsz=320
         ```
 
 These smaller versions of the dataset allow for rapid iterations during the development process while still providing valuable and realistic image classification tasks.
@@ -140,7 +140,7 @@ To train a YOLO model on the ImageNette dataset for 100 epochs, you can use the 
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=imagenette model=yolov8n-cls.pt epochs=100 imgsz=224
+        yolo classify train data=imagenette model=yolov8n-cls.pt epochs=100 imgsz=224
         ```
 
 For more details, see the [Training](../../modes/train.md) documentation page.

--- a/docs/en/datasets/classify/imagewoof.md
+++ b/docs/en/datasets/classify/imagewoof.md
@@ -44,7 +44,7 @@ To train a CNN model on the ImageWoof dataset for 100 epochs with an image size 
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=imagewoof model=yolov8n-cls.pt epochs=100 imgsz=224
+        yolo classify train data=imagewoof model=yolov8n-cls.pt epochs=100 imgsz=224
         ```
 
 ## Dataset Variants
@@ -113,7 +113,7 @@ To train a Convolutional Neural Network (CNN) model on the ImageWoof dataset usi
     === "CLI"
     
         ```bash
-        yolo detect train data=imagewoof model=yolov8n-cls.pt epochs=100 imgsz=224
+        yolo classify train data=imagewoof model=yolov8n-cls.pt epochs=100 imgsz=224
         ```
 
 For more details on available training arguments, refer to the [Training](../../modes/train.md) page.

--- a/docs/en/datasets/classify/mnist.md
+++ b/docs/en/datasets/classify/mnist.md
@@ -52,7 +52,7 @@ To train a CNN model on the MNIST dataset for 100 epochs with an image size of 3
 
         ```bash
         # Start training from a pretrained *.pt model
-        cnn detect train data=mnist model=yolov8n-cls.pt epochs=100 imgsz=28
+        yolo classify train data=mnist model=yolov8n-cls.pt epochs=100 imgsz=28
         ```
 
 ## Sample Images and Annotations
@@ -113,7 +113,7 @@ To train a model on the MNIST dataset using Ultralytics YOLO, you can follow the
     
         ```bash
         # Start training from a pretrained *.pt model
-        cnn detect train data=mnist model=yolov8n-cls.pt epochs=100 imgsz=28
+        yolo classify train data=mnist model=yolov8n-cls.pt epochs=100 imgsz=28
         ```
 
 For a detailed list of available training arguments, refer to the [Training](../../modes/train.md) page.

--- a/docs/en/datasets/obb/index.md
+++ b/docs/en/datasets/obb/index.md
@@ -50,7 +50,7 @@ To train a model using these OBB formats:
 
         ```bash
         # Train a new YOLOv8n-OBB model on the DOTAv2 dataset
-        yolo detect train data=DOTAv1.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo obb train data=DOTAv1.yaml model=yolov8n-obb.pt epochs=100 imgsz=640
         ```
 
 ## Supported Datasets
@@ -125,7 +125,7 @@ Training a YOLOv8 model with OBBs involves ensuring your dataset is in the YOLO 
     
         ```bash
         # Train a new YOLOv8n-OBB model on the custom dataset
-        yolo detect train data=your_dataset.yaml model=yolov8n.pt epochs=100 imgsz=640
+        yolo obb train data=your_dataset.yaml model=yolov8n-obb.yaml epochs=100 imgsz=640
         ```
         
 This ensures your model leverages the detailed OBB annotations for improved detection accuracy.

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -71,7 +71,7 @@ To train a YOLOv8n-pose model on the COCO-Pose dataset for 100 epochs with an im
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
+        yolo pose train data=coco-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations
@@ -133,7 +133,7 @@ Training a YOLOv8 model on the COCO-Pose dataset can be accomplished using eithe
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
+        yolo pose train data=coco-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 For more details on the training process and available arguments, check the [training page](../../modes/train.md).

--- a/docs/en/datasets/pose/coco8-pose.md
+++ b/docs/en/datasets/pose/coco8-pose.md
@@ -44,7 +44,7 @@ To train a YOLOv8n-pose model on the COCO8-Pose dataset for 100 epochs with an i
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco8-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
+        yolo pose train data=coco8-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations
@@ -105,7 +105,7 @@ To train a YOLOv8n-pose model on the COCO8-Pose dataset for 100 epochs with an i
     === "CLI"
     
         ```bash
-        yolo detect train data=coco8-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
+        yolo pose train data=coco8-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 For a comprehensive list of training arguments, refer to the model [Training](../../modes/train.md) page.

--- a/docs/en/datasets/pose/index.md
+++ b/docs/en/datasets/pose/index.md
@@ -82,7 +82,7 @@ The `train` and `val` fields specify the paths to the directories containing the
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco8-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
+        yolo pose train data=coco8-pose.yaml model=yolov8n-pose.pt epochs=100 imgsz=640
         ```
 
 ## Supported Datasets

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -69,7 +69,7 @@ To train a YOLOv8n-seg model on the COCO-Seg dataset for 100 epochs with an imag
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
+        yolo segment train data=coco-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations
@@ -131,7 +131,7 @@ To train a YOLOv8n-seg model on the COCO-Seg dataset for 100 epochs with an imag
     
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
+        yolo segment train data=coco-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 ### What are the key features of the COCO-Seg dataset?

--- a/docs/en/datasets/segment/coco8-seg.md
+++ b/docs/en/datasets/segment/coco8-seg.md
@@ -44,7 +44,7 @@ To train a YOLOv8n-seg model on the COCO8-Seg dataset for 100 epochs with an ima
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco8-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
+        yolo segment train data=coco8-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 ## Sample Images and Annotations
@@ -106,7 +106,7 @@ To train a **YOLOv8n-seg** model on the COCO8-Seg dataset for 100 epochs with an
     
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco8-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
+        yolo segment train data=coco8-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 For a thorough explanation of available arguments and configuration options, you can check the [Training](../../modes/train.md) documentation.

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -84,7 +84,7 @@ The `train` and `val` fields specify the paths to the directories containing the
 
         ```bash
         # Start training from a pretrained *.pt model
-        yolo detect train data=coco8-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
+        yolo segment train data=coco8-seg.yaml model=yolov8n-seg.pt epochs=100 imgsz=640
         ```
 
 ## Supported Datasets


### PR DESCRIPTION
Hi, 
fix and correction of CLI `yolo` commands in the Datasets examples for correct and more consistency in the documentation. Thanks!

My Feedback:
The YOLOv8 package and the training pipelines provided, the easy to read and understand documentation, the variety of tasks the models can solve are just fantastic.👍 Thanks a lot! Keep going.🚀



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated command syntax in documentation for training models across various datasets to ensure clear and consistent usage.

### 📊 Key Changes
- Replaced `yolo detect train` with `yolo classify train` for classification datasets like Caltech101, CIFAR-10, and MNIST.
- Adjusted command `yolo detect train` to `yolo obb train` for datasets using oriented bounding boxes (OBB) like DOTAv1.
- Changed `yolo detect train` to `yolo pose train` for pose estimation datasets such as COCO-Pose.
- Modified `yolo detect train` to `yolo segment train` for segmentation datasets like COCO-Seg.

### 🎯 Purpose & Impact
- **Clarity**: Ensures users have the correct commands for specific tasks, reducing errors and confusion.
- **Consistency**: Aligns command syntax with the function they perform, improving user experience and documentation accuracy.
- **Efficiency**: Enables users to efficiently train models by following streamlined and error-free instructions.

📘 This helps both new and experienced users follow documentation more easily, ensuring they can train models correctly without having to guess or correct commands.