### PR TITLE
Delete Docker Cache before building Image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,8 +82,13 @@ jobs:
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
     steps:
-      - name: Delete huge unnecessary tools folder
-        run: rm -rf /opt/hostedtoolcache
+      - name: Cleanup toolcache
+        run: |
+          echo "Free space before deletion:"
+          df -h /
+          rm -rf /opt/hostedtoolcache
+          echo "Free space after deletion:"
+          df -h /
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -83,6 +83,7 @@ jobs:
           #   platforms: "linux/amd64"
     steps:
       - name: Cleanup toolcache
+        # Free up to 10GB of disk space per https://github.com/ultralytics/ultralytics/pull/14894
         run: |
           echo "Free space before deletion:"
           df -h /

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,6 +82,8 @@ jobs:
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
     steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,6 +84,7 @@ jobs:
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
@glenn-jocher We can try this first. It is based on [this discussion](https://github.com/orgs/community/discussions/25678#discussioncomment-5242449)

Did multiple runs [here](https://github.com/ultralytics/ultralytics/actions/runs/10201556460) to verify.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR introduces a step to clean up the tool cache in the GitHub Actions workflow to free up disk space.

### 📊 Key Changes
- Added a new step in the `docker.yaml` workflow file to delete the hosted tool cache directory.
- Implemented commands to display disk space before and after the cleanup.

### 🎯 Purpose & Impact
- **Purpose:** The primary goal is to free up to 10GB of disk space during the CI/CD pipeline runs.
- **Impact:** This will help prevent disk space issues, ensuring smoother and more reliable workflow executions for developers. 🚀