### PR TITLE
Fix the docstring of xywhr2xyxyxyxy

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -551,7 +551,7 @@ def xyxyxyxy2xywhr(x):
 def xywhr2xyxyxyxy(x):
     """
     Convert batched Oriented Bounding Boxes (OBB) from [xywh, rotation] to [xy1, xy2, xy3, xy4]. Rotation values should
-    be in degrees from 0 to 90.
+    be in radians from 0 to pi/4.
 
     Args:
         x (numpy.ndarray | torch.Tensor): Boxes in [cx, cy, w, h, rotation] format of shape (n, 5) or (b, n, 5).

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -528,7 +528,7 @@ def ltwh2xywh(x):
 def xyxyxyxy2xywhr(x):
     """
     Convert batched Oriented Bounding Boxes (OBB) from [xy1, xy2, xy3, xy4] to [xywh, rotation]. Rotation values are
-    expected in degrees from 0 to 90.
+    returned in radians from 0 to pi/2.
 
     Args:
         x (numpy.ndarray | torch.Tensor): Input box corners [xy1, xy2, xy3, xy4] of shape (n, 8).
@@ -551,7 +551,7 @@ def xyxyxyxy2xywhr(x):
 def xywhr2xyxyxyxy(x):
     """
     Convert batched Oriented Bounding Boxes (OBB) from [xywh, rotation] to [xy1, xy2, xy3, xy4]. Rotation values should
-    be in radians from 0 to pi/4.
+    be in radians from 0 to pi/2.
 
     Args:
         x (numpy.ndarray | torch.Tensor): Boxes in [cx, cy, w, h, rotation] format of shape (n, 5) or (b, n, 5).


### PR DESCRIPTION
Addressing issue #8514 by fixing the docstring.

Context: The `xywhr2xyxyxyxy` function actually accepts rotation in radians and not degrees, but the docstring was saying otherwise, leading to potential bugs in the user codebase. This PR fixes it.

Old docstring:
`Convert batched Oriented Bounding Boxes (OBB) from [xywh, rotation] to [xy1, xy2, xy3, xy4]. Rotation values should be in degrees from 0 to 90.`
New docstring:
`Convert batched Oriented Bounding Boxes (OBB) from [xywh, rotation] to [xy1, xy2, xy3, xy4]. Rotation values should be in radians from 0 to pi/4.`

cc @glenn-jocher @YuriGagarine

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated bounding box rotation values from degrees to radians in utility functions.

### 📊 Key Changes
- Changed documentation in `xyxyxyxy2xywhr` function to indicate rotation values are now returned in radians (0 to pi/2).
- Modified `xywhr2xyxyxyxy` function documentation to specify that rotation values should be in radians (0 to pi/2).

### 🎯 Purpose & Impact
- 📏 **Consistency:** Improves the consistency of rotation value handling by standardizing to radians, a common unit in computational tasks.
- 🤖 **Accuracy:** Potentially increases the accuracy of bounding box calculations and manipulations.
- 🛠️ **Developer Clarity:** Provides clearer guidance to developers on the expected format of rotation values, reducing errors and confusion.