### PR TITLE
fix example for plotting Ray Tune history

### DIFF
--- a/docs/en/integrations/ray-tune.md
+++ b/docs/en/integrations/ray-tune.md
@@ -165,7 +165,7 @@ You can plot the history of reported metrics for each trial to see how the metri
 ```python
 import matplotlib.pyplot as plt
 
-for result in result_grid:
+for i, result in enumerate(result_grid):
     plt.plot(
         result.metrics_dataframe["training_iteration"],
         result.metrics_dataframe["mean_accuracy"],


### PR DESCRIPTION
This fixes a small mistake in the example for plotting the history of Ray Tune.

- [x] I have checked for similar PRs
- [x] I have checked for related issues

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor update to an example script in the Ray Tune integration documentation.

### 📊 Key Changes
- 🔄 Changed loop variable in a plotting script from `result` to `i, result`.

### 🎯 Purpose & Impact
- 🛠️ **Improvement in Example Code**: Enhances the clarity and potential future use of the loop by introducing an index variable `i`.
- 📚 **Better Documentation**: Ensures the example provided is more illustrative and aligned with potential best practices, benefiting users who follow the documentation.