### PR TITLE
Ignore Vimeo 401 'unauthorized' errors

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,6 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 # Continuous Integration (CI) GitHub Actions tests broken link checker using https://github.com/lycheeverse/lychee
 # Ignores the following status codes to reduce false positives:
+#   - 401(Vimeo, 'unauthorized')
 #   - 403(OpenVINO, 'forbidden')
 #   - 429(Instagram, 'too many requests')
 #   - 500(Zenodo, 'cached')
@@ -38,7 +39,7 @@ jobs:
             --scheme https \
             --timeout 60 \
             --insecure \
-            --accept 403,429,500,502,999 \
+            --accept 401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
             --exclude-path docs/zh \
@@ -68,7 +69,7 @@ jobs:
             --scheme https \
             --timeout 60 \
             --insecure \
-            --accept 429,999 \
+            --accept 401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
             --exclude-path '**/ci.yaml' \


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
🔗 Enhanced the CI process to better handle specific HTTP status codes when checking for broken links.

### 📊 Key Changes
- Updated the `.github/workflows/links.yml` file to include HTTP status code `401 (Unauthorized)` in the list of accepted codes during the link checking process.
- Adjusted both sections where HTTP status codes are configured to ensure `401` is recognized.

### 🎯 Purpose & Impact
- **Purpose**: By including `401 (Unauthorized)` in the accepted codes, the CI process will reduce false positives when URLs require authorization.
- **Impact**: This change improves the accuracy of the broken link checker, ensuring that valid URLs requiring authorization do not trigger unnecessary alerts, leading to smoother workflows and fewer manual checks for developers. 🚀