### PR TITLE
Add `allow_background_images=True` in split_dota.py

### DIFF
--- a/ultralytics/data/split_dota.py
+++ b/ultralytics/data/split_dota.py
@@ -175,20 +175,18 @@ def crop_and_save(anno, windows, window_objs, im_dir, lb_dir, allow_background_i
         ph, pw = patch_im.shape[:2]
 
         label = window_objs[i]
-        if len(label) == 0:
-            if allow_background_images:
-                cv2.imwrite(str(Path(im_dir) / f"{new_name}.jpg"), patch_im)
-            continue
-        label[:, 1::2] -= x_start
-        label[:, 2::2] -= y_start
-        label[:, 1::2] /= pw
-        label[:, 2::2] /= ph
+        if len(label) or allow_background_images:
+            cv2.imwrite(str(Path(im_dir) / f"{new_name}.jpg"), patch_im)
+        if len(label):
+            label[:, 1::2] -= x_start
+            label[:, 2::2] -= y_start
+            label[:, 1::2] /= pw
+            label[:, 2::2] /= ph
 
-        cv2.imwrite(str(Path(im_dir) / f"{new_name}.jpg"), patch_im)
-        with open(Path(lb_dir) / f"{new_name}.txt", "w") as f:
-            for lb in label:
-                formatted_coords = ["{:.6g}".format(coord) for coord in lb[1:]]
-                f.write(f"{int(lb[0])} {' '.join(formatted_coords)}\n")
+            with open(Path(lb_dir) / f"{new_name}.txt", "w") as f:
+                for lb in label:
+                    formatted_coords = ["{:.6g}".format(coord) for coord in lb[1:]]
+                    f.write(f"{int(lb[0])} {' '.join(formatted_coords)}\n")
 
 
 def split_images_and_labels(data_root, save_dir, split="train", crop_sizes=(1024,), gaps=(200,)):

--- a/ultralytics/data/split_dota.py
+++ b/ultralytics/data/split_dota.py
@@ -144,7 +144,7 @@ def get_window_obj(anno, windows, iof_thr=0.7):
         return [np.zeros((0, 9), dtype=np.float32) for _ in range(len(windows))]  # window_anns
 
 
-def crop_and_save(anno, windows, window_objs, im_dir, lb_dir):
+def crop_and_save(anno, windows, window_objs, im_dir, lb_dir, reserve=True):
     """
     Crop images and save new labels.
 
@@ -154,6 +154,7 @@ def crop_and_save(anno, windows, window_objs, im_dir, lb_dir):
         window_objs (list): A list of labels inside each window.
         im_dir (str): The output directory path of images.
         lb_dir (str): The output directory path of labels.
+        reserve (bool): Whether reserving images without label or not.
 
     Notes:
         The directory structure assumed for the DOTA dataset:
@@ -173,15 +174,17 @@ def crop_and_save(anno, windows, window_objs, im_dir, lb_dir):
         patch_im = im[y_start:y_stop, x_start:x_stop]
         ph, pw = patch_im.shape[:2]
 
-        cv2.imwrite(str(Path(im_dir) / f"{new_name}.jpg"), patch_im)
         label = window_objs[i]
         if len(label) == 0:
+            if reserve:
+                cv2.imwrite(str(Path(im_dir) / f"{new_name}.jpg"), patch_im)
             continue
         label[:, 1::2] -= x_start
         label[:, 2::2] -= y_start
         label[:, 1::2] /= pw
         label[:, 2::2] /= ph
 
+        cv2.imwrite(str(Path(im_dir) / f"{new_name}.jpg"), patch_im)
         with open(Path(lb_dir) / f"{new_name}.txt", "w") as f:
             for lb in label:
                 formatted_coords = ["{:.6g}".format(coord) for coord in lb[1:]]

--- a/ultralytics/data/split_dota.py
+++ b/ultralytics/data/split_dota.py
@@ -144,7 +144,7 @@ def get_window_obj(anno, windows, iof_thr=0.7):
         return [np.zeros((0, 9), dtype=np.float32) for _ in range(len(windows))]  # window_anns
 
 
-def crop_and_save(anno, windows, window_objs, im_dir, lb_dir, reserve=True):
+def crop_and_save(anno, windows, window_objs, im_dir, lb_dir, allow_background_images=True):
     """
     Crop images and save new labels.
 
@@ -154,7 +154,7 @@ def crop_and_save(anno, windows, window_objs, im_dir, lb_dir, reserve=True):
         window_objs (list): A list of labels inside each window.
         im_dir (str): The output directory path of images.
         lb_dir (str): The output directory path of labels.
-        reserve (bool): Whether reserving images without label or not.
+        allow_background_images (bool): Whether to include background images without labels.
 
     Notes:
         The directory structure assumed for the DOTA dataset:
@@ -176,7 +176,7 @@ def crop_and_save(anno, windows, window_objs, im_dir, lb_dir, reserve=True):
 
         label = window_objs[i]
         if len(label) == 0:
-            if reserve:
+            if allow_background_images:
                 cv2.imwrite(str(Path(im_dir) / f"{new_name}.jpg"), patch_im)
             continue
         label[:, 1::2] -= x_start


### PR DESCRIPTION
The default value of  'reserve' is set to 'True' to reserve images without label. Manually set it to 'False' to ignore these background images and therefore reduce dataset size. Solve Issue https://github.com/ultralytics/ultralytics/issues/15030

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Small enhancement to the `crop_and_save` function for better handling of background images.

### 📊 Key Changes
- Added `allow_background_images` parameter to the `crop_and_save` function.
- Modified logic to save image patches even if they contain no labels, based on the new parameter.

### 🎯 Purpose & Impact
- 🖼️ **Purpose**: Allow optional saving of background image patches without labels.
- 🌟 **Impact**: Facilitates the use of background images in training, potentially enhancing model training by providing more diverse data.