### PR TITLE
`ultralytics 8.2.79` YOLOv10 CoreML and MPS training "gather" op error fix

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.2.78"
+__version__ = "8.2.79"
 
 import os
 

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -159,7 +159,7 @@ class Detect(nn.Module):
         labels = index % nc
         index = index // nc
         # Set int64 dtype for MPS and CoreML compatibility to avoid 'gather_along_axis' ops error
-        if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
             index = index.to(torch.int64)
         boxes = boxes.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, boxes.shape[-1]))
 

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -159,7 +159,7 @@ class Detect(nn.Module):
         labels = index % nc
         index = index // nc
         # Set int64 dtype for MPS and CoreML compatibility to avoid 'gather_along_axis' ops error
-        if index.device.type == "mps":
+        if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
             index = index.to(torch.int64)
         boxes = boxes.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, boxes.shape[-1]))
 

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -157,7 +157,10 @@ class Detect(nn.Module):
 
         scores, index = torch.topk(scores.flatten(1), max_det, axis=-1)
         labels = index % nc
-        index = index // nc
+        if torch.backends.mps.is_available(): #explicitly set to "int64" to ensure Metal Performance Shaders (MPS) compability as well as CoreML format export completion, by circumventing CoreML/MPS 'gather' to 'gather_along_axis" ops error.
+            index = (index // nc).to(torch.int64)
+        else:
+            index = index // nc
         boxes = boxes.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, boxes.shape[-1]))
 
         return torch.cat([boxes, scores.unsqueeze(-1), labels.unsqueeze(-1).to(boxes.dtype)], dim=-1)

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -157,10 +157,10 @@ class Detect(nn.Module):
 
         scores, index = torch.topk(scores.flatten(1), max_det, axis=-1)
         labels = index % nc
-        if torch.backends.mps.is_available():  # explicitly set to "int64" to ensure Metal Performance Shaders (MPS) compatibility as well as CoreML format export completion, by circumventing CoreML/MPS 'gather' to 'gather_along_axis" ops error.
-            index = (index // nc).to(torch.int64)
-        else:
-            index = index // nc
+        index = index // nc
+        # Set int64 dtype for MPS and CoreML compatibility to avoid 'gather_along_axis' ops error
+        if index.device.type == 'mps':  
+            index = index.to(torch.int64)
         boxes = boxes.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, boxes.shape[-1]))
 
         return torch.cat([boxes, scores.unsqueeze(-1), labels.unsqueeze(-1).to(boxes.dtype)], dim=-1)

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 from torch.nn.init import constant_, xavier_uniform_
 
+from ultralytics.utils import MACOS
 from ultralytics.utils.tal import TORCH_1_10, dist2bbox, dist2rbox, make_anchors
 
 from .block import DFL, BNContrastiveHead, ContrastiveHead, Proto
@@ -151,7 +152,7 @@ class Detect(nn.Module):
         boxes = torch.gather(boxes, dim=1, index=index.repeat(1, 1, boxes.shape[-1]))
         scores = torch.gather(scores, dim=1, index=index.repeat(1, 1, scores.shape[-1]))
 
-        # NOTE: simplify but result slightly lower mAP
+        # NOTE: simplify result but slightly lower mAP
         # scores, labels = scores.max(dim=-1)
         # return torch.cat([boxes, scores.unsqueeze(-1), labels.unsqueeze(-1)], dim=-1)
 
@@ -159,7 +160,7 @@ class Detect(nn.Module):
         labels = index % nc
         index = index // nc
         # Set int64 dtype for MPS and CoreML compatibility to avoid 'gather_along_axis' ops error
-        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        if MACOS:
             index = index.to(torch.int64)
         boxes = boxes.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, boxes.shape[-1]))
 

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -157,7 +157,7 @@ class Detect(nn.Module):
 
         scores, index = torch.topk(scores.flatten(1), max_det, axis=-1)
         labels = index % nc
-        if torch.backends.mps.is_available(): #explicitly set to "int64" to ensure Metal Performance Shaders (MPS) compability as well as CoreML format export completion, by circumventing CoreML/MPS 'gather' to 'gather_along_axis" ops error.
+        if torch.backends.mps.is_available():  # explicitly set to "int64" to ensure Metal Performance Shaders (MPS) compatibility as well as CoreML format export completion, by circumventing CoreML/MPS 'gather' to 'gather_along_axis" ops error.
             index = (index // nc).to(torch.int64)
         else:
             index = index // nc

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -159,7 +159,7 @@ class Detect(nn.Module):
         labels = index % nc
         index = index // nc
         # Set int64 dtype for MPS and CoreML compatibility to avoid 'gather_along_axis' ops error
-        if index.device.type == 'mps':  
+        if index.device.type == "mps":
             index = index.to(torch.int64)
         boxes = boxes.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, boxes.shape[-1]))
 


### PR DESCRIPTION
Hello, 
attempting a Yolov10 model export into a CoreML format failed at 99% because of a CoreML error with the "gather" op into "gather_along_axis".
Similarly, starting the training of a Yolov10 model using Metal Perfomance Shaders (MPS) for device, would immediately bring a failed assertion from the "MPSNDArrayGatherND" MPS kernel.

> ERROR - converting 'gather' op (located at: '23'):
> CoreML: export failure ❌ 4.5s: Op "boxes" (op_type: gather_along_axis) Input indices="1195" expects tensor or scalar of dtype from type domain ['int32'] but got tensor[1,300,4,fp32] 

> [...]/MetalPerformanceShaders/MPSNDArray/Kernels/MPSNDArrayGatherND.mm:255: failed assertion `Rank of updates array (1) must be greater than or equal to inner-most dimension of indices array (300)'

The issue appeared to be related to the Yolov10 n̶o̶n̶ ̶m̶a̶x̶i̶m̶u̶... "Post-Processing" part in the "head" module, specifically in the "torch.gather" operation between "boxes" and "indices".

Swapping with "simpler part" that's commented in the code allowed exporting, but I still couldn't train with "device=mps".
Other, working approach was to use "torch.arrange" instead of "torch.gather" but I was concerned about accuracy.

In the end, simply **setting the tensor explicitly to "int64" for the index just before the last "gather" operation fixed the issues.**

I wasn't sure about the implications for other platforms, although from my understanding the "torch.gather" op wants an "int64" anyway, so I put as condition "if torch.backends.mps.is_available()" for the change to only apply to the platform of the matter.

It's my first PR,
Kind regards,


--->
I have read the CLA Document and I sign the CLA





[Issues/13342](https://github.com/ultralytics/ultralytics/issues/13342)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Metal Performance Shaders (MPS) compatibility in model post-processing.

### 📊 Key Changes
- Added a condition to convert tensor indices to "int64" type when MPS backend is available.

### 🎯 Purpose & Impact
- 🛠️ **Enhanced Compatibility**: Ensures seamless operation with Apple's Metal Performance Shaders (MPS) and CoreML, avoiding runtime errors.
- 🚀 **Improved Exporting**: Facilitates successful model export to CoreML format by preventing specific operational errors.
- 🔧 **User Experience**: Allows broader hardware support, particularly for users on Apple devices, ensuring models work efficiently without additional tweaks.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor version upgrade with code improvements for compatibility with macOS and CoreML.

### 📊 Key Changes
- Increased version from `8.2.78` to `8.2.79`.
- Added a check for `MACOS` to handle specific dtype settings in `postprocess` function in `ultralytics/nn/modules/head.py`.

### 🎯 Purpose & Impact
- **Compatibility Enhancements**: Ensures better performance and fewer errors on macOS and CoreML platforms by addressing dtype issues.
- **Code Maintenance**: Keeps the software versioning up-to-date, reflecting the latest changes and fixes.