### PR TITLE
Missing best.pt resumed checkpoint upload spelling

### DIFF
--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -350,10 +350,10 @@ class HUBTrainingSession:
             last = weights.with_name("last" + weights.suffix)
             if final and last.is_file():
                 LOGGER.warning(
-                    f"{PREFIX} ARNING ⚠️ Model 'best.pt' not found, copying 'last.pt' to 'best.pt' and uploading. "
+                    f"{PREFIX} WARNING ⚠️ Model 'best.pt' not found, copying 'last.pt' to 'best.pt' and uploading. "
                     "This often happens when resuming training in transient environments like Google Colab. "
                     "For more reliable training, consider using Ultralytics HUB Cloud. "
-                    "Learn more at https://docs.ultralytics.com/hub/cloud-training/."
+                    "Learn more at https://docs.ultralytics.com/hub/cloud-training."
                 )
                 shutil.copy(last, weights)  # copy last.pt to best.pt
             else:


### PR DESCRIPTION
This PR fixes [this](https://github.com/ultralytics/ultralytics/pull/15754/files#diff-9a8f35e10c3ac02a449639cf43585490df23cfd85ccf328635b79214fe710bfaR353) spelling issue.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor text correction in a log message to improve user understanding.

### 📊 Key Changes
- Corrected a typo in a warning log message from "ARNING ⚠️" to "WARNING ⚠️".
- Updated a URL in the same warning message for documentation consistency.

### 🎯 Purpose & Impact
- 📝 **Improved Clarity:** The corrected typo ensures the warning message is accurately conveyed.
- 🌐 **Documentation Consistency:** The updated URL enhances user navigation to the corresponding documentation, aiding in better user guidance for using Ultralytics HUB Cloud.