### PR TITLE
Properly use cmake variable in ONNXRuntime

### DIFF
--- a/examples/YOLOv8-ONNXRuntime-CPP/CMakeLists.txt
+++ b/examples/YOLOv8-ONNXRuntime-CPP/CMakeLists.txt
@@ -49,6 +49,9 @@ elseif (APPLE)
     # set(ONNXRUNTIME_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime-osx-x64-${ONNXRUNTIME_VERSION}")
     # Apple Universal binary
     # set(ONNXRUNTIME_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime-osx-universal2-${ONNXRUNTIME_VERSION}")
+else ()
+    message(SEND_ERROR "Variable ONNXRUNTIME_ROOT is not set properly. Please check if your cmake project \
+    is not compiled with `-D WIN32=TRUE`, `-D LINUX=TRUE`, or `-D APPLE=TRUE`!")
 endif ()
 
 include_directories(${PROJECT_NAME} ${ONNXRUNTIME_ROOT}/include)

--- a/examples/YOLOv8-ONNXRuntime-CPP/README.md
+++ b/examples/YOLOv8-ONNXRuntime-CPP/README.md
@@ -82,6 +82,18 @@ Note (2): Due to ONNX Runtime, we need to use CUDA 11 and cuDNN 8. Keep in mind 
    cmake ..
    ```
 
+   **Notice**:
+
+   If you encounter an error indicating that the `ONNXRUNTIME_ROOT` variable is not set correctly, you can resolve this by building the project using the appropriate command tailored to your system.
+      ```console
+      # compiled in a win32 system
+      cmake -D WIN32=TRUE ..
+      # compiled in a linux system
+      cmake -D LINUX=TRUE ..
+      # compiled in an apple system
+      cmake -D APPLE=TRUE ..
+      ```
+
 5. Build the project:
 
    ```console

--- a/examples/YOLOv8-ONNXRuntime-CPP/README.md
+++ b/examples/YOLOv8-ONNXRuntime-CPP/README.md
@@ -85,14 +85,15 @@ Note (2): Due to ONNX Runtime, we need to use CUDA 11 and cuDNN 8. Keep in mind 
    **Notice**:
 
    If you encounter an error indicating that the `ONNXRUNTIME_ROOT` variable is not set correctly, you can resolve this by building the project using the appropriate command tailored to your system.
-      ```console
-      # compiled in a win32 system
-      cmake -D WIN32=TRUE ..
-      # compiled in a linux system
-      cmake -D LINUX=TRUE ..
-      # compiled in an apple system
-      cmake -D APPLE=TRUE ..
-      ```
+
+   ```console
+   # compiled in a win32 system
+   cmake -D WIN32=TRUE ..
+   # compiled in a linux system
+   cmake -D LINUX=TRUE ..
+   # compiled in an apple system
+   cmake -D APPLE=TRUE ..
+   ```
 
 5. Build the project:
 


### PR DESCRIPTION
I have compiled this code in my ubuntu 22.04 system recently, but I find that variables WIN32, LINUX or APPLE is unset. So I add this commit to provide a warning to confirm that this system variable is set rightly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated CMake configuration and README instructions for better error handling and build guidance in YOLOv8-ONNXRuntime-CPP example.

### 📊 Key Changes
- ✅ Added CMake error message if `ONNXRUNTIME_ROOT` is not set correctly.
- 📝 Updated README with troubleshooting steps for `ONNXRUNTIME_ROOT` errors and commands for different OS builds.

### 🎯 Purpose & Impact
- 🛠️ **Improved Error Handling**: Helps catch and diagnose misconfiguration issues early in the build process, saving time for developers.
- 📚 **Clearer Documentation**: Provides explicit build commands for different operating systems, making it easier for users to set up the project correctly.

These changes enhance user experience by making the setup process more foolproof and well-documented. 🚀