### PR TITLE
Fix YOLOv8 C++ ONNXRuntime transpose op

### DIFF
--- a/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
+++ b/examples/YOLOv8-ONNXRuntime-CPP/inference.cpp
@@ -221,8 +221,8 @@ char* YOLO_V8::TensorProcess(clock_t& starttime_1, cv::Mat& iImg, N& blob, std::
     case YOLO_DETECT_V8:
     case YOLO_DETECT_V8_HALF:
     {
-        int strideNum = outputNodeDims[1];//8400
-        int signalResultNum = outputNodeDims[2];//84
+        int signalResultNum = outputNodeDims[1];//84
+        int strideNum = outputNodeDims[2];//8400
         std::vector<int> class_ids;
         std::vector<float> confidences;
         std::vector<cv::Rect> boxes;
@@ -230,18 +230,18 @@ char* YOLO_V8::TensorProcess(clock_t& starttime_1, cv::Mat& iImg, N& blob, std::
         if (modelType == YOLO_DETECT_V8)
         {
             // FP32
-            rawData = cv::Mat(strideNum, signalResultNum, CV_32F, output);
+            rawData = cv::Mat(signalResultNum, strideNum, CV_32F, output);
         }
         else
         {
             // FP16
-            rawData = cv::Mat(strideNum, signalResultNum, CV_16F, output);
+            rawData = cv::Mat(signalResultNum, strideNum, CV_16F, output);
             rawData.convertTo(rawData, CV_32F);
         }
         //Note:
         //ultralytics add transpose operator to the output of yolov8 model.which make yolov8/v5/v7 has same shape
         //https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt
-        //rowData = rowData.t();
+        rawData = rawData.t();
 
         float* data = (float*)rawData.data;
 


### PR DESCRIPTION
As the YOLOv8 model has incorporated a transpose operation, the resulting output shape becomes (1, 84, 8400). Consequently, the values of `strideNum` and `signalResultNum` which were initially intended to represent dimensions other than 84 and 8400, respectively, do not align with the current output structure, failing to meet our initial expectations. 

To rectify this, I have modified the corresponding code segments. Additionally, I have **transposed** `rawData` to ensure compatibility and maintain the functionality of subsequent code blocks.

**The predictions of Yolov8 model with modified code:**
![a](https://github.com/user-attachments/assets/0ec69d87-308f-433c-aa62-0bb9f54e1a13)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes the matrix dimension handling in YOLOv8 ONNXRuntime C++ example to correct the result processing. 🛠️

### 📊 Key Changes
- **Adjusted Dimension Indices**: Changed the assignment of matrix dimensions in the tensor processing function.
- **Transposition Fix**: Reinforced a correct transposition (`rawData = rawData.t();`) for compatibility with Ultralytics model output. 

### 🎯 Purpose & Impact
- **Bug Fix**: Corrects an incorrect indexing in handling tensor output dimensions, thereby ensuring accurate result processing for the YOLOv8 model.
- **Increased Compatibility**: Ensures that the model output shape aligns across different YOLO versions (v5, v7, v8).
- **Improved Accuracy**: Fixes the erroneous output shape handling to avoid potential misinterpretations in object detection tasks, leading to more reliable detections. 🎯