### PR TITLE
Fix typo in docstring in `metrics.py`

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -178,7 +178,7 @@ def _get_covariance_matrix(boxes):
         boxes (torch.Tensor): A tensor of shape (N, 5) representing rotated bounding boxes, with xywhr format.
 
     Returns:
-        (torch.Tensor): Covariance metrixs corresponding to original rotated bounding boxes.
+        (torch.Tensor): Covariance matrices corresponding to original rotated bounding boxes.
     """
     # Gaussian bounding boxes, ignore the center points (the first two columns) because they are not needed here.
     gbbs = torch.cat((boxes[:, 2:4].pow(2) / 12, boxes[:, 4:]), dim=-1)


### PR DESCRIPTION
Hi,
minor typo fix in docstring `_get_covariance_matrix(boxes)`. Thanks!

`Covariance metrixs` --> `Covariance matrices`



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixed a typo in the documentation of the `_get_covariance_matrix` function in the `metrics.py` file.

### 📊 Key Changes
- Corrected the word "metrixs" to "matrices" in the docstring.

### 🎯 Purpose & Impact
- **Purpose**: Improve the documentation clarity by fixing the typo.
- **Impact**: Ensures the code documentation is accurate and professional, aiding both developers and users in better understanding the code.