### PR TITLE
Cleanup GitHub Runner for Docker CI

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -86,20 +86,15 @@ jobs:
         # Free up to 10GB of disk space per https://github.com/ultralytics/ultralytics/pull/14894
         run: |
           echo "Free space before deletion:"
-          df -h
-          echo "Free space after deleting hostedtoolcache:"
+          df -h /
           rm -rf /opt/hostedtoolcache
-          df -h
-          echo "Free space after deleting dotnet:"
-          rm -rf /usr/share/dotnet
-          df -h
-          echo "Free space after deleting swift:"
-          /usr/share/swift
-          echo "Free space after deleting android:"
-          /usr/local/lib/android
           echo "Free space after deletion:"
-          df -h
-
+          df -h /
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        run: |
+          echo "Free space after deletion:"
+          df -h /
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,8 +82,8 @@ jobs:
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
     steps:
-      # Free up to 30GB of disk space per https://github.com/ultralytics/ultralytics/pull/15848
       - name: Cleanup disk
+        # Free up to 30GB of disk space per https://github.com/ultralytics/ultralytics/pull/15848
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,14 +82,14 @@ jobs:
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
     steps:
-      - name: Free space before deletion
+      - name: Free space before disk cleanup
         run: |
           df -h /
       - name: Cleanup disk
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
-      - name: Free space after deletion
+      - name: Free space after disk cleanup
         run: |
           df -h /
       - name: Checkout repo

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,22 +82,16 @@ jobs:
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
     steps:
-      - name: Cleanup toolcache
-        # Free up to 10GB of disk space per https://github.com/ultralytics/ultralytics/pull/14894
+      - name: Free space before deletion
         run: |
-          echo "Free space before deletion:"
-          df -h /
-          rm -rf /opt/hostedtoolcache
-          echo "Free space after deletion:"
-          df -h /
-      - name: Free Disk Space (Ubuntu)
+          df -h 
+      - name: Cleanup disk
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
-      - name: Space after deleting everything
+      - name: Free space after deletion
         run: |
-          echo "Free space after deletion:"
-          df -h /
+          df -h 
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -86,6 +86,7 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,6 +82,7 @@ jobs:
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
     steps:
+      # Free up to 30GB of disk space per https://github.com/ultralytics/ultralytics/pull/15848
       - name: Cleanup disk
         uses: jlumbroso/free-disk-space@v1.3.1
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,16 +82,10 @@ jobs:
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
     steps:
-      - name: Free space before disk cleanup
-        run: |
-          df -h /
       - name: Cleanup disk
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
-      - name: Free space after disk cleanup
-        run: |
-          df -h /
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,14 +84,14 @@ jobs:
     steps:
       - name: Free space before deletion
         run: |
-          df -h 
+          df -h /
       - name: Cleanup disk
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
       - name: Free space after deletion
         run: |
-          df -h 
+          df -h /
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -86,10 +86,19 @@ jobs:
         # Free up to 10GB of disk space per https://github.com/ultralytics/ultralytics/pull/14894
         run: |
           echo "Free space before deletion:"
-          df -h /
+          df -h
+          echo "Free space after deleting hostedtoolcache:"
           rm -rf /opt/hostedtoolcache
+          df -h
+          echo "Free space after deleting dotnet:"
+          rm -rf /usr/share/dotnet
+          df -h
+          echo "Free space after deleting swift:"
+          /usr/share/swift
+          echo "Free space after deleting android:"
+          /usr/local/lib/android
           echo "Free space after deletion:"
-          df -h /
+          df -h
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -92,6 +92,7 @@ jobs:
           df -h /
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
+      - name: Space after deleting everything
         run: |
           echo "Free space after deletion:"
           df -h /

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -92,6 +92,8 @@ jobs:
           df -h /
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
       - name: Space after deleting everything
         run: |
           echo "Free space after deletion:"


### PR DESCRIPTION
This is at the testing stage

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the GitHub Actions workflow for more efficient disk space management during CI builds.

### 📊 Key Changes
- Updated the cleanup step from manually deleting files to using a pre-built action for freeing disk space.
- The new action can free up to 30GB of disk space instead of the previous 10GB.

### 🎯 Purpose & Impact
- **Efficiency Boost**: The new approach is more efficient, potentially speeding up CI runs by better managing disk space. 🚀
- **Simplification**: Replacing manual commands with a dedicated action reduces complexity and potential errors in the workflow. 🛠️