### PR TITLE
Run Conda tests with aligned tag/version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -329,13 +329,9 @@ jobs:
           results = model.export(format='onnx', imgsz=160)
           "
       - name: PyTest
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          command: |
-            git clone https://github.com/ultralytics/ultralytics
-            pytest ultralytics/tests
+        run: |
+          git clone https://github.com/ultralytics/ultralytics
+          pytest ultralytics/tests
 
   Summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -330,11 +330,11 @@ jobs:
           "
       - name: PyTest
         run: |
-          ULTRALYTICS_VERSION=$(conda list ultralytics | grep ultralytics | awk '{print $2}')
-          echo "Ultralytics version: $ULTRALYTICS_VERSION"
-          git clone --branch v$ULTRALYTICS_VERSION https://github.com/ultralytics/ultralytics.git
+          VERSION=$(conda list ultralytics | grep ultralytics | awk '{print $2}')
+          echo "Ultralytics version: $VERSION"
+          git clone https://github.com/ultralytics/ultralytics.git
           cd ultralytics
-          git checkout tags/v$ULTRALYTICS_VERSION
+          git checkout tags/v$VERSION
           pytest tests
 
   Summary:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -330,8 +330,12 @@ jobs:
           "
       - name: PyTest
         run: |
-          git clone https://github.com/ultralytics/ultralytics
-          pytest ultralytics/tests
+          ULTRALYTICS_VERSION=$(conda list ultralytics | grep ultralytics | awk '{print $2}')
+          echo "Ultralytics version: $ULTRALYTICS_VERSION"
+          git clone --branch v$ULTRALYTICS_VERSION https://github.com/ultralytics/ultralytics.git
+          cd ultralytics
+          git checkout tags/v$ULTRALYTICS_VERSION
+          pytest tests
 
   Summary:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts ultralytics/ultralytics#15884

Perhaps theres another solution but this one fails with "pytest not found" so seems to be spinning up new environment.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the Continuous Integration (CI) workflow for more reliable and version-specific testing.

### 📊 Key Changes
- **Revised PyTest action:** Replaced the retry mechanism of `nick-fields/retry@v2` with a direct script.
- **Version-specific testing:** Added steps to ensure tests are run against the exact version of the code being tested.

### 🎯 Purpose & Impact
- **Increased reliability:** Ensures tests run on the same code version as intended, reducing errors due to version mismatches.
- **Simplified CI configuration:** Streamlines the process by removing an external dependency and using direct commands.