### PR TITLE
Explorer tests require torch>=1.13

### DIFF
--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -8,7 +8,7 @@ from ultralytics.utils import ASSETS
 from ultralytics.utils.torch_utils import TORCH_1_13
 
 
-#@pytest.mark.slow
+# @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_similarity():
     """Test the correctness and response length of similarity calculations and SQL queries in the Explorer."""
@@ -26,7 +26,7 @@ def test_similarity():
     assert len(sql) == 1
 
 
-#@pytest.mark.slow
+# @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_det():
     """Test detection functionalities and verify embedding table includes bounding boxes."""
@@ -40,7 +40,7 @@ def test_det():
     assert isinstance(similar, PIL.Image.Image)
 
 
-#@pytest.mark.slow
+# @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_seg():
     """Test segmentation functionalities and ensure the embedding table includes segmentation masks."""
@@ -53,7 +53,7 @@ def test_seg():
     assert isinstance(similar, PIL.Image.Image)
 
 
-#@pytest.mark.slow
+# @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_pose():
     """Test pose estimation functionality and verify the embedding table includes keypoints."""

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -5,9 +5,11 @@ import pytest
 
 from ultralytics import Explorer
 from ultralytics.utils import ASSETS
+from ultralytics.utils.torch_utils import TORCH_1_13
 
 
-@pytest.mark.slow
+#@pytest.mark.slow
+@pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_similarity():
     """Test the correctness and response length of similarity calculations and SQL queries in the Explorer."""
     exp = Explorer(data="coco8.yaml")
@@ -24,7 +26,8 @@ def test_similarity():
     assert len(sql) == 1
 
 
-@pytest.mark.slow
+#@pytest.mark.slow
+@pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_det():
     """Test detection functionalities and verify embedding table includes bounding boxes."""
     exp = Explorer(data="coco8.yaml", model="yolov8n.pt")
@@ -37,7 +40,8 @@ def test_det():
     assert isinstance(similar, PIL.Image.Image)
 
 
-@pytest.mark.slow
+#@pytest.mark.slow
+@pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_seg():
     """Test segmentation functionalities and ensure the embedding table includes segmentation masks."""
     exp = Explorer(data="coco8-seg.yaml", model="yolov8n-seg.pt")
@@ -49,7 +53,8 @@ def test_seg():
     assert isinstance(similar, PIL.Image.Image)
 
 
-@pytest.mark.slow
+#@pytest.mark.slow
+@pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_pose():
     """Test pose estimation functionality and verify the embedding table includes keypoints."""
     exp = Explorer(data="coco8-pose.yaml", model="yolov8n-pose.pt")

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -8,7 +8,7 @@ from ultralytics.utils import ASSETS
 from ultralytics.utils.torch_utils import TORCH_1_13
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_similarity():
     """Test the correctness and response length of similarity calculations and SQL queries in the Explorer."""
@@ -26,7 +26,7 @@ def test_similarity():
     assert len(sql) == 1
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_det():
     """Test detection functionalities and verify embedding table includes bounding boxes."""
@@ -40,7 +40,7 @@ def test_det():
     assert isinstance(similar, PIL.Image.Image)
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_seg():
     """Test segmentation functionalities and ensure the embedding table includes segmentation masks."""
@@ -53,7 +53,7 @@ def test_seg():
     assert isinstance(similar, PIL.Image.Image)
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")
 def test_pose():
     """Test pose estimation functionality and verify the embedding table includes keypoints."""


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Mandatory checks for PyTorch version in Explorer tests

### 📊 Key Changes
- Added version check `@pytest.mark.skipif(not TORCH_1_13, reason="Explorer requires torch>=1.13")` to skip tests if PyTorch version is not >=1.13.
- Updated import to include `TORCH_1_13` from `ultralytics.utils.torch_utils`.

### 🎯 Purpose & Impact
- **Ensure Compatibility**: Tests will only run if the required PyTorch version (1.13 or higher) is installed, preventing potential errors due to version incompatibility.
- **Improved Reliability**: Guarantees that Explorer functionality is only tested in supported environments, leading to more accurate and reliable test outcomes.