### PR TITLE
Add failing Windows Test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows]
+        os: [ubuntu-latest, macos-14, windows-latest]
         python-version: ["3.11"]
         torch: [latest]
         include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, windows]
         python-version: ["3.11"]
         torch: [latest]
         include:

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -252,6 +252,8 @@ def test_labels_and_crops():
     for r in results:
         im_name = Path(r.path).stem
         cls_idxs = r.boxes.cls.int().tolist()
+        # Check correct detections
+        assert cls_idxs == ([0, 0, 5, 0, 7] if r.path.endswith("bus.jpg") else [0, 0])  # bus.jpg and zidane.jpg classes
         # Check label path
         labels = save_path / f"labels/{im_name}.txt"
         assert labels.exists()


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced CI environment and added validation checks in tests for more robust and reliable code.

### 📊 Key Changes
- **CI Workflow Update:**
  - Added `windows-latest` to OS matrix in the CI pipeline.
- **Testing Enhancements:**
  - Added assertions to verify correct class detections in `test_labels_and_crops`.

### 🎯 Purpose & Impact
- **CI Workflow Improvement:** 
  - Ensures code compatibility and robustness across Windows OS, in addition to existing Ubuntu and macOS environments. 🚀
- **Improved Testing:**
  - Validates the accuracy of class detections, ensuring higher confidence in the test results and overall system reliability. 🔍