### PR TITLE
Remove Raspberry Pi CI reboot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,7 +230,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,6 +264,7 @@ jobs:
         run: |
           cat benchmarks.log
           echo "$(cat benchmarks.log)" >> $GITHUB_STEP_SUMMARY
+      # The below is fixed in: https://github.com/ultralytics/ultralytics/pull/15987
       # - name: Reboot # run a reboot command in the background to free resources for next run and not crash main thread
       #   run: sudo bash -c "sleep 10; reboot" &
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,7 +230,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:
@@ -264,8 +264,8 @@ jobs:
         run: |
           cat benchmarks.log
           echo "$(cat benchmarks.log)" >> $GITHUB_STEP_SUMMARY
-      - name: Reboot # run a reboot command in the background to free resources for next run and not crash main thread
-        run: sudo bash -c "sleep 10; reboot" &
+      # - name: Reboot # run a reboot command in the background to free resources for next run and not crash main thread
+      #   run: sudo bash -c "sleep 10; reboot" &
 
   Conda:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.conda == 'true')


### PR DESCRIPTION
It is expected that the RPi CI does not need a reboot after [this fix](https://github.com/ultralytics/ultralytics/pull/15976)

Will experiment here and see.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR disables a reboot step in the CI workflow, which was causing issues.

### 📊 Key Changes
- 🛠️ Commented out the reboot command in the CI workflow.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: To avoid crashes and resource issues during the CI process.
- 👍 **Impact**: More stable CI runs, which means more reliable and efficient development and testing workflows for the team.