### PR TITLE
fix Objects365.yaml error names

### DIFF
--- a/ultralytics/cfg/datasets/Objects365.yaml
+++ b/ultralytics/cfg/datasets/Objects365.yaml
@@ -113,7 +113,7 @@ names:
   95: Pot
   96: Cow
   97: Cake
-  98: Dinning Table
+  98: Dining Table
   99: Sheep
   100: Hanger
   101: Blackboard/Whiteboard
@@ -304,7 +304,7 @@ names:
   286: Hammer
   287: Cue
   288: Avocado
-  289: Hamimelon
+  289: Hami melon
   290: Flask
   291: Mushroom
   292: Screwdriver
@@ -328,7 +328,7 @@ names:
   310: Dishwasher
   311: Crab
   312: Hoverboard
-  313: Meat ball
+  313: Meatball
   314: Rice Cooker
   315: Tuba
   316: Calculator


### PR DESCRIPTION
I found this repo use Objects365.yaml is Objects v2 version.
The original project stated that the original Objects365v2 dataset class index had some errors that needed to be fixed, but I searched the library and found three class name errors, and this submission gives the corresponding solution.

Origin link: https://github.com/open-mmlab/mmdetection/blob/main/configs/mm_grounding_dino/dataset_prepare_zh-CN.md#1-object365-v2

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor corrections were made to dataset labels in the Objects365 configuration file.

### 📊 Key Changes
- Corrected "Dinning Table" to "Dining Table"
- Corrected "Hamimelon" to "Hami melon"
- Corrected "Meat ball" to "Meatball" 

### 🎯 Purpose & Impact
- **Improves Data Accuracy**: Correcting these names ensures that the dataset labels are accurate and standardized, which is crucial for training reliable machine learning models.
- **Enhances Usability**: Correct names make the dataset easier to understand and use, reducing potential confusion for developers and researchers.