### PR TITLE
CoreML export: updated nms flag for end2end models

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -610,12 +610,9 @@ class Exporter:
         f = self.file.with_suffix(".mlmodel" if mlmodel else ".mlpackage")
         if f.is_dir():
             shutil.rmtree(f)
-        if self.args.nms and hasattr(self.model, "end2end"):
-            if self.model.end2end:
-                LOGGER.warning(
-                    f"{prefix} WARNING ⚠️ 'nms=True' is not available for end2end models forcing 'nms=False'."
-                )
-                self.args.nms = False
+        if self.args.nms and getattr(self.model, "end2end", False)
+            LOGGER.warning(f"{prefix} WARNING ⚠️ 'nms=True' is not available for end2end models. Forcing 'nms=False'.")
+            self.args.nms = False
 
         bias = [0.0, 0.0, 0.0]
         scale = 1 / 255

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -610,6 +610,10 @@ class Exporter:
         f = self.file.with_suffix(".mlmodel" if mlmodel else ".mlpackage")
         if f.is_dir():
             shutil.rmtree(f)
+        if self.args.nms and hasattr(self.model, "end2end"):
+            if self.model.end2end:
+                LOGGER.warning(f"{prefix} WARNING ⚠️ 'nms=True' is not available for end2end models forcing 'nms=False'.")
+                self.args.nms = False
 
         bias = [0.0, 0.0, 0.0]
         scale = 1 / 255

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -612,7 +612,9 @@ class Exporter:
             shutil.rmtree(f)
         if self.args.nms and hasattr(self.model, "end2end"):
             if self.model.end2end:
-                LOGGER.warning(f"{prefix} WARNING ⚠️ 'nms=True' is not available for end2end models forcing 'nms=False'.")
+                LOGGER.warning(
+                    f"{prefix} WARNING ⚠️ 'nms=True' is not available for end2end models forcing 'nms=False'."
+                )
                 self.args.nms = False
 
         bias = [0.0, 0.0, 0.0]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -610,7 +610,7 @@ class Exporter:
         f = self.file.with_suffix(".mlmodel" if mlmodel else ".mlpackage")
         if f.is_dir():
             shutil.rmtree(f)
-        if self.args.nms and getattr(self.model, "end2end", False)
+        if self.args.nms and getattr(self.model, "end2end", False):
             LOGGER.warning(f"{prefix} WARNING ⚠️ 'nms=True' is not available for end2end models. Forcing 'nms=False'.")
             self.args.nms = False
 


### PR DESCRIPTION
Test with:
```python
from ultralytics import YOLO
model = YOLO("yolov10n.pt")
model.export(format="coreml", nms=True)
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to handle NMS setting for end-to-end models in CoreML export.

### 📊 Key Changes
- Added a check to disable `nms` (non-max suppression) for models with end-to-end support during CoreML export.
- A warning message is logged if `nms=True` is attempted for such models.

### 🎯 Purpose & Impact
- Ensures compatibility by automatically adjusting settings when exporting end-to-end models to CoreML.
- Improves user experience by providing a clear warning when `nms` is not supported, preventing potential export issues.