### PR TITLE
MPS unified memory cache empty 

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -453,7 +453,11 @@ class BaseTrainer:
                 self.stop |= epoch >= self.epochs  # stop if exceeded epochs
             self.run_callbacks("on_fit_epoch_end")
             gc.collect()
-            torch.cuda.empty_cache()  # clear GPU memory at end of epoch, may help reduce CUDA out of memory errors
+            if MACOS:
+                torch.mps.empty_cache()   # clear unified memory at end of epoch, may help MPS' management of 'unlimited' virtual memoy
+            else:
+                torch.cuda.empty_cache()  # clear GPU memory at end of epoch, may help reduce CUDA out of memory errors
+
 
             # Early Stopping
             if RANK != -1:  # if DDP training
@@ -475,7 +479,11 @@ class BaseTrainer:
                 self.plot_metrics()
             self.run_callbacks("on_train_end")
         gc.collect()
-        torch.cuda.empty_cache()
+        if MACOS:
+            torch.mps.empty_cache()
+        else:
+            torch.cuda.empty_cache()
+
         self.run_callbacks("teardown")
 
     def read_results_csv(self):

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -28,6 +28,7 @@ from ultralytics.utils import (
     DEFAULT_CFG,
     LOCAL_RANK,
     LOGGER,
+    MACOS,
     RANK,
     TQDM,
     __version__,
@@ -36,7 +37,6 @@ from ultralytics.utils import (
     colorstr,
     emojis,
     yaml_save,
-    MACOS,
 )
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, check_model_file_from_stem, print_args

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -454,10 +454,9 @@ class BaseTrainer:
             self.run_callbacks("on_fit_epoch_end")
             gc.collect()
             if MACOS:
-                torch.mps.empty_cache()   # clear unified memory at end of epoch, may help MPS' management of 'unlimited' virtual memoy
+                torch.mps.empty_cache()  # clear unified memory at end of epoch, may help MPS' management of 'unlimited' virtual memoy
             else:
                 torch.cuda.empty_cache()  # clear GPU memory at end of epoch, may help reduce CUDA out of memory errors
-
 
             # Early Stopping
             if RANK != -1:  # if DDP training

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -36,6 +36,7 @@ from ultralytics.utils import (
     colorstr,
     emojis,
     yaml_save,
+    MACOS,
 )
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, check_model_file_from_stem, print_args


### PR DESCRIPTION
Hi,
a bold claim.

Using `torch.mps.empty_cache() `for macOS with MPS device, drastically betters memory management: I found out when I realized the duration of my single class, yolov8, 8000 images, 45000 objects training , was massively reduced, nearly 50% (40% speed increase).

I did some test with default settings and 9000 augmented images generated from the 4 "coco" images dataset, and the results showed a significant, `25% speed increase` (30% duration reduction) starting from epoch 2.
![Screenshot 2024-08-31 at 13 26 54](https://github.com/user-attachments/assets/a7530534-51ad-43f7-ae62-00ccba827567)
![Screenshot 2024-08-31 at 16 34 34](https://github.com/user-attachments/assets/2d576aa2-570f-411e-84dd-8a5d5d254c25)

![image](https://github.com/user-attachments/assets/b1dd2ac2-6a42-4678-aae3-d76861d09d26)

I had previously made a long message to explain the two aspects of macOS' unified memory administration of virtual memory, but let's make it short:
vmem can be considered unlimited,
vmem "chunks" double in size each time

This causes issues because it's not flushed, it's not unlimited, it's much slower.

My understanding of the effects of the change, is that when emptying the cache, unneeded RAM is freed, which reduces the needs for virtual memory.

As usual with me, it's two lines of code.








## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced memory management for MacOS users to improve training performance and stability.

### 📊 Key Changes
- Added a conditional check for MacOS to use `torch.mps.empty_cache()` for memory clearing.
- Retained `torch.cuda.empty_cache()` for non-MacOS platforms.

### 🎯 Purpose & Impact
- 🖥️ Improves GPU memory management on MacOS devices by optimizing the use of unified memory.
- 🚀 Reduces the likelihood of running out of memory during model training, enhancing stability.
- 📈 Enables better performance and resource utilization for MacOS users, potentially reducing training interruptions.