### PR TITLE
Revert to ONNXSlim 0.1.32

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -391,7 +391,7 @@ class Exporter:
         """YOLOv8 ONNX export."""
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
-            requirements += ["onnxslim>=0.1.31", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
+            requirements += ["onnxslim==0.1.32", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
         import onnx  # noqa
 


### PR DESCRIPTION
Fixes breaking YOLOv10 TFLite export issues with `onnxslim==0.1.33` in https://github.com/ultralytics/ultralytics/actions/runs/10746932941


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the ONNX export dependencies for YOLOv8.

### 📊 Key Changes
- Changed the version requirement for `onnxslim` from `>=0.1.31` to `==0.1.32`.

### 🎯 Purpose & Impact
- **Stability**: Ensures compatibility and stability by locking to a specific `onnxslim` version.
- **Performance**: May improve export functionality by using a tested version.