### PR TITLE
Update more/missing type qualifiers to lowercase MkDocs admonitions

### DIFF
--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -59,7 +59,7 @@ def create_markdown(py_filepath: Path, module_path: str, classes: list, function
     pretty = url.replace("__init__.py", "\\_\\_init\\_\\_.py")  # properly display __init__.py filenames
     title_content = (
         f"# Reference for `{module_path}.py`\n\n"
-        f"!!! Note\n\n"
+        f"!!! note\n\n"
         f"    This file is available at [{pretty}]({url}). If you spot a problem please help fix it by [contributing]"
         f"(https://docs.ultralytics.com/help/contributing/) a [Pull Request]({edit}) 🛠️. Thank you 🙏!\n\n"
     )

--- a/docs/en/datasets/classify/imagewoof.md
+++ b/docs/en/datasets/classify/imagewoof.md
@@ -59,7 +59,7 @@ ImageWoof dataset comes in three different sizes to accommodate various research
 
 To use these variants in your training, simply replace 'imagewoof' in the dataset argument with 'imagewoof320' or 'imagewoof160'. For example:
 
-!!! example "Example"
+!!! example
 
     === "Python"
 

--- a/docs/en/datasets/explorer/dashboard.md
+++ b/docs/en/datasets/explorer/dashboard.md
@@ -29,7 +29,7 @@ Explorer GUI is like a playground build using [Ultralytics Explorer API](api.md)
 pip install ultralytics[explorer]
 ```
 
-!!! note "Note"
+!!! note
 
     Ask AI feature works using OpenAI, so you'll be prompted to set the api key for OpenAI when you first run the GUI.
     You can set it like this - `yolo settings openai_api_key="..."`

--- a/docs/en/datasets/explorer/index.md
+++ b/docs/en/datasets/explorer/index.md
@@ -50,7 +50,7 @@ The GUI demo runs in your browser allowing you to create embeddings for your dat
 yolo explorer
 ```
 
-!!! note "Note"
+!!! note
 
     Ask AI feature works using OpenAI, so you'll be prompted to set the api key for OpenAI when you first run the GUI.
     You can set it like this - `yolo settings openai_api_key="..."`

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -33,7 +33,7 @@ Here is an example of the YOLO dataset format for a single image with two object
 1 0.504 0.000 0.501 0.004 0.498 0.004 0.493 0.010 0.492 0.0104
 ```
 
-!!! tip "Tip"
+!!! tip
 
       - The length of each row does **not** have to be equal.
       - Each segmentation label must have a **minimum of 3 xy points**: `<class-index> <x1> <y1> <x2> <y2> <x3> <y3>`

--- a/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
+++ b/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
@@ -85,7 +85,7 @@ After installing the runtime, you need to plug in your Coral Edge TPU into a USB
 
 To use the Edge TPU, you need to convert your model into a compatible format. It is recommended that you run export on Google Colab, x86_64 Linux machine, using the official [Ultralytics Docker container](docker-quickstart.md), or using [Ultralytics HUB](../hub/quickstart.md), since the Edge TPU compiler is not available on ARM. See the [Export Mode](../modes/export.md) for the available arguments.
 
-!!! exporting the model
+!!! note "Exporting the model"
 
     === "Python"
 
@@ -111,7 +111,7 @@ The exported model will be saved in the `<model_name>_saved_model/` folder with 
 
 After exporting your model, you can run inference with it using the following code:
 
-!!! running the model
+!!! note "Running the model"
 
     === "Python"
 
@@ -170,7 +170,7 @@ Make sure to uninstall any previous Coral Edge TPU runtime versions by following
 
 Yes, you can export your Ultralytics YOLOv8 model to be compatible with the Coral Edge TPU. It is recommended to perform the export on Google Colab, an x86_64 Linux machine, or using the [Ultralytics Docker container](docker-quickstart.md). You can also use Ultralytics HUB for exporting. Here is how you can export your model using Python and CLI:
 
-!!! exporting the model
+!!! note "Exporting the model"
 
     === "Python"
 
@@ -212,7 +212,7 @@ For a specific wheel, such as TensorFlow 2.15.0 `tflite-runtime`, you can downlo
 
 After exporting your YOLOv8 model to an Edge TPU-compatible format, you can run inference using the following code snippets:
 
-!!! running the model
+!!! note "Running the model"
 
     === "Python"
 

--- a/docs/en/guides/distance-calculation.md
+++ b/docs/en/guides/distance-calculation.md
@@ -73,7 +73,7 @@ Measuring the gap between two objects is known as distance calculation within a 
         cv2.destroyAllWindows()
         ```
 
-???+ tip "Note"
+???+ note
 
     - Mouse Right Click will delete all drawn points
     - Mouse Left Click can be used to draw points

--- a/docs/en/guides/isolating-segmentation-objects.md
+++ b/docs/en/guides/isolating-segmentation-objects.md
@@ -137,7 +137,7 @@ After performing the [Segment Task](../tasks/segment.md), it's sometimes desirab
 
     ### Object Isolation Options
 
-    !!! example ""
+    !!! example
 
         === "Black Background Pixels"
 

--- a/docs/en/guides/ros-quickstart.md
+++ b/docs/en/guides/ros-quickstart.md
@@ -129,7 +129,7 @@ while True:
     rospy.spin()
 ```
 
-??? Example "Complete code"
+??? example "Complete code"
 
     ```python
     import time
@@ -297,7 +297,7 @@ while True:
     rospy.spin()
 ```
 
-??? Example "Complete code"
+??? example "Complete code"
 
     ```python
     import time
@@ -448,7 +448,7 @@ for index, class_id in enumerate(classes):
     o3d.visualization.draw_geometries([pcd])
 ```
 
-??? Example "Complete code"
+??? example "Complete code"
 
     ```python
     import sys

--- a/docs/en/guides/security-alarm-system.md
+++ b/docs/en/guides/security-alarm-system.md
@@ -29,7 +29,7 @@ The Security Alarm System Project utilizing Ultralytics YOLOv8 integrates advanc
 
 #### Set up the parameters of the message
 
-???+ tip "Note"
+???+ note
 
     App Password Generation is necessary
 

--- a/docs/en/hub/cloud-training.md
+++ b/docs/en/hub/cloud-training.md
@@ -28,7 +28,7 @@ Follow the [Train Model](./models.md#train-model) instructions from the [Models]
 
 ![Ultralytics HUB screenshot of the Train Model dialog with arrows pointing to the Cloud Training options and the Start Training button](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-train-model-dialog.avif)
 
-??? note "Note"
+??? note
 
     When you are on this step, you have the option to close the **Train Model** dialog and start training your model from the Model page later.
 
@@ -36,13 +36,13 @@ Follow the [Train Model](./models.md#train-model) instructions from the [Models]
 
 Most of the times, you will use the Epochs training. The number of epochs can be adjusted on this step (if the training didn't start yet) and represents the number of times your dataset needs to go through the cycle of train, label, and test. The exact pricing based on the number of epochs is hard to determine, reason why we only allow the [Account Balance](./pro.md#account-balance) payment method.
 
-!!! note "Note"
+!!! note
 
     When using the Epochs training, your [account balance](./pro.md#account-balance) needs to be at least US$5.00 to start training. In case you have a low balance, you can top-up directly from this step.
 
     ![Ultralytics HUB screenshot of the Train Model dialog with an arrow pointing to the Top-Up button](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-train-model-dialog-top-up.avif)
 
-!!! note "Note"
+!!! note
 
     When using the Epochs training, the [account balance](./pro.md#account-balance) is deducted after every epoch.
 
@@ -64,7 +64,7 @@ Before the training session starts, the initialization process spins up a dedica
 
 ![Ultralytics HUB screenshot of the Model page during the initialization process](https://github.com/ultralytics/docs/releases/download/0/model-page-initialization-process.avif)
 
-!!! note "Note"
+!!! note
 
     The account balance is not deducted during the initialization process (before the training session starts).
 
@@ -74,7 +74,7 @@ If needed, you can stop the training by clicking on the **Stop Training** button
 
 ![Ultralytics HUB screenshot of the Model page of a model that is currently training with an arrow pointing to the Stop Training button](https://github.com/ultralytics/docs/releases/download/0/model-page-training-stop-button.avif)
 
-!!! note "Note"
+!!! note
 
     You can resume training your model from the last checkpoint saved.
 
@@ -90,7 +90,7 @@ If needed, you can stop the training by clicking on the **Stop Training** button
   <strong>Watch:</strong> Pause and Resume Model Training Using Ultralytics HUB
 </p>
 
-!!! note "Note"
+!!! note
 
     Unfortunately, at the moment, you can only train one model at a time using Ultralytics Cloud.
 

--- a/docs/en/hub/datasets.md
+++ b/docs/en/hub/datasets.md
@@ -58,7 +58,7 @@ Once your dataset ZIP is ready, navigate to the [Datasets](https://hub.ultralyti
 
 ![Ultralytics HUB screenshot of the Datasets page with an arrow pointing to the Datasets button in the sidebar and one to the Upload Dataset button](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-datasets-upload.avif)
 
-??? tip "Tip"
+??? tip
 
     You can upload a dataset directly from the [Home](https://hub.ultralytics.com/home) page.
 
@@ -82,7 +82,7 @@ You can view the images in your dataset grouped by splits (Train, Validation, Te
 
 ![Ultralytics HUB screenshot of the Dataset page with an arrow pointing to the Images tab](https://github.com/ultralytics/docs/releases/download/0/hub-dataset-page-images-tab.avif)
 
-??? tip "Tip"
+??? tip
 
     Each image can be enlarged for better visualization.
 
@@ -104,7 +104,7 @@ Navigate to the Dataset page of the dataset you want to download, open the datas
 
 ![Ultralytics HUB screenshot of the Dataset page with an arrow pointing to the Download option](https://github.com/ultralytics/docs/releases/download/0/hub-download-dataset-1.avif)
 
-??? tip "Tip"
+??? tip
 
     You can download a dataset directly from the [Datasets](https://hub.ultralytics.com/datasets) page.
 
@@ -112,11 +112,11 @@ Navigate to the Dataset page of the dataset you want to download, open the datas
 
 ## Share Dataset
 
-!!! info "Info"
+!!! info
 
     [Ultralytics HUB](https://www.ultralytics.com/hub)'s sharing functionality provides a convenient way to share datasets with others. This feature is designed to accommodate both existing [Ultralytics HUB](https://www.ultralytics.com/hub) users and those who have yet to create an account.
 
-!!! note "Note"
+!!! note
 
     You have control over the general access of your datasets.
 
@@ -126,7 +126,7 @@ Navigate to the Dataset page of the dataset you want to share, open the dataset 
 
 ![Ultralytics HUB screenshot of the Dataset page with an arrow pointing to the Share option](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-share-dataset.avif)
 
-??? tip "Tip"
+??? tip
 
     You can share a dataset directly from the [Datasets](https://hub.ultralytics.com/datasets) page.
 
@@ -138,7 +138,7 @@ Set the general access to "Unlisted" and click **Save**.
 
 Now, anyone who has the direct link to your dataset can view it.
 
-??? tip "Tip"
+??? tip
 
     You can easily click on the dataset's link shown in the **Share Dataset** dialog to copy it.
 
@@ -150,7 +150,7 @@ Navigate to the Dataset page of the dataset you want to edit, open the dataset a
 
 ![Ultralytics HUB screenshot of the Dataset page with an arrow pointing to the Edit option](https://github.com/ultralytics/docs/releases/download/0/hub-edit-dataset-1.avif)
 
-??? tip "Tip"
+??? tip
 
     You can edit a dataset directly from the [Datasets](https://hub.ultralytics.com/datasets) page.
 
@@ -166,13 +166,13 @@ Navigate to the Dataset page of the dataset you want to delete, open the dataset
 
 ![Ultralytics HUB screenshot of the Dataset page with an arrow pointing to the Delete option](https://github.com/ultralytics/docs/releases/download/0/hub-delete-dataset-option.avif)
 
-??? tip "Tip"
+??? tip
 
     You can delete a dataset directly from the [Datasets](https://hub.ultralytics.com/datasets) page.
 
     ![Ultralytics HUB screenshot of the Datasets page with an arrow pointing to the Delete option of one of the datasets](https://github.com/ultralytics/docs/releases/download/0/hub-delete-dataset-page.avif)
 
-!!! note "Note"
+!!! note
 
     If you change your mind, you can restore the dataset from the [Trash](https://hub.ultralytics.com/trash) page.
 

--- a/docs/en/hub/inference-api.md
+++ b/docs/en/hub/inference-api.md
@@ -24,7 +24,7 @@ After you [train a model](./models.md#train-model), you can use the [Shared Infe
 
 In response to high demand and widespread interest, we are thrilled to unveil the [Ultralytics HUB](https://www.ultralytics.com/hub) Dedicated Inference API, offering single-click deployment in a dedicated environment for our [Pro](./pro.md) users!
 
-!!! note "Note"
+!!! note
 
     We are excited to offer this feature FREE during our public beta as part of the [Pro Plan](./pro.md), with paid tiers possible in the future.
 
@@ -37,7 +37,7 @@ To use the [Ultralytics HUB](https://www.ultralytics.com/hub) Dedicated Inferenc
 
 ![Ultralytics HUB screenshot of the Deploy tab inside the Model page with an arrow pointing to the Start Endpoint button in Dedicated Inference API card](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-dedicated-inference-api.avif)
 
-!!! tip "Tip"
+!!! tip
 
     Choose the region with the lowest latency for the best performance as described in the [documentation](https://docs.ultralytics.com/reference/hub/google/__init__).
 
@@ -83,7 +83,7 @@ with open("path/to/image.jpg", "rb") as image_file:
 print(response.json())
 ```
 
-!!! note "Note"
+!!! note
 
     Replace `MODEL_ID` with the desired model ID, `API_KEY` with your actual API key, and `path/to/image.jpg` with the path to the image you want to run inference on.
 
@@ -102,7 +102,7 @@ curl -X POST "https://api.ultralytics.com/v1/predict/MODEL_ID" \
 	-F "iou=0.45"
 ```
 
-!!! note "Note"
+!!! note
 
     Replace `MODEL_ID` with the desired model ID, `API_KEY` with your actual API key, and `path/to/image.jpg` with the path to the image you want to run inference on.
 

--- a/docs/en/hub/integrations.md
+++ b/docs/en/hub/integrations.md
@@ -44,7 +44,7 @@ Navigate to the Dataset page of the [Roboflow](https://roboflow.com/?ref=ultraly
 
 ![Ultralytics HUB screenshot of the Dataset page of a Roboflow Universe dataset with an arrow pointing to the Remove option](https://github.com/ultralytics/docs/releases/download/0/hub-roboflow-universe-remove.avif)
 
-??? tip "Tip"
+??? tip
 
     You can remove an imported [Roboflow](https://roboflow.com/?ref=ultralytics) dataset directly from the [Datasets](https://hub.ultralytics.com/datasets) page.
 
@@ -60,7 +60,7 @@ Navigate to the [Integrations](https://hub.ultralytics.com/settings?tab=integrat
 
 Type your [Roboflow](https://roboflow.com/?ref=ultralytics) Workspace private API key and click on the **Add** button.
 
-??? tip "Tip"
+??? tip
 
     You can click on the **Get my API key** button which will redirect you to the settings of your [Roboflow](https://roboflow.com/?ref=ultralytics) Workspace from where you can obtain your private API key.
 
@@ -80,13 +80,13 @@ Navigate to the [Integrations](https://hub.ultralytics.com/settings?tab=integrat
 
 ![Ultralytics HUB screenshot of the Integrations page  with an arrow pointing to the Integrations button in the sidebar and one to the Unlink button of one of the connected workspaces](https://github.com/ultralytics/docs/releases/download/0/hub-roboflow-workspace-remove-1.avif)
 
-??? tip "Tip"
+??? tip
 
     You can remove a connected [Roboflow](https://roboflow.com/?ref=ultralytics) Workspace directly from the Dataset page of one of the datasets from your [Roboflow](https://roboflow.com/?ref=ultralytics) Workspace.
 
     ![Ultralytics HUB screenshot of the Dataset page of a Roboflow Workspace dataset with an arrow pointing to the remove option](https://github.com/ultralytics/docs/releases/download/0/hub-roboflow-workspace-remove-2.avif)
 
-??? tip "Tip"
+??? tip
 
     You can remove a connected [Roboflow](https://roboflow.com/?ref=ultralytics) Workspace directly from the [Datasets](https://hub.ultralytics.com/datasets) page.
 

--- a/docs/en/hub/models.md
+++ b/docs/en/hub/models.md
@@ -26,7 +26,7 @@ Navigate to the [Models](https://hub.ultralytics.com/models) page by clicking on
 
 ![Ultralytics HUB screenshot of the Models page with an arrow pointing to the Models button in the sidebar and one to the Train Model button](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-train-model-page.avif)
 
-??? tip "Tip"
+??? tip
 
     You can train a model directly from the [Home](https://hub.ultralytics.com/home) page.
 
@@ -40,7 +40,7 @@ In this step, you have to select the dataset you want to train your model on. Af
 
 ![Ultralytics HUB screenshot of the Train Model dialog with an arrow pointing to a dataset and one to the Continue button](https://github.com/ultralytics/docs/releases/download/0/hub-train-model-dialog-dataset-step.avif)
 
-??? tip "Tip"
+??? tip
 
     You can skip this step if you train a model directly from the Dataset page.
 
@@ -52,7 +52,7 @@ In this step, you have to choose the project in which you want to create your mo
 
 ![Ultralytics HUB screenshot of the Train Model dialog with arrows pointing to the project dropdown, model name and Continue button](https://github.com/ultralytics/docs/releases/download/0/hub-train-model-dialog.avif)
 
-??? note "Note"
+??? note
 
     Ultralytics HUB will try to pre-select the project.
 
@@ -64,7 +64,7 @@ In this step, you have to choose the project in which you want to create your mo
 
     In case you don't have a project created yet, you can set the name of your project in this step and it will be created together with your model.
 
-!!! info "Info"
+!!! info
 
     You can read more about the available [YOLOv8](https://docs.ultralytics.com/models/yolov8) (and [YOLOv5](https://docs.ultralytics.com/models/yolov5)) architectures in our documentation.
 
@@ -72,7 +72,7 @@ By default, your model will use a pre-trained model (trained on the [COCO](https
 
 ![Ultralytics HUB screenshot of the Train Model dialog with an arrow pointing to the Advanced Model Configuration accordion](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-train-model-dialog-2.avif)
 
-!!! note "Note"
+!!! note
 
     You can easily change the most common model configuration options (such as the number of epochs) but you can also use the **Custom** option to access all [Train Settings](https://docs.ultralytics.com/modes/train/#train-settings) relevant to [Ultralytics HUB](https://www.ultralytics.com/hub).
 
@@ -97,7 +97,7 @@ When you're happy with your model configuration, click **Continue**.
 
 In this step, you will start training you model.
 
-??? note "Note"
+??? note
 
     When you are on this step, you have the option to close the **Train Model** dialog and start training your model from the Model page later.
 
@@ -133,7 +133,7 @@ When the training starts, you can click **Done** and monitor the training progre
 
 ![Ultralytics HUB screenshot of the Model page of a model that is currently training](https://github.com/ultralytics/docs/releases/download/0/hub-train-model-progress.avif)
 
-!!! note "Note"
+!!! note
 
     In case the training stops and a checkpoint was saved, you can resume training your model from the Model page.
 
@@ -169,7 +169,7 @@ When the training starts, you can click **Done** and monitor the training progre
 
 ![Ultralytics HUB screenshot of the Model page of a model that is currently training](https://github.com/ultralytics/docs/releases/download/0/model-training-progress.avif)
 
-!!! note "Note"
+!!! note
 
     In case the training stops and a checkpoint was saved, you can resume training your model from the Model page.
 
@@ -187,7 +187,7 @@ To access all model metrics, click on the **Charts** tab.
 
 ![Ultralytics HUB screenshot of the Preview tab inside the Model page with an arrow pointing to the Charts tab](https://github.com/ultralytics/docs/releases/download/0/hub-analyze-model-2.avif)
 
-??? tip "Tip"
+??? tip
 
     Each chart can be enlarged for better visualization.
 
@@ -207,7 +207,7 @@ In the **Test** card, you can select a preview image from the dataset used durin
 
 ![Ultralytics HUB screenshot of the Preview tab inside the Model page with an arrow pointing to Charts tab and one to the Test card](https://github.com/ultralytics/docs/releases/download/0/hub-preview-model-charts-test-card.avif)
 
-!!! note "Note"
+!!! note
 
     You can also use your camera to take a picture and run inference on it directly.
 
@@ -223,13 +223,13 @@ After you [train a model](#train-model), you can export it to 13 different forma
 
 ![Ultralytics HUB screenshot of the Deploy tab inside the Model page with an arrow pointing to the Export card and all formats exported](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-deploy-export-formats.avif)
 
-??? tip "Tip"
+??? tip
 
     You can customize the export options of each format if you open the export actions dropdown and click on the **Advanced** option.
 
     ![Ultralytics HUB screenshot of the Deploy tab inside the Model page with an arrow pointing to the Advanced option of one of the formats](https://github.com/ultralytics/docs/releases/download/0/hub-deploy-model-advanced-option.avif)
 
-!!! note "Note"
+!!! note
 
     You can re-export each format if you open the export actions dropdown and click on the **Advanced** option.
 
@@ -241,11 +241,11 @@ Read the [Ultralytics Inference API](./inference-api.md) documentation for more 
 
 ## Share Model
 
-!!! info "Info"
+!!! info
 
     [Ultralytics HUB](https://www.ultralytics.com/hub)'s sharing functionality provides a convenient way to share models with others. This feature is designed to accommodate both existing [Ultralytics HUB](https://www.ultralytics.com/hub) users and those who have yet to create an account.
 
-??? note "Note"
+??? note
 
     You have control over the general access of your models.
 
@@ -255,7 +255,7 @@ Navigate to the Model page of the model you want to share, open the model action
 
 ![Ultralytics HUB screenshot of the Model page with an arrow pointing to the Share option](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-share-model.avif)
 
-??? tip "Tip"
+??? tip
 
     You can also share a model directly from the [Models](https://hub.ultralytics.com/models) page or from the Project page of the project where your model is located.
 
@@ -267,7 +267,7 @@ Set the general access to "Unlisted" and click **Save**.
 
 Now, anyone who has the direct link to your model can view it.
 
-??? tip "Tip"
+??? tip
 
     You can easily click on the model's link shown in the **Share Model** dialog to copy it.
 
@@ -279,7 +279,7 @@ Navigate to the Model page of the model you want to edit, open the model actions
 
 ![Ultralytics HUB screenshot of the Model page with an arrow pointing to the Edit option](https://github.com/ultralytics/docs/releases/download/0/hub-edit-model-1.avif)
 
-??? tip "Tip"
+??? tip
 
     You can also edit a model directly from the [Models](https://hub.ultralytics.com/models) page or from the Project page of the project where your model is located.
 
@@ -295,13 +295,13 @@ Navigate to the Model page of the model you want to delete, open the model actio
 
 ![Ultralytics HUB screenshot of the Model page with an arrow pointing to the Delete option](https://github.com/ultralytics/docs/releases/download/0/hub-delete-model-1.avif)
 
-??? tip "Tip"
+??? tip
 
     You can also delete a model directly from the [Models](https://hub.ultralytics.com/models) page or from the Project page of the project where your model is located.
 
     ![Ultralytics HUB screenshot of the Models page with an arrow pointing to the Delete option of one of the models](https://github.com/ultralytics/docs/releases/download/0/hub-delete-model-2.avif)
 
-!!! note "Note"
+!!! note
 
     If you change your mind, you can restore the model from the [Trash](https://hub.ultralytics.com/trash) page.
 

--- a/docs/en/hub/pro.md
+++ b/docs/en/hub/pro.md
@@ -26,7 +26,7 @@ Next, select the Pro Plan.
 
 ![Ultralytics HUB screenshot of the Upgrade dialog with an arrow pointing to the Select Plan button](https://github.com/ultralytics/docs/releases/download/0/hub-pro-upgrade-select-plan.avif)
 
-!!! tip "Tip"
+!!! tip
 
     You can save 20% if you choose the annual Pro Plan.
 
@@ -36,7 +36,7 @@ Fill in your details during the checkout.
 
 ![Ultralytics HUB screenshot of the Checkout with an arrow pointing to the checkbox for saving the payment information for future purchases](https://github.com/ultralytics/docs/releases/download/0/hub-pro-upgrade-save-payment-info.avif)
 
-!!! tip "Tip"
+!!! tip
 
     We recommend ticking the checkbox to save your payment information for future purchases, facilitating easier top-ups to your account balance.
 

--- a/docs/en/hub/projects.md
+++ b/docs/en/hub/projects.md
@@ -26,7 +26,7 @@ Navigate to the [Projects](https://hub.ultralytics.com/projects) page by clickin
 
 ![Ultralytics HUB screenshot of the Projects page with an arrow pointing to the Projects button in the sidebar and one to the Create Project button](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-create-project-page.avif)
 
-??? tip "Tip"
+??? tip
 
     You can create a project directly from the [Home](https://hub.ultralytics.com/home) page.
 
@@ -52,11 +52,11 @@ Next, [train a model](./models.md#train-model) inside your project.
 
 ## Share Project
 
-!!! info "Info"
+!!! info
 
     [Ultralytics HUB](https://www.ultralytics.com/hub)'s sharing functionality provides a convenient way to share projects with others. This feature is designed to accommodate both existing [Ultralytics HUB](https://www.ultralytics.com/hub) users and those who have yet to create an account.
 
-??? note "Note"
+??? note
 
     You have control over the general access of your projects.
 
@@ -66,7 +66,7 @@ Navigate to the Project page of the project you want to share, open the project 
 
 ![Ultralytics HUB screenshot of the Project page with an arrow pointing to the Share option](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-share-project-dialog.avif)
 
-??? tip "Tip"
+??? tip
 
     You can share a project directly from the [Projects](https://hub.ultralytics.com/projects) page.
 
@@ -76,13 +76,13 @@ Set the general access to "Unlisted" and click **Save**.
 
 ![Ultralytics HUB screenshot of the Share Project dialog with an arrow pointing to the dropdown and one to the Save button](https://github.com/ultralytics/docs/releases/download/0/hub-share-project-dialog.avif)
 
-!!! warning "Warning"
+!!! warning
 
     When changing the general access of a project, the general access of the models inside the project will be changed as well.
 
 Now, anyone who has the direct link to your project can view it.
 
-??? tip "Tip"
+??? tip
 
     You can easily click on the project's link shown in the **Share Project** dialog to copy it.
 
@@ -94,7 +94,7 @@ Navigate to the Project page of the project you want to edit, open the project a
 
 ![Ultralytics HUB screenshot of the Project page with an arrow pointing to the Edit option](https://github.com/ultralytics/docs/releases/download/0/hub-edit-project-1.avif)
 
-??? tip "Tip"
+??? tip
 
     You can edit a project directly from the [Projects](https://hub.ultralytics.com/projects) page.
 
@@ -110,17 +110,17 @@ Navigate to the Project page of the project you want to delete, open the project
 
 ![Ultralytics HUB screenshot of the Project page with an arrow pointing to the Delete option](https://github.com/ultralytics/docs/releases/download/0/hub-delete-project-option.avif)
 
-??? tip "Tip"
+??? tip
 
     You can delete a project directly from the [Projects](https://hub.ultralytics.com/projects) page.
 
     ![Ultralytics HUB screenshot of the Projects page with an arrow pointing to the Delete option of one of the projects](https://github.com/ultralytics/docs/releases/download/0/hub-delete-project-option-1.avif)
 
-!!! warning "Warning"
+!!! warning
 
     When deleting a project, the models inside the project will be deleted as well.
 
-!!! note "Note"
+!!! note
 
     If you change your mind, you can restore the project from the [Trash](https://hub.ultralytics.com/trash) page.
 
@@ -136,7 +136,7 @@ This will display all the relevant charts. Each chart corresponds to a different
 
 ![Ultralytics HUB screenshot of the Charts tab inside the Project page](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-charts-tab.avif)
 
-??? tip "Tip"
+??? tip
 
     Each chart can be enlarged for better visualization.
 
@@ -148,7 +148,7 @@ This will display all the relevant charts. Each chart corresponds to a different
 
     ![Ultralytics HUB screenshot of the Charts tab inside the Project page with one of the charts expanded and zoomed](https://github.com/ultralytics/docs/releases/download/0/hub-charts-tab-expanded-zoomed.avif)
 
-??? tip "Tip"
+??? tip
 
     You have the flexibility to customize your view by selectively hiding certain models. This feature allows you to concentrate on the models of interest.
 
@@ -156,7 +156,7 @@ This will display all the relevant charts. Each chart corresponds to a different
 
 ## Reorder Models
 
-??? note "Note"
+??? note
 
     Ultralytics HUB's reordering functionality works only inside projects you own.
 
@@ -170,7 +170,7 @@ Navigate to the Project page of the project where the model you want to mode is 
 
 ![Ultralytics HUB screenshot of the Project page with an arrow pointing to the Transfer option of one of the models](https://github.com/ultralytics/docs/releases/download/0/hub-transfer-models-1.avif)
 
-??? tip "Tip"
+??? tip
 
     You can also transfer a model directly from the [Models](https://hub.ultralytics.com/models) page.
 

--- a/docs/en/hub/quickstart.md
+++ b/docs/en/hub/quickstart.md
@@ -28,7 +28,7 @@ During the signup, you will be asked to complete your profile.
 
 ![Ultralytics HUB screenshot of the Signup page profile form](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-signup-profile-form.avif)
 
-??? tip "Tip"
+??? tip
 
     You can update your profile from the [Account](https://hub.ultralytics.com/settings?tab=account) tab on the [Settings](https://hub.ultralytics.com/settings) page.
 
@@ -80,7 +80,7 @@ We value your feedback! Feel free to leave a review at any time.
 
 ![Ultralytics HUB screenshot of the Feedback dialog](https://github.com/ultralytics/docs/releases/download/0/ultralytics-hub-feedback-dialog.avif)
 
-??? info "Info"
+??? info
 
     Only our team will see your feedback, and we will use it to improve our platform.
 
@@ -90,12 +90,12 @@ If you encounter any issues or have questions, we're here to assist you.
 
 You can report a bug, request a feature, or ask a question on <a href="https://github.com/ultralytics/hub/issues/new/choose">GitHub</a>.
 
-!!! note "Note"
+!!! note
 
     When reporting a bug, please include your Environment Details from the [Support](https://hub.ultralytics.com/support) page.
 
     ![Ultralytics HUB screenshot of the Support page with an arrow pointing to Support button in the sidebar and one to the Copy Environment Details button](https://github.com/ultralytics/docs/releases/download/0/hub-support-page.avif)
 
-??? tip "Tip"
+??? tip
 
     You can join our <a href="https://ultralytics.com/discord">Discord</a> community for questions and discussions!

--- a/docs/en/hub/teams.md
+++ b/docs/en/hub/teams.md
@@ -10,13 +10,13 @@ We're excited to introduce you to the new Teams feature within [Ultralytics HUB]
 
 Here, you'll learn how to manage team members, share resources seamlessly, and collaborate efficiently on various projects.
 
-!!! note "Note"
+!!! note
 
     As this is a new feature, we're still in the process of developing and refining it to ensure it meets your needs.
 
 ## Create Team
 
-!!! note "Note"
+!!! note
 
     You need to [upgrade](./pro.md#upgrade) to the [Pro Plan](./pro.md) in order to create a team.
 
@@ -56,7 +56,7 @@ Navigate to the [Teams](https://hub.ultralytics.com/settings?tab=teams) page, op
 
 ![Ultralytics HUB screenshot of the Teams page with an arrow pointing to the Delete option of one of the teams](https://github.com/ultralytics/docs/releases/download/0/hub-delete-team-option.avif)
 
-!!! warning "Warning"
+!!! warning
 
     When deleting a team, the team can't be restored.
 
@@ -72,7 +72,7 @@ Type the email and select the role of the new member and click **Invite**.
 
 ![Ultralytics HUB screenshot of the Team page with a new member invited](https://github.com/ultralytics/docs/releases/download/0/hub-invite-member-3.avif)
 
-??? tip "Tip"
+??? tip
 
     You can cancel the invite before the new member accepts it.
 
@@ -82,7 +82,7 @@ The **Pending** status disappears after the new member accepts the invite.
 
 ![Ultralytics HUB screenshot of the Team page with two members](https://github.com/ultralytics/docs/releases/download/0/team-page-two-members.avif)
 
-??? tip "Tip"
+??? tip
 
     You can update a member's role at any time.
 
@@ -132,7 +132,7 @@ If you don't want to join the team, click on the **Reject Invitation** button.
 
 ![Ultralytics HUB screenshot of the Team page with an arrow pointing to the Reject Invitation button](https://github.com/ultralytics/docs/releases/download/0/hub-join-team-reject-invitation.avif)
 
-??? tip "Tip"
+??? tip
 
     You can join the team directly from the [Teams](https://hub.ultralytics.com/settings?tab=teams) page.
 
@@ -158,7 +158,7 @@ That's it! Your team now has access to your dataset.
 
 ![Ultralytics HUB screenshot of the Team page with a dataset shared](https://github.com/ultralytics/docs/releases/download/0/hub-share-dataset-team-page.avif)
 
-??? tip "Tip"
+??? tip
 
     As a team owner or team admin, you can remove a shared dataset.
 
@@ -178,13 +178,13 @@ That's it! Your team now has access to your project.
 
 ![Ultralytics HUB screenshot of the Team page with a project shared](https://github.com/ultralytics/docs/releases/download/0/team-page-project-shared.avif)
 
-??? tip "Tip"
+??? tip
 
     As a team owner or team admin, you can remove a shared project.
 
     ![Ultralytics HUB screenshot of the Team page with an arrow pointing to the Remove option of one of the projects shared](https://github.com/ultralytics/docs/releases/download/0/hub-share-project-remove-option.avif)
 
-!!! note "Note"
+!!! note
 
     When you share a project with your team, all models inside the project are shared as well.
 

--- a/docs/en/models/yolo-world.md
+++ b/docs/en/models/yolo-world.md
@@ -77,7 +77,7 @@ The YOLO-World models are easy to integrate into your Python applications. Ultra
 
 ### Train Usage
 
-!!! tip "Tip"
+!!! tip
 
     We strongly recommend to use `yolov8-worldv2` model for custom training, because it supports deterministic training and also easy to export other formats i.e onnx/tensorrt.
 

--- a/docs/en/modes/benchmark.md
+++ b/docs/en/modes/benchmark.md
@@ -43,7 +43,7 @@ Once your model is trained and validated, the next logical step is to evaluate i
 - **OpenVINO:** For Intel hardware optimization
 - **CoreML, TensorFlow SavedModel, and More:** For diverse deployment needs.
 
-!!! tip "Tip"
+!!! tip
 
     * Export to ONNX or OpenVINO for up to 3x CPU speedup.
     * Export to TensorRT for up to 5x GPU speedup.

--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -39,7 +39,7 @@ Here are some of the standout functionalities:
 - **Optimized Inference:** Exported models are optimized for quicker inference times.
 - **Tutorial Videos:** In-depth guides and tutorials for a smooth exporting experience.
 
-!!! tip "Tip"
+!!! tip
 
     * Export to [ONNX](../integrations/onnx.md) or [OpenVINO](../integrations/openvino.md) for up to 3x CPU speedup.
     * Export to [TensorRT](../integrations/tensorrt.md) for up to 5x GPU speedup.

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -100,7 +100,7 @@ Ultralytics YOLO models return either a Python list of `Results` objects, or a m
 
 YOLOv8 can process different types of input sources for inference, as shown in the table below. The sources include static images, video streams, and various data formats. The table also indicates whether each source can be used in streaming mode with the argument `stream=True` ✅. Streaming mode is beneficial for processing videos or live streams as it creates a generator of results instead of loading all frames into memory.
 
-!!! tip "Tip"
+!!! tip
 
     Use `stream=True` for processing long videos or large datasets to efficiently manage memory. When `stream=False`, the results for all frames or data points are stored in memory, which can quickly add up and cause out-of-memory errors for large inputs. In contrast, `stream=True` utilizes a generator, which only keeps the results of the current frame or data point in memory, significantly reducing memory consumption and preventing out-of-memory issues.
 

--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -41,7 +41,7 @@ The following are some notable features of YOLOv8's Train mode:
 - **Hyperparameter Configuration:** The option to modify hyperparameters through YAML configuration files or CLI arguments.
 - **Visualization and Monitoring:** Real-time tracking of training metrics and visualization of the learning process for better insights.
 
-!!! tip "Tip"
+!!! tip
 
     * YOLOv8 datasets like COCO, VOC, ImageNet and many others automatically download on first use, i.e. `yolo train data=coco.yaml`
 

--- a/docs/en/modes/val.md
+++ b/docs/en/modes/val.md
@@ -41,7 +41,7 @@ These are the notable functionalities offered by YOLOv8's Val mode:
 - **CLI and Python API:** Choose from command-line interface or Python API based on your preference for validation.
 - **Data Compatibility:** Works seamlessly with datasets used during the training phase as well as custom datasets.
 
-!!! tip "Tip"
+!!! tip
 
     * YOLOv8 models automatically remember their training settings, so you can validate a model at the same image size and on the original dataset easily with just `yolo val model=yolov8n.pt` or `model('yolov8n.pt').val()`
 

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -141,7 +141,7 @@ Ultralytics provides various installation methods including pip, conda, and Dock
 
 See the `ultralytics` [pyproject.toml](https://github.com/ultralytics/ultralytics/blob/main/pyproject.toml) file for a list of dependencies. Note that all examples above install all required dependencies.
 
-!!! tip "Tip"
+!!! tip
 
     PyTorch requirements vary by operating system and CUDA requirements, so it's recommended to install PyTorch first following instructions at [https://pytorch.org/get-started/locally](https://pytorch.org/get-started/locally/).
 
@@ -208,7 +208,7 @@ The Ultralytics command line interface (CLI) allows for simple single-line comma
         yolo cfg
         ```
 
-!!! warning "Warning"
+!!! warning
 
     Arguments must be passed as `arg=val` pairs, split by an equals `=` sign and delimited by spaces between pairs. Do not use `--` argument prefixes or commas `,` between arguments.
 

--- a/docs/en/reference/cfg/__init__.md
+++ b/docs/en/reference/cfg/__init__.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, configuration, cfg2dict, get_cfg, check_cfg, save_d
 
 # Reference for `ultralytics/cfg/__init__.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/\_\_init\_\_.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/__init__.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/cfg/__init__.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/annotator.md
+++ b/docs/en/reference/data/annotator.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, image annotation, YOLO, SAM, Python script, GitHub, objec
 
 # Reference for `ultralytics/data/annotator.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/annotator.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/annotator.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/annotator.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/augment.md
+++ b/docs/en/reference/data/augment.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, image augmentation, MixUp, Mosaic, Random Perspective, de
 
 # Reference for `ultralytics/data/augment.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/augment.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/augment.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/augment.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/base.md
+++ b/docs/en/reference/data/base.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, BaseDataset, image processing, data augmentation, YOLO, d
 
 # Reference for `ultralytics/data/base.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/base.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/base.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/base.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/build.md
+++ b/docs/en/reference/data/build.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, Data Builders, InfiniteDataLoader, YOLO dataset, build.py
 
 # Reference for `ultralytics/data/build.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/build.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/build.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/build.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/converter.md
+++ b/docs/en/reference/data/converter.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, data conversion, YOLO models, COCO, DOTA, YOLO bbox2segme
 
 # Reference for `ultralytics/data/converter.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/converter.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/converter.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/converter.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/dataset.md
+++ b/docs/en/reference/data/dataset.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLODataset, object detection, segmentation, dataset load
 
 # Reference for `ultralytics/data/dataset.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/dataset.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/dataset.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/dataset.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/explorer/explorer.md
+++ b/docs/en/reference/data/explorer/explorer.md
@@ -6,7 +6,7 @@ keywords: Ultralytics, YOLO, data explorer, image querying, embeddings, similari
 
 # Reference for `ultralytics/data/explorer/explorer.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/explorer/explorer.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/explorer/explorer.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/explorer/explorer.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/explorer/gui/dash.md
+++ b/docs/en/reference/data/explorer/gui/dash.md
@@ -6,7 +6,7 @@ keywords: Ultralytics, Explorer, GUI, dash, documentation, data explorer, AI que
 
 # Reference for `ultralytics/data/explorer/gui/dash.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/explorer/gui/dash.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/explorer/gui/dash.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/explorer/gui/dash.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/explorer/utils.md
+++ b/docs/en/reference/data/explorer/utils.md
@@ -6,7 +6,7 @@ keywords: Ultralytics, data explorer, utils, schema, sanitize batch, plot query 
 
 # Reference for `ultralytics/data/explorer/utils.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/explorer/utils.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/explorer/utils.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/explorer/utils.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/loaders.md
+++ b/docs/en/reference/data/loaders.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, data loaders, SourceTypes, LoadStreams, LoadScreenshots, 
 
 # Reference for `ultralytics/data/loaders.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/loaders.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/loaders.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/loaders.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/split_dota.md
+++ b/docs/en/reference/data/split_dota.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, DOTA dataset, data splitting, YOLO, Python, bbox_iof, loa
 
 # Reference for `ultralytics/data/split_dota.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/split_dota.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/split_dota.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/split_dota.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/data/utils.md
+++ b/docs/en/reference/data/utils.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, dataset utils, data handling, image verification, Python,
 
 # Reference for `ultralytics/data/utils.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/utils.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/utils.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/data/utils.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/engine/exporter.md
+++ b/docs/en/reference/engine/exporter.md
@@ -5,7 +5,7 @@ keywords: YOLOv8, export formats, ONNX, TensorRT, CoreML, machine learning model
 
 # Reference for `ultralytics/engine/exporter.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/exporter.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/exporter.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/engine/exporter.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/engine/model.md
+++ b/docs/en/reference/engine/model.md
@@ -5,7 +5,7 @@ keywords: YOLO model, Ultralytics, machine learning, deep learning, PyTorch mode
 
 # Reference for `ultralytics/engine/model.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/model.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/model.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/engine/model.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/engine/predictor.md
+++ b/docs/en/reference/engine/predictor.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, Base Predictor, image inference, video inference, m
 
 # Reference for `ultralytics/engine/predictor.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/predictor.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/predictor.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/engine/predictor.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/engine/results.md
+++ b/docs/en/reference/engine/results.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, engine results, BaseTensor, Results class, Boxes, Masks, 
 
 # Reference for `ultralytics/engine/results.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/results.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/results.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/engine/results.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/engine/trainer.md
+++ b/docs/en/reference/engine/trainer.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, BaseTrainer, model training, configuration, dataset
 
 # Reference for `ultralytics/engine/trainer.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/trainer.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/trainer.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/engine/trainer.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/engine/tuner.md
+++ b/docs/en/reference/engine/tuner.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, hyperparameter tuning, machine learning, deep learn
 
 # Reference for `ultralytics/engine/tuner.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/tuner.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/tuner.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/engine/tuner.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/engine/validator.md
+++ b/docs/en/reference/engine/validator.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, BaseValidator, model validation, PyTorch, TensorFlow, ONN
 
 # Reference for `ultralytics/engine/validator.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/validator.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/validator.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/engine/validator.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/hub/__init__.md
+++ b/docs/en/reference/hub/__init__.md
@@ -5,7 +5,7 @@ keywords: Ultralytics HUB API, login, logout, reset model, export model, check d
 
 # Reference for `ultralytics/hub/__init__.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/\_\_init\_\_.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/__init__.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/hub/__init__.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/hub/auth.md
+++ b/docs/en/reference/hub/auth.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, authentication, API key, cookies, Auth class, YOLO, API, 
 
 # Reference for `ultralytics/hub/auth.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/auth.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/auth.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/hub/auth.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/hub/google/__init__.md
+++ b/docs/en/reference/hub/google/__init__.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, GCP, Google Cloud Platform, regions, latency testing, clo
 
 # Reference for `ultralytics/hub/google/__init__.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/google/\_\_init\_\_.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/google/__init__.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/hub/google/__init__.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/hub/session.md
+++ b/docs/en/reference/hub/session.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, HUBTrainingSession, model training, heartbeats, che
 
 # Reference for `ultralytics/hub/session.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/session.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/session.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/hub/session.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/hub/utils.md
+++ b/docs/en/reference/hub/utils.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, HUB, Utilities, YOLO, smart_request, request_with_credent
 
 # Reference for `ultralytics/hub/utils.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/utils.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/hub/utils.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/hub/utils.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/fastsam/model.md
+++ b/docs/en/reference/models/fastsam/model.md
@@ -5,7 +5,7 @@ keywords: FastSAM, Ultralytics, model interface, YOLO, deep learning, machine le
 
 # Reference for `ultralytics/models/fastsam/model.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/model.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/model.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/fastsam/model.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/fastsam/predict.md
+++ b/docs/en/reference/models/fastsam/predict.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, Fast SAM Predictor, YOLO, segmentation, prediction, AI mo
 
 # Reference for `ultralytics/models/fastsam/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/fastsam/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/fastsam/utils.md
+++ b/docs/en/reference/models/fastsam/utils.md
@@ -5,7 +5,7 @@ keywords: FastSAM, bounding boxes, IoU, Ultralytics, image processing, computer 
 
 # Reference for `ultralytics/models/fastsam/utils.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/utils.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/utils.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/fastsam/utils.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/fastsam/val.md
+++ b/docs/en/reference/models/fastsam/val.md
@@ -5,7 +5,7 @@ keywords: FastSAM Validator, Ultralytics, YOLO, segmentation, validation, metric
 
 # Reference for `ultralytics/models/fastsam/val.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/val.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/val.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/fastsam/val.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/nas/model.md
+++ b/docs/en/reference/models/nas/model.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, YOLO-NAS, object detection, pre-trained models, mac
 
 # Reference for `ultralytics/models/nas/model.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/nas/model.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/nas/model.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/nas/model.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/nas/predict.md
+++ b/docs/en/reference/models/nas/predict.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, NASPredictor, object detection, machine learning, A
 
 # Reference for `ultralytics/models/nas/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/nas/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/nas/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/nas/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/nas/val.md
+++ b/docs/en/reference/models/nas/val.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, NASValidator, object detection, non-maximum suppres
 
 # Reference for `ultralytics/models/nas/val.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/nas/val.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/nas/val.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/nas/val.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/rtdetr/model.md
+++ b/docs/en/reference/models/rtdetr/model.md
@@ -5,7 +5,7 @@ keywords: RT-DETR, real-time object detection, Vision Transformer, Ultralytics, 
 
 # Reference for `ultralytics/models/rtdetr/model.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/rtdetr/model.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/rtdetr/model.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/rtdetr/model.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/rtdetr/predict.md
+++ b/docs/en/reference/models/rtdetr/predict.md
@@ -5,7 +5,7 @@ keywords: RTDETRPredictor, Ultralytics, Real-Time Detection Transformer, object 
 
 # Reference for `ultralytics/models/rtdetr/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/rtdetr/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/rtdetr/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/rtdetr/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/rtdetr/train.md
+++ b/docs/en/reference/models/rtdetr/train.md
@@ -5,7 +5,7 @@ keywords: RTDETRTrainer, real-time object detection, Vision Transformers, YOLO, 
 
 # Reference for `ultralytics/models/rtdetr/train.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/rtdetr/train.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/rtdetr/train.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/rtdetr/train.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/rtdetr/val.md
+++ b/docs/en/reference/models/rtdetr/val.md
@@ -5,7 +5,7 @@ keywords: RTDETR, Ultralytics, object detection, tracking, YOLO, RTDETRDataset, 
 
 # Reference for `ultralytics/models/rtdetr/val.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/rtdetr/val.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/rtdetr/val.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/rtdetr/val.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/amg.md
+++ b/docs/en/reference/models/sam/amg.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM, AMG, API Reference, models, mask stability, crop box
 
 # Reference for `ultralytics/models/sam/amg.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/amg.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/amg.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/amg.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/build.md
+++ b/docs/en/reference/models/sam/build.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM model, Segment Anything Model, SAM 2 model, Segment A
 
 # Reference for `ultralytics/models/sam/build.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/build.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/build.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/build.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/model.md
+++ b/docs/en/reference/models/sam/model.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM, Segment Anything Model, SAM 2, Segment Anything Mode
 
 # Reference for `ultralytics/models/sam/model.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/model.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/model.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/model.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/modules/blocks.md
+++ b/docs/en/reference/models/sam/modules/blocks.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM encoder, SAM 2 encoder, DropPath, MaskDownSampler, CX
 
 # Reference for `ultralytics/models/sam/modules/blocks.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/blocks.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/blocks.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/modules/blocks.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/modules/decoders.md
+++ b/docs/en/reference/models/sam/modules/decoders.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, MaskDecoder, MLP, machine learning, transformer architect
 
 # Reference for `ultralytics/models/sam/modules/decoders.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/decoders.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/decoders.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/modules/decoders.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/modules/encoders.md
+++ b/docs/en/reference/models/sam/modules/encoders.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM encoder, ImageEncoderViT, PromptEncoder, PositionEmbe
 
 # Reference for `ultralytics/models/sam/modules/encoders.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/encoders.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/encoders.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/modules/encoders.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/modules/memory_attention.md
+++ b/docs/en/reference/models/sam/modules/memory_attention.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM 2 encoder, MemoryAttentionLayer, MemoryAttention
 
 # Reference for `ultralytics/models/sam/modules/memory_attention.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/memory_attention.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/memory_attention.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/modules/memory_attention.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/modules/sam.md
+++ b/docs/en/reference/models/sam/modules/sam.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM Module, SAM 2 Module, object segmentation, image enco
 
 # Reference for `ultralytics/models/sam/modules/sam.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/sam.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/sam.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/modules/sam.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/modules/tiny_encoder.md
+++ b/docs/en/reference/models/sam/modules/tiny_encoder.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, TinyViT, Conv2d_BN, PatchEmbed, MBConv, Attention, PyTorc
 
 # Reference for `ultralytics/models/sam/modules/tiny_encoder.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/tiny_encoder.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/tiny_encoder.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/modules/tiny_encoder.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/modules/transformer.md
+++ b/docs/en/reference/models/sam/modules/transformer.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, TwoWayTransformer, module, deep learning, transformer, ob
 
 # Reference for `ultralytics/models/sam/modules/transformer.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/transformer.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/transformer.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/modules/transformer.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/modules/utils.md
+++ b/docs/en/reference/models/sam/modules/utils.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM, SAM 2, API Reference, models, window partition, data
 
 # Reference for `ultralytics/models/sam/modules/utils.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/utils.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/modules/utils.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/modules/utils.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/sam/predict.md
+++ b/docs/en/reference/models/sam/predict.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, SAM, Segment Anything Model, SAM 2, Segment Anything Mode
 
 # Reference for `ultralytics/models/sam/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/sam/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/sam/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/utils/loss.md
+++ b/docs/en/reference/models/utils/loss.md
@@ -5,7 +5,7 @@ keywords: ultralytics, YOLO, DETR, RT-DETR, loss functions, object detection, de
 
 # Reference for `ultralytics/models/utils/loss.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/utils/loss.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/utils/loss.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/utils/loss.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/utils/ops.md
+++ b/docs/en/reference/models/utils/ops.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, models, utils, operations, HungarianMatcher, get_cdn_grou
 
 # Reference for `ultralytics/models/utils/ops.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/utils/ops.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/utils/ops.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/utils/ops.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/classify/predict.md
+++ b/docs/en/reference/models/yolo/classify/predict.md
@@ -5,7 +5,7 @@ keywords: YOLO, ClassificationPredictor, Ultralytics, model prediction, preproce
 
 # Reference for `ultralytics/models/yolo/classify/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/classify/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/classify/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/classify/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/classify/train.md
+++ b/docs/en/reference/models/yolo/classify/train.md
@@ -5,7 +5,7 @@ keywords: YOLO, Ultralytics, classification, training, machine learning, deep le
 
 # Reference for `ultralytics/models/yolo/classify/train.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/classify/train.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/classify/train.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/classify/train.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/classify/val.md
+++ b/docs/en/reference/models/yolo/classify/val.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, classification, validation, ClassifyMetrics, Confus
 
 # Reference for `ultralytics/models/yolo/classify/val.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/classify/val.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/classify/val.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/classify/val.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/detect/predict.md
+++ b/docs/en/reference/models/yolo/detect/predict.md
@@ -5,7 +5,7 @@ keywords: YOLO, Ultralytics, DetectionPredictor, object detection, Python, machi
 
 # Reference for `ultralytics/models/yolo/detect/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/detect/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/detect/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/detect/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/detect/train.md
+++ b/docs/en/reference/models/yolo/detect/train.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, DetectionTrainer, training, object detection, machi
 
 # Reference for `ultralytics/models/yolo/detect/train.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/detect/train.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/detect/train.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/detect/train.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/detect/val.md
+++ b/docs/en/reference/models/yolo/detect/val.md
@@ -5,7 +5,7 @@ keywords: YOLO validation, detection validation, YOLO metrics, Ultralytics, obje
 
 # Reference for `ultralytics/models/yolo/detect/val.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/detect/val.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/detect/val.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/detect/val.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/model.md
+++ b/docs/en/reference/models/yolo/model.md
@@ -5,7 +5,7 @@ keywords: YOLO, object detection, Ultralytics, YOLO model, machine learning, Pyt
 
 # Reference for `ultralytics/models/yolo/model.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/model.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/model.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/model.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/obb/predict.md
+++ b/docs/en/reference/models/yolo/obb/predict.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, OBBPredictor, oriented bounding box, object detecti
 
 # Reference for `ultralytics/models/yolo/obb/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/obb/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/obb/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/obb/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/obb/train.md
+++ b/docs/en/reference/models/yolo/obb/train.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, OBB Trainer, Oriented Bounding Box, Machine Learnin
 
 # Reference for `ultralytics/models/yolo/obb/train.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/obb/train.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/obb/train.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/obb/train.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/obb/val.md
+++ b/docs/en/reference/models/yolo/obb/val.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, OBBValidator, Oriented Bounding Boxes, DetectionVal
 
 # Reference for `ultralytics/models/yolo/obb/val.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/obb/val.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/obb/val.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/obb/val.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/pose/predict.md
+++ b/docs/en/reference/models/yolo/pose/predict.md
@@ -5,7 +5,7 @@ keywords: YOLO, Pose Prediction, Ultralytics, PosePredictor, YOLOv8, Machine Lea
 
 # Reference for `ultralytics/models/yolo/pose/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/pose/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/pose/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/pose/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/pose/train.md
+++ b/docs/en/reference/models/yolo/pose/train.md
@@ -5,7 +5,7 @@ keywords: PoseTrainer, YOLO, Ultralytics, pose models, training, model configura
 
 # Reference for `ultralytics/models/yolo/pose/train.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/pose/train.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/pose/train.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/pose/train.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/pose/val.md
+++ b/docs/en/reference/models/yolo/pose/val.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, PoseValidator, pose validation, machine learning, o
 
 # Reference for `ultralytics/models/yolo/pose/val.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/pose/val.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/pose/val.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/pose/val.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/segment/predict.md
+++ b/docs/en/reference/models/yolo/segment/predict.md
@@ -5,7 +5,7 @@ keywords: YOLO, SegmentationPredictor, machine learning, computer vision, object
 
 # Reference for `ultralytics/models/yolo/segment/predict.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/segment/predict.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/segment/predict.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/segment/predict.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/segment/train.md
+++ b/docs/en/reference/models/yolo/segment/train.md
@@ -5,7 +5,7 @@ keywords: YOLO, segmentation, train, Ultralytics, SegmentationTrainer, Python, m
 
 # Reference for `ultralytics/models/yolo/segment/train.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/segment/train.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/segment/train.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/segment/train.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/segment/val.md
+++ b/docs/en/reference/models/yolo/segment/val.md
@@ -5,7 +5,7 @@ keywords: YOLO, segmentation, validator, Ultralytics, model validation, machine 
 
 # Reference for `ultralytics/models/yolo/segment/val.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/segment/val.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/segment/val.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/segment/val.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/world/train.md
+++ b/docs/en/reference/models/yolo/world/train.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, World Model, training, deep learning, computer visi
 
 # Reference for `ultralytics/models/yolo/world/train.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/world/train.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/world/train.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/world/train.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/models/yolo/world/train_world.md
+++ b/docs/en/reference/models/yolo/world/train_world.md
@@ -5,7 +5,7 @@ keywords: YOLO, WorldTrainer, open-set datasets, training, evaluation, build dat
 
 # Reference for `ultralytics/models/yolo/world/train_world.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/world/train_world.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/yolo/world/train_world.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/models/yolo/world/train_world.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/nn/autobackend.md
+++ b/docs/en/reference/nn/autobackend.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, AutoBackend, check_class_names, YOLO, YOLO models, optimi
 
 # Reference for `ultralytics/nn/autobackend.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/autobackend.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/autobackend.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/nn/autobackend.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/nn/modules/activation.md
+++ b/docs/en/reference/nn/modules/activation.md
@@ -5,7 +5,7 @@ keywords: ultralytics, activation functions, neural networks, Unified activation
 
 # Reference for `ultralytics/nn/modules/activation.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/activation.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/activation.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/nn/modules/activation.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/nn/modules/block.md
+++ b/docs/en/reference/nn/modules/block.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, neural networks, block modules, DFL, Proto, HGStem,
 
 # Reference for `ultralytics/nn/modules/block.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/block.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/nn/modules/block.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/nn/modules/conv.md
+++ b/docs/en/reference/nn/modules/conv.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, convolution modules, Conv, LightConv, GhostConv, YOLO, de
 
 # Reference for `ultralytics/nn/modules/conv.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/conv.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/nn/modules/conv.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/nn/modules/head.md
+++ b/docs/en/reference/nn/modules/head.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, Detection, Pose, RTDETRDecoder, nn modules, guides
 
 # Reference for `ultralytics/nn/modules/head.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/head.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/head.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/nn/modules/head.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/nn/modules/transformer.md
+++ b/docs/en/reference/nn/modules/transformer.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, Ultralytics documentation, TransformerEncoderLayer, Trans
 
 # Reference for `ultralytics/nn/modules/transformer.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/transformer.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/transformer.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/nn/modules/transformer.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/nn/modules/utils.md
+++ b/docs/en/reference/nn/modules/utils.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, PyTorch, utils, initialization, inverse sigmoid, multisca
 
 # Reference for `ultralytics/nn/modules/utils.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/utils.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/modules/utils.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/nn/modules/utils.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/nn/tasks.md
+++ b/docs/en/reference/nn/tasks.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, nn tasks, DetectionModel, PoseModel, RTDETRDetectio
 
 # Reference for `ultralytics/nn/tasks.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/nn/tasks.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/ai_gym.md
+++ b/docs/en/reference/solutions/ai_gym.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, AI Gym, YOLO, pose detection, gym step counting, real-tim
 
 # Reference for `ultralytics/solutions/ai_gym.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/ai_gym.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/ai_gym.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/ai_gym.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/analytics.md
+++ b/docs/en/reference/solutions/analytics.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, Analytics, Python, visual analytics, line chart, bar char
 
 # Reference for `ultralytics/solutions/analytics.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/analytics.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/analytics.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/analytics.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/distance_calculation.md
+++ b/docs/en/reference/solutions/distance_calculation.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, distance calculation, object tracking, real-time video, c
 
 # Reference for `ultralytics/solutions/distance_calculation.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/distance_calculation.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/distance_calculation.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/distance_calculation.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/heatmap.md
+++ b/docs/en/reference/solutions/heatmap.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, Heatmap, Python, Real-time Video, Object Tracking, cv2, S
 
 # Reference for `ultralytics/solutions/heatmap.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/heatmap.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/heatmap.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/heatmap.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/object_counter.md
+++ b/docs/en/reference/solutions/object_counter.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, Object Counter, Real-time Tracking, Video Stream, Python,
 
 # Reference for `ultralytics/solutions/object_counter.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/object_counter.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/object_counter.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/object_counter.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/parking_management.md
+++ b/docs/en/reference/solutions/parking_management.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, parking management, computer vision, parking monito
 
 # Reference for `ultralytics/solutions/parking_management.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/parking_management.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/parking_management.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/parking_management.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/queue_management.md
+++ b/docs/en/reference/solutions/queue_management.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, queue management, object tracking, real-time video, Pytho
 
 # Reference for `ultralytics/solutions/queue_management.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/queue_management.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/queue_management.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/queue_management.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/speed_estimation.md
+++ b/docs/en/reference/solutions/speed_estimation.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, speed estimation, YOLO, real-time tracking, object tracki
 
 # Reference for `ultralytics/solutions/speed_estimation.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/speed_estimation.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/speed_estimation.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/speed_estimation.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/solutions/streamlit_inference.md
+++ b/docs/en/reference/solutions/streamlit_inference.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLOv8, live inference, real-time object detection, Strea
 
 # Reference for `ultralytics/solutions/streamlit_inference.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/streamlit_inference.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/solutions/streamlit_inference.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/solutions/streamlit_inference.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/trackers/basetrack.md
+++ b/docs/en/reference/trackers/basetrack.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, object tracking, BaseTrack, TrackState, tracking me
 
 # Reference for `ultralytics/trackers/basetrack.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/basetrack.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/basetrack.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/trackers/basetrack.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/trackers/bot_sort.md
+++ b/docs/en/reference/trackers/bot_sort.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, Bot SORT, BOTrack, BOTSORT, YOLOv8, object tracking, Kalm
 
 # Reference for `ultralytics/trackers/bot_sort.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/bot_sort.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/bot_sort.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/trackers/bot_sort.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/trackers/byte_tracker.md
+++ b/docs/en/reference/trackers/byte_tracker.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, BYTETracker, object tracking, Kalman filter, YOLOv8, docu
 
 # Reference for `ultralytics/trackers/byte_tracker.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/byte_tracker.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/byte_tracker.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/trackers/byte_tracker.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/trackers/track.md
+++ b/docs/en/reference/trackers/track.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, object tracking, track.py, on_predict_start, on_pre
 
 # Reference for `ultralytics/trackers/track.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/track.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/track.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/trackers/track.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/trackers/utils/gmc.md
+++ b/docs/en/reference/trackers/utils/gmc.md
@@ -5,7 +5,7 @@ keywords: GMC, Generalized Motion Compensation, Ultralytics, tracking, object de
 
 # Reference for `ultralytics/trackers/utils/gmc.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/utils/gmc.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/utils/gmc.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/trackers/utils/gmc.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/trackers/utils/kalman_filter.md
+++ b/docs/en/reference/trackers/utils/kalman_filter.md
@@ -5,7 +5,7 @@ keywords: Kalman Filter, Object Tracking, Python, Ultralytics, YOLO, Bounding Bo
 
 # Reference for `ultralytics/trackers/utils/kalman_filter.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/utils/kalman_filter.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/utils/kalman_filter.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/trackers/utils/kalman_filter.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/trackers/utils/matching.md
+++ b/docs/en/reference/trackers/utils/matching.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, matching utils, linear assignment, IoU distance, embeddin
 
 # Reference for `ultralytics/trackers/utils/matching.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/utils/matching.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/trackers/utils/matching.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/trackers/utils/matching.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/__init__.md
+++ b/docs/en/reference/utils/__init__.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, utils, TQDM, Python, ML, Machine Learning utilities, YOLO
 
 # Reference for `ultralytics/utils/__init__.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/\_\_init\_\_.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/__init__.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/__init__.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/autobatch.md
+++ b/docs/en/reference/utils/autobatch.md
@@ -5,7 +5,7 @@ keywords: YOLO batch size, CUDA memory, PyTorch autobatch, Ultralytics, machine 
 
 # Reference for `ultralytics/utils/autobatch.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/autobatch.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/autobatch.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/autobatch.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/benchmarks.md
+++ b/docs/en/reference/utils/benchmarks.md
@@ -5,7 +5,7 @@ keywords: YOLO, model benchmarking, ONNX, TensorRT, PyTorch, TensorFlow, CoreML,
 
 # Reference for `ultralytics/utils/benchmarks.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/benchmarks.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/benchmarks.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/benchmarks.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/base.md
+++ b/docs/en/reference/utils/callbacks/base.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, base callbacks, training, validation, prediction, model e
 
 # Reference for `ultralytics/utils/callbacks/base.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/base.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/base.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/base.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/clearml.md
+++ b/docs/en/reference/utils/callbacks/clearml.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, ClearML, integration, callbacks, pretraining, train
 
 # Reference for `ultralytics/utils/callbacks/clearml.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/clearml.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/clearml.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/clearml.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/comet.md
+++ b/docs/en/reference/utils/callbacks/comet.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, Comet, callbacks, logging, machine learning, monito
 
 # Reference for `ultralytics/utils/callbacks/comet.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/comet.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/comet.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/comet.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/dvc.md
+++ b/docs/en/reference/utils/callbacks/dvc.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, DVC, DVCLive, machine learning, logging, training, callba
 
 # Reference for `ultralytics/utils/callbacks/dvc.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/dvc.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/dvc.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/dvc.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/hub.md
+++ b/docs/en/reference/utils/callbacks/hub.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, callbacks, pretrain, model save, train start, train end, 
 
 # Reference for `ultralytics/utils/callbacks/hub.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/hub.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/hub.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/hub.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/mlflow.md
+++ b/docs/en/reference/utils/callbacks/mlflow.md
@@ -5,7 +5,7 @@ keywords: MLflow, Ultralytics YOLO, logging, metrics, parameters, model artifact
 
 # Reference for `ultralytics/utils/callbacks/mlflow.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/mlflow.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/mlflow.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/mlflow.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/neptune.md
+++ b/docs/en/reference/utils/callbacks/neptune.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, NeptuneAI, YOLO, experiment logging, machine learning, AI
 
 # Reference for `ultralytics/utils/callbacks/neptune.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/neptune.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/neptune.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/neptune.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/raytune.md
+++ b/docs/en/reference/utils/callbacks/raytune.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, Ray Tune, hyperparameter tuning, YOLO, machine learning, 
 
 # Reference for `ultralytics/utils/callbacks/raytune.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/raytune.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/raytune.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/raytune.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/tensorboard.md
+++ b/docs/en/reference/utils/callbacks/tensorboard.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, TensorBoard, callbacks, machine learning, training visual
 
 # Reference for `ultralytics/utils/callbacks/tensorboard.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/tensorboard.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/tensorboard.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/tensorboard.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/callbacks/wb.md
+++ b/docs/en/reference/utils/callbacks/wb.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, WandB, callbacks, logging, metrics, visualizations,
 
 # Reference for `ultralytics/utils/callbacks/wb.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/wb.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/wb.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/callbacks/wb.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/checks.md
+++ b/docs/en/reference/utils/checks.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, utility functions, version checks, requirements, im
 
 # Reference for `ultralytics/utils/checks.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/checks.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/checks.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/checks.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/dist.md
+++ b/docs/en/reference/utils/dist.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, distributed training, DDP, multi-node training, network p
 
 # Reference for `ultralytics/utils/dist.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/dist.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/dist.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/dist.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/downloads.md
+++ b/docs/en/reference/utils/downloads.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, download utilities, URL validation, zip directory, unzip 
 
 # Reference for `ultralytics/utils/downloads.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/downloads.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/downloads.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/downloads.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/errors.md
+++ b/docs/en/reference/utils/errors.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, error handling, HUBModelError, model fetching, cust
 
 # Reference for `ultralytics/utils/errors.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/errors.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/errors.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/errors.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/files.md
+++ b/docs/en/reference/utils/files.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, file utilities, Python, WorkingDirectory, increment_path,
 
 # Reference for `ultralytics/utils/files.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/files.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/files.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/files.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/instance.md
+++ b/docs/en/reference/utils/instance.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, bounding boxes, Instances, bbox formats, conversions, AI,
 
 # Reference for `ultralytics/utils/instance.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/instance.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/instance.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/instance.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/loss.md
+++ b/docs/en/reference/utils/loss.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, loss functions, Varifocal Loss, Focal Loss, Bbox Loss, Ro
 
 # Reference for `ultralytics/utils/loss.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/loss.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/loss.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/loss.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/metrics.md
+++ b/docs/en/reference/utils/metrics.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, metrics, model validation, performance analysis, IoU, con
 
 # Reference for `ultralytics/utils/metrics.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/metrics.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/metrics.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/metrics.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/ops.md
+++ b/docs/en/reference/utils/ops.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, utility operations, non-max suppression, bounding box tra
 
 # Reference for `ultralytics/utils/ops.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/ops.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/ops.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/ops.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/patches.md
+++ b/docs/en/reference/utils/patches.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, utils, patches, imread, imwrite, imshow, torch_save, Open
 
 # Reference for `ultralytics/utils/patches.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/patches.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/patches.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/patches.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/plotting.md
+++ b/docs/en/reference/utils/plotting.md
@@ -5,7 +5,7 @@ keywords: ultralytics, plotting, utilities, documentation, data visualization, a
 
 # Reference for `ultralytics/utils/plotting.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/plotting.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/plotting.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/plotting.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/tal.md
+++ b/docs/en/reference/utils/tal.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, YOLO, TaskAlignedAssigner, object detection, machine lear
 
 # Reference for `ultralytics/utils/tal.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/tal.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/tal.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/tal.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, torch utils, model optimization, device selection, infere
 
 # Reference for `ultralytics/utils/torch_utils.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/torch_utils.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/torch_utils.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/torch_utils.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/triton.md
+++ b/docs/en/reference/utils/triton.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, TritonRemoteModel, Triton Inference Server, model client,
 
 # Reference for `ultralytics/utils/triton.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/triton.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/triton.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/triton.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/reference/utils/tuner.md
+++ b/docs/en/reference/utils/tuner.md
@@ -5,7 +5,7 @@ keywords: Ultralytics, tuner, hyperparameter tuning, Ray Tune, YOLO, machine lea
 
 # Reference for `ultralytics/utils/tuner.py`
 
-!!! Note
+!!! note
 
     This file is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/tuner.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/tuner.py). If you spot a problem please help fix it by [contributing](https://docs.ultralytics.com/help/contributing/) a [Pull Request](https://github.com/ultralytics/ultralytics/edit/main/ultralytics/utils/tuner.py) 🛠️. Thank you 🙏!
 

--- a/docs/en/usage/cli.md
+++ b/docs/en/usage/cli.md
@@ -79,7 +79,7 @@ Where:
 - `MODE` (required) is one of `[train, val, predict, export, track, benchmark]`
 - `ARGS` (optional) are any number of custom `arg=value` pairs like `imgsz=320` that override defaults. For a full list of available `ARGS` see the [Configuration](cfg.md) page and `defaults.yaml`
 
-!!! warning "Warning"
+!!! warning
 
     Arguments must be passed as `arg=val` pairs, split by an equals `=` sign and delimited by spaces ` ` between pairs. Do not use `--` argument prefixes or commas `,` between arguments.
 
@@ -91,7 +91,7 @@ Where:
 
 Train YOLOv8n on the COCO8 dataset for 100 epochs at image size 640. For a full list of available arguments see the [Configuration](cfg.md) page.
 
-!!! example "Example"
+!!! example
 
     === "Train"
 
@@ -111,7 +111,7 @@ Train YOLOv8n on the COCO8 dataset for 100 epochs at image size 640. For a full 
 
 Validate trained YOLOv8n model accuracy on the COCO8 dataset. No argument need to passed as the `model` retains its training `data` and arguments as model attributes.
 
-!!! example "Example"
+!!! example
 
     === "Official"
 
@@ -131,7 +131,7 @@ Validate trained YOLOv8n model accuracy on the COCO8 dataset. No argument need t
 
 Use a trained YOLOv8n model to run predictions on images.
 
-!!! example "Example"
+!!! example
 
     === "Official"
 
@@ -151,7 +151,7 @@ Use a trained YOLOv8n model to run predictions on images.
 
 Export a YOLOv8n model to a different format like ONNX, CoreML, etc.
 
-!!! example "Example"
+!!! example
 
     === "Official"
 
@@ -177,7 +177,7 @@ See full `export` details in the [Export](../modes/export.md) page.
 
 Default arguments can be overridden by simply passing them as arguments in the CLI in `arg=value` pairs.
 
-!!! tip ""
+!!! tip
 
     === "Train"
 

--- a/docs/en/yolov5/tutorials/train_custom_data.md
+++ b/docs/en/yolov5/tutorials/train_custom_data.md
@@ -137,11 +137,11 @@ Train a YOLOv5s model on COCO128 by specifying dataset, batch-size, image size a
 python train.py --img 640 --epochs 3 --data coco128.yaml --weights yolov5s.pt
 ```
 
-!!! tip "Tip"
+!!! tip
 
     💡 Add `--cache ram` or `--cache disk` to speed up training (requires significant RAM/disk resources).
 
-!!! tip "Tip"
+!!! tip
 
     💡 Always train from a local dataset. Mounted or network drives like Google Drive will be very slow.
 


### PR DESCRIPTION
Hi,
this PR is in addition to #15990: "Update to lowercase MkDocs admonitions". In #15990 not all types were found and changed to match the MkDocs style guide (see: https://squidfunk.github.io/mkdocs-material/reference/admonitions/) and result of discussion in PR. This PR fixes and changes missing types/pattern to have consistency across docs.
Thanks!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR standardizes the appearance of note blocks in documentation to improve readability.

### 📊 Key Changes
- Updated the style for various documentation blocks such as "Note" and "Example."
- Maintained consistent formatting across multiple documentation files.

### 🎯 Purpose & Impact
- 📘 **Consistency**: Enhances uniformity in documentation, making it easier to read and follow.
- ✏️ **Clarity**: Improved formatting ensures that important notes and examples stand out for better user understanding.