### PR TITLE
Fix publish docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,11 +12,9 @@
 # D407: Missing dashed underline after section
 # D413: Missing blank line after last section
 
-name: Publish Docs
+name: Build Docs
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -34,7 +32,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0
       - name: Set up Python
@@ -48,7 +45,7 @@ jobs:
         continue-on-error: true
         run: ruff check --fix --unsafe-fixes --select D --ignore=D100,D104,D203,D205,D212,D213,D401,D406,D407,D413 .
       - name: Update Docs Reference Section and Push Changes
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           python docs/build_reference.py
           git pull origin ${{ github.head_ref || github.ref }}
@@ -68,7 +65,7 @@ jobs:
           python docs/build_docs.py
       - name: Commit and Push Docs changes
         continue-on-error: true
-        if: always() && github.event_name == 'pull_request_target'
+        if: always() && github.event_name == 'pull_request'
         run: |
           git pull origin ${{ github.head_ref || github.ref }}
           git add --update  # only add updated files
@@ -78,21 +75,4 @@ jobs:
             git push
           else
             echo "No changes to commit"
-          fi
-      - name: Publish Docs to https://docs.ultralytics.com
-        if: github.event_name == 'push'
-        run: |
-          git clone https://github.com/ultralytics/docs.git docs-repo
-          cd docs-repo
-          git checkout gh-pages || git checkout -b gh-pages
-          rm -rf *
-          cp -R ../site/* .
-          echo "${{ secrets.INDEXNOW_KEY_DOCS }}" > "${{ secrets.INDEXNOW_KEY_DOCS }}.txt"
-          git add .
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            LATEST_HASH=$(git rev-parse --short=7 HEAD)
-            git commit -m "Update Docs for 'ultralytics ${{ steps.check_pypi.outputs.version }} - $LATEST_HASH'"
-            git push https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/ultralytics/docs.git gh-pages
           fi

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,48 @@
+name: Publish Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  publish-docs:
+    runs-on: macos-14
+    steps:
+      - name: Git config
+        run: |
+          git config --global user.name "UltralyticsAssistant"
+          git config --global user.email "web@ultralytics.com"
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: "pip" # caching pip dependencies
+      - name: Install Dependencies
+        run: pip install ruff black tqdm mkdocs-material "mkdocstrings[python]" mkdocs-jupyter mkdocs-redirects mkdocs-ultralytics-plugin mkdocs-macros-plugin
+      - name: Build Docs
+        run: |
+          export JUPYTER_PLATFORM_DIRS=1
+          python docs/build_docs.py
+      - name: Publish Docs to https://docs.ultralytics.com
+        run: |
+          git clone https://github.com/ultralytics/docs.git docs-repo
+          cd docs-repo
+          git checkout gh-pages || git checkout -b gh-pages
+          rm -rf *
+          cp -R ../site/* .
+          echo "${{ secrets.INDEXNOW_KEY_DOCS }}" > "${{ secrets.INDEXNOW_KEY_DOCS }}.txt"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            LATEST_HASH=$(git rev-parse --short=7 HEAD)
+            git commit -m "Update Docs for 'ultralytics $LATEST_HASH'"
+            git push https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/ultralytics/docs.git gh-pages


### PR DESCRIPTION
@glenn-jocher @yogendrasinghx A possible solution, still a work in progress but I want to know your feedback!! 

The idea here is to build the documentation (and update references) with an action at each update of the `HEAD` to see if everything is ok. Then publish the documentation only when a PR is merged into the `main` with another action that has access to the secrets. This way we are 100% sure. 



<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR separates the build and publish workflows for Ultralytics documentation. 📚

### 📊 Key Changes
- **Workflow Renaming:** Renames "Publish Docs" to "Build Docs."
- **Workflow Split:** Introduces a new `publish-docs.yml` file to handle documentation publishing.
- **Branch Trigger Adjustments:** The original build now triggers on pull requests only, while publishing triggers on push to `main`.
- **Simplified Logic:** Removes unnecessary token usage and combines similar steps for clarity.

### 🎯 Purpose & Impact
- **Organized Processes:** Clearly separates building and publishing, improving workflow management.
- **Easier Maintenance:** Each workflow now focuses on its specific task, making it easier to update and troubleshoot.
- **Efficient Publishing:** Streamlines doc updates by automating publishing only upon code merging to `main`.