### PR TITLE
Fix inaccuracies in OBB docs

### DIFF
--- a/docs/en/datasets/obb/dota-v2.md
+++ b/docs/en/datasets/obb/dota-v2.md
@@ -111,15 +111,15 @@ To train a model on the DOTA v1 dataset, you can utilize the following code snip
         # Create a new YOLOv8n-OBB model from scratch
         model = YOLO("yolov8n-obb.yaml")
 
-        # Train the model on the DOTAv2 dataset
-        results = model.train(data="DOTAv1.yaml", epochs=100, imgsz=640)
+        # Train the model on the DOTAv1 dataset
+        results = model.train(data="DOTAv1.yaml", epochs=100, imgsz=1024)
         ```
 
     === "CLI"
 
         ```bash
-        # Train a new YOLOv8n-OBB model on the DOTAv2 dataset
-        yolo obb train data=DOTAv1.yaml model=yolov8n-obb.pt epochs=100 imgsz=640
+        # Train a new YOLOv8n-OBB model on the DOTAv1 dataset
+        yolo obb train data=DOTAv1.yaml model=yolov8n-obb.pt epochs=100 imgsz=1024
         ```
 
 ## Sample Data and Annotations
@@ -180,14 +180,14 @@ To train a model on the DOTA dataset, you can use the following example with Ult
         model = YOLO("yolov8n-obb.yaml")
 
         # Train the model on the DOTAv1 dataset
-        results = model.train(data="DOTAv1.yaml", epochs=100, imgsz=640)
+        results = model.train(data="DOTAv1.yaml", epochs=100, imgsz=1024)
         ```
 
     === "CLI"
 
         ```bash
         # Train a new YOLOv8n-OBB model on the DOTAv1 dataset
-        yolo obb train data=DOTAv1.yaml model=yolov8n-obb.pt epochs=100 imgsz=640
+        yolo obb train data=DOTAv1.yaml model=yolov8n-obb.pt epochs=100 imgsz=1024
         ```
 
 For more details on how to split and preprocess the DOTA images, refer to the [split DOTA images section](#split-dota-images).

--- a/docs/en/datasets/obb/index.md
+++ b/docs/en/datasets/obb/index.md
@@ -58,7 +58,7 @@ To train a model using these OBB formats:
 Currently, the following datasets with Oriented Bounding Boxes are supported:
 
 - [DOTA-v1](dota-v2.md): The first version of the DOTA dataset, providing a comprehensive set of aerial images with oriented bounding boxes for object detection.
-- [DOTA-v1.25](dota-v2.md): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
+- [DOTA-v1.5](dota-v2.md): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md): DOTA (A Large-scale Dataset for Object Detection in Aerial Images) version 2, emphasizes detection from aerial perspectives and contains oriented bounding boxes with 1.7 million instances and 11,268 images.
 - [DOTA8](dota8.md): A small, 8-image subset of the full DOTA dataset suitable for testing workflows and Continuous Integration (CI) checks of OBB training in the `ultralytics` repository.
 
@@ -136,7 +136,7 @@ This ensures your model leverages the detailed OBB annotations for improved dete
 Currently, Ultralytics supports the following datasets for OBB training:
 
 - [DOTA-v1](dota-v2.md): The first version of the DOTA dataset, providing a comprehensive set of aerial images with oriented bounding boxes for object detection.
-- [DOTA-v1.25](dota-v2.md): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
+- [DOTA-v1.5](dota-v2.md): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md): This dataset includes 1.7 million instances with oriented bounding boxes and 11,268 images, primarily focusing on aerial object detection.
 - [DOTA8](dota8.md): A smaller, 8-image subset of the DOTA dataset used for testing and continuous integration (CI) checks.
 

--- a/docs/en/datasets/obb/index.md
+++ b/docs/en/datasets/obb/index.md
@@ -42,21 +42,23 @@ To train a model using these OBB formats:
         # Create a new YOLOv8n-OBB model from scratch
         model = YOLO("yolov8n-obb.yaml")
 
-        # Train the model on the DOTAv2 dataset
-        results = model.train(data="DOTAv1.yaml", epochs=100, imgsz=640)
+        # Train the model on the DOTAv1 dataset
+        results = model.train(data="DOTAv1.yaml", epochs=100, imgsz=1024)
         ```
 
     === "CLI"
 
         ```bash
-        # Train a new YOLOv8n-OBB model on the DOTAv2 dataset
-        yolo obb train data=DOTAv1.yaml model=yolov8n-obb.pt epochs=100 imgsz=640
+        # Train a new YOLOv8n-OBB model on the DOTAv1 dataset
+        yolo obb train data=DOTAv1.yaml model=yolov8n-obb.pt epochs=100 imgsz=1024
         ```
 
 ## Supported Datasets
 
 Currently, the following datasets with Oriented Bounding Boxes are supported:
 
+- [DOTA-v1](dota-v2.md): The first version of the DOTA dataset, providing a comprehensive set of aerial images with oriented bounding boxes for object detection.
+- [DOTA-v1.25](dota-v2.md): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md): DOTA (A Large-scale Dataset for Object Detection in Aerial Images) version 2, emphasizes detection from aerial perspectives and contains oriented bounding boxes with 1.7 million instances and 11,268 images.
 - [DOTA8](dota8.md): A small, 8-image subset of the full DOTA dataset suitable for testing workflows and Continuous Integration (CI) checks of OBB training in the `ultralytics` repository.
 
@@ -133,6 +135,8 @@ This ensures your model leverages the detailed OBB annotations for improved dete
 
 Currently, Ultralytics supports the following datasets for OBB training:
 
+- [DOTA-v1](dota-v2.md): The first version of the DOTA dataset, providing a comprehensive set of aerial images with oriented bounding boxes for object detection.
+- [DOTA-v1.25](dota-v2.md): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md): This dataset includes 1.7 million instances with oriented bounding boxes and 11,268 images, primarily focusing on aerial object detection.
 - [DOTA8](dota8.md): A smaller, 8-image subset of the DOTA dataset used for testing and continuous integration (CI) checks.
 


### PR DESCRIPTION
YOLOv8 OBB uses `imgsz=1024` to train on DOTAv1. Reflect that correctly in the docs. And also add the DOTAv1 and DOTAv1.5 to supported datasets list.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation updates to improve clarity and consistency in DOTA dataset training instructions.

### 📊 Key Changes
- Changed image size for training from 640 to 1024 in DOTA dataset examples.
- Corrected dataset references from "DOTAv2" to "DOTAv1."
- Added descriptions for DOTA-v1 and DOTA-v1.5 datasets.

### 🎯 Purpose & Impact
- **Improved Clarity**: Correcting dataset names and enhancing image size guidance helps users follow accurate training procedures.
- **Enhanced Training**: Larger image sizes (1024) can lead to better model training performance and accuracy.
- **User Guidance**: Adding details about dataset versions aids users in selecting the appropriate data for their needs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Increased image size for training on DOTA datasets to improve model performance.

### 📊 Key Changes
- Updated training commands and scripts across documentation from `imgsz=640` to `imgsz=1024`.
- Clarified the use of DOTA v1 and v1.5 datasets with descriptions.

### 🎯 Purpose & Impact
- **Enhanced Performance**: Using larger image sizes aims to improve model accuracy and detail in object detection tasks. 📈
- **Clearer Guidance**: Improved documentation helps users understand dataset options and configurations. 📚