### PR TITLE
Remove `half` when profiling ONNX models

### DIFF
--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -325,6 +325,9 @@ class ProfileModels:
             half (bool, optional): Flag to indicate whether to use FP16 half-precision for TensorRT profiling.
             trt (bool, optional): Flag to indicate whether to profile using TensorRT. Default is True.
             device (torch.device, optional): Device used for profiling. If None, it is determined automatically.
+
+        Notes:
+            FP16 'half' argument option removed for ONNX as slower on CPU than FP32
         """
         self.paths = paths
         self.num_timed_runs = num_timed_runs

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -356,10 +356,10 @@ class ProfileModels:
                 model_info = model.info()
                 if self.trt and self.device.type != "cpu" and not engine_file.is_file():
                     engine_file = model.export(
-                        format="engine", half=self.half, imgsz=self.imgsz, device=self.device, verbose=False
+                        format="engine", half=self.half, imgsz=self.imgsz, device=self.device, verbose=False,
                     )
                 onnx_file = model.export(
-                    format="onnx", imgsz=self.imgsz, simplify=True, device=self.device, verbose=False
+                    format="onnx", imgsz=self.imgsz, simplify=True, device=self.device, verbose=False,
                 )
             elif file.suffix == ".onnx":
                 model_info = self.get_onnx_model_info(file)

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -322,7 +322,7 @@ class ProfileModels:
             num_warmup_runs (int, optional): Number of warmup runs before the actual profiling starts. Default is 10.
             min_time (float, optional): Minimum time in seconds for profiling a model. Default is 60.
             imgsz (int, optional): Size of the image used during profiling. Default is 640.
-            half (bool, optional): Flag to indicate whether to use half-precision floating point for trt profiling.
+            half (bool, optional): Flag to indicate whether to use FP16 half-precision for TensorRT profiling.
             trt (bool, optional): Flag to indicate whether to profile using TensorRT. Default is True.
             device (torch.device, optional): Device used for profiling. If None, it is determined automatically.
         """

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -356,10 +356,18 @@ class ProfileModels:
                 model_info = model.info()
                 if self.trt and self.device.type != "cpu" and not engine_file.is_file():
                     engine_file = model.export(
-                        format="engine", half=self.half, imgsz=self.imgsz, device=self.device, verbose=False,
+                        format="engine",
+                        half=self.half,
+                        imgsz=self.imgsz,
+                        device=self.device,
+                        verbose=False,
                     )
                 onnx_file = model.export(
-                    format="onnx", imgsz=self.imgsz, simplify=True, device=self.device, verbose=False,
+                    format="onnx",
+                    imgsz=self.imgsz,
+                    simplify=True,
+                    device=self.device,
+                    verbose=False,
                 )
             elif file.suffix == ".onnx":
                 model_info = self.get_onnx_model_info(file)

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -322,7 +322,7 @@ class ProfileModels:
             num_warmup_runs (int, optional): Number of warmup runs before the actual profiling starts. Default is 10.
             min_time (float, optional): Minimum time in seconds for profiling a model. Default is 60.
             imgsz (int, optional): Size of the image used during profiling. Default is 640.
-            half (bool, optional): Flag to indicate whether to use half-precision floating point for profiling.
+            half (bool, optional): Flag to indicate whether to use half-precision floating point for trt profiling.
             trt (bool, optional): Flag to indicate whether to profile using TensorRT. Default is True.
             device (torch.device, optional): Device used for profiling. If None, it is determined automatically.
         """
@@ -356,7 +356,7 @@ class ProfileModels:
                         format="engine", half=self.half, imgsz=self.imgsz, device=self.device, verbose=False
                     )
                 onnx_file = model.export(
-                    format="onnx", half=self.half, imgsz=self.imgsz, simplify=True, device=self.device, verbose=False
+                    format="onnx", imgsz=self.imgsz, simplify=True, device=self.device, verbose=False
                 )
             elif file.suffix == ".onnx":
                 model_info = self.get_onnx_model_info(file)


### PR DESCRIPTION
@glenn-jocher Remove the `half` option when exporting onnx for profiling since it's much slower. I guess CPU onnx inference does not support fp16 and has to do an extra conversion from fp16 to fp32 before actual inference, hence slower speed.
| Model   | size<br><sup>(pixels) | Speed<br><sup>CPU ONNX<br>(ms) | notes      |
|---------|-----------------------|--------------------------------|------------|
| yolov8n | 640                   | 29.23 ± 0.33 ms                | half=True  |
| yolov8n | 640                   | 19.59 ± 0.28 ms                | half=False |



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced profiling performance for TensorRT and ONNX models.

### 📊 Key Changes
- Updated the `half` precision flag to specify FP16 use only for TensorRT, not ONNX.
- Adjusted model export settings for both TensorRT and ONNX.

### 🎯 Purpose & Impact
- ⚡ **Improved Performance:** Restricting FP16 to TensorRT optimizes model performance, as FP16 is slower on CPU for ONNX.
- 🛠 **Better Precision Handling:** Ensures the right precision is used for each format, enhancing efficiency in model profiling.