### PR TITLE
Fix bug about ultralytics.utils.torch_utils.select_device inner hard arg “cuda:0" 

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -208,7 +208,7 @@ def select_device(device="", batch=0, newline=False, verbose=True):
         for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
-        arg = "cuda:0"
+        arg = f"cuda:{devices[0]}"
     elif mps and TORCH_2_0 and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f"MPS ({get_cpu_info()})\n"


### PR DESCRIPTION
Selects the first value based on the devices object, rather than forcing it to be 0

reference： https://github.com/ultralytics/ultralytics/issues/16456

```
>>> devices="1,2,3,4"
>>> devices=devices.split(",")
>>> arg = f"cuda:{devices[0]}"
>>> arg
'cuda:1'
>>> devices="0"
>>> arg = f"cuda:{devices[0]}"
>>> arg
'cuda:0'
>>>

```

This is also being fixed in https://github.com/ultralytics/ultralytics/pull/6731/files, but I think just a neat line of code will do

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to device selection logic in the code's hardware configuration utility.

### 📊 Key Changes
- Adjusted the default device assignment from a fixed "cuda:0" to use the first available CUDA device dynamically (`cuda:{devices[0]}`).

### 🎯 Purpose & Impact
- **Purpose**: To improve flexibility and ensure the code utilizes the first detected GPU device instead of assuming "cuda:0".
- **Impact**: Enhances hardware compatibility and optimizes resource usage for users with multiple GPUs, likely leading to better performance for those setups. 🚀


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves device selection in Ultralytics with enhanced CUDA recognition.

### 📊 Key Changes
- Modified the default CUDA device selection to dynamically use the first available device (`cuda:{devices[0]}`).

### 🎯 Purpose & Impact
- **Enhanced Flexibility**: Automatically selects the first available CUDA device, optimizing hardware usage.
- **User Convenience**: Reduces configuration effort for users, particularly those with multiple GPUs.