### PR TITLE
Remove `dill` package from Ultralytics

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -377,7 +377,7 @@ class Model(nn.Module):
         self.model.load(weights)
         return self
 
-    def save(self, filename: Union[str, Path] = "saved_model.pt", use_dill=True) -> None:
+    def save(self, filename: Union[str, Path] = "saved_model.pt") -> None:
         """
         Saves the current model state to a file.
 
@@ -386,7 +386,6 @@ class Model(nn.Module):
 
         Args:
             filename (Union[str, Path]): The name of the file to save the model to.
-            use_dill (bool): Whether to try using dill for serialization if available.
 
         Raises:
             AssertionError: If the model is not a PyTorch model.
@@ -408,7 +407,7 @@ class Model(nn.Module):
             "license": "AGPL-3.0 License (https://ultralytics.com/license)",
             "docs": "https://docs.ultralytics.com",
         }
-        torch.save({**self.ckpt, **updates}, filename, use_dill=use_dill)
+        torch.save({**self.ckpt, **updates}, filename)
 
     def info(self, detailed: bool = False, verbose: bool = True):
         """

--- a/ultralytics/models/sam/build.py
+++ b/ultralytics/models/sam/build.py
@@ -207,11 +207,9 @@ def _build_sam(
     if checkpoint is not None:
         checkpoint = attempt_download_asset(checkpoint)
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)
+            state_dict = torch.load(f, weights_only=False)
         sam.load_state_dict(state_dict)
     sam.eval()
-    # sam.load_state_dict(torch.load(checkpoint), strict=True)
-    # sam.eval()
     return sam
 
 
@@ -300,7 +298,7 @@ def _build_sam2(
     if checkpoint is not None:
         checkpoint = attempt_download_asset(checkpoint)
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)["model"]
+            state_dict = torch.load(f, weights_only=False)["model"]
         sam2.load_state_dict(state_dict)
     sam2.eval()
     return sam2

--- a/ultralytics/models/sam/build.py
+++ b/ultralytics/models/sam/build.py
@@ -207,7 +207,7 @@ def _build_sam(
     if checkpoint is not None:
         checkpoint = attempt_download_asset(checkpoint)
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f, weights_only=False)
+            state_dict = torch.load(f)
         sam.load_state_dict(state_dict)
     sam.eval()
     return sam
@@ -298,7 +298,7 @@ def _build_sam2(
     if checkpoint is not None:
         checkpoint = attempt_download_asset(checkpoint)
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f, weights_only=False)["model"]
+            state_dict = torch.load(f)["model"]
         sam2.load_state_dict(state_dict)
     sam2.eval()
     return sam2

--- a/ultralytics/utils/files.py
+++ b/ultralytics/utils/files.py
@@ -219,4 +219,4 @@ def update_models(model_names=("yolov8n.pt",), source_dir=Path("."), update_name
 
         # Save model using model.save()
         print(f"Re-saving {model_name} model to {save_path}")
-        model.save(save_path, use_dill=False)
+        model.save(save_path)

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -86,25 +86,15 @@ def torch_load(*args, **kwargs):
     return _torch_load(*args, **kwargs)
 
 
-def torch_save(*args, use_dill=True, **kwargs):
+def torch_save(*args, **kwargs):
     """
     Optionally use dill to serialize lambda functions where pickle does not, adding robustness with 3 retries and
     exponential standoff in case of save failure.
 
     Args:
         *args (tuple): Positional arguments to pass to torch.save.
-        use_dill (bool): Whether to try using dill for serialization if available. Defaults to True.
         **kwargs (Any): Keyword arguments to pass to torch.save.
     """
-    try:
-        assert use_dill
-        import dill as pickle
-    except (AssertionError, ImportError):
-        import pickle
-
-    if "pickle_module" not in kwargs:
-        kwargs["pickle_module"] = pickle
-
     for i in range(4):  # 3 retries
         try:
             return _torch_save(*args, **kwargs)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -595,7 +595,7 @@ def strip_optimizer(f: Union[str, Path] = "best.pt", s: str = "", updates: dict 
 
     # Save
     combined = {**metadata, **x, **(updates or {})}
-    torch.save(combined, s or f, use_dill=False)  # combine dicts (prefer to the right)
+    torch.save(combined, s or f)  # combine dicts (prefer to the right)
     mb = os.path.getsize(s or f) / 1e6  # file size
     LOGGER.info(f"Optimizer stripped from {f},{f' saved as {s},' if s else ''} {mb:.1f}MB")
     return combined


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR removes the `use_dill` option from several `torch.save` functions.

### 📊 Key Changes
- Eliminated the `use_dill` parameter from model saving functions.
- Removed redundant comments in `build.py`.
- Simplified `torch_save` function by removing conditional dill import.

### 🎯 Purpose & Impact
- **Simplification**: Streamlines the model saving process by eliminating the unnecessary `dill` option.
- **Efficiency**: Reduces complexity and potential errors related to serialization.
- **User Clarity**: Simplifies the API, making it more straightforward for users to save models.