### PR TITLE
Fix button text in `docs/home` to match link

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -58,7 +58,7 @@ Explore the Ultralytics Docs, a comprehensive resource designed to help you unde
 - **Predict** new images and videos with YOLO &nbsp; [:octicons-image-16: Predict on Images](modes/predict.md){ .md-button }
 - **Train** a new YOLO model on your own custom dataset &nbsp; [:fontawesome-solid-brain: Train a Model](modes/train.md){ .md-button }
 - **Tasks** YOLO tasks like segment, classify, pose and track &nbsp; [:material-magnify-expand: Explore Tasks](tasks/index.md){ .md-button }
-- **[YOLO11](models/yolo11.md) NEW 🚀**: Ultralytics' latest SOTA models &nbsp; [:material-magnify-expand: Explore a Dataset](models/yolo11.md){ .md-button }
+- **[YOLO11](models/yolo11.md) NEW 🚀**: Ultralytics' latest SOTA models &nbsp; [:material-magnify-expand: Explore new YOLO11 models](models/yolo11.md){ .md-button }
 
 <p align="center">
   <br>


### PR DESCRIPTION
Hi,
minor fix to the button text label to match the link.
Thanks! 🚀

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation update to improve clarity and navigation.

### 📊 Key Changes
- Updated link text from "Explore a Dataset" to "Explore new YOLO11 models" in the documentation.

### 🎯 Purpose & Impact
- Enhances clarity by accurately describing the content, leading to better user understanding.
- Improves navigation by making it clear that the link leads to information about new YOLO11 models.