### PR TITLE
Auto-correct for export formats

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -171,6 +171,7 @@ class Exporter:
     def __call__(self, model=None) -> str:
         """Returns list of exported files/dirs after running callbacks."""
         import difflib
+
         self.run_callbacks("on_export_start")
         t = time.time()
         fmt = self.args.format.lower()  # to lowercase
@@ -184,7 +185,8 @@ class Exporter:
             closest_match = difflib.get_close_matches(fmt, fmts, n=1, cutoff=0.6)
             if closest_match:
                 LOGGER.warning(
-                    f"WARNING ⚠️ Invalid export format='{fmt}'. Automatically updating to nearest valid format: '{closest_match[0]}'")
+                    f"WARNING ⚠️ Invalid export format='{fmt}'. Automatically updating to nearest valid format: '{closest_match[0]}'"
+                )
                 fmt = closest_match[0]
             else:
                 raise ValueError(f"Invalid export format='{fmt}'. Valid formats are {fmts}")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -180,6 +180,7 @@ class Exporter:
         fmts = tuple(export_formats()["Argument"][1:])  # available export formats
         if fmt not in fmts:
             import difflib
+
             # Get the closest match if format is invalid
             closest_match = difflib.get_close_matches(
                 fmt, fmts, n=1, cutoff=0.6

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -170,8 +170,6 @@ class Exporter:
     @smart_inference_mode()
     def __call__(self, model=None) -> str:
         """Returns list of exported files/dirs after running callbacks."""
-        import difflib
-
         self.run_callbacks("on_export_start")
         t = time.time()
         fmt = self.args.format.lower()  # to lowercase
@@ -181,6 +179,7 @@ class Exporter:
             fmt = "coreml"
         fmts = tuple(export_formats()["Argument"][1:])  # available export formats
         if fmt not in fmts:
+            import difflib
             # Get the closest match if format is invalid
             closest_match = difflib.get_close_matches(fmt, fmts, n=1, cutoff=0.6)   # cutoff 0.6 mean a 60% match required for auto-selection.
             if closest_match:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -182,13 +182,9 @@ class Exporter:
             import difflib
 
             # Get the closest match if format is invalid
-            closest_match = difflib.get_close_matches(
-                fmt, fmts, n=1, cutoff=0.6
-            )  # cutoff 0.6 mean a 60% match required for auto-selection.
+            matches = difflib.get_close_matches(fmt, fmts, n=1, cutoff=0.6)  # 60% similarity required to match
             if closest_match:
-                LOGGER.warning(
-                    f"WARNING ⚠️ Invalid export format='{fmt}'. Automatically updating to nearest valid format: '{closest_match[0]}'"
-                )
+                LOGGER.warning(f"WARNING ⚠️ Invalid export format='{fmt}', updating to format='{matches[0]}'")
                 fmt = closest_match[0]
             else:
                 raise ValueError(f"Invalid export format='{fmt}'. Valid formats are {fmts}")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -182,7 +182,9 @@ class Exporter:
         fmts = tuple(export_formats()["Argument"][1:])  # available export formats
         if fmt not in fmts:
             # Get the closest match if format is invalid
-            closest_match = difflib.get_close_matches(fmt, fmts, n=1, cutoff=0.6)   # cutoff 0.6 mean a 60% match required for auto-selection.
+            closest_match = difflib.get_close_matches(
+                fmt, fmts, n=1, cutoff=0.6
+            )  # cutoff 0.6 mean a 60% match required for auto-selection.
             if closest_match:
                 LOGGER.warning(
                     f"WARNING ⚠️ Invalid export format='{fmt}'. Automatically updating to nearest valid format: '{closest_match[0]}'"

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -181,7 +181,7 @@ class Exporter:
         fmts = tuple(export_formats()["Argument"][1:])  # available export formats
         if fmt not in fmts:
             # Get the closest match if format is invalid
-            closest_match = difflib.get_close_matches(fmt, fmts, n=1, cutoff=0.6)
+            closest_match = difflib.get_close_matches(fmt, fmts, n=1, cutoff=0.6)   # cutoff 0.6 mean a 60% match required for auto-selection.
             if closest_match:
                 LOGGER.warning(
                     f"WARNING ⚠️ Invalid export format='{fmt}'. Automatically updating to nearest valid format: '{closest_match[0]}'")


### PR DESCRIPTION
@glenn-jocher 

This feature can help prevent errors when a user enters an incorrect export format name.  

e.g.

`yolo export model=yolo11n.pt format=open` #openvino
`yolo export model=yolo11n.pt format=torchscriptfunny`  #torchscript
`yolo export model=yolo11n.pt format=torchscript2` #torchscript

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling for model export formats.

### 📊 Key Changes
- Added a check for invalid export formats and suggested the nearest valid format using similarity matching.
- Included a warning message if the format is auto-corrected to a similar valid format.
- Raised a clear error if no similar format is found.

### 🎯 Purpose & Impact
- 🛠️ Enhances user experience by preventing invalid export formats and providing helpful suggestions.
- 🚀 Reduces potential errors and confusion during model export.
- 🔍 Increases robustness and user-friendliness of the export process.