### PR TITLE
Fix overridden train_args when close_mosaic

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 import time
 import warnings
-from copy import deepcopy
+from copy import deepcopy, copy
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -749,7 +749,7 @@ class BaseTrainer:
             self.train_loader.dataset.mosaic = False
         if hasattr(self.train_loader.dataset, "close_mosaic"):
             LOGGER.info("Closing dataloader mosaic")
-            self.train_loader.dataset.close_mosaic(hyp=self.args)
+            self.train_loader.dataset.close_mosaic(hyp=copy(self.args))
 
     def build_optimizer(self, model, name="auto", lr=0.001, momentum=0.9, decay=1e-5, iterations=1e5):
         """

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 import time
 import warnings
-from copy import deepcopy, copy
+from copy import copy, deepcopy
 from datetime import datetime, timedelta
 from pathlib import Path
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data loader mosaic handling for enhanced training stability.

### 📊 Key Changes
- Updated import statements to include `copy` from the `copy` module.
- Modified the `close_mosaic` function call to use a shallow copy of `self.args`.

### 🎯 Purpose & Impact
- 🛠️ **Stability**: Using `copy` ensures changes during the function don't affect the original arguments, reducing side effects.
- 🚀 **Reliability**: Enhances training process by minimizing unintended modifications to training arguments, leading to more consistent results.