### PR TITLE
Improve `scikit-learn` support for exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev = [
 export = [
     "onnx>=1.12.0", # ONNX export
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
+    "scikit-learn>=1.5.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
     "openvino>=2024.0.0", # OpenVINO export
     "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ dev = [
 export = [
     "onnx>=1.12.0", # ONNX export
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
-    "scikit-learn>=1.5.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
+    "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
     "openvino>=2024.0.0", # OpenVINO export
     "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow


### PR DESCRIPTION
@sergiuwaxmann may improve support for CoreML exports


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced CoreML export compatibility by adding scikit-learn dependency.

### 📊 Key Changes
- Added `scikit-learn>=1.3.2` to the dependencies for non-Windows platforms with Python up to 3.11.

### 🎯 Purpose & Impact
- **Improved Functionality**: Supports k-means quantization for CoreML exports, enhancing model efficiency and performance.
- **Broader Compatibility**: Ensures better functionality across macOS and Linux when exporting models to CoreML.