### PR TITLE
Update CLI usage

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -776,7 +776,7 @@ def entrypoint(debug=""):
     if task:
         if task not in TASKS:
             LOGGER.warning(f"Invalid 'task={task}'. Valid tasks are {TASKS}.Using 'task=detect'.")
-            task="detect"
+            task = "detect"
         if "model" not in overrides:
             overrides["model"] = TASK2MODEL[task]
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -437,9 +437,7 @@ def check_dict_alignment(base: Dict, custom: Dict, e=None):
             matches = [f"{k}={base[k]}" if base.get(k) is not None else k for k in matches]
             match_str = f"Similar arguments are i.e. {matches}." if matches else ""
             string += f"'{colorstr('red', 'bold', x)}' is not a valid YOLO argument. {match_str}\n"
-
         print(f"Warning: Some arguments will be skipped!!! {mismatched}")
-        # raise SyntaxError(string + CLI_HELP_MSG) from e
 
 
 def merge_equals_args(args: List[str]) -> List[str]:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -775,7 +775,7 @@ def entrypoint(debug=""):
     task = overrides.pop("task", None)
     if task:
         if task not in TASKS:
-            LOGGER.warning(f"WARNING ⚠️ 'task' unknown. Using default 'task=detect'.")
+            LOGGER.warning(f"Invalid 'task={task}'. Valid tasks are {TASKS}.Using 'task=detect'.")
             task="detect"
         if "model" not in overrides:
             overrides["model"] = TASK2MODEL[task]

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -775,8 +775,8 @@ def entrypoint(debug=""):
     task = overrides.pop("task", None)
     if task:
         if task not in TASKS:
-            LOGGER.warning(f"WARNING ⚠️ 'task' unknown. Using default 'task=detect'.")
-            task="detect"
+            LOGGER.warning("WARNING ⚠️ 'task' unknown. Using default 'task=detect'.")
+            task = "detect"
         if "model" not in overrides:
             overrides["model"] = TASK2MODEL[task]
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -437,7 +437,9 @@ def check_dict_alignment(base: Dict, custom: Dict, e=None):
             matches = [f"{k}={base[k]}" if base.get(k) is not None else k for k in matches]
             match_str = f"Similar arguments are i.e. {matches}." if matches else ""
             string += f"'{colorstr('red', 'bold', x)}' is not a valid YOLO argument. {match_str}\n"
-        raise SyntaxError(string + CLI_HELP_MSG) from e
+
+        print(f"Warning: Some arguments will be skipped!!! {mismatched}")
+        # raise SyntaxError(string + CLI_HELP_MSG) from e
 
 
 def merge_equals_args(args: List[str]) -> List[str]:
@@ -775,7 +777,8 @@ def entrypoint(debug=""):
     task = overrides.pop("task", None)
     if task:
         if task not in TASKS:
-            raise ValueError(f"Invalid 'task={task}'. Valid tasks are {TASKS}.\n{CLI_HELP_MSG}")
+            LOGGER.warning(f"WARNING ⚠️ 'task' unknown. Using default 'task=detect'.")
+            task="detect"
         if "model" not in overrides:
             overrides["model"] = TASK2MODEL[task]
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -437,7 +437,7 @@ def check_dict_alignment(base: Dict, custom: Dict, e=None):
             matches = [f"{k}={base[k]}" if base.get(k) is not None else k for k in matches]
             match_str = f"Similar arguments are i.e. {matches}." if matches else ""
             string += f"'{colorstr('red', 'bold', x)}' is not a valid YOLO argument. {match_str}\n"
-        print(f"Warning: Some arguments will be skipped!!! {mismatched}")
+        print(f"Warning: ⚠️ {mismatched} argument will be skipped, reason not supported!!!")
 
 
 def merge_equals_args(args: List[str]) -> List[str]:


### PR DESCRIPTION
@glenn-jocher I have tried to solve the CLI arguments issue.

- If a user inputs incorrect arguments like `yolo etect est pretrain mode=train data=coco8.yaml epochs=2 imgsz=640 model=yolov8n.pt abc`, the code currently throws an error. Instead, we can show a warning and set the `detect` task as the default automatically.
- If the user passes additional arguments, It will help the code to stop execution. Instead the new changes will show the warnings :)

**Best Example**
```CLI
[
/opt/conda/bin/yolo,
task=d,
etect,
mode=train,
model=yolov5m.pt,
data=/kaggle/working/football-players-detection-1/data.yaml,
epochs=100,
imgsz=640
]
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling and default task assignment in configuration.

### 📊 Key Changes
- Changed a `SyntaxError` to a warning message when invalid arguments are detected.
- Updated the handling of invalid tasks by logging a warning and defaulting to "detect".

### 🎯 Purpose & Impact
- 🛠️ Provides users with clearer warnings instead of abrupt errors, enhancing user experience.
- 🔄 Automatically defaults to a viable task, reducing configuration issues for users.