### PR TITLE
Replace YOLO11-seg table with macro 

### DIFF
--- a/docs/en/datasets/detect/coco.md
+++ b/docs/en/datasets/detect/coco.md
@@ -157,6 +157,8 @@ Pretrained YOLO11 models on the COCO dataset can be downloaded from the links pr
 - [YOLO11n](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt)
 - [YOLO11s](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11s.pt)
 - [YOLO11m](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11m.pt)
+- [YOLO11l](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11l.pt)
+- [YOLO11x](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11x.pt)
 
 These models vary in size, mAP, and inference speed, providing options for different performance and resource requirements.
 

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -141,13 +141,7 @@ The COCO-Seg dataset includes several key features:
 
 The COCO-Seg dataset supports multiple pretrained YOLO11 segmentation models with varying performance metrics. Here's a summary of the available models and their key metrics:
 
-| Model                                                                                        | size<br><sup>(pixels) | mAP<sup>box<br>50-95 | mAP<sup>mask<br>50-95 | Speed<br><sup>CPU ONNX<br>(ms) | Speed<br><sup>A100 TensorRT<br>(ms) | params<br><sup>(M) | FLOPs<br><sup>(B) |
-| -------------------------------------------------------------------------------------------- | --------------------- | -------------------- | --------------------- | ------------------------------ | ----------------------------------- | ------------------ | ----------------- |
-| [YOLO11n-seg](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-seg.pt) | 640                   | 36.7                 | 30.5                  | 96.1                           | 1.21                                | 3.4                | 12.6              |
-| [YOLO11s-seg](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11s-seg.pt) | 640                   | 44.6                 | 36.8                  | 155.7                          | 1.47                                | 11.8               | 42.6              |
-| [YOLO11m-seg](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11m-seg.pt) | 640                   | 49.9                 | 40.8                  | 317.0                          | 2.18                                | 27.3               | 110.2             |
-| [YOLO11l-seg](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11l-seg.pt) | 640                   | 52.3                 | 42.6                  | 572.4                          | 2.79                                | 46.0               | 220.5             |
-| [YOLO11x-seg](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11x-seg.pt) | 640                   | 53.4                 | 43.4                  | 712.1                          | 4.02                                | 71.8               | 344.1             |
+{% include "macros/yolo-seg-perf.md" %}
 
 ### How is the COCO-Seg dataset structured and what subsets does it contain?
 


### PR DESCRIPTION
Hi,

Minor fix for correct and better docs:

- Addition to PR #16598: Remove old wrong table. (find out: has naming of `YOLO11` models but stats values of old `YOLOv8` models in table.)
- Add missing but available models in description to complete list

Thank you! 🚀

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced YOLO11 model documentation with new model links and optimized content structure.

### 📊 Key Changes
- Added links to new YOLO11 large (`YOLO11l`) and extra-large (`YOLO11x`) models in the detection documentation.
- Streamlined segmentation model documentation using macros for better content management.

### 🎯 Purpose & Impact
- 📈 **Expanded Options:** Users have access to more pretrained models for different performance needs.
- 🔧 **Improved Maintenance:** Using macros simplifies updates and ensures consistency in documentation.