### PR TITLE
Remove unused arguments in Ultralytics `heatmaps`

### DIFF
--- a/docs/en/guides/heatmaps.md
+++ b/docs/en/guides/heatmaps.md
@@ -34,10 +34,6 @@ A heatmap generated with [Ultralytics YOLO11](https://github.com/ultralytics/ult
 | ![Ultralytics YOLO11 Transportation Heatmap](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-transportation-heatmap.avif) | ![Ultralytics YOLO11 Retail Heatmap](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-retail-heatmap.avif) |
 |                                                      Ultralytics YOLO11 Transportation Heatmap                                                       |                                                  Ultralytics YOLO11 Retail Heatmap                                                   |
 
-!!! tip "Heatmap Configuration"
-
-    - `heatmap_alpha`: Ensure this value is within the range (0.0 - 1.0).
-    - `decay_factor`: Used for removing heatmap after an object is no longer in the frame, its value should also be in the range (0.0 - 1.0).
 
 !!! example "Heatmaps using Ultralytics YOLO11 Example"
 
@@ -274,10 +270,7 @@ A heatmap generated with [Ultralytics YOLO11](https://github.com/ultralytics/ult
 | Name               | Type             | Default            | Description                                                       |
 | ------------------ | ---------------- | ------------------ | ----------------------------------------------------------------- |
 | `names`            | `list`           | `None`             | Dictionary of class names.                                        |
-| `imw`              | `int`            | `0`                | Image width.                                                      |
-| `imh`              | `int`            | `0`                | Image height.                                                     |
 | `colormap`         | `int`            | `cv2.COLORMAP_JET` | Colormap to use for the heatmap.                                  |
-| `heatmap_alpha`    | `float`          | `0.5`              | Alpha blending value for heatmap overlay.                         |
 | `view_img`         | `bool`           | `False`            | Whether to display the image with the heatmap overlay.            |
 | `view_in_counts`   | `bool`           | `True`             | Whether to display the count of objects entering the region.      |
 | `view_out_counts`  | `bool`           | `True`             | Whether to display the count of objects exiting the region.       |
@@ -288,7 +281,6 @@ A heatmap generated with [Ultralytics YOLO11](https://github.com/ultralytics/ult
 | `region_thickness` | `int`            | `5`                | Thickness of the region line.                                     |
 | `line_dist_thresh` | `int`            | `15`               | Distance threshold for line-based counting.                       |
 | `line_thickness`   | `int`            | `2`                | Thickness of the lines used in drawing.                           |
-| `decay_factor`     | `float`          | `0.99`             | Decay factor for the heatmap to reduce intensity over time.       |
 | `shape`            | `str`            | `"circle"`         | Shape of the heatmap blobs ('circle' or 'rect').                  |
 
 ### Arguments `model.track`

--- a/docs/en/guides/heatmaps.md
+++ b/docs/en/guides/heatmaps.md
@@ -34,7 +34,6 @@ A heatmap generated with [Ultralytics YOLO11](https://github.com/ultralytics/ult
 | ![Ultralytics YOLO11 Transportation Heatmap](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-transportation-heatmap.avif) | ![Ultralytics YOLO11 Retail Heatmap](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-retail-heatmap.avif) |
 |                                                      Ultralytics YOLO11 Transportation Heatmap                                                       |                                                  Ultralytics YOLO11 Retail Heatmap                                                   |
 
-
 !!! example "Heatmaps using Ultralytics YOLO11 Example"
 
     === "Heatmap"

--- a/ultralytics/solutions/heatmap.py
+++ b/ultralytics/solutions/heatmap.py
@@ -19,10 +19,7 @@ class Heatmap:
     def __init__(
         self,
         names,
-        imw=0,
-        imh=0,
         colormap=cv2.COLORMAP_JET,
-        heatmap_alpha=0.5,
         view_img=False,
         view_in_counts=True,
         view_out_counts=True,
@@ -33,7 +30,6 @@ class Heatmap:
         region_thickness=5,
         line_dist_thresh=15,
         line_thickness=2,
-        decay_factor=0.99,
         shape="circle",
     ):
         """Initializes the heatmap class with default values for Visual, Image, track, count and heatmap parameters."""
@@ -46,8 +42,6 @@ class Heatmap:
         self.names = names  # Classes names
 
         # Image information
-        self.imw = imw
-        self.imh = imh
         self.im0 = None
         self.tf = line_thickness
         self.view_in_counts = view_in_counts
@@ -56,7 +50,6 @@ class Heatmap:
         # Heatmap colormap and heatmap np array
         self.colormap = colormap
         self.heatmap = None
-        self.heatmap_alpha = heatmap_alpha
 
         # Predict/track information
         self.boxes = []
@@ -78,9 +71,6 @@ class Heatmap:
         self.count_txt_color = count_txt_color
         self.count_bg_color = count_bg_color
         self.cls_txtdisplay_gap = 50
-
-        # Decay factor
-        self.decay_factor = decay_factor
 
         # Check if environment supports imshow
         self.env_check = check_imshow(warn=True)
@@ -133,7 +123,7 @@ class Heatmap:
             self.heatmap = np.zeros((int(self.im0.shape[0]), int(self.im0.shape[1])), dtype=np.float32)
             self.initialized = True
 
-        self.heatmap *= self.decay_factor  # decay factor
+        self.heatmap *= 0.99  # decay factor
 
         self.extract_results(tracks)
         self.annotator = Annotator(self.im0, self.tf, None)
@@ -239,7 +229,7 @@ class Heatmap:
         # Normalize, apply colormap to heatmap and combine with original image
         heatmap_normalized = cv2.normalize(self.heatmap, None, 0, 255, cv2.NORM_MINMAX)
         heatmap_colored = cv2.applyColorMap(heatmap_normalized.astype(np.uint8), self.colormap)
-        self.im0 = cv2.addWeighted(self.im0, 1 - self.heatmap_alpha, heatmap_colored, self.heatmap_alpha, 0)
+        self.im0 = cv2.addWeighted(self.im0, 0.5, heatmap_colored, 0.5, 0)
 
         if self.env_check and self.view_img:
             self.display_frames()

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -182,8 +182,10 @@ def select_device(device="", batch=0, newline=False, verbose=True):
                 if torch.cuda.device_count() == 0
                 else ""
             )
-            raise ValueError(
-                f"Invalid CUDA 'device={device}' requested."
+
+            LOGGER.warning(
+            # raise ValueError(
+                f"Invalid CUDA 'device={device}' requested. Using 'device=cpu'"
                 f" Use 'device=cpu' or pass valid CUDA device(s) if available,"
                 f" i.e. 'device=0' or 'device=0,1,2,3' for Multi-GPU.\n"
                 f"\ntorch.cuda.is_available(): {torch.cuda.is_available()}"

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -182,10 +182,8 @@ def select_device(device="", batch=0, newline=False, verbose=True):
                 if torch.cuda.device_count() == 0
                 else ""
             )
-
-            LOGGER.warning(
-            # raise ValueError(
-                f"Invalid CUDA 'device={device}' requested. Using 'device=cpu'"
+            raise ValueError(
+                f"Invalid CUDA 'device={device}' requested."
                 f" Use 'device=cpu' or pass valid CUDA device(s) if available,"
                 f" i.e. 'device=0' or 'device=0,1,2,3' for Multi-GPU.\n"
                 f"\ntorch.cuda.is_available(): {torch.cuda.is_available()}"


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refined heatmap feature by simplifying configuration parameters.

### 📊 Key Changes
- Removed `heatmap_alpha`, `decay_factor`, `imw`, and `imh` from configurations.
- Updated the default values directly in code rather than as user-configurable parameters.

### 🎯 Purpose & Impact
- 📉 **Simplified Configuration**: Reduces complexity for users by removing unnecessary parameters.
- 🛠️ **Improved Usability**: Ensures default settings are more appropriate for general use, enhancing user experience.
- 📈 **Consistent Performance**: Maintains essential functionality while streamlining code for easier maintenance.