### PR TITLE
Fix UINT8 overflow for >255 segmentation masks

### DIFF
--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -210,13 +210,13 @@ def polygons2masks_overlap(imgsz, segments, downsample_ratio=1):
     """Return a (640, 640) overlap mask."""
     masks = np.zeros(
         (imgsz[0] // downsample_ratio, imgsz[1] // downsample_ratio),
-        dtype=np.int32 if len(segments) > 255 else np.uint8,
+        dtype=np.int32,
     )
     areas = []
     ms = []
     for si in range(len(segments)):
         mask = polygon2mask(imgsz, [segments[si].reshape(-1)], downsample_ratio=downsample_ratio, color=1)
-        ms.append(mask)
+        ms.append(mask.astype(np.uint32))
         areas.append(mask.sum())
     areas = np.asarray(areas)
     index = np.argsort(-areas)

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -216,7 +216,7 @@ def polygons2masks_overlap(imgsz, segments, downsample_ratio=1):
     ms = []
     for si in range(len(segments)):
         mask = polygon2mask(imgsz, [segments[si].reshape(-1)], downsample_ratio=downsample_ratio, color=1)
-        ms.append(mask.astype(np.uint32))
+        ms.append(mask.astype(masks.dtype))
         areas.append(mask.sum())
     areas = np.asarray(areas)
     index = np.argsort(-areas)

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -210,7 +210,7 @@ def polygons2masks_overlap(imgsz, segments, downsample_ratio=1):
     """Return a (640, 640) overlap mask."""
     masks = np.zeros(
         (imgsz[0] // downsample_ratio, imgsz[1] // downsample_ratio),
-        dtype=np.int32,
+        dtype=np.int32 if len(segments) > 255 else np.uint8,
     )
     areas = []
     ms = []

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -119,7 +119,7 @@ class BaseValidator:
             self.args.plots &= trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs - 1)
             model.eval()
         else:
-            if Path(self.args.model).suffix == ".yaml":
+            if str(self.args.model).endswith(".yaml"):
                 LOGGER.warning("WARNING ⚠️ validating an untrained model YAML will result in 0 mAP.")
             callbacks.add_integration_callbacks(self)
             model = AutoBackend(


### PR DESCRIPTION

Like the title suggests, when the number of objects in an image was more than 255, it caused uint8 overflow. [Line 219] To fix this, dtype of the a mask appended to the list *masks* was changed to uint32. 
This alone was not enough fix as the datatype of *masks* list could be assigned to uint8 on line 213. I changed the conditional datatype to int32. 



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to data type handling and file validation process.

### 📊 Key Changes
- Updated the `polygons2masks_overlap` function to ensure masks have consistent data types.
- Improved file extension checking logic in the validator by using `str.endswith(".yaml")`.

### 🎯 Purpose & Impact
- 🛠️ **Improved Consistency**: Ensures mask data types are consistent, reducing potential errors in mask operations.
- 🧠 **Better Validation**: Simplifies YAML file checks, enhancing code readability and maintainability.
- ⚠️ **User Alert**: Provides a clearer warning for users about the validation of untrained models, preventing potential confusion.