### PR TITLE
Update MkDocs extra.js

### DIFF
--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -90,13 +90,14 @@ document.addEventListener("DOMContentLoaded", () => {
       },
       properties: {
         chatButtonType: "PILL",
+        fixedPositionXOffset: "1rem",
         fixedPositionYOffset: "3rem",
-        chatButtonBgColor: "#F3F3F3",
+        chatButtonBgColor: "#E1FF25",
         baseSettings: {
           apiKey: "13dfec2e75982bc9bae3199a08e13b86b5fbacd64e9b2f89", // required
           integrationId: "cm1shscmm00y26sj83lgxzvkw", // required
           organizationId: "org_e3869az6hQZ0mXdF", // required
-          primaryBrandColor: "#111F68", // Ultralytics brand color
+          primaryBrandColor: "#E1FF25", // Ultralytics brand color
           organizationDisplayName: "Ultralytics",
           theme: {
             stylesheetUrls: ["../stylesheets/style.css"],


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to the chat button styling in the documentation.

### 📊 Key Changes
- Updated chat button's background color to a bright yellow (`#E1FF25`).
- Changed primary brand color to match the new button color.
- Introduced an offset for the button's horizontal position.

### 🎯 Purpose & Impact
- 💡 **Improved Visibility**: The brighter chat button enhances visibility, making it easier for users to access help.
- 🖌️ **Consistent Branding**: Aligns the button color with the brand theme for a cohesive look.
- 📍 **Better Placement**: The position offset can enhance user experience by ensuring the button is effectively placed across different devices.