### PR TITLE
Adding `OMP_NUM_THREADS=1`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,8 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_BREAK_SYSTEM_PACKAGES=1 \
-    MKL_THREADING_LAYER=GNU
+    MKL_THREADING_LAYER=GNU \
+    OMP_NUM_THREADS=1 
 
 # Downloads to user config dir
 ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \


### PR DESCRIPTION
@Laughing-q @Burhan-Q @ambitious-octopus adding this back into our Dockerfile as without this I see complete CPU saturation and can't train.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated Docker configuration to improve performance and resource management.

### 📊 Key Changes
- Adjusted the Dockerfile by setting `OMP_NUM_THREADS=1`.

### 🎯 Purpose & Impact
- **Performance Optimization**: Limits the number of OpenMP threads to enhance resource efficiency, potentially reducing CPU usage.
- **Better Resource Management**: Helps in environments with limited computational resources, ensuring more stable and predictable performance.