### PR TITLE
Respect ENV value for `OMP_NUM_THREADS` if set

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -5,7 +5,9 @@ __version__ = "8.3.7"
 import os
 
 # Set ENV Variables (place before imports), ONLY if ENV variable not set
-os.environ["OMP_NUM_THREADS"] = os.environ.get("OMP_NUM_THREADS", "1")  # default for reduced CPU utilization during training 
+os.environ["OMP_NUM_THREADS"] = os.environ.get(
+    "OMP_NUM_THREADS", "1"
+)  # default for reduced CPU utilization during training
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import NAS, RTDETR, SAM, YOLO, FastSAM, YOLOWorld

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -5,9 +5,8 @@ __version__ = "8.3.7"
 import os
 
 # Set ENV Variables (place before imports), ONLY if ENV variable not set
-os.environ["OMP_NUM_THREADS"] = os.environ.get(
-    "OMP_NUM_THREADS", "1"
-)  # default for reduced CPU utilization during training
+if not os.environ.get("OMP_NUM_THREADS"):
+    os.environ["OMP_NUM_THREADS"] = "1"  # default for reduced CPU utilization during training
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import NAS, RTDETR, SAM, YOLO, FastSAM, YOLOWorld

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -4,7 +4,7 @@ __version__ = "8.3.7"
 
 import os
 
-# Set ENV Variables (place before imports), ONLY if ENV variable not set
+# Set ENV variables (place before imports)
 if not os.environ.get("OMP_NUM_THREADS"):
     os.environ["OMP_NUM_THREADS"] = "1"  # default for reduced CPU utilization during training
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -4,8 +4,8 @@ __version__ = "8.3.7"
 
 import os
 
-# Set ENV Variables (place before imports)
-os.environ["OMP_NUM_THREADS"] = "1"  # reduce CPU utilization during training
+# Set ENV Variables (place before imports), ONLY if ENV variable not set
+os.environ["OMP_NUM_THREADS"] = os.environ.get("OMP_NUM_THREADS", "1")  # default for reduced CPU utilization during training 
 
 from ultralytics.data.explorer.explorer import Explorer
 from ultralytics.models import NAS, RTDETR, SAM, YOLO, FastSAM, YOLOWorld

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -685,7 +685,7 @@ def create_synthetic_coco_dataset():
             # Read image filenames from label list file
             label_list_file = dir / f"{subset}.txt"
             if label_list_file.exists():
-                with open(label_list_file, "r") as f:
+                with open(label_list_file) as f:
                     image_files = [dir / line.strip() for line in f]
 
                 # Submit all tasks


### PR DESCRIPTION
- Updated to use ENV value for `OMP_NUM_THREADS` if set, otherwise defaults to "1"

Since `OMP_NUM_THREADS` can be set in environment, instead of overriding by default, first check if variable is set (as is for Docker containers) to ensure value from environment is used instead of enforcing default value. This should allow for testing with other values for `OMP_NUM_THREADS` and will not override environment variable.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves default environment setting for efficient CPU utilization during training.

### 📊 Key Changes
- Modified the setup of the `OMP_NUM_THREADS` environment variable to check if it's already defined before setting a default value.

### 🎯 Purpose & Impact
- 🧠 **Efficiency**: Ensures optimal CPU usage by only setting the `OMP_NUM_THREADS` variable if it's not already specified by the user.
- ⚙️ **Flexibility**: Allows users to customize this setting more easily without interference.
- 🌟 **Performance**: Helps avoid unnecessary resource allocation, potentially improving training efficiency.