### PR TITLE
Fix display of admonition in W&B docs 

### DIFF
--- a/docs/en/integrations/weights-biases.md
+++ b/docs/en/integrations/weights-biases.md
@@ -106,16 +106,19 @@ Before diving into the usage instructions for YOLO11 model training with Weights
 | project  | `None`  | Specifies the name of the project logged locally and in W&B. This way you can group multiple runs together.        |
 | name     | `None`  | The name of the training run. This determines the name used to create subfolders and the name used for W&B logging |
 
-!!! Tip "Enable or Disable Weights & Biases"
-If you want to enable or disable Weights & Biases logging, you can use the `wandb` command. By default, Weights & Biases logging is enabled.
+!!! tip "Enable or Disable Weights & Biases"
 
-    ```bash
-    # Enable Weights & Biases logging
-    wandb enabled
+    If you want to enable or disable Weights & Biases logging, you can use the `wandb` command. By default, Weights & Biases logging is enabled.
 
-    # Disable Weights & Biases logging
-    wandb disabled
-    ```
+    === "CLI"
+
+        ```bash
+        # Enable Weights & Biases logging
+        wandb enabled
+
+        # Disable Weights & Biases logging
+        wandb disabled
+        ```
 
 ### Understanding the Output
 

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -685,7 +685,7 @@ def create_synthetic_coco_dataset():
             # Read image filenames from label list file
             label_list_file = dir / f"{subset}.txt"
             if label_list_file.exists():
-                with open(label_list_file, "r") as f:
+                with open(label_list_file) as f:
                     image_files = [dir / line.strip() for line in f]
 
                 # Submit all tasks


### PR DESCRIPTION
Hi,

fix the display of admonition with a code block in W&B docs. Incorrect formatting of a code block within an admonition.

Thanks! 🚀

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved documentation formatting and code simplification in data conversion.

### 📊 Key Changes
- Reformatted the Weights & Biases integration docs for better readability.
- Simplified file opening code in the data converter by removing an unnecessary parameter.

### 🎯 Purpose & Impact
- 📘 **Enhanced Documentation:** Provides a clearer guideline for enabling/disabling Weights & Biases logging, making it easier to follow.
- 🛠️ **Code Efficiency:** Simplifies file handling in the data converter, which reduces potential errors and improves code readability.