### PR TITLE
Fix `results.show()` for Jupyter notebooks

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -13,8 +13,8 @@ import torch
 from PIL import Image, ImageDraw, ImageFont
 from PIL import __version__ as pil_version
 
-from ultralytics.utils import IS_JUPYTER, LOGGER, TryExcept, ops, plt_settings, threaded
-from ultralytics.utils.checks import check_font, check_requirements, check_version, is_ascii
+from ultralytics.utils import LOGGER, TryExcept, ops, plt_settings, threaded, IS_COLAB, IS_KAGGLE
+from ultralytics.utils.checks import check_font, check_version, is_ascii
 from ultralytics.utils.files import increment_path
 
 
@@ -525,16 +525,12 @@ class Annotator:
     def show(self, title=None):
         """Show the annotated image."""
         im = Image.fromarray(np.asarray(self.im)[..., ::-1])  # Convert numpy array to PIL Image with RGB to BGR
-        if IS_JUPYTER:
-            check_requirements("ipython")
+        if IS_COLAB or IS_KAGGLE:  # can not use IS_JUPYTER as will run for all ipython environments
             try:
-                from IPython.display import display
-
-                display(im)
+                display(im)  # noqa - display() function only available in ipython environments
             except ImportError as e:
                 LOGGER.warning(f"Unable to display image in Jupyter notebooks: {e}")
         else:
-            # Convert numpy array to PIL Image and show
             im.show(title=title)
 
     def save(self, filename="image.jpg"):

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -13,7 +13,7 @@ import torch
 from PIL import Image, ImageDraw, ImageFont
 from PIL import __version__ as pil_version
 
-from ultralytics.utils import LOGGER, TryExcept, ops, plt_settings, threaded, IS_COLAB, IS_KAGGLE
+from ultralytics.utils import IS_COLAB, IS_KAGGLE, LOGGER, TryExcept, ops, plt_settings, threaded
 from ultralytics.utils.checks import check_font, check_version, is_ascii
 from ultralytics.utils.files import increment_path
 


### PR DESCRIPTION
@Burhan-Q @ambitious-octopus show fix

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image display compatibility for Colab and Kaggle environments.

### 📊 Key Changes
- Replaced `IS_JUPYTER` with `IS_COLAB` and `IS_KAGGLE` for environment checks.
- Simplified image display code to better target specific environments.

### 🎯 Purpose & Impact
- 🖥️ Ensures that images display properly in Colab and Kaggle without affecting other environments.
- 🔧 Reduces warnings and potential errors when displaying images, improving the user experience.