### PR TITLE
Fix wrong parameter count while profiling

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1061,10 +1061,10 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
 
         m_ = nn.Sequential(*(m(*args) for _ in range(n))) if n > 1 else m(*args)  # module
         t = str(m)[8:-2].replace("__main__.", "")  # module type
-        m.np = sum(x.numel() for x in m_.parameters())  # number params
+        m_.np = sum(x.numel() for x in m_.parameters())  # number params
         m_.i, m_.f, m_.type = i, f, t  # attach index, 'from' index, type
         if verbose:
-            LOGGER.info(f"{i:>3}{str(f):>20}{n_:>3}{m.np:10.0f}  {t:<45}{str(args):<30}")  # print
+            LOGGER.info(f"{i:>3}{str(f):>20}{n_:>3}{m_.np:10.0f}  {t:<45}{str(args):<30}")  # print
         save.extend(x % i for x in ([f] if isinstance(f, int) else f) if x != -1)  # append to savelist
         layers.append(m_)
         if i == 0:


### PR DESCRIPTION
Resolves #16788

```python
from ultralytics import YOLO, ASSETS 
import torch
model = YOLO("yolo11n.yaml", verbose=True)
dummy = torch.rand(1,3,640,640).to("cuda:0")
results = model(ASSETS / "bus.jpg", device=0, profile=True)
_= model.model._predict_once(dummy, profile=True)
```

```
 time (ms)     GFLOPs     params  module
      0.26       0.09        464  ultralytics.nn.modules.conv.Conv
      0.21       0.24       4672  ultralytics.nn.modules.conv.Conv
      0.60       0.33       6640  ultralytics.nn.modules.block.C3k2
      0.33       0.47      36992  ultralytics.nn.modules.conv.Conv
      0.40       0.33      26080  ultralytics.nn.modules.block.C3k2
      0.36       0.47     147712  ultralytics.nn.modules.conv.Conv
      0.90       0.28      87040  ultralytics.nn.modules.block.C3k2
      0.22       0.24     295424  ultralytics.nn.modules.conv.Conv
      0.74       0.28     346112  ultralytics.nn.modules.block.C3k2
      0.26       0.13     164608  ultralytics.nn.modules.block.SPPF
      0.99       0.20     249728  ultralytics.nn.modules.block.C2PSA
      0.02       0.00          0  torch.nn.modules.upsampling.Upsample
      0.02       0.00          0  ultralytics.nn.modules.conv.Concat
      0.36       0.35     111296  ultralytics.nn.modules.block.C3k2
      0.04       0.00          0  torch.nn.modules.upsampling.Upsample
      0.06       0.00          0  ultralytics.nn.modules.conv.Concat
      0.43       0.41      32096  ultralytics.nn.modules.block.C3k2
      0.20       0.12      36992  ultralytics.nn.modules.conv.Conv
      0.02       0.00          0  ultralytics.nn.modules.conv.Concat
      0.36       0.28      86720  ultralytics.nn.modules.block.C3k2
      0.20       0.12     147712  ultralytics.nn.modules.conv.Conv
      0.02       0.00          0  ultralytics.nn.modules.conv.Concat
      0.76       0.30     378880  ultralytics.nn.modules.block.C3k2
      3.95       5.76     717680  ultralytics.nn.modules.head.Segment
     11.71          -          -  Total
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor fix for accurate parameter logging in neural network models.

### 📊 Key Changes
- Corrected a reference from `m.np` to `m_.np` to fix parameter count logging.

### 🎯 Purpose & Impact
- 🛠️ Ensures the parameter count displayed in logs is accurate, improving debugging and model analysis.
- 📈 Helps users better understand the resource demands of their models.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes parameter counting in neural network models.

### 📊 Key Changes
- Corrected the assignment of the parameter count attribute from `m` to `m_` in the model parsing function.
- Updated logging to reflect the corrected parameter count.

### 🎯 Purpose & Impact
- 🛠️ **Accuracy**: Ensures the parameter count is correctly assigned and logged for each neural network module.
- 📈 **Debugging & Analysis**: Improved logging helps developers accurately assess and debug model details.
- 🤖 **Model Building**: Better accuracy in model descriptions enhances user confidence and usability when building models.