### PR TITLE
Sort alphabetical integrations in docs

### DIFF
--- a/docs/en/integrations/index.md
+++ b/docs/en/integrations/index.md
@@ -27,65 +27,65 @@ Welcome to the Ultralytics Integrations page! This page provides an overview of 
 
 ## Training Integrations
 
+- [Amazon SageMaker](amazon-sagemaker.md): Leverage Amazon SageMaker to efficiently build, train, and deploy Ultralytics models, providing an all-in-one platform for the ML lifecycle.
+
 - [ClearML](clearml.md): Automate your Ultralytics ML workflows, monitor experiments, and foster team collaboration.
 
 - [Comet ML](comet.md): Enhance your model development with Ultralytics by tracking, comparing, and optimizing your machine learning experiments.
 
 - [DVC](dvc.md): Implement version control for your Ultralytics machine learning projects, synchronizing data, code, and models effectively.
 
+- [Google Colab](google-colab.md): Use Google Colab to train and evaluate Ultralytics models in a cloud-based environment that supports collaboration and sharing.
+
+- [IBM Watsonx](ibm-watsonx.md): See how IBM Watsonx simplifies the training and evaluation of Ultralytics models with its cutting-edge AI tools, effortless integration, and advanced model management system.
+
+- [JupyterLab](jupyterlab.md): Find out how to use JupyterLab's interactive and customizable environment to train and evaluate Ultralytics models with ease and efficiency.
+
+- [Kaggle](kaggle.md): Explore how you can use Kaggle to train and evaluate Ultralytics models in a cloud-based environment with pre-installed libraries, GPU support, and a vibrant community for collaboration and sharing.
+
 - [MLFlow](mlflow.md): Streamline the entire ML lifecycle of Ultralytics models, from experimentation and reproducibility to deployment.
 
-- [Ultralytics HUB](https://hub.ultralytics.com/): Access and contribute to a community of pre-trained Ultralytics models.
-
 - [Neptune](https://neptune.ai/): Maintain a comprehensive log of your ML experiments with Ultralytics in this metadata store designed for MLOps.
+
+- [Paperspace Gradient](paperspace.md): Paperspace Gradient simplifies working on YOLO11 projects by providing easy-to-use cloud tools for training, testing, and deploying your models quickly.
 
 - [Ray Tune](ray-tune.md): Optimize the hyperparameters of your Ultralytics models at any scale.
 
 - [TensorBoard](tensorboard.md): Visualize your Ultralytics ML workflows, monitor model metrics, and foster team collaboration.
 
+- [Ultralytics HUB](https://hub.ultralytics.com/): Access and contribute to a community of pre-trained Ultralytics models.
+
 - [Weights & Biases (W&B)](weights-biases.md): Monitor experiments, visualize metrics, and foster reproducibility and collaboration on Ultralytics projects.
-
-- [Amazon SageMaker](amazon-sagemaker.md): Leverage Amazon SageMaker to efficiently build, train, and deploy Ultralytics models, providing an all-in-one platform for the ML lifecycle.
-
-- [Paperspace Gradient](paperspace.md): Paperspace Gradient simplifies working on YOLO11 projects by providing easy-to-use cloud tools for training, testing, and deploying your models quickly.
-
-- [Google Colab](google-colab.md): Use Google Colab to train and evaluate Ultralytics models in a cloud-based environment that supports collaboration and sharing.
-
-- [Kaggle](kaggle.md): Explore how you can use Kaggle to train and evaluate Ultralytics models in a cloud-based environment with pre-installed libraries, GPU support, and a vibrant community for collaboration and sharing.
-
-- [JupyterLab](jupyterlab.md): Find out how to use JupyterLab's interactive and customizable environment to train and evaluate Ultralytics models with ease and efficiency.
-
-- [IBM Watsonx](ibm-watsonx.md): See how IBM Watsonx simplifies the training and evaluation of Ultralytics models with its cutting-edge AI tools, effortless integration, and advanced model management system.
 
 ## Deployment Integrations
 
-- [Neural Magic](neural-magic.md): Leverage Quantization Aware Training (QAT) and pruning techniques to optimize Ultralytics models for superior performance and leaner size.
+- [CoreML](coreml.md): CoreML, developed by [Apple](https://www.apple.com/), is a framework designed for efficiently integrating machine learning models into applications across iOS, macOS, watchOS, and tvOS, using Apple's hardware for effective and secure [model deployment](https://www.ultralytics.com/glossary/model-deployment).
 
 - [Gradio](gradio.md) 🚀 NEW: Deploy Ultralytics models with Gradio for real-time, interactive object detection demos.
 
-- [TorchScript](torchscript.md): Developed as part of the [PyTorch](https://pytorch.org/) framework, TorchScript enables efficient execution and deployment of machine learning models in various production environments without the need for Python dependencies.
+- [NCNN](ncnn.md): Developed by [Tencent](http://www.tencent.com/), NCNN is an efficient [neural network](https://www.ultralytics.com/glossary/neural-network-nn) inference framework tailored for mobile devices. It enables direct deployment of AI models into apps, optimizing performance across various mobile platforms.
+
+- [Neural Magic](neural-magic.md): Leverage Quantization Aware Training (QAT) and pruning techniques to optimize Ultralytics models for superior performance and leaner size.
 
 - [ONNX](onnx.md): An open-source format created by [Microsoft](https://www.microsoft.com/) for facilitating the transfer of AI models between various frameworks, enhancing the versatility and deployment flexibility of Ultralytics models.
 
 - [OpenVINO](openvino.md): Intel's toolkit for optimizing and deploying [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models efficiently across various Intel CPU and GPU platforms.
 
-- [TensorRT](tensorrt.md): Developed by [NVIDIA](https://www.nvidia.com/), this high-performance [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) inference framework and model format optimizes AI models for accelerated speed and efficiency on NVIDIA GPUs, ensuring streamlined deployment.
+- [PaddlePaddle](paddlepaddle.md): An open-source deep learning platform by [Baidu](https://www.baidu.com/), PaddlePaddle enables the efficient deployment of AI models and focuses on the scalability of industrial applications.
 
-- [CoreML](coreml.md): CoreML, developed by [Apple](https://www.apple.com/), is a framework designed for efficiently integrating machine learning models into applications across iOS, macOS, watchOS, and tvOS, using Apple's hardware for effective and secure [model deployment](https://www.ultralytics.com/glossary/model-deployment).
+- [TF GraphDef](tf-graphdef.md): Developed by [Google](https://www.google.com/), GraphDef is TensorFlow's format for representing computation graphs, enabling optimized execution of machine learning models across diverse hardware.
 
 - [TF SavedModel](tf-savedmodel.md): Developed by [Google](https://www.google.com/), TF SavedModel is a universal serialization format for [TensorFlow](https://www.ultralytics.com/glossary/tensorflow) models, enabling easy sharing and deployment across a wide range of platforms, from servers to edge devices.
 
-- [TF GraphDef](tf-graphdef.md): Developed by [Google](https://www.google.com/), GraphDef is TensorFlow's format for representing computation graphs, enabling optimized execution of machine learning models across diverse hardware.
+- [TF.js](tfjs.md): Developed by [Google](https://www.google.com/) to facilitate machine learning in browsers and Node.js, TF.js allows JavaScript-based deployment of ML models.
 
 - [TFLite](tflite.md): Developed by [Google](https://www.google.com/), TFLite is a lightweight framework for deploying machine learning models on mobile and edge devices, ensuring fast, efficient inference with minimal memory footprint.
 
 - [TFLite Edge TPU](edge-tpu.md): Developed by [Google](https://www.google.com/) for optimizing TensorFlow Lite models on Edge TPUs, this model format ensures high-speed, efficient [edge computing](https://www.ultralytics.com/glossary/edge-computing).
 
-- [TF.js](tfjs.md): Developed by [Google](https://www.google.com/) to facilitate machine learning in browsers and Node.js, TF.js allows JavaScript-based deployment of ML models.
+- [TensorRT](tensorrt.md): Developed by [NVIDIA](https://www.nvidia.com/), this high-performance [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) inference framework and model format optimizes AI models for accelerated speed and efficiency on NVIDIA GPUs, ensuring streamlined deployment.
 
-- [PaddlePaddle](paddlepaddle.md): An open-source deep learning platform by [Baidu](https://www.baidu.com/), PaddlePaddle enables the efficient deployment of AI models and focuses on the scalability of industrial applications.
-
-- [NCNN](ncnn.md): Developed by [Tencent](http://www.tencent.com/), NCNN is an efficient [neural network](https://www.ultralytics.com/glossary/neural-network-nn) inference framework tailored for mobile devices. It enables direct deployment of AI models into apps, optimizing performance across various mobile platforms.
+- [TorchScript](torchscript.md): Developed as part of the [PyTorch](https://pytorch.org/) framework, TorchScript enables efficient execution and deployment of machine learning models in various production environments without the need for Python dependencies.
 
 - [VS Code](vscode.md): An extension for VS Code that provides code snippets for accelerating development workflows with Ultralytics and also for anyone looking for examples to help learn or get started with Ultralytics.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -391,36 +391,36 @@ nav:
               - Comet Logging: yolov5/tutorials/comet_logging_integration.md
               - Clearml Logging: yolov5/tutorials/clearml_logging_integration.md
   - Integrations:
-    - integrations/index.md
-    - Amazon SageMaker: integrations/amazon-sagemaker.md
-    - ClearML: integrations/clearml.md
-    - Comet ML: integrations/comet.md
-    - CoreML: integrations/coreml.md
-    - DVC: integrations/dvc.md
-    - Google Colab: integrations/google-colab.md
-    - Gradio: integrations/gradio.md
-    - IBM Watsonx: integrations/ibm-watsonx.md
-    - JupyterLab: integrations/jupyterlab.md
-    - Kaggle: integrations/kaggle.md
-    - MLflow: integrations/mlflow.md
-    - NCNN: integrations/ncnn.md
-    - Neural Magic: integrations/neural-magic.md
-    - ONNX: integrations/onnx.md
-    - OpenVINO: integrations/openvino.md
-    - PaddlePaddle: integrations/paddlepaddle.md
-    - Paperspace Gradient: integrations/paperspace.md
-    - Ray Tune: integrations/ray-tune.md
-    - Roboflow: integrations/roboflow.md
-    - TF GraphDef: integrations/tf-graphdef.md
-    - TF SavedModel: integrations/tf-savedmodel.md
-    - TF.js: integrations/tfjs.md
-    - TFLite: integrations/tflite.md
-    - TFLite Edge TPU: integrations/edge-tpu.md
-    - TensorBoard: integrations/tensorboard.md
-    - TensorRT: integrations/tensorrt.md
-    - TorchScript: integrations/torchscript.md
-    - VS Code: integrations/vscode.md
-    - Weights & Biases: integrations/weights-biases.md
+      - integrations/index.md
+      - Amazon SageMaker: integrations/amazon-sagemaker.md
+      - ClearML: integrations/clearml.md
+      - Comet ML: integrations/comet.md
+      - CoreML: integrations/coreml.md
+      - DVC: integrations/dvc.md
+      - Google Colab: integrations/google-colab.md
+      - Gradio: integrations/gradio.md
+      - IBM Watsonx: integrations/ibm-watsonx.md
+      - JupyterLab: integrations/jupyterlab.md
+      - Kaggle: integrations/kaggle.md
+      - MLflow: integrations/mlflow.md
+      - NCNN: integrations/ncnn.md
+      - Neural Magic: integrations/neural-magic.md
+      - ONNX: integrations/onnx.md
+      - OpenVINO: integrations/openvino.md
+      - PaddlePaddle: integrations/paddlepaddle.md
+      - Paperspace Gradient: integrations/paperspace.md
+      - Ray Tune: integrations/ray-tune.md
+      - Roboflow: integrations/roboflow.md
+      - TF GraphDef: integrations/tf-graphdef.md
+      - TF SavedModel: integrations/tf-savedmodel.md
+      - TF.js: integrations/tfjs.md
+      - TFLite: integrations/tflite.md
+      - TFLite Edge TPU: integrations/edge-tpu.md
+      - TensorBoard: integrations/tensorboard.md
+      - TensorRT: integrations/tensorrt.md
+      - TorchScript: integrations/torchscript.md
+      - VS Code: integrations/vscode.md
+      - Weights & Biases: integrations/weights-biases.md
   - HUB:
       - hub/index.md
       - Web:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -391,36 +391,36 @@ nav:
               - Comet Logging: yolov5/tutorials/comet_logging_integration.md
               - Clearml Logging: yolov5/tutorials/clearml_logging_integration.md
   - Integrations:
-      - integrations/index.md
-      - TorchScript: integrations/torchscript.md
-      - ONNX: integrations/onnx.md
-      - OpenVINO: integrations/openvino.md
-      - TensorRT: integrations/tensorrt.md
-      - CoreML: integrations/coreml.md
-      - TF SavedModel: integrations/tf-savedmodel.md
-      - TF GraphDef: integrations/tf-graphdef.md
-      - TFLite: integrations/tflite.md
-      - TFLite Edge TPU: integrations/edge-tpu.md
-      - TF.js: integrations/tfjs.md
-      - PaddlePaddle: integrations/paddlepaddle.md
-      - NCNN: integrations/ncnn.md
-      - Comet ML: integrations/comet.md
-      - Ray Tune: integrations/ray-tune.md
-      - Roboflow: integrations/roboflow.md
-      - MLflow: integrations/mlflow.md
-      - ClearML: integrations/clearml.md
-      - DVC: integrations/dvc.md
-      - Weights & Biases: integrations/weights-biases.md
-      - Neural Magic: integrations/neural-magic.md
-      - Gradio: integrations/gradio.md
-      - TensorBoard: integrations/tensorboard.md
-      - Amazon SageMaker: integrations/amazon-sagemaker.md
-      - Paperspace Gradient: integrations/paperspace.md
-      - Google Colab: integrations/google-colab.md
-      - Kaggle: integrations/kaggle.md
-      - JupyterLab: integrations/jupyterlab.md
-      - IBM Watsonx: integrations/ibm-watsonx.md
-      - VS Code: integrations/vscode.md
+    - integrations/index.md
+    - Amazon SageMaker: integrations/amazon-sagemaker.md
+    - ClearML: integrations/clearml.md
+    - Comet ML: integrations/comet.md
+    - CoreML: integrations/coreml.md
+    - DVC: integrations/dvc.md
+    - Google Colab: integrations/google-colab.md
+    - Gradio: integrations/gradio.md
+    - IBM Watsonx: integrations/ibm-watsonx.md
+    - JupyterLab: integrations/jupyterlab.md
+    - Kaggle: integrations/kaggle.md
+    - MLflow: integrations/mlflow.md
+    - NCNN: integrations/ncnn.md
+    - Neural Magic: integrations/neural-magic.md
+    - ONNX: integrations/onnx.md
+    - OpenVINO: integrations/openvino.md
+    - PaddlePaddle: integrations/paddlepaddle.md
+    - Paperspace Gradient: integrations/paperspace.md
+    - Ray Tune: integrations/ray-tune.md
+    - Roboflow: integrations/roboflow.md
+    - TF GraphDef: integrations/tf-graphdef.md
+    - TF SavedModel: integrations/tf-savedmodel.md
+    - TF.js: integrations/tfjs.md
+    - TFLite: integrations/tflite.md
+    - TFLite Edge TPU: integrations/edge-tpu.md
+    - TensorBoard: integrations/tensorboard.md
+    - TensorRT: integrations/tensorrt.md
+    - TorchScript: integrations/torchscript.md
+    - VS Code: integrations/vscode.md
+    - Weights & Biases: integrations/weights-biases.md
   - HUB:
       - hub/index.md
       - Web:


### PR DESCRIPTION
Hi,

Sort the integrations alphabetically. I think this helps to scan faster if a particular integration is supported and a page exists in the docs. I think it looks cleaner now. Before there was no real sorting or meaningful grouping.

Thanks! 🚀

Note: I think it is also possible to subdivide the sidebar into topics like training, deployment, ... but to follow the docs style this would mean creating a separate index.md. Which I think is a bit overkill for now.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced documentation for Ultralytics model integrations.

### 📊 Key Changes
- Updated the integrations documentation to improve clarity and accessibility.
- Reorganized the list of training and deployment integrations.
- Added new integration guides and refined existing ones for better user experience.

### 🎯 Purpose & Impact
- ✨ Makes it easier for users to find and utilize Ultralytics model integrations.
- 🔄 Supports streamlined workflow and collaboration by providing clearer guidance.
- 🌍 Enhances the accessibility of diverse platforms and tools for model training and deployment.