### PR TITLE
Fix typos in Tasks in docs so description matches example code

### DIFF
--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -49,7 +49,7 @@ YOLO11 pretrained OBB models are shown here, which are pretrained on the [DOTAv1
 
 ## Train
 
-Train YOLO11n-obb on the `dota8.yaml` dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
+Train YOLO11n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
 !!! example
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -73,7 +73,7 @@ YOLO11 pretrained Pose models are shown here. Detect, Segment and Pose models ar
 
 ## Train
 
-Train a YOLO11-pose model on the COCO128-pose dataset.
+Train a YOLO11-pose model on the COCO8-pose dataset.
 
 !!! example
 
@@ -110,7 +110,7 @@ YOLO pose dataset format can be found in detail in the [Dataset Guide](../datase
 
 ## Val
 
-Validate trained YOLO11n-pose model [accuracy](https://www.ultralytics.com/glossary/accuracy) on the COCO128-pose dataset. No arguments are needed as the `model` retains its training `data` and arguments as model attributes.
+Validate trained YOLO11n-pose model [accuracy](https://www.ultralytics.com/glossary/accuracy) on the COCO8-pose dataset. No arguments are needed as the `model` retains its training `data` and arguments as model attributes.
 
 !!! example
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -41,7 +41,7 @@ YOLO11 pretrained Segment models are shown here. Detect, Segment and Pose models
 
 ## Train
 
-Train YOLO11n-seg on the COCO128-seg dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
+Train YOLO11n-seg on the COCO8-seg dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
 !!! example
 
@@ -78,7 +78,7 @@ YOLO segmentation dataset format can be found in detail in the [Dataset Guide](.
 
 ## Val
 
-Validate trained YOLO11n-seg model [accuracy](https://www.ultralytics.com/glossary/accuracy) on the COCO128-seg dataset. No arguments are needed as the `model` retains its training `data` and arguments as model attributes.
+Validate trained YOLO11n-seg model [accuracy](https://www.ultralytics.com/glossary/accuracy) on the COCO8-seg dataset. No arguments are needed as the `model` retains its training `data` and arguments as model attributes.
 
 !!! example
 


### PR DESCRIPTION
Hi,

- The dataset names in the text did not match the datasets in the code examples.
- Also change "`dota8.yaml` dataset" to "DOTA8 dataset" to be consistent throughout the page.

Thanks! 🚀






## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated dataset names in the documentation for consistency and clarity.

### 📊 Key Changes
- **Dataset Name Correction**: 
  - Changed `dota8.yaml` to `DOTA8` in the object bounding box (OBB) task documentation.
  - Replaced `COCO128-pose` with `COCO8-pose` in the pose task documentation.
  - Updated `COCO128-seg` to `COCO8-seg` in the segmentation task documentation.

### 🎯 Purpose & Impact
- **Clarity**: Ensures consistent dataset terminology across documentation, reducing confusion for users.
- **User Experience**: Simplifies instructions for training and validation tasks, making it more straightforward for both new and experienced users.