### PR TITLE
Adding missing MNIST160 reference in Docs

### DIFF
--- a/docs/en/datasets/classify/index.md
+++ b/docs/en/datasets/classify/index.md
@@ -113,7 +113,7 @@ Ultralytics supports the following datasets with automatic download:
 - [Imagenette](imagenette.md): A smaller subset of ImageNet that contains 10 easily distinguishable classes for quicker training and testing.
 - [Imagewoof](imagewoof.md): A more challenging subset of ImageNet containing 10 dog breed categories for image classification tasks.
 - [MNIST](mnist.md): A dataset of 70,000 grayscale images of handwritten digits for image classification tasks.
-- [MNIST160](classify/mnist.md):  First 8 images of each MNIST category from the MNIST dataset. Dataset contains 160 images total.
+- [MNIST160](classify/mnist.md): First 8 images of each MNIST category from the MNIST dataset. Dataset contains 160 images total.
 
 ### Adding your own dataset
 

--- a/docs/en/datasets/classify/index.md
+++ b/docs/en/datasets/classify/index.md
@@ -113,7 +113,7 @@ Ultralytics supports the following datasets with automatic download:
 - [Imagenette](imagenette.md): A smaller subset of ImageNet that contains 10 easily distinguishable classes for quicker training and testing.
 - [Imagewoof](imagewoof.md): A more challenging subset of ImageNet containing 10 dog breed categories for image classification tasks.
 - [MNIST](mnist.md): A dataset of 70,000 grayscale images of handwritten digits for image classification tasks.
-- [MNIST160](classify/mnist.md): First 8 images of each MNIST category from the MNIST dataset. Dataset contains 160 images total.
+- [MNIST160](mnist.md): First 8 images of each MNIST category from the MNIST dataset. Dataset contains 160 images total.
 
 ### Adding your own dataset
 

--- a/docs/en/datasets/classify/index.md
+++ b/docs/en/datasets/classify/index.md
@@ -113,6 +113,7 @@ Ultralytics supports the following datasets with automatic download:
 - [Imagenette](imagenette.md): A smaller subset of ImageNet that contains 10 easily distinguishable classes for quicker training and testing.
 - [Imagewoof](imagewoof.md): A more challenging subset of ImageNet containing 10 dog breed categories for image classification tasks.
 - [MNIST](mnist.md): A dataset of 70,000 grayscale images of handwritten digits for image classification tasks.
+- [MNIST160](classify/mnist.md):  First 8 images of each MNIST category from the MNIST dataset. Dataset contains 160 images total.
 
 ### Adding your own dataset
 

--- a/docs/en/datasets/index.md
+++ b/docs/en/datasets/index.md
@@ -85,6 +85,7 @@ Pose estimation is a technique used to determine the pose of the object relative
 - [Imagenette](classify/imagenette.md): A smaller subset of ImageNet that contains 10 easily distinguishable classes for quicker training and testing.
 - [Imagewoof](classify/imagewoof.md): A more challenging subset of ImageNet containing 10 dog breed categories for image classification tasks.
 - [MNIST](classify/mnist.md): A dataset of 70,000 grayscale images of handwritten digits for image classification tasks.
+- [MNIST160](classify/mnist.md):  First 8 images of each MNIST category from the MNIST dataset. Dataset contains 160 images total.
 
 ## [Oriented Bounding Boxes (OBB)](obb/index.md)
 

--- a/docs/en/datasets/index.md
+++ b/docs/en/datasets/index.md
@@ -85,7 +85,7 @@ Pose estimation is a technique used to determine the pose of the object relative
 - [Imagenette](classify/imagenette.md): A smaller subset of ImageNet that contains 10 easily distinguishable classes for quicker training and testing.
 - [Imagewoof](classify/imagewoof.md): A more challenging subset of ImageNet containing 10 dog breed categories for image classification tasks.
 - [MNIST](classify/mnist.md): A dataset of 70,000 grayscale images of handwritten digits for image classification tasks.
-- [MNIST160](classify/mnist.md):  First 8 images of each MNIST category from the MNIST dataset. Dataset contains 160 images total.
+- [MNIST160](classify/mnist.md): First 8 images of each MNIST category from the MNIST dataset. Dataset contains 160 images total.
 
 ## [Oriented Bounding Boxes (OBB)](obb/index.md)
 

--- a/docs/en/usage/python.md
+++ b/docs/en/usage/python.md
@@ -51,7 +51,7 @@ Train mode is used for training a YOLO11 model on a custom dataset. In this mode
 
 !!! example "Train"
 
-    === "From pretrained(recommended)"
+    === "From pretrained (recommended)"
 
         ```python
         from ultralytics import YOLO


### PR DESCRIPTION
Hi,

I noticed that the MNIST160 dataset is only mentioned in Tasks/Classify as a training example dataset, but not in the Datasets section. Fixed that.

Thanks! 🚀

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
New dataset entry added to documentation for easier dataset management.

### 📊 Key Changes
- Added **MNIST160** to the list of supported datasets, featuring a smaller subset of MNIST with 160 total images.
- Minor formatting correction in the Python usage guide.

### 🎯 Purpose & Impact
- 🗂️ **Enhanced Dataset Accessibility**: Users can now access a smaller, more manageable version of the MNIST dataset, making it suitable for quick tests and demonstrations.
- 🧹 **Improved Readability**: Small typo fix enhances clarity in the documentation.