### PR TITLE
Use EdgeTPU export `--delegate_search_step 30`

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -965,7 +965,7 @@ class Exporter:
             f'--out_dir "{Path(f).parent}" '
             "--show_operations "
             "--search_delegate "
-            "--delegate_search_step 3 "
+            "--delegate_search_step 30 "
             "--timeout_sec 180 "
             f'"{tflite_model}"'
         )


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Increased delegate search step for Edge TPU export in the Ultralytics exporter.

### 📊 Key Changes
- Adjusted the `--delegate_search_step` parameter from 3 to 30 in the Edge TPU export function.

### 🎯 Purpose & Impact
- **Improved Efficiency**: By increasing the search step size, the export process may become more efficient, potentially reducing the time it takes to optimize models for Edge TPU.
- **Enhanced Performance**: This change could lead to better performance of models deployed on Edge TPUs, especially for larger and more complex models.