### PR TITLE
Fix naming of dataset for OBB in Google Colab Tutorial

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -582,7 +582,7 @@
         "from ultralytics import YOLO\n",
         "\n",
         "model = YOLO('yolo11n-obb.pt')  # load a pretrained YOLO OBB model\n",
-        "model.train(data='coco8-dota.yaml', epochs=3)  # train the model\n",
+        "model.train(data='dota8.yaml', epochs=3)  # train the model\n",
         "model('https://ultralytics.com/images/bus.jpg')  # predict on an image"
       ],
       "metadata": {


### PR DESCRIPTION
```python
RuntimeError: Dataset 'coco8-dota.yaml' error ❌ 'coco8-dota.yaml' does not exis
```

Dataset name `coco8-dota.yaml` is not valid, should be `dota8.yaml` (also the dota8 dataset is used for the examples in [docs](https://docs.ultralytics.com/tasks/obb/) )

Thanks! 🚀

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
A tutorial update for using a different dataset configuration file.

### 📊 Key Changes
- Updated the training data file in the tutorial from `coco8-dota.yaml` to `dota8.yaml`.

### 🎯 Purpose & Impact
- 🏋️‍♂️ **Improved Training Guidance**: Helps users train models with a more relevant dataset configuration.
- 🌐 **Enhanced Usability**: Makes the tutorial more aligned with supported datasets, benefiting users working with object bounding box models.