### PR TITLE
Fix Home "Where to Start" grid card link alignment in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          token: ${{ secrets._GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0
       - name: Set up Python

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -70,7 +70,7 @@ Explore the Ultralytics Docs, a comprehensive resource designed to help you unde
 
     ***
 
-    Predict on new images, videos and streams with YOLO <br />
+    Predict on new images, videos and streams with YOLO <br /> &nbsp;
 
     ***
 
@@ -90,7 +90,7 @@ Explore the Ultralytics Docs, a comprehensive resource designed to help you unde
 
     ***
 
-    Discover YOLO tasks like detect, segment, classify, pose, OBB and track <br />
+    Discover YOLO tasks like detect, segment, classify, pose, OBB and track <br /> &nbsp;
 
     ***
 
@@ -100,7 +100,7 @@ Explore the Ultralytics Docs, a comprehensive resource designed to help you unde
 
     ***
 
-    Discover Ultralytics' latest state-of-the-art YOLO11 models and their capabilities <br />
+    Discover Ultralytics' latest state-of-the-art YOLO11 models and their capabilities <br /> &nbsp;
 
     ***
 


### PR DESCRIPTION
Addition to #16846. Fix horizontal alignment of links at the bottom of cards. Autoformat accidentally removed trailing spaces. New fix/hack should work to get the intended layout.
Thanks! 🚀

![grafik](https://github.com/user-attachments/assets/e148c462-afbc-4785-af19-c31d5164b767)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor improvements to the documentation's formatting for enhanced readability.

### 📊 Key Changes
- Added non-breaking spaces (`&nbsp;`) to improve line spacing and text flow in the documentation.

### 🎯 Purpose & Impact
- **Enhanced Readability**: These adjustments make the documentation easier to read by ensuring consistent text spacing.
- **Improved User Experience**: Users will find information more accessible, potentially reducing cognitive load when reading through sections.