### PR TITLE
Fix display of links in yolov5 docs

### DIFF
--- a/docs/en/yolov5/index.md
+++ b/docs/en/yolov5/index.md
@@ -22,11 +22,11 @@ keywords: YOLOv5, Ultralytics, object detection, computer vision, deep learning,
 <br>
 <br>
 
-Welcome to the Ultralytics' <a href="https://github.com/ultralytics/yolov5">YOLOv5</a>🚀 Documentation! YOLOv5, the fifth iteration of the revolutionary "You Only Look Once" [object detection](https://www.ultralytics.com/glossary/object-detection) model, is designed to deliver high-speed, high-accuracy results in real-time.
+Welcome to the Ultralytics' <a href="https://github.com/ultralytics/yolov5">YOLOv5</a>🚀 Documentation! YOLOv5, the fifth iteration of the revolutionary "You Only Look Once" <a href="https://www.ultralytics.com/glossary/object-detection">object detection</a> model, is designed to deliver high-speed, high-accuracy results in real-time.
 
 <br><br>
 
-Built on PyTorch, this powerful [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) framework has garnered immense popularity for its versatility, ease of use, and high performance. Our documentation guides you through the installation process, explains the architectural nuances of the model, showcases various use-cases, and provides a series of detailed tutorials. These resources will help you harness the full potential of YOLOv5 for your [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) projects. Let's get started!
+Built on PyTorch, this powerful <a href="https://www.ultralytics.com/glossary/deep-learning-dl">deep learning</a> framework has garnered immense popularity for its versatility, ease of use, and high performance. Our documentation guides you through the installation process, explains the architectural nuances of the model, showcases various use-cases, and provides a series of detailed tutorials. These resources will help you harness the full potential of YOLOv5 for your <a href="https://www.ultralytics.com/glossary/computer-vision-cv">computer vision</a> projects. Let's get started!
 
 </div>
 


### PR DESCRIPTION
Markdown syntax inside HTML block does not work here --> Links displayed incorrectly. Fixed that

Thanks! 🚀

OLD:
![grafik](https://github.com/user-attachments/assets/a7943484-bc03-4efa-9257-43a7de3aa4e6)

NEW (PR): 
![grafik](https://github.com/user-attachments/assets/0265aab9-7cf9-407e-89b9-296a48b51897)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation improvement for the YOLOv5 page, enhancing link formatting for consistency.

### 📊 Key Changes
- Changed plain-text links to HTML anchor tags for "object detection," "deep learning," and "computer vision" in the YOLOv5 documentation page.

### 🎯 Purpose & Impact
- 📘 **Improved Readability**: By using anchor tags, the documentation becomes more visually consistent, enhancing the reading experience.
- 🌐 **Enhanced Navigation**: These changes provide clear, clickable links, making it easier for users to explore related topics and resources directly from the documentation.