### PR TITLE
Add `ultralytics>8.3.0` warning for YOLOv3, YOLOv5, YOLOv6, YOLOv8 and YOLOv9 training.

### DIFF
--- a/docs/en/models/yolov3.md
+++ b/docs/en/models/yolov3.md
@@ -44,6 +44,10 @@ This table provides an at-a-glance view of the capabilities of each YOLOv3 varia
 
 This example provides simple YOLOv3 training and inference examples. For full documentation on these and other [modes](../modes/index.md) see the [Predict](../modes/predict.md), [Train](../modes/train.md), [Val](../modes/val.md) and [Export](../modes/export.md) docs pages.
 
+!!! warning
+
+    Training YOLOv3 with `ultralytics>=8.3.0` will make use of an updated head based on YOLO11. This means the number of parameters and GFLOPs will be different from the original model, and the pretrained weights for the final layer will not get transfered during training. If you wish to train using the original head, you would need to use `ultralytics<8.3.0`.
+
 !!! example
 
     === "Python"

--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -56,6 +56,10 @@ This table provides a detailed overview of the YOLOv5u model variants, highlight
 
 This example provides simple YOLOv5 training and inference examples. For full documentation on these and other [modes](../modes/index.md) see the [Predict](../modes/predict.md), [Train](../modes/train.md), [Val](../modes/val.md) and [Export](../modes/export.md) docs pages.
 
+!!! warning
+
+    Training YOLOv5 with `ultralytics>=8.3.0` will make use of an updated head based on YOLO11. This means the number of parameters and GFLOPs will be different from the original model, and the pretrained weights for the final layer will not get transfered during training. If you wish to train using the original head, you would need to use `ultralytics<8.3.0`.
+
 !!! example
 
     === "Python"

--- a/docs/en/models/yolov6.md
+++ b/docs/en/models/yolov6.md
@@ -36,6 +36,10 @@ YOLOv6 also provides quantized models for different [precisions](https://www.ult
 
 This example provides simple YOLOv6 training and inference examples. For full documentation on these and other [modes](../modes/index.md) see the [Predict](../modes/predict.md), [Train](../modes/train.md), [Val](../modes/val.md) and [Export](../modes/export.md) docs pages.
 
+!!! warning
+
+    Training YOLOv6 with `ultralytics>=8.3.0` will make use of an updated head based on YOLO11. This means the number of parameters and GFLOPs will be different from the original model, and the pretrained weights for the final layer will not get transfered during training. If you wish to train using the original head, you would need to use `ultralytics<8.3.0`.
+
 !!! example
 
     === "Python"

--- a/docs/en/models/yolov8.md
+++ b/docs/en/models/yolov8.md
@@ -129,6 +129,10 @@ This example provides simple YOLOv8 training and inference examples. For full do
 
 Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for object detection. For additional supported tasks see the [Segment](../tasks/segment.md), [Classify](../tasks/classify.md), [OBB](../tasks/obb.md) docs and [Pose](../tasks/pose.md) docs.
 
+!!! warning
+
+    Training YOLOv8 with `ultralytics>=8.3.0` will make use of an updated head based on YOLO11. This means the number of parameters and GFLOPs will be different from the original model, and the pretrained weights for the final layer will not get transfered during training. If you wish to train using the original head, you would need to use `ultralytics<8.3.0`.
+
 !!! example
 
     === "Python"

--- a/docs/en/models/yolov9.md
+++ b/docs/en/models/yolov9.md
@@ -128,6 +128,10 @@ YOLOv9 represents a pivotal development in real-time object detection, offering 
 
 This example provides simple YOLOv9 training and inference examples. For full documentation on these and other [modes](../modes/index.md) see the [Predict](../modes/predict.md), [Train](../modes/train.md), [Val](../modes/val.md) and [Export](../modes/export.md) docs pages.
 
+!!! warning
+
+    Training YOLOv9 with `ultralytics>=8.3.0` will make use of an updated head based on YOLO11. This means the number of parameters and GFLOPs will be different from the original model, and the pretrained weights for the final layer will not get transfered during training. If you wish to train using the original head, you would need to use `ultralytics<8.3.0`.
+
 !!! example
 
     === "Python"

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -870,8 +870,9 @@ def torch_safe_load(weight, safe_only=False):
             # Model is likely using a Detect head prior to 8.3.0
             LOGGER.warning(
                 f"WARNING ⚠️ '{weight}' appears to be a YOLO model trained with ultralytics<8.3.0. "
-                f"Training this model with ultralytics>=8.3.0 will use the updated YOLO11 head instead of original head."
-                f"The pretrained weights of the last layer will not be transferred during training, and the number of parameters and GFLOPs will differ from the original. "
+                f"Training this model with ultralytics>=8.3.0 will use the updated YOLO11 head instead of "
+                f"the original head. The pretrained weights of the last layer will not be transferred during "
+                f"training, and the number of parameters and GFLOPs will differ from the original."
             )
 
     return ckpt, file

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -864,6 +864,17 @@ def torch_safe_load(weight, safe_only=False):
         )
         ckpt = {"model": ckpt.model}
 
+    if isinstance(ckpt["model"].model[-1], Detect):
+        l = ckpt["model"].model[-1].cv3
+        if not any([isinstance(m[1], DWConv) for m in l.named_modules()]):
+            # Model is likely using a Detect head prior to 8.3.0
+            LOGGER.warning(
+                f"WARNING ⚠️ '{weight}' appears to be a YOLO model trained with ultralytics<8.3.0. "
+                f"Training this model with ultralytics>=8.3.0 will use the updated YOLO11 head instead of original head."
+                f"The pretrained weights of the last layer will not be transfered during training, and the number of parameters and GFLOPs will differ from the original. "
+            )
+
+
     return ckpt, file
 
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -871,9 +871,8 @@ def torch_safe_load(weight, safe_only=False):
             LOGGER.warning(
                 f"WARNING ⚠️ '{weight}' appears to be a YOLO model trained with ultralytics<8.3.0. "
                 f"Training this model with ultralytics>=8.3.0 will use the updated YOLO11 head instead of original head."
-                f"The pretrained weights of the last layer will not be transfered during training, and the number of parameters and GFLOPs will differ from the original. "
+                f"The pretrained weights of the last layer will not be transferred during training, and the number of parameters and GFLOPs will differ from the original. "
             )
-
 
     return ckpt, file
 


### PR DESCRIPTION
Closes #16678, closes #17004

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
The PR introduces a warning about the new model head for YOLO versions 3 through 9, due to changes made for YOLO11, impacting training dynamics in Ultralytics 8.3.0 and later.

### 📊 Key Changes
- Added warnings in documentation for YOLOv3 to YOLOv9 about changes in model head starting with Ultralytics version 8.3.0.
- Updated code in `tasks.py` to issue a warning when loading models trained with a previous version if detected.

### 🎯 Purpose & Impact
- **Enhanced Model Head**: The change to a YOLO11-based head aims to enhance performance, though it alters model complexity (parameters, GFLOPs).
- **Training Adjustments**: Pretrained weights for the last layer are not transferred for models trained on versions >= 8.3.0, requiring users to adapt their workflows.
- **Backward Compatibility Notifications**: Warnings ensure users are aware of potential differences when using models trained in previous versions, enhancing clarity and aiding transition.