### PR TITLE
`ultralytics 8.3.20` W&B `plots=False` logging fix

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.3.19"
+__version__ = "8.3.20"
 
 import os
 

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -137,17 +137,19 @@ def on_train_end(trainer):
     if trainer.best.exists():
         art.add_file(trainer.best)
         wb.run.log_artifact(art, aliases=["best"])
-    for curve_name, curve_values in zip(trainer.validator.metrics.curves, trainer.validator.metrics.curves_results):
-        x, y, x_title, y_title = curve_values
-        _plot_curve(
-            x,
-            y,
-            names=list(trainer.validator.metrics.names.values()),
-            id=f"curves/{curve_name}",
-            title=curve_name,
-            x_title=x_title,
-            y_title=y_title,
-        )
+    # Check if we actually have plots to save
+    if trainer.args.plots:
+        for curve_name, curve_values in zip(trainer.validator.metrics.curves, trainer.validator.metrics.curves_results):
+            x, y, x_title, y_title = curve_values
+            _plot_curve(
+                x,
+                y,
+                names=list(trainer.validator.metrics.names.values()),
+                id=f"curves/{curve_name}",
+                title=curve_name,
+                x_title=x_title,
+                y_title=y_title,
+            )
     wb.run.finish()  # required or run continues on dashboard
 
 


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/16738

Simple fix to prevent Wandb trying (and failing) to access non-existent plots, if `plots = False`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved handling of training curves logging in the Weights & Biases (W&B) integration.

### 📊 Key Changes
- Added a condition to check if plotting is enabled before generating curve plots in `on_train_end` callback.

### 🎯 Purpose & Impact
- **Improvement in Efficiency**: The change ensures that curve plots are only generated if the `plots` argument is set by the user, preventing unnecessary operations when plots are not needed. 📉
- **Enhanced User Control**: Users have more control over their logging process, saving time and resources during training if plots are not required. 🕒💻

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to training end processes with conditional plot saving in Ultralytics YOLO.

### 📊 Key Changes
- The version number is updated from 8.3.19 to 8.3.20.
- Added a conditional check for plot generation in the `on_train_end` function.

### 🎯 Purpose & Impact
- **Purpose**: Ensures that plot generation during training end is executed only when explicitly enabled, optimizing performance for users who do not require plots.
- **Impact**: Users can expect reduced unnecessary computational overhead, leading to potentially faster processing and a cleaner workflow when plots are not needed.