### PR TITLE
Add YOLO publication notice in Docs

### DIFF
--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -10,7 +10,7 @@ keywords: YOLO11, state-of-the-art object detection, YOLO series, Ultralytics, c
 
 !!! tip "Ultralytics YOLO11 Publication"
 
-    Ultralytics has not published a formal research paper for YOLO11 due to the rapidly evolving nature of the models. We focus on advancing the technology and making it easier to use, rather than producing static documentation. For the most up-to-date information on YOLO11’s architecture, features, and usage, please refer to our [GitHub repository](https://github.com/ultralytics/ultralytics) and [documentation](https://docs.ultralytics.com).
+    Ultralytics has not published a formal research paper for YOLO11 due to the rapidly evolving nature of the models. We focus on advancing the technology and making it easier to use, rather than producing static documentation. For the most up-to-date information on YOLO architecture, features, and usage, please refer to our [GitHub repository](https://github.com/ultralytics/ultralytics) and [documentation](https://docs.ultralytics.com).
 
 YOLO11 is the latest iteration in the [Ultralytics](https://www.ultralytics.com/) YOLO series of real-time object detectors, redefining what's possible with cutting-edge [accuracy](https://www.ultralytics.com/glossary/accuracy), speed, and efficiency. Building upon the impressive advancements of previous YOLO versions, YOLO11 introduces significant improvements in architecture and training methods, making it a versatile choice for a wide range of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks.
 

--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -8,6 +8,10 @@ keywords: YOLO11, state-of-the-art object detection, YOLO series, Ultralytics, c
 
 ## Overview
 
+!!! tip "Ultralytics YOLO11 Research Paper"
+    
+    There is no official Ultralytics YOLO11 research paper. For comprehensive details on YOLO11, please refer to the official [Documentation](https://docs.ultralytics.com) and [GitHub](https://github.com/ultralytics/ultralytics). Although formal academic papers may not be available, these resources offer in-depth information on model architectures, features, and usage.
+    
 YOLO11 is the latest iteration in the [Ultralytics](https://www.ultralytics.com/) YOLO series of real-time object detectors, redefining what's possible with cutting-edge [accuracy](https://www.ultralytics.com/glossary/accuracy), speed, and efficiency. Building upon the impressive advancements of previous YOLO versions, YOLO11 introduces significant improvements in architecture and training methods, making it a versatile choice for a wide range of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks.
 
 ![Ultralytics YOLO11 Comparison Plots](https://github.com/user-attachments/assets/a311a4ed-bbf2-43b5-8012-5f183a28a845)

--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -10,7 +10,7 @@ keywords: YOLO11, state-of-the-art object detection, YOLO series, Ultralytics, c
 
 !!! tip "Ultralytics YOLO11 Publication"
 
-    There is no official Ultralytics YOLO11 research paper. For comprehensive details on YOLO11, please refer to the official [documentation](https://docs.ultralytics.com) and [GitHub repository](https://github.com/ultralytics/ultralytics). Although formal academic papers may not be available, these resources offer in-depth information on model architectures, features, and usage.
+    Ultralytics has not published a formal research paper for YOLO11 due to the rapidly evolving nature of the models. We focus on advancing the technology and making it easier to use, rather than producing static documentation. For the most up-to-date information on YOLO11’s architecture, features, and usage, please refer to our [GitHub repository](https://github.com/ultralytics/ultralytics) and [documentation](https://docs.ultralytics.com).
 
 YOLO11 is the latest iteration in the [Ultralytics](https://www.ultralytics.com/) YOLO series of real-time object detectors, redefining what's possible with cutting-edge [accuracy](https://www.ultralytics.com/glossary/accuracy), speed, and efficiency. Building upon the impressive advancements of previous YOLO versions, YOLO11 introduces significant improvements in architecture and training methods, making it a versatile choice for a wide range of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks.
 

--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -10,7 +10,7 @@ keywords: YOLO11, state-of-the-art object detection, YOLO series, Ultralytics, c
 
 !!! tip "Ultralytics YOLO11 Research Paper"
     
-    There is no official Ultralytics YOLO11 research paper. For comprehensive details on YOLO11, please refer to the official [Documentation](https://docs.ultralytics.com) and [GitHub](https://github.com/ultralytics/ultralytics). Although formal academic papers may not be available, these resources offer in-depth information on model architectures, features, and usage.
+    There is no official Ultralytics YOLO11 research paper. For comprehensive details on YOLO11, please refer to the official [documentation](https://docs.ultralytics.com) and [GitHub repository](https://github.com/ultralytics/ultralytics). Although formal academic papers may not be available, these resources offer in-depth information on model architectures, features, and usage.
     
 YOLO11 is the latest iteration in the [Ultralytics](https://www.ultralytics.com/) YOLO series of real-time object detectors, redefining what's possible with cutting-edge [accuracy](https://www.ultralytics.com/glossary/accuracy), speed, and efficiency. Building upon the impressive advancements of previous YOLO versions, YOLO11 introduces significant improvements in architecture and training methods, making it a versatile choice for a wide range of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks.
 

--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -9,9 +9,9 @@ keywords: YOLO11, state-of-the-art object detection, YOLO series, Ultralytics, c
 ## Overview
 
 !!! tip "Ultralytics YOLO11 Research Paper"
-    
+
     There is no official Ultralytics YOLO11 research paper. For comprehensive details on YOLO11, please refer to the official [documentation](https://docs.ultralytics.com) and [GitHub repository](https://github.com/ultralytics/ultralytics). Although formal academic papers may not be available, these resources offer in-depth information on model architectures, features, and usage.
-    
+
 YOLO11 is the latest iteration in the [Ultralytics](https://www.ultralytics.com/) YOLO series of real-time object detectors, redefining what's possible with cutting-edge [accuracy](https://www.ultralytics.com/glossary/accuracy), speed, and efficiency. Building upon the impressive advancements of previous YOLO versions, YOLO11 introduces significant improvements in architecture and training methods, making it a versatile choice for a wide range of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks.
 
 ![Ultralytics YOLO11 Comparison Plots](https://github.com/user-attachments/assets/a311a4ed-bbf2-43b5-8012-5f183a28a845)

--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -8,7 +8,7 @@ keywords: YOLO11, state-of-the-art object detection, YOLO series, Ultralytics, c
 
 ## Overview
 
-!!! tip "Ultralytics YOLO11 Research Paper"
+!!! tip "Ultralytics YOLO11 Publication"
 
     There is no official Ultralytics YOLO11 research paper. For comprehensive details on YOLO11, please refer to the official [documentation](https://docs.ultralytics.com) and [GitHub repository](https://github.com/ultralytics/ultralytics). Although formal academic papers may not be available, these resources offer in-depth information on model architectures, features, and usage.
 

--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -14,7 +14,7 @@ keywords: YOLO11, state-of-the-art object detection, YOLO series, Ultralytics, c
 
 YOLO11 is the latest iteration in the [Ultralytics](https://www.ultralytics.com/) YOLO series of real-time object detectors, redefining what's possible with cutting-edge [accuracy](https://www.ultralytics.com/glossary/accuracy), speed, and efficiency. Building upon the impressive advancements of previous YOLO versions, YOLO11 introduces significant improvements in architecture and training methods, making it a versatile choice for a wide range of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks.
 
-![Ultralytics YOLO11 Comparison Plots](hhttps://raw.githubusercontent.com/ultralytics/assets/refs/heads/main/yolo/performance-comparison.png)
+![Ultralytics YOLO11 Comparison Plots](https://raw.githubusercontent.com/ultralytics/assets/refs/heads/main/yolo/performance-comparison.png)
 
 <p align="center">
   <br>

--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -4,7 +4,11 @@ description: Explore YOLOv5u, an advanced object detection model with optimized 
 keywords: YOLOv5, YOLOv5u, object detection, Ultralytics, anchor-free, pre-trained models, accuracy, speed, real-time detection
 ---
 
-# YOLOv5
+# Ultralytics YOLOv5
+
+!!! tip "Ultralytics YOLOv5 Publication"
+
+    Ultralytics has not published a formal research paper for YOLOv5 due to the rapidly evolving nature of the models. We focus on advancing the technology and making it easier to use, rather than producing static documentation. For the most up-to-date information on YOLO architecture, features, and usage, please refer to our [GitHub repository](https://github.com/ultralytics/ultralytics) and [documentation](https://docs.ultralytics.com).
 
 ## Overview
 

--- a/docs/en/models/yolov8.md
+++ b/docs/en/models/yolov8.md
@@ -6,6 +6,10 @@ keywords: YOLOv8, real-time object detection, YOLO series, Ultralytics, computer
 
 # Ultralytics YOLOv8
 
+!!! tip "Ultralytics YOLOv8 Research Paper"
+    
+    There is no official research paper for Ultralytics YOLOv8. For detailed information on YOLOv8, please refer to the official [documentation](https://docs.ultralytics.com) and [GitHub repository](https://github.com/ultralytics/ultralytics). While formal academic papers may not be available, these resources provide comprehensive insights into the model architectures, features, and usage.
+
 ## Overview
 
 YOLOv8 is the latest iteration in the YOLO series of real-time object detectors, offering cutting-edge performance in terms of accuracy and speed. Building upon the advancements of previous YOLO versions, YOLOv8 introduces new features and optimizations that make it an ideal choice for various [object detection](https://www.ultralytics.com/glossary/object-detection) tasks in a wide range of applications.

--- a/docs/en/models/yolov8.md
+++ b/docs/en/models/yolov8.md
@@ -8,7 +8,7 @@ keywords: YOLOv8, real-time object detection, YOLO series, Ultralytics, computer
 
 !!! tip "Ultralytics YOLOv8 Publication"
 
-    There is no official research paper for Ultralytics YOLOv8. For detailed information on YOLOv8, please refer to the official [documentation](https://docs.ultralytics.com) and [GitHub repository](https://github.com/ultralytics/ultralytics). While formal academic papers may not be available, these resources provide comprehensive insights into the model architectures, features, and usage.
+    Ultralytics has not published a formal research paper for YOLOv8 due to the rapidly evolving nature of the models. We focus on advancing the technology and making it easier to use, rather than producing static documentation. For the most up-to-date information on YOLOv8’s architecture, features, and usage, please refer to our [GitHub repository](https://github.com/ultralytics/ultralytics) and [documentation](https://docs.ultralytics.com).
 
 ## Overview
 

--- a/docs/en/models/yolov8.md
+++ b/docs/en/models/yolov8.md
@@ -6,7 +6,7 @@ keywords: YOLOv8, real-time object detection, YOLO series, Ultralytics, computer
 
 # Ultralytics YOLOv8
 
-!!! tip "Ultralytics YOLOv8 Research Paper"
+!!! tip "Ultralytics YOLOv8 Publication"
 
     There is no official research paper for Ultralytics YOLOv8. For detailed information on YOLOv8, please refer to the official [documentation](https://docs.ultralytics.com) and [GitHub repository](https://github.com/ultralytics/ultralytics). While formal academic papers may not be available, these resources provide comprehensive insights into the model architectures, features, and usage.
 

--- a/docs/en/models/yolov8.md
+++ b/docs/en/models/yolov8.md
@@ -8,7 +8,7 @@ keywords: YOLOv8, real-time object detection, YOLO series, Ultralytics, computer
 
 !!! tip "Ultralytics YOLOv8 Publication"
 
-    Ultralytics has not published a formal research paper for YOLOv8 due to the rapidly evolving nature of the models. We focus on advancing the technology and making it easier to use, rather than producing static documentation. For the most up-to-date information on YOLOv8’s architecture, features, and usage, please refer to our [GitHub repository](https://github.com/ultralytics/ultralytics) and [documentation](https://docs.ultralytics.com).
+    Ultralytics has not published a formal research paper for YOLOv8 due to the rapidly evolving nature of the models. We focus on advancing the technology and making it easier to use, rather than producing static documentation. For the most up-to-date information on YOLO architecture, features, and usage, please refer to our [GitHub repository](https://github.com/ultralytics/ultralytics) and [documentation](https://docs.ultralytics.com).
 
 ## Overview
 

--- a/docs/en/models/yolov8.md
+++ b/docs/en/models/yolov8.md
@@ -7,7 +7,7 @@ keywords: YOLOv8, real-time object detection, YOLO series, Ultralytics, computer
 # Ultralytics YOLOv8
 
 !!! tip "Ultralytics YOLOv8 Research Paper"
-    
+
     There is no official research paper for Ultralytics YOLOv8. For detailed information on YOLOv8, please refer to the official [documentation](https://docs.ultralytics.com) and [GitHub repository](https://github.com/ultralytics/ultralytics). While formal academic papers may not be available, these resources provide comprehensive insights into the model architectures, features, and usage.
 
 ## Overview

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -109,7 +109,7 @@ class LoadStreams:
         self.sources = [ops.clean_str(x) for x in sources]  # clean source names for later
         for i, s in enumerate(sources):  # index, source
             # Start thread to read frames from video stream
-            st = f"{i + 1}/{n}: {s}... "
+            st =f"{i + 1}/{n}: {s}... "
             if urlparse(s).hostname in {"www.youtube.com", "youtube.com", "youtu.be"}:  # if source is YouTube video
                 # YouTube format i.e. 'https://www.youtube.com/watch?v=Jsn8D3aC840' or 'https://youtu.be/Jsn8D3aC840'
                 s = get_best_youtube_url(s)

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -109,7 +109,7 @@ class LoadStreams:
         self.sources = [ops.clean_str(x) for x in sources]  # clean source names for later
         for i, s in enumerate(sources):  # index, source
             # Start thread to read frames from video stream
-            st =f"{i + 1}/{n}: {s}... "
+            st = f"{i + 1}/{n}: {s}... "
             if urlparse(s).hostname in {"www.youtube.com", "youtube.com", "youtu.be"}:  # if source is YouTube video
                 # YouTube format i.e. 'https://www.youtube.com/watch?v=Jsn8D3aC840' or 'https://youtu.be/Jsn8D3aC840'
                 s = get_best_youtube_url(s)


### PR DESCRIPTION
Hi @glenn-jocher, I've added an informational message regarding the Ultralytics YOLO11 and YOLOv8 research papers to the relevant documentation pages. :)

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/3158a016-cbf9-427a-9e84-38ae6176b368" alt="Screenshot 1" width="400px" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/3354d586-a35c-4c7a-a37a-125df1aa6496" alt="Screenshot 2" width="400px" />
    </td>
  </tr>
</table>



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates the documentation for YOLO11, YOLOv5, and YOLOv8, adding information about the lack of formal research papers for these models.

### 📊 Key Changes
- Added a note to the YOLO11 documentation explaining the absence of a formal research publication due to the fast-paced evolution of the models.
- Similar notes were added to the YOLOv5 and YOLOv8 documentation.
- Fixed a typo in the URL of the YOLO11 performance comparison image link.

### 🎯 Purpose & Impact
- **Clarification for Users:** Helps users understand why there is no formal research publication and where to find the latest information on the models. 📚
- **Accessibility:** Directs users to the most current resources available on GitHub and the official documentation for updated information. 🧭
- **Improved Documentation:** Provides transparency about Ultralytics' focus on innovation over static documentation, appealing to both developers and wider users seeking cutting-edge solutions. 🚀