### PR TITLE
Fix arbitrary imgsz for TFLite

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -882,16 +882,16 @@ class Exporter:
         # Export to ONNX
         self.args.simplify = True
         f_onnx, _ = self.export_onnx()
-        
+
         # Export to TF
         np_data = None
-        if self.args.int8:      
+        if self.args.int8:
             tmp_file = f / "tmp_tflite_int8_calibration_images.npy"  # int8 calibration images file
             if self.args.data:
                 f.mkdir()
                 images = [batch["img"].permute(0, 2, 3, 1) for batch in self.get_int8_calibration_dataloader(prefix)]
                 if len(set(self.imgsz)) == 2:
-                    images = [img[:,:self.imgsz[0],:self.imgsz[1], :] for img in images]
+                    images = [img[:, : self.imgsz[0], : self.imgsz[1], :] for img in images]
                 images = torch.cat(images, 0).float()
                 np.save(str(tmp_file), images.numpy().astype(np.float32))  # BHWC
                 np_data = [["images", tmp_file, [[[[0, 0, 0]]]], [[[[255, 255, 255]]]]]]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -882,14 +882,21 @@ class Exporter:
         # Export to ONNX
         self.args.simplify = True
         f_onnx, _ = self.export_onnx()
+        
+        custom_imgsz = None
+        if len(set(self.imgsz)) == 2:
+            custom_imgsz = self.imgsz
+            self.imgsz = [max(self.imgsz)]
 
         # Export to TF
         np_data = None
-        if self.args.int8:
+        if self.args.int8:      
             tmp_file = f / "tmp_tflite_int8_calibration_images.npy"  # int8 calibration images file
             if self.args.data:
                 f.mkdir()
                 images = [batch["img"].permute(0, 2, 3, 1) for batch in self.get_int8_calibration_dataloader(prefix)]
+                if custom_imgsz is not None:
+                    images = [img[:,:custom_imgsz[0],:custom_imgsz[1], :] for img in images]
                 images = torch.cat(images, 0).float()
                 np.save(str(tmp_file), images.numpy().astype(np.float32))  # BHWC
                 np_data = [["images", tmp_file, [[[[0, 0, 0]]]], [[[[255, 255, 255]]]]]]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -891,7 +891,9 @@ class Exporter:
             if self.args.data:
                 f.mkdir()
                 images = [batch["img"] for batch in self.get_int8_calibration_dataloader(prefix)]
-                images = torch.nn.functional.interpolate(torch.cat(images, 0).float(), size=self.imgsz).permute(0, 2, 3, 1)
+                images = torch.nn.functional.interpolate(torch.cat(images, 0).float(), size=self.imgsz).permute(
+                    0, 2, 3, 1
+                )
                 np.save(str(tmp_file), images.numpy().astype(np.float32))  # BHWC
                 np_data = [["images", tmp_file, [[[[0, 0, 0]]]], [[[[255, 255, 255]]]]]]
 


### PR DESCRIPTION
This seems a bit of a hack, probably not the best solution (what do you think @Laughing-q ). In short: the problem here is that using an arbitrary imgsz the export with `tflite` fails silently. This is caused by the onnx model being exported with the correct size but the data has a different shape. For now what I do is simply crop the image to fix the problem.

## Test

```python
from ultralytics import YOLO

imgsz = (320, 640)
model = YOLO('yolo11n.pt')
model.export(format='tflite', imgsz=imgsz, int8=True)
model = YOLO('yolo11n_saved_model/yolo11n_full_integer_quant.tflite')
res = model.predict(imgsz=imgsz)
res[0].plot(show=True)
```

## PR:
![image](https://github.com/user-attachments/assets/c488f296-030a-4767-a4da-a2c2a114e21e)

## Main:
![image](https://github.com/user-attachments/assets/32d4bace-9816-4709-95f0-bb831f649e2f)


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
The PR modifies the process for exporting TensorFlow SavedModels, focusing on how Int8 calibration images are handled.

### 📊 Key Changes
- Updated the preparation of Int8 calibration images by adding an interpolation step to match a specified image size (`self.imgsz`).
- Changed the image data preparation for saving, focusing on maintaining consistency in dimension order (BHWC format).

### 🎯 Purpose & Impact
- **Enhanced Compatibility**: Interpolating images to a fixed size ensures compatibility with models expecting specific input dimensions, potentially improving model accuracy and deployment reliability. 📐
- **Data Precision**: By ensuring the correct data format and precision, this change aims to maintain high-quality model performance during the export process. 🧠