### PR TITLE
`ultralytics 8.3.23` fix `bbox2segment` when no segments generated

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.3.22"
+__version__ = "8.3.23"
 
 import os
 

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -632,9 +632,10 @@ def yolo_bbox2segment(im_dir, save_dir=None, sam_model="sam_b.pt"):
         txt_file = save_dir / lb_name
         cls = label["cls"]
         for i, s in enumerate(label["segments"]):
+            if len(s) == 0:
+                continue
             line = (int(cls[i]), *s.reshape(-1))
             texts.append(("%g " * len(line)).rstrip() % line)
-        if texts:
             with open(txt_file, "a") as f:
                 f.writelines(text + "\n" for text in texts)
     LOGGER.info(f"Generated segment labels saved in {save_dir}")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates the YOLO version and fixes a bug in the data converter module.

### 📊 Key Changes
- Bumped the software version from `8.3.22` to `8.3.23`.
- Added a check for non-empty segment lists in `yolo_bbox2segment`, skipping empty segments.

### 🎯 Purpose & Impact
- **Version Update**: Incrementing the version number signals minor improvements or bug fixes, helping users and developers manage software updates more efficiently.
- **Bug Fix**: The update in the data converter prevents errors caused by empty segment lists, enhancing data processing stability and reliability. This means fewer interruptions and unexpected issues for users converting YOLO bounding boxes into segments. 🚀🔧