### PR TITLE
Decrease default confidence threshold to start tracking new tracks

### DIFF
--- a/ultralytics/cfg/trackers/botsort.yaml
+++ b/ultralytics/cfg/trackers/botsort.yaml
@@ -2,7 +2,7 @@
 # Default YOLO tracker settings for BoT-SORT tracker https://github.com/NirAharon/BoT-SORT
 
 tracker_type: botsort # tracker type, ['botsort', 'bytetrack']
-track_high_thresh: 0.5 # threshold for the first association
+track_high_thresh: 0.25 # threshold for the first association
 track_low_thresh: 0.1 # threshold for the second association
 new_track_thresh: 0.25 # threshold for init new track if the detection does not match any tracks
 track_buffer: 30 # buffer to calculate the time when to remove tracks

--- a/ultralytics/cfg/trackers/botsort.yaml
+++ b/ultralytics/cfg/trackers/botsort.yaml
@@ -4,7 +4,7 @@
 tracker_type: botsort # tracker type, ['botsort', 'bytetrack']
 track_high_thresh: 0.5 # threshold for the first association
 track_low_thresh: 0.1 # threshold for the second association
-new_track_thresh: 0.6 # threshold for init new track if the detection does not match any tracks
+new_track_thresh: 0.25 # threshold for init new track if the detection does not match any tracks
 track_buffer: 30 # buffer to calculate the time when to remove tracks
 match_thresh: 0.8 # threshold for matching tracks
 fuse_score: True # Whether to fuse confidence scores with the iou distances before matching

--- a/ultralytics/cfg/trackers/bytetrack.yaml
+++ b/ultralytics/cfg/trackers/bytetrack.yaml
@@ -4,7 +4,7 @@
 tracker_type: bytetrack # tracker type, ['botsort', 'bytetrack']
 track_high_thresh: 0.5 # threshold for the first association
 track_low_thresh: 0.1 # threshold for the second association
-new_track_thresh: 0.6 # threshold for init new track if the detection does not match any tracks
+new_track_thresh: 0.25 # threshold for init new track if the detection does not match any tracks
 track_buffer: 30 # buffer to calculate the time when to remove tracks
 match_thresh: 0.8 # threshold for matching tracks
 fuse_score: True # Whether to fuse confidence scores with the iou distances before matching

--- a/ultralytics/cfg/trackers/bytetrack.yaml
+++ b/ultralytics/cfg/trackers/bytetrack.yaml
@@ -2,7 +2,7 @@
 # Default YOLO tracker settings for ByteTrack tracker https://github.com/ifzhang/ByteTrack
 
 tracker_type: bytetrack # tracker type, ['botsort', 'bytetrack']
-track_high_thresh: 0.5 # threshold for the first association
+track_high_thresh: 0.25 # threshold for the first association
 track_low_thresh: 0.1 # threshold for the second association
 new_track_thresh: 0.25 # threshold for init new track if the detection does not match any tracks
 track_buffer: 30 # buffer to calculate the time when to remove tracks


### PR DESCRIPTION
Closes #14821

This has to be explained too often to users, i.e. how to download the tracker yaml file manually, lower the threshold and pass it as arg to `model.track()`, indicating that the default threshold is higher than what most people are expecting. Most people expect `model.track()` to have similar detections as `model.predict()`. The higher new track threshold drops a lot of predictions compared to `model.predict()`. Lowered it to match the default `model.predict()` confidence threshold.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Thresholds for initialization and association in BoT-SORT and ByteTrack trackers have been lowered to improve tracking performance.

### 📊 Key Changes
- **Track High Threshold:** Reduced from 0.5 to 0.25 for both BoT-SORT and ByteTrack.
- **New Track Threshold:** Lowered from 0.6 to 0.25 for both trackers.
  
### 🎯 Purpose & Impact
- **Enhanced Detection Initiation:** Lower thresholds allow the trackers to initiate new tracks more easily, potentially improving tracking of objects with lower confidence scores.
- **Improved Association:** By reducing the high thresholds, the trackers are more capable of associating detections that might have been missed previously, thus refining tracking accuracy.