### PR TITLE
Fix EdgeTPU wrong PyTorch device

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -345,6 +345,7 @@ class AutoBackend(nn.Module):
                     model_path=w,
                     experimental_delegates=[load_delegate(delegate, options={"device": device})],
                 )
+                device = "cpu"  # Required, otherwise PyTorch will try to use the wrong device
             else:  # TFLite
                 LOGGER.info(f"Loading {w} for TensorFlow Lite inference...")
                 interpreter = Interpreter(model_path=w)  # load TFLite model


### PR DESCRIPTION
Fixes https://github.com/orgs/ultralytics/discussions/8398#discussioncomment-11064662
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixed an issue with device handling in the auto backend for more reliable model loading.

### 📊 Key Changes
- Added a line to specify the device as "cpu" in the `wrap_frozen_graph` function to ensure correct device allocation.

### 🎯 Purpose & Impact
- **Correct Device Usage:** Ensures that models are loaded using the correct computing device, avoiding potential errors or performance issues.
- **Enhanced Reliability:** This tweak helps prevent PyTorch from attempting to use an incorrect device, which can lead to execution failures or inconsistent behavior.