### PR TITLE
Change OpenVINO version for ARM + set OMP_WAIT_POLICY=PASSIVE

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,8 @@ jobs:
   Benchmarks:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.benchmarks == 'true'
     runs-on: ${{ matrix.os }}
+    env:
+      OMP_WAIT_POLICY: PASSIVE
     strategy:
       fail-fast: false
       matrix:
@@ -234,9 +236,11 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
+    env:
+      OMP_WAIT_POLICY: PASSIVE
     steps:
       - uses: actions/checkout@v4
       - name: Activate Virtual Environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,8 +96,8 @@ jobs:
   Benchmarks:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.benchmarks == 'true'
     runs-on: ${{ matrix.os }}
-    env:
-      OMP_WAIT_POLICY: PASSIVE
+    # env:
+    #   OMP_WAIT_POLICY: PASSIVE
     strategy:
       fail-fast: false
       matrix:
@@ -239,8 +239,8 @@ jobs:
     # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
-    env:
-      OMP_WAIT_POLICY: PASSIVE
+    # env:
+    #   OMP_WAIT_POLICY: PASSIVE
     steps:
       - uses: actions/checkout@v4
       - name: Activate Virtual Environment

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -457,7 +457,7 @@ class Exporter:
     @try_export
     def export_openvino(self, prefix=colorstr("OpenVINO:")):
         """YOLO OpenVINO export."""
-        check_requirements(f'openvino{"<=2024.0.0" if ARM64 else ">=2024.0.0"}')  # fix OpenVINO issue on ARM64
+        check_requirements("openvino>=2024.5.0")
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")
@@ -485,7 +485,7 @@ class Exporter:
         if self.args.int8:
             fq = str(self.file).replace(self.file.suffix, f"_int8_openvino_model{os.sep}")
             fq_ov = str(Path(fq) / self.file.with_suffix(".xml").name)
-            check_requirements("nncf>=2.8.0")
+            check_requirements("nncf>=2.14.0")
             import nncf
 
             def transform_fn(data_item) -> np.ndarray:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -457,7 +457,7 @@ class Exporter:
     @try_export
     def export_openvino(self, prefix=colorstr("OpenVINO:")):
         """YOLO OpenVINO export."""
-        check_requirements("openvino>=2024.5.0")
+        check_requirements("openvino-nightly")
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")


### PR DESCRIPTION
This PR depend on https://github.com/ultralytics/ultralytics/pull/16600
I would like to compare performance a new version of OpenVINO (https://github.com/ultralytics/ultralytics/pull/16600) with a modified OMP_WAIT_POLICY flag. OpenMP (in pytotch) has conflict between some different threading libraries (e.g. OneTBB) - you can find description [here](https://github.com/openvinotoolkit/openvino/pull/26950/files).

I found performance degradation without the flag in OpenVINO and NCNN on Apple Silicon (locally)

CC @adrianboguszewski @alvoron 

Thank you.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates the GitHub workflow configurations and adjusts dependencies for exporting models to OpenVINO.

### 📊 Key Changes
- 🔧 Commented out environmental settings (`OMP_WAIT_POLICY: PASSIVE`) in CI and Raspberry Pi workflows.
- 🚀 Updated OpenVINO export dependency from a version-specific requirement to `openvino-nightly`.
- 📈 Changed NNCF dependency version from `>=2.8.0` to `>=2.14.0` for INT8 model export.

### 🎯 Purpose & Impact
- 🛠️ **Enhanced Compatibility**: By using `openvino-nightly`, the codebase stays current with OpenVINO's latest developments, improving compatibility and potentially including the latest features or fixes.
- ⏩ **Streamlined Testing**: Commenting environmental variables and conditions streamlines CI testing configurations, possibly reducing unexpected interactions or simplifying debugging.
- 📊 **Improved Model Export**: Increasing the minimum NNCF version ensures users benefit from the latest improvements or bug fixes in INT8 optimizations, enhancing performance in model deployment.