### PR TITLE
Pin `numpy<=2.0.0` on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ classifiers = [
 
 # Required dependencies ------------------------------------------------------------------------------------------------
 dependencies = [
-    "numpy>=1.23.0", # temporary patch for compat errors https://github.com/ultralytics/yolov5/actions/runs/9538130424/job/26286956354
+    "numpy>=1.23.0",
+    "numpy<2.0.0; sys_platform == 'darwin'", # macOS OpenVINO errors https://github.com/ultralytics/ultralytics/pull/17221
     "matplotlib>=3.3.0",
     "opencv-python>=4.6.0",
     "pillow>=7.1.2",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -457,7 +457,8 @@ class Exporter:
     @try_export
     def export_openvino(self, prefix=colorstr("OpenVINO:")):
         """YOLO OpenVINO export."""
-        check_requirements(("openvino>=2024.0.0", "numpy<2.0.0"))  # fix numpy>=2.0.0 issue with OpenVINO
+        # WARNING: numpy>=2.0.0 issue with OpenVINO on macOS https://github.com/ultralytics/ultralytics/pull/17221
+        check_requirements("openvino>=2024.0.0")
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -457,7 +457,7 @@ class Exporter:
     @try_export
     def export_openvino(self, prefix=colorstr("OpenVINO:")):
         """YOLO OpenVINO export."""
-        check_requirements("openvino>=2024.0.0")  # fix OpenVINO issue on ARM64
+        check_requirements(("openvino>=2024.0.0", "numpy<2.0.0")  # fix numpy>=2.0.0 issue with OpenVINO
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -457,7 +457,7 @@ class Exporter:
     @try_export
     def export_openvino(self, prefix=colorstr("OpenVINO:")):
         """YOLO OpenVINO export."""
-        check_requirements(("openvino>=2024.0.0", "numpy<2.0.0")  # fix numpy>=2.0.0 issue with OpenVINO
+        check_requirements(("openvino>=2024.0.0", "numpy<2.0.0"))  # fix numpy>=2.0.0 issue with OpenVINO
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -457,7 +457,7 @@ class Exporter:
     @try_export
     def export_openvino(self, prefix=colorstr("OpenVINO:")):
         """YOLO OpenVINO export."""
-        check_requirements(f'openvino{"<=2024.0.0" if ARM64 else ">=2024.0.0"}')  # fix OpenVINO issue on ARM64
+        check_requirements("openvino>=2024.0.0")  # fix OpenVINO issue on ARM64
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -458,7 +458,7 @@ class Exporter:
     def export_openvino(self, prefix=colorstr("OpenVINO:")):
         """YOLO OpenVINO export."""
         # WARNING: numpy>=2.0.0 issue with OpenVINO on macOS https://github.com/ultralytics/ultralytics/pull/17221
-        check_requirements("openvino>=2024.0.0")
+        check_requirements(f'openvino{"<=2024.0.0" if ARM64 else ">=2024.0.0"}')  # fix OpenVINO issue on ARM64
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update addresses compatibility issues with macOS when using the OpenVINO export feature.

### 📊 Key Changes
- Added a version restriction for the `numpy` library to be less than 2.0.0 specifically for macOS users.
- Included a warning comment in the OpenVINO export function about potential issues with `numpy>=2.0.0` on macOS.

### 🎯 Purpose & Impact
- **Improved Stability**: By restricting `numpy` versions on macOS, it mitigates errors that occur with OpenVINO, ensuring smoother functionality for macOS users. 🖥️
- **Enhanced Issues Communication**: The warning comment helps developers be aware of specific compatibility concerns when updating dependencies in the future. ⚠️