### PR TITLE
Case-insensitive optimizer name

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -791,7 +791,7 @@ class BaseTrainer:
                 else:  # weight (with decay)
                     g[0].append(param)
 
-        optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "SGD", "auto"}        
+        optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "SGD", "auto"}
         name = {x.lower(): x for x in optimizers}.get(name.lower(), None)
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optimizer = getattr(optim, name, optim.Adam)(g[2], lr=lr, betas=(momentum, 0.999), weight_decay=0.0)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -792,8 +792,9 @@ class BaseTrainer:
                     g[0].append(param)
 
         # Normalize the optimizer name to handle case insensitivity
-        name = {"nadam": "NAdam", "radam": "RAdam", "adamw": "AdamW", "rmsprop": "RMSProp",
-                "sgd": "SGD"}.get(name.lower(), name.capitalize())
+        name = {"nadam": "NAdam", "radam": "RAdam", "adamw": "AdamW", "rmsprop": "RMSProp", "sgd": "SGD"}.get(
+            name.lower(), name.capitalize()
+        )
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optimizer = getattr(optim, name, optim.Adam)(g[2], lr=lr, betas=(momentum, 0.999), weight_decay=0.0)
         elif name == "RMSProp":

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -792,7 +792,8 @@ class BaseTrainer:
                     g[0].append(param)
 
         # Normalize the optimizer name to handle case insensitivity
-        name = {"nadam": "NAdam", "radam": "RAdam", "adamw": "AdamW"}.get(name.lower(), name.capitalize())
+        name = {"nadam": "NAdam", "radam": "RAdam", "adamw": "AdamW", "rmsprop": "RMSProp",
+                "sgd": "SGD"}.get(name.lower(), name.capitalize())
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optimizer = getattr(optim, name, optim.Adam)(g[2], lr=lr, betas=(momentum, 0.999), weight_decay=0.0)
         elif name == "RMSProp":

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -790,6 +790,7 @@ class BaseTrainer:
                     g[1].append(param)
                 else:  # weight (with decay)
                     g[0].append(param)
+
         # Normalize the optimizer name to handle case insensitivity
         name = {"nadam": "NAdam", "radam": "RAdam", "adamw": "AdamW"}.get(name.lower(), name.capitalize())
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -790,7 +790,9 @@ class BaseTrainer:
                     g[1].append(param)
                 else:  # weight (with decay)
                     g[0].append(param)
-
+        # Normalize the optimizer name to handle case insensitivity:
+        name = "NAdam" if name.lower() == "nadam" else "RAdam" if name.lower() == "radam" else "AdamW" \
+            if name.lower() == "adamw" else name.capitalize()
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optimizer = getattr(optim, name, optim.Adam)(g[2], lr=lr, betas=(momentum, 0.999), weight_decay=0.0)
         elif name == "RMSProp":

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -791,10 +791,8 @@ class BaseTrainer:
                 else:  # weight (with decay)
                     g[0].append(param)
 
-        # Normalize the optimizer name to handle case insensitivity
-        name = {"nadam": "NAdam", "radam": "RAdam", "adamw": "AdamW", "rmsprop": "RMSProp", "sgd": "SGD"}.get(
-            name.lower(), name.capitalize()
-        )
+        optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "SGD", "auto"}        
+        name = {x.lower(): x for x in optimizers}.get(name.lower(), None)
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optimizer = getattr(optim, name, optim.Adam)(g[2], lr=lr, betas=(momentum, 0.999), weight_decay=0.0)
         elif name == "RMSProp":
@@ -803,9 +801,8 @@ class BaseTrainer:
             optimizer = optim.SGD(g[2], lr=lr, momentum=momentum, nesterov=True)
         else:
             raise NotImplementedError(
-                f"Optimizer '{name}' not found in list of available optimizers "
-                f"[Adam, AdamW, NAdam, RAdam, RMSProp, SGD, auto]."
-                "To request support for addition optimizers please visit https://github.com/ultralytics/ultralytics."
+                f"Optimizer '{name}' not found in list of available optimizers {optimizers}. "
+                "Request support for addition optimizers at https://github.com/ultralytics/ultralytics."
             )
 
         optimizer.add_param_group({"params": g[0], "weight_decay": decay})  # add g0 with weight_decay

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -790,9 +790,8 @@ class BaseTrainer:
                     g[1].append(param)
                 else:  # weight (with decay)
                     g[0].append(param)
-        # Normalize the optimizer name to handle case insensitivity:
-        name = "NAdam" if name.lower() == "nadam" else "RAdam" if name.lower() == "radam" else "AdamW" \
-            if name.lower() == "adamw" else name.capitalize()
+        # Normalize the optimizer name to handle case insensitivity
+        name = {"nadam": "NAdam", "radam": "RAdam", "adamw": "AdamW"}.get(name.lower(), name.capitalize())
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optimizer = getattr(optim, name, optim.Adam)(g[2], lr=lr, betas=(momentum, 0.999), weight_decay=0.0)
         elif name == "RMSProp":


### PR DESCRIPTION
@glenn-jocher Hi, I noticed that when a user passes `optimizer=adam`, the current code throws an error because it’s case-sensitive and doesn't recognize 'Adam.' I've added case sensitivity to fix this. Thanks :)

**Code**
```
yolo detect train data=coco8.yaml epochs=1 optimizer=adam   # ❌ exisiting code failing
yolo detect train data=coco8.yaml epochs=1 optimizer=adam   # ✅ this PR will resolve this issue.
```




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved optimizer selection process in the training engine, enhancing flexibility and error handling.

### 📊 Key Changes
- Added a dictionary to map optimizer names in lowercase, ensuring case-insensitivity in naming.
- Updated the error message to dynamically include the list of supported optimizers.

### 🎯 Purpose & Impact
- **User Flexibility**: Allows users to specify optimizers without worrying about capitalization, making the system more user-friendly. 🔄
- **Improved Error Messaging**: Provides clearer feedback when an unsupported optimizer is chosen, reducing user confusion and improving overall user experience. 📣