### PR TITLE
Skip MNN export for Raspberry Pi and NVIDIA Jetson

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -191,8 +191,8 @@ def test_export_paddle():
     """Test YOLO exports to Paddle format, noting protobuf conflicts with ONNX."""
     YOLO(MODEL).export(format="paddle", imgsz=32)
 
-
 @pytest.mark.slow
+@pytest.mark.skipif(IS_RASPBERRYPI, reason="MNN not supported on Raspberry Pi")
 def test_export_mnn():
     """Test YOLO exports to MNN format (WARNING: MNN test must precede NCNN test or CI error on Windows)."""
     file = YOLO(MODEL).export(format="mnn", imgsz=32)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -191,6 +191,7 @@ def test_export_paddle():
     """Test YOLO exports to Paddle format, noting protobuf conflicts with ONNX."""
     YOLO(MODEL).export(format="paddle", imgsz=32)
 
+
 @pytest.mark.slow
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="MNN not supported on Raspberry Pi")
 def test_export_mnn():

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -77,6 +77,7 @@ from ultralytics.utils import (
     ARM64,
     DEFAULT_CFG,
     IS_JETSON,
+    IS_RASPBERRYPI,
     LINUX,
     LOGGER,
     MACOS,
@@ -244,6 +245,8 @@ class Exporter:
                 "WARNING ⚠️ INT8 export requires a missing 'data' arg for calibration. "
                 f"Using default 'data={self.args.data}'."
             )
+        if mnn and (IS_RASPBERRYPI or IS_JETSON):
+            raise SystemError("MNN export not supported on Raspberry Pi and NVIDIA Jetson")
         # Input
         im = torch.zeros(self.args.batch, 3, *self.imgsz).to(self.device)
         file = Path(


### PR DESCRIPTION
@glenn-jocher FYI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Add checks to prevent MNN export on Raspberry Pi and Jetson devices due to unsupported compatibility.

### 📊 Key Changes
- Added a condition to skip the `test_export_mnn` for Raspberry Pi devices in the test suite.
- Introduced a system check in the exporter code to raise an error when attempting to export to MNN format on both Raspberry Pi and NVIDIA Jetson.

### 🎯 Purpose & Impact
- **Improved Compatibility Checks**: Ensures that users don’t encounter errors when trying to export models to MNN format on unsupported devices like Raspberry Pi and Jetson, enhancing user experience by preventing failed exports. 🛡️
- **Increased Test Reliability**: By skipping the test on unsupported hardware, it reduces false negatives in test results, providing clearer insights during development and deployment. 🧪