### PR TITLE
Fix Ray Tune error

### DIFF
--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -14,7 +14,7 @@ from ultralytics.utils import DATASETS_DIR, SETTINGS
 from ultralytics.utils.checks import check_requirements
 
 
-#@pytest.mark.skipif(not check_requirements("ray", install=False), reason="ray[tune] not installed")
+# @pytest.mark.skipif(not check_requirements("ray", install=False), reason="ray[tune] not installed")
 def test_model_ray_tune():
     """Tune YOLO model using Ray for hyperparameter optimization."""
     YOLO("yolo11n-cls.yaml").tune(

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -14,7 +14,7 @@ from ultralytics.utils import DATASETS_DIR, SETTINGS
 from ultralytics.utils.checks import check_requirements
 
 
-# @pytest.mark.skipif(not check_requirements("ray", install=False), reason="ray[tune] not installed")
+@pytest.mark.skipif(not check_requirements("ray", install=False), reason="ray[tune] not installed")
 def test_model_ray_tune():
     """Tune YOLO model using Ray for hyperparameter optimization."""
     YOLO("yolo11n-cls.yaml").tune(

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -14,7 +14,7 @@ from ultralytics.utils import DATASETS_DIR, SETTINGS
 from ultralytics.utils.checks import check_requirements
 
 
-@pytest.mark.skipif(not check_requirements("ray", install=False), reason="ray[tune] not installed")
+#@pytest.mark.skipif(not check_requirements("ray", install=False), reason="ray[tune] not installed")
 def test_model_ray_tune():
     """Tune YOLO model using Ray for hyperparameter optimization."""
     YOLO("yolo11n-cls.yaml").tune(

--- a/ultralytics/utils/callbacks/raytune.py
+++ b/ultralytics/utils/callbacks/raytune.py
@@ -16,8 +16,7 @@ def on_fit_epoch_end(trainer):
     """Sends training metrics to Ray Tune at end of each epoch."""
     if ray.train._internal.session._get_session():  # replacement for deprecated ray.tune.is_session_enabled()
         metrics = trainer.metrics
-        metrics["epoch"] = trainer.epoch
-        session.report(metrics)
+        session.report({**metrics, **{"epoch": trainer.epoch}})
 
 
 callbacks = (

--- a/ultralytics/utils/callbacks/raytune.py
+++ b/ultralytics/utils/callbacks/raytune.py
@@ -16,7 +16,7 @@ def on_fit_epoch_end(trainer):
     """Sends training metrics to Ray Tune at end of each epoch."""
     if ray.train._internal.session._get_session():  # replacement for deprecated ray.tune.is_session_enabled()
         metrics = trainer.metrics
-        session.report({**metrics, **{"epoch": trainer.epoch}})
+        session.report({**metrics, **{"epoch": trainer.epoch + 2}})
 
 
 callbacks = (

--- a/ultralytics/utils/callbacks/raytune.py
+++ b/ultralytics/utils/callbacks/raytune.py
@@ -16,7 +16,7 @@ def on_fit_epoch_end(trainer):
     """Sends training metrics to Ray Tune at end of each epoch."""
     if ray.train._internal.session._get_session():  # replacement for deprecated ray.tune.is_session_enabled()
         metrics = trainer.metrics
-        session.report({**metrics, **{"epoch": trainer.epoch + 2}})
+        session.report({**metrics, **{"epoch": trainer.epoch + 1}})
 
 
 callbacks = (


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/17379

Adding "epoch" to metrics causes the `results.csv`to be corrupt since that extra column gets written while saving metrics leading to an extra column.

**MRE**
```python
from ultralytics import YOLO
from ray import tune

model = YOLO("yolo11n.pt")

space = {
"lr0": tune.uniform(0.008, 0.1),
'momentum': tune.uniform(0.6, 0.98),
'weight_decay': tune.uniform(0.0003, 0.0007),
'dfl': tune.uniform(0.8, 1.8)
}

results = model.tune(data="coco128.yaml",
space=space,
epochs=10,
iterations=1,
use_ray=True,
gpu_per_trial=1)
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved integration with Ray Tune by updating how epoch metrics are reported.

### 📊 Key Changes
- Modified the `on_fit_epoch_end` function to adjust how training metrics are sent to Ray Tune at the end of each epoch.
- Simplified the reporting of metrics by directly including the incremented epoch number in the report dictionary.

### 🎯 Purpose & Impact
- 🛠️ Ensures compatibility with Ray Tune's current session handling, avoiding deprecated methods.
- 🚀 Enhances the accuracy of epoch reporting in metrics, potentially improving the clarity and reliability of the training process for users using Ray Tune for hyperparameter tuning.