### PR TITLE
`ultralytics 8.3.30` AutoBatch `0.50` default

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
-__version__ = "8.3.29"
+__version__ = "8.3.30"
 
 import os
 

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -32,14 +32,14 @@ def check_train_batch_size(model, imgsz=640, amp=True, batch=-1):
         return autobatch(deepcopy(model).train(), imgsz, fraction=batch if 0.0 < batch < 1.0 else 0.6)
 
 
-def autobatch(model, imgsz=640, fraction=0.60, batch_size=DEFAULT_CFG.batch):
+def autobatch(model, imgsz=640, fraction=0.50, batch_size=DEFAULT_CFG.batch):
     """
     Automatically estimate the best YOLO batch size to use a fraction of the available CUDA memory.
 
     Args:
         model (torch.nn.module): YOLO model to compute batch size for.
         imgsz (int, optional): The image size used as input for the YOLO model. Defaults to 640.
-        fraction (float, optional): The fraction of available CUDA memory to use. Defaults to 0.60.
+        fraction (float, optional): The fraction of available CUDA memory to use. Defaults to 0.50.
         batch_size (int, optional): The default batch size to use if an error is detected. Defaults to 16.
 
     Returns:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates the auto-batch estimation method in Ultralytics to use less CUDA memory, optimizing performance.

### 📊 Key Changes
- Version update from 8.3.29 to 8.3.30.
- Adjusted default `fraction` for memory usage in `autobatch` from 60% to 50%.

### 🎯 Purpose & Impact
- **Improve Stability**: By reducing the fraction of CUDA memory used, this change aims to prevent out-of-memory errors and enhance the stability of YOLO training processes.
- **Optimize Performance**: Ensures more reliable training even on devices with limited resources, potentially benefiting users running resource-intensive models on less powerful hardware.