### PR TITLE
Fix broken Jetson doc URL

### DIFF
--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -54,7 +54,7 @@ The first step after getting your hands on an NVIDIA Jetson device is to flash N
 
 1. If you own an official NVIDIA Development Kit such as the Jetson Orin Nano Developer Kit, you can [download an image and prepare an SD card with JetPack for booting the device](https://developer.nvidia.com/embedded/learn/get-started-jetson-orin-nano-devkit).
 2. If you own any other NVIDIA Development Kit, you can [flash JetPack to the device using SDK Manager](https://docs.nvidia.com/sdk-manager/install-with-sdkm-jetson/index.html).
-3. If you own a Seeed Studio reComputer J4012 device, you can [flash JetPack to the included SSD](https://wiki.seeedstudio.com/reComputer_J4012_Flash_Jetpack/) and if you own a Seeed Studio reComputer J1020 v2 device, you can [flash JetPack to the eMMC/ SSD](https://wiki.seeedstudio.com/reComputer_J2021_J202_Flash_Jetpack/).
+3. If you own a Seeed Studio reComputer J4012 device, you can [flash JetPack to the included SSD](https://wiki.seeedstudio.com/recomputer_j4012_flash_jetpack/) and if you own a Seeed Studio reComputer J1020 v2 device, you can [flash JetPack to the eMMC/ SSD](https://wiki.seeedstudio.com/reComputer_J2021_J202_Flash_Jetpack/).
 4. If you own any other third party device powered by the NVIDIA Jetson module, it is recommended to follow [command-line flashing](https://docs.nvidia.com/jetson/archives/r35.5.0/DeveloperGuide/IN/QuickStart.html).
 
 !!! note


### PR DESCRIPTION
@glenn-jocher FYI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor correction in the NVIDIA Jetson setup guide to fix a hyperlink for the Seeed Studio reComputer J4012 flash instructions.

### 📊 Key Changes
- Corrected a hyperlink in the NVIDIA Jetson setup documentation for the Seeed Studio reComputer J4012 device.

### 🎯 Purpose & Impact
- 📘 **Enhanced Documentation**: Ensures users can easily access accurate instructions for flashing JetPack, improving the workflow for setting up Jetson devices.
- 🤝 **User-Friendliness**: Simplifies the setup process for Seeed Studio device users by directing them to the correct resources.