### PR TITLE
Fix: wandb reporting error if no positive examples

### DIFF
--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -138,7 +138,7 @@ def on_train_end(trainer):
         art.add_file(trainer.best)
         wb.run.log_artifact(art, aliases=["best"])
     # Check if we actually have plots to save
-    if trainer.args.plots and hasattr(trainer.validator.metrics, 'curves_results'):
+    if trainer.args.plots and hasattr(trainer.validator.metrics, "curves_results"):
         for curve_name, curve_values in zip(trainer.validator.metrics.curves, trainer.validator.metrics.curves_results):
             x, y, x_title, y_title = curve_values
             _plot_curve(

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -138,7 +138,7 @@ def on_train_end(trainer):
         art.add_file(trainer.best)
         wb.run.log_artifact(art, aliases=["best"])
     # Check if we actually have plots to save
-    if trainer.args.plots:
+    if trainer.args.plots and hasattr(trainer.validator.metrics, 'curves_results'):
         for curve_name, curve_values in zip(trainer.validator.metrics.curves, trainer.validator.metrics.curves_results):
             x, y, x_title, y_title = curve_values
             _plot_curve(


### PR DESCRIPTION
Fixes #17543; when there are no positive examples in the validator, `trainer.validator.curves_results` does not exist on `trainer.validator`. We add a simple check to make sure this attribute exists on the validator before proceeding with plotting the curves.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced artifact logging in training to conditionally include plot data.

### 📊 Key Changes
- Modified the condition for saving plots: Plots are now saved only if both `trainer.args.plots` is enabled and `trainer.validator.metrics` includes `curves_results`.

### 🎯 Purpose & Impact
- **Improved efficiency**: Prevents unnecessary plot saving when `curves_results` does not exist, optimizing storage and logging during training.
- **Enhanced functionality**: Ensures that only valid plot data is logged, leading to a cleaner and more relevant artifact history for users leveraging training visualizations.