### PR TITLE
Fix W&B project name separator compatibility

### DIFF
--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -109,9 +109,12 @@ def _log_plots(plots, step):
 
 def on_pretrain_routine_start(trainer):
     """Initiate and start project if module is present."""
-    project = trainer.args.project.replace("/", "-")
-    name = trainer.args.name.replace("/", "-")
-    wb.run or wb.init(project=project or "Ultralytics", name=name, config=vars(trainer.args))
+    if not wb.run:
+        wb.init(
+            project=str(trainer.args.project).replace("/", "-") if trainer.args.project else "Ultralytics", 
+            name=str(trainer.args.name).replace("/", "-"), 
+            config=vars(trainer.args),
+               )
 
 
 def on_fit_epoch_end(trainer):

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -109,7 +109,9 @@ def _log_plots(plots, step):
 
 def on_pretrain_routine_start(trainer):
     """Initiate and start project if module is present."""
-    wb.run or wb.init(project=trainer.args.project or "Ultralytics", name=trainer.args.name, config=vars(trainer.args))
+    project = trainer.args.project.replace("/", "-")
+    name = trainer.args.name.replace("/", "-")
+    wb.run or wb.init(project=project or "Ultralytics", name=name, config=vars(trainer.args))
 
 
 def on_fit_epoch_end(trainer):

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -111,10 +111,10 @@ def on_pretrain_routine_start(trainer):
     """Initiate and start project if module is present."""
     if not wb.run:
         wb.init(
-            project=str(trainer.args.project).replace("/", "-") if trainer.args.project else "Ultralytics", 
-            name=str(trainer.args.name).replace("/", "-"), 
+            project=str(trainer.args.project).replace("/", "-") if trainer.args.project else "Ultralytics",
+            name=str(trainer.args.name).replace("/", "-"),
             config=vars(trainer.args),
-               )
+        )
 
 
 def on_fit_epoch_end(trainer):


### PR DESCRIPTION
In Yolo, project name allows "/" to create hierachical folders (e.g. `project="runs/model_train_1119"`), but this project name cannot be accepted by wandb. This small fix can solve the issue, providing more campatibility. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved how project names are handled in the training setup to avoid issues with special characters. 🚀

### 📊 Key Changes
- Updated the `on_pretrain_routine_start` function to sanitize project and name strings by replacing any '/' characters with '-'.

### 🎯 Purpose & Impact
- **Purpose**: This change ensures that project names and runs are sanitized to prevent errors when using names with special characters.
- **Impact**: Users will experience fewer issues related to naming conventions in project setups, resulting in smoother setup and organization of training runs.