### PR TITLE
Fix `imx500` YOLO support in export table

### DIFF
--- a/docs/en/macros/export-table.md
+++ b/docs/en/macros/export-table.md
@@ -14,4 +14,4 @@
 | [PaddlePaddle](../integrations/paddlepaddle.md)   | `paddle`          | `{{ model_name or "yolo11n" }}_paddle_model/`   | ✅       | `imgsz`, `batch`                                                     |
 | [MNN](../integrations/mnn.md)                     | `mnn`             | `{{ model_name or "yolo11n" }}.mnn`             | ✅       | `imgsz`, `batch`, `int8`, `half`                                     |
 | [NCNN](../integrations/ncnn.md)                   | `ncnn`            | `{{ model_name or "yolo11n" }}_ncnn_model/`     | ✅       | `imgsz`, `half`, `batch`                                             |
-| [IMX500](../integrations/sony-imx500.md)          | `imx`             | `{{ model_name or "yolo11n" }}_imx_model/`      | ✅       | `imgsz`, `int8`                                                      |
+| [IMX500](../integrations/sony-imx500.md)          | `imx`             | `{{ model_name or "yolov8n" }}_imx_model/`      | ✅       | `imgsz`, `int8`                                                      |


### PR DESCRIPTION
@glenn-jocher FYI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation update for the export table in the Ultralytics project.

### 📊 Key Changes
- Corrected the model name from "yolo11n" to "yolov8n" in the IMX500 export table entry.

### 🎯 Purpose & Impact
- **Accuracy Improvement**: This change ensures that the documentation accurately reflects the supported model version, preventing potential confusion for users.
- **Enhanced Clarity**: Improves the understanding of supported exports for IMX500 users.