### PR TITLE
Standardize default region points in docs

### DIFF
--- a/docs/en/guides/heatmaps.md
+++ b/docs/en/guides/heatmaps.md
@@ -49,7 +49,7 @@ A heatmap generated with [Ultralytics YOLO11](https://github.com/ultralytics/ult
         yolo solutions heatmap colormap=cv2.COLORMAP_INFERNO
 
         # Heatmaps + object counting
-        yolo solutions heatmap region=[(20, 400), (1080, 404), (1080, 360), (20, 360)]
+        yolo solutions heatmap region=[(20, 400), (1080, 400), (1080, 360), (20, 360)]
         ```
 
     === "Python"
@@ -67,9 +67,9 @@ A heatmap generated with [Ultralytics YOLO11](https://github.com/ultralytics/ult
         video_writer = cv2.VideoWriter("heatmap_output.avi", cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
 
         # In case you want to apply object counting + heatmaps, you can pass region points.
-        # region_points = [(20, 400), (1080, 404)]  # Define line points
-        # region_points = [(20, 400), (1080, 404), (1080, 360), (20, 360)]  # Define region points
-        # region_points = [(20, 400), (1080, 404), (1080, 360), (20, 360), (20, 400)]  # Define polygon points
+        # region_points = [(20, 400), (1080, 400)]  # Define line points
+        # region_points = [(20, 400), (1080, 400), (1080, 360), (20, 360)]  # Define region points
+        # region_points = [(20, 400), (1080, 400), (1080, 360), (20, 360), (20, 400)]  # Define polygon points
 
         # Init heatmap
         heatmap = solutions.Heatmap(

--- a/docs/en/guides/object-counting.md
+++ b/docs/en/guides/object-counting.md
@@ -58,7 +58,7 @@ Object counting with [Ultralytics YOLO11](https://github.com/ultralytics/ultraly
         yolo solutions count source="path/to/video/file.mp4"
 
         # Pass region coordinates
-        yolo solutions count region=[(20, 400), (1080, 404), (1080, 360), (20, 360)]
+        yolo solutions count region=[(20, 400), (1080, 400), (1080, 360), (20, 360)]
         ```
 
     === "Python"
@@ -74,8 +74,8 @@ Object counting with [Ultralytics YOLO11](https://github.com/ultralytics/ultraly
 
         # Define region points
         # region_points = [(20, 400), (1080, 400)]  # For line counting
-        region_points = [(20, 400), (1080, 404), (1080, 360), (20, 360)]  # For rectangle region counting
-        # region_points = [(20, 400), (1080, 404), (1080, 360), (20, 360), (20, 400)]  # For polygon region counting
+        region_points = [(20, 400), (1080, 400), (1080, 360), (20, 360)]  # For rectangle region counting
+        # region_points = [(20, 400), (1080, 400), (1080, 360), (20, 360), (20, 400)]  # For polygon region counting
 
         # Video writer
         video_writer = cv2.VideoWriter("object_counting_output.avi", cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
@@ -148,7 +148,7 @@ def count_objects_in_region(video_path, output_video_path, model_path):
     w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH, cv2.CAP_PROP_FRAME_HEIGHT, cv2.CAP_PROP_FPS))
     video_writer = cv2.VideoWriter(output_video_path, cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
 
-    region_points = [(20, 400), (1080, 404), (1080, 360), (20, 360)]
+    region_points = [(20, 400), (1080, 400), (1080, 360), (20, 360)]
     counter = solutions.ObjectCounter(show=True, region=region_points, model=model_path)
 
     while cap.isOpened():

--- a/docs/en/guides/queue-management.md
+++ b/docs/en/guides/queue-management.md
@@ -45,7 +45,7 @@ Queue management using [Ultralytics YOLO11](https://github.com/ultralytics/ultra
         yolo solutions queue source="path/to/video/file.mp4"
 
         # Pass queue coordinates
-        yolo solutions queue region=[(20, 400), (1080, 404), (1080, 360), (20, 360)]
+        yolo solutions queue region=[(20, 400), (1080, 400), (1080, 360), (20, 360)]
         ```
 
     === "Python"
@@ -64,8 +64,8 @@ Queue management using [Ultralytics YOLO11](https://github.com/ultralytics/ultra
         video_writer = cv2.VideoWriter("queue_management.avi", cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
 
         # Define queue region points
-        queue_region = [(20, 400), (1080, 404), (1080, 360), (20, 360)]  # Define queue region points
-        # queue_region = [(20, 400), (1080, 404), (1080, 360), (20, 360), (20, 400)]  # Define queue polygon points
+        queue_region = [(20, 400), (1080, 400), (1080, 360), (20, 360)]  # Define queue region points
+        # queue_region = [(20, 400), (1080, 400), (1080, 360), (20, 360), (20, 400)]  # Define queue polygon points
 
         # Init Queue Manager
         queue = solutions.QueueManager(
@@ -126,7 +126,7 @@ import cv2
 from ultralytics import solutions
 
 cap = cv2.VideoCapture("path/to/video.mp4")
-queue_region = [(20, 400), (1080, 404), (1080, 360), (20, 360)]
+queue_region = [(20, 400), (1080, 400), (1080, 360), (20, 360)]
 
 queue = solutions.QueueManager(
     model="yolo11n.pt",

--- a/docs/en/guides/region-counting.md
+++ b/docs/en/guides/region-counting.md
@@ -47,7 +47,7 @@ keywords: object counting, regions, YOLOv8, computer vision, Ultralytics, effici
          w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH, cv2.CAP_PROP_FRAME_HEIGHT, cv2.CAP_PROP_FPS))
 
          # Define region points
-         # region_points = [(20, 400), (1080, 404), (1080, 360), (20, 360)] # Pass region as list
+         # region_points = [(20, 400), (1080, 400), (1080, 360), (20, 360)] # Pass region as list
 
          # pass region as dictionary
          region_points = {

--- a/docs/en/guides/speed-estimation.md
+++ b/docs/en/guides/speed-estimation.md
@@ -50,7 +50,7 @@ keywords: Ultralytics YOLO11, speed estimation, object tracking, computer vision
         yolo solutions speed source="path/to/video/file.mp4"
 
         # Pass region coordinates
-        yolo solutions speed region=[(20, 400), (1080, 404), (1080, 360), (20, 360)]
+        yolo solutions speed region=[(20, 400), (1080, 400), (1080, 360), (20, 360)]
         ```
 
     === "Python"
@@ -68,7 +68,7 @@ keywords: Ultralytics YOLO11, speed estimation, object tracking, computer vision
         video_writer = cv2.VideoWriter("speed_management.avi", cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
 
         # Define speed region points
-        speed_region = [(20, 400), (1080, 404), (1080, 360), (20, 360)]
+        speed_region = [(20, 400), (1080, 400), (1080, 360), (20, 360)]
 
         speed = solutions.SpeedEstimator(
             show=True,  # Display the output

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -83,13 +83,13 @@ SOLUTIONS_HELP_MSG = f"""
                 See all ARGS at https://docs.ultralytics.com/usage/cfg or with 'yolo cfg'
 
     1. Call object counting solution
-        yolo solutions count source="path/to/video/file.mp4" region=[(20, 400), (1080, 404), (1080, 360), (20, 360)]
+        yolo solutions count source="path/to/video/file.mp4" region=[(20, 400), (1080, 400), (1080, 360), (20, 360)]
 
     2. Call heatmaps solution
         yolo solutions heatmap colormap=cv2.COLORMAP_PARAULA model=yolo11n.pt
 
     3. Call queue management solution
-        yolo solutions queue region=[(20, 400), (1080, 404), (1080, 360), (20, 360)] model=yolo11n.pt
+        yolo solutions queue region=[(20, 400), (1080, 400), (1080, 360), (20, 360)] model=yolo11n.pt
 
     4. Call workouts monitoring solution for push-ups
         yolo solutions workout model=yolo11n-pose.pt kpts=[6, 8, 10]


### PR DESCRIPTION
@glenn-jocher replaced region point values in docs from `[(20, 400), (1080, 404), (1080, 360), (20, 360)]` to `[(20, 400), (1080, 400), (1080, 360), (20, 360)]`. Thanks :)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR corrects the coordinates for defining regions in multiple documentation guides related to Ultralytics YOLO features.

### 📊 Key Changes
- Corrected y-coordinate values from `404` to `400` in various documentations for better accuracy.
- Updates are applied across multiple guides, including heatmaps, object counting, queue management, region counting, and speed estimation.

### 🎯 Purpose & Impact
- 🛠️ **Improved Accuracy**: These changes ensure the documented region coordinates match the intended application, improving user comprehension and model execution.
- 📚 **Better Guidance**: Users will now have correct examples for region points, which is crucial for accurate object detection and analysis.
- 🚀 **Streamlined Usage**: By correcting coordinates, it enhances the consistency and reliability of the instructions, making the YOLO solutions easier to implement for users at all levels.