### PR TITLE
Fix labels padding for Letterbox with `center=False`

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1591,7 +1591,7 @@ class LetterBox:
             labels["ratio_pad"] = (labels["ratio_pad"], (left, top))  # for evaluation
 
         if len(labels):
-            labels = self._update_labels(labels, ratio, dw, dh)
+            labels = self._update_labels(labels, ratio, left, top)
             labels["img"] = img
             labels["resized_shape"] = new_shape
             return labels


### PR DESCRIPTION
Closes #17727 

Padding with `top` and `left` value is more correct and general than padding with `dw` and `dh` since the latter doesn't work if `center=False`. If `center=True`, then `left = dw` and `top = dh` so it's still correct. But if it isn't, they are both 0 while `dw` and `dh` aren't.

**`center=False` without PR**
![val_batch0_labels](https://github.com/user-attachments/assets/691b3ba6-ac3f-4bf3-82d7-88807f0c0e37)

**`center=False` with PR**
![val_batch0_labels](https://github.com/user-attachments/assets/1cba0615-f532-483d-8733-c45d7c5178b7)



<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
A minor update was made to improve the label augmentation process in the code.

### 📊 Key Changes
- Adjusted the function call to `_update_labels` to use `left, top` instead of `dw, dh`.

### 🎯 Purpose & Impact
- **Purpose**: This change aims to correctly update label positions during image augmentation by using accurate parameters.
- **Impact**: Users should experience more precise label adjustments during the augmentation process, improving model training and evaluation accuracy. 📈