### PR TITLE
Fix missing labels when all segment points are out of bounds

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1142,9 +1142,9 @@ class RandomPerspective:
         xy = xy @ M.T  # transform
         xy = xy[:, :2] / xy[:, 2:3]
         segments = xy.reshape(n, -1, 2)
+        segments[..., 0] = segments[..., 0].clip(0, self.size[0])
+        segments[..., 1] = segments[..., 1].clip(0, self.size[1])
         bboxes = np.stack([segment2box(xy, self.size[0], self.size[1]) for xy in segments], 0)
-        segments[..., 0] = segments[..., 0].clip(bboxes[:, 0:1], bboxes[:, 2:3])
-        segments[..., 1] = segments[..., 1].clip(bboxes[:, 1:2], bboxes[:, 3:4])
         return bboxes, segments
 
     def apply_keypoints(self, keypoints, M):

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1142,9 +1142,9 @@ class RandomPerspective:
         xy = xy @ M.T  # transform
         xy = xy[:, :2] / xy[:, 2:3]
         segments = xy.reshape(n, -1, 2)
-        segments[..., 0] = segments[..., 0].clip(0, self.size[0])
-        segments[..., 1] = segments[..., 1].clip(0, self.size[1])
         bboxes = np.stack([segment2box(xy, self.size[0], self.size[1]) for xy in segments], 0)
+        segments[..., 0] = segments[..., 0].clip(bboxes[:, 0:1], bboxes[:, 2:3])
+        segments[..., 1] = segments[..., 1].clip(bboxes[:, 1:2], bboxes[:, 3:4])
         return bboxes, segments
 
     def apply_keypoints(self, keypoints, M):

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -75,9 +75,8 @@ def segment2box(segment, width=640, height=640):
         (np.ndarray): the minimum and maximum x and y values of the segment.
     """
     x, y = segment.T  # segment xy
-    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
-    x = x[inside]
-    y = y[inside]
+    x = x.clip(0, width)
+    y = y.clip(0, height)
     return (
         np.array([x.min(), y.min(), x.max(), y.max()], dtype=segment.dtype)
         if any(x)


### PR DESCRIPTION
Closes #17796 

**Tests with modified labels**
Label: `0 0.0 0.0 1.0 0.0 1.0 1.0 0.0 1.0`

**Without PR**
![image](https://github.com/user-attachments/assets/1a5f27fe-501f-404c-bfb3-e26cd274e974)


**With PR**
![train_batch1](https://github.com/user-attachments/assets/bc4a0366-0201-45b6-92e0-9102b9579f70)



<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved handling of out-of-bounds coordinates in segmentation-to-bounding-box conversion for better robustness and efficiency. 🚀

### 📊 Key Changes  
- Replaced the manual bounds-check logic with the use of `clip()` to constrain coordinates within valid image dimensions.  
  - Before: Filtered coordinates to discard values outside bounds (`>= 0` and `<= width/height`).  
  - After: Used `np.clip()` to limit all values between 0 and the specified width/height.  

### 🎯 Purpose & Impact  
- **Purpose**: Streamline the code for better readability and maintainability while ensuring edge-case data is handled more robustly.  
- **Impact**:  
  - Faster and more efficient processing of segmentation data.  
  - Improved bounding-box conversion accuracy, reducing the risk of out-of-bound values causing issues.  
  - Simplifies the code, making it easier for developers to maintain or extend. 👍