### PR TITLE
Add BGR to RGB conversion in LibTorch example

### DIFF
--- a/examples/YOLOv8-LibTorch-CPP-Inference/main.cc
+++ b/examples/YOLOv8-LibTorch-CPP-Inference/main.cc
@@ -226,6 +226,7 @@ int main() {
         cv::Mat image = cv::imread("/path/to/bus.jpg");
         cv::Mat input_image;
         letterbox(image, input_image, {640, 640});
+        cv::cvtColor(input_image, input_image, cv::COLOR_BGR2RGB);
 
         torch::Tensor image_tensor = torch::from_blob(input_image.data, {input_image.rows, input_image.cols, 3}, torch::kByte).to(device);
         image_tensor = image_tensor.toType(torch::kFloat32).div(255);


### PR DESCRIPTION
Reported by @yuriiluzhkov in https://github.com/ultralytics/ultralytics/issues/17734#issuecomment-2501745698

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added a crucial color conversion step in the YOLOv8 LibTorch C++ example to ensure color accuracy during inference. 🎨

### 📊 Key Changes  
- Included a line to convert an image from BGR to RGB using `cv::cvtColor()` before processing it for inference.  

### 🎯 Purpose & Impact  
- **Purpose**: Ensures the image is in the correct color format (RGB) required for accurate model inference.  
- **Impact**: Improves detection results by avoiding color mismatches, especially for users implementing this example in real-world applications. 🌟