### PR TITLE
Fix typo in Sony IMX500 doc

### DIFF
--- a/docs/en/integrations/sony-imx500.md
+++ b/docs/en/integrations/sony-imx500.md
@@ -162,7 +162,7 @@ cd examples/imx500
 Step 3: Run YOLOv8 object detection, using the labels.txt file that has been generated during the IMX500 export.
 
 ```bash
-python imx500_object_detection_demo.py --model <path to network.rpk> --fps 25 --bbox-normalization --ignore-dash-labels --bbox-order xy –labels <path to labels.txt>
+python imx500_object_detection_demo.py --model <path to network.rpk> --fps 25 --bbox-normalization --ignore-dash-labels --bbox-order xy --labels <path to labels.txt>
 ```
 
 Then you will be able to see live inference output as follows


### PR DESCRIPTION
@glenn-jocher FYI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Fixed a minor typo in the command-line example for Sony IMX500 integration documentation.

### 📊 Key Changes  
- Corrected a typo in the command for running YOLOv8 object detection. The incorrect dash (`–`) in `--labels` was replaced with the correct double-dash (`--`).

### 🎯 Purpose & Impact  
- 🛠 **Improved Usability:** Ensures users following the documentation can run the command without errors caused by the typo.  
- 📚 **Enhanced Accuracy:** Makes the integration documentation clearer and more reliable for implementation.