### PR TITLE
Add `MNN` benchmarks to Raspberry Pi doc

### DIFF
--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -142,9 +142,10 @@ YOLO11 benchmarks were run by the Ultralytics team on nine different model forma
 
 We have only included benchmarks for YOLO11n and YOLO11s models because other models sizes are too big to run on the Raspberry Pis and does not offer decent performance.
 
-<div style="text-align: center;">
+<figure style="text-align: center;">
     <img width="800" src="https://github.com/ultralytics/docs/releases/download/0/rpi-yolo11-benchmarks.avif" alt="YOLO11 benchmarks on RPi 5">
-</div>
+    <figcaption style="font-style: italic; color: gray;">Benchmarked with Ultralytics v8.3.39</figcaption>
+</figure>
 
 ### Detailed Comparison Table
 
@@ -156,29 +157,33 @@ The below table represents the benchmark results for two different models (YOLO1
 
         | Format        | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
         |---------------|--------|-------------------|-------------|------------------------|
-        | PyTorch       | ✅      | 5.4               | 0.61        | 524.828                |
-        | TorchScript   | ✅      | 10.5              | 0.6082      | 666.874                |
-        | ONNX          | ✅      | 10.2              | 0.6082      | 181.818                |
-        | OpenVINO      | ✅      | 10.4              | 0.6082      | 530.224                |
-        | TF SavedModel | ✅      | 25.8              | 0.6082      | 405.964                |
-        | TF GraphDef   | ✅      | 10.3              | 0.6082      | 473.558                |
-        | TF Lite       | ✅      | 10.3              | 0.6082      | 324.158                |
-        | PaddlePaddle  | ✅      | 20.4              | 0.6082      | 644.312                |
-        | NCNN          | ✅      | 10.2              | 0.6106      | 93.938                 |
+        | PyTorch       | ✅      | 5.4               | 0.6100      | 405.238                |
+        | TorchScript   | ✅      | 10.5              | 0.6082      | 526.628                |
+        | ONNX          | ✅      | 10.2              | 0.6082      | 168.082                |
+        | OpenVINO      | ✅      | 10.4              | 0.6082      | 81.192                 |
+        | TF SavedModel | ✅      | 25.8              | 0.6082      | 377.968                |
+        | TF GraphDef   | ✅      | 10.3              | 0.6082      | 487.244                |
+        | TF Lite       | ✅      | 10.3              | 0.6082      | 317.398                |
+        | PaddlePaddle  | ✅      | 20.4              | 0.6082      | 561.892                |
+        | MNN           | ✅      | 10.1              | 0.6106      | 112.554                |
+        | NCNN          | ✅      | 10.2              | 0.6106      | 88.026                 |
 
     === "YOLO11s"
 
         | Format        | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
         |---------------|--------|-------------------|-------------|------------------------|
-        | PyTorch       | ✅      | 18.4              | 0.7526      | 1226.426               |
-        | TorchScript   | ✅      | 36.5              | 0.7416      | 1507.95                |
-        | ONNX          | ✅      | 36.3              | 0.7416      | 415.24                 |
-        | OpenVINO      | ✅      | 36.4              | 0.7416      | 1167.102               |
-        | TF SavedModel | ✅      | 91.1              | 0.7416      | 776.14                 |
-        | TF GraphDef   | ✅      | 36.4              | 0.7416      | 1014.396               |
-        | TF Lite       | ✅      | 36.4              | 0.7416      | 845.934                |
-        | PaddlePaddle  | ✅      | 72.5              | 0.7416      | 1567.824               |
-        | NCNN          | ✅      | 36.2              | 0.7419      | 197.358                |
+        | PyTorch       | ✅      | 18.4              | 0.7526      | 1011.60                |
+        | TorchScript   | ✅      | 36.5              | 0.7416      | 1268.502               |
+        | ONNX          | ✅      | 36.3              | 0.7416      | 324.17                 |
+        | OpenVINO      | ✅      | 36.4              | 0.7416      | 179.324                |
+        | TF SavedModel | ✅      | 91.1              | 0.7416      | 714.382                |
+        | TF GraphDef   | ✅      | 36.4              | 0.7416      | 1019.83                |
+        | TF Lite       | ✅      | 36.4              | 0.7416      | 849.86                 |
+        | PaddlePaddle  | ✅      | 72.5              | 0.7416      | 1276.34                |
+        | MNN           | ✅      | 36.2              | 0.7409      | 273.032                |
+        | NCNN          | ✅      | 36.2              | 0.7419      | 194.858                |
+
+    Benchmarked with Ultralytics `v8.3.39`
 
 ## Reproduce Our Results
 

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -143,7 +143,7 @@ YOLO11 benchmarks were run by the Ultralytics team on nine different model forma
 We have only included benchmarks for YOLO11n and YOLO11s models because other models sizes are too big to run on the Raspberry Pis and does not offer decent performance.
 
 <figure style="text-align: center;">
-    <img width="800" src="https://github.com/ultralytics/docs/releases/download/0/rpi-yolo11-benchmarks.avif" alt="YOLO11 benchmarks on RPi 5">
+    <img width="800" src="https://github.com/ultralytics/assets/releases/download/v0.0.0/rpi-yolo11-benchmarks.avif" alt="YOLO11 benchmarks on RPi 5">
     <figcaption style="font-style: italic; color: gray;">Benchmarked with Ultralytics v8.3.39</figcaption>
 </figure>
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced Raspberry Pi YOLO benchmarks with updated formatting, additional details, and new framework testing. 📈🤖

### 📊 Key Changes  
- Replaced `<div>` tag with `<figure>` for improved benchmark image formatting with captions.  
- Added benchmark results for MNN framework, detailing size on disk, mAP performance, and inference time. 🆕  
- Updated inference time values for various frameworks, refining performance metrics.  

### 🎯 Purpose & Impact  
- **Improved Clarity**: The new `<figure>` tag organizes content more cleanly and adds context via captions. 🖼️  
- **Expanded Comparisons**: Including MNN offers users more options and insights into framework performance.  
- **Better Accuracy**: Refined inference times give more precise benchmarks, aiding users in selecting the best framework for their needs. 🚀