### PR TITLE
Add on_model_save callback to log model checkpoints during training

### DIFF
--- a/ultralytics/utils/callbacks/clearml.py
+++ b/ultralytics/utils/callbacks/clearml.py
@@ -96,8 +96,11 @@ def on_train_epoch_end(trainer):
         for k, v in trainer.lr.items():
             task.get_logger().report_scalar("lr", k, v, iteration=trainer.epoch)
 
+
 def on_model_save(trainer):
-    """Log output models during the training process by updating the task with the latest model checkpoint and, at specified intervals, with epoch-specific model checkpoints."""
+    """Log output models during the training process by updating the task with the latest model checkpoint and, at
+    specified intervals, with epoch-specific model checkpoints.
+    """
     if task := Task.current_task():
         # Log last model
         task.update_output_model(


### PR DESCRIPTION
In the current version of the code, there is no capability to save intermediate weights during ClearML training. Therefore, in the event of an interruption, it is impossible to resume training. The addition of this callback is aimed at addressing this issue.

This callback `on_save_model` is designed to be used as a callback during the ClearML training process. It saves the current state of the model at the end of each epoch and updates the task with the last model. If a save period is specified, it also saves the model at specified epochs.
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced ClearML integration with automated model checkpoint logging during training! 🚀  

### 📊 Key Changes  
- Added a new `on_model_save` callback to log model checkpoints to ClearML at specified intervals during training.  
  - Logs the latest "last" model checkpoint.  
  - Logs epoch-specific checkpoint files based on a configurable save period.  
- Integrated the `on_model_save` callback into the existing ClearML callback registry.

### 🎯 Purpose & Impact  
- 🛠️ **Purpose**: Improves workflow efficiency by automatically updating ClearML with model checkpoints, eliminating manual effort.  
- 📈 **Impact**:  
  - Streamlines model versioning and checkpoint tracking within ClearML.  
  - Enhances reproducibility and traceability of experiments.  
  - Especially useful for users relying heavily on ClearML for experiment management.