### PR TITLE
Save arg

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -694,6 +694,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
     from ultralytics.utils.files import increment_path  # for output directory path update
 
     save = overrides.pop("save", None)
+    vw = None  # Initialize VideoWriter outside the loop
     if save:
         w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH, cv2.CAP_PROP_FRAME_HEIGHT, cv2.CAP_PROP_FPS))
         if s_n == "analytics":  # analytical graphs follow fixed shape for output i.e w=1920, h=1080
@@ -709,7 +710,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
             if not success:
                 break
             frame = process(frame, f_n := f_n + 1) if s_n == "analytics" else process(frame)
-            if save:
+            if vw is not None:  # Write frame to video file if VideoWriter is initialized
                 vw.write(frame)
             if cv2.waitKey(1) & 0xFF == ord("q"):
                 break

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -693,12 +693,14 @@ def handle_yolo_solutions(args: List[str]) -> None:
 
     from ultralytics.utils.files import increment_path  # for output directory path update
 
-    w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH, cv2.CAP_PROP_FRAME_HEIGHT, cv2.CAP_PROP_FPS))
-    if s_n == "analytics":  # analytical graphs follow fixed shape for output i.e w=1920, h=1080
-        w, h = 1920, 1080
-    save_dir = increment_path(Path("runs") / "solutions" / "exp", exist_ok=False)
-    save_dir.mkdir(parents=True, exist_ok=True)  # create the output directory
-    vw = cv2.VideoWriter(os.path.join(save_dir, "solution.avi"), cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
+    save = overrides.pop("save", None)
+    if save:
+        w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH, cv2.CAP_PROP_FRAME_HEIGHT, cv2.CAP_PROP_FPS))
+        if s_n == "analytics":  # analytical graphs follow fixed shape for output i.e w=1920, h=1080
+            w, h = 1920, 1080
+        save_dir = increment_path(Path("runs") / "solutions" / "exp", exist_ok=False)
+        save_dir.mkdir(parents=True, exist_ok=True)  # create the output directory
+        vw = cv2.VideoWriter(os.path.join(save_dir, "solution.avi"), cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
 
     try:  # Process video frames
         f_n = 0  # frame number, required for analytical graphs
@@ -707,7 +709,8 @@ def handle_yolo_solutions(args: List[str]) -> None:
             if not success:
                 break
             frame = process(frame, f_n := f_n + 1) if s_n == "analytics" else process(frame)
-            vw.write(frame)
+            if save:
+                vw.write(frame)
             if cv2.waitKey(1) & 0xFF == ord("q"):
                 break
     finally:


### PR DESCRIPTION
@glenn-jocher Hi, this PR introduces the ability for users to explicitly use the `save=True` argument with a solutions call. Previously, the output video was automatically saved regardless of whether the user-specified `save=True` or not. Thank you 😊

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced video processing functionality to support optional saving of output videos. 🛠️🎥

### 📊 Key Changes  
- Introduced a conditional `save` parameter to control whether output videos are saved.  
- Adjusted `VideoWriter` initialization to occur only when saving is enabled.  
- Included checks to ensure frames are written to a video file only if saving is active.  

### 🎯 Purpose & Impact  
- 🛡️ **Purpose**: Avoid unnecessary resource usage by enabling video saving only when explicitly required.  
- ⚡ **Impact**: Improves efficiency, especially for users who don't need to save processed video outputs, while maintaining existing functionality.  
- 💾 Reduces storage consumption by making video saving optional.