### PR TITLE
Fix `np.empty_like` function input type

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -469,7 +469,7 @@ def xyxy2xywhn(x, w=640, h=640, clip=False, eps=0.0):
     if clip:
         x = clip_boxes(x, (h - eps, w - eps))
     assert x.shape[-1] == 4, f"input shape last dimension expected 4 but input shape is {x.shape}"
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x, dtype=float)  # faster than clone/copy    # faster than clone/copy
+    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x, dtype=float)  # faster than clone/copy
     y[..., 0] = ((x[..., 0] + x[..., 2]) / 2) / w  # x center
     y[..., 1] = ((x[..., 1] + x[..., 3]) / 2) / h  # y center
     y[..., 2] = (x[..., 2] - x[..., 0]) / w  # width

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -469,7 +469,7 @@ def xyxy2xywhn(x, w=640, h=640, clip=False, eps=0.0):
     if clip:
         x = clip_boxes(x, (h - eps, w - eps))
     assert x.shape[-1] == 4, f"input shape last dimension expected 4 but input shape is {x.shape}"
-    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x)  # faster than clone/copy
+    y = torch.empty_like(x) if isinstance(x, torch.Tensor) else np.empty_like(x, dtype=float)  # faster than clone/copy    # faster than clone/copy
     y[..., 0] = ((x[..., 0] + x[..., 2]) / 2) / w  # x center
     y[..., 1] = ((x[..., 1] + x[..., 3]) / 2) / h  # y center
     y[..., 2] = (x[..., 2] - x[..., 0]) / w  # width


### PR DESCRIPTION
@glenn-jocher @Laughing-q Hi, the user opened the issue #18043:

_"""
When x1, y1, x2, y2 are all integers, the output of ultralytics.utils.ops.xywhn2xyxy is always an array with elements of 0
"""_

I have performed testing and it seems like the `np.empty_like` method by default doesn't convert the int values to float, so additional conversion will be required for correct results. I am not sure If this change will resolve the issue completely, but I have opened the PR, let's see If all checks pass 😊

**Existing Code Test**

```python
import numpy as np
from ultralytics.utils.ops import xyxy2xywhn

x = np.array([0, 0, 20, 20])
w=40
h=40
print(xyxy2xywhn(x, w, h, eps=0.0))

# output
>>> [0 0 0 0]
```

**Updated Code with PR**

```python
import numpy as np
from ultralytics.utils.ops import xyxy2xywhn

x = np.array([0, 0, 20, 20])
w=40
h=40
print(xyxy2xywhn(x, w, h, eps=0.0))

# output
>>> [0.25        0.25         0.5         0.5]
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced data type handling for numpy arrays to improve reliability in the `xyxy2xywhn` function.

### 📊 Key Changes  
- Updated the `np.empty_like` call to explicitly set `dtype=float` when handling numpy arrays, ensuring consistency in data type.

### 🎯 Purpose & Impact  
- 🛠️ **Improved Reliability**: Fixes potential issues with inconsistent data types in numpy operations, enhancing stability and preventing unexpected errors.  
- 🚀 **Performance Upgrade**: Maintains efficiency with minimal computational overhead while improving data handling robustness.  
- 💡 **Better User Experience**: Reduces debugging headaches for developers by providing predictable and error-free behavior.