### PR TITLE
Change index to start from 1 by default in `predictions.json`

### DIFF
--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -74,7 +74,7 @@ class DetectionValidator(BaseValidator):
             and (val.endswith(f"{os.sep}val2017.txt") or val.endswith(f"{os.sep}test-dev2017.txt"))
         )  # is COCO
         self.is_lvis = isinstance(val, str) and "lvis" in val and not self.is_coco  # is LVIS
-        self.class_map = converter.coco80_to_coco91_class() if self.is_coco else list(range(len(model.names)))
+        self.class_map = converter.coco80_to_coco91_class() if self.is_coco else list(range(1, len(model.names)+1))
         self.args.save_json |= self.args.val and (self.is_coco or self.is_lvis) and not self.training  # run final val
         self.names = model.names
         self.nc = len(model.names)
@@ -288,8 +288,7 @@ class DetectionValidator(BaseValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
-                    "category_id": self.class_map[int(p[5])]
-                    + (1 if self.is_lvis else 0),  # index starts from 1 if it's lvis
+                    "category_id": self.class_map[int(p[5])],
                     "bbox": [round(x, 3) for x in b],
                     "score": round(p[4], 5),
                 }

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -74,7 +74,7 @@ class DetectionValidator(BaseValidator):
             and (val.endswith(f"{os.sep}val2017.txt") or val.endswith(f"{os.sep}test-dev2017.txt"))
         )  # is COCO
         self.is_lvis = isinstance(val, str) and "lvis" in val and not self.is_coco  # is LVIS
-        self.class_map = converter.coco80_to_coco91_class() if self.is_coco else list(range(1, len(model.names)+1))
+        self.class_map = converter.coco80_to_coco91_class() if self.is_coco else list(range(1, len(model.names) + 1))
         self.args.save_json |= self.args.val and (self.is_coco or self.is_lvis) and not self.training  # run final val
         self.names = model.names
         self.nc = len(model.names)

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -160,7 +160,7 @@ class OBBValidator(DetectionValidator):
             for d in data:
                 image_id = d["image_id"]
                 score = d["score"]
-                classname = self.names[d["category_id"]].replace(" ", "-")
+                classname = self.names[d["category_id"] - 1].replace(" ", "-")
                 p = d["poly"]
 
                 with open(f'{pred_txt / f"Task1_{classname}"}.txt', "a") as f:
@@ -175,7 +175,7 @@ class OBBValidator(DetectionValidator):
                 image_id = d["image_id"].split("__")[0]
                 pattern = re.compile(r"\d+___\d+")
                 x, y = (int(c) for c in re.findall(pattern, d["image_id"])[0].split("___"))
-                bbox, score, cls = d["rbox"], d["score"], d["category_id"]
+                bbox, score, cls = d["rbox"], d["score"], d["category_id"] - 1
                 bbox[0] += x
                 bbox[1] += y
                 bbox.extend([score, cls])


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/18136

The `category_id` in COCO JSON format starts from 1 in general, not just for LVIS. This is also the assumption used in the `convert_coco` function, and hence we subtract 1:
https://github.com/ultralytics/ultralytics/blob/d170f1ab6ad740369e5508788ab267a6639fc851/ultralytics/data/converter.py#L302

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved class mapping logic for YOLO evaluation to address indexing inconsistencies in COCO and LVIS datasets.

### 📊 Key Changes  
- Adjusted `class_map` indexing for non-COCO datasets to start from 1 instead of 0.  
- Removed unnecessary indexing condition for LVIS-specific dataset parsing.  
- Fixed category ID offset during bounding box evaluation in OBB (oriented bounding box) results for consistency.

### 🎯 Purpose & Impact  
- 🛠️ **Better compatibility:** Standardizes class indexing across datasets (COCO, LVIS) to ensure evaluation consistency.  
- 🐛 **Bug fixes:** Resolves indexing offset issues, particularly for models handling smaller datasets or custom datasets.  
- 📈 **Improved accuracy:** Ensures proper labeling and metric computation during evaluation, leading to more reliable results for developers and researchers.