### PR TITLE
Add argument validation for export

### DIFF
--- a/docs/en/reference/engine/exporter.md
+++ b/docs/en/reference/engine/exporter.md
@@ -23,6 +23,10 @@ keywords: YOLOv8, export formats, ONNX, TensorRT, CoreML, machine learning model
 
 <br><br><hr><br>
 
+## ::: ultralytics.engine.exporter.validate_args
+
+<br><br><hr><br>
+
 ## ::: ultralytics.engine.exporter.gd_outputs
 
 <br><br><hr><br>

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -84,7 +84,6 @@
   username: Skillnoob
 79740115+0xSynapse@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/79740115?v=4
-  # Note original username deleted: 0xSynapse
   username: github
 8401806+wangzhaode@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/8401806?v=4

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -84,7 +84,8 @@
   username: Skillnoob
 79740115+0xSynapse@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/79740115?v=4
-  username: 0xSynapse
+  # Note original username deleted: 0xSynapse
+  username: github
 8401806+wangzhaode@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/8401806?v=4
   username: wangzhaode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -415,7 +415,6 @@ nav:
       - TF.js: integrations/tfjs.md
       - TFLite: integrations/tflite.md
       - TFLite Edge TPU: integrations/edge-tpu.md
-      - Sony IMX500: integrations/sony-imx500.md
       - TensorBoard: integrations/tensorboard.md
       - TensorRT: integrations/tensorrt.md
       - TorchScript: integrations/torchscript.md

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -152,11 +152,7 @@ def validate_args(format, passed_args):
 
     valid_args = supported_args.get(format.lower(), None)
     assert valid_args is not None, f"ERROR ❌️ valid arguments for '{format}' not listed."
-    custom = {
-        "batch": 1,
-        "data": None,
-        "device": None
-    }  # exporter defaults
+    custom = {"batch": 1, "data": None, "device": None}  # exporter defaults
     default_args = get_cfg(DEFAULT_CFG, custom)
     for arg in export_args:
         not_default = getattr(passed_args, arg, None) != getattr(default_args, arg, None)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -153,12 +153,9 @@ def validate_args(format, passed_args):
     valid_args = supported_args.get(format.lower(), None)
     assert valid_args is not None, f"ERROR ❌️ valid arguments for '{format}' not listed."
     custom = {
-        "imgsz": self.model.args["imgsz"],
         "batch": 1,
         "data": None,
-        "device": None,
-        "verbose": False,
-        "mode": "export",
+        "device": None
     }  # exporter defaults
     default_args = get_cfg(DEFAULT_CFG, custom)
     for arg in export_args:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -158,7 +158,7 @@ def validate_args(format, passed_args):
     for arg in export_args:
         not_default = getattr(passed_args, arg, None) != getattr(DEFAULT_CFG, arg, None)
         if not_default:
-            assert arg in valid_args, f"ERROR ❌️ argument '{arg}' is not supported for format '{format}'"
+            assert arg in valid_args, f"ERROR ❌️ argument '{arg}' is not supported for format='{format}'"
 
 
 def gd_outputs(gd):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -153,13 +153,13 @@ def validate_args(format, passed_args):
     valid_args = supported_args.get(format.lower(), None)
     assert valid_args is not None, f"ERROR ❌️ valid arguments for '{format}' not listed."
     custom = {
-            "imgsz": self.model.args["imgsz"],
-            "batch": 1,
-            "data": None,
-            "device": None,
-            "verbose": False,
-            "mode": "export",
-        }  # exporter defaults
+        "imgsz": self.model.args["imgsz"],
+        "batch": 1,
+        "data": None,
+        "device": None,
+        "verbose": False,
+        "mode": "export",
+    }  # exporter defaults
     default_args = get_cfg(DEFAULT_CFG, custom)
     for arg in export_args:
         not_default = getattr(passed_args, arg, None) != getattr(default_args, arg, None)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -121,11 +121,13 @@ def export_formats():
 
 
 def validate_args(format, passed_args):
-    """Validates arguments based on format.
+    """
+    Validates arguments based on format.
 
     Args:
         format (str): The export format.
         passed_args (Namespace): The arguments used during export.
+
     Raises:
         AssertionError: If an argument that's not supported by the export
         format is used, or if format doesn't have the supported arguments
@@ -147,16 +149,17 @@ def validate_args(format, passed_args):
         "paddle": ["batch"],
         "mnn": ["batch", "int8", "half"],
         "ncnn": ["half", "batch"],
-        "imx": ["int8"]
+        "imx": ["int8"],
     }
-    
+
     valid_args = supported_args.get(format.lower(), None)
     assert valid_args is not None, f"ERROR ❌️ valid arguments for '{format}' not listed."
-    
+
     for arg in export_args:
         not_default = getattr(passed_args, arg, None) != getattr(DEFAULT_CFG, arg, None)
         if not_default:
             assert arg in valid_args, f"ERROR ❌️ argument '{arg}' is not supported for format '{format}'"
+
 
 def gd_outputs(gd):
     """TensorFlow GraphDef model output node names."""

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -152,9 +152,17 @@ def validate_args(format, passed_args):
 
     valid_args = supported_args.get(format.lower(), None)
     assert valid_args is not None, f"ERROR ❌️ valid arguments for '{format}' not listed."
-
+    custom = {
+            "imgsz": self.model.args["imgsz"],
+            "batch": 1,
+            "data": None,
+            "device": None,
+            "verbose": False,
+            "mode": "export",
+        }  # exporter defaults
+    default_args = get_cfg(DEFAULT_CFG, custom)
     for arg in export_args:
-        not_default = getattr(passed_args, arg, None) != getattr(DEFAULT_CFG, arg, None)
+        not_default = getattr(passed_args, arg, None) != getattr(default_args, arg, None)
         if not_default:
             assert arg in valid_args, f"ERROR ❌️ argument '{arg}' is not supported for format='{format}'"
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -129,9 +129,7 @@ def validate_args(format, passed_args):
         passed_args (Namespace): The arguments used during export.
 
     Raises:
-        AssertionError: If an argument that's not supported by the export
-        format is used, or if format doesn't have the supported arguments
-        listed.
+        AssertionError: If an argument that's not supported by the export format is used, or if format doesn't have the supported arguments listed.
     """
     # Only check valid usage of these args
     export_args = ["half", "int8", "dynamic", "keras", "nms", "batch"]


### PR DESCRIPTION
Right now, we don't check if the passed argument is valid for the format, which leads to confusion when the export goes through, but the behavior remains unaltered.

**W/O PR**
```python
In [7]: model.export(format="onnx", int8=True)
Ultralytics 8.3.49 🚀 Python-3.10.14 torch-2.5.1+cu124 CPU (AMD EPYC 7V12 64-Core Processor)
WARNING ⚠️ INT8 export requires a missing 'data' arg for calibration. Using default 'data=coco8.yaml'.
YOLO11n summary (fused): 238 layers, 2,616,248 parameters, 0 gradients, 6.5 GFLOPs

PyTorch: starting from 'yolo11n.pt' with input shape (1, 3, 640, 640) BCHW and output shape(s) (1, 84, 8400) (5.4 MB)

ONNX: starting export with onnx 1.15.0 opset 19...
ONNX: slimming with onnxslim 0.1.34...
ONNX: export success ✅ 1.4s, saved as 'yolo11n.onnx' (10.2 MB)

Export complete (1.7s)
Results saved to /ultralytics
Predict:         yolo predict task=detect model=yolo11n.onnx imgsz=640 int8 
Validate:        yolo val task=detect model=yolo11n.onnx imgsz=640 data=/usr/src/ultralytics/ultralytics/cfg/datasets/coco.yaml int8 
Visualize:       https://netron.app
Out[7]: 'yolo11n.onnx'
```
```python
In [8]: model.export(format="onnx", nms=True)
Ultralytics 8.3.49 🚀 Python-3.10.14 torch-2.5.1+cu124 CPU (AMD EPYC 7V12 64-Core Processor)
YOLO11n summary (fused): 238 layers, 2,616,248 parameters, 0 gradients, 6.5 GFLOPs

PyTorch: starting from 'yolo11n.pt' with input shape (1, 3, 640, 640) BCHW and output shape(s) (1, 84, 8400) (5.4 MB)

ONNX: starting export with onnx 1.15.0 opset 19...
ONNX: slimming with onnxslim 0.1.34...
ONNX: export success ✅ 1.0s, saved as 'yolo11n.onnx' (10.2 MB)

Export complete (1.3s)
Results saved to /ultralytics
Predict:         yolo predict task=detect model=yolo11n.onnx imgsz=640  
Validate:        yolo val task=detect model=yolo11n.onnx imgsz=640 data=/usr/src/ultralytics/ultralytics/cfg/datasets/coco.yaml  
Visualize:       https://netron.app
Out[8]: 'yolo11n.onnx'
```

**W/ PR**
```python
In [10]: model.export(format="onnx", nms=True)
Ultralytics 8.3.49 🚀 Python-3.10.14 torch-2.5.1+cu124 CPU (AMD EPYC 7V12 64-Core Processor)
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In[10], line 1
----> 1 model.export(format="onnx", nms=True)

File /ultralytics/ultralytics/engine/model.py:738, in Model.export(self, **kwargs)
    730 custom = {
    731     "imgsz": self.model.args["imgsz"],
    732     "batch": 1,
   (...)
    735     "verbose": False,
    736 }  # method defaults
    737 args = {**self.overrides, **custom, **kwargs, "mode": "export"}  # highest priority args on the right
--> 738 return Exporter(overrides=args, _callbacks=self.callbacks)(model=self.model)

File /ultralytics/ultralytics/engine/exporter.py:267, in Exporter.__call__(self, model)
    264 self.device = select_device("cpu" if self.args.device is None else self.args.device)
    266 # Argument compatibility checks
--> 267 validate_args(fmt, self.args)
    268 if imx and not self.args.int8:
    269     LOGGER.warning("WARNING ⚠️ IMX only supports int8 export, setting int8=True.")

File /ultralytics/ultralytics/engine/exporter.py:159, in validate_args(format, passed_args)
    157 not_default = getattr(passed_args, arg, None) != getattr(DEFAULT_CFG, arg, None)
    158 if not_default:
--> 159     assert arg in valid_args, f"ERROR ❌️ argument '{arg}' is not supported for format='{format}'"

AssertionError: ERROR ❌️ argument 'nms' is not supported for format='onnx'
```
```python
In [5]: model.export(format="onnx", int8=True)
Ultralytics 8.3.49 🚀 Python-3.10.14 torch-2.5.1+cu124 CPU (AMD EPYC 7V12 64-Core Processor)
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In[5], line 1
----> 1 model.export(format="onnx", int8=True)

File /ultralytics/ultralytics/engine/model.py:738, in Model.export(self, **kwargs)
    730 custom = {
    731     "imgsz": self.model.args["imgsz"],
    732     "batch": 1,
   (...)
    735     "verbose": False,
    736 }  # method defaults
    737 args = {**self.overrides, **custom, **kwargs, "mode": "export"}  # highest priority args on the right
--> 738 return Exporter(overrides=args, _callbacks=self.callbacks)(model=self.model)

File /ultralytics/ultralytics/engine/exporter.py:267, in Exporter.__call__(self, model)
    264 self.device = select_device("cpu" if self.args.device is None else self.args.device)
    266 # Argument compatibility checks
--> 267 validate_args(fmt, self.args)
    268 if imx and not self.args.int8:
    269     LOGGER.warning("WARNING ⚠️ IMX only supports int8 export, setting int8=True.")

File /ultralytics/ultralytics/engine/exporter.py:159, in validate_args(format, passed_args)
    157 not_default = getattr(passed_args, arg, None) != getattr(DEFAULT_CFG, arg, None)
    158 if not_default:
--> 159     assert arg in valid_args, f"ERROR ❌️ argument '{arg}' is not supported for format='{format}'"

AssertionError: ERROR ❌️ argument 'int8' is not supported for format='onnx'
```

Closes https://github.com/ultralytics/ultralytics/issues/18109
Closes https://github.com/ultralytics/ultralytics/issues/16732
Closes https://github.com/ultralytics/ultralytics/issues/17454

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Introduced argument validation for export formats to ensure compatibility during model export.  

### 📊 Key Changes  
- Added a new `validate_args` function to check if export arguments are compatible with the selected export format.  
- Defined a list of supported arguments for multiple export formats (e.g., TorchScript, ONNX, CoreML).  
- Updated documentation to include the new `validate_args` function.  
- Removed Sony IMX500 documentation reference from integrations.  

### 🎯 Purpose & Impact  
- 📋 **Improved robustness**: Ensures incompatible arguments are flagged early, preventing errors during export.  
- ✅ **Better user guidance**: Clear checks for argument compatibility reduce confusion for users.  
- 🚀 **Streamlined model exports**: Enhances reliability across different export formats, improving overall user experience.  
- 📉 **Minor impact on docs**: The Sony IMX500 integration reference was removed, signaling it may no longer be supported.  

This update improves reliability for developers and users exporting models across various formats! 🌟