### PR TITLE
Fix validation callbacks not triggered during OBB model training

### DIFF
--- a/ultralytics/models/yolo/obb/train.py
+++ b/ultralytics/models/yolo/obb/train.py
@@ -39,4 +39,6 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
     def get_validator(self):
         """Return an instance of OBBValidator for validation of YOLO model."""
         self.loss_names = "box_loss", "cls_loss", "dfl_loss"
-        return yolo.obb.OBBValidator(self.test_loader, save_dir=self.save_dir, args=copy(self.args))
+        return yolo.obb.OBBValidator(
+            self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
+        )


### PR DESCRIPTION
Currently validation callbacks (e.g. on_val_start, on_val_batch_end) are not called during the training of OBB models. This is because callbacks are not passed from the OBBTrainer to OBBValidator. This pull request fixes this issue.
