### PR TITLE
Add `imx500` and `MNN` in `tutorial.ipynb` export table

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -42,6 +42,13 @@
         "\n",
         "We hope that the resources in this notebook will help you get the most out of YOLO11. Please browse the YOLO11 <a href=\"https://docs.ultralytics.com/\">Docs</a> for details, raise an issue on <a href=\"https://github.com/ultralytics/ultralytics\">GitHub</a> for support, and join our <a href=\"https://ultralytics.com/discord\">Discord</a> community for questions and discussions!\n",
         "\n",
+        "  <a href=\"https://www.youtube.com/watch?v=ZN3nRZT7b24\" target=\"_blank\">\n",
+        "    <img src=\"https://img.youtube.com/vi/ZN3nRZT7b24/maxresdefault.jpg\" alt=\"Ultralytics Video\" width=\"720\" style=\"border-radius: 10px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);\"></a>\n",
+        "  \n",
+        "  <p style=\"font-size: 16px; font-family: Arial, sans-serif; color: #555;\">\n",
+        "    <strong>Watch: </strong> How to Train\n",
+        "  <a href=\"https://github.com/ultralytics/ultralytics\">Ultralytics</a>\n",
+        "  <a href=\"https://docs.ultralytics.com/models/yolo11/\">YOLO11</a> Model on Custom Dataset using Google Colab Notebook 🚀</p>\n",
         "</div>"
       ]
     },

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -388,8 +388,8 @@
         "| [TF Edge TPU](https://docs.ultralytics.com/integrations/edge-tpu)        | `edgetpu`         | `yolo11n_edgetpu.tflite`  | ✅        | `imgsz`                                                              |\n",
         "| [TF.js](https://docs.ultralytics.com/integrations/tfjs)                  | `tfjs`            | `yolo11n_web_model/`      | ✅        | `imgsz`, `half`, `int8`, `batch`                                     |\n",
         "| [PaddlePaddle](https://docs.ultralytics.com/integrations/paddlepaddle)   | `paddle`          | `yolo11n_paddle_model/`   | ✅        | `imgsz`, `batch`                                                     |\n",
-        "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |\n",
         "| [MNN](https://docs.ultralytics.com/integrations/mnn)                   | `mnn`            | `yolo11n.mnn`     | ✅        | `imgsz`, `batch`, `int8`, `half`                                             |\n",
+        "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |\n",
         "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500)                   | `imx`            | `yolo11n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
       ],
       "metadata": {

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -390,7 +390,7 @@
         "| [PaddlePaddle](https://docs.ultralytics.com/integrations/paddlepaddle)   | `paddle`          | `yolo11n_paddle_model/`   | ✅        | `imgsz`, `batch`                                                     |\n",
         "| [MNN](https://docs.ultralytics.com/integrations/mnn)                   | `mnn`            | `yolo11n.mnn`     | ✅        | `imgsz`, `batch`, `int8`, `half`                                             |\n",
         "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |\n",
-        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500)                   | `imx`            | `yolo11n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
+        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500)                   | `imx`            | `yolov8n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
       ],
       "metadata": {
         "id": "nPZZeNrLCQG6"

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -376,9 +376,9 @@
         "| [TF Edge TPU](https://docs.ultralytics.com/integrations/edge-tpu)        | `edgetpu`         | `yolo11n_edgetpu.tflite`  | ✅        | `imgsz`                                                              |\n",
         "| [TF.js](https://docs.ultralytics.com/integrations/tfjs)                  | `tfjs`            | `yolo11n_web_model/`      | ✅        | `imgsz`, `half`, `int8`, `batch`                                     |\n",
         "| [PaddlePaddle](https://docs.ultralytics.com/integrations/paddlepaddle)   | `paddle`          | `yolo11n_paddle_model/`   | ✅        | `imgsz`, `batch`                                                     |\n",
-        "| [MNN](https://docs.ultralytics.com/integrations/mnn)                   | `mnn`            | `yolo11n.mnn`     | ✅        | `imgsz`, `batch`, `int8`, `half`                                             |\n",
+        "| [MNN](https://docs.ultralytics.com/integrations/mnn)                     | `mnn`             | `yolo11n.mnn`             | ✅        | `imgsz`, `batch`, `int8`, `half`                                     |\n",
         "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |\n",
-        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500)                   | `imx`            | `yolov8n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
+        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500)          | `imx`             | `yolov8n_imx_model/`      | ✅        | `imgsz`, `int8`                                                      |"
       ],
       "metadata": {
         "id": "nPZZeNrLCQG6"

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -389,6 +389,8 @@
         "| [TF.js](https://docs.ultralytics.com/integrations/tfjs)                  | `tfjs`            | `yolo11n_web_model/`      | ✅        | `imgsz`, `half`, `int8`, `batch`                                     |\n",
         "| [PaddlePaddle](https://docs.ultralytics.com/integrations/paddlepaddle)   | `paddle`          | `yolo11n_paddle_model/`   | ✅        | `imgsz`, `batch`                                                     |\n",
         "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |"
+        "| [MNN](https://docs.ultralytics.com/integrations/mnn)                   | `mnn`            | `yolo11n.mnn`     | ✅        | `imgsz`, `batch`, `int8`, `half`                                             |"
+        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500.md)                   | `mnn`            | `yolo11n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
       ],
       "metadata": {
         "id": "nPZZeNrLCQG6"

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -390,7 +390,7 @@
         "| [PaddlePaddle](https://docs.ultralytics.com/integrations/paddlepaddle)   | `paddle`          | `yolo11n_paddle_model/`   | ✅        | `imgsz`, `batch`                                                     |\n",
         "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |\n",
         "| [MNN](https://docs.ultralytics.com/integrations/mnn)                   | `mnn`            | `yolo11n.mnn`     | ✅        | `imgsz`, `batch`, `int8`, `half`                                             |\n",
-        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500.md)                   | `mnn`            | `yolo11n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
+        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500)                   | `mnn`            | `yolo11n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
       ],
       "metadata": {
         "id": "nPZZeNrLCQG6"

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -390,7 +390,7 @@
         "| [PaddlePaddle](https://docs.ultralytics.com/integrations/paddlepaddle)   | `paddle`          | `yolo11n_paddle_model/`   | ✅        | `imgsz`, `batch`                                                     |\n",
         "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |\n",
         "| [MNN](https://docs.ultralytics.com/integrations/mnn)                   | `mnn`            | `yolo11n.mnn`     | ✅        | `imgsz`, `batch`, `int8`, `half`                                             |\n",
-        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500)                   | `mnn`            | `yolo11n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
+        "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500)                   | `imx`            | `yolo11n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
       ],
       "metadata": {
         "id": "nPZZeNrLCQG6"

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -388,8 +388,8 @@
         "| [TF Edge TPU](https://docs.ultralytics.com/integrations/edge-tpu)        | `edgetpu`         | `yolo11n_edgetpu.tflite`  | ✅        | `imgsz`                                                              |\n",
         "| [TF.js](https://docs.ultralytics.com/integrations/tfjs)                  | `tfjs`            | `yolo11n_web_model/`      | ✅        | `imgsz`, `half`, `int8`, `batch`                                     |\n",
         "| [PaddlePaddle](https://docs.ultralytics.com/integrations/paddlepaddle)   | `paddle`          | `yolo11n_paddle_model/`   | ✅        | `imgsz`, `batch`                                                     |\n",
-        "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |"
-        "| [MNN](https://docs.ultralytics.com/integrations/mnn)                   | `mnn`            | `yolo11n.mnn`     | ✅        | `imgsz`, `batch`, `int8`, `half`                                             |"
+        "| [NCNN](https://docs.ultralytics.com/integrations/ncnn)                   | `ncnn`            | `yolo11n_ncnn_model/`     | ✅        | `imgsz`, `half`, `batch`                                             |\n",
+        "| [MNN](https://docs.ultralytics.com/integrations/mnn)                   | `mnn`            | `yolo11n.mnn`     | ✅        | `imgsz`, `batch`, `int8`, `half`                                             |\n",
         "| [IMX500](https://docs.ultralytics.com/integrations/sony-imx500.md)                   | `mnn`            | `yolo11n_imx_model/`     | ✅        | `imgsz`, `int8`                                             |"
       ],
       "metadata": {

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -54,25 +54,6 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "<div align=\"center\">\n",
-        "  \n",
-        "  <a href=\"https://www.youtube.com/watch?v=ZN3nRZT7b24\" target=\"_blank\">\n",
-        "    <img src=\"https://img.youtube.com/vi/ZN3nRZT7b24/maxresdefault.jpg\" alt=\"Ultralytics Video\" width=\"720\" style=\"border-radius: 10px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);\"></a>\n",
-        "  \n",
-        "  <p style=\"font-size: 16px; font-family: Arial, sans-serif; color: #555;\">\n",
-        "    <strong>Watch: </strong> How to Train\n",
-        "  <a href=\"https://github.com/ultralytics/ultralytics\">Ultralytics</a>\n",
-        "  <a href=\"https://docs.ultralytics.com/models/yolo11/\">YOLO11</a> Model on Custom Dataset using Google Colab Notebook 🚀</p>\n",
-        "\n",
-        "</div>"
-      ],
-      "metadata": {
-        "id": "DXHD1DC5M64G"
-      }
-    },
-    {
-      "cell_type": "markdown",
       "metadata": {
         "id": "7mGmQbAO5pQb"
       },

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -786,7 +786,7 @@ class Annotator:
             stage_text, (int(center_kpt[0]), int(center_kpt[1]) + angle_height + count_height + 40), color, txt_color
         )
 
-    def seg_bbox(self, mask, mask_color=(255, 0, 255), label=None, txt_color=(255, 255, 255)):
+    def seg_bbox(self, mask, mask_color=(255, 0, 255), label=None, txt_color=None):
         """
         Function for drawing segmented object in bounding box shape.
 
@@ -796,6 +796,8 @@ class Annotator:
             label (str, optional): Text label for the object. If None, no label is drawn.
             txt_color (tuple): RGB color for the label text.
         """
+        if txt_color is None:
+            txt_color = self.get_txt_color(mask_color)
         if mask.size == 0:  # no masks to plot
             return
 

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -786,7 +786,7 @@ class Annotator:
             stage_text, (int(center_kpt[0]), int(center_kpt[1]) + angle_height + count_height + 40), color, txt_color
         )
 
-    def seg_bbox(self, mask, mask_color=(255, 0, 255), label=None, txt_color=None):
+    def seg_bbox(self, mask, mask_color=(255, 0, 255), label=None, txt_color=(255, 255, 255)):
         """
         Function for drawing segmented object in bounding box shape.
 
@@ -796,8 +796,6 @@ class Annotator:
             label (str, optional): Text label for the object. If None, no label is drawn.
             txt_color (tuple): RGB color for the label text.
         """
-        if txt_color is None:
-            txt_color = self.get_txt_color(mask_color)
         if mask.size == 0:  # no masks to plot
             return
 


### PR DESCRIPTION
@glenn-jocher 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced **YOLO11 tutorial notebook** and integrations list for better usability and expanded support. 🚀

### 📊 Key Changes  
- 📝 Removed redundant `<div>` tags in the tutorial notebook for cleaner markdown formatting.  
- ✨ Added new export format support:  
  - **MNN** integration entry added with support for `imgsz`, `batch`, `int8`, `half` arguments.  
  - **IMX500** (Sony IMX500) integration entry added with `imgsz`, `int8` compatibility.  

### 🎯 Purpose & Impact  
- 🛠️ Improved readability and maintainability of the example tutorial notebook by cleaning up formatting.  
- 🌐 Expanded export options for YOLO11 models to **MNN** and **IMX500**, providing broader deployment flexibility for users leveraging diverse hardware platforms and applications.  
- 🚀 These updates make it easier for developers to integrate YOLO11 across more edge and production environments.