### PR TITLE
Fix JetPack6 Dockerfile for NVIDIA Jetson

### DIFF
--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -32,9 +32,6 @@ COPY . .
 RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
-# Download onnxruntime-gpu 1.18.0 from https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
-ADD https://nvidia.box.com/shared/static/48dtuob7meiw6ebgfsfqakc9vse62sg4.whl onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl
-
 # Pip install onnxruntime-gpu, torch, torchvision and ultralytics
 RUN python3 -m pip install --upgrade pip uv
 RUN uv pip install --system \


### PR DESCRIPTION
@glenn-jocher This is a minor fix. I failed to remove some stuff earlier which is repeated later.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated the Jetson JetPack 6 Dockerfile by removing a specific ONNX Runtime GPU package reference for a cleaner and more streamlined setup. 🚀  

### 📊 Key Changes  
- 🗑️ Removed the manual addition of the `onnxruntime-gpu 1.18.0` package using a pre-downloaded `.whl` file within the Dockerfile.  

### 🎯 Purpose & Impact  
- 🔧 **Simplifies setup**: Reduces dependencies on external sources, making the Dockerfile more maintainable and reducing potential errors during builds.  
- 🌍 **Improves adaptability**: Allows users to install their preferred versions of `onnxruntime-gpu`, enhancing flexibility for various hardware configurations.  
- 💡 **Streamlined experience**: Cleaner build process for JetPack 6 users developing AI models with Ultralytics tools.