### PR TITLE
Min CI Python 3.9 from 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,7 +165,7 @@ jobs:
         torch: [latest]
         include:
           - os: ubuntu-latest
-            python-version: "3.8" # torch 1.8.0 requires python >=3.6, <=3.8
+            python-version: "3.9" # torch 1.8.0 requires python >=3.6, <=3.9
             torch: "1.8.0" # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
3.8 Python runners will sunset in January as default runners migrate linux versions.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated Python version in CI testing workflow to align with compatibility requirements for PyTorch 1.8.0. 🛠️🐍  

### 📊 Key Changes  
- Modified the CI workflow (`ci.yaml`) to test with Python 3.9 instead of 3.8.  

### 🎯 Purpose & Impact  
- **Purpose**: Ensures compatibility with the Python versions supported by PyTorch 1.8.0 (now using Python 3.9 as its upper limit).  
- **Impact**: Improves CI testing accuracy and aligns tests with the latest compatible environments, leading to more reliable codebase maintenance for users and contributors. 🚀