### PR TITLE
fix bug in the ConfusionMatrix class

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -372,10 +372,9 @@ class ConfusionMatrix:
             else:
                 self.matrix[self.nc, gc] += 1  # true background
 
-        if n:
-            for i, dc in enumerate(detection_classes):
-                if not any(m1 == i):
-                    self.matrix[dc, self.nc] += 1  # predicted background
+        for i, dc in enumerate(detection_classes):
+            if not any(m1 == i):
+                self.matrix[dc, self.nc] += 1  # predicted background
 
     def matrix(self):
         """Returns the confusion matrix."""


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/18407

When a prediction doesn't match any ground truth, and a ground truth doesn't match any prediction, we expect the confusion matrix to show 1 FP and 1 FN.

However, current implementation only shows 1 FN and no FP.

**Minimum Reproducible Code**
```python
from ultralytics.utils.metrics import ConfusionMatrix
import torch

matrix = ConfusionMatrix(nc=1)
detections = torch.tensor([[50, 50, 100, 100, 0.6, 0]])
gt_bboxes = torch.tensor([[200, 200, 300, 300]])
gt_cls = torch.tensor([0])

matrix.process_batch(detections, gt_bboxes, gt_cls)

print(matrix.matrix)
```

**main**
```python
In [8]: print(matrix.matrix)
[[          0           0]
 [          1           0]]
```

**PR**
```python
In [9]: print(matrix.matrix)
[[          0           1]
 [          1           0]]
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->