### PR TITLE
Fix Path objects lacking split method

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -151,7 +151,6 @@ Below are code examples for using each source type:
         # Load a pretrained YOLO11n model
         model = YOLO("yolo11n.pt")
 
-
         # Define current screenshot as source
         source = "screen"
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -26,7 +26,7 @@ In the world of [machine learning](https://www.ultralytics.com/glossary/machine-
 ## Real-world Applications
 
 |                   Manufacturing                   |                        Sports                        |                   Safety                    |
-| :-----------------------------------------------: | :--------------------------------------------------: | :-----------------------------------------: |
+| :-----------------------------------------: | :--------------------------------------------------: | :-----------------------------------------: |
 | ![Vehicle Spare Parts Detection][car spare parts] | ![Football Player Detection][football player detect] | ![People Fall Detection][human fall detect] |
 |           Vehicle Spare Parts Detection           |              Football Player Detection               |            People Fall Detection            |
 
@@ -150,6 +150,8 @@ Below are code examples for using each source type:
 
         # Load a pretrained YOLO11n model
         model = YOLO("yolo11n.pt")
+
+
 
         # Define current screenshot as source
         source = "screen"

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -26,7 +26,7 @@ In the world of [machine learning](https://www.ultralytics.com/glossary/machine-
 ## Real-world Applications
 
 |                   Manufacturing                   |                        Sports                        |                   Safety                    |
-| :-----------------------------------------: | :--------------------------------------------------: | :-----------------------------------------: |
+| :-----------------------------------------------: | :--------------------------------------------------: | :-----------------------------------------: |
 | ![Vehicle Spare Parts Detection][car spare parts] | ![Football Player Detection][football player detect] | ![People Fall Detection][human fall detect] |
 |           Vehicle Spare Parts Detection           |              Football Player Detection               |            People Fall Detection            |
 
@@ -150,7 +150,6 @@ Below are code examples for using each source type:
 
         # Load a pretrained YOLO11n model
         model = YOLO("yolo11n.pt")
-
 
 
         # Define current screenshot as source

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -303,7 +303,7 @@ def get_cfg(cfg: Union[str, Path, Dict, SimpleNamespace] = DEFAULT_CFG_DICT, ove
         if k in cfg and isinstance(cfg[k], (int, float)):
             cfg[k] = str(cfg[k])
     if cfg.get("name") == "model":  # assign model to 'name' arg
-        cfg["name"] = cfg.get("model", "").split(".")[0]
+        cfg["name"] = str(cfg.get("model", "")).split(".")[0]
         LOGGER.warning(f"WARNING ⚠️ 'name=model' automatically updated to 'name={cfg['name']}'.")
 
     # Type and Value checks


### PR DESCRIPTION
# Reason for modification:

When I create an instance of YOLO, if the parameter input is `'yolo11s'` instead of `'yolo11s.pt'`, and the `name` is set to `'model'` in the `model.train()` method, an error occurs. Specifically, due to `cfg.get("model", "")` on Line 306 of `get_cfg()` in `ultralytics/cfg/__init__.py` obtaining a `pathlib.Path` object instead of the expected `str` object, an error is reported when the `.split()` method is called. Below is the specific code:

---------- Running Code ----------

```python
from ultralytics import YOLO

model = YOLO("yolo11s")  # 🚨'yoloo11s' instead of 'yolo11s.pt'

results = model.train(
    data="ultralytics/cfg/datasets/coco128.yaml", 
    epochs=10, 
    batch=4,
    imgsz=640, 
    device=[0],
    project='__test',
    name='model',
)
```

---------- Error Message ----------

```
Traceback (most recent call last):
  File "/mnt/d/GitHub/ultralytics/train.py", line 5, in <module>
    results = model.train(
  File "/mnt/d/GitHub/ultralytics/ultralytics/engine/model.py", line 800, in train
    self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
  File "/mnt/d/GitHub/ultralytics/ultralytics/engine/trainer.py", line 101, in __init__
    self.args = get_cfg(cfg, overrides)
  File "/mnt/d/GitHub/ultralytics/ultralytics/cfg/__init__.py", line 306, in get_cfg
    cfg["name"] = cfg.get("model", "").split(".")[0]
AttributeError: 'PosixPath' object has no attribute 'split'
```

Error message corresponding code:

```python
# Special handling for numeric project/name
for k in "project", "name":
	if k in cfg and isinstance(cfg[k], (int, float)):
		cfg[k] = str(cfg[k])
if cfg.get("name") == "model":  # assign model to 'name' arg
	cfg["name"] = cfg.get("model", "").split(".")[0]  # 🚨Here!
	LOGGER.warning(f"WARNING ⚠️ 'name=model' automatically updated to 'name={cfg['name']}'.")
```

# Code modification: 

To avoid this situation, I used the `str()` method to convert the `pathlib.Path` object into a `str` object, thereby solving the error.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor update to improve type handling for the `name` attribute in configuration files. 🛠️

### 📊 Key Changes  
- Updated the code to ensure that the `model` value is explicitly converted to a string before extracting the `name` attribute. 

### 🎯 Purpose & Impact  
- **Purpose**: Prevent unexpected type errors by explicitly handling data as strings.  
- **Impact**: Improves reliability of configuration management and reduces the likelihood of runtime issues related to type mismatches. 🔒  
- **User Benefit**: Smoother experience when defining models in configuration files with better error prevention. 🚀