### PR TITLE
Add warning about Windows multi-processing error when launching training

### DIFF
--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -50,7 +50,7 @@ The following are some notable features of YOLO11's Train mode:
 Train YOLO11n on the COCO8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. The training device can be specified using the `device` argument. If no argument is passed GPU `device=0` will be used if available, otherwise `device='cpu'` will be used. See Arguments section below for a full list of training arguments.
 
 !!! warning "Windows Multi-Processing Error"
-    On Windows, you may receive a `RuntimeError` when launching the training as a script. Add a `if __name__ == "__main__":` block before your training code to resolve it.
+On Windows, you may receive a `RuntimeError` when launching the training as a script. Add a `if __name__ == "__main__":` block before your training code to resolve it.
 
 !!! example "Single-GPU and CPU Training Example"
 

--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -49,6 +49,9 @@ The following are some notable features of YOLO11's Train mode:
 
 Train YOLO11n on the COCO8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. The training device can be specified using the `device` argument. If no argument is passed GPU `device=0` will be used if available, otherwise `device='cpu'` will be used. See Arguments section below for a full list of training arguments.
 
+!!! warning "Windows Multi-Processing Error"
+    On Windows, you may receive a `RuntimeError` when launching the training as a script. Add a `if __name__ == "__main__":` block before your training code to resolve it.
+
 !!! example "Single-GPU and CPU Training Example"
 
     Device is determined automatically. If a GPU is available then it will be used, otherwise training will start on CPU.

--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -50,7 +50,8 @@ The following are some notable features of YOLO11's Train mode:
 Train YOLO11n on the COCO8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. The training device can be specified using the `device` argument. If no argument is passed GPU `device=0` will be used if available, otherwise `device='cpu'` will be used. See Arguments section below for a full list of training arguments.
 
 !!! warning "Windows Multi-Processing Error"
-On Windows, you may receive a `RuntimeError` when launching the training as a script. Add a `if __name__ == "__main__":` block before your training code to resolve it.
+
+    On Windows, you may receive a `RuntimeError` when launching the training as a script. Add a `if __name__ == "__main__":` block before your training code to resolve it.
 
 !!! example "Single-GPU and CPU Training Example"
 


### PR DESCRIPTION
This has been reported over a dozen times across Discord and GitHub. It occurs when you use `model.train()` inside a Python script and launch it with `python script.py` on Windows.

Example: https://github.com/ultralytics/ultralytics/issues/17096

Probably a good idea to add the solution to docs.
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added a troubleshooting note to address a known issue with Windows multi-processing during training.

### 📊 Key Changes  
- 🛠 Added a warning section in the `train.md` documentation explaining how to fix a `RuntimeError` when running training scripts on Windows.  
- ⚙️ Suggested using a `if __name__ == "__main__":` block to resolve this error.

### 🎯 Purpose & Impact  
- 🚨 **Purpose**: To help Windows users avoid runtime crashes when launching training scripts by providing a clear and simple troubleshooting step.  
- 😊 **Impact**: Improves the training experience for Windows users, reduces confusion, and ensures smoother script execution.