### PR TITLE
Add benchmarks for Pi 4B/5

### DIFF
--- a/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
+++ b/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
@@ -181,19 +181,19 @@ Find comprehensive information on the [Predict](../modes/predict.md) page for fu
 
         | Image Size | Model   | Standard Inference Time (ms) | High Frequency Inference Time (ms) |
         |------------|---------|------------------------------|------------------------------------|
-        | 320        | yolov8n | 32.2                         | 26.7                               |
-        | 320        | yolov8s | 47.1                         | 39.8                               |
-        | 512        | yolov8n | 73.5                         | 60.7                               |
-        | 512        | yolov8s | 149.6                        | 125.3                              |
+        | 320        | YOLOv8n | 32.2                         | 26.7                               |
+        | 320        | YOLOv8s | 47.1                         | 39.8                               |
+        | 512        | YOLOv8n | 73.5                         | 60.7                               |
+        | 512        | YOLOv8s | 149.6                        | 125.3                              |
 
     === "Raspberry Pi 5 8GB"
 
         | Image Size | Model   | Standard Inference Time (ms) | High Frequency Inference Time (ms) |
         |------------|---------|------------------------------|------------------------------------|
-        | 320        | yolov8n | 22.2                         | 16.7                               |
-        | 320        | yolov8s | 40.1                         | 32.2                               |
-        | 512        | yolov8n | 53.5                         | 41.6                               |
-        | 512        | yolov8s | 132.0                        | 103.3                              |
+        | 320        | YOLOv8n | 22.2                         | 16.7                               |
+        | 320        | YOLOv8s | 40.1                         | 32.2                               |
+        | 512        | YOLOv8n | 53.5                         | 41.6                               |
+        | 512        | YOLOv8s | 132.0                        | 103.3                              |
 
     On average:
 

--- a/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
+++ b/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
@@ -50,7 +50,7 @@ First, we need to install the Edge TPU runtime. There are many different version
 The high frequency version runs the Edge TPU at a higher clock speed, which improves performance. However, it might result in the Edge TPU thermal throttling, so it is recommended to have some sort of cooling mechanism in place.
 
 | Raspberry Pi OS | High frequency mode | Version to download                        |
-|-----------------|:-------------------:|--------------------------------------------|
+| --------------- | :-----------------: | ------------------------------------------ |
 | Bullseye 32bit  |         No          | `libedgetpu1-std_ ... .bullseye_armhf.deb` |
 | Bullseye 64bit  |         No          | `libedgetpu1-std_ ... .bullseye_arm64.deb` |
 | Bullseye 32bit  |         Yes         | `libedgetpu1-max_ ... .bullseye_armhf.deb` |

--- a/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
+++ b/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
@@ -47,9 +47,10 @@ This guide assumes that you already have a working Raspberry Pi OS install and h
 ### Installing the Edge TPU runtime
 
 First, we need to install the Edge TPU runtime. There are many different versions available, so you need to choose the right version for your operating system.
+The high frequency version runs the Edge TPU at a higher clock speed, which improves performance. However, it might result in the Edge TPU thermal throttling, so it is recommended to have some sort of cooling mechanism in place.
 
 | Raspberry Pi OS | High frequency mode | Version to download                        |
-| --------------- | :-----------------: | ------------------------------------------ |
+|-----------------|:-------------------:|--------------------------------------------|
 | Bullseye 32bit  |         No          | `libedgetpu1-std_ ... .bullseye_armhf.deb` |
 | Bullseye 64bit  |         No          | `libedgetpu1-std_ ... .bullseye_arm64.deb` |
 | Bullseye 32bit  |         Yes         | `libedgetpu1-max_ ... .bullseye_armhf.deb` |
@@ -166,6 +167,39 @@ Find comprehensive information on the [Predict](../modes/predict.md) page for fu
 
         model.predict("path/to/source.png", device="tpu:1")  # Select the second TPU
         ```
+
+## Benchmarks
+
+!!! tip "Benchmarks"
+
+    Tested with Raspberry Pi Os Bookworm 64-Bit and a USB Coral Edge TPU.
+
+    !!! note
+        Shown is the inference time, pre-/postprocessing is not included.
+
+    === "Raspberry Pi 4B 2GB"
+
+        | Image Size | Model   | Standard Inference Time (ms) | High Frequency Inference Time (ms) |
+        |------------|---------|------------------------------|------------------------------------|
+        | 320        | yolov8n | 32.2                         | 26.7                               |
+        | 320        | yolov8s | 47.1                         | 39.8                               |
+        | 512        | yolov8n | 73.5                         | 60.7                               |
+        | 512        | yolov8s | 149.6                        | 125.3                              |
+
+    === "Raspberry Pi 5 8GB"
+
+        | Image Size | Model   | Standard Inference Time (ms) | High Frequency Inference Time (ms) |
+        |------------|---------|------------------------------|------------------------------------|
+        | 320        | yolov8n | 22.2                         | 16.7                               |
+        | 320        | yolov8s | 40.1                         | 32.2                               |
+        | 512        | yolov8n | 53.5                         | 41.6                               |
+        | 512        | yolov8s | 132.0                        | 103.3                              |
+
+    On average:
+
+    - The Raspberry Pi 5 is 22% faster with the standard mode than the Raspberry Pi 4B.
+    - The Raspberry Pi 5 is 30.2% faster with the high frequency mode than the Raspberry Pi 4B.
+    - The high frequency mode is 28.4% faster than the standard mode.
 
 ## FAQ
 


### PR DESCRIPTION
Added the benchmarks I did here: https://github.com/ultralytics/ultralytics/issues/8035 to the docs.
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced guide for using Coral Edge TPU on Raspberry Pi with added performance benchmarking and mode details. 🚀  

### 📊 Key Changes  
- 📖 Added explanation of the Coral Edge TPU's "High Frequency" mode, which boosts performance but may need cooling to prevent throttling.  
- 📊 Introduced **benchmark results** comparing performance of standard vs. high-frequency modes on Raspberry Pi 4B and Raspberry Pi 5, showcasing improvements.  
- Provided tables detailing inference times for YOLOv8 models (Nano and Small) with different image sizes.  
- 🆕 Highlighted Raspberry Pi 5's speed advantage over Raspberry Pi 4B and the impact of high-frequency mode.

### 🎯 Purpose & Impact  
- **Purpose**: Help users optimize Coral Edge TPU performance with clearer guidance and benchmark data.  
- **Impact**: Users can now make informed decisions about hardware and modes to achieve faster and more efficient YOLO model performance on Raspberry Pi setups. 💡  
- **Bonus**: Encourages adding cooling solutions for better reliability with high-frequency mode. 🆒