### PR TITLE
Update `package-seg.yaml`

### DIFF
--- a/ultralytics/cfg/datasets/package-seg.yaml
+++ b/ultralytics/cfg/datasets/package-seg.yaml
@@ -9,8 +9,8 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: ../datasets/package-seg # dataset root dir
-train: images/train # train images (relative to 'path') 1920 images
-val: images/val # val images (relative to 'path') 89 images
+train: train/images # train images (relative to 'path') 1920 images
+val: valid/images # val images (relative to 'path') 89 images
 test: test/images # test images (relative to 'path') 188 images
 
 # Classes


### PR DESCRIPTION
@glenn-jocher Hi, I noticed that the image path was incorrect `images/train`, I have updated it to `train/images`, and it should work fine now. Thanks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Adjusted dataset paths in the `package-seg.yaml` file for better organization and consistency.

### 📊 Key Changes  
- Updated training image path from `images/train` to `train/images`.  
- Updated validation image path from `images/val` to `valid/images`.  

### 🎯 Purpose & Impact  
- 🗂️ **Improved File Organization**: These changes enhance clarity and structure by ensuring paths are more intuitive and aligned with dataset naming conventions.  
- 🚀 **Better Usability**: Users managing datasets will find it easier to navigate and work with the updated structure, reducing the likelihood of path-related errors.