### PR TITLE
Add `mobile-sam` auto-annotation to segmentation datasets docs

### DIFF
--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -142,7 +142,7 @@ To auto-annotate your dataset using the Ultralytics framework, you can use the `
 
 {% include "macros/sam-auto-annotate.md" %}
 
-The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection and [SAM segmentation models](../../models/sam.md), the device to run the models on, and the output directory for saving the annotated results.
+The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection and [SAM](../../models/sam.md)/[MobileSAM](../../models/mobile-sam.md) segmentation models, the device to run the models on, and the output directory for saving the annotated results.
 
 By leveraging the power of pre-trained models, auto-annotation can significantly reduce the time and effort required for creating high-quality segmentation datasets. This feature is particularly useful for researchers and developers working with large image collections, as it allows them to focus on model development and evaluation rather than manual annotation.
 
@@ -189,7 +189,7 @@ Auto-annotation in Ultralytics YOLO allows you to generate segmentation annotati
 ```python
 from ultralytics.data.annotator import auto_annotate
 
-auto_annotate(data="path/to/images", det_model="yolo11x.pt", sam_model="sam_b.pt")
+auto_annotate(data="path/to/images", det_model="yolo11x.pt", sam_model="sam_b.pt")  # or sam_model="mobile_sam.pt"
 ```
 
-This function automates the annotation process, making it faster and more efficient. For more details, explore the [Auto-Annotation](#auto-annotation) section.
+This function automates the annotation process, making it faster and more efficient. For more details, explore the [Auto-Annotate Reference](../../reference/data/annotator/#ultralytics.data.annotator.auto_annotate).

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -140,13 +140,7 @@ To auto-annotate your dataset using the Ultralytics framework, you can use the `
         auto_annotate(data="path/to/images", det_model="yolo11x.pt", sam_model="sam_b.pt")
         ```
 
-| Argument     | Type                    | Description                                                                                                 | Default        |
-| ------------ | ----------------------- | ----------------------------------------------------------------------------------------------------------- | -------------- |
-| `data`       | `str`                   | Path to a folder containing images to be annotated.                                                         | `None`         |
-| `det_model`  | `str, optional`         | Pre-trained YOLO detection model. Defaults to `'yolo11x.pt'`.                                               | `'yolo11x.pt'` |
-| `sam_model`  | `str, optional`         | Pre-trained SAM segmentation model. Defaults to `'sam_b.pt'`.                                               | `'sam_b.pt'`   |
-| `device`     | `str, optional`         | Device to run the models on. Defaults to an empty string (CPU or GPU, if available).                        | `''`           |
-| `output_dir` | `str or None, optional` | Directory to save the annotated results. Defaults to a `'labels'` folder in the same directory as `'data'`. | `None`         |
+{% include "macros/sam-auto-annotate.md" %}
 
 The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection and [SAM segmentation models](../../models/sam.md), the device to run the models on, and the output directory for saving the annotated results.
 

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -142,7 +142,7 @@ To auto-annotate your dataset using the Ultralytics framework, you can use the `
 
 {% include "macros/sam-auto-annotate.md" %}
 
-The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection and [SAM](../../models/sam.md)/[MobileSAM](../../models/mobile-sam.md) segmentation models, the device to run the models on, and the output directory for saving the annotated results.
+The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection models i.e [YOLO11](../../models/yolo11.md), [YOLOv8](../../models/yolov8.md) or other models  and [SAM](../../models/sam.md), [SAM2](../../models/sam-2.md) or [MobileSAM](../../models/mobile-sam.md) segmentation models, the device to run the models on, and the output directory for saving the annotated results.
 
 By leveraging the power of pre-trained models, auto-annotation can significantly reduce the time and effort required for creating high-quality segmentation datasets. This feature is particularly useful for researchers and developers working with large image collections, as it allows them to focus on model development and evaluation rather than manual annotation.
 

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -192,4 +192,4 @@ from ultralytics.data.annotator import auto_annotate
 auto_annotate(data="path/to/images", det_model="yolo11x.pt", sam_model="sam_b.pt")  # or sam_model="mobile_sam.pt"
 ```
 
-This function automates the annotation process, making it faster and more efficient. For more details, explore the [Auto-Annotate Reference](https://docs.ultralytics.com/reference/data/annotator/#ultralytics.data.annotator.auto_annotate).
+This function automates the annotation process, making it faster and more efficient. For more details, explore the [Auto-Annotate Reference](../../reference/data/annotator/#ultralytics.data.annotator.auto_annotate).

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -142,7 +142,7 @@ To auto-annotate your dataset using the Ultralytics framework, you can use the `
 
 {% include "macros/sam-auto-annotate.md" %}
 
-The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection models i.e [YOLO11](../../models/yolo11.md), [YOLOv8](../../models/yolov8.md) or other models  and [SAM](../../models/sam.md), [SAM2](../../models/sam-2.md) or [MobileSAM](../../models/mobile-sam.md) segmentation models, the device to run the models on, and the output directory for saving the annotated results.
+The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection models i.e [YOLO11](../../models/yolo11.md), [YOLOv8](../../models/yolov8.md) or other models and [SAM](../../models/sam.md), [SAM2](../../models/sam-2.md) or [MobileSAM](../../models/mobile-sam.md) segmentation models, the device to run the models on, and the output directory for saving the annotated results.
 
 By leveraging the power of pre-trained models, auto-annotation can significantly reduce the time and effort required for creating high-quality segmentation datasets. This feature is particularly useful for researchers and developers working with large image collections, as it allows them to focus on model development and evaluation rather than manual annotation.
 

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -192,4 +192,4 @@ from ultralytics.data.annotator import auto_annotate
 auto_annotate(data="path/to/images", det_model="yolo11x.pt", sam_model="sam_b.pt")  # or sam_model="mobile_sam.pt"
 ```
 
-This function automates the annotation process, making it faster and more efficient. For more details, explore the [Auto-Annotate Reference](../../reference/data/annotator/#ultralytics.data.annotator.auto_annotate).
+This function automates the annotation process, making it faster and more efficient. For more details, explore the [Auto-Annotate Reference](https://docs.ultralytics.com/reference/data/annotator/#ultralytics.data.annotator.auto_annotate).

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -142,7 +142,7 @@ To auto-annotate your dataset using the Ultralytics framework, you can use the `
 
 {% include "macros/sam-auto-annotate.md" %}
 
-The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection models i.e [YOLO11](../../models/yolo11.md), [YOLOv8](../../models/yolov8.md) or other models and [SAM](../../models/sam.md), [SAM2](../../models/sam-2.md) or [MobileSAM](../../models/mobile-sam.md) segmentation models, the device to run the models on, and the output directory for saving the annotated results.
+The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pre-trained detection models i.e. [YOLO11](../../models/yolo11.md), [YOLOv8](../../models/yolov8.md) or other [models](../../models/index.md) and segmentation models i.e, [SAM](../../models/sam.md), [SAM2](../../models/sam-2.md) or [MobileSAM](../../models/mobile-sam.md), the device to run the models on, and the output directory for saving the annotated results.
 
 By leveraging the power of pre-trained models, auto-annotation can significantly reduce the time and effort required for creating high-quality segmentation datasets. This feature is particularly useful for researchers and developers working with large image collections, as it allows them to focus on model development and evaluation rather than manual annotation.
 

--- a/docs/en/macros/sam-auto-annotate.md
+++ b/docs/en/macros/sam-auto-annotate.md
@@ -1,12 +1,12 @@
-| Argument     | Type        | Default        | Description                                                                       |
-| ------------ | ----------- | -------------- | --------------------------------------------------------------------------------- |
-| `data`       | `str`       | required       | Path to directory containing target images/videos for annotation or segmentation. |
-| `det_model`  | `str`       | `"yolo11x.pt"` | YOLO detection model path for initial object detection.                           |
-| `sam_model`  | `str`       | `"sam2_b.pt"`  | SAM2 model path for segmentation (supports t/s/b/l variants and SAM2.1 models).   |
-| `device`     | `str`       | `""`           | Computation device (e.g., 'cuda:0', 'cpu', or '' for automatic device detection). |
-| `conf`       | `float`     | `0.25`         | YOLO detection confidence threshold for filtering weak detections.                |
-| `iou`        | `float`     | `0.45`         | IoU threshold for Non-Maximum Suppression to filter overlapping boxes.            |
-| `imgsz`      | `int`       | `640`          | Input size for resizing images (must be multiple of 32).                          |
-| `max_det`    | `int`       | `300`          | Maximum number of detections per image for memory efficiency.                     |
-| `classes`    | `list[int]` | `None`         | List of class indices to detect (e.g., `[0, 1]` for person & bicycle).            |
-| `output_dir` | `str`       | `None`         | Save directory for annotations (defaults to './labels' relative to data path).    |
+| Argument     | Type        | Default        | Description                                                                                 |
+| ------------ | ----------- | -------------- |---------------------------------------------------------------------------------------------|
+| `data`       | `str`       | required       | Path to directory containing target images/videos for annotation or segmentation.           |
+| `det_model`  | `str`       | `"yolo11x.pt"` | YOLO detection model path for initial object detection.                                     |
+| `sam_model`  | `str`       | `"sam2_b.pt"`  | SAM2 model path for segmentation (supports t/s/b/l variants, SAM2.1 and mobile_sam models). |
+| `device`     | `str`       | `""`           | Computation device (e.g., 'cuda:0', 'cpu', or '' for automatic device detection).           |
+| `conf`       | `float`     | `0.25`         | YOLO detection confidence threshold for filtering weak detections.                          |
+| `iou`        | `float`     | `0.45`         | IoU threshold for Non-Maximum Suppression to filter overlapping boxes.                      |
+| `imgsz`      | `int`       | `640`          | Input size for resizing images (must be multiple of 32).                                    |
+| `max_det`    | `int`       | `300`          | Maximum number of detections per image for memory efficiency.                               |
+| `classes`    | `list[int]` | `None`         | List of class indices to detect (e.g., `[0, 1]` for person & bicycle).                      |
+| `output_dir` | `str`       | `None`         | Save directory for annotations (defaults to './labels' relative to data path).              |

--- a/docs/en/macros/sam-auto-annotate.md
+++ b/docs/en/macros/sam-auto-annotate.md
@@ -1,5 +1,5 @@
 | Argument     | Type        | Default        | Description                                                                                    |
-| ------------ | ----------- | -------------- |------------------------------------------------------------------------------------------------|
+| ------------ | ----------- | -------------- | ---------------------------------------------------------------------------------------------- |
 | `data`       | `str`       | required       | Path to directory containing target images/videos for annotation or segmentation.              |
 | `det_model`  | `str`       | `"yolo11x.pt"` | YOLO detection model path for initial object detection.                                        |
 | `sam_model`  | `str`       | `"sam2_b.pt"`  | SAM2 model path for segmentation (supports t/s/b/l variants and SAM2.1) and mobile_sam models. |

--- a/docs/en/macros/sam-auto-annotate.md
+++ b/docs/en/macros/sam-auto-annotate.md
@@ -1,5 +1,5 @@
 | Argument     | Type        | Default        | Description                                                                                 |
-| ------------ | ----------- | -------------- |---------------------------------------------------------------------------------------------|
+| ------------ | ----------- | -------------- | ------------------------------------------------------------------------------------------- |
 | `data`       | `str`       | required       | Path to directory containing target images/videos for annotation or segmentation.           |
 | `det_model`  | `str`       | `"yolo11x.pt"` | YOLO detection model path for initial object detection.                                     |
 | `sam_model`  | `str`       | `"sam2_b.pt"`  | SAM2 model path for segmentation (supports t/s/b/l variants, SAM2.1 and mobile_sam models). |

--- a/docs/en/macros/sam-auto-annotate.md
+++ b/docs/en/macros/sam-auto-annotate.md
@@ -1,12 +1,12 @@
-| Argument     | Type        | Default        | Description                                                                                 |
-| ------------ | ----------- | -------------- | ------------------------------------------------------------------------------------------- |
-| `data`       | `str`       | required       | Path to directory containing target images/videos for annotation or segmentation.           |
-| `det_model`  | `str`       | `"yolo11x.pt"` | YOLO detection model path for initial object detection.                                     |
-| `sam_model`  | `str`       | `"sam2_b.pt"`  | SAM2 model path for segmentation (supports t/s/b/l variants, SAM2.1 and mobile_sam models). |
-| `device`     | `str`       | `""`           | Computation device (e.g., 'cuda:0', 'cpu', or '' for automatic device detection).           |
-| `conf`       | `float`     | `0.25`         | YOLO detection confidence threshold for filtering weak detections.                          |
-| `iou`        | `float`     | `0.45`         | IoU threshold for Non-Maximum Suppression to filter overlapping boxes.                      |
-| `imgsz`      | `int`       | `640`          | Input size for resizing images (must be multiple of 32).                                    |
-| `max_det`    | `int`       | `300`          | Maximum number of detections per image for memory efficiency.                               |
-| `classes`    | `list[int]` | `None`         | List of class indices to detect (e.g., `[0, 1]` for person & bicycle).                      |
-| `output_dir` | `str`       | `None`         | Save directory for annotations (defaults to './labels' relative to data path).              |
+| Argument     | Type        | Default        | Description                                                                                    |
+| ------------ | ----------- | -------------- |------------------------------------------------------------------------------------------------|
+| `data`       | `str`       | required       | Path to directory containing target images/videos for annotation or segmentation.              |
+| `det_model`  | `str`       | `"yolo11x.pt"` | YOLO detection model path for initial object detection.                                        |
+| `sam_model`  | `str`       | `"sam2_b.pt"`  | SAM2 model path for segmentation (supports t/s/b/l variants and SAM2.1) and mobile_sam models. |
+| `device`     | `str`       | `""`           | Computation device (e.g., 'cuda:0', 'cpu', or '' for automatic device detection).              |
+| `conf`       | `float`     | `0.25`         | YOLO detection confidence threshold for filtering weak detections.                             |
+| `iou`        | `float`     | `0.45`         | IoU threshold for Non-Maximum Suppression to filter overlapping boxes.                         |
+| `imgsz`      | `int`       | `640`          | Input size for resizing images (must be multiple of 32).                                       |
+| `max_det`    | `int`       | `300`          | Maximum number of detections per image for memory efficiency.                                  |
+| `classes`    | `list[int]` | `None`         | List of class indices to detect (e.g., `[0, 1]` for person & bicycle).                         |
+| `output_dir` | `str`       | `None`         | Save directory for annotations (defaults to './labels' relative to data path).                 |


### PR DESCRIPTION
@fcakyon as discussed, Thanks

@glenn-jocher.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced the auto-annotation documentation and functionality by supporting additional models and refining feature details. 📚✨

### 📊 Key Changes
- Updated the auto-annotation documentation to clarify supported models, such as YOLO11, YOLOv8, and SAM2/SAM2.1/MobileSAM. 🖼️🔍
- Introduced a new modular documentation structure using macro inclusion for improved readability and maintenance. 🛠️📄
- Enhanced the parameter descriptions for `auto_annotate`, including supported devices, confidence thresholds, and output directories. 🚀✅
- Added specific references and links in the docs for easier navigation (e.g., linking to model overviews and function references). 🌐🔗

### 🎯 Purpose & Impact
- **Improved Clarity**: Makes it easier for users to understand how to use the auto-annotation feature and the wide range of supported models. 🧑‍💻📖
- **Broader Functionality**: Enables seamless integration with more advanced and mobile-friendly models like MobileSAM, catering to diverse user needs. 📱🤖
- **Saved Time**: Simplifies dataset annotation, especially for researchers and developers with large image sets, by automating tedious tasks. ⏱️✨
- **Better User Experience**: Streamlined documentation leads to faster adoption and fewer learning hurdles for new and existing users. 🙌📘