### PR TITLE
Fix MNN example missing BGR to RGB conversion

### DIFF
--- a/docs/en/integrations/mnn.md
+++ b/docs/en/integrations/mnn.md
@@ -100,6 +100,7 @@ A function that relies solely on MNN for YOLO11 inference and preprocessing is i
             image = cv2.resize(
                 image, (640, 640), 0.0, 0.0, cv2.INTER_LINEAR, -1, [0.0, 0.0, 0.0], [1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0]
             )
+            image = image[..., ::-1]
             input_var = np.expand_dims(image, 0)
             input_var = MNN.expr.convert(input_var, MNN.expr.NC4HW4)
             output_var = net.forward(input_var)
@@ -210,6 +211,7 @@ A function that relies solely on MNN for YOLO11 inference and preprocessing is i
             auto pads = _Const(static_cast<void*>(padvals.data()), {3, 2}, NCHW, halide_type_of<int>());
             auto image = _Pad(original_image, pads, CONSTANT);
             image = resize(image, Size(640, 640), 0, 0, INTER_LINEAR, -1, {0., 0., 0.}, {1./255., 1./255., 1./255.});
+            image = cvtColor(image, COLOR_BGR2RGB);
             auto input = _Unsqueeze(image, {0});
             input = _Convert(input, NC4HW4);
             auto outputs = net->onForward({input});

--- a/docs/en/integrations/mnn.md
+++ b/docs/en/integrations/mnn.md
@@ -100,7 +100,7 @@ A function that relies solely on MNN for YOLO11 inference and preprocessing is i
             image = cv2.resize(
                 image, (640, 640), 0.0, 0.0, cv2.INTER_LINEAR, -1, [0.0, 0.0, 0.0], [1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0]
             )
-            image = image[..., ::-1]
+            image = image[..., ::-1]  # BGR to RGB
             input_var = np.expand_dims(image, 0)
             input_var = MNN.expr.convert(input_var, MNN.expr.NC4HW4)
             output_var = net.forward(input_var)


### PR DESCRIPTION
Ultralytics offers compatibility with diverse data sources via internal preprocessing, whereas MNN does not. The MNN deployment example reads images in an OpenCV-like format, which means the channel order is BGR. Consequently, the code in documentation should explicitly include a conversion from BGR to RGB.

I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved YOLO11 inference pipeline by ensuring consistent image color format. 🎨

### 📊 Key Changes  
- Added a step to convert images from BGR to RGB format during preprocessing in the MNN-based YOLO11 inference pipeline.  
  - Python implementation: `image = image[..., ::-1]`  
  - C++ implementation: `image = cvtColor(image, COLOR_BGR2RGB)`

### 🎯 Purpose & Impact  
- **Purpose**:  
  - Ensures compatibility with models that expect RGB images, reducing potential inference errors caused by incorrect color formats.  
- **Impact**:  
  - Enhances accuracy and consistency of YOLO11 object detection results.  
  - Improves interoperability with various models and frameworks expecting standardized preprocessing. 🚀