### PR TITLE
Fix random dataloader freezes

### DIFF
--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -47,6 +47,13 @@ class InfiniteDataLoader(dataloader.DataLoader):
         for _ in range(len(self)):
             yield next(self.iterator)
 
+    def __del__(self):
+        """Ensure that workers are terminated."""
+        for w in self.iterator._workers:  # force terminate
+            if w.is_alive():
+                w.terminate()
+        self.iterator._shutdown_workers() # cleanup
+
     def reset(self):
         """
         Reset iterator.
@@ -142,7 +149,6 @@ def build_dataloader(dataset, batch, workers, shuffle=True, rank=-1):
         collate_fn=getattr(dataset, "collate_fn", None),
         worker_init_fn=seed_worker,
         generator=generator,
-        persistent_workers=True,
     )
 
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -142,6 +142,7 @@ def build_dataloader(dataset, batch, workers, shuffle=True, rank=-1):
         collate_fn=getattr(dataset, "collate_fn", None),
         worker_init_fn=seed_worker,
         generator=generator,
+        persistent_workers=True,
     )
 
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -52,7 +52,7 @@ class InfiniteDataLoader(dataloader.DataLoader):
         for w in self.iterator._workers:  # force terminate
             if w.is_alive():
                 w.terminate()
-        self.iterator._shutdown_workers() # cleanup
+        self.iterator._shutdown_workers()  # cleanup
 
     def reset(self):
         """


### PR DESCRIPTION
This is a fix for a longstanding issue with the dataloader freezing. It had been reported several times, usually manifests itself as "stuck on optimizer":
https://github.com/ultralytics/ultralytics/issues/6803
https://github.com/ultralytics/ultralytics/issues/673
https://github.com/ultralytics/ultralytics/issues/8896

The issue can be reproduced pretty consistently:
1. Start Python console session.
2. Launch a small training using Python API:
```python
from ultralytics import YOLO, ASSETS
model = YOLO("yolo11n.pt")
results = model.train(data="coco8.yaml", epochs=1, exist_ok=True)
```
3. Wait for it to finish. And then launch the training again. 
4. It would get stuck at the `optimizer` log or at some random point the second or third time a training is launched in the same session. Presumably, when the garbage collector kicks in and it's trying to delete the old dataloader which is when `shutdown_workers` gets called.

The issue comes from `_shutdown_worker()` waiting for workers to terminate. I am not sure why it happens, probably something to with how `InfiniteDataloader` reuses the same iterator. I tried several ways to gracefully shut down the workers, but it always stays stuck. I tried draining the workers, using [snippets from torch](https://github.com/pytorch/pytorch/blob/7e1c1e65ebf52a1b26d24a7bd2a234e3a5101f48/torch/utils/data/dataloader.py#L4) to mark them as dead. But the only way that seems to work is to forcefully terminate the workers.

I don't think it would be problematic to forcefully terminate the workers in `__del__`, since that's what PyTorch eventually does after timing out. The timeout takes about a minute or so, even though it's supposed to [take 5 seconds](https://github.com/pytorch/pytorch/blob/7c52c97a65f58e1de2967509ab732e20f468dae8/torch/utils/data/_utils/__init__.py#L20).

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
6. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
7. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
8. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced the dataset iterator to ensure worker processes are properly terminated upon deletion, improving resource management.

### 📊 Key Changes  
- Added a `__del__` method to the dataset iterator class to:  
  - Forcefully terminate any active worker processes.  
  - Shutdown worker processes cleanly during object destruction.

### 🎯 Purpose & Impact  
- 🛠️ **Purpose**: Prevent "zombie" worker processes from persisting after the dataset is no longer in use. This ensures better system resource utilization and avoids potential memory or CPU issues.  
- 🚀 **Impact**: Improves reliability and efficiency, especially during model training or batch processing, reducing the likelihood of system slowdowns or crashes.