### PR TITLE
Fixed wrong GPU comment in docker-quickstart

### DIFF
--- a/docs/en/guides/docker-quickstart.md
+++ b/docs/en/guides/docker-quickstart.md
@@ -98,7 +98,7 @@ Here's how to execute the Ultralytics Docker container:
 ### Using only the CPU
 
 ```bash
-# Run with all GPUs
+# Run without GPU
 sudo docker run -it --ipc=host $t
 ```
 


### PR DESCRIPTION
Comment fix

    I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor documentation fix to correct instructions for CPU-only Docker usage. 📝

### 📊 Key Changes  
- Updated the Docker command comment to correctly state "Run without GPU" instead of "Run with all GPUs" in the `docker-quickstart.md` guide.

### 🎯 Purpose & Impact  
- 🛠 Ensures accurate instructions for users running Docker without a GPU.  
- 🌍 Reduces potential confusion for CPU-only users, making the setup process smoother and more beginner-friendly.