### PR TITLE
Allow tuning directory to be set using `name`

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -101,7 +101,8 @@ class Tuner:
             "copy_paste": (0.0, 1.0),  # segment copy-paste (probability)
         }
         self.args = get_cfg(overrides=args)
-        self.tune_dir = get_save_dir(self.args, name="tune")
+        self.tune_dir = get_save_dir(self.args, name=self.args.name or "tune")
+        self.args.name = None  # reset to not affect training directory
         self.tune_csv = self.tune_dir / "tune_results.csv"
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
         self.prefix = colorstr("Tuner: ")

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -134,7 +134,7 @@ def run_ray_tune(
     tuner_callbacks = [WandbLoggerCallback(project="YOLOv8-tune")] if wandb else []
 
     # Create the Ray Tune hyperparameter search tuner
-    tune_dir = get_save_dir(DEFAULT_CFG, name="tune").resolve()  # must be absolute dir
+    tune_dir = get_save_dir(DEFAULT_CFG, name=train_args.pop("name", "tune")).resolve()  # must be absolute dir
     tune_dir.mkdir(parents=True, exist_ok=True)
     tuner = tune.Tuner(
         trainable_with_resources,

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from ultralytics.cfg import TASK2DATA, TASK2METRIC, get_save_dir, get_cfg
+from ultralytics.cfg import TASK2DATA, TASK2METRIC, get_cfg, get_save_dir
 from ultralytics.utils import DEFAULT_CFG, DEFAULT_CFG_DICT, LOGGER, NUM_THREADS, checks
 
 

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from ultralytics.cfg import TASK2DATA, TASK2METRIC, get_save_dir
+from ultralytics.cfg import TASK2DATA, TASK2METRIC, get_save_dir, get_cfg
 from ultralytics.utils import DEFAULT_CFG, DEFAULT_CFG_DICT, LOGGER, NUM_THREADS, checks
 
 
@@ -134,7 +134,8 @@ def run_ray_tune(
     tuner_callbacks = [WandbLoggerCallback(project="YOLOv8-tune")] if wandb else []
 
     # Create the Ray Tune hyperparameter search tuner
-    tune_dir = get_save_dir(DEFAULT_CFG, name=train_args.pop("name", "tune")).resolve()  # must be absolute dir
+    args = get_cfg(DEFAULT_CFG, train_args)
+    tune_dir = get_save_dir(args, name=train_args.pop("name", "tune")).resolve()  # must be absolute dir
     tune_dir.mkdir(parents=True, exist_ok=True)
     tuner = tune.Tuner(
         trainable_with_resources,

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -134,7 +134,9 @@ def run_ray_tune(
     tuner_callbacks = [WandbLoggerCallback(project="YOLOv8-tune")] if wandb else []
 
     # Create the Ray Tune hyperparameter search tuner
-    tune_dir = get_save_dir(get_cfg(DEFAULT_CFG, train_args), name=train_args.pop("name", "tune")).resolve()  # must be absolute dir
+    tune_dir = get_save_dir(
+        get_cfg(DEFAULT_CFG, train_args), name=train_args.pop("name", "tune")
+    ).resolve()  # must be absolute dir
     tune_dir.mkdir(parents=True, exist_ok=True)
     tuner = tune.Tuner(
         trainable_with_resources,

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -134,8 +134,7 @@ def run_ray_tune(
     tuner_callbacks = [WandbLoggerCallback(project="YOLOv8-tune")] if wandb else []
 
     # Create the Ray Tune hyperparameter search tuner
-    args = get_cfg(DEFAULT_CFG, train_args)
-    tune_dir = get_save_dir(args, name=train_args.pop("name", "tune")).resolve()  # must be absolute dir
+    tune_dir = get_save_dir(get_cfg(DEFAULT_CFG, train_args), name=train_args.pop("name", "tune")).resolve()  # must be absolute dir
     tune_dir.mkdir(parents=True, exist_ok=True)
     tuner = tune.Tuner(
         trainable_with_resources,


### PR DESCRIPTION
It will enable a workaround for users to resume tuning by specifying the last tune directory using `name` with `exist_ok`, at least for normal tuning without Ray Tune.

https://github.com/ultralytics/ultralytics/issues/18729#issuecomment-2598087427

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlined the directory naming and configuration handling for hyperparameter tuning in Ultralytics.

### 📊 Key Changes
- Updated how the tuning directory (`tune_dir`) is named by using the `name` parameter from the configuration or defaulting to "tune".
- Ensured the `name` parameter is reset after use, avoiding interference with training processes.
- Fixed imports to include missing `get_cfg` for improved configuration management during tuning.

### 🎯 Purpose & Impact
- **Improved Consistency**: Ensures cleaner and more predictable tuning directory structures. 📂
- **Enhanced Usability**: Avoids unintended side effects by fully resetting the `name` parameter after creating directories, simplifying reusability. 🔄
- **Better Code Maintenance**: Streamlined imports and configuration handling makes the tuning process more robust and easier for developers to manage. 🛠️

This improves reliability and the user experience for anyone leveraging hyperparameter tuning. 🚀