### PR TITLE
Pin `numpy` 1.23.5 for JetPack 4 on NVIDIA Jetson Nano

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,6 @@ export = [
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "keras", # not installed automatically by tensorflow>=2.16
     "flatbuffers>=23.5.26,<100; platform_machine == 'aarch64'", # update old 'flatbuffers' included inside tensorflow package
-    "numpy==1.23.5; platform_machine == 'aarch64'", # fix error: `np.bool` was a deprecated alias for the builtin `bool` when using TensorRT models on NVIDIA Jetson
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
 ]
 solutions = [

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -802,7 +802,7 @@ class Exporter:
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx, _ = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
-        if IS_JETSON and PYTHON_VERSION == "3.8.0":
+        if IS_JETSON and PYTHON_VERSION <= "3.8.0":
             # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python 3.8.0
             check_requirements("numpy==1.23.5")
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -803,7 +803,7 @@ class Exporter:
         f_onnx, _ = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
         if IS_JETSON and PYTHON_VERSION <= "3.8.0":
-            # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python 3.8.0
+            # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python <= 3.8.0
             check_requirements("numpy==1.23.5")
 
         try:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -802,10 +802,6 @@ class Exporter:
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx, _ = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
-        if IS_JETSON and PYTHON_VERSION <= "3.8.0":
-            # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python <= 3.8.0
-            check_requirements("numpy==1.23.5")
-
         try:
             import tensorrt as trt  # noqa
         except ImportError:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -802,6 +802,10 @@ class Exporter:
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx, _ = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
+        if IS_JETSON and PYTHON_VERSION == "3.8.0":
+            # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python 3.8.0
+            check_requirements("numpy==1.23.5") 
+
         try:
             import tensorrt as trt  # noqa
         except ImportError:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -804,7 +804,7 @@ class Exporter:
 
         if IS_JETSON and PYTHON_VERSION == "3.8.0":
             # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python 3.8.0
-            check_requirements("numpy==1.23.5") 
+            check_requirements("numpy==1.23.5")
 
         try:
             import tensorrt as trt  # noqa

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 from PIL import Image
 
-from ultralytics.utils import ARM64, IS_JETSON, IS_RASPBERRYPI, LINUX, LOGGER, ROOT, yaml_load
+from ultralytics.utils import ARM64, IS_JETSON, IS_RASPBERRYPI, LINUX, LOGGER, ROOT, PYTHON_VERSION, yaml_load
 from ultralytics.utils.checks import check_requirements, check_suffix, check_version, check_yaml
 from ultralytics.utils.downloads import attempt_download_asset, is_url
 
@@ -262,6 +262,11 @@ class AutoBackend(nn.Module):
         # TensorRT
         elif engine:
             LOGGER.info(f"Loading {w} for TensorRT inference...")
+
+            if IS_JETSON and PYTHON_VERSION <= "3.8.0":
+                # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python <= 3.8.0
+                check_requirements("numpy==1.23.5")
+
             try:
                 import tensorrt as trt  # noqa https://developer.nvidia.com/nvidia-tensorrt-download
             except ImportError:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 from PIL import Image
 
-from ultralytics.utils import ARM64, IS_JETSON, IS_RASPBERRYPI, LINUX, LOGGER, ROOT, PYTHON_VERSION, yaml_load
+from ultralytics.utils import ARM64, IS_JETSON, IS_RASPBERRYPI, LINUX, LOGGER, PYTHON_VERSION, ROOT, yaml_load
 from ultralytics.utils.checks import check_requirements, check_suffix, check_version, check_yaml
 from ultralytics.utils.downloads import attempt_download_asset, is_url
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved compatibility for TensorRT models on NVIDIA Jetson devices with specific Python versions. 🚀  

### 📊 Key Changes  
- Removed a fixed dependency for `numpy==1.23.5` from `export` in `pyproject.toml`.  
- Added a dynamic check to install `numpy==1.23.5` when using TensorRT on Jetson devices with Python <= 3.8.0.  

### 🎯 Purpose & Impact  
- 🛠️ **Purpose**: Ensures the correct version of `numpy` is installed only when needed, specifically to resolve compatibility issues for Jetson users with older Python versions.  
- 🌍 **Impact**: Reduces unnecessary library constraints for other users, improves flexibility, and ensures TensorRT inference works seamlessly for Jetson devices under specific conditions.