### PR TITLE
Remove run_callback of on_fit_epoch_end in final_eval - issue #18735 

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -687,7 +687,6 @@ class BaseTrainer:
                     self.validator.args.plots = self.args.plots
                     self.metrics = self.validator(model=f)
                     self.metrics.pop("fitness", None)
-                    self.run_callbacks("on_fit_epoch_end")
 
     def check_resume(self, overrides):
         """Check if resume checkpoint exists and update arguments accordingly."""

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -140,7 +140,6 @@ class ClassificationTrainer(BaseTrainer):
                     self.validator.args.plots = self.args.plots
                     self.metrics = self.validator(model=f)
                     self.metrics.pop("fitness", None)
-                    self.run_callbacks("on_fit_epoch_end")
 
     def plot_training_samples(self, batch, ni):
         """Plots training samples with their annotations."""


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->

This PR removes the call to the `on_fit_epoch_end` callback in the final_eval of the trainer.
When using the `on_fit_epoch_end` callback to for example log metrics to mlflow in a custom callback function, it will log twice with the same epoch, once at the final epoch and once after the final eval, which is wrong.
Either there should be a separate callback event for the final eval or it should be dropped all together as proposed in this PR.

If users wish to have a callback after the final evaluation, they can also use the existing `on_train_end` callback event.

See issue #18735 for a reproducible example. Tagging @Y-T-G who suggested to remove the callback in the final_eval function.

I have read the CLA Document and I sign the CLA

Fixes #18735
Fixes https://github.com/ultralytics/ultralytics/issues/18001


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removes a callback trigger during the final evaluation phase of training to streamline the process.

### 📊 Key Changes
- Removed the call to `self.run_callbacks("on_fit_epoch_end")` from the `final_eval` method in both the general trainer and YOLO classification trainer.

### 🎯 Purpose & Impact
- 🛠️ Prevents unnecessary or duplicate callback executions at the end of training, making the evaluation phase cleaner.
- 🚀 Reduces the risk of unintended side effects or repeated actions during final evaluation.
- 👍 Results in a more predictable and efficient training workflow for users.