### PR TITLE
Move `task=classify` with `mode=track` warning to tracker `on_predict_start`

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -921,12 +921,7 @@ def entrypoint(debug=""):
     # Task
     task = overrides.pop("task", None)
     if task:
-        if task == "classify" and mode == "track":
-            raise ValueError(
-                f"❌ Classification doesn't support 'mode=track'. Valid modes for classification are"
-                f" {MODES - {'track'}}.\n{CLI_HELP_MSG}"
-            )
-        elif task not in TASKS:
+        if task not in TASKS:
             if task == "track":
                 LOGGER.warning(
                     "WARNING ⚠️ invalid 'task=track', setting 'task=detect' and 'mode=track'. Valid tasks are {TASKS}.\n{CLI_HELP_MSG}."

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -32,7 +32,7 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
         >>> on_predict_start(predictor, persist=True)
     """
     if predictor.args.task == "classify":
-        raise ValueError(f"❌ Classification doesn't support 'mode=track'")
+        raise ValueError("❌ Classification doesn't support 'mode=track'")
 
     if hasattr(predictor, "trackers") and persist:
         return

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -31,6 +31,9 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
         >>> predictor = SomePredictorClass()
         >>> on_predict_start(predictor, persist=True)
     """
+    if predictor.args.task == "classify":
+        raise ValueError(f"❌ Classification doesn't support 'mode=track'")
+
     if hasattr(predictor, "trackers") and persist:
         return
 


### PR DESCRIPTION
@RizwanMunawar FYI, https://github.com/ultralytics/ultralytics/pull/18621#issuecomment-2602421983

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improves error handling for unsupported tasks in tracking mode, ensuring better clarity and usability. 🚀  

### 📊 Key Changes  
- 🛠️ Removed a redundant check from `__init__.py` for classification tasks used with tracking mode.  
- 🚨 Added a new validation step in `track.py` to raise an error when attempting classification (`task=classify`) in tracking mode (`mode=track`).  

### 🎯 Purpose & Impact  
- ✅ **Improved clarity**: Prevents users from mistakenly using incompatible configurations (classification in tracking).  
- 🔧 **Better error handling**: Users now receive immediate, clear feedback when using unsupported combinations, avoiding confusion and runtime issues.  
- 🧑‍💻 **Streamlined code**: Simplifies logic in the configuration file while maintaining robust checks in relevant parts of the code.