### PR TITLE
Update HUB Shared Inference API limits

### DIFF
--- a/docs/en/hub/inference-api.md
+++ b/docs/en/hub/inference-api.md
@@ -49,15 +49,9 @@ To shut down the dedicated endpoint, click on the **Stop Endpoint** button.
 
 To use the [Ultralytics HUB](https://www.ultralytics.com/hub) Shared Inference API, follow the guides below.
 
-Free users have the following usage limits:
+The [Ultralytics HUB](https://www.ultralytics.com/hub) Shared Inference API has the following usage limits:
 
 - 100 calls / hour
-- 1000 calls / month
-
-[Pro](./pro.md) users have the following usage limits:
-
-- 1000 calls / hour
-- 10000 calls / month
 
 ## Python
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated documentation for the Ultralytics HUB Shared Inference API to clarify usage limits. 🛠️📖  

### 📊 Key Changes  
- Simplified the explanation of API usage limits by merging free and Pro user limits into a general description.  
- Removed Pro user-specific details about higher usage limits from the documentation.  

### 🎯 Purpose & Impact  
- 🧹 **Streamlined documentation**: Makes the API usage limits section easier to read and reduces redundancy.  
- 🚸 **Improved clarity**: Helps users quickly understand the Shared Inference API limits without confusion over tiers.  
- 📉 **Potential impact**: Pro users may need to look elsewhere for specific details about their higher-tier limits.