### PR TITLE
Fix export test matrices to exclude `nms` from Classify models

### DIFF
--- a/docs/overrides/javascript/benchmark.js
+++ b/docs/overrides/javascript/benchmark.js
@@ -118,8 +118,12 @@ function updateChart(initialDatasets = []) {
 
   // Always include all models in the dataset creation
   const datasets = Object.keys(data).map((algorithm, i) => {
-    const baseColor = colorMap[algorithm] || `hsl(${Math.random() * 360}, 70%, 50%)`;
-    const lineColor = Object.keys(data).indexOf(algorithm) === 0 ? baseColor : lightenHexColor(baseColor, 0.6);
+    const baseColor =
+      colorMap[algorithm] || `hsl(${Math.random() * 360}, 70%, 50%)`;
+    const lineColor =
+      Object.keys(data).indexOf(algorithm) === 0
+        ? baseColor
+        : lightenHexColor(baseColor, 0.6);
 
     return {
       label: algorithm,
@@ -137,7 +141,8 @@ function updateChart(initialDatasets = []) {
       pointBorderColor: "#ffffff",
       borderWidth: i === 0 ? 3 : 1.5,
       // Set hidden based on whether the model is in initialDatasets
-      hidden: initialDatasets.length > 0 && !initialDatasets.includes(algorithm),
+      hidden:
+        initialDatasets.length > 0 && !initialDatasets.includes(algorithm),
     };
   });
 

--- a/docs/overrides/javascript/benchmark.js
+++ b/docs/overrides/javascript/benchmark.js
@@ -140,7 +140,8 @@ function updateChart(initialDatasets = []) {
       pointBackgroundColor: lineColor,
       pointBorderColor: "#ffffff",
       borderWidth: i === 0 ? 3 : 1.5,
-      hidden: initialDatasets.length > 0 && !initialDatasets.includes(algorithm),
+      hidden:
+        initialDatasets.length > 0 && !initialDatasets.includes(algorithm),
     };
   });
 

--- a/docs/overrides/javascript/benchmark.js
+++ b/docs/overrides/javascript/benchmark.js
@@ -140,9 +140,7 @@ function updateChart(initialDatasets = []) {
       pointBackgroundColor: lineColor,
       pointBorderColor: "#ffffff",
       borderWidth: i === 0 ? 3 : 1.5,
-      // Set hidden based on whether the model is in initialDatasets
-      hidden:
-        initialDatasets.length > 0 && !initialDatasets.includes(algorithm),
+      hidden: initialDatasets.length > 0 && !initialDatasets.includes(algorithm),
     };
   });
 

--- a/docs/overrides/javascript/benchmark.js
+++ b/docs/overrides/javascript/benchmark.js
@@ -116,18 +116,10 @@ function updateChart(initialDatasets = []) {
     EfficientDet: "#000000",
   };
 
-  // Get the selected algorithms from the initialDatasets or all if empty.
-  const selectedAlgorithms =
-    initialDatasets.length > 0 ? initialDatasets : Object.keys(data);
-
-  // Create the datasets for the selected algorithms.
-  const datasets = selectedAlgorithms.map((algorithm, i) => {
-    const baseColor =
-      colorMap[algorithm] || `hsl(${Math.random() * 360}, 70%, 50%)`;
-    const lineColor =
-      Object.keys(data).indexOf(algorithm) === 0
-        ? baseColor
-        : lightenHexColor(baseColor, 0.6); // Lighten non-primary lines
+  // Always include all models in the dataset creation
+  const datasets = Object.keys(data).map((algorithm, i) => {
+    const baseColor = colorMap[algorithm] || `hsl(${Math.random() * 360}, 70%, 50%)`;
+    const lineColor = Object.keys(data).indexOf(algorithm) === 0 ? baseColor : lightenHexColor(baseColor, 0.6);
 
     return {
       label: algorithm,
@@ -137,14 +129,15 @@ function updateChart(initialDatasets = []) {
         version: version.toUpperCase(),
       })),
       fill: false,
-      borderColor: lineColor, // Use the lightened color for the line.
+      borderColor: lineColor,
       tension: 0.2,
       pointRadius: Object.keys(data).indexOf(algorithm) === 0 ? 7 : 4,
       pointHoverRadius: Object.keys(data).indexOf(algorithm) === 0 ? 9 : 6,
       pointBackgroundColor: lineColor,
-      pointBorderColor: "#ffffff", // Add a border around points for contrast.
-      borderWidth: i === 0 ? 3 : 1.5, // Slightly increase line size for the primary dataset.
-      hidden: false,
+      pointBorderColor: "#ffffff",
+      borderWidth: i === 0 ? 3 : 1.5,
+      // Set hidden based on whether the model is in initialDatasets
+      hidden: initialDatasets.length > 0 && !initialDatasets.includes(algorithm),
     };
   });
 
@@ -152,7 +145,7 @@ function updateChart(initialDatasets = []) {
   modelComparisonChart = new Chart(
     document.getElementById("modelComparisonChart").getContext("2d"),
     {
-      type: "line", // Set the chart type to line.
+      type: "line",
       data: { datasets },
       options: {
         //aspectRatio: 2.5,  // higher is wider

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -44,7 +44,7 @@ def test_export_openvino():
 @pytest.mark.skipif(not TORCH_1_13, reason="OpenVINO requires torch>=1.13")
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch, nms",
-    [  # generate all combinations but exclude cases where both int8 and half or classify and nms are True
+    [  # generate all combinations except for exclusion cases
         (task, dynamic, int8, half, batch, nms)
         for task, dynamic, int8, half, batch, nms in product(
             TASKS, [True, False], [True, False], [True, False], [1, 2], [True, False]
@@ -77,7 +77,7 @@ def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch, simplify, nms",
-    [  # generate all combinations but exclude cases where both int8 and half or classify and nms are True
+    [  # generate all combinations except for exclusion cases
         (task, dynamic, int8, half, batch, simplify, nms)
         for task, dynamic, int8, half, batch, simplify, nms in product(
             TASKS, [True, False], [False], [False], [1, 2], [True, False], [True, False]
@@ -97,7 +97,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch, nms",
-    [  # generate all combinations but exclude those where both int8 and half are True
+    [  # generate all combinations except for exclusion cases
         (task, dynamic, int8, half, batch, nms)
         for task, dynamic, int8, half, batch, nms in product(TASKS, [False], [False], [False], [1, 2], [True, False])
         if not (task == "classify" and nms)
@@ -108,7 +108,7 @@ def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms):
     file = YOLO(TASK2MODEL[task]).export(
         format="torchscript", imgsz=32, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms
     )
-    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference at batch=3
+    YOLO(file)([SOURCE] * 3, imgsz=64 if dynamic else 32)  # exported model inference at batch=3
     Path(file).unlink()  # cleanup
 
 
@@ -118,10 +118,10 @@ def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms):
 @pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="CoreML not supported in Python 3.12")
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch",
-    [  # generate all combinations but exclude those where both int8 and half are True
+    [  # generate all combinations except for exclusion cases
         (task, dynamic, int8, half, batch)
         for task, dynamic, int8, half, batch in product(TASKS, [False], [True, False], [True, False], [1])
-        if not (int8 and half)  # exclude cases where both int8 and half are True
+        if not (int8 and half)
     ],
 )
 def test_export_coreml_matrix(task, dynamic, int8, half, batch):
@@ -143,7 +143,7 @@ def test_export_coreml_matrix(task, dynamic, int8, half, batch):
 @pytest.mark.skipif(not LINUX, reason="Test disabled as TF suffers from install conflicts on Windows and macOS")
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch, nms",
-    [  # generate all combinations but exclude those where both int8 and half are True
+    [  # generate all combinations except for exclusion cases
         (task, dynamic, int8, half, batch, nms)
         for task, dynamic, int8, half, batch, nms in product(
             TASKS, [False], [True, False], [True, False], [1], [True, False]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -56,7 +56,14 @@ def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms):
     """Test YOLO model exports to OpenVINO under various configuration matrix conditions."""
     imgsz = 224 if nms and int8 and task == "obb" else 32  # OBB has error with lower imgsz
     file = YOLO(TASK2MODEL[task]).export(
-        format="openvino", imgsz=imgsz, dynamic=dynamic, int8=int8, half=half, batch=batch, data=TASK2DATA[task], nms=nms
+        format="openvino",
+        imgsz=imgsz,
+        dynamic=dynamic,
+        int8=int8,
+        half=half,
+        batch=batch,
+        data=TASK2DATA[task],
+        nms=nms,
     )
     if WINDOWS:
         # Use unique filenames due to Windows file permissions bug possibly due to latent threaded use
@@ -75,7 +82,7 @@ def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms):
         for task, dynamic, int8, half, batch, simplify, nms in product(
             TASKS, [True, False], [False], [False], [1, 2], [True, False], [True, False]
         )
-        if not ((int8 and half) or (task == "classify" and nms)) 
+        if not ((int8 and half) or (task == "classify" and nms))
     ],
 )
 def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -107,7 +107,7 @@ def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms):
     file = YOLO(TASK2MODEL[task]).export(
         format="torchscript", imgsz=32, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms
     )
-    YOLO(file)([SOURCE] * 3, imgsz=64 if dynamic else 32)  # exported model inference at batch=3
+    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
     Path(file).unlink()  # cleanup
 
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -54,10 +54,9 @@ def test_export_openvino():
 )
 def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms):
     """Test YOLO model exports to OpenVINO under various configuration matrix conditions."""
-    imgsz = 224 if nms and int8 and task == "obb" else 32  # OBB has error with lower imgsz
     file = YOLO(TASK2MODEL[task]).export(
         format="openvino",
-        imgsz=imgsz,
+        imgsz=32,
         dynamic=dynamic,
         int8=int8,
         half=half,
@@ -70,7 +69,7 @@ def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms):
         # See https://github.com/ultralytics/ultralytics/actions/runs/8957949304/job/24601616830?pr=10423
         file = Path(file)
         file = file.rename(file.with_stem(f"{file.stem}-{uuid.uuid4()}"))
-    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else imgsz)  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
     shutil.rmtree(file, ignore_errors=True)  # retry in case of potential lingering multi-threaded file usage errors
 
 
@@ -153,11 +152,10 @@ def test_export_coreml_matrix(task, dynamic, int8, half, batch):
 )
 def test_export_tflite_matrix(task, dynamic, int8, half, batch, nms):
     """Test YOLO exports to TFLite format considering various export configurations."""
-    imgsz = 128 if nms and task != "obb" else 32  # error with lower imgsz
     file = YOLO(TASK2MODEL[task]).export(
-        format="tflite", imgsz=imgsz, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms
+        format="tflite", imgsz=32, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms
     )
-    YOLO(file)([SOURCE] * batch, imgsz=imgsz)  # exported model inference at batch=3
+    YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference at batch=3
     Path(file).unlink()  # cleanup
 
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -75,7 +75,7 @@ from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import check_class_names, default_class_names
 from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder
-from ultralytics.nn.tasks import DetectionModel, SegmentationModel, WorldModel
+from ultralytics.nn.tasks import DetectionModel, SegmentationModel, WorldModel, ClassificationModel
 from ultralytics.utils import (
     ARM64,
     DEFAULT_CFG,
@@ -282,6 +282,7 @@ class Exporter:
         if self.args.int8 and tflite:
             assert not getattr(model, "end2end", False), "TFLite INT8 export not supported for end2end models."
         if self.args.nms:
+            assert not isinstance(model, ClassificationModel), "'nms=True' is not valid for classification models."
             if getattr(model, "end2end", False):
                 LOGGER.warning("WARNING ⚠️ 'nms=True' is not available for end2end models. Forcing 'nms=False'.")
                 self.args.nms = False
@@ -507,6 +508,7 @@ class Exporter:
         output_names = ["output0", "output1"] if isinstance(self.model, SegmentationModel) else ["output0"]
         dynamic = self.args.dynamic
         if dynamic:
+            self.model.cpu()  # dynamic=True only compatible with cpu
             dynamic = {"images": {0: "batch", 2: "height", 3: "width"}}  # shape(1,3,640,640)
             if isinstance(self.model, SegmentationModel):
                 dynamic["output0"] = {0: "batch", 2: "anchors"}  # shape(1, 116, 8400)
@@ -518,13 +520,14 @@ class Exporter:
         if self.args.nms and self.model.task == "obb":
             self.args.opset = opset_version  # for NMSModel
             # OBB error https://github.com/pytorch/pytorch/issues/110859#issuecomment-1757841865
-            torch.onnx.register_custom_op_symbolic("aten::lift_fresh", lambda g, x: x, opset_version)
+            try:
+                torch.onnx.register_custom_op_symbolic("aten::lift_fresh", lambda g, x: x, opset_version)
+            except RuntimeError: # it will fail if it's already registered
+                pass
             check_requirements("onnxslim>=0.1.46")  # Older versions has bug with OBB
 
         torch.onnx.export(
-            NMSModel(self.model.cpu() if dynamic else self.model, self.args)
-            if self.args.nms
-            else self.model,  # dynamic=True only compatible with cpu
+            NMSModel(self.model, self.args) if self.args.nms else self.model,
             self.im.cpu() if dynamic else self.im,
             f,
             verbose=False,
@@ -1570,7 +1573,7 @@ class NMSModel(torch.nn.Module):
                 # TFLite GatherND error if mask is empty
                 score *= mask
                 # Explicit length otherwise reshape error, hardcoded to `self.args.max_det * 5`
-                mask = score.topk(self.args.max_det * 5).indices
+                mask = score.topk(min(self.args.max_det * 5, score.shape[0])).indices
             box, score, cls, extra = box[mask], score[mask], cls[mask], extra[mask]
             if not self.obb:
                 box = xywh2xyxy(box)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -75,7 +75,7 @@ from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import check_class_names, default_class_names
 from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder
-from ultralytics.nn.tasks import DetectionModel, SegmentationModel, WorldModel, ClassificationModel
+from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel, WorldModel
 from ultralytics.utils import (
     ARM64,
     DEFAULT_CFG,
@@ -522,7 +522,7 @@ class Exporter:
             # OBB error https://github.com/pytorch/pytorch/issues/110859#issuecomment-1757841865
             try:
                 torch.onnx.register_custom_op_symbolic("aten::lift_fresh", lambda g, x: x, opset_version)
-            except RuntimeError: # it will fail if it's already registered
+            except RuntimeError:  # it will fail if it's already registered
                 pass
             check_requirements("onnxslim>=0.1.46")  # Older versions has bug with OBB
 


### PR DESCRIPTION
There's this error which I am not sure where it's from. I suspect it's related to not being able to register it because `torch.onnx.export` has already been used in the session. Is it possible to run the test in a fresh session?
`RuntimeError: Failed to register operator aten::lift_fresh. The domain aten is already a used domain.`

I did not experience it locally. The failing tests pass locally. So unless it's related to PyTorch or Python version, it should also pass in CI now.

```bash
pytest tests/test_exports.py::test_export_onnx_matrix --slow
=============================================== test session starts ================================================
platform linux -- Python 3.11.10, pytest-8.3.4, pluggy-1.5.0
rootdir: /ultralytics
configfile: pyproject.toml
plugins: hypothesis-6.115.3, anyio-4.6.2.post1
collected 72 items                                                                                                 

tests/test_exports.py ........................................................................             [100%]

============================================== slowest 30 durations ==============================================
42.90s call     tests/test_exports.py::test_export_onnx_matrix[obb-True-False-False-2-True-True]
42.00s call     tests/test_exports.py::test_export_onnx_matrix[obb-True-False-False-1-True-True]
31.56s call     tests/test_exports.py::test_export_onnx_matrix[segment-True-False-False-1-True-True]
30.09s call     tests/test_exports.py::test_export_onnx_matrix[segment-True-False-False-2-True-True]
28.40s call     tests/test_exports.py::test_export_onnx_matrix[segment-True-False-False-2-True-False]
28.31s call     tests/test_exports.py::test_export_onnx_matrix[segment-True-False-False-1-True-False]
22.11s call     tests/test_exports.py::test_export_onnx_matrix[pose-True-False-False-2-True-True]
21.60s call     tests/test_exports.py::test_export_onnx_matrix[pose-True-False-False-1-True-True]
21.30s call     tests/test_exports.py::test_export_onnx_matrix[detect-True-False-False-2-True-True]
21.10s call     tests/test_exports.py::test_export_onnx_matrix[pose-True-False-False-1-True-False]
20.99s call     tests/test_exports.py::test_export_onnx_matrix[pose-True-False-False-2-True-False]
20.89s call     tests/test_exports.py::test_export_onnx_matrix[obb-True-False-False-2-True-False]
20.80s call     tests/test_exports.py::test_export_onnx_matrix[detect-True-False-False-1-True-True]
20.60s call     tests/test_exports.py::test_export_onnx_matrix[obb-True-False-False-1-True-False]
20.10s call     tests/test_exports.py::test_export_onnx_matrix[detect-True-False-False-2-True-False]
20.00s call     tests/test_exports.py::test_export_onnx_matrix[detect-True-False-False-1-True-False]
5.69s call     tests/test_exports.py::test_export_onnx_matrix[obb-False-False-False-2-True-True]
4.59s call     tests/test_exports.py::test_export_onnx_matrix[obb-False-False-False-1-True-True]
3.30s call     tests/test_exports.py::test_export_onnx_matrix[segment-False-False-False-2-True-True]
3.21s call     tests/test_exports.py::test_export_onnx_matrix[segment-False-False-False-1-True-True]
3.20s call     tests/test_exports.py::test_export_onnx_matrix[pose-False-False-False-1-True-True]
3.11s call     tests/test_exports.py::test_export_onnx_matrix[pose-False-False-False-2-True-True]
2.80s call     tests/test_exports.py::test_export_onnx_matrix[detect-False-False-False-2-True-True]
2.80s call     tests/test_exports.py::test_export_onnx_matrix[detect-False-False-False-1-True-True]
2.39s call     tests/test_exports.py::test_export_onnx_matrix[segment-False-False-False-2-True-False]
2.31s call     tests/test_exports.py::test_export_onnx_matrix[obb-False-False-False-1-True-False]
2.30s call     tests/test_exports.py::test_export_onnx_matrix[classify-True-False-False-2-True-False]
2.20s call     tests/test_exports.py::test_export_onnx_matrix[pose-False-False-False-1-True-False]
2.20s call     tests/test_exports.py::test_export_onnx_matrix[pose-False-False-False-2-True-False]
2.11s call     tests/test_exports.py::test_export_onnx_matrix[segment-True-False-False-1-False-False]
========================================= 72 passed in 526.46s (0:08:46) =========================================
```

```bash
============================================== slowest 30 durations ==============================================
71.26s call     tests/test_exports.py::test_export_tflite_matrix[obb-False-True-False-1-True]
61.34s call     tests/test_exports.py::test_export_tflite_matrix[segment-False-True-False-1-True]
60.77s call     tests/test_exports.py::test_export_tflite_matrix[pose-False-True-False-1-True]
57.11s call     tests/test_exports.py::test_export_tflite_matrix[detect-False-True-False-1-True]
52.13s call     tests/test_exports.py::test_export_tflite_matrix[pose-False-True-False-1-False]
51.35s call     tests/test_exports.py::test_export_tflite_matrix[segment-False-True-False-1-False]
51.03s call     tests/test_exports.py::test_export_tflite_matrix[obb-False-True-False-1-False]
47.28s call     tests/test_exports.py::test_export_tflite_matrix[detect-False-True-False-1-False]
37.78s call     tests/test_exports.py::test_export_tflite_matrix[classify-False-True-False-1-False]
27.47s call     tests/test_exports.py::test_export_tflite_matrix[obb-False-False-True-1-True]
26.79s call     tests/test_exports.py::test_export_tflite_matrix[obb-False-False-False-1-True]
18.94s call     tests/test_exports.py::test_export_tflite_matrix[segment-False-False-False-1-True]
18.57s call     tests/test_exports.py::test_export_tflite_matrix[segment-False-False-True-1-True]
18.34s call     tests/test_exports.py::test_export_tflite_matrix[pose-False-False-True-1-True]
18.18s call     tests/test_exports.py::test_export_tflite_matrix[pose-False-False-False-1-True]
16.83s call     tests/test_exports.py::test_export_tflite_matrix[detect-False-False-False-1-True]
16.75s call     tests/test_exports.py::test_export_tflite_matrix[detect-False-False-True-1-True]
15.32s call     tests/test_exports.py::test_export_tflite_matrix[pose-False-False-False-1-False]
15.28s call     tests/test_exports.py::test_export_tflite_matrix[pose-False-False-True-1-False]
14.87s call     tests/test_exports.py::test_export_tflite_matrix[obb-False-False-True-1-False]
14.77s call     tests/test_exports.py::test_export_tflite_matrix[segment-False-False-True-1-False]
14.66s call     tests/test_exports.py::test_export_tflite_matrix[obb-False-False-False-1-False]
14.51s call     tests/test_exports.py::test_export_tflite_matrix[segment-False-False-False-1-False]
13.73s call     tests/test_exports.py::test_export_tflite_matrix[detect-False-False-False-1-False]
13.36s call     tests/test_exports.py::test_export_tflite_matrix[detect-False-False-True-1-False]
8.44s call     tests/test_exports.py::test_export_tflite_matrix[classify-False-False-False-1-False]
7.62s call     tests/test_exports.py::test_export_tflite_matrix[classify-False-False-True-1-False]

(3 durations < 0.005s hidden.  Use -vv to show these durations.)
========================================= 27 passed in 785.53s (0:13:05) =========================================
```

```bash
pytest tests/test_exports.py::test_export_torchscript_matrix --slow
============================================== test session starts ===============================================
platform linux -- Python 3.11.10, pytest-8.3.4, pluggy-1.5.0
rootdir: /ultralytics
configfile: pyproject.toml
plugins: hypothesis-6.115.3, anyio-4.6.2.post1
collected 18 items                                                                                               

tests/test_exports.py ..................                                                                   [100%]

============================================== slowest 30 durations ==============================================
3.27s call     tests/test_exports.py::test_export_torchscript_matrix[detect-False-False-False-1-True]
2.88s call     tests/test_exports.py::test_export_torchscript_matrix[obb-False-False-False-2-True]
2.85s call     tests/test_exports.py::test_export_torchscript_matrix[segment-False-False-False-2-True]
2.75s call     tests/test_exports.py::test_export_torchscript_matrix[pose-False-False-False-2-True]
2.75s call     tests/test_exports.py::test_export_torchscript_matrix[segment-False-False-False-1-True]
2.64s call     tests/test_exports.py::test_export_torchscript_matrix[obb-False-False-False-1-True]
2.60s call     tests/test_exports.py::test_export_torchscript_matrix[pose-False-False-False-1-True]
2.58s call     tests/test_exports.py::test_export_torchscript_matrix[detect-False-False-False-2-True]
2.40s call     tests/test_exports.py::test_export_torchscript_matrix[segment-False-False-False-2-False]
2.34s call     tests/test_exports.py::test_export_torchscript_matrix[segment-False-False-False-1-False]
2.34s call     tests/test_exports.py::test_export_torchscript_matrix[pose-False-False-False-2-False]
2.33s call     tests/test_exports.py::test_export_torchscript_matrix[obb-False-False-False-2-False]
2.32s call     tests/test_exports.py::test_export_torchscript_matrix[detect-False-False-False-2-False]
2.24s call     tests/test_exports.py::test_export_torchscript_matrix[pose-False-False-False-1-False]
2.23s call     tests/test_exports.py::test_export_torchscript_matrix[obb-False-False-False-1-False]
2.08s call     tests/test_exports.py::test_export_torchscript_matrix[detect-False-False-False-1-False]
1.22s call     tests/test_exports.py::test_export_torchscript_matrix[classify-False-False-False-2-False]
1.13s call     tests/test_exports.py::test_export_torchscript_matrix[classify-False-False-False-1-False]

(12 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================== 18 passed in 43.84s ===============================================
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced model export processes for multiple formats with better configuration checks and usability improvements. 🚀  

### 📊 Key Changes  
- **Chart Updates**: Ensured all models are included in the benchmark visualizations by default.  
- **Export Tests**: Improved matrix testing for `OpenVINO`, `ONNX`, `CoreML`, `TorchScript`, and `TFLite` exports to exclude invalid parameter combinations (e.g., `int8` + `half`).  
- **Validation Improvements**:
  - Disallowed NMS for classification models during export to prevent invalid configurations.
  - Added checks for supported cases, like requiring CPU compatibility for dynamic ONNX exports.  
  - Fixed errors when handling mask sizes in TFLite processing.  
- **Code Refactor**: Streamlined task imports and updated function logic across the `ultralytics` export codebase for better reliability.  

### 🎯 Purpose & Impact  
- **Improved Usability**: Helps users avoid invalid export combinations (e.g., `int8` & `half` together, or NMS with classifiers). 🛠  
- **Increased Stability**: Makes the model export pipeline more robust across frameworks, reducing errors during execution. ✅  
- **Enhanced Visualization**: Updated charts for better inclusivity and representation of all models. 📊  
- **Future Scalability**: Logical checks and refactoring make the code easier to maintain and extend. 💡