### PR TITLE
Temporarily disable Raspberry Pi CI due to maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    if: false # temporarily disable RPi CI for maintainance
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:
@@ -346,11 +347,11 @@ jobs:
 
   Summary:
     runs-on: ubuntu-latest
-    needs: [HUB, Benchmarks, Tests, GPU, RaspberryPi, Conda]
+    needs: [HUB, Benchmarks, Tests, GPU, Conda]
     if: always()
     steps:
       - name: Check for failure and notify
-        if: (needs.HUB.result == 'failure' || needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.GPU.result == 'failure' || needs.RaspberryPi.result == 'failure' || needs.Conda.result == 'failure' ) && github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
+        if: (needs.HUB.result == 'failure' || needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.GPU.result == 'failure' || needs.Conda.result == 'failure' ) && github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook-type: incoming-webhook


### PR DESCRIPTION
@glenn-jocher We can re-enable them once I replace the current 8GB runners with 16GB runners. Thank you.

Related to:
https://github.com/ultralytics/ultralytics/pull/18898#issuecomment-2616739644

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Raspberry Pi CI has been temporarily disabled for maintenance.  

### 📊 Key Changes  
- 🛠️ **Disabled Raspberry Pi CI workflows:** The Raspberry Pi CI step has been commented out and replaced with `if: false` to halt execution.  
- 📉 **Adjusted summary dependencies:** Removed Raspberry Pi from the list of required tasks for the "Summary" job.  

### 🎯 Purpose & Impact  
- 🔧 **Purpose:** Temporarily pause Raspberry Pi CI workflows for maintenance to address any potential issues or updates.  
- 🚀 **Impact:** Streamlines other workflows while the Raspberry Pi CI is under maintenance. Users may notice a temporary absence of Raspberry Pi-related testing until the workflow is re-enabled.