### PR TITLE
Add DLA specific core usage

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -295,7 +295,9 @@ class AutoBackend(nn.Module):
                 model = runtime.deserialize_cuda_engine(f.read())  # read engine
                 if "dla" in str(device.type):
                     dla_core = int(device.type.split(":")[1])
-                    assert dla_core in {0, 1}, "Expected device type for inference in DLA is 'dla:0' or 'dla:1', but received '{device.type}'"
+                    assert dla_core in {0, 1}, (
+                        "Expected device type for inference in DLA is 'dla:0' or 'dla:1', but received '{device.type}'"
+                    )
                     runtime.DLA_core = dla_core
 
             # Model context

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -293,6 +293,10 @@ class AutoBackend(nn.Module):
                 except UnicodeDecodeError:
                     f.seek(0)  # engine file may lack embedded Ultralytics metadata
                 model = runtime.deserialize_cuda_engine(f.read())  # read engine
+                if "dla" in str(device.type):
+                    dla_core = int(device.type.split(":")[1])
+                    assert dla_core in {0, 1}, "Expected device type for inference in DLA is 'dla:0' or 'dla:1', but received '{device.type}'"
+                    runtime.DLA_core = dla_core
 
             # Model context
             try:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->
Closes https://github.com/ultralytics/ultralytics/issues/18916 Trying to add support for using a specific DLA core during inference.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added support for NVIDIA's DLA-specific configurations, enhancing compatibility for inference on specialized hardware. 🚀  

### 📊 Key Changes  
- Introduced a check for `dla` device types in the codebase.  
- Implemented validation to ensure `dla` device types are correctly specified as `dla:0` or `dla:1`.  
- Configured the runtime to assign the specified DLA core (`runtime.DLA_core`) for inference.  

### 🎯 Purpose & Impact  
- **Purpose**: Improve compatibility for models running on NVIDIA's Deep Learning Accelerator (DLA), ensuring smoother performance on specialized hardware.  
- **Impact**: Users leveraging NVIDIA DLA for model inference benefit from proper hardware utilization and reduced errors. This change enhances the flexibility and efficiency of Ultralytics software on diverse devices. 🎉