### PR TITLE
Update branch of `picamera2` in Sony IMX500 Doc

### DIFF
--- a/docs/en/integrations/sony-imx500.md
+++ b/docs/en/integrations/sony-imx500.md
@@ -158,7 +158,7 @@ The above will generate a `network.rpk` file inside the specified output folder.
 Step 2: Clone `picamera2` repository, install it and navigate to the imx500 examples
 
 ```bash
-git clone -b next https://github.com/raspberrypi/picamera2
+git clone https://github.com/raspberrypi/picamera2
 cd picamera2
 pip install -e .  --break-system-packages
 cd examples/imx500
@@ -319,7 +319,7 @@ After exporting to IMX500 format:
 2. Clone and install picamera2:
 
     ```bash
-    git clone -b next https://github.com/raspberrypi/picamera2
+    git clone https://github.com/raspberrypi/picamera2
     cd picamera2 && pip install -e . --break-system-packages
     ```
 


### PR DESCRIPTION
@glenn-jocher Now the main branch of `picamera2` has all the updates from `next` branch we had earlier. I have tested this and verified on-device. PR is good to go.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Simplification of `picamera2` repository cloning instructions in Sony IMX500 integration docs. 📚✨

### 📊 Key Changes  
- Updated the repository cloning commands by removing the `-b next` branch flag in the Sony IMX500 setup documentation.

### 🎯 Purpose & Impact  
- **Purpose:** Ensures the instructions always fetch the default branch of the `picamera2` repository, preventing potential issues if the `-b next` branch becomes outdated or missing.  
- **Impact:** Simplifies setup for users, reduces confusion, and minimizes errors during integration. 🙌🔧