### PR TITLE
Remove `not_in_nav`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,10 +139,6 @@ validation:
     unrecognized_links: warn
 
 # Primary navigation ---------------------------------------------------------------------------------------------------
-not_in_nav: |
-  /compare
-  /macros
-
 nav:
   - Home:
       - Home: index.md


### PR DESCRIPTION
@glenn-jocher I think it's not necessary! What do you think? Thanks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Removed unused documentation entries from the `mkdocs.yml` configuration file to clean up unused resources.

### 📊 Key Changes  
- Deleted unused navigation items `/compare` and `/macros` from the `not_in_nav` section of the `mkdocs.yml` file.

### 🎯 Purpose & Impact  
- 🧹 **Purpose**: This change simplifies the documentation configuration by removing references to unused or irrelevant items.  
- 🚀 **Impact**: Results in a cleaner and more maintainable documentation setup, ensuring no misleading or outdated links confuse contributors or users.