### PR TITLE
Fix missing data.yaml error on int8 export

### DIFF
--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -152,7 +152,9 @@ def benchmark(
                 filename = model.pt_path or model.ckpt_path or model.model_name
                 exported_model = model  # PyTorch format
             else:
-                filename = model.export(imgsz=imgsz, format=format, half=half, int8=int8, data=data, device=device, verbose=False)
+                filename = model.export(
+                    imgsz=imgsz, format=format, half=half, int8=int8, data=data, device=device, verbose=False
+                )
                 exported_model = YOLO(filename, task=model.task)
                 assert suffix in str(filename), "export failed"
             emoji = "❎"  # indicates export succeeded

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -152,7 +152,7 @@ def benchmark(
                 filename = model.pt_path or model.ckpt_path or model.model_name
                 exported_model = model  # PyTorch format
             else:
-                filename = model.export(imgsz=imgsz, format=format, half=half, int8=int8, device=device, verbose=False)
+                filename = model.export(imgsz=imgsz, format=format, half=half, int8=int8, data=data, device=device, verbose=False)
                 exported_model = YOLO(filename, task=model.task)
                 assert suffix in str(filename), "export failed"
             emoji = "❎"  # indicates export succeeded
@@ -163,7 +163,7 @@ def benchmark(
             assert i != 5 or platform.system() == "Darwin", "inference only supported on macOS>=10.13"  # CoreML
             if i in {13}:
                 assert not is_end2end, "End-to-end torch.topk operation is not supported for NCNN prediction yet"
-            exported_model.predict(ASSETS / "bus.jpg", imgsz=imgsz, device=device, half=half, data=data, verbose=False)
+            exported_model.predict(ASSETS / "bus.jpg", imgsz=imgsz, device=device, half=half, verbose=False)
 
             # Validate
             results = exported_model.val(


### PR DESCRIPTION
Meant to pass data to the export method, not predict.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary 
Enhanced export and prediction functions for benchmarking models with improved parameter handling. 🚀

### 📊 Key Changes 
- Added a new `data` parameter to the `model.export()` function for better configurability during model export.
- Removed the redundant `data` parameter from `exported_model.predict()` for streamlined prediction calls.

### 🎯 Purpose & Impact 
- **Improved flexibility**: The updated `model.export()` now supports more customizable data definition during export, making it more versatile. 🛠️
- **Cleaner code**: Simplifying `exported_model.predict()` reduces potential confusion and ensures a cleaner flow. 🧹
- **User experience boost**: These tweaks improve the overall usability and accuracy of benchmarking processes for developers. 🌟