### PR TITLE
Enable custom runs directory while using external loggers

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -413,10 +413,10 @@ def get_save_dir(args, name=None):
 
     project = Path(base_dir) / args.project if args.project else Path(base_dir) / args.task
     name = name or args.name or f"{args.mode}"
-    
+
     # Ensure only RANK -1 or 0 affect exist_ok behavior
     exist_ok = args.exist_ok if RANK in {-1, 0} else True
-    
+
     return increment_path(project / name, exist_ok=exist_ok)
 
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -403,16 +403,21 @@ def get_save_dir(args, name=None):
         >>> print(save_dir)
         my_project/detect/train
     """
-    if getattr(args, "save_dir", None):
-        save_dir = args.save_dir
+    from ultralytics.utils.files import increment_path
+
+    # Ensure RUNS_DIR takes precedence, but fall back to args.project if it's not set
+    if TESTS_RUNNING:
+        base_dir = ROOT.parent / "tests/tmp/runs"
     else:
-        from ultralytics.utils.files import increment_path
+        base_dir = RUNS_DIR if RUNS_DIR else args.project  # RUNS_DIR has priority
 
-        project = args.project or (ROOT.parent / "tests/tmp/runs" if TESTS_RUNNING else RUNS_DIR) / args.task
-        name = name or args.name or f"{args.mode}"
-        save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True)
-
-    return Path(save_dir)
+    project = Path(base_dir) / args.project if args.project else Path(base_dir) / args.task
+    name = name or args.name or f"{args.mode}"
+    
+    # Ensure only RANK -1 or 0 affect exist_ok behavior
+    exist_ok = args.exist_ok if RANK in {-1, 0} else True
+    
+    return increment_path(project / name, exist_ok=exist_ok)
 
 
 def _handle_deprecation(custom):


### PR DESCRIPTION
This PR addresses the issue, that setting a local runs directory fails in some cases, especially when using external loggers like mlflow or wandb, which rely on the `project` parameter.

As has been described in:
https://github.com/ultralytics/ultralytics/issues/3527#issuecomment-2643049146

The project parameter determines both the save directory and external logger project name, leading to conflicts when using MLflow or WandB. A potential fix provided here, is to give RUNS_DIR precedence over project in get_save_dir(), ensuring a local save path while still allowing project for logging.


This will also remove the redundant check for "save_dir".

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved how save directories are created for training runs, making directory management more consistent and reliable. 📁✨

### 📊 Key Changes
- Refactored the logic for determining where training results are saved.
- Ensured that the `RUNS_DIR` setting always takes priority over other directory options.
- Improved handling for test environments and distributed training scenarios.
- Centralized the use of the `increment_path` utility for creating unique save directories.

### 🎯 Purpose & Impact
- 🛠️ Makes it easier for users to find and organize their training results.
- 🚀 Reduces confusion and potential errors when specifying custom save locations.
- 🤝 Ensures consistent behavior across different environments, including testing and distributed setups.
- 📂 Helps prevent accidental overwriting of previous runs by reliably creating unique directories.