### PR TITLE
`ultralytics 8.3.74` Fix Ray Tune callback error

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.73"
+__version__ = "8.3.74"
 
 import os
 

--- a/ultralytics/utils/callbacks/raytune.py
+++ b/ultralytics/utils/callbacks/raytune.py
@@ -14,7 +14,7 @@ except (ImportError, AssertionError):
 
 def on_fit_epoch_end(trainer):
     """Sends training metrics to Ray Tune at end of each epoch."""
-    if ray.train._internal.session._get_session():  # replacement for deprecated ray.tune.is_session_enabled()
+    if ray.train._internal.session.get_session():  # replacement for deprecated ray.tune.is_session_enabled()
         metrics = trainer.metrics
         session.report({**metrics, **{"epoch": trainer.epoch + 1}})
 


### PR DESCRIPTION
Fixes https://github.com/ultralytics/ultralytics/issues/9856
Fixes https://github.com/ultralytics/ultralytics/issues/10011
Fixes #19143 
Fixes ULTRALYTICS-1X5K

The correct function seems to be `get_session()`

https://github.com/ray-project/ray/blob/9e3ec5972cd952d2b50f3b20abc24ced5abb8b54/python/ray/train/_internal/session.py#L593


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated the Ray Tune integration to use modern methods, preventing potential errors and ensuring compatibility with latest Ray versions.  

### 📊 Key Changes  
- 🔧 Updated internal Ray Tune session call from `ray.tune.is_session_enabled()` to `ray.train._internal.session.get_session()`, replacing deprecated code.  
- 🆙 Bumped the Ultralytics version from `8.3.73` to `8.3.74`.  

### 🎯 Purpose & Impact  
- 🚀 Ensures compatibility with the latest versions of Ray, reducing the risk of runtime errors related to deprecated methods.  
- 🔄 Small version bump assures users there’s a minor but meaningful update to the framework.  
- ✅ Improved stability and future-proofing for users leveraging Ray Tune in their training workflows.