### PR TITLE
Return PIL image if `pil=True`

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -583,7 +583,7 @@ class Results(SimpleClass):
         if save:
             annotator.save(filename)
 
-        return annotator.result()
+        return annotator.im if pil else annotator.result()
 
     def show(self, *args, **kwargs):
         """


### PR DESCRIPTION
Closes #19145 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved image rendering options in the `plot` method for better flexibility and compatibility. 🖼️✨

### 📊 Key Changes  
- Modified the `plot` method to return `annotator.im` instead of `annotator.result()` when the `pil` option is used.

### 🎯 Purpose & Impact  
- **Flexibility**: Enables users to get a PIL image object (`annotator.im`) directly, improving compatibility with PIL-based workflows.  
- **Enhanced Usability**: Makes it easier to integrate Ultralytics visualization outputs into custom applications or pipelines requiring PIL images. 🚀  
- **Backwards Compatibility**: Maintains existing behavior for non-PIL outputs, ensuring no disruptions for users. ✅