### PR TITLE
Fix updating of best epoch during early stopping

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -746,7 +746,7 @@ class EarlyStopping:
         if fitness is None:  # check if fitness=None (happens when val=False)
             return False
 
-        if fitness >= self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
+        if fitness > self.best_fitness or self.best_fitness == 0:  # allow for early zero-fitness stage of training
             self.best_epoch = epoch
             self.best_fitness = fitness
         delta = epoch - self.best_epoch  # epochs without improvement


### PR DESCRIPTION
EarlyStopping currently updates the best epoch even when the new fitness is equal to the best one, rendering the patience parameter ineffective.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved training logic to better handle fitness updates during early training stages. 🚀  

### 📊 Key Changes  
- Adjusted the fitness comparison logic in `torch_utils.py` to trigger updates when:  
  - Fitness surpasses previous best fitness, OR  
  - Best fitness is initially set to zero.  

### 🎯 Purpose & Impact  
- Ensures smoother performance tracking during the early training stage when fitness values are still initializing.  
- Leads to more robust and accurate fitness improvement detection for users. ✅