### PR TITLE
Switch to `perf_counter()` for latency measurement

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -59,7 +59,7 @@ class Profile(contextlib.ContextDecorator):
         """Get current time."""
         if self.cuda:
             torch.cuda.synchronize(self.device)
-        return time.time()
+        return time.perf_counter()
 
 
 def segment2box(segment, width=640, height=640):


### PR DESCRIPTION
`time.perf_counter()` is more precise and [recommended for benchmarking](https://discuss.pytorch.org/t/best-way-to-measure-timing/39496/2).

`time.time()` sometimes returns `0.0` when the difference is small.

**main**
```python
import cv2
import time
from ultralytics import YOLO, ASSETS

img = cv2.imread(ASSETS / "bus.jpg")
model = YOLO("yolo11n.pt")

def test_latency(f, *args, **kwargs):
    s = time.time()
    results = f(*args, **kwargs)
    e = time.time()
    infer = sum(results[0].speed.values())
    tracker_ms = ((e - s) * 1000) - infer
    if tracker_ms == 0:
        print("Encountered 0 latency")
        print(results[0].speed)
        print("Infer:", infer)
        print("Tracker:" ,tracker_ms )
        print("End2End:", (e - s) * 1000)
        return False
    return True

for i in range(100):
    if not test_latency(model.track, img, tracker="bytetrack.yaml", persist=True, verbose=False): break

```
```
Encountered 0 latency
{'preprocess': 1.4903545379638672, 'inference': 52.018165588378906, 'postprocess': 0.0}
Infer: 53.50852012634277
Tracker: 0.0
End2End: 53.50852012634277
```

**PR**
```python
import cv2
import time
from ultralytics import YOLO, ASSETS

img = cv2.imread(ASSETS / "bus.jpg")
model = YOLO("yolo11n.pt")

def test_latency(f, *args, **kwargs):
    s = time.perf_counter()
    results = f(*args, **kwargs)
    e = time.perf_counter()
    infer = sum(results[0].speed.values())
    tracker_ms = ((e - s) * 1000) - infer
    if tracker_ms == 0:
        print("Encountered 0 latency")
        print(results[0].speed)
        print("Infer:", infer)
        print("Tracker:", tracker_ms)
        print("End2End:", (e - s) * 1000)
        return False
    return True

for i in range(100):
    if not test_latency(model.track, img, tracker="bytetrack.yaml", persist=True, verbose=False): break
else:
   print("No 0 latency encountered")
```
```
No 0 latency encountered
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated time measurement method in `ops.py` to improve precision and reliability. 🕒✨

### 📊 Key Changes  
- Replaced `time.time()` with `time.perf_counter()` for time measurement in the `time()` function.  

### 🎯 Purpose & Impact  
- **Improved Precision**: `time.perf_counter()` offers higher resolution for time measurements, making it more accurate for benchmarking or profiling.  
- **Better Reliability**: Ensures consistent and precise timing across different systems, especially for performance-critical tasks.  
- **User Benefit**: Developers and users running timing-sensitive operations (e.g., training, inference) will enjoy more dependable performance monitoring. 🚀