### PR TITLE
Fix `bus.jpg` path in `predict.md`

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -404,7 +404,7 @@ Below are code examples for using each source type:
     model = YOLO("yolo11n.pt")
 
     # Run inference on 'bus.jpg' with arguments
-    model.predict("bus.jpg", save=True, imgsz=320, conf=0.5)
+    model.predict("https://ultralytics.com/images/bus.jpg", save=True, imgsz=320, conf=0.5)
     ```
 
 Inference arguments:

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -473,8 +473,8 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
     model = YOLO("yolo11n.pt")
 
     # Run inference on an image
-    results = model("bus.jpg")  # list of 1 Results object
-    results = model(["bus.jpg", "zidane.jpg"])  # list of 2 Results objects
+    results = model("https://ultralytics.com/images/bus.jpg")  # list of 1 Results object
+    results = model(["https://ultralytics.com/images/bus.jpg", "https://ultralytics.com/images/zidane.jpg"])  # list of 2 Results objects
     ```
 
 `Results` objects have the following attributes:
@@ -530,7 +530,7 @@ For more details see the [`Results` class documentation](../reference/engine/res
     model = YOLO("yolo11n.pt")
 
     # Run inference on an image
-    results = model("bus.jpg")  # results list
+    results = model("https://ultralytics.com/images/bus.jpg")  # results list
 
     # View results
     for r in results:
@@ -568,7 +568,7 @@ For more details see the [`Boxes` class documentation](../reference/engine/resul
     model = YOLO("yolo11n-seg.pt")
 
     # Run inference on an image
-    results = model("bus.jpg")  # results list
+    results = model("https://ultralytics.com/images/bus.jpg")  # results list
 
     # View results
     for r in results:
@@ -601,7 +601,7 @@ For more details see the [`Masks` class documentation](../reference/engine/resul
     model = YOLO("yolo11n-pose.pt")
 
     # Run inference on an image
-    results = model("bus.jpg")  # results list
+    results = model("https://ultralytics.com/images/bus.jpg")  # results list
 
     # View results
     for r in results:
@@ -635,7 +635,7 @@ For more details see the [`Keypoints` class documentation](../reference/engine/r
     model = YOLO("yolo11n-cls.pt")
 
     # Run inference on an image
-    results = model("bus.jpg")  # results list
+    results = model("https://ultralytics.com/images/bus.jpg")  # results list
 
     # View results
     for r in results:
@@ -670,7 +670,7 @@ For more details see the [`Probs` class documentation](../reference/engine/resul
     model = YOLO("yolo11n-obb.pt")
 
     # Run inference on an image
-    results = model("boats.jpg")  # results list
+    results = model("https://ultralytics.com/images/boats.jpg")  # results list
 
     # View results
     for r in results:
@@ -710,7 +710,7 @@ The `plot()` method in `Results` objects facilitates visualization of prediction
     model = YOLO("yolo11n.pt")
 
     # Run inference on 'bus.jpg'
-    results = model(["bus.jpg", "zidane.jpg"])  # results list
+    results = model(["https://ultralytics.com/images/bus.jpg", "https://ultralytics.com/images/zidane.jpg"])  # results list
 
     # Visualize the results
     for i, r in enumerate(results):

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -474,7 +474,9 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 
     # Run inference on an image
     results = model("https://ultralytics.com/images/bus.jpg")  # list of 1 Results object
-    results = model(["https://ultralytics.com/images/bus.jpg", "https://ultralytics.com/images/zidane.jpg"])  # list of 2 Results objects
+    results = model(
+        ["https://ultralytics.com/images/bus.jpg", "https://ultralytics.com/images/zidane.jpg"]
+    )  # list of 2 Results objects
     ```
 
 `Results` objects have the following attributes:


### PR DESCRIPTION
@glenn-jocher 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated documentation to use public and accessible image URLs for clarity and consistency in inference examples.

### 📊 Key Changes  
- Replaced local image file paths (e.g., `"bus.jpg"`) with publicly accessible URLs (e.g., `"https://ultralytics.com/images/bus.jpg"`) in multiple examples across the `predict.md` documentation.  
- Adjusted code snippets across various model types (`YOLO`, `segmentation`, `pose`, etc.) to reflect this change.

### 🎯 Purpose & Impact  
- 📖 **Improved Clarity**: Using public URLs ensures that users following the examples won't run into issues with missing local image files.  
- 🌎 **Enhanced Accessibility**: Examples now work out-of-the-box without the need for additional local assets, making them more user-friendly and beginner-friendly.  
- 🚀 **Consistency Across Examples**: All code snippets now utilize the same standardized image links, improving the readability and professional feel of the documentation.