### PR TITLE
Fix Docker QEMU issues while building JetPack 6 Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
+          image: tonistiigi/binfmt:qemu-v7.0.0-28 # pin version for JetPack 6 failing Docker build: https://github.com/ultralytics/ultralytics/pull/19216
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.0-46
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          image: tonistiigi/binfmt:qemu-v9.2.0-46
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
@glenn-jocher It seems that Docker builds were passing 2 PRs ago because it was using `qemu-v7.0.0-28` for the build.
![CleanShot 2025-02-12 at 10 31 02](https://github.com/user-attachments/assets/44c9b447-e0c1-448d-8633-a94efbb04fbe)

The failing Docker build is using `qemu-v9.2.0-51`
![CleanShot 2025-02-12 at 10 31 36@2x](https://github.com/user-attachments/assets/3846c6ec-2429-4a68-bc28-3c32f0da3e88)

So I have pinned `qemu-v7.0.0-28` and the builds are passing:
https://github.com/ultralytics/ultralytics/actions/runs/13292293281/job/37115813848

We can pin this for the time being or I can investigate further into this.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Pinned a specific QEMU version in the Docker workflow to address a compatibility issue with JetPack 6. 🚀

### 📊 Key Changes  
- Updated the `docker.yml` workflow by explicitly setting the QEMU version to `qemu-v7.0.0-28` for the `docker/setup-qemu-action@v3`. 🛠️

### 🎯 Purpose & Impact  
- **Purpose**: This change solves a failing Docker build issue associated with JetPack 6 by ensuring compatibility with a stable QEMU version. ✅  
- **Impact**: Improves reliability for users relying on Docker workflows, particularly those working with JetPack 6 environments. Less troubleshooting, more productivity! 🎉