### PR TITLE
Initialize `model_name` attribute

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -122,6 +122,7 @@ class Model(torch.nn.Module):
         self.metrics = None  # validation/training metrics
         self.session = None  # HUB session
         self.task = task  # task type
+        self.model_name = None  # model name
         model = str(model).strip()
 
         # Check if Ultralytics HUB model from https://hub.ultralytics.com


### PR DESCRIPTION
When I look at the file engine/model.py, the model_name variable is not clearly declared in the init function.This makes me a little confused when reading the code.This may happen to other people too.So wanna add an variable[model_name] in the def __init__ function which is in engine/model.py to make this variable obvious.Thanks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added support for storing the model's name in the engine for better organization and tracking. 🏷️

### 📊 Key Changes  
- Introduced a new `self.model_name` attribute in the model class to store the model's name.  

### 🎯 Purpose & Impact  
- 🗂️ **Improved organization**: Helps track and identify models more easily during training, validation, or deployment.  
- 🚀 **Enhanced usability**: Provides a more seamless and intuitive experience for users working with multiple models.