### PR TITLE
`ultralytics 8.3.79` Fix shift in HSV augmentation

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.78"
+__version__ = "8.3.79"
 
 import os
 

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1366,14 +1366,14 @@ class RandomHSV:
         """
         img = labels["img"]
         if self.hgain or self.sgain or self.vgain:
-            r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain] + 1  # random gains
+            r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain]  # random gains
             hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
             dtype = img.dtype  # uint8
 
             x = np.arange(0, 256, dtype=r.dtype)
-            lut_hue = ((x * r[0]) % 180).astype(dtype)
-            lut_sat = np.clip(x * r[1], 0, 255).astype(dtype)
-            lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
+            lut_hue = np.mod(x + r[0] * 180, 180).astype(dtype)
+            lut_sat = np.clip(x * (1 + r[1]), 0, 255).astype(dtype)
+            lut_val = np.clip(x * (1 + r[2]), 0, 255).astype(dtype)
 
             im_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))
             cv2.cvtColor(im_hsv, cv2.COLOR_HSV2BGR, dst=img)  # no return needed

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1367,16 +1367,16 @@ class RandomHSV:
         if self.hgain or self.sgain or self.vgain:
             img = labels["img"]
             dtype = img.dtype  # uint8
-            # original implementation
+            x = np.arange(0, 256, dtype=r.dtype)
+
+            # Original implementation
             # r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain] + 1  # random gains
-            # x = np.arange(0, 256, dtype=r.dtype)
             # lut_hue = ((x * r[0]) % 180).astype(dtype)
             # lut_sat = np.clip(x * r[1], 0, 255).astype(dtype)
             # lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
 
-            # correct implementation
+            # Fixed implementation from https://github.com/ultralytics/ultralytics/pull/19311
             r = np.random.uniform(-1, 1, 3) * (self.hgain, self.sgain, self.vgain) * (180, 255, 255)  # random gains
-            x = np.arange(0, 256, dtype=r.dtype)
             lut_hue = ((x + r[0]) % 180).astype(dtype)
             lut_sat = np.clip(x + r[1], 0, 255).astype(dtype)
             lut_val = np.clip(x + r[2], 0, 255).astype(dtype)

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1373,7 +1373,7 @@ class RandomHSV:
             x = np.arange(0, 256, dtype=r.dtype)
             lut_hue = ((x + r[0]) % 180).astype(dtype)
             lut_sat = np.clip(x + r[1], 0, 255).astype(dtype)
-            lut_sat[0] = 0 # prevent pure white changing color
+            lut_sat[0] = 0  # prevent pure white changing color
             lut_val = np.clip(x + r[2], 0, 255).astype(dtype)
 
             im_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1366,13 +1366,14 @@ class RandomHSV:
         """
         img = labels["img"]
         if self.hgain or self.sgain or self.vgain:
-            r = np.random.uniform(-1, 1, 3) * (self.hgain, self.sgain, self.vgain) * (180, 1, 256)  # random gains
+            r = np.random.uniform(-1, 1, 3) * (self.hgain, self.sgain, self.vgain) * (180, 255, 255)  # random gains
             hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
             dtype = img.dtype  # uint8
 
             x = np.arange(0, 256, dtype=r.dtype)
             lut_hue = ((x + r[0]) % 180).astype(dtype)
-            lut_sat = np.clip(x * (1 + r[1]), 0, 255).astype(dtype)
+            lut_sat = np.clip(x + r[1], 0, 255).astype(dtype)
+            lut_sat[0] = 0 # prevent pure white changing color
             lut_val = np.clip(x + r[2], 0, 255).astype(dtype)
 
             im_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1366,14 +1366,14 @@ class RandomHSV:
         """
         img = labels["img"]
         if self.hgain or self.sgain or self.vgain:
-            r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain]  # random gains
+            r = np.random.uniform(-1, 1, 3) * (self.hgain, self.sgain, self.vgain) * (180, 1, 256)  # random gains
             hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
             dtype = img.dtype  # uint8
 
             x = np.arange(0, 256, dtype=r.dtype)
-            lut_hue = np.mod(x + r[0] * 180, 180).astype(dtype)
+            lut_hue = ((x + r[0]) % 180).astype(dtype)
             lut_sat = np.clip(x * (1 + r[1]), 0, 255).astype(dtype)
-            lut_val = np.clip(x * (1 + r[2]), 0, 255).astype(dtype)
+            lut_val = np.clip(x + r[2], 0, 255).astype(dtype)
 
             im_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))
             cv2.cvtColor(im_hsv, cv2.COLOR_HSV2BGR, dst=img)  # no return needed

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1367,16 +1367,17 @@ class RandomHSV:
         if self.hgain or self.sgain or self.vgain:
             img = labels["img"]
             dtype = img.dtype  # uint8
-            x = np.arange(0, 256, dtype=r.dtype)
 
             # Original implementation
             # r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain] + 1  # random gains
+            # x = np.arange(0, 256, dtype=r.dtype)
             # lut_hue = ((x * r[0]) % 180).astype(dtype)
             # lut_sat = np.clip(x * r[1], 0, 255).astype(dtype)
             # lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
 
             # Fixed implementation from https://github.com/ultralytics/ultralytics/pull/19311
             r = np.random.uniform(-1, 1, 3) * (self.hgain, self.sgain, self.vgain) * (180, 255, 255)  # random gains
+            x = np.arange(0, 256, dtype=r.dtype)
             lut_hue = ((x + r[0]) % 180).astype(dtype)
             lut_sat = np.clip(x + r[1], 0, 255).astype(dtype)
             lut_val = np.clip(x + r[2], 0, 255).astype(dtype)

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1364,8 +1364,8 @@ class RandomHSV:
             >>> hsv_augmenter(labels)
             >>> augmented_img = labels["img"]
         """
-        img = labels["img"]
         if self.hgain or self.sgain or self.vgain:
+            img = labels["img"]
             dtype = img.dtype  # uint8
             # original implementation
             # r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain] + 1  # random gains

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1368,14 +1368,14 @@ class RandomHSV:
             img = labels["img"]
             dtype = img.dtype  # uint8
 
-            # Original implementation
+            # Original implementation (bug) from ultralytics<=8.3.78
             # r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain] + 1  # random gains
             # x = np.arange(0, 256, dtype=r.dtype)
             # lut_hue = ((x * r[0]) % 180).astype(dtype)
             # lut_sat = np.clip(x * r[1], 0, 255).astype(dtype)
             # lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
 
-            # Fixed implementation from https://github.com/ultralytics/ultralytics/pull/19311
+            # Fixed implementation in https://github.com/ultralytics/ultralytics/pull/19311
             r = np.random.uniform(-1, 1, 3) * (self.hgain, self.sgain, self.vgain) * (180, 255, 255)  # random gains
             x = np.arange(0, 256, dtype=r.dtype)
             lut_hue = ((x + r[0]) % 180).astype(dtype)

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1366,16 +1366,23 @@ class RandomHSV:
         """
         img = labels["img"]
         if self.hgain or self.sgain or self.vgain:
-            r = np.random.uniform(-1, 1, 3) * (self.hgain, self.sgain, self.vgain) * (180, 255, 255)  # random gains
-            hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
             dtype = img.dtype  # uint8
+            # original implementation
+            # r = np.random.uniform(-1, 1, 3) * [self.hgain, self.sgain, self.vgain] + 1  # random gains
+            # x = np.arange(0, 256, dtype=r.dtype)
+            # lut_hue = ((x * r[0]) % 180).astype(dtype)
+            # lut_sat = np.clip(x * r[1], 0, 255).astype(dtype)
+            # lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
 
+            # correct implementation
+            r = np.random.uniform(-1, 1, 3) * (self.hgain, self.sgain, self.vgain) * (180, 255, 255)  # random gains
             x = np.arange(0, 256, dtype=r.dtype)
             lut_hue = ((x + r[0]) % 180).astype(dtype)
             lut_sat = np.clip(x + r[1], 0, 255).astype(dtype)
-            lut_sat[0] = 0  # prevent pure white changing color
             lut_val = np.clip(x + r[2], 0, 255).astype(dtype)
+            lut_sat[0] = 0  # prevent pure white changing color
 
+            hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
             im_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))
             cv2.cvtColor(im_hsv, cv2.COLOR_HSV2BGR, dst=img)  # no return needed
         return labels


### PR DESCRIPTION
First pointed out by @JacekMaksymiuk

Hue, Saturation, Value fixed to shift correctly.

```python
import cv2
import numpy as np
import matplotlib.pyplot as plt

!wget "https://i.pinimg.com/originals/56/ad/53/56ad5334915d999d8ecc6e503f14fb29.png" -O sat.jpg

img = cv2.imread("sat.jpg")

def hsv_new(h, s, v, img):
    r = np.array((1, 1, 1)) * [h, s, v] * (180, 255, 255)  # random gains
    hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
    dtype = img.dtype  # uint8
    
    x = np.arange(0, 256, dtype=r.dtype)
    lut_hue = ((x + r[0]) % 180).astype(dtype)
    lut_sat = np.clip(x + r[1], 0, 255).astype(dtype)
    lut_sat[0] = 0 # Fix white changing color
    lut_val = np.clip(x + r[2], 0, 255).astype(dtype)
    
    im_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))
    return cv2.cvtColor(im_hsv, cv2.COLOR_HSV2BGR)

img = cv2.imread('sat.jpg')

values = [-1, 0, 1]
fig, axes = plt.subplots(3, 3, figsize=(8, 6))

for i, param in enumerate(['hue', 'sat', 'val']):
    for j, v in enumerate(values):
        h, s, v_ = (v, 0, 0) if param == 'hue' else (0, v, 0) if param == 'sat' else (0, 0, v)
        shifted_img = hsv_new(h, s, v_, img.copy())
        
        ax = axes[i, j]
        ax.imshow(shifted_img)
        ax.set_title(f"{param}={v}")
        ax.axis('off')

plt.suptitle("Ultralytics - fixed")
plt.tight_layout()
plt.show()
```
![download](https://github.com/user-attachments/assets/4bb6ebef-3748-4eac-90c2-d839353b9c3d)
![download](https://github.com/user-attachments/assets/43510ad6-f8d1-477d-9a0b-fb62a77cd07a)

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
A bug fix in image augmentation improves the stability and accuracy of training by correcting HSV augmentation logic. 🚀

### 📊 Key Changes  
- 🛠️ Corrected the HSV augmentation logic in the `hsv_augmenter` function by using accurate random gain calculations for hue, saturation, and value.
- Fixed implementation ensures proper handling of extreme values (e.g., preventing white pixels from changing color).
- Updated the version from `8.3.78` to `8.3.79`.

### 🎯 Purpose & Impact  
- 🖼️ **Improved Augmentation Quality**: The fix ensures that HSV augmentation reflects realistic transformations without unintended artifacts, improving training consistency.  
- 🤖 **Better Model Training**: Models trained with this accurate augmentation are likely to perform better on diverse datasets.  
- 🛡️ **Stability**: Prevents possible issues in environments where augmentation impacts downstream tasks (e.g., white pixel color bleeding addressed).  

This update is essential for users relying on image augmentation for robust model training. 🎉