### PR TITLE
Display message for `-` export format

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -213,10 +213,7 @@ class Exporter:
         t = time.time()
         fmt = self.args.format.lower()  # to lowercase
         if fmt == "-":
-            LOGGER.info(
-                f"✅ Model already in PyTorch format."
-                f"\nVisualize:       https://netron.app"
-            )
+            LOGGER.info("✅ Model already in PyTorch format.\nVisualize:       https://netron.app")
             return
         if fmt in {"tensorrt", "trt"}:  # 'engine' aliases
             fmt = "engine"

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -212,6 +212,12 @@ class Exporter:
         self.run_callbacks("on_export_start")
         t = time.time()
         fmt = self.args.format.lower()  # to lowercase
+        if fmt == "-":
+            LOGGER.info(
+                f"✅ Model already in PyTorch format."
+                f"\nVisualize:       https://netron.app"
+            )
+            return
         if fmt in {"tensorrt", "trt"}:  # 'engine' aliases
             fmt = "engine"
         if fmt in {"mlmodel", "mlpackage", "mlprogram", "apple", "ios", "coreml"}:  # 'coreml' aliases


### PR DESCRIPTION
@glenn-jocher I have noticed If the user calls the export command: i.e ```yolo export model=yolo11n.pt format=-```. It's throwing an error as mentioned below.

```
Traceback (most recent call last):
  File "F:\Apps\Python\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "F:\Apps\Python\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "F:\Apps\Python\Scripts\yolo.exe\__main__.py", line 7, in <module>
  File "F:\Apps\Python\lib\site-packages\ultralytics\cfg\__init__.py", line 986, in entrypoint
    getattr(model, mode)(**overrides)  # default args from model
  File "F:\Apps\Python\lib\site-packages\ultralytics\engine\model.py", line 742, in export
    return Exporter(overrides=args, _callbacks=self.callbacks)(model=self.model)
  File "F:\Apps\Python\lib\site-packages\ultralytics\engine\exporter.py", line 227, in __call__
    raise ValueError(f"Invalid export format='{fmt}'. Valid formats are {fmts}")
ValueError: Invalid export format='-'. Valid formats are ('torchscript', 'onnx', 'openvino', 'engine', 'coreml', 'saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs', 'paddle', 'mnn', 'ncnn', 'imx', 'rknn')
```

With this PR, If the user will call ```yolo export model=yolo11n.pt format=-```. It will display a message like:

```
✅ Model already in PyTorch format.
Visualize:       https://netron.app
💡 Learn more at https://docs.ultralytics.com/modes/export
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Streamlined the export process by adding a quick mechanism for detecting and handling pre-exported PyTorch models.  

### 📊 Key Changes  
- Added a check in the exporter to detect if the model is already in PyTorch format (`fmt == "-"`).  
- Logs a message to inform users that the model is already export-ready with a direct link to visualize it on [Netron](https://netron.app).  
- The process exits early in this case, skipping redundant export steps.

### 🎯 Purpose & Impact  
- **Improved Efficiency**: Saves time by eliminating redundant operations when the model is already in the desired format. 🚀  
- **User-Friendly Logging**: Clear and informative log messages enhance user experience and guide users to visualize their model directly. 🖼️  
- **Reduced Errors**: Avoids potential confusion or errors from attempting unnecessary exports. ✅