### PR TITLE
Fix keypoints data display in `pose.md`

### DIFF
--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -31,21 +31,37 @@ The output of a pose estimation model is a set of points that represent the keyp
     In the default YOLO11 pose model, there are 17 keypoints, each representing a different part of the human body. Here is the mapping of each index to its respective body joint:
 
     0: Nose
+
     1: Left Eye
+
     2: Right Eye
+
     3: Left Ear
+
     4: Right Ear
+
     5: Left Shoulder
+
     6: Right Shoulder
+
     7: Left Elbow
+
     8: Right Elbow
+
     9: Left Wrist
+
     10: Right Wrist
+
     11: Left Hip
+
     12: Right Hip
+
     13: Left Knee
+
     14: Right Knee
+
     15: Left Ankle
+
     16: Right Ankle
 
 ## [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models/11)

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -30,39 +30,23 @@ The output of a pose estimation model is a set of points that represent the keyp
 
     In the default YOLO11 pose model, there are 17 keypoints, each representing a different part of the human body. Here is the mapping of each index to its respective body joint:
 
-    0: Nose
-
-    1: Left Eye
-
-    2: Right Eye
-
-    3: Left Ear
-
-    4: Right Ear
-
-    5: Left Shoulder
-
-    6: Right Shoulder
-
-    7: Left Elbow
-
-    8: Right Elbow
-
-    9: Left Wrist
-
-    10: Right Wrist
-
-    11: Left Hip
-
-    12: Right Hip
-
-    13: Left Knee
-
-    14: Right Knee
-
-    15: Left Ankle
-
-    16: Right Ankle
+    0. Nose
+    1. Left Eye
+    2. Right Eye
+    3. Left Ear
+    4. Right Ear
+    5. Left Shoulder
+    6. Right Shoulder
+    7. Left Elbow
+    8. Right Elbow
+    9. Left Wrist
+    10. Right Wrist
+    11. Left Hip
+    12. Right Hip
+    13. Left Knee
+    14. Right Knee
+    15. Left Ankle
+    16. Right Ankle
 
 ## [Models](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models/11)
 


### PR DESCRIPTION
I have noticed the key points details are not formatted correctly at: https://docs.ultralytics.com/tasks/pose/

![Screenshot 2025-02-20 200551](https://github.com/user-attachments/assets/bd2f388a-f112-4bba-bfe2-92e1bff40842)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor formatting update to improve the clarity of the pose estimation documentation. ✏️

### 📊 Key Changes  
- Updated the list of keypoints in the pose estimation documentation by changing the format from `N:` to `N.` for better readability.

### 🎯 Purpose & Impact  
- 🧾 **Improved Readability:** Enhances the clarity of the documentation by aligning the keypoints list with commonly accepted Markdown formatting.
- 🛠 **Ease of Use:** Helps users quickly understand the keypoint mapping, especially when referencing the documentation for pose estimation tasks.