### PR TITLE
Det models with `nc=1` when `single_cls=True`

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -567,6 +567,10 @@ class BaseTrainer:
         except Exception as e:
             raise RuntimeError(emojis(f"Dataset '{clean_url(self.args.data)}' error ❌ {e}")) from e
         self.data = data
+        if self.args.single_cls:
+            LOGGER.info("Overriding class names with single class.")
+            self.data["names"] = {0: "item"}
+            self.data["nc"] = 1
         return data["train"], data.get("val") or data.get("test")
 
     def setup_model(self):


### PR DESCRIPTION
## 🧐 What?  

While benchmarking raw detection performance with `single_cls=True`, I noticed that the implementation differs from `yolov5`. The model still maintains **N classes** but always assigns detections to class `0`.  

This PR ensures that when `single_cls=True`, the model has **only one class** in its inference output, making it _truly_ single-class. 

## 🤔 Why?  

For consistency and expected behavior—if we train a single-class model, it should actually output **one class**.  

## 🔧 How?  

Override `data["names"]` and `data["nc"]` in the engine trainer when `single_cls=True`.  
 
## Testing

### Before

```console
engine/trainer: task=detect, mode=train, model=yolo11n.pt, data=/mnt/datasets/yolo/TRAIN_BB_THERMAL_2024_09/dataset.yaml, epochs=100, time=None, patience=100, batch=-1, imgsz=640, save=True, save_period=-1, cache=False, device=0, workers=8, project=ultralytics, name=yolo11n, exist_ok=False, pretrained=True, optimizer=auto, verbose=True, seed=0, deterministic=True, single_cls=True, rect=False, cos_lr=False, close_mosaic=10, resume=False, amp=True, fraction=1.0, profile=False, freeze=None, multi_scale=False, overlap_mask=True, mask_ratio=4, dropout=0.0, val=True, split=val, save_json=False, save_hybrid=False, conf=0.1, iou=0.1, max_det=100, half=False, dnn=False, plots=True, source=None, vid_stride=1, stream_buffer=False, visualize=False, augment=False, agnostic_nms=True, classes=None, retina_masks=False, embed=None, show=False, save_frames=False, save_txt=False, save_conf=False, save_crop=False, show_labels=True, show_conf=True, show_boxes=True, line_width=None, format=torchscript, keras=False, optimize=False, int8=False, dynamic=False, simplify=True, opset=None, workspace=None, nms=False, lr0=0.001, lrf=0.01, momentum=0.937, weight_decay=0.0005, warmup_epochs=3.0, warmup_momentum=0.8, warmup_bias_lr=0.1, box=7.5, cls=0.5, dfl=1.5, pose=12.0, kobj=1.0, nbs=64, hsv_h=0.0, hsv_s=0.0, hsv_v=0.0, degrees=10.0, translate=0.1, scale=0.25, shear=0.0, perspective=0.0, flipud=0.0, fliplr=0.5, bgr=0.0, mosaic=1.0, mixup=0.0, copy_paste=0.0, copy_paste_mode=flip, auto_augment=randaugment, erasing=0.4, crop_fraction=1.0, cfg=../ultralytics/ultralytics/cfg/custom.yaml, tracker=botsort.yaml, save_dir=ultralytics/yolo11n
Overriding model.yaml nc=80 with nc=10
```
 
![image](https://github.com/user-attachments/assets/ed29ebdf-7605-4a52-a532-190f23b552e3)

### After


```console
engine/trainer: task=detect, mode=train, model=yolo11n.pt, data=/mnt/datasets/yolo/TRAIN_BB_THERMAL_2024_09/dataset.yaml, epochs=100, time=None, patience=100, batch=-1, imgsz=640, save=True, save_period=-1, cache=False, device=0, workers=8, project=ultralytics, name=yolo11n, exist_ok=False, pretrained=True, optimizer=auto, verbose=True, seed=0, deterministic=True, single_cls=True, rect=False, cos_lr=False, close_mosaic=10, resume=False, amp=True, fraction=1.0, profile=False, freeze=None, multi_scale=False, overlap_mask=True, mask_ratio=4, dropout=0.0, val=True, split=val, save_json=False, save_hybrid=False, conf=0.1, iou=0.1, max_det=100, half=False, dnn=False, plots=True, source=None, vid_stride=1, stream_buffer=False, visualize=False, augment=False, agnostic_nms=True, classes=None, retina_masks=False, embed=None, show=False, save_frames=False, save_txt=False, save_conf=False, save_crop=False, show_labels=True, show_conf=True, show_boxes=True, line_width=None, format=torchscript, keras=False, optimize=False, int8=False, dynamic=False, simplify=True, opset=None, workspace=None, nms=False, lr0=0.001, lrf=0.01, momentum=0.937, weight_decay=0.0005, warmup_epochs=3.0, warmup_momentum=0.8, warmup_bias_lr=0.1, box=7.5, cls=0.5, dfl=1.5, pose=12.0, kobj=1.0, nbs=64, hsv_h=0.0, hsv_s=0.0, hsv_v=0.0, degrees=10.0, translate=0.1, scale=0.25, shear=0.0, perspective=0.0, flipud=0.0, fliplr=0.5, bgr=0.0, mosaic=1.0, mixup=0.0, copy_paste=0.0, copy_paste_mode=flip, auto_augment=randaugment, erasing=0.4, crop_fraction=1.0, cfg=../ultralytics/ultralytics/cfg/custom.yaml, tracker=botsort.yaml, save_dir=ultralytics/yolo11n
Overriding model.yaml nc=80 with nc=1
```

![image](https://github.com/user-attachments/assets/14c9af68-f44c-4f0c-886d-e01e040363cd)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added support for single-class training overrides to streamline dataset handling for specific use cases. 🛠️

### 📊 Key Changes  
- 🆕 Implemented a check for `single_cls` argument in the training process.  
- 🔄 Automatically overrides dataset class names to `{0: "item"}` and the number of classes (`nc`) to 1 when `single_cls` is enabled.  
- 🖋️ Logs a message to inform users that single-class mode has been activated.

### 🎯 Purpose & Impact  
- ✅ **Purpose**: Simplify training for scenarios where only one class is required, reducing setup effort from users.
- 🚀 **Impact**: Speeds up model preparation and ensures compatibility with single-class datasets, especially helpful for niche tasks or specialized models.