### PR TITLE
Fix rbox regularization

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -799,10 +799,11 @@ def regularize_rboxes(rboxes):
         (torch.Tensor): The regularized boxes.
     """
     x, y, w, h, t = rboxes.unbind(dim=-1)
-    # Swap edge and angle if h >= w
-    w_ = torch.where(w > h, w, h)
-    h_ = torch.where(w > h, h, w)
-    t = torch.where(w > h, t, t + math.pi / 2) % (math.pi / 2)
+    # Swap edge if t >= pi/2 while not being symmetrically opposite
+    swap = t % math.pi >= math.pi / 2
+    w_ = torch.where(swap, h, w)
+    h_ = torch.where(swap, w, h)
+    t = t % (math.pi / 2)
     return torch.stack([x, y, w_, h_, t], dim=-1)  # regularized boxes
 
 

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -802,7 +802,7 @@ def regularize_rboxes(rboxes):
     # Swap edge and angle if h >= w
     w_ = torch.where(w > h, w, h)
     h_ = torch.where(w > h, h, w)
-    t = torch.where(w > h, t, t + math.pi / 2) % math.pi
+    t = torch.where(w > h, t, t + math.pi / 2) % (math.pi / 2)
     return torch.stack([x, y, w_, h_, t], dim=-1)  # regularized boxes
 
 


### PR DESCRIPTION
The description says it regularizes the angles to be between 0 and 90:
https://github.com/ultralytics/ultralytics/blob/bad9200cc00858532f90feef9eca0b191b7e79a7/ultralytics/utils/ops.py#L791-L793

But it isn't doing that. It is simply ensuring that width is always greater than height:
https://github.com/ultralytics/ultralytics/blob/bad9200cc00858532f90feef9eca0b191b7e79a7/ultralytics/utils/ops.py#L802

However that's not important for Ultralytics OBB because we're using the OpenCV definition (since we use `minAreaRect`), and not the LongEdge definition:
https://mmrotate.readthedocs.io/en/latest/intro.html
![image](https://github.com/user-attachments/assets/8f3443a0-f68d-49d2-8178-85da2f746c60)

The important part for OpenCV definition is that the angle is always between 0 and 90.

Updated the function to regularize based on angles.

```python
from ultralytics import YOLO
import math
from ultralytics.engine.results import Results
from ultralytics.utils.ops import xywhr2xyxyxyxy, xyxyxyxy2xywhr , regularize_rboxes
import matplotlib.pyplot as plt
import torch
img = torch.ones(100,100,3, dtype=torch.uint8)
rbox = torch.tensor((50, 50, 15, 45, 245 * torch.pi / 180, 0.5, 0))[None]
print("Original:\t", rbox)
print("Regularize:\t", torch.cat((regularize_rboxes(rbox[:, :5]), rbox[:, 5:]), dim=-1))
print("Inverse Test:\t", (torch.cat((xyxyxyxy2xywhr(xywhr2xyxyxyxy(rbox[:, :5])), rbox[:, 5:]), dim=-1)))
results = Results(obb=rbox, orig_img=img.numpy(), path="", names={0:"0"})
plt.imshow(results.plot(conf=False, labels=False))
```

**main**
Regularized box doesn't match inverted box (`xywhr` to `xyxyxyxyxy` to `xywhr`).
```python
Original:        tensor([[50.0000, 50.0000, 15.0000, 45.0000,  4.2761,  0.5000,  0.0000]])
Regularize:      tensor([[50.0000, 50.0000, 45.0000, 15.0000,  2.7053,  0.5000,  0.0000]])
Inverse Test:    tensor([[50.0000, 50.0000, 15.0000, 45.0000,  1.1345,  0.5000,  0.0000]])
```

**PR**
Regularized box matches inverted box (`xywhr` to `xyxyxyxyxy` to `xywhr`).
```python
Original:        tensor([[50.0000, 50.0000, 15.0000, 45.0000,  4.2761,  0.5000,  0.0000]])
Regularize:      tensor([[50.0000, 50.0000, 15.0000, 45.0000,  1.1345,  0.5000,  0.0000]])
Inverse Test:    tensor([[50.0000, 50.0000, 15.0000, 45.0000,  1.1345,  0.5000,  0.0000]])
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improves the handling of rotated bounding boxes by refining their regularization logic. 🛠️✨  

### 📊 Key Changes  
- Adjusted logic in the `regularize_rboxes` function to swap width (`w`) and height (`h`) based on angle conditions, ensuring bounding box consistency.  
- Simplified angle regularization to handle values more efficiently, ensuring they stay within a valid range (mod `π/2`).  

### 🎯 Purpose & Impact  
- **Purpose**: Improves geometric consistency for rotated bounding boxes by fixing edge-case errors and ensuring better alignment. 🖼️  
- **Impact**: Users analyzing or processing rotated objects will see improved accuracy and reliability in their bounding box calculations, particularly for edge cases involving angles near `π/2`. 🚀