### PR TITLE
`ultralytics 8.3.82` ONNX `dynamic` and `half` export

### DIFF
--- a/docs/en/reference/engine/exporter.md
+++ b/docs/en/reference/engine/exporter.md
@@ -37,4 +37,8 @@ keywords: YOLOv8, export formats, ONNX, TensorRT, CoreML, machine learning model
 
 ## ::: ultralytics.engine.exporter.try_export
 
+<br><br><hr><br>
+
+## ::: ultralytics.engine.exporter.arange_patch
+
 <br><br>

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.81"
+__version__ = "8.3.82"
 
 import os
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -62,6 +62,7 @@ import shutil
 import subprocess
 import time
 import warnings
+from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
@@ -183,7 +184,7 @@ def try_export(inner_func):
     return outer_func
 
 
-@__import__("contextlib").contextmanager
+@contextmanager
 def arange_patch(args):
     """
     Workaround for ONNX torch.arange incompatibility with FP16.

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -186,7 +186,7 @@ def try_export(inner_func):
 @__import__("contextlib").contextmanager
 def arange_patch(args):
     """Workaround for ONNX torch.arange incompatibility with FP16."""
-    if args.dynamic and args.half:
+    if args.dynamic and args.half and args.format == "onnx":
         func = torch.arange
 
         def arange(*args, dtype=None, **kwargs):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -185,7 +185,7 @@ def try_export(inner_func):
 
 @__import__("contextlib").contextmanager
 def arange_patch(args):
-    """Workaround for ONNX torch.arange incompatibility with FP16."""
+    """Workaround for ONNX torch.arange incompatibility with FP16. https://github.com/pytorch/pytorch/issues/148041"""
     if args.dynamic and args.half and args.format == "onnx":
         func = torch.arange
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -185,7 +185,7 @@ def try_export(inner_func):
 
 @__import__("contextlib").contextmanager
 def arange_patch(args):
-    """Workaround for ONNX torch.arange incompatibility with FP16. https://github.com/pytorch/pytorch/issues/148041"""
+    """Workaround for ONNX torch.arange incompatibility with FP16. https://github.com/pytorch/pytorch/issues/148041."""
     if args.dynamic and args.half and args.format == "onnx":
         func = torch.arange
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -183,6 +183,22 @@ def try_export(inner_func):
     return outer_func
 
 
+@__import__("contextlib").contextmanager
+def arange_patch(args):
+    """Workaround for ONNX torch.arange incompatibility with FP16."""
+    if args.dynamic and args.half:
+        func = torch.arange
+
+        def arange(*args, dtype=None, **kwargs):
+            return func(*args, **kwargs).to(dtype)  # workaround arange FP16 incompatibility
+
+        torch.arange = arange  # patch
+        yield
+        torch.arange = func  # unpatch
+    else:
+        yield
+
+
 class Exporter:
     """
     A class for exporting a model.
@@ -263,7 +279,6 @@ class Exporter:
         if self.args.half and onnx and self.device.type == "cpu":
             LOGGER.warning("WARNING ⚠️ half=True only compatible with GPU export, i.e. use device=0")
             self.args.half = False
-            assert not self.args.dynamic, "half=True not compatible with dynamic=True, i.e. use only one."
         self.imgsz = check_imgsz(self.args.imgsz, stride=model.stride, min_dim=2)  # check image size
         if self.args.int8 and engine:
             self.args.dynamic = True  # enforce dynamic to export TensorRT INT8
@@ -515,7 +530,6 @@ class Exporter:
         output_names = ["output0", "output1"] if isinstance(self.model, SegmentationModel) else ["output0"]
         dynamic = self.args.dynamic
         if dynamic:
-            self.model.cpu()  # dynamic=True only compatible with cpu
             dynamic = {"images": {0: "batch", 2: "height", 3: "width"}}  # shape(1,3,640,640)
             if isinstance(self.model, SegmentationModel):
                 dynamic["output0"] = {0: "batch", 2: "anchors"}  # shape(1, 116, 8400)
@@ -533,17 +547,18 @@ class Exporter:
                 pass
             check_requirements("onnxslim>=0.1.46")  # Older versions has bug with OBB
 
-        torch.onnx.export(
-            NMSModel(self.model, self.args) if self.args.nms else self.model,
-            self.im.cpu() if dynamic else self.im,
-            f,
-            verbose=False,
-            opset_version=opset_version,
-            do_constant_folding=True,  # WARNING: DNN inference with torch>=1.12 may require do_constant_folding=False
-            input_names=["images"],
-            output_names=output_names,
-            dynamic_axes=dynamic or None,
-        )
+        with arange_patch(self.args):
+            torch.onnx.export(
+                NMSModel(self.model, self.args) if self.args.nms else self.model,
+                self.im,
+                f,
+                verbose=False,
+                opset_version=opset_version,
+                do_constant_folding=True,  # WARNING: DNN inference with torch>=1.12 may require do_constant_folding=False
+                input_names=["images"],
+                output_names=output_names,
+                dynamic_axes=dynamic or None,
+            )
 
         # Checks
         model_onnx = onnx.load(f)  # load onnx model

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -185,7 +185,11 @@ def try_export(inner_func):
 
 @__import__("contextlib").contextmanager
 def arange_patch(args):
-    """Workaround for ONNX torch.arange incompatibility with FP16. https://github.com/pytorch/pytorch/issues/148041."""
+    """
+    Workaround for ONNX torch.arange incompatibility with FP16.
+
+    https://github.com/pytorch/pytorch/issues/148041.
+    """
     if args.dynamic and args.half and args.format == "onnx":
         func = torch.arange
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -190,7 +190,7 @@ def arange_patch(args):
         func = torch.arange
 
         def arange(*args, dtype=None, **kwargs):
-            return func(*args, **kwargs).to(dtype)  # workaround arange FP16 incompatibility
+            return func(*args, **kwargs).to(dtype)  # cast to dtype instead of passing dtype
 
         torch.arange = arange  # patch
         yield


### PR DESCRIPTION
The ONNX export with dynamic and half together fails due to an incompatibility with `torch.arange`:
https://github.com/pytorch/pytorch/issues/148041

Added a workaround patch where `torch.arange` doesn't pass `dtype` but casts to FP16 after creating the tensor with `arange`.

`yolo export model=yolo11n.pt format=onnx half=True dynamic=True device=0`

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary 
Adds a patch to handle compatibility issues with FP16 data type when exporting ONNX models dynamically.

### 📊 Key Changes
- 🚀 Introduced `arange_patch` context manager to fix ONNX export issues with `torch.arange` and FP16 precision.
- 🔄 Modified ONNX export logic to apply the new patch during dynamic ONNX exports.
- 🛠️ Removed outdated restrictions, such as requiring models to be on CPU for dynamic exports.
- 📄 Updated docs and bumped the version to `8.3.82`.

### 🎯 Purpose & Impact
- ✅ **Purpose**: Resolves a known incompatibility between PyTorch's `torch.arange` and FP16 precision in ONNX, ensuring smoother model exports.
- 🌟 **Impact**: Users exporting models to ONNX with FP16 and dynamic dimensions will now experience fewer issues, enhancing compatibility and reliability in deployment workflows.