### PR TITLE
Update SAM 2 research paper links

### DIFF
--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -49,7 +49,7 @@ Users can iteratively refine the segmentation results by providing additional pr
 
 SAM 2 includes mechanisms to manage common video segmentation challenges, such as object occlusion and reappearance. It uses a sophisticated memory mechanism to keep track of objects across frames, ensuring continuity even when objects are temporarily obscured or exit and re-enter the scene.
 
-For a deeper understanding of SAM 2's architecture and capabilities, explore the [SAM 2 research paper](https://arxiv.org/abs/2401.12741).
+For a deeper understanding of SAM 2's architecture and capabilities, explore the [SAM 2 research paper](https://arxiv.org/abs/2408.00714).
 
 ## Performance and Technical Details
 
@@ -338,7 +338,7 @@ SAM 2, the successor to Meta's [Segment Anything Model (SAM)](sam.md), is a cutt
 - **Interactive Refinement**: Allows users to iteratively refine segmentation results by providing additional prompts.
 - **Advanced Handling of Visual Challenges**: Manages common video segmentation challenges like object occlusion and reappearance.
 
-For more details on SAM 2's architecture and capabilities, explore the [SAM 2 research paper](https://arxiv.org/abs/2401.12741).
+For more details on SAM 2's architecture and capabilities, explore the [SAM 2 research paper](https://arxiv.org/abs/2408.00714).
 
 ### How can I use SAM 2 for real-time video segmentation?
 


### PR DESCRIPTION
Fixes two links in the SAM 2 documentation that point to the research paper.

The previous link was: https://arxiv.org/abs/2401.12741 which led to "Polynomial representation of TU-games".
I updated it to: https://arxiv.org/abs/2408.00714 which leads to "SAM 2: Segment Anything in Images and Videos". 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated the SAM 2 documentation links to point to the correct research paper for better user reference.

### 📊 Key Changes  
- Replaced incorrect links to the SAM 2 research paper with the correct URL in multiple sections of the documentation.

### 🎯 Purpose & Impact  
- 🛠 **Improved Documentation Accuracy**: Ensures users are directed to the correct resource for understanding SAM 2's architecture and functionalities.  
- 🌍 **Better User Experience**: Reduces confusion for users researching SAM 2, enhancing accessibility to reliable information.