### PR TITLE
Fix dataset_dir error with `open-images-v7.yaml`

### DIFF
--- a/ultralytics/cfg/datasets/open-images-v7.yaml
+++ b/ultralytics/cfg/datasets/open-images-v7.yaml
@@ -633,6 +633,7 @@ download: |
   import warnings
 
   name = 'open-images-v7'
+  fo.config.dataset_zoo_dir = Path(SETTINGS["datasets_dir"]) / "fiftyone" / name
   fraction = 1.0  # fraction of full dataset to use
   LOGGER.warning('WARNING ⚠️ Open Images V7 dataset requires at least **561 GB of free space. Starting download...')
   for split in 'train', 'validation':  # 1743042 train, 41620 val images

--- a/ultralytics/cfg/datasets/open-images-v7.yaml
+++ b/ultralytics/cfg/datasets/open-images-v7.yaml
@@ -642,7 +642,6 @@ download: |
       dataset = foz.load_zoo_dataset(name,
                                      split=split,
                                      label_types=['detections'],
-                                     dataset_dir=Path(SETTINGS['datasets_dir']) / 'fiftyone' / name,
                                      max_samples=round((1743042 if train else 41620) * fraction))
 
       # Define classes


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated the Open Images V7 dataset configuration to improve how the dataset directory is managed. 🚀  

### 📊 Key Changes  
- Moved the `dataset_zoo_dir` configuration to a central location (`fo.config.dataset_zoo_dir`) for improved clarity and consistency.  
- Removed the `dataset_dir` argument from the `foz.load_zoo_dataset` function call since it's now handled globally via `fo.config.dataset_zoo_dir`.

### 🎯 Purpose & Impact  
- **Streamlined Configuration**: Simplifies dataset management by centralizing the directory setup, reducing potential misconfigurations.  
- **Improved Code Maintainability**: Cleaner and more efficient code, making it easier for developers to work with and modify dataset configurations.  
- **No Immediate User Impact**: End-users shouldn't notice any changes in behavior; the improvements are primarily under-the-hood. 👩‍💻