### PR TITLE
Clean up Raspberry Pi CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
         run: |
           cat benchmarks.log
           echo "$(cat benchmarks.log)" >> $GITHUB_STEP_SUMMARY
-      - name: Clean up self-hosted runner
+      - name: Clean up runner
         uses: eviden-actions/clean-self-hosted-runner@v1
       # The below is fixed in: https://github.com/ultralytics/ultralytics/pull/15987
       # - name: Reboot # run a reboot command in the background to free resources for next run and not crash main thread

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   RaspberryPi:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event.inputs.raspberrypi == 'true')
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:
@@ -275,6 +275,8 @@ jobs:
         run: |
           cat benchmarks.log
           echo "$(cat benchmarks.log)" >> $GITHUB_STEP_SUMMARY
+      - name: Clean up self-hosted runner
+        uses: eviden-actions/clean-self-hosted-runner@v1
       # The below is fixed in: https://github.com/ultralytics/ultralytics/pull/15987
       # - name: Reboot # run a reboot command in the background to free resources for next run and not crash main thread
       #   run: sudo bash -c "sleep 10; reboot" &


### PR DESCRIPTION
@glenn-jocher let's implement this as a best practice. Seems it is better to have specifically for self-hosted runners because cleanup is taken care automatically for GitHub-hosted runners.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improves CI workflow efficiency by adding a cleanup step for self-hosted runners. 🛠️✨

### 📊 Key Changes  
- Added a new step to clean up self-hosted runners using the `eviden-actions/clean-self-hosted-runner@v1` action. 🧹

### 🎯 Purpose & Impact  
- **Purpose**: Ensures that self-hosted runners are properly cleaned up after testing, preventing resource conflicts or leftover processes. 🔄  
- **Impact**: Enhances the stability and efficiency of the CI/CD workflow, reducing potential issues in subsequent jobs. 🚀