### PR TITLE
Exclude `ort.pyke.io` from link checking

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   Links:
+    if: github.repository == "ultralytics/ultralytics"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +41,7 @@ jobs:
             --insecure \
             --accept 401,403,429,500,502,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|ort\.pyke\.io)' \
+            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
             --exclude-path docs/zh \
             --exclude-path docs/es \
             --exclude-path docs/ru \
@@ -70,7 +71,7 @@ jobs:
             --insecure \
             --accept 401,403,429,500,502,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|ort\.pyke\.io)' \
+            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
             --exclude-path '**/ci.yml' \
             --exclude-path docs/zh \
             --exclude-path docs/es \

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -40,7 +40,7 @@ jobs:
             --insecure \
             --accept 401,403,429,500,502,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
+            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|ort\.pyke\.io)' \
             --exclude-path docs/zh \
             --exclude-path docs/es \
             --exclude-path docs/ru \
@@ -70,7 +70,7 @@ jobs:
             --insecure \
             --accept 401,403,429,500,502,999 \
             --exclude-all-private \
-            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
+            --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com|ort\.pyke\.io)' \
             --exclude-path '**/ci.yml' \
             --exclude-path docs/zh \
             --exclude-path docs/es \


### PR DESCRIPTION
Due to this repo's large number of forks, the broken link check action is causing large traffic spikes to my domain. Please exclude it so the traffic doesn't continue to grow.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Conditional execution added to GitHub Actions workflow to ensure it only runs in the correct repository. 🛠️  

### 📊 Key Changes  
- Added a condition (`if: github.repository == "ultralytics/ultralytics"`) to the `Links` job in `.github/workflows/links.yml`.  

### 🎯 Purpose & Impact  
- **Purpose**: Prevents the workflow from running in forks or repositories outside the official `ultralytics/ultralytics` repository.  
- **Impact**: Improves efficiency and avoids unnecessary workflow executions, reducing resource usage and potential confusion for contributors. 🌍✔️