### PR TITLE
Fix BBox Out-of-Bounds Issue in MNN Example

### DIFF
--- a/docs/en/integrations/mnn.md
+++ b/docs/en/integrations/mnn.md
@@ -128,6 +128,8 @@ A function that relies solely on MNN for YOLO11 inference and preprocessing is i
             x1 = cx + w * 0.5
             y1 = cy + h * 0.5
             boxes = np.stack([x0, y0, x1, y1], axis=1)
+            # ensure ratio is within the valid range [0.0, 1.0]
+            boxes = np.clip(boxes, 0, 1)
             # get max prob and idx
             scores = np.max(probs, 0)
             class_ids = np.argmax(probs, 0)
@@ -143,6 +145,9 @@ A function that relies solely on MNN for YOLO11 inference and preprocessing is i
                 y1 = int(y1 * scale)
                 x0 = int(x0 * scale)
                 x1 = int(x1 * scale)
+                // clamp to the original image size to handle cases where padding was applied
+                x1 = min(iw, x1)
+                y1 = min(ih, y1);
                 print(result_class_ids[i])
                 cv2.rectangle(original_image, (x0, y0), (x1, y1), (0, 0, 255), 2)
             cv2.imwrite("res.jpg", original_image)
@@ -243,6 +248,9 @@ A function that relies solely on MNN for YOLO11 inference and preprocessing is i
             auto x1 = cx + w * _Const(0.5);
             auto y1 = cy + h * _Const(0.5);
             auto boxes = _Stack({x0, y0, x1, y1}, 1);
+            // ensure ratio is within the valid range [0.0, 1.0]
+            boxes = _Maximum(boxes, _Scalar<float>(0.0f));
+            boxes = _Minimum(boxes, _Scalar<float>(1.0f));
             auto scores = _ReduceMax(probs, {0});
             auto ids = _ArgMax(probs, 0);
             auto result_ids = _Nms(boxes, scores, 100, 0.45, 0.25);
@@ -257,6 +265,9 @@ A function that relies solely on MNN for YOLO11 inference and preprocessing is i
                 auto y0 = box_ptr[idx * 4 + 1] * scale;
                 auto x1 = box_ptr[idx * 4 + 2] * scale;
                 auto y1 = box_ptr[idx * 4 + 3] * scale;
+                // clamp to the original image size to handle cases where padding was applied
+                x1 = std::min(static_cast<float>(iw), x1);
+                y1 = std::min(static_cast<float>(ih), y1);
                 auto class_idx = ids_ptr[idx];
                 auto score = score_ptr[idx];
                 rectangle(original_image, {x0, y0}, {x1, y1}, {0, 0, 255}, 2);


### PR DESCRIPTION
This PR fixes a bounding box (BBox) out-of-bounds issue in the MNN example, which can occur in two scenarios:

1. Inference Value Exceeding Valid Range:
In rare cases, the inferred BBox values may slightly exceed the expected range. While this is uncommon and typically minor, it has been addressed to ensure numerical stability.

2. BBox Exceeding Original Image Bounds Due to Padding:
When the original image is padded from a rectangle to a square, the inferred BBox may extend into the padded region. While valid within the padded image, it becomes out-of-bounds when mapped back to the original image.

This fix ensures that BBox values remain within valid limits.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved bounding box handling in MNN YOLO inference to ensure better accuracy and compatibility for object detection.  

### 📊 Key Changes  
- Added clipping of bounding box coordinates to ensure values stay within the valid range ([0.0, 1.0] for ratios). 🧮  
- Adjusted bounding boxes to fit original image dimensions, accounting for padding during inference. 📏  

### 🎯 Purpose & Impact  
- **Enhanced Accuracy**: Prevents invalid bounding box values and ensures results align with the image size.  
- **Improved Robustness**: Handles edge cases effectively, providing more reliable object detection outputs. 💪  
- **User-Friendly Outputs**: Ensures final bounding boxes remain usable for downstream tasks like visualization or further analysis. 🎯