### PR TITLE
Remove QEMU emulator in favor of Github-hosted Arm64 Ubuntu runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,6 +88,7 @@ jobs:
           # - dockerfile: "Dockerfile-conda"
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
+    
     runs-on: ${{ matrix.runs_on }}
     outputs:
       new_release: ${{ steps.check_tag.outputs.new_release }}
@@ -165,16 +166,16 @@ jobs:
               .
 
       - name: Check Environment
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile-conda' # arm64 images not supported on GitHub CI runners
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
 
       - name: Run Tests
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile-conda' # arm64 images not supported on GitHub CI runners
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
 
       - name: Run Benchmarks
         # WARNING: Dockerfile (GPU) error on TF.js export 'module 'numpy' has no attribute 'object'.
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda' # arm64 images not supported on GitHub CI runners
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
 
       - name: Push Docker Image with Ultralytics version tag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -165,16 +165,16 @@ jobs:
               .
 
       - name: Check Environment
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.platforms == 'linux/arm64' && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
 
       - name: Run Tests
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.platforms == 'linux/arm64' && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
 
       - name: Run Benchmarks
         # WARNING: Dockerfile (GPU) error on TF.js export 'module 'numpy' has no attribute 'object'.
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.platforms == 'linux/arm64' && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
 
       - name: Push Docker Image with Ultralytics version tag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -169,7 +169,7 @@ jobs:
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
 
       - name: Run Tests
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
 
       - name: Run Benchmarks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,6 @@ jobs:
   docker:
     if: github.repository == 'ultralytics/ultralytics'
     name: Push
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -61,27 +60,35 @@ jobs:
           - dockerfile: "Dockerfile"
             tags: "latest"
             platforms: "linux/amd64"
+            runs_on: "ubuntu-latest"
           - dockerfile: "Dockerfile-cpu"
             tags: "latest-cpu"
             platforms: "linux/amd64"
+            runs_on: "ubuntu-latest"
           - dockerfile: "Dockerfile-arm64"
             tags: "latest-arm64"
             platforms: "linux/arm64"
+            runs_on: "ubuntu-24.04-arm"
           - dockerfile: "Dockerfile-jetson-jetpack6"
             tags: "latest-jetson-jetpack6"
             platforms: "linux/arm64"
+            runs_on: "ubuntu-24.04-arm"
           - dockerfile: "Dockerfile-jetson-jetpack5"
             tags: "latest-jetson-jetpack5"
             platforms: "linux/arm64"
+            runs_on: "ubuntu-24.04-arm"
           - dockerfile: "Dockerfile-jetson-jetpack4"
             tags: "latest-jetson-jetpack4"
             platforms: "linux/arm64"
+            runs_on: "ubuntu-24.04-arm"
           - dockerfile: "Dockerfile-python"
             tags: "latest-python"
             platforms: "linux/amd64"
+            runs_on: "ubuntu-latest"
           # - dockerfile: "Dockerfile-conda"
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
+    runs-on: ${{ matrix.runs_on }}
     outputs:
       new_release: ${{ steps.check_tag.outputs.new_release }}
     steps:
@@ -92,11 +99,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # copy full .git directory to access full git history in Docker images
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28 # pin version for JetPack 6 failing Docker build: https://github.com/ultralytics/ultralytics/pull/19216
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -163,16 +165,16 @@ jobs:
               .
 
       - name: Check Environment
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile-conda' # arm64 images not supported on GitHub CI runners
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.platforms == 'linux/arm64' && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
 
       - name: Run Tests
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile-conda' # arm64 images not supported on GitHub CI runners
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.platforms == 'linux/arm64' && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
 
       - name: Run Benchmarks
         # WARNING: Dockerfile (GPU) error on TF.js export 'module 'numpy' has no attribute 'object'.
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda' # arm64 images not supported on GitHub CI runners
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.platforms == 'linux/arm64' && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
 
       - name: Push Docker Image with Ultralytics version tag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run Benchmarks
         # WARNING: Dockerfile (GPU) error on TF.js export 'module 'numpy' has no attribute 'object'.
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
 
       - name: Push Docker Image with Ultralytics version tag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -169,12 +169,12 @@ jobs:
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
 
       - name: Run Tests
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
 
       - name: Run Benchmarks
         # WARNING: Dockerfile (GPU) error on TF.js export 'module 'numpy' has no attribute 'object'.
-        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && matrix.platforms == 'linux/amd64' && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
+        if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
         run: docker run ultralytics/ultralytics:${{ matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
 
       - name: Push Docker Image with Ultralytics version tag


### PR DESCRIPTION
@glenn-jocher We do not need QEMU emulator on x86 runners anymore because we can directly use arm64 runners when building arm64 Docker images.

I have tested [here](https://github.com/ultralytics/ultralytics/actions/runs/13753479188/job/38457376303) and Docker builds are passing. 

This cuts down arm64 docker builds from 8 minutes to 2 minutes 🚀

![CleanShot 2025-03-09 at 16 15 06@2x](https://github.com/user-attachments/assets/b65e1bbb-115c-4009-b657-39fdb910965a)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved Docker workflow by refining platform-specific configurations and simplifying setup steps. 🐳✨  

### 📊 Key Changes  
- Added `runs_on` fields for specific Dockerfile builds to target appropriate environments (e.g., `ubuntu-24.04-arm` for Jetson builds).  
- Removed redundant `runs-on: ubuntu-latest` declaration at the job level, now dynamically set per matrix configuration.  
- Eliminated the `Set up QEMU` step, simplifying the workflow and removing dependency on QEMU for Jetson builds.  

### 🎯 Purpose & Impact  
- **Streamlined Workflow**: Simplifies Docker build configurations, making them more maintainable and targeted for specific platforms.  
- **Improved Compatibility**: Ensures platform-specific builds (e.g., Jetson) are executed in the correct environment, reducing potential build failures.  
- **Reduced Complexity**: By removing the QEMU setup, the workflow is cleaner and less prone to errors, benefiting developers managing Docker builds.  

This update enhances the reliability and maintainability of Docker workflows for Ultralytics projects. 🚀