### PR TITLE
Remove parking slots annotator from tests

### DIFF
--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -72,7 +72,7 @@ def test_major_solutions():
     cap = cv2.VideoCapture(str(TMP / PARKING_VIDEO))
     assert cap.isOpened(), "Error reading video file"
     parkingmanager = solutions.ParkingManagement(
-        json_file=str(TMP / PARKING_AREAS_JSON), model=str(TMP / PARKING_MODEL), show=True
+        json_file=str(TMP / PARKING_AREAS_JSON), model=str(TMP / PARKING_MODEL), show=False
     )
     while cap.isOpened():
         success, im0 = cap.read()
@@ -80,14 +80,6 @@ def test_major_solutions():
             break
         _ = parkingmanager.process_data(im0)
     cap.release()
-
-
-@pytest.mark.slow
-def test_parking_annotator():
-    """Test the parking annotator."""
-    from ultralytics import solutions
-
-    solutions.ParkingPtsSelection()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
@glenn-jocher FYI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved test behavior for Parking Management and removed an outdated test to streamline the codebase. 🛠️

### 📊 Key Changes  
- Changed the `show` parameter in the `ParkingManagement` test from `True` to `False` to disable video display during testing. 🖥️➡️❌  
- Removed the `test_parking_annotator` function, which tested the `ParkingPtsSelection` feature, as it is no longer relevant. 🗑️  

### 🎯 Purpose & Impact  
- **Purpose**:  
  - Disabling video display (`show=False`) ensures smoother and faster automated testing without unnecessary UI interruptions. 🚀  
  - Removing the outdated test cleans up the codebase, reducing maintenance overhead. 🧹  

- **Impact**:  
  - Improves testing efficiency and reliability for developers.  
  - Simplifies the test suite, making it easier to manage and understand.