### PR TITLE
Revert `shell=True` for `model.tune()`

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -26,7 +26,7 @@ import numpy as np
 import torch
 
 from ultralytics.cfg import get_cfg, get_save_dir
-from ultralytics.utils import DEFAULT_CFG, LOGGER, callbacks, colorstr, remove_colorstr, yaml_print, yaml_save
+from ultralytics.utils import DEFAULT_CFG, LOGGER, ROOT, callbacks, colorstr, remove_colorstr, yaml_print, yaml_save
 from ultralytics.utils.plotting import plot_tune_results
 
 
@@ -191,8 +191,9 @@ class Tuner:
             weights_dir = save_dir / "weights"
             try:
                 # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
-                cmd = ["yolo", "train", *(f"{k}={v}" for k, v in train_args.items())]
-                return_code = subprocess.run(" ".join(cmd), check=True, shell=True).returncode
+                launch = [__import__("sys").executable, "-m", f"{ROOT}.cfg.__init__"]  # workaround yolo not found issue
+                cmd = [*launch, "train", *(f"{k}={v)}" for k, v in train_args.items())]
+                return_code = subprocess.run(cmd, check=True).returncode
                 ckpt_file = weights_dir / ("best.pt" if (weights_dir / "best.pt").exists() else "last.pt")
                 metrics = torch.load(ckpt_file)["train_metrics"]
                 assert return_code == 0, "training failed"

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -191,11 +191,7 @@ class Tuner:
             weights_dir = save_dir / "weights"
             try:
                 # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
-                launch = [
-                    __import__("sys").executable,
-                    "-m",
-                    "ultralytics.cfg.__init__"
-                ]  # workaround yolo not found
+                launch = [__import__("sys").executable, "-m", "ultralytics.cfg.__init__"]  # workaround yolo not found
                 cmd = [*launch, "train", *(f"{k}={v}" for k, v in train_args.items())]
                 return_code = subprocess.run(cmd, check=True).returncode
                 ckpt_file = weights_dir / ("best.pt" if (weights_dir / "best.pt").exists() else "last.pt")

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -191,7 +191,11 @@ class Tuner:
             weights_dir = save_dir / "weights"
             try:
                 # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
-                launch = [__import__("sys").executable, "-m", "ultralytics.cfg.__init__"]  # workaround yolo not found issue
+                launch = [
+                    __import__("sys").executable,
+                    "-m",
+                    "ultralytics.cfg.__init__",
+                ]  # workaround yolo not found issue
                 cmd = [*launch, "train", *(f"{k}={v}" for k, v in train_args.items())]
                 return_code = subprocess.run(cmd, check=True).returncode
                 ckpt_file = weights_dir / ("best.pt" if (weights_dir / "best.pt").exists() else "last.pt")

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -26,7 +26,7 @@ import numpy as np
 import torch
 
 from ultralytics.cfg import get_cfg, get_save_dir
-from ultralytics.utils import DEFAULT_CFG, LOGGER, ROOT, callbacks, colorstr, remove_colorstr, yaml_print, yaml_save
+from ultralytics.utils import DEFAULT_CFG, LOGGER, callbacks, colorstr, remove_colorstr, yaml_print, yaml_save
 from ultralytics.utils.plotting import plot_tune_results
 
 
@@ -191,8 +191,8 @@ class Tuner:
             weights_dir = save_dir / "weights"
             try:
                 # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
-                launch = [__import__("sys").executable, "-m", f"{ROOT}.cfg.__init__"]  # workaround yolo not found issue
-                cmd = [*launch, "train", *(f"{k}={v)}" for k, v in train_args.items())]
+                launch = [__import__("sys").executable, "-m", "ultralytics.cfg.__init__"]  # workaround yolo not found issue
+                cmd = [*launch, "train", *(f"{k}={v}" for k, v in train_args.items())]
                 return_code = subprocess.run(cmd, check=True).returncode
                 ckpt_file = weights_dir / ("best.pt" if (weights_dir / "best.pt").exists() else "last.pt")
                 metrics = torch.load(ckpt_file)["train_metrics"]

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -194,8 +194,8 @@ class Tuner:
                 launch = [
                     __import__("sys").executable,
                     "-m",
-                    "ultralytics.cfg.__init__",
-                ]  # workaround yolo not found issue
+                    "ultralytics.cfg.__init__"
+                ]  # workaround yolo not found
                 cmd = [*launch, "train", *(f"{k}={v}" for k, v in train_args.items())]
                 return_code = subprocess.run(cmd, check=True).returncode
                 ckpt_file = weights_dir / ("best.pt" if (weights_dir / "best.pt").exists() else "last.pt")


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/19620

PR https://github.com/ultralytics/ultralytics/pull/18284 added `shell=True` to workaround the `yolo not found` issue. But it has other side-effects, as in the issue above, besides also being unsafe. This PR reverts it and uses a different approach to execute the command by executing the module directly with Python.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved the YOLO model training process in the hyperparameter tuning workflow to fix a command execution issue. 🚀

### 📊 Key Changes  
- Updated the subprocess command for training YOLO models during hyperparameter tuning:
  - Replaced the direct `"yolo train"` command with a Python module-based execution (`sys.executable -m ultralytics.cfg.__init__`).
  - Ensures the correct module is located and executed, avoiding "command not found" errors.

### 🎯 Purpose & Impact  
- **Purpose**: Fixes an issue where the YOLO command might not be recognized in certain environments, improving reliability during hyperparameter tuning. 🛠️  
- **Impact**: Users will experience fewer errors when running hyperparameter tuning, especially in setups where the YOLO CLI is not directly accessible. This enhances usability and reduces troubleshooting time. 🌟