### PR TITLE
Pin `tensorflow=2.18.0` & `tf-keras<=2.18.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,10 @@ dev = [
 ]
 export = [
     "onnx>=1.12.0", # ONNX export
-    "onnx2tf>1.17.5,<=1.26.3",
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
     "openvino>=2024.0.0,!=2025.0.0", # OpenVINO export
-    "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "keras", # not installed automatically by tensorflow>=2.16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,8 @@ export = [
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
     "openvino>=2024.0.0,!=2025.0.0", # OpenVINO export
-    "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
-    "tensorflowjs>=4.22.0", # TF.js export, automatically installs tensorflow
+    "tensorflow>=2.0.0,<=2.18.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "keras", # not installed automatically by tensorflow>=2.16
     "flatbuffers>=23.5.26,<100; platform_machine == 'aarch64'", # update old 'flatbuffers' included inside tensorflow package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ dev = [
 ]
 export = [
     "onnx>=1.12.0", # ONNX export
+    "onnx2tf>1.17.5,<=1.26.3",
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
     "openvino>=2024.0.0,!=2025.0.0", # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ export = [
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
     "openvino>=2024.0.0,!=2025.0.0", # OpenVINO export
-    "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflow>=2.0.0,<2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "keras", # not installed automatically by tensorflow>=2.16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,8 @@ export = [
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
     "openvino>=2024.0.0,!=2025.0.0", # OpenVINO export
-    "tensorflow>=2.0.0,<=2.18.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
-    "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow
+    "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflowjs>=4.22.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "keras", # not installed automatically by tensorflow>=2.16
     "flatbuffers>=23.5.26,<100; platform_machine == 'aarch64'", # update old 'flatbuffers' included inside tensorflow package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ export = [
     "coremltools>=7.0; platform_system != 'Windows' and python_version <= '3.11'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.11'", # CoreML k-means quantization
     "openvino>=2024.0.0,!=2025.0.0", # OpenVINO export
-    "tensorflow>=2.0.0,<2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflow>=2.0.0,<=2.18.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=3.9.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "keras", # not installed automatically by tensorflow>=2.16

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1002,7 +1002,7 @@ class Exporter:
         check_requirements(
             (
                 "keras",  # required by 'onnx2tf' package
-                "tf_keras<=2.18.0",  # required by 'onnx2tf' package
+                "tf_keras",  # required by 'onnx2tf' package
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "onnx>=1.12.0",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1002,7 +1002,7 @@ class Exporter:
         check_requirements(
             (
                 "keras",  # required by 'onnx2tf' package
-                "tf_keras",  # required by 'onnx2tf' package
+                "tf_keras<=2.18.0",  # required by 'onnx2tf' package
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "onnx>=1.12.0",


### PR DESCRIPTION
@glenn-jocher [TensorFlow](https://github.com/tensorflow/tensorflow/releases/tag/v2.19.0) and [tf-keras](https://github.com/keras-team/tf-keras/releases) released a new version (2 hours ago), which is breaking the CI benchmark tests (mainly for [tfjs](https://docs.ultralytics.com/integrations/tfjs/)) for the latest Mac and Linux, I have opened the PR for this fix :smiley:

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated TensorFlow and tf_keras dependency versions to address compatibility issues and improve export stability. 🚀  

### 📊 Key Changes  
- Restricted TensorFlow version to `<=2.18.0` to resolve a known bug.  
- Updated `tf_keras` dependency to `<=2.18.0` for compatibility with the `onnx2tf` package.  

### 🎯 Purpose & Impact  
- 🛠 **Bug Fix**: Ensures smoother TensorFlow exports by avoiding issues with newer versions.  
- ✅ **Improved Stability**: Enhances compatibility for exporting models, especially when using ONNX-to-TensorFlow workflows.  
- 🌍 **User Benefit**: Provides a more reliable experience for users exporting models across platforms.