### PR TITLE
Fix solutions CI

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -684,7 +684,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
     check_dict_alignment(full_args_dict, overrides)  # dict alignment
 
     # Get solution name
-    args = args if args else (LOGGER.warning("⚠️ No solution provided. Defaulting to 'count'."), ["count"])[1]
+    args = args if args else (LOGGER.warning("⚠️ No solution name provided. i.e `yolo solutions count`. Defaulting to 'count'."), ["count"])[1]
     if args[0] == "help":
         LOGGER.info(SOLUTIONS_HELP_MSG)
         return  # Early return for 'help' case

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -684,6 +684,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
     check_dict_alignment(full_args_dict, overrides)  # dict alignment
 
     # Get solution name
+    args = args if args else (LOGGER.warning("⚠️ No solution provided. Defaulting to 'count'."), ["count"])[1]
     if args[0] == "help":
         LOGGER.info(SOLUTIONS_HELP_MSG)
         return  # Early return for 'help' case

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -684,7 +684,9 @@ def handle_yolo_solutions(args: List[str]) -> None:
     check_dict_alignment(full_args_dict, overrides)  # dict alignment
 
     # Get solution name
-    args = args if args else (LOGGER.warning("⚠️ No solution name provided. i.e `yolo solutions count`. Defaulting to 'count'."), ["count"])[1]
+    if not args:
+        LOGGER.warning("⚠️ No solution name provided. i.e `yolo solutions count`. Defaulting to 'count'.")
+        args = ["count"]
     if args[0] == "help":
         LOGGER.info(SOLUTIONS_HELP_MSG)
         return  # Early return for 'help' case

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -684,7 +684,14 @@ def handle_yolo_solutions(args: List[str]) -> None:
     check_dict_alignment(full_args_dict, overrides)  # dict alignment
 
     # Get solution name
-    args = args if args else (LOGGER.warning("⚠️ No solution name provided. i.e `yolo solutions count`. Defaulting to 'count'."), ["count"])[1]
+    args = (
+        args
+        if args
+        else (
+            LOGGER.warning("⚠️ No solution name provided. i.e `yolo solutions count`. Defaulting to 'count'."),
+            ["count"],
+        )[1]
+    )
     if args[0] == "help":
         LOGGER.info(SOLUTIONS_HELP_MSG)
         return  # Early return for 'help' case


### PR DESCRIPTION
@glenn-jocher This check is missed! If a user runs `yolo solutions` without specifying a solution name, the code was breaking. I think we should default to the "count" solution with a warning instead.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved handling of missing solution names in YOLO commands with a default fallback and clearer warnings. ⚠️  

### 📊 Key Changes  
- Added a warning message when no solution name is provided in YOLO commands.  
- Defaulted the solution name to "count" if none is specified.  

### 🎯 Purpose & Impact  
- **Purpose**: Ensures smoother user experience by preventing errors when solution names are omitted.  
- **Impact**: Users benefit from clearer guidance and a default behavior, reducing confusion and potential command failures. 🚀