### PR TITLE
AssertionError: Benchmark failure for TensorFlow SavedModel: No module named 'ai_edge_litert'

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1007,7 +1007,7 @@ class Exporter:
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "onnx>=1.12.0",
-                "onnx2tf>=1.26.3",
+                "onnx2tf==1.26.3",
                 "onnxslim>=0.1.31",
                 "tflite_support<=0.4.3" if IS_JETSON else "tflite_support",  # fix ImportError 'GLIBCXX_3.4.29'
                 "flatbuffers>=23.5.26,<100",  # update old 'flatbuffers' included inside tensorflow package

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1007,12 +1007,13 @@ class Exporter:
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "onnx>=1.12.0",
-                "onnx2tf==1.26.3",
+                "onnx2tf>=1.26.3",
                 "onnxslim>=0.1.31",
                 "tflite_support<=0.4.3" if IS_JETSON else "tflite_support",  # fix ImportError 'GLIBCXX_3.4.29'
                 "flatbuffers>=23.5.26,<100",  # update old 'flatbuffers' included inside tensorflow package
                 "onnxruntime-gpu" if cuda else "onnxruntime",
                 "protobuf>=5",  # tflite_support pins <=4 but >=5 works
+                "ai-edge-litert>=1.2.0" # ai-edge-litert is missing if onnx2tf==1.27.0
             ),
             cmds="--extra-index-url https://pypi.ngc.nvidia.com",  # onnx_graphsurgeon only on NVIDIA
         )


### PR DESCRIPTION
I noticed that the current version has the following error: `AssertionError: Benchmark failure for TensorFlow SavedModel: No module named 'ai_edge_litert'` when running the tests. 

I believe this issue is related to `onnx2tf`, which was updated from version `1.26.9` to `1.27.0` just three hours (at the time of writing) ago. Coincidentally, the latest `onnx2tf` seems to be updated right after the latest ultralytics pull request merging, which is why the error was not raised earlier. This aligns with the following observation:

```bash
  File "/Users/runner/work/ultralytics/ultralytics/ultralytics/engine/exporter.py", line 1028, in export_saved_model
    import onnx2tf
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/onnx2tf/__init__.py", line 1, in <module>
    from onnx2tf.onnx2tf import convert, main
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/onnx2tf/onnx2tf.py", line 44, in <module>
    from onnx2tf.utils.common_functions import (
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/onnx2tf/utils/common_functions.py", line 19, in <module>
    from ai_edge_litert.interpreter import Interpreter
ModuleNotFoundError: No module named 'ai_edge_litert'
```

To validate this hypothesis, I first fixed the version to `onnx2tf==1.26.9` instead of `onnx2tf>=1.26.9` in `ultralytics/engine/exporter.py`, and the error was resolved. This confirms that the error is indeed caused by the latest `onnx2tf==1.27.0` version, which might have bypassed or missed the `ai-edge-litert` installation. 

To resolve this issue, instead of fixing `onnx2tf==1.26.9`, we can simply add an additional dependency requirement, `ai-edge-litert>=1.2.0`, in `ultralytics/engine/exporter.py` to ensure this package is installed regardless of the `onnx2tf` version." This `ai-edge-litert>=1.2.0` passed all the tests.

Note that this does not modify the dependencies in `pyproject.toml`. We only have to edit the dependency requirements in `ultralytics/engine/exporter.py`, since this only involves the export process.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added a new dependency to ensure compatibility with ONNX-to-TensorFlow conversions.

### 📊 Key Changes  
- Included `ai-edge-litert>=1.2.0` as a required dependency when using `onnx2tf==1.27.0`.

### 🎯 Purpose & Impact  
- 🛠 **Purpose**: Fixes missing dependency issues during ONNX-to-TensorFlow model conversions, ensuring smoother workflows.  
- 🚀 **Impact**: Improves reliability and compatibility for users exporting models to TensorFlow formats, reducing potential errors.