### PR TITLE
Update deepstream-nvidia-jetson.md

### DIFF
--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -139,7 +139,7 @@ Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcosluc
 6.  Copy the generated `.onnx` model file and `labels.txt` file to the `DeepStream-Yolo` folder
 
     ```bash
-    cp yolo11s.pt.onnx labels.txt ~/DeepStream-Yolo
+    cp yolo11s.onnx labels.txt ~/DeepStream-Yolo
     cd ~/DeepStream-Yolo
     ```
 


### PR DESCRIPTION
@glenn-jocher @lakshanthad When exporting on PC/Linux, the output file is `yolo11n.pt.onnx`, whereas on Jetson devices, it is `yolo11n.onnx`. Since DeepStream is primarily used with Jetson devices, removing `.pt` from the filename will ensure consistency and make it easier for users to follow the steps without confusion. Thanks!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor documentation fix for NVIDIA Jetson DeepStream guide.

### 📊 Key Changes  
- Corrected a file name in the guide from `yolo11s.pt.onnx` to `yolo11s.onnx`.

### 🎯 Purpose & Impact  
- 🛠 Ensures accuracy in the documentation, preventing potential confusion for users following the guide.  
- 📚 Improves the user experience by aligning instructions with the correct file naming conventions.