### PR TITLE
Fix `Autobackend` Python version check

### DIFF
--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -126,7 +126,7 @@ class HUBTrainingSession:
 
         self.model_url = f"{HUB_WEB_ROOT}/models/{self.model.id}"
         if self.model.is_trained():
-            print(emojis(f"Loading trained HUB model {self.model_url} 🚀"))
+            LOGGER.info(f"Loading trained HUB model {self.model_url} 🚀")
             url = self.model.get_weights_url("best")  # download URL with auth
             self.model_file = checks.check_file(url, download_dir=Path(SETTINGS["weights_dir"]) / "hub" / self.model.id)
             return

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -281,7 +281,7 @@ class AutoBackend(nn.Module):
         elif engine:
             LOGGER.info(f"Loading {w} for TensorRT inference...")
 
-            if IS_JETSON and check_version(PYTHON_VERSION, "<3.8.0"):
+            if IS_JETSON and check_version(PYTHON_VERSION, "<=3.8.0"):
                 # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python <= 3.8.0
                 check_requirements("numpy==1.23.5")
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -281,7 +281,7 @@ class AutoBackend(nn.Module):
         elif engine:
             LOGGER.info(f"Loading {w} for TensorRT inference...")
 
-            if IS_JETSON and PYTHON_VERSION <= "3.8.0":
+            if IS_JETSON and check_version(PYTHON_VERSION, "<3.8.0"):
                 # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python <= 3.8.0
                 check_requirements("numpy==1.23.5")
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -947,7 +947,7 @@ class TryExcept(contextlib.ContextDecorator):
     def __exit__(self, exc_type, value, traceback):
         """Defines behavior when exiting a 'with' block, prints error message if necessary."""
         if self.verbose and value:
-            print(emojis(f"{self.msg}{': ' if self.msg else ''}{value}"))
+            LOGGER.warning(f"{self.msg}{': ' if self.msg else ''}{value}")
         return True
 
 


### PR DESCRIPTION
PR addressing the [Issue 19721](https://github.com/ultralytics/ultralytics/issues/19721)

On Jetson devices, Ultralytics incorrectly detects Python versions greater than 3.8.0 as [≤"3.8.0"](https://github.com/ultralytics/ultralytics/blob/d3d523bcbd528e2d11c6c273ec8919291abe3477/ultralytics/nn/autobackend.py#L284) due to string-based version comparison. This forces the installation of numpy==1.23.5 even when newer, compatible versions are available.

I have `python 3.10.12`
Python versions as strings are being compared lexicographically.
`"3.10.12" <= "3.8.0"` is True in lexicographical order, even though 3.10 is greater than 3.8.


I simply used one of the existing functions in utils called check_version to fix this. I tested this fix and it works as expected.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved logging consistency and compatibility for better user experience and maintainability. 🛠️✨  

### 📊 Key Changes  
- Replaced `print` statements with `LOGGER` calls for standardized logging across the codebase. 📋  
- Updated Python version check logic for Jetson devices to use a more robust `check_version` function. 🐍  
- Ensured compatibility with specific NumPy versions for older Python setups on Jetson devices. 🔧  

### 🎯 Purpose & Impact  
- **Enhanced Logging**: Switching to `LOGGER` ensures consistent and professional logging, making debugging and monitoring easier for users and developers. 📖  
- **Improved Compatibility**: The refined Python version check and NumPy requirement fix prevent potential errors on Jetson devices, ensuring smoother operation for users with older setups. 🚀  
- **Better Maintainability**: These changes streamline the codebase, making it easier to maintain and extend in the future. 🤝