### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -230,7 +230,7 @@ The Ultralytics command-line interface (CLI) allows for simple single-line comma
 
     === "Inference with Streamlit"
 
-        Perform object detection, instance segmentation, or pose estimation in a web browser using [Streamlit](https://www.ultralytics.com/reference/solutions/streamlit_inference):
+        Perform object detection, instance segmentation, or pose estimation in a web browser using [Streamlit](https://docs.ultralytics.com/reference/solutions/streamlit_inference):
         ```bash
         yolo solutions inference
 

--- a/docs/en/usage/cfg.md
+++ b/docs/en/usage/cfg.md
@@ -154,7 +154,7 @@ Adjust these settings to meet dataset and task requirements. Experimenting with 
 
 Logging, checkpoints, plotting, and file management are important when training a YOLO model:
 
-- **Logging**: Track the model's progress and diagnose issues using libraries like [TensorBoard](https://www.ultralytics.com/integrations/tensorboard) or by writing to a file.
+- **Logging**: Track the model's progress and diagnose issues using libraries like [TensorBoard](https://docs.ultralytics.com/integrations/tensorboard) or by writing to a file.
 - **Checkpoints**: Save the model at regular intervals to resume training or experiment with different configurations.
 - **Plotting**: Visualize performance and training progress using libraries like matplotlib or TensorBoard.
 - **File management**: Organize files generated during training, such as checkpoints, log files, and plots, for easy access and analysis.

--- a/docs/en/usage/engine.md
+++ b/docs/en/usage/engine.md
@@ -58,7 +58,7 @@ trainer = CustomTrainer(overrides={...})
 trainer.train()
 ```
 
-Further customize the trainer by modifying the [loss function](https://www.ultralytics.com/glossary/loss-function) or adding a [callback](https://www.ultralytics.com/glossary/callback) to upload the model to Google Drive every 10 [epochs](https://www.ultralytics.com/glossary/epoch). Here's an example:
+Further customize the trainer by modifying the [loss function](https://www.ultralytics.com/glossary/loss-function) or adding a [callback](callbacks.md) to upload the model to Google Drive every 10 [epochs](https://www.ultralytics.com/glossary/epoch). Here's an example:
 
 ```python
 from ultralytics.models.yolo.detect import DetectionTrainer

--- a/docs/en/usage/python.md
+++ b/docs/en/usage/python.md
@@ -195,7 +195,7 @@ For example, users can load a model, train it, evaluate its performance on a val
 
     === "Export to ONNX"
 
-        Export an official YOLO model to [ONNX](https://www.ultralytics.com/glossary/onnx) with dynamic batch-size and image-size.
+        Export an official YOLO model to [ONNX](https://www.ultralytics.com/glossary/onnx-open-neural-network-exchange) with dynamic batch-size and image-size.
         ```python
         from ultralytics import YOLO
 

--- a/docs/en/usage/simple-utilities.md
+++ b/docs/en/usage/simple-utilities.md
@@ -84,7 +84,7 @@ convert_segment_masks_to_yolo_seg(masks_dir="path/to/masks_dir", output_dir="pat
 
 ### Convert COCO into YOLO Format
 
-Use this to convert [COCO](https://www.ultralytics.com/datasets/detect/coco) JSON annotations into the YOLO format. For object detection (bounding box) datasets, set both `use_segments` and `use_keypoints` to `False`.
+Use this to convert [COCO](https://docs.ultralytics.com/datasets/detect/coco) JSON annotations into the YOLO format. For object detection (bounding box) datasets, set both `use_segments` and `use_keypoints` to `False`.
 
 ```python
 from ultralytics.data.converter import convert_coco


### PR DESCRIPTION
@glenn-jocher

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved documentation links for better navigation and clarity. 📚✨  

### 📊 Key Changes  
- Updated outdated links in the documentation to point to the correct Ultralytics resources.  
  - Streamlit, TensorBoard, and COCO dataset links now direct to the updated `docs.ultralytics.com` pages.  
  - Fixed a callback link to reference the correct local documentation file.  
  - Clarified ONNX export link to include its full name ("Open Neural Network Exchange").  

### 🎯 Purpose & Impact  
- 🧭 **Enhanced Navigation**: Users can now easily access accurate and up-to-date resources, reducing confusion.  
- 📖 **Improved Clarity**: Clearer documentation ensures a smoother experience for both new and experienced users.  
- 🚀 **Streamlined Learning**: These fixes make it easier to explore Ultralytics features and tools effectively.