### PR TITLE
Resolve CBAM kernel_size misconfiguration in YAML parsing

### DIFF
--- a/ultralytics/nn/modules/conv.py
+++ b/ultralytics/nn/modules/conv.py
@@ -635,6 +635,7 @@ class CBAM(nn.Module):
             c1 (int): Number of input channels.
             c2 (int): Number of output channels. Must match `c1` since CBAM does not alter channel dimensions.
             kernel_size (int, optional): Size of the convolutional kernel for spatial attention. Must be 3 or 7. Defaults to 7.
+
         Raises:
             AssertionError: If `c1` does not equal `c2` or if `kernel_size` is not 3 or 7
         """

--- a/ultralytics/nn/modules/conv.py
+++ b/ultralytics/nn/modules/conv.py
@@ -627,15 +627,19 @@ class CBAM(nn.Module):
         spatial_attention (SpatialAttention): Spatial attention module.
     """
 
-    def __init__(self, c1, kernel_size=7):
+    def __init__(self, c1, c2, kernel_size=7):
         """
-        Initialize CBAM with given parameters.
+        Initialize CBAM (Convolutional Block Attention Module) with given parameters.
 
         Args:
             c1 (int): Number of input channels.
-            kernel_size (int): Size of the convolutional kernel for spatial attention.
+            c2 (int): Number of output channels. Must match `c1` since CBAM does not alter channel dimensions.
+            kernel_size (int, optional): Size of the convolutional kernel for spatial attention. Must be 3 or 7. Defaults to 7.
+        Raises:
+            AssertionError: If `c1` does not equal `c2` or if `kernel_size` is not 3 or 7
         """
         super().__init__()
+        assert c1 == c2, f"CBAM requires c1 == c2. Got c1={c1}, c2={c2}"
         self.channel_attention = ChannelAttention(c1)
         self.spatial_attention = SpatialAttention(kernel_size)
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->

I have read the CLA Document and I sign the CLA

### Issue
The `CBAM` module incorrectly interprets the first YAML argument as scaled `c2` (output channels), leading to an invalid `kernel_size` being passed to `SpatialAttention`. This results in the following error:

AssertionError: kernel size must be 3 or 7

more in issue [#19733](https://github.com/ultralytics/ultralytics/issues/19733)

the issue being if a the yaml file , if CBAM was imported to tasks.py and used in yaml
`- [-1, 1, CBAM, [7]]`
it was rasing a kernel size issue , after explicitly passing both channels and kernels it raised issue of arguments being incorrect

In the YAML configuration, [-1, 1, CBAM, [7]] passes 7 as the output channel (c2), not the kernel_size

I tried to print the kernel size and it was show as 8

because during parsing, c2 is scaled by width_multiple (e.g., if width_multiple=1.25, 7 * 1.25 = 8.75 → rounded to 8

i have fixed this by 
Modified `CBAM` to explicitly accept `c1`, `c2`, and `kernel_size`
and now in the yaml file both channels and kernel size can be passed which fixed the issue

e.g., `[-1, 1, CBAM, [128, 7]]`

If there is a better way this can be fixed I'd be glad to do it accordingly

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the CBAM module by adding stricter input checks and clearer initialization parameters. 🛠️

### 📊 Key Changes
- Added a new `c2` (output channels) parameter to the CBAM module's initialization.
- Enforced that input and output channels (`c1` and `c2`) must be equal for CBAM.
- Added validation to ensure the kernel size is either 3 or 7.
- Improved documentation and error messages for easier debugging.

### 🎯 Purpose & Impact
- Prevents misconfiguration by catching channel mismatches early, reducing runtime errors.
- Makes the CBAM module easier to use and integrate, especially for developers customizing models.
- Enhances code clarity and reliability, benefiting both new and experienced users. 🚀