### PR TITLE
Use lowercase `dict/list/tuple` for type hint in docstrings

### DIFF
--- a/examples/RTDETR-ONNXRuntime-Python/main.py
+++ b/examples/RTDETR-ONNXRuntime-Python/main.py
@@ -25,7 +25,7 @@ class RTDETR:
         conf_thres (float): Confidence threshold for filtering detections.
         iou_thres (float): IoU threshold for non-maximum suppression.
         session (ort.InferenceSession): ONNX runtime inference session.
-        model_input (List): Model input metadata.
+        model_input (list): Model input metadata.
         input_width (int): Width dimension required by the model.
         input_height (int): Height dimension required by the model.
         classes (List[str]): List of class names from COCO dataset.

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -24,7 +24,7 @@ class YOLOv8Seg:
     Attributes:
         session (ort.InferenceSession): ONNX Runtime inference session for model execution.
         imgsz (Tuple[int, int]): Input image size as (height, width) for the model.
-        classes (Dict): Dictionary mapping class indices to class names from the dataset.
+        classes (dict): Dictionary mapping class indices to class names from the dataset.
         conf (float): Confidence threshold for filtering detections.
         iou (float): IoU threshold used by non-maximum suppression.
 

--- a/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
+++ b/examples/YOLOv8-Segmentation-ONNXRuntime-Python/main.py
@@ -125,7 +125,7 @@ class YOLOv8Seg:
         Args:
             img (np.ndarray): The original input image.
             prep_img (np.ndarray): The preprocessed image used for inference.
-            outs (List): Model outputs containing predictions and prototype masks.
+            outs (list): Model outputs containing predictions and prototype masks.
 
         Returns:
             (List[Results]): Processed detection results containing bounding boxes and segmentation masks.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def pytest_collection_modifyitems(config, items):
 
     Args:
         config (pytest.config.Config): The pytest configuration object that provides access to command-line options.
-        items (List): The list of collected pytest item objects to be modified based on the presence of --slow option.
+        items (list): The list of collected pytest item objects to be modified based on the presence of --slow option.
 
     Returns:
         (None): The function modifies the 'items' list in place.

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -251,7 +251,7 @@ def cfg2dict(cfg: Union[str, Path, Dict, SimpleNamespace]) -> Dict:
             a string, a dictionary, or a SimpleNamespace object.
 
     Returns:
-        (Dict): Configuration object in dictionary format.
+        (dict): Configuration object in dictionary format.
 
     Examples:
         Convert a YAML file path to a dictionary:
@@ -334,7 +334,7 @@ def check_cfg(cfg: Dict, hard: bool = True) -> None:
     `CFG_FRACTION_KEYS`, `CFG_INT_KEYS`, and `CFG_BOOL_KEYS`.
 
     Args:
-        cfg (Dict): Configuration dictionary to validate.
+        cfg (dict): Configuration dictionary to validate.
         hard (bool): If True, raises exceptions for invalid types and values; if False, attempts to convert them.
 
     Examples:
@@ -424,7 +424,7 @@ def _handle_deprecation(custom: Dict) -> Dict:
     Handles deprecated configuration keys by mapping them to current equivalents with deprecation warnings.
 
     Args:
-        custom (Dict): Configuration dictionary potentially containing deprecated keys.
+        custom (dict): Configuration dictionary potentially containing deprecated keys.
 
     Examples:
         >>> custom_config = {"boxes": True, "hide_labels": "False", "line_thickness": 2}
@@ -463,8 +463,8 @@ def check_dict_alignment(base: Dict, custom: Dict, e: Exception = None) -> None:
     messages for mismatched keys.
 
     Args:
-        base (Dict): The base configuration dictionary containing valid keys.
-        custom (Dict): The custom configuration dictionary to be checked for alignment.
+        base (dict): The base configuration dictionary containing valid keys.
+        custom (dict): The custom configuration dictionary to be checked for alignment.
         e (Exception | None): Optional error instance passed by the calling function.
 
     Raises:

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -86,10 +86,10 @@ class BaseTransform:
         logic.
 
         Args:
-            labels (Dict): A dictionary containing label information, including object instances.
+            labels (dict): A dictionary containing label information, including object instances.
 
         Returns:
-            (Dict): The modified labels dictionary with transformed object instances.
+            (dict): The modified labels dictionary with transformed object instances.
 
         Examples:
             >>> transform = BaseTransform()
@@ -127,11 +127,11 @@ class BaseTransform:
         image and object instances, respectively.
 
         Args:
-            labels (Dict): A dictionary containing image data and annotations. Expected keys include 'img' for
+            labels (dict): A dictionary containing image data and annotations. Expected keys include 'img' for
                 the image data, and 'instances' for object instances.
 
         Returns:
-            (Dict): The input labels dictionary with transformed image and instances.
+            (dict): The input labels dictionary with transformed image and instances.
 
         Examples:
             >>> transform = BaseTransform()
@@ -374,10 +374,10 @@ class BaseMixTransform:
         selects additional images, applies pre-transforms if specified, and then performs the mix transform.
 
         Args:
-            labels (Dict): A dictionary containing label data for an image.
+            labels (dict): A dictionary containing label data for an image.
 
         Returns:
-            (Dict): The transformed labels dictionary, which may include mixed data from other images.
+            (dict): The transformed labels dictionary, which may include mixed data from other images.
 
         Examples:
             >>> transform = BaseMixTransform(dataset, pre_transform=None, p=0.5)
@@ -414,11 +414,11 @@ class BaseMixTransform:
         Mosaic. It modifies the input label dictionary in-place with the augmented data.
 
         Args:
-            labels (Dict): A dictionary containing image and label data. Expected to have a 'mix_labels' key
+            labels (dict): A dictionary containing image and label data. Expected to have a 'mix_labels' key
                 with a list of additional image and label data for mixing.
 
         Returns:
-            (Dict): The modified labels dictionary with augmented data after applying the mix transform.
+            (dict): The modified labels dictionary with augmented data after applying the mix transform.
 
         Examples:
             >>> transform = BaseMixTransform(dataset)
@@ -450,11 +450,11 @@ class BaseMixTransform:
         creating a unified set of text labels and updating class IDs accordingly.
 
         Args:
-            labels (Dict): A dictionary containing label information, including 'texts' and 'cls' fields,
+            labels (dict): A dictionary containing label information, including 'texts' and 'cls' fields,
                 and optionally a 'mix_labels' field with additional label dictionaries.
 
         Returns:
-            (Dict): The updated labels dictionary with unified text labels and updated class IDs.
+            (dict): The updated labels dictionary with unified text labels and updated class IDs.
 
         Examples:
             >>> labels = {
@@ -576,12 +576,12 @@ class Mosaic(BaseMixTransform):
         mosaic augmentation.
 
         Args:
-            labels (Dict): A dictionary containing image data and annotations. Expected keys include:
+            labels (dict): A dictionary containing image data and annotations. Expected keys include:
                 - 'rect_shape': Should be None as rect and mosaic are mutually exclusive.
                 - 'mix_labels': A list of dictionaries containing data for other images to be used in the mosaic.
 
         Returns:
-            (Dict): A dictionary containing the mosaic-augmented image and updated annotations.
+            (dict): A dictionary containing the mosaic-augmented image and updated annotations.
 
         Raises:
             AssertionError: If 'rect_shape' is not None or if 'mix_labels' is empty.
@@ -604,12 +604,12 @@ class Mosaic(BaseMixTransform):
         additional images on either side. It's part of the Mosaic augmentation technique used in object detection.
 
         Args:
-            labels (Dict): A dictionary containing image and label information for the main (center) image.
+            labels (dict): A dictionary containing image and label information for the main (center) image.
                 Must include 'img' key with the image array, and 'mix_labels' key with a list of two
                 dictionaries containing information for the side images.
 
         Returns:
-            (Dict): A dictionary with the mosaic image and updated labels. Keys include:
+            (dict): A dictionary with the mosaic image and updated labels. Keys include:
                 - 'img' (np.ndarray): The mosaic image array with shape (H, W, C).
                 - Other keys from the input labels, updated to reflect the new image dimensions.
 
@@ -663,11 +663,11 @@ class Mosaic(BaseMixTransform):
         updates the corresponding labels for each image in the mosaic.
 
         Args:
-            labels (Dict): A dictionary containing image data and labels for the base image (index 0) and three
+            labels (dict): A dictionary containing image data and labels for the base image (index 0) and three
                 additional images (indices 1-3) in the 'mix_labels' key.
 
         Returns:
-            (Dict): A dictionary containing the mosaic image and updated labels. The 'img' key contains the mosaic
+            (dict): A dictionary containing the mosaic image and updated labels. The 'img' key contains the mosaic
                 image as a numpy array, and other keys contain the combined and adjusted labels for all four images.
 
         Examples:
@@ -721,7 +721,7 @@ class Mosaic(BaseMixTransform):
         and eight additional images from the dataset are placed around it in a 3x3 grid pattern.
 
         Args:
-            labels (Dict): A dictionary containing the input image and its associated labels. It should have
+            labels (dict): A dictionary containing the input image and its associated labels. It should have
                 the following keys:
                 - 'img' (numpy.ndarray): The input image.
                 - 'resized_shape' (Tuple[int, int]): The shape of the resized image (height, width).
@@ -729,7 +729,7 @@ class Mosaic(BaseMixTransform):
                   eight images, each with the same structure as the input labels.
 
         Returns:
-            (Dict): A dictionary containing the mosaic image and updated labels. It includes the following keys:
+            (dict): A dictionary containing the mosaic image and updated labels. It includes the following keys:
                 - 'img' (numpy.ndarray): The final mosaic image.
                 - Other keys from the input labels, updated to reflect the new mosaic arrangement.
 
@@ -794,12 +794,12 @@ class Mosaic(BaseMixTransform):
         values. It also denormalizes the coordinates if they were previously normalized.
 
         Args:
-            labels (Dict): A dictionary containing image and instance information.
+            labels (dict): A dictionary containing image and instance information.
             padw (int): Padding width to be added to the x-coordinates.
             padh (int): Padding height to be added to the y-coordinates.
 
         Returns:
-            (Dict): Updated labels dictionary with adjusted instance coordinates.
+            (dict): Updated labels dictionary with adjusted instance coordinates.
 
         Examples:
             >>> labels = {"img": np.zeros((100, 100, 3)), "instances": Instances(...)}
@@ -823,7 +823,7 @@ class Mosaic(BaseMixTransform):
             mosaic_labels (List[Dict]): A list of label dictionaries for each image in the mosaic.
 
         Returns:
-            (Dict): A dictionary containing concatenated and processed labels for the mosaic image, including:
+            (dict): A dictionary containing concatenated and processed labels for the mosaic image, including:
                 - im_file (str): File path of the first image in the mosaic.
                 - ori_shape (Tuple[int, int]): Original shape of the first image.
                 - resized_shape (Tuple[int, int]): Shape of the mosaic image (imgsz * 2, imgsz * 2).
@@ -932,10 +932,10 @@ class MixUp(BaseMixTransform):
         "mixup: Beyond Empirical Risk Minimization" (https://arxiv.org/abs/1710.09412).
 
         Args:
-            labels (Dict): A dictionary containing the original image and label information.
+            labels (dict): A dictionary containing the original image and label information.
 
         Returns:
-            (Dict): A dictionary containing the mixed-up image and combined label information.
+            (dict): A dictionary containing the mixed-up image and combined label information.
 
         Examples:
             >>> mixer = MixUp(dataset)
@@ -1191,7 +1191,7 @@ class RandomPerspective:
         and keypoints accordingly.
 
         Args:
-            labels (Dict): A dictionary containing image data and annotations.
+            labels (dict): A dictionary containing image data and annotations.
                 Must include:
                     'img' (np.ndarray): The input image.
                     'cls' (np.ndarray): Class labels.
@@ -1200,7 +1200,7 @@ class RandomPerspective:
                     'mosaic_border' (Tuple[int, int]): Border size for mosaic augmentation.
 
         Returns:
-            (Dict): Transformed labels dictionary containing:
+            (dict): Transformed labels dictionary containing:
                 - 'img' (np.ndarray): The transformed image.
                 - 'cls' (np.ndarray): Updated class labels.
                 - 'instances' (Instances): Updated object instances.
@@ -1351,7 +1351,7 @@ class RandomHSV:
         The adjustments are made within the limits set by hgain, sgain, and vgain during initialization.
 
         Args:
-            labels (Dict): A dictionary containing image data and metadata. Must include an 'img' key with
+            labels (dict): A dictionary containing image data and metadata. Must include an 'img' key with
                 the image as a numpy array.
 
         Returns:
@@ -1439,13 +1439,13 @@ class RandomFlip:
         match the flipped image.
 
         Args:
-            labels (Dict): A dictionary containing the following keys:
+            labels (dict): A dictionary containing the following keys:
                 'img' (numpy.ndarray): The image to be flipped.
                 'instances' (ultralytics.utils.instance.Instances): An object containing bounding boxes and
                     optionally keypoints.
 
         Returns:
-            (Dict): The same dictionary with the flipped image and updated instances:
+            (dict): The same dictionary with the flipped image and updated instances:
                 'img' (numpy.ndarray): The flipped image.
                 'instances' (ultralytics.utils.instance.Instances): Updated instances matching the flipped image.
 
@@ -1611,13 +1611,13 @@ class LetterBox:
         to account for resizing and padding applied during letterboxing.
 
         Args:
-            labels (Dict): A dictionary containing image labels and instances.
+            labels (dict): A dictionary containing image labels and instances.
             ratio (Tuple[float, float]): Scaling ratios (width, height) applied to the image.
             padw (float): Padding width added to the image.
             padh (float): Padding height added to the image.
 
         Returns:
-            (Dict): Updated labels dictionary with modified instance coordinates.
+            (dict): Updated labels dictionary with modified instance coordinates.
 
         Examples:
             >>> letterbox = LetterBox(new_shape=(640, 640))
@@ -1879,13 +1879,13 @@ class Albumentations:
         spatial and non-spatial transformations on the input image and its corresponding labels.
 
         Args:
-            labels (Dict): A dictionary containing image data and annotations. Expected keys are:
+            labels (dict): A dictionary containing image data and annotations. Expected keys are:
                 - 'img': numpy.ndarray representing the image
                 - 'cls': numpy.ndarray of class labels
                 - 'instances': object containing bounding boxes and other instance information
 
         Returns:
-            (Dict): The input dictionary with augmented image and updated annotations.
+            (dict): The input dictionary with augmented image and updated annotations.
 
         Examples:
             >>> transform = Albumentations(p=0.5)
@@ -2019,13 +2019,13 @@ class Format:
         applying normalization if required.
 
         Args:
-            labels (Dict): A dictionary containing image and annotation data with the following keys:
+            labels (dict): A dictionary containing image and annotation data with the following keys:
                 - 'img': The input image as a numpy array.
                 - 'cls': Class labels for instances.
                 - 'instances': An Instances object containing bounding boxes, segments, and keypoints.
 
         Returns:
-            (Dict): A dictionary with formatted data, including:
+            (dict): A dictionary with formatted data, including:
                 - 'img': Formatted image tensor.
                 - 'cls': Class label's tensor.
                 - 'bboxes': Bounding boxes tensor in the specified format.
@@ -2222,10 +2222,10 @@ class RandomLoadText:
         new sampled text order.
 
         Args:
-            labels (Dict): A dictionary containing image labels and metadata. Must include 'texts' and 'cls' keys.
+            labels (dict): A dictionary containing image labels and metadata. Must include 'texts' and 'cls' keys.
 
         Returns:
-            (Dict): Updated labels dictionary with new 'cls' and 'texts' entries.
+            (dict): Updated labels dictionary with new 'cls' and 'texts' entries.
 
         Examples:
             >>> loader = RandomLoadText(prompt_format="A photo of {}", neg_samples=(5, 10), max_samples=20)

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -285,7 +285,7 @@ class Compose:
         Converts the list of transforms to a standard Python list.
 
         Returns:
-            (List): A list containing all the transform objects in the Compose instance.
+            (list): A list containing all the transform objects in the Compose instance.
 
         Examples:
             >>> transforms = [RandomFlip(), RandomPerspective(10), CenterCrop()]

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -39,11 +39,11 @@ class BaseDataset(Dataset):
         batch_size (int): Size of batches.
         stride (int): Stride used in the model.
         pad (float): Padding value.
-        buffer (List): Buffer for mosaic images.
+        buffer (list): Buffer for mosaic images.
         max_buffer_length (int): Maximum buffer size.
-        ims (List): List of loaded images.
-        im_hw0 (List): List of original image dimensions (h, w).
-        im_hw (List): List of resized image dimensions (h, w).
+        ims (list): List of loaded images.
+        im_hw0 (list): List of original image dimensions (h, w).
+        im_hw (list): List of resized image dimensions (h, w).
         npy_files (List[Path]): List of numpy file paths.
         cache (str): Cache images to RAM or disk during training.
         transforms (callable): Image transformation function.

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -94,7 +94,7 @@ class BaseDataset(Dataset):
             stride (int, optional): Stride used in the model.
             pad (float, optional): Padding value.
             single_cls (bool, optional): If True, single class training is used.
-            classes (List, optional): List of included classes.
+            classes (list, optional): List of included classes.
             fraction (float, optional): Fraction of dataset to utilize.
         """
         super().__init__()
@@ -179,7 +179,7 @@ class BaseDataset(Dataset):
         Update labels to include only specified classes.
 
         Args:
-            include_class (List, optional): List of classes to include. If None, all classes are included.
+            include_class (list, optional): List of classes to include. If None, all classes are included.
         """
         include_class_array = np.array(include_class).reshape(1, -1)
         for i in range(len(self.labels)):

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -21,7 +21,7 @@ def coco91_to_coco80_class():
     Converts 91-index COCO class IDs to 80-index COCO class IDs.
 
     Returns:
-        (List): A list of 91 class IDs where the index represents the 80-index class ID and the value is the
+        (list): A list of 91 class IDs where the index represents the 80-index class ID and the value is the
             corresponding 91-index class ID.
     """
     return [

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -408,7 +408,7 @@ class GroundingDataset(YOLODataset):
             img_path (str): Path to the directory containing images.
 
         Returns:
-            (List): Empty list as image files are read in get_labels.
+            (list): Empty list as image files are read in get_labels.
         """
         return []
 
@@ -537,7 +537,7 @@ class ClassificationDataset:
     Attributes:
         cache_ram (bool): Indicates if caching in RAM is enabled.
         cache_disk (bool): Indicates if caching on disk is enabled.
-        samples (List): A list of tuples, each containing the path to an image, its class index, path to its .npy cache
+        samples (list): A list of tuples, each containing the path to an image, its class index, path to its .npy cache
                         file (if caching on disk), and optionally the loaded image array (if caching in RAM).
         torch_transforms (callable): PyTorch transforms to be applied to the images.
         root (str): Root directory of the dataset.
@@ -635,7 +635,7 @@ class ClassificationDataset:
         Verify all images in dataset.
 
         Returns:
-            (List): List of valid samples after verification.
+            (list): List of valid samples after verification.
         """
         desc = f"{self.prefix}Scanning {self.root}..."
         path = Path(self.root).with_suffix(".cache")  # *.cache file path

--- a/ultralytics/data/split_dota.py
+++ b/ultralytics/data/split_dota.py
@@ -163,7 +163,7 @@ def crop_and_save(anno, windows, window_objs, im_dir, lb_dir, allow_background_i
     Crop images and save new labels.
 
     Args:
-        anno (Dict): Annotation dict, including `filepath`, `label`, `ori_size` as its keys.
+        anno (dict): Annotation dict, including `filepath`, `label`, `ori_size` as its keys.
         windows (np.ndarray): Array of windows coordinates with shape (n, 4).
         window_objs (List): A list of labels inside each window.
         im_dir (str): The output directory path of images.

--- a/ultralytics/data/split_dota.py
+++ b/ultralytics/data/split_dota.py
@@ -165,7 +165,7 @@ def crop_and_save(anno, windows, window_objs, im_dir, lb_dir, allow_background_i
     Args:
         anno (dict): Annotation dict, including `filepath`, `label`, `ori_size` as its keys.
         windows (np.ndarray): Array of windows coordinates with shape (n, 4).
-        window_objs (List): A list of labels inside each window.
+        window_objs (list): A list of labels inside each window.
         im_dir (str): The output directory path of images.
         lb_dir (str): The output directory path of labels.
         allow_background_images (bool): Whether to include background images without labels.

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -138,7 +138,7 @@ def validate_args(format, passed_args, valid_args):
     Args:
         format (str): The export format.
         passed_args (Namespace): The arguments used during export.
-        valid_args (List): List of valid arguments for the format.
+        valid_args (list): List of valid arguments for the format.
 
     Raises:
         AssertionError: If an unsupported argument is used, or if the format lacks supported argument listings.

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -219,8 +219,8 @@ class Exporter:
 
         Args:
             cfg (str, optional): Path to a configuration file.
-            overrides (Dict, optional): Configuration overrides.
-            _callbacks (Dict, optional): Dictionary of callback functions.
+            overrides (dict, optional): Configuration overrides.
+            _callbacks (dict, optional): Dictionary of callback functions.
         """
         self.args = get_cfg(cfg, overrides)
         if self.args.format.lower() in {"coreml", "mlmodel"}:  # fix attempt for protobuf<3.20.x errors

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -210,7 +210,7 @@ class Exporter:
 
     Attributes:
         args (SimpleNamespace): Configuration for the exporter.
-        callbacks (List, optional): List of callback functions.
+        callbacks (list, optional): List of callback functions.
     """
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -35,15 +35,15 @@ class Model(torch.nn.Module):
     loaded from local files, Ultralytics HUB, or Triton Server.
 
     Attributes:
-        callbacks (Dict): A dictionary of callback functions for various events during model operations.
+        callbacks (dict): A dictionary of callback functions for various events during model operations.
         predictor (BasePredictor): The predictor object used for making predictions.
         model (torch.nn.Module): The underlying PyTorch model.
         trainer (BaseTrainer): The trainer object used for training the model.
-        ckpt (Dict): The checkpoint data if the model is loaded from a *.pt file.
+        ckpt (dict): The checkpoint data if the model is loaded from a *.pt file.
         cfg (str): The configuration of the model if loaded from a *.yaml file.
         ckpt_path (str): The path to the checkpoint file.
-        overrides (Dict): A dictionary of overrides for model configuration.
-        metrics (Dict): The latest training/validation metrics.
+        overrides (dict): A dictionary of overrides for model configuration.
+        metrics (dict): The latest training/validation metrics.
         session (HUBTrainingSession): The Ultralytics HUB session, if applicable.
         task (str): The type of task the model is intended for.
         model_name (str): The name of the model.
@@ -652,7 +652,7 @@ class Model(torch.nn.Module):
                 - format (str): Export format name for specific benchmarking.
 
         Returns:
-            (Dict): A dictionary containing the results of the benchmarking process, including metrics for
+            (dict): A dictionary containing the results of the benchmarking process, including metrics for
                 different export formats.
 
         Raises:
@@ -820,7 +820,7 @@ class Model(torch.nn.Module):
                 overrides and defaults to configure the tuning process.
 
         Returns:
-            (Dict): Results of the hyperparameter search, including best parameters and performance metrics.
+            (dict): Results of the hyperparameter search, including best parameters and performance metrics.
 
         Raises:
             TypeError: If the model is not a PyTorch model.

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -82,9 +82,9 @@ class BasePredictor:
         plotted_img (numpy.ndarray): Last plotted image.
         source_type (SimpleNamespace): Type of input source.
         seen (int): Number of images processed.
-        windows (List): List of window names for visualization.
+        windows (list): List of window names for visualization.
         batch (tuple): Current batch data.
-        results (List): Current batch results.
+        results (list): Current batch results.
         transforms (callable): Image transforms for classification.
         callbacks (dict): Callback functions for different events.
         txt_path (Path): Path to save text results.

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -199,8 +199,8 @@ class Results(SimpleClass):
         probs (Probs | None): Classification probabilities.
         keypoints (Keypoints | None): Detected keypoints.
         obb (OBB | None): Oriented bounding boxes.
-        speed (Dict): Dictionary containing inference speed information.
-        names (Dict): Dictionary mapping class indices to class names.
+        speed (dict): Dictionary containing inference speed information.
+        names (dict): Dictionary mapping class indices to class names.
         path (str): Path to the input image file.
         save_dir (str | None): Directory to save results.
 
@@ -243,7 +243,7 @@ class Results(SimpleClass):
         Args:
             orig_img (numpy.ndarray): The original image as a numpy array.
             path (str): The path to the image file.
-            names (Dict): A dictionary of class names.
+            names (dict): A dictionary of class names.
             boxes (torch.Tensor | None): A 2D tensor of bounding box coordinates for each detection.
             masks (torch.Tensor | None): A 3D tensor of detection masks, where each mask is a binary image.
             probs (torch.Tensor | None): A 1D tensor of probabilities of each class for classification task.

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -87,7 +87,7 @@ class BaseTrainer:
         fitness (float): Current fitness value.
         loss (float): Current loss value.
         tloss (float): Total loss value.
-        loss_names (List): List of loss names.
+        loss_names (list): List of loss names.
         csv (Path): Path to results CSV file.
         metrics (dict): Dictionary of metrics.
         plots (dict): Dictionary of plots.

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -100,7 +100,7 @@ class BaseTrainer:
         Args:
             cfg (str, optional): Path to a configuration file. Defaults to DEFAULT_CFG.
             overrides (dict, optional): Configuration overrides. Defaults to None.
-            _callbacks (List, optional): List of callback functions. Defaults to None.
+            _callbacks (list, optional): List of callback functions. Defaults to None.
         """
         self.args = get_cfg(cfg, overrides)
         self.check_resume(overrides)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -89,8 +89,8 @@ class BaseTrainer:
         tloss (float): Total loss value.
         loss_names (List): List of loss names.
         csv (Path): Path to results CSV file.
-        metrics (Dict): Dictionary of metrics.
-        plots (Dict): Dictionary of plots.
+        metrics (dict): Dictionary of metrics.
+        plots (dict): Dictionary of plots.
     """
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -99,7 +99,7 @@ class BaseTrainer:
 
         Args:
             cfg (str, optional): Path to a configuration file. Defaults to DEFAULT_CFG.
-            overrides (Dict, optional): Configuration overrides. Defaults to None.
+            overrides (dict, optional): Configuration overrides. Defaults to None.
             _callbacks (List, optional): List of callback functions. Defaults to None.
         """
         self.args = get_cfg(cfg, overrides)

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -39,7 +39,7 @@ class Tuner:
         tune_dir (Path): Directory where evolution logs and results will be saved.
         tune_csv (Path): Path to the CSV file where evolution logs are saved.
         args (dict): Configuration arguments for the tuning process.
-        callbacks (List): Callback functions to be executed during tuning.
+        callbacks (list): Callback functions to be executed during tuning.
         prefix (str): Prefix string for logging messages.
 
     Methods:

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -35,10 +35,10 @@ class Tuner:
     search space and retraining the model to evaluate their performance.
 
     Attributes:
-        space (Dict): Hyperparameter search space containing bounds and scaling factors for mutation.
+        space (dict): Hyperparameter search space containing bounds and scaling factors for mutation.
         tune_dir (Path): Directory where evolution logs and results will be saved.
         tune_csv (Path): Path to the CSV file where evolution logs are saved.
-        args (Dict): Configuration arguments for the tuning process.
+        args (dict): Configuration arguments for the tuning process.
         callbacks (List): Callback functions to be executed during tuning.
         prefix (str): Prefix string for logging messages.
 
@@ -63,7 +63,7 @@ class Tuner:
         Initialize the Tuner with configurations.
 
         Args:
-            args (Dict): Configuration for hyperparameter evolution.
+            args (dict): Configuration for hyperparameter evolution.
             _callbacks (List, optional): Callback functions to be executed during tuning.
         """
         self.space = args.pop("space", None) or {  # key: (min, max, gain(optional))
@@ -115,7 +115,7 @@ class Tuner:
             sigma (float): Standard deviation for Gaussian random number generator.
 
         Returns:
-            (Dict): A dictionary containing mutated hyperparameters.
+            (dict): A dictionary containing mutated hyperparameters.
         """
         if self.tune_csv.exists():  # if CSV file exists: select best hyps and mutate
             # Select parent(s)

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -64,7 +64,7 @@ class Tuner:
 
         Args:
             args (dict): Configuration for hyperparameter evolution.
-            _callbacks (List, optional): Callback functions to be executed during tuning.
+            _callbacks (list, optional): Callback functions to be executed during tuning.
         """
         self.space = args.pop("space", None) or {  # key: (min, max, gain(optional))
             # 'optimizer': tune.choice(['SGD', 'Adam', 'AdamW', 'NAdam', 'RAdam', 'RMSProp']),

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -100,7 +100,7 @@ class BaseValidator:
             save_dir (Path, optional): Directory to save results.
             pbar (tqdm.tqdm, optional): Progress bar for displaying progress.
             args (SimpleNamespace, optional): Configuration for the validator.
-            _callbacks (Dict, optional): Dictionary to store various callback functions.
+            _callbacks (dict, optional): Dictionary to store various callback functions.
         """
         self.args = get_cfg(overrides=args)
         self.dataloader = dataloader

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -61,7 +61,7 @@ class BaseValidator:
         confusion_matrix: Confusion matrix for classification evaluation.
         nc (int): Number of classes.
         iouv (torch.Tensor): IoU thresholds from 0.50 to 0.95 in spaces of 0.05.
-        jdict (List): List to store JSON validation results.
+        jdict (list): List to store JSON validation results.
         speed (dict): Dictionary with keys 'preprocess', 'inference', 'loss', 'postprocess' and their respective
             batch processing times in milliseconds.
         save_dir (Path): Directory to save results.

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -51,22 +51,22 @@ class BaseValidator:
         dataloader (DataLoader): Dataloader to use for validation.
         pbar (tqdm): Progress bar to update during validation.
         model (nn.Module): Model to validate.
-        data (Dict): Data dictionary containing dataset information.
+        data (dict): Data dictionary containing dataset information.
         device (torch.device): Device to use for validation.
         batch_i (int): Current batch index.
         training (bool): Whether the model is in training mode.
-        names (Dict): Class names mapping.
+        names (dict): Class names mapping.
         seen (int): Number of images seen so far during validation.
-        stats (Dict): Statistics collected during validation.
+        stats (dict): Statistics collected during validation.
         confusion_matrix: Confusion matrix for classification evaluation.
         nc (int): Number of classes.
         iouv (torch.Tensor): IoU thresholds from 0.50 to 0.95 in spaces of 0.05.
         jdict (List): List to store JSON validation results.
-        speed (Dict): Dictionary with keys 'preprocess', 'inference', 'loss', 'postprocess' and their respective
+        speed (dict): Dictionary with keys 'preprocess', 'inference', 'loss', 'postprocess' and their respective
             batch processing times in milliseconds.
         save_dir (Path): Directory to save results.
-        plots (Dict): Dictionary to store plots for visualization.
-        callbacks (Dict): Dictionary to store various callback functions.
+        plots (dict): Dictionary to store plots for visualization.
+        callbacks (dict): Dictionary to store various callback functions.
 
     Methods:
         __call__: Execute validation process, running inference on dataloader and computing performance metrics.

--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -95,7 +95,7 @@ class HUBTrainingSession:
 
         Args:
             identifier (str): Model identifier used to initialize the HUB training session.
-            args (Dict, optional): Arguments for creating a new model if identifier is not a HUB model URL.
+            args (dict, optional): Arguments for creating a new model if identifier is not a HUB model URL.
 
         Returns:
             (HUBTrainingSession | None): An authenticated session or None if creation fails.

--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -26,13 +26,13 @@ class HUBTrainingSession:
     Attributes:
         model_id (str): Identifier for the YOLO model being trained.
         model_url (str): URL for the model in Ultralytics HUB.
-        rate_limits (Dict): Rate limits for different API calls (in seconds).
-        timers (Dict): Timers for rate limiting.
-        metrics_queue (Dict): Queue for the model's metrics.
-        metrics_upload_failed_queue (Dict): Queue for metrics that failed to upload.
-        model (Dict): Model data fetched from Ultralytics HUB.
+        rate_limits (dict): Rate limits for different API calls (in seconds).
+        timers (dict): Timers for rate limiting.
+        metrics_queue (dict): Queue for the model's metrics.
+        metrics_upload_failed_queue (dict): Queue for metrics that failed to upload.
+        model (dict): Model data fetched from Ultralytics HUB.
         model_file (str): Path to the model file.
-        train_args (Dict): Arguments for training the model.
+        train_args (dict): Arguments for training the model.
         client (HUBClient): Client for interacting with Ultralytics HUB.
         filename (str): Filename of the model.
 
@@ -141,7 +141,7 @@ class HUBTrainingSession:
         Initialize a HUB training session with the specified model arguments.
 
         Args:
-            model_args (Dict): Arguments for creating the model, including batch size, epochs, image size, etc.
+            model_args (dict): Arguments for creating the model, including batch size, epochs, image size, etc.
 
         Returns:
             (None): If the model could not be created.

--- a/ultralytics/hub/utils.py
+++ b/ultralytics/hub/utils.py
@@ -177,7 +177,7 @@ class Events:
     Attributes:
         url (str): The URL to send anonymous events.
         rate_limit (float): The rate limit in seconds for sending events.
-        metadata (Dict): A dictionary containing metadata about the environment.
+        metadata (dict): A dictionary containing metadata about the environment.
         enabled (bool): A flag to enable or disable Events based on certain conditions.
     """
 

--- a/ultralytics/models/fastsam/model.py
+++ b/ultralytics/models/fastsam/model.py
@@ -43,14 +43,14 @@ class FastSAM(Model):
             source (str | PIL.Image | numpy.ndarray): Input source for prediction, can be a file path, URL, PIL image,
                 or numpy array.
             stream (bool): Whether to enable real-time streaming mode for video inputs.
-            bboxes (List): Bounding box coordinates for prompted segmentation in format [[x1, y1, x2, y2], ...].
-            points (List): Point coordinates for prompted segmentation in format [[x, y], ...].
-            labels (List): Class labels for prompted segmentation.
-            texts (List): Text prompts for segmentation guidance.
+            bboxes (list): Bounding box coordinates for prompted segmentation in format [[x1, y1, x2, y2], ...].
+            points (list): Point coordinates for prompted segmentation in format [[x, y], ...].
+            labels (list): Class labels for prompted segmentation.
+            texts (list): Text prompts for segmentation guidance.
             **kwargs (Any): Additional keyword arguments passed to the predictor.
 
         Returns:
-            (List): List of Results objects containing the prediction results.
+            (list): List of Results objects containing the prediction results.
         """
         prompts = dict(bboxes=bboxes, points=points, labels=labels, texts=texts)
         return super().predict(source, stream, prompts=prompts, **kwargs)

--- a/ultralytics/models/fastsam/predict.py
+++ b/ultralytics/models/fastsam/predict.py
@@ -20,7 +20,7 @@ class FastSAMPredictor(SegmentationPredictor):
     single-class segmentation.
 
     Attributes:
-        prompts (Dict): Dictionary containing prompt information for segmentation (bboxes, points, labels, texts).
+        prompts (dict): Dictionary containing prompt information for segmentation (bboxes, points, labels, texts).
         device (torch.device): Device on which model and tensors are processed.
         clip_model (Any, optional): CLIP model for text-based prompting, loaded on demand.
         clip_preprocess (Any, optional): CLIP preprocessing function for images, loaded on demand.

--- a/ultralytics/models/fastsam/val.py
+++ b/ultralytics/models/fastsam/val.py
@@ -17,7 +17,7 @@ class FastSAMValidator(SegmentationValidator):
         save_dir (Path): The directory where validation results will be saved.
         pbar (tqdm.tqdm): A progress bar object for displaying validation progress.
         args (SimpleNamespace): Additional arguments for customization of the validation process.
-        _callbacks (List): List of callback functions to be invoked during validation.
+        _callbacks (list): List of callback functions to be invoked during validation.
     """
 
     def __init__(self, dataloader=None, save_dir=None, pbar=None, args=None, _callbacks=None):
@@ -29,7 +29,7 @@ class FastSAMValidator(SegmentationValidator):
             save_dir (Path, optional): Directory to save results.
             pbar (tqdm.tqdm): Progress bar for displaying progress.
             args (SimpleNamespace): Configuration for the validator.
-            _callbacks (List): List of callback functions to be invoked during validation.
+            _callbacks (list): List of callback functions to be invoked during validation.
 
         Notes:
             Plots for ConfusionMatrix and other related metrics are disabled in this class to avoid errors.

--- a/ultralytics/models/nas/predict.py
+++ b/ultralytics/models/nas/predict.py
@@ -19,7 +19,7 @@ class NASPredictor(BasePredictor):
         args (Namespace): Namespace containing various configurations for post-processing including confidence threshold,
             IoU threshold, agnostic NMS flag, maximum detections, and class filtering options.
         model (torch.nn.Module): The YOLO NAS model used for inference.
-        batch (List): Batch of inputs for processing.
+        batch (list): Batch of inputs for processing.
 
     Examples:
         >>> from ultralytics import NAS

--- a/ultralytics/models/rtdetr/model.py
+++ b/ultralytics/models/rtdetr/model.py
@@ -51,7 +51,7 @@ class RTDETR(Model):
         Returns a task map for RT-DETR, associating tasks with corresponding Ultralytics classes.
 
         Returns:
-            (Dict): A dictionary mapping task names to Ultralytics task classes for the RT-DETR model.
+            (dict): A dictionary mapping task names to Ultralytics task classes for the RT-DETR model.
         """
         return {
             "detect": {

--- a/ultralytics/models/rtdetr/predict.py
+++ b/ultralytics/models/rtdetr/predict.py
@@ -19,7 +19,7 @@ class RTDETRPredictor(BasePredictor):
         imgsz (int): Image size for inference (must be square and scale-filled).
         args (dict): Argument overrides for the predictor.
         model (torch.nn.Module): The loaded RT-DETR model.
-        batch (List): Current batch of processed inputs.
+        batch (list): Current batch of processed inputs.
 
     Examples:
         >>> from ultralytics.utils import ASSETS

--- a/ultralytics/models/rtdetr/train.py
+++ b/ultralytics/models/rtdetr/train.py
@@ -42,7 +42,7 @@ class RTDETRTrainer(DetectionTrainer):
         Initialize and return an RT-DETR model for object detection tasks.
 
         Args:
-            cfg (Dict, optional): Model configuration.
+            cfg (dict, optional): Model configuration.
             weights (str, optional): Path to pre-trained model weights.
             verbose (bool): Verbose logging if True.
 

--- a/ultralytics/models/rtdetr/train.py
+++ b/ultralytics/models/rtdetr/train.py
@@ -21,8 +21,8 @@ class RTDETRTrainer(DetectionTrainer):
 
     Attributes:
         loss_names (Tuple[str]): Names of the loss components used for training.
-        data (Dict): Dataset configuration containing class count and other parameters.
-        args (Dict): Training arguments and hyperparameters.
+        data (dict): Dataset configuration containing class count and other parameters.
+        args (dict): Training arguments and hyperparameters.
         save_dir (Path): Directory to save training results.
         test_loader (DataLoader): DataLoader for validation/testing data.
 
@@ -91,10 +91,10 @@ class RTDETRTrainer(DetectionTrainer):
         Preprocess a batch of images by scaling and converting to float format.
 
         Args:
-            batch (Dict): Dictionary containing a batch of images, bboxes, and labels.
+            batch (dict): Dictionary containing a batch of images, bboxes, and labels.
 
         Returns:
-            (Dict): Preprocessed batch with ground truth bounding boxes and classes separated by batch index.
+            (dict): Preprocessed batch with ground truth bounding boxes and classes separated by batch index.
         """
         batch = super().preprocess_batch(batch)
         bs = len(batch["img"])

--- a/ultralytics/models/rtdetr/val.py
+++ b/ultralytics/models/rtdetr/val.py
@@ -134,10 +134,10 @@ class RTDETRValidator(DetectionValidator):
 
         Args:
             si (int): Batch index.
-            batch (Dict): Batch data containing images and annotations.
+            batch (dict): Batch data containing images and annotations.
 
         Returns:
-            (Dict): Prepared batch with transformed annotations.
+            (dict): Prepared batch with transformed annotations.
         """
         idx = batch["batch_idx"] == si
         cls = batch["cls"][idx].squeeze(-1)
@@ -157,7 +157,7 @@ class RTDETRValidator(DetectionValidator):
 
         Args:
             pred (torch.Tensor): Raw predictions.
-            pbatch (Dict): Prepared batch information.
+            pbatch (dict): Prepared batch information.
 
         Returns:
             (torch.Tensor): Predictions scaled to original image dimensions.

--- a/ultralytics/models/rtdetr/val.py
+++ b/ultralytics/models/rtdetr/val.py
@@ -31,7 +31,7 @@ class RTDETRDataset(YOLODataset):
         Build transformation pipeline for the dataset.
 
         Args:
-            hyp (Dict, optional): Hyperparameters for transformations.
+            hyp (dict, optional): Hyperparameters for transformations.
 
         Returns:
             (Compose): Composition of transformation functions.

--- a/ultralytics/models/sam/model.py
+++ b/ultralytics/models/sam/model.py
@@ -94,7 +94,7 @@ class SAM(Model):
             **kwargs (Any): Additional keyword arguments for prediction.
 
         Returns:
-            (List): The model predictions.
+            (list): The model predictions.
 
         Examples:
             >>> sam = SAM("sam_b.pt")
@@ -124,7 +124,7 @@ class SAM(Model):
             **kwargs (Any): Additional keyword arguments to be passed to the predict method.
 
         Returns:
-            (List): The model predictions, typically containing segmentation masks and other relevant information.
+            (list): The model predictions, typically containing segmentation masks and other relevant information.
 
         Examples:
             >>> sam = SAM("sam_b.pt")

--- a/ultralytics/models/sam/modules/blocks.py
+++ b/ultralytics/models/sam/modules/blocks.py
@@ -707,7 +707,7 @@ class PositionEmbeddingSine(nn.Module):
         temperature (int): Temperature parameter for the sinusoidal functions.
         normalize (bool): Whether to normalize the positional embeddings.
         scale (float): Scaling factor for the embeddings when normalize is True.
-        cache (Dict): Cache for storing precomputed embeddings.
+        cache (dict): Cache for storing precomputed embeddings.
 
     Methods:
         _encode_xy: Encodes 2D positions using sine and cosine functions.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -48,7 +48,7 @@ class Predictor(BasePredictor):
         device (torch.device): The device (CPU or GPU) on which the model is loaded.
         im (torch.Tensor): The preprocessed input image.
         features (torch.Tensor): Extracted image features.
-        prompts (Dict): Dictionary to store various types of prompts (e.g., bboxes, points, masks).
+        prompts (dict): Dictionary to store various types of prompts (e.g., bboxes, points, masks).
         segment_all (bool): Flag to indicate if full image segmentation should be performed.
         mean (torch.Tensor): Mean values for image normalization.
         std (torch.Tensor): Standard deviation values for image normalization.
@@ -86,7 +86,7 @@ class Predictor(BasePredictor):
         for optimal results.
 
         Args:
-            cfg (Dict): Configuration dictionary containing default settings.
+            cfg (dict): Configuration dictionary containing default settings.
             overrides (Dict | None): Dictionary of values to override default configuration.
             _callbacks (Dict | None): Dictionary of callback functions to customize behavior.
 
@@ -634,7 +634,7 @@ class SAM2Predictor(Predictor):
         device (torch.device): The device (CPU or GPU) on which the model is loaded.
         features (Dict[str, torch.Tensor]): Cached image features for efficient inference.
         segment_all (bool): Flag to indicate if all segments should be predicted.
-        prompts (Dict): Dictionary to store various types of prompts for inference.
+        prompts (dict): Dictionary to store various types of prompts for inference.
 
     Methods:
         get_model: Retrieves and initializes the SAM2 model.
@@ -818,11 +818,11 @@ class SAM2VideoPredictor(SAM2Predictor):
     clearing memory for non-conditional inputs, and setting up callbacks for prediction events.
 
     Attributes:
-        inference_state (Dict): A dictionary to store the current state of inference operations.
+        inference_state (dict): A dictionary to store the current state of inference operations.
         non_overlap_masks (bool): A flag indicating whether masks should be non-overlapping.
         clear_non_cond_mem_around_input (bool): A flag to control clearing non-conditional memory around inputs.
         clear_non_cond_mem_for_multi_obj (bool): A flag to control clearing non-conditional memory for multi-object scenarios.
-        callbacks (Dict): A dictionary of callbacks for various prediction lifecycle events.
+        callbacks (dict): A dictionary of callbacks for various prediction lifecycle events.
 
     Args:
         cfg (Dict, Optional): Configuration settings for the predictor. Defaults to DEFAULT_CFG.
@@ -844,7 +844,7 @@ class SAM2VideoPredictor(SAM2Predictor):
         that control the behavior of the predictor.
 
         Args:
-            cfg (Dict): Configuration dictionary containing default settings.
+            cfg (dict): Configuration dictionary containing default settings.
             overrides (Dict | None): Dictionary of values to override default configuration.
             _callbacks (Dict | None): Dictionary of callback functions to customize behavior.
 
@@ -1284,7 +1284,7 @@ class SAM2VideoPredictor(SAM2Predictor):
         Run tracking on a single frame based on current inputs and previous memory.
 
         Args:
-            output_dict (Dict): The dictionary containing the output states of the tracking process.
+            output_dict (dict): The dictionary containing the output states of the tracking process.
             frame_idx (int): The index of the current frame.
             batch_size (int): The batch size for processing the frame.
             is_init_cond_frame (bool): Indicates if the current frame is an initial conditioning frame.
@@ -1559,7 +1559,7 @@ class SAM2VideoPredictor(SAM2Predictor):
 
         Args:
             frame_idx (int): The index of the current frame.
-            current_out (Dict): The current output dictionary containing multi-object outputs.
+            current_out (dict): The current output dictionary containing multi-object outputs.
             storage_key (str): The key used to store the output in the per-object output dictionary.
         """
         maskmem_features = current_out["maskmem_features"]

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -827,7 +827,7 @@ class SAM2VideoPredictor(SAM2Predictor):
     Args:
         cfg (dict, Optional): Configuration settings for the predictor. Defaults to DEFAULT_CFG.
         overrides (dict, Optional): Additional configuration overrides. Defaults to None.
-        _callbacks (List, Optional): Custom callbacks to be added. Defaults to None.
+        _callbacks (list, Optional): Custom callbacks to be added. Defaults to None.
 
     Note:
         The `fill_hole_area` attribute is defined but not used in the current implementation.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -825,8 +825,8 @@ class SAM2VideoPredictor(SAM2Predictor):
         callbacks (dict): A dictionary of callbacks for various prediction lifecycle events.
 
     Args:
-        cfg (Dict, Optional): Configuration settings for the predictor. Defaults to DEFAULT_CFG.
-        overrides (Dict, Optional): Additional configuration overrides. Defaults to None.
+        cfg (dict, Optional): Configuration settings for the predictor. Defaults to DEFAULT_CFG.
+        overrides (dict, Optional): Additional configuration overrides. Defaults to None.
         _callbacks (List, Optional): Custom callbacks to be added. Defaults to None.
 
     Note:
@@ -1288,7 +1288,7 @@ class SAM2VideoPredictor(SAM2Predictor):
             frame_idx (int): The index of the current frame.
             batch_size (int): The batch size for processing the frame.
             is_init_cond_frame (bool): Indicates if the current frame is an initial conditioning frame.
-            point_inputs (Dict, Optional): Input points and their labels. Defaults to None.
+            point_inputs (dict, Optional): Input points and their labels. Defaults to None.
             mask_inputs (torch.Tensor, Optional): Input binary masks. Defaults to None.
             reverse (bool): Indicates if the tracking should be performed in reverse order.
             run_mem_encoder (bool): Indicates if the memory encoder should be executed.

--- a/ultralytics/models/utils/loss.py
+++ b/ultralytics/models/utils/loss.py
@@ -356,7 +356,7 @@ class RTDETRDetectionLoss(DETRLoss):
             batch (dict): Batch data containing ground truth information.
             dn_bboxes (torch.Tensor, optional): Denoising bounding boxes.
             dn_scores (torch.Tensor, optional): Denoising scores.
-            dn_meta (Dict, optional): Metadata for denoising.
+            dn_meta (dict, optional): Metadata for denoising.
 
         Returns:
             (dict): Dictionary containing total loss and denoising loss if applicable.

--- a/ultralytics/models/utils/loss.py
+++ b/ultralytics/models/utils/loss.py
@@ -19,7 +19,7 @@ class DETRLoss(nn.Module):
 
     Attributes:
         nc (int): Number of classes.
-        loss_gain (Dict): Coefficients for different loss components.
+        loss_gain (dict): Coefficients for different loss components.
         aux_loss (bool): Whether to compute auxiliary losses.
         use_fl (bool): Whether to use FocalLoss.
         use_vfl (bool): Whether to use VarifocalLoss.
@@ -42,7 +42,7 @@ class DETRLoss(nn.Module):
 
         Args:
             nc (int): Number of classes.
-            loss_gain (Dict): Coefficients for different loss components.
+            loss_gain (dict): Coefficients for different loss components.
             aux_loss (bool): Whether to use auxiliary losses from each decoder layer.
             use_fl (bool): Whether to use FocalLoss.
             use_vfl (bool): Whether to use VarifocalLoss.
@@ -162,7 +162,7 @@ class DETRLoss(nn.Module):
             gt_mask (torch.Tensor, optional): Ground truth masks if using segmentation.
 
         Returns:
-            (Dict): Dictionary of auxiliary losses.
+            (dict): Dictionary of auxiliary losses.
         """
         # NOTE: loss class, bbox, giou, mask, dice
         loss = torch.zeros(5 if masks is not None else 3, device=pred_bboxes.device)
@@ -276,7 +276,7 @@ class DETRLoss(nn.Module):
             match_indices (List[tuple], optional): Pre-computed matching indices.
 
         Returns:
-            (Dict): Dictionary of losses.
+            (dict): Dictionary of losses.
         """
         if match_indices is None:
             match_indices = self.matcher(
@@ -307,7 +307,7 @@ class DETRLoss(nn.Module):
         Args:
             pred_bboxes (torch.Tensor): Predicted bounding boxes, shape [l, b, query, 4].
             pred_scores (torch.Tensor): Predicted class scores, shape [l, b, query, num_classes].
-            batch (Dict): Batch information containing:
+            batch (dict): Batch information containing:
                 cls (torch.Tensor): Ground truth classes, shape [num_gts].
                 bboxes (torch.Tensor): Ground truth bounding boxes, shape [num_gts, 4].
                 gt_groups (List[int]): Number of ground truths for each image in the batch.
@@ -315,7 +315,7 @@ class DETRLoss(nn.Module):
             **kwargs (Any): Additional arguments, may include 'match_indices'.
 
         Returns:
-            (Dict): Computed losses, including main and auxiliary (if enabled).
+            (dict): Computed losses, including main and auxiliary (if enabled).
 
         Notes:
             Uses last elements of pred_bboxes and pred_scores for main loss, and the rest for auxiliary losses if
@@ -353,13 +353,13 @@ class RTDETRDetectionLoss(DETRLoss):
 
         Args:
             preds (tuple): Tuple containing predicted bounding boxes and scores.
-            batch (Dict): Batch data containing ground truth information.
+            batch (dict): Batch data containing ground truth information.
             dn_bboxes (torch.Tensor, optional): Denoising bounding boxes.
             dn_scores (torch.Tensor, optional): Denoising scores.
             dn_meta (Dict, optional): Metadata for denoising.
 
         Returns:
-            (Dict): Dictionary containing total loss and denoising loss if applicable.
+            (dict): Dictionary containing total loss and denoising loss if applicable.
         """
         pred_bboxes, pred_scores = preds
         total_loss = super().forward(pred_bboxes, pred_scores, batch)

--- a/ultralytics/models/utils/ops.py
+++ b/ultralytics/models/utils/ops.py
@@ -18,7 +18,7 @@ class HungarianMatcher(nn.Module):
     function that considers classification scores, bounding box coordinates, and optionally, mask predictions.
 
     Attributes:
-        cost_gain (Dict): Dictionary of cost coefficients: 'class', 'bbox', 'giou', 'mask', and 'dice'.
+        cost_gain (dict): Dictionary of cost coefficients: 'class', 'bbox', 'giou', 'mask', and 'dice'.
         use_fl (bool): Indicates whether to use Focal Loss for the classification cost calculation.
         with_mask (bool): Indicates whether the model makes mask predictions.
         num_sample_points (int): The number of sample points used in mask cost calculation.
@@ -150,7 +150,7 @@ def get_cdn_group(
     Get contrastive denoising training group with positive and negative samples from ground truths.
 
     Args:
-        batch (Dict): A dict that includes 'gt_cls' (torch.Tensor with shape (num_gts, )), 'gt_bboxes'
+        batch (dict): A dict that includes 'gt_cls' (torch.Tensor with shape (num_gts, )), 'gt_bboxes'
             (torch.Tensor with shape (num_gts, 4)), 'gt_groups' (List[int]) which is a list of batch size length
             indicating the number of gts of each image.
         num_classes (int): Number of classes.

--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -17,7 +17,7 @@ class ClassificationPredictor(BasePredictor):
     and postprocessing predictions to generate classification results.
 
     Attributes:
-        args (Dict): Configuration arguments for the predictor.
+        args (dict): Configuration arguments for the predictor.
         _legacy_transform_name (str): Name of the legacy transform class for backward compatibility.
 
     Methods:

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -22,7 +22,7 @@ class ClassificationTrainer(BaseTrainer):
 
     Attributes:
         model (ClassificationModel): The classification model to be trained.
-        data (Dict): Dictionary containing dataset information including class names and number of classes.
+        data (dict): Dictionary containing dataset information including class names and number of classes.
         loss_names (List[str]): Names of the loss functions used during training.
         validator (ClassificationValidator): Validator instance for model evaluation.
 

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -20,7 +20,7 @@ class ClassificationValidator(BaseValidator):
         targets (List[torch.Tensor]): Ground truth class labels.
         pred (List[torch.Tensor]): Model predictions.
         metrics (ClassifyMetrics): Object to calculate and store classification metrics.
-        names (Dict): Mapping of class indices to class names.
+        names (dict): Mapping of class indices to class names.
         nc (int): Number of classes.
         confusion_matrix (ConfusionMatrix): Matrix to evaluate model performance across classes.
 

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -15,7 +15,7 @@ class DetectionPredictor(BasePredictor):
     Attributes:
         args (namespace): Configuration arguments for the predictor.
         model (nn.Module): The detection model used for inference.
-        batch (List): Batch of images and metadata for processing.
+        batch (list): Batch of images and metadata for processing.
 
     Methods:
         postprocess: Process raw model predictions into detection results.

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -25,7 +25,7 @@ class DetectionTrainer(BaseTrainer):
 
     Attributes:
         model (DetectionModel): The YOLO detection model being trained.
-        data (Dict): Dictionary containing dataset information including class names and number of classes.
+        data (dict): Dictionary containing dataset information including class names and number of classes.
         loss_names (Tuple[str]): Names of the loss components used in training (box_loss, cls_loss, dfl_loss).
 
     Methods:
@@ -92,10 +92,10 @@ class DetectionTrainer(BaseTrainer):
         Preprocess a batch of images by scaling and converting to float.
 
         Args:
-            batch (Dict): Dictionary containing batch data with 'img' tensor.
+            batch (dict): Dictionary containing batch data with 'img' tensor.
 
         Returns:
-            (Dict): Preprocessed batch with normalized images.
+            (dict): Preprocessed batch with normalized images.
         """
         batch["img"] = batch["img"].to(self.device, non_blocking=True).float() / 255
         if self.args.multi_scale:
@@ -182,7 +182,7 @@ class DetectionTrainer(BaseTrainer):
         Plot training samples with their annotations.
 
         Args:
-            batch (Dict): Dictionary containing batch data.
+            batch (dict): Dictionary containing batch data.
             ni (int): Number of iterations.
         """
         plot_images(

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -49,7 +49,7 @@ class DetectionValidator(BaseValidator):
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to use for validation.
             save_dir (Path, optional): Directory to save results.
             pbar (Any, optional): Progress bar for displaying progress.
-            args (Dict, optional): Arguments for the validator.
+            args (dict, optional): Arguments for the validator.
             _callbacks (List, optional): List of callback functions.
         """
         super().__init__(dataloader, save_dir, pbar, args, _callbacks)

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -32,7 +32,7 @@ class DetectionValidator(BaseValidator):
         niou (int): Number of IoU thresholds.
         lb (List): List for storing ground truth labels for hybrid saving.
         jdict (List): List for storing JSON detection results.
-        stats (Dict): Dictionary for storing statistics during validation.
+        stats (dict): Dictionary for storing statistics during validation.
 
     Examples:
         >>> from ultralytics.models.yolo.detect import DetectionValidator
@@ -74,10 +74,10 @@ class DetectionValidator(BaseValidator):
         Preprocess batch of images for YOLO validation.
 
         Args:
-            batch (Dict): Batch containing images and annotations.
+            batch (dict): Batch containing images and annotations.
 
         Returns:
-            (Dict): Preprocessed batch.
+            (dict): Preprocessed batch.
         """
         batch["img"] = batch["img"].to(self.device, non_blocking=True)
         batch["img"] = (batch["img"].half() if self.args.half else batch["img"].float()) / 255
@@ -154,10 +154,10 @@ class DetectionValidator(BaseValidator):
 
         Args:
             si (int): Batch index.
-            batch (Dict): Batch data containing images and annotations.
+            batch (dict): Batch data containing images and annotations.
 
         Returns:
-            (Dict): Prepared batch with processed annotations.
+            (dict): Prepared batch with processed annotations.
         """
         idx = batch["batch_idx"] == si
         cls = batch["cls"][idx].squeeze(-1)
@@ -176,7 +176,7 @@ class DetectionValidator(BaseValidator):
 
         Args:
             pred (torch.Tensor): Model predictions.
-            pbatch (Dict): Prepared batch information.
+            pbatch (dict): Prepared batch information.
 
         Returns:
             (torch.Tensor): Prepared predictions in native space.
@@ -193,7 +193,7 @@ class DetectionValidator(BaseValidator):
 
         Args:
             preds (List[torch.Tensor]): List of predictions from the model.
-            batch (Dict): Batch data containing ground truth.
+            batch (dict): Batch data containing ground truth.
         """
         for si, pred in enumerate(preds):
             self.seen += 1
@@ -258,7 +258,7 @@ class DetectionValidator(BaseValidator):
         Calculate and return metrics statistics.
 
         Returns:
-            (Dict): Dictionary containing metrics results.
+            (dict): Dictionary containing metrics results.
         """
         stats = {k: torch.cat(v, 0).cpu().numpy() for k, v in self.stats.items()}  # to numpy
         self.nt_per_class = np.bincount(stats["target_cls"].astype(int), minlength=self.nc)
@@ -338,7 +338,7 @@ class DetectionValidator(BaseValidator):
         Plot validation image samples.
 
         Args:
-            batch (Dict): Batch containing images and annotations.
+            batch (dict): Batch containing images and annotations.
             ni (int): Batch index.
         """
         plot_images(
@@ -357,7 +357,7 @@ class DetectionValidator(BaseValidator):
         Plot predicted bounding boxes on input images and save the result.
 
         Args:
-            batch (Dict): Batch containing images and annotations.
+            batch (dict): Batch containing images and annotations.
             preds (List[torch.Tensor]): List of predictions from the model.
             ni (int): Batch index.
         """
@@ -416,10 +416,10 @@ class DetectionValidator(BaseValidator):
         Evaluate YOLO output in JSON format and return performance statistics.
 
         Args:
-            stats (Dict): Current statistics dictionary.
+            stats (dict): Current statistics dictionary.
 
         Returns:
-            (Dict): Updated statistics dictionary with COCO/LVIS evaluation results.
+            (dict): Updated statistics dictionary with COCO/LVIS evaluation results.
         """
         if self.args.save_json and (self.is_coco or self.is_lvis) and len(self.jdict):
             pred_json = self.save_dir / "predictions.json"  # predictions

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -50,7 +50,7 @@ class DetectionValidator(BaseValidator):
             save_dir (Path, optional): Directory to save results.
             pbar (Any, optional): Progress bar for displaying progress.
             args (dict, optional): Arguments for the validator.
-            _callbacks (List, optional): List of callback functions.
+            _callbacks (list, optional): List of callback functions.
         """
         super().__init__(dataloader, save_dir, pbar, args, _callbacks)
         self.nt_per_class = None

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -26,12 +26,12 @@ class DetectionValidator(BaseValidator):
         nt_per_image (np.ndarray): Number of targets per image.
         is_coco (bool): Whether the dataset is COCO.
         is_lvis (bool): Whether the dataset is LVIS.
-        class_map (List): Mapping from model class indices to dataset class indices.
+        class_map (list): Mapping from model class indices to dataset class indices.
         metrics (DetMetrics): Object detection metrics calculator.
         iouv (torch.Tensor): IoU thresholds for mAP calculation.
         niou (int): Number of IoU thresholds.
-        lb (List): List for storing ground truth labels for hybrid saving.
-        jdict (List): List for storing JSON detection results.
+        lb (list): List for storing ground truth labels for hybrid saving.
+        jdict (list): List for storing JSON detection results.
         stats (dict): Dictionary for storing statistics during validation.
 
     Examples:

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -18,7 +18,7 @@ class OBBValidator(DetectionValidator):
     satellite imagery where objects can appear at various orientations.
 
     Attributes:
-        args (Dict): Configuration arguments for the validator.
+        args (dict): Configuration arguments for the validator.
         metrics (OBBMetrics): Metrics object for evaluating OBB model performance.
         is_dota (bool): Flag indicating whether the validation dataset is in DOTA format.
 

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -16,9 +16,9 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
     of pose keypoints alongside bounding boxes.
 
     Attributes:
-        args (Dict): Configuration arguments for training.
+        args (dict): Configuration arguments for training.
         model (PoseModel): The pose estimation model being trained.
-        data (Dict): Dataset configuration including keypoint shape information.
+        data (dict): Dataset configuration including keypoint shape information.
         loss_names (Tuple[str]): Names of the loss components used in training.
 
     Methods:

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -22,7 +22,7 @@ class PoseValidator(DetectionValidator):
     Attributes:
         sigma (np.ndarray): Sigma values for OKS calculation, either from OKS_SIGMA or ones divided by number of keypoints.
         kpt_shape (List[int]): Shape of the keypoints, typically [17, 3] for COCO format.
-        args (Dict): Arguments for the validator including task set to "pose".
+        args (dict): Arguments for the validator including task set to "pose".
         metrics (PoseMetrics): Metrics object for pose evaluation.
 
     Methods:
@@ -119,7 +119,7 @@ class PoseValidator(DetectionValidator):
 
         Args:
             preds (List[torch.Tensor]): List of prediction tensors from the model.
-            batch (Dict): Batch data containing images and ground truth annotations.
+            batch (dict): Batch data containing images and ground truth annotations.
         """
         for si, pred in enumerate(preds):
             self.seen += 1

--- a/ultralytics/models/yolo/segment/predict.py
+++ b/ultralytics/models/yolo/segment/predict.py
@@ -15,7 +15,7 @@ class SegmentationPredictor(DetectionPredictor):
     Attributes:
         args (dict): Configuration arguments for the predictor.
         model (torch.nn.Module): The loaded YOLO segmentation model.
-        batch (List): Current batch of images being processed.
+        batch (list): Current batch of images being processed.
 
     Methods:
         postprocess: Applies non-max suppression and processes detections.

--- a/ultralytics/models/yolo/segment/predict.py
+++ b/ultralytics/models/yolo/segment/predict.py
@@ -13,7 +13,7 @@ class SegmentationPredictor(DetectionPredictor):
     prediction results.
 
     Attributes:
-        args (Dict): Configuration arguments for the predictor.
+        args (dict): Configuration arguments for the predictor.
         model (torch.nn.Module): The loaded YOLO segmentation model.
         batch (List): Current batch of images being processed.
 

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -22,7 +22,7 @@ class SegmentationValidator(DetectionValidator):
     to compute metrics such as mAP for both detection and segmentation tasks.
 
     Attributes:
-        plot_masks (List): List to store masks for plotting.
+        plot_masks (list): List to store masks for plotting.
         process (callable): Function to process masks based on save_json and save_txt flags.
         args (namespace): Arguments for the validator.
         metrics (SegmentMetrics): Metrics calculator for segmentation tasks.
@@ -94,7 +94,7 @@ class SegmentationValidator(DetectionValidator):
         Post-process YOLO predictions and return output detections with proto.
 
         Args:
-            preds (List): Raw predictions from the model.
+            preds (list): Raw predictions from the model.
 
         Returns:
             p (torch.Tensor): Processed detection predictions.
@@ -142,7 +142,7 @@ class SegmentationValidator(DetectionValidator):
         Update metrics with the current batch predictions and targets.
 
         Args:
-            preds (List): Predictions from the model.
+            preds (list): Predictions from the model.
             batch (dict): Batch data containing images and targets.
         """
         for si, (pred, proto) in enumerate(zip(preds[0], preds[1])):
@@ -287,7 +287,7 @@ class SegmentationValidator(DetectionValidator):
 
         Args:
             batch (dict): Batch data containing images.
-            preds (List): Predictions from the model.
+            preds (list): Predictions from the model.
             ni (int): Batch index.
         """
         plot_images(

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -44,7 +44,7 @@ class SegmentationValidator(DetectionValidator):
             save_dir (Path, optional): Directory to save results.
             pbar (Any, optional): Progress bar for displaying progress.
             args (namespace, optional): Arguments for the validator.
-            _callbacks (List, optional): List of callback functions.
+            _callbacks (list, optional): List of callback functions.
         """
         super().__init__(dataloader, save_dir, pbar, args, _callbacks)
         self.plot_masks = None

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -26,7 +26,7 @@ class SegmentationValidator(DetectionValidator):
         process (callable): Function to process masks based on save_json and save_txt flags.
         args (namespace): Arguments for the validator.
         metrics (SegmentMetrics): Metrics calculator for segmentation tasks.
-        stats (Dict): Dictionary to store statistics during validation.
+        stats (dict): Dictionary to store statistics during validation.
 
     Examples:
         >>> from ultralytics.models.yolo.segment import SegmentationValidator
@@ -110,10 +110,10 @@ class SegmentationValidator(DetectionValidator):
 
         Args:
             si (int): Batch index.
-            batch (Dict): Batch data containing images and targets.
+            batch (dict): Batch data containing images and targets.
 
         Returns:
-            (Dict): Prepared batch with processed images and targets.
+            (dict): Prepared batch with processed images and targets.
         """
         prepared_batch = super()._prepare_batch(si, batch)
         midx = [si] if self.args.overlap_mask else batch["batch_idx"] == si
@@ -126,7 +126,7 @@ class SegmentationValidator(DetectionValidator):
 
         Args:
             pred (torch.Tensor): Raw predictions from the model.
-            pbatch (Dict): Prepared batch data.
+            pbatch (dict): Prepared batch data.
             proto (torch.Tensor): Prototype masks for segmentation.
 
         Returns:
@@ -143,7 +143,7 @@ class SegmentationValidator(DetectionValidator):
 
         Args:
             preds (List): Predictions from the model.
-            batch (Dict): Batch data containing images and targets.
+            batch (dict): Batch data containing images and targets.
         """
         for si, (pred, proto) in enumerate(zip(preds[0], preds[1])):
             self.seen += 1
@@ -266,7 +266,7 @@ class SegmentationValidator(DetectionValidator):
         Plot validation samples with bounding box labels and masks.
 
         Args:
-            batch (Dict): Batch data containing images and targets.
+            batch (dict): Batch data containing images and targets.
             ni (int): Batch index.
         """
         plot_images(
@@ -286,7 +286,7 @@ class SegmentationValidator(DetectionValidator):
         Plot batch predictions with masks and bounding boxes.
 
         Args:
-            batch (Dict): Batch data containing images.
+            batch (dict): Batch data containing images.
             preds (List): Predictions from the model.
             ni (int): Batch index.
         """

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -309,7 +309,7 @@ class SegmentationValidator(DetectionValidator):
             predn (torch.Tensor): Predictions in the format [x1, y1, x2, y2, conf, cls].
             pred_masks (torch.Tensor): Predicted masks.
             save_conf (bool): Whether to save confidence scores.
-            shape (Tuple): Original image shape.
+            shape (tuple): Original image shape.
             file (Path): File path to save the detections.
         """
         from ultralytics.engine.results import Results

--- a/ultralytics/models/yolo/world/train.py
+++ b/ultralytics/models/yolo/world/train.py
@@ -49,7 +49,7 @@ class WorldTrainer(yolo.detect.DetectionTrainer):
         Args:
             cfg (dict): Configuration for the trainer.
             overrides (dict, optional): Configuration overrides.
-            _callbacks (List, optional): List of callback functions.
+            _callbacks (list, optional): List of callback functions.
         """
         if overrides is None:
             overrides = {}

--- a/ultralytics/models/yolo/world/train.py
+++ b/ultralytics/models/yolo/world/train.py
@@ -32,8 +32,8 @@ class WorldTrainer(yolo.detect.DetectionTrainer):
         clip (module): The CLIP module for text-image understanding.
         text_model (module): The text encoder model from CLIP.
         model (WorldModel): The YOLO World model being trained.
-        data (Dict): Dataset configuration containing class information.
-        args (Dict): Training arguments and configuration.
+        data (dict): Dataset configuration containing class information.
+        args (dict): Training arguments and configuration.
 
     Examples:
         >>> from ultralytics.models.yolo.world import WorldModel
@@ -47,7 +47,7 @@ class WorldTrainer(yolo.detect.DetectionTrainer):
         Initialize a WorldTrainer object with given arguments.
 
         Args:
-            cfg (Dict): Configuration for the trainer.
+            cfg (dict): Configuration for the trainer.
             overrides (Dict, optional): Configuration overrides.
             _callbacks (List, optional): List of callback functions.
         """

--- a/ultralytics/models/yolo/world/train.py
+++ b/ultralytics/models/yolo/world/train.py
@@ -48,7 +48,7 @@ class WorldTrainer(yolo.detect.DetectionTrainer):
 
         Args:
             cfg (dict): Configuration for the trainer.
-            overrides (Dict, optional): Configuration overrides.
+            overrides (dict, optional): Configuration overrides.
             _callbacks (List, optional): List of callback functions.
         """
         if overrides is None:

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -15,8 +15,8 @@ class WorldTrainerFromScratch(WorldTrainer):
     supporting training YOLO-World models with combined vision-language capabilities.
 
     Attributes:
-        cfg (Dict): Configuration dictionary with default parameters for model training.
-        overrides (Dict): Dictionary of parameter overrides to customize the configuration.
+        cfg (dict): Configuration dictionary with default parameters for model training.
+        overrides (dict): Dictionary of parameter overrides to customize the configuration.
         _callbacks (List): List of callback functions to be executed during different stages of training.
 
     Examples:
@@ -126,7 +126,7 @@ class WorldTrainerFromScratch(WorldTrainer):
         Configures the validator with appropriate dataset and split information before running evaluation.
 
         Returns:
-            (Dict): Dictionary containing evaluation metrics and results.
+            (dict): Dictionary containing evaluation metrics and results.
         """
         val = self.args.data["val"]["yolo_data"][0]
         self.validator.args.data = val

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -17,7 +17,7 @@ class WorldTrainerFromScratch(WorldTrainer):
     Attributes:
         cfg (dict): Configuration dictionary with default parameters for model training.
         overrides (dict): Dictionary of parameter overrides to customize the configuration.
-        _callbacks (List): List of callback functions to be executed during different stages of training.
+        _callbacks (list): List of callback functions to be executed during different stages of training.
 
     Examples:
         >>> from ultralytics.models.yolo.world.train_world import WorldTrainerFromScratch

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -554,7 +554,7 @@ class AutoBackend(nn.Module):
             im (torch.Tensor): The image tensor to perform inference on.
             augment (bool): Whether to perform data augmentation during inference. Defaults to False.
             visualize (bool): Whether to visualize the output predictions. Defaults to False.
-            embed (List, optional): A list of feature vectors/embeddings to return.
+            embed (list, optional): A list of feature vectors/embeddings to return.
 
         Returns:
             (torch.Tensor | List[torch.Tensor]): The raw output tensor(s) from the model.

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -78,7 +78,7 @@ class AutoBackend(nn.Module):
         model (torch.nn.Module): The loaded YOLO model.
         device (torch.device): The device (CPU or GPU) on which the model is loaded.
         task (str): The type of task the model performs (detect, segment, classify, pose).
-        names (Dict): A dictionary of class names that the model can detect.
+        names (dict): A dictionary of class names that the model can detect.
         stride (int): The model stride, typically 32 for YOLO models.
         fp16 (bool): Whether the model uses half-precision (FP16) inference.
 

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -686,7 +686,7 @@ class ImagePoolingAttn(nn.Module):
 
         Args:
             ec (int): Embedding channels.
-            ch (Tuple): Channel dimensions for feature maps.
+            ch (tuple): Channel dimensions for feature maps.
             ct (int): Channel dimension for text embeddings.
             nh (int): Number of attention heads.
             k (int): Kernel size for pooling.

--- a/ultralytics/nn/modules/transformer.py
+++ b/ultralytics/nn/modules/transformer.py
@@ -484,7 +484,7 @@ class MSDeformAttn(nn.Module):
             refer_bbox (torch.Tensor): Tensor with shape [bs, query_length, n_levels, 2], range in [0, 1],
                 top-left (0,0), bottom-right (1, 1), including padding area.
             value (torch.Tensor): Tensor with shape [bs, value_length, C].
-            value_shapes (List): List with shape [n_levels, 2], [(H_0, W_0), (H_1, W_1), ..., (H_{L-1}, W_{L-1})].
+            value_shapes (list): List with shape [n_levels, 2], [(H_0, W_0), (H_1, W_1), ..., (H_{L-1}, W_{L-1})].
             value_mask (torch.Tensor, optional): Tensor with shape [bs, value_length], True for non-padding elements,
                 False for padding elements.
 
@@ -599,7 +599,7 @@ class DeformableTransformerDecoderLayer(nn.Module):
             embed (torch.Tensor): Input embeddings.
             refer_bbox (torch.Tensor): Reference bounding boxes.
             feats (torch.Tensor): Feature maps.
-            shapes (List): Feature shapes.
+            shapes (list): Feature shapes.
             padding_mask (torch.Tensor, optional): Padding mask.
             attn_mask (torch.Tensor, optional): Attention mask.
             query_pos (torch.Tensor, optional): Query position embeddings.
@@ -674,7 +674,7 @@ class DeformableTransformerDecoder(nn.Module):
             embed (torch.Tensor): Decoder embeddings.
             refer_bbox (torch.Tensor): Reference bounding boxes.
             feats (torch.Tensor): Image features.
-            shapes (List): Feature shapes.
+            shapes (list): Feature shapes.
             bbox_head (nn.Module): Bounding box prediction head.
             score_head (nn.Module): Score prediction head.
             pos_mlp (nn.Module): Position MLP.

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -175,7 +175,7 @@ class BaseModel(torch.nn.Module):
         Args:
             m (torch.nn.Module): The layer to be profiled.
             x (torch.Tensor): The input data to the layer.
-            dt (List): A list to store the computation time of the layer.
+            dt (list): A list to store the computation time of the layer.
         """
         c = m == self.model[-1] and isinstance(x, list)  # is final layer list, copy input as inplace fix
         flops = thop.profile(m, inputs=[x.copy() if c else x], verbose=False)[0] / 1e9 * 2 if thop else 0  # GFLOPs

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -122,7 +122,7 @@ class BaseModel(torch.nn.Module):
             profile (bool): Print the computation time of each layer if True.
             visualize (bool): Save the feature maps of the model if True.
             augment (bool): Augment image during prediction.
-            embed (List, optional): A list of feature vectors/embeddings to return.
+            embed (list, optional): A list of feature vectors/embeddings to return.
 
         Returns:
             (torch.Tensor): The last output of the model.
@@ -139,7 +139,7 @@ class BaseModel(torch.nn.Module):
             x (torch.Tensor): The input tensor to the model.
             profile (bool): Print the computation time of each layer if True.
             visualize (bool): Save the feature maps of the model if True.
-            embed (List, optional): A list of feature vectors/embeddings to return.
+            embed (list, optional): A list of feature vectors/embeddings to return.
 
         Returns:
             (torch.Tensor): The last output of the model.
@@ -650,7 +650,7 @@ class RTDETRDetectionModel(DetectionModel):
             visualize (bool): If True, save feature maps for visualization.
             batch (dict, optional): Ground truth data for evaluation.
             augment (bool): If True, perform data augmentation during inference.
-            embed (List, optional): A list of feature vectors/embeddings to return.
+            embed (list, optional): A list of feature vectors/embeddings to return.
 
         Returns:
             (torch.Tensor): Model's output tensor.
@@ -729,7 +729,7 @@ class WorldModel(DetectionModel):
             visualize (bool): If True, save feature maps for visualization.
             txt_feats (torch.Tensor, optional): The text features, use it if it's given.
             augment (bool): If True, perform data augmentation during inference.
-            embed (List, optional): A list of feature vectors/embeddings to return.
+            embed (list, optional): A list of feature vectors/embeddings to return.
 
         Returns:
             (torch.Tensor): Model's output tensor.

--- a/ultralytics/solutions/analytics.py
+++ b/ultralytics/solutions/analytics.py
@@ -33,7 +33,7 @@ class Analytics(BaseSolution):
         fig (Figure): Matplotlib figure object for the chart.
         ax (Axes): Matplotlib axes object for the chart.
         canvas (FigureCanvas): Canvas for rendering the chart.
-        lines (Dict): Dictionary to store line objects for area charts.
+        lines (dict): Dictionary to store line objects for area charts.
         color_mapping (Dict[str, str]): Dictionary mapping class labels to colors for consistent visualization.
 
     Methods:

--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -158,7 +158,7 @@ class ObjectCounter(BaseSolution):
 
         Returns:
             (SolutionResults): Contains processed image `im0`, 'in_count' (int, count of objects entering the region),
-                'out_count' (int, count of objects exiting the region), 'classwise_count' (Dict, per-class object count),
+                'out_count' (int, count of objects exiting the region), 'classwise_count' (dict, per-class object count),
                 and 'total_tracks' (int, total number of tracked objects).
 
         Examples:

--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -17,7 +17,7 @@ class RegionCounter(BaseSolution):
     Attributes:
         region_template (dict): Template for creating new counting regions with default attributes including name,
             polygon coordinates, and display colors.
-        counting_regions (List): List storing all defined regions, where each entry is based on `region_template`
+        counting_regions (list): List storing all defined regions, where each entry is based on `region_template`
             and includes specific region settings like name, coordinates, and color.
         region_counts (dict): Dictionary storing the count of objects for each named region.
 

--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -47,8 +47,8 @@ class RegionCounter(BaseSolution):
         Args:
             name (str): Name assigned to the new region.
             polygon_points (List[Tuple]): List of (x, y) coordinates defining the region's polygon.
-            region_color (Tuple): BGR color for region visualization.
-            text_color (Tuple): BGR color for the text within the region.
+            region_color (tuple): BGR color for region visualization.
+            text_color (tuple): BGR color for the text within the region.
         """
         region = self.region_template.copy()
         region.update(

--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -70,7 +70,7 @@ class RegionCounter(BaseSolution):
 
         Returns:
             (SolutionResults): Contains processed image `plot_im`, 'total_tracks' (int, total number of tracked objects),
-                and 'region_counts' (Dict, counts of objects per region).
+                and 'region_counts' (dict, counts of objects per region).
         """
         self.extract_tracks(im0)
         annotator = SolutionAnnotator(im0, line_width=self.line_width)

--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -15,11 +15,11 @@ class RegionCounter(BaseSolution):
     counting in specified areas, such as monitoring zones or segmented sections.
 
     Attributes:
-        region_template (Dict): Template for creating new counting regions with default attributes including name,
+        region_template (dict): Template for creating new counting regions with default attributes including name,
             polygon coordinates, and display colors.
         counting_regions (List): List storing all defined regions, where each entry is based on `region_template`
             and includes specific region settings like name, coordinates, and color.
-        region_counts (Dict): Dictionary storing the count of objects for each named region.
+        region_counts (dict): Dictionary storing the count of objects for each named region.
 
     Methods:
         add_region: Adds a new counting region with specified attributes.

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -22,7 +22,7 @@ class BaseSolution:
         LineString (shapely.geometry.LineString): Class for creating line string geometries.
         Polygon (shapely.geometry.Polygon): Class for creating polygon geometries.
         Point (shapely.geometry.Point): Class for creating point geometries.
-        CFG (Dict): Configuration dictionary loaded from a YAML file and updated with kwargs.
+        CFG (dict): Configuration dictionary loaded from a YAML file and updated with kwargs.
         region (List[Tuple[int, int]]): List of coordinate tuples defining a region of interest.
         line_width (int): Width of lines used in visualizations.
         model (ultralytics.YOLO): Loaded YOLO model instance.
@@ -712,7 +712,7 @@ class SolutionResults:
         filled_slots (int): The number of filled slots in a monitored area.
         email_sent (bool): A flag indicating whether an email notification was sent.
         total_tracks (int): The total number of tracked objects.
-        region_counts (Dict): The count of objects within a specific region.
+        region_counts (dict): The count of objects within a specific region.
         speed_dict (Dict[str, float]): A dictionary containing speed information for tracked objects.
         total_crop_objects (int): Total number of cropped objects using ObjectCropper class.
     """

--- a/ultralytics/solutions/streamlit_inference.py
+++ b/ultralytics/solutions/streamlit_inference.py
@@ -20,7 +20,7 @@ class Inference:
 
     Attributes:
         st (module): Streamlit module for UI creation.
-        temp_dict (Dict): Temporary dictionary to store the model path and other configuration.
+        temp_dict (dict): Temporary dictionary to store the model path and other configuration.
         model_path (str): Path to the loaded model.
         model (YOLO): The YOLO model instance.
         source (str): Selected video source (webcam or video file).

--- a/ultralytics/trackers/basetrack.py
+++ b/ultralytics/trackers/basetrack.py
@@ -38,7 +38,7 @@ class BaseTrack:
         is_activated (bool): Flag indicating whether the track is currently active.
         state (TrackState): Current state of the track.
         history (OrderedDict): Ordered history of the track's states.
-        features (List): List of features extracted from the object for tracking.
+        features (list): List of features extracted from the object for tracking.
         curr_feature (Any): The current feature of the object being tracked.
         score (float): The confidence score of the tracking.
         start_frame (int): The frame number where tracking started.

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -19,7 +19,7 @@ class GMC:
         method (str): The tracking method to use. Options include 'orb', 'sift', 'ecc', 'sparseOptFlow', 'none'.
         downscale (int): Factor by which to downscale the frames for processing.
         prevFrame (np.ndarray): Previous frame for tracking.
-        prevKeyPoints (List): Keypoints from the previous frame.
+        prevKeyPoints (list): Keypoints from the previous frame.
         prevDescriptors (np.ndarray): Descriptors from the previous frame.
         initializedFirstFrame (bool): Flag indicating if the first frame has been processed.
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1183,7 +1183,7 @@ class SettingsManager(JSONDict):
     Attributes:
         file (Path): The path to the JSON file used for persistence.
         version (str): The version of the settings schema.
-        defaults (Dict): A dictionary containing default settings.
+        defaults (dict): A dictionary containing default settings.
         help_msg (str): A help message for users on how to view and update settings.
 
     Methods:

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -24,9 +24,9 @@ def _custom_table(x, y, classes, title="Precision Recall Curve", x_title="Recall
     different classes.
 
     Args:
-        x (List): Values for the x-axis; expected to have length N.
-        y (List): Corresponding values for the y-axis; also expected to have length N.
-        classes (List): Labels identifying the class of each point; length N.
+        x (list): Values for the x-axis; expected to have length N.
+        y (list): Corresponding values for the y-axis; also expected to have length N.
+        classes (list): Labels identifying the class of each point; length N.
         title (str): Title for the plot; defaults to 'Precision Recall Curve'.
         x_title (str): Label for the x-axis; defaults to 'Recall'.
         y_title (str): Label for the y-axis; defaults to 'Precision'.
@@ -64,7 +64,7 @@ def _plot_curve(
     Args:
         x (np.ndarray): Data points for the x-axis with length N.
         y (np.ndarray): Corresponding data points for the y-axis with shape (C, N), where C is the number of classes.
-        names (List): Names of the classes corresponding to the y-axis data; length C.
+        names (list): Names of the classes corresponding to the y-axis data; length C.
         id (str): Unique identifier for the logged data in wandb.
         title (str): Title for the visualization plot.
         x_title (str): Label for the x-axis.

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -622,7 +622,7 @@ def segments2boxes(segments):
     Convert segment labels to box labels, i.e. (cls, xy1, xy2, ...) to (cls, xywh).
 
     Args:
-        segments (List): List of segments, each segment is a list of points, each point is a list of x, y coordinates.
+        segments (list): List of segments, each segment is a list of points, each point is a list of x, y coordinates.
 
     Returns:
         (np.ndarray): The xywh coordinates of the bounding boxes.
@@ -639,11 +639,11 @@ def resample_segments(segments, n=1000):
     Inputs a list of segments (n,2) and returns a list of segments (n,2) up-sampled to n points each.
 
     Args:
-        segments (List): A list of (n,2) arrays, where n is the number of points in the segment.
+        segments (list): A list of (n,2) arrays, where n is the number of points in the segment.
         n (int): Number of points to resample the segment to.
 
     Returns:
-        segments (List): The resampled segments.
+        segments (list): The resampled segments.
     """
     for i, s in enumerate(segments):
         if len(s) == n:
@@ -820,7 +820,7 @@ def masks2segments(masks, strategy="all"):
         strategy (str): 'all' or 'largest'.
 
     Returns:
-        (List): List of segment masks.
+        (list): List of segment masks.
     """
     from ultralytics.data.converter import merge_multi_segment
 

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -534,7 +534,7 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     Args:
         boxes (np.ndarray): Bounding box coordinates in format [x, y, width, height].
         cls (np.ndarray): Class indices.
-        names (Dict, optional): Dictionary mapping class indices to class names.
+        names (dict, optional): Dictionary mapping class indices to class names.
         save_dir (Path, optional): Directory to save the plot.
         on_plot (Callable, optional): Function to call after plot is saved.
     """

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -789,7 +789,7 @@ def profile(input, ops, n=10, device=None, max_num_obj=0):
         max_num_obj (int, optional): Maximum number of objects for simulation. Defaults to 0.
 
     Returns:
-        (List): Profile results for each operation.
+        (list): Profile results for each operation.
 
     Examples:
         >>> from ultralytics.utils.torch_utils import profile


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR standardizes type annotations across the codebase by replacing `List`, `Dict`, and `Tuple` with their lowercase counterparts (`list`, `dict`, and `tuple`).

### 📊 Key Changes
- Replaced all instances of `List`, `Dict`, and `Tuple` with `list`, `dict`, and `tuple` in type annotations across various files.
- Updated docstrings to reflect the changes in type annotations.
- Ensured consistency in type usage for better readability and alignment with Python's modern type hinting practices.

### 🎯 Purpose & Impact
- **Purpose**: Simplify and modernize type annotations by adhering to Python's native type hinting conventions introduced in Python 3.9+.
- **Impact**:
  - Improves code readability and maintainability.
  - Aligns with best practices for Python type annotations.
  - Reduces dependency on `typing` imports for these common types, making the code cleaner and more concise. 🚀