### PR TITLE
Fix C++ Example letterbox

### DIFF
--- a/examples/YOLOv8-LibTorch-CPP-Inference/main.cc
+++ b/examples/YOLOv8-LibTorch-CPP-Inference/main.cc
@@ -50,7 +50,7 @@ float letterbox(cv::Mat &input_image, cv::Mat &output_image, const std::vector<i
                0, 0, cv::INTER_AREA);
 
     cv::copyMakeBorder(output_image, output_image, top, bottom, left, right,
-                       cv::BORDER_CONSTANT, cv::Scalar(114.));
+                       cv::BORDER_CONSTANT, cv::Scalar(114., 114., 114));
     return resize_scale;
 }
 


### PR DESCRIPTION
issue：https://github.com/ultralytics/ultralytics/issues/19894#issue-2952017362  
I find a bug on line 53 in the G:\pyqtfile\ultralytics-main\ultralytics-main\examples\YOLOv8-LibTorch-CPP-Inference\main.cc.  
This will pad image with the color of blue or not gray.and make the inference to error when the image is not square and the dataset is not colorful.  
    I have read the CLA Document and I sign the CLA



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved color consistency in YOLO8 LibTorch C++ inference by refining padding behavior.

### 📊 Key Changes  
- Updated the `cv::copyMakeBorder` function to use a consistent RGB color value (`114, 114, 114`) for padding instead of a single grayscale value (`114.`).

### 🎯 Purpose & Impact  
- 🖼️ **Enhanced Visual Consistency**: Ensures padding color matches the expected RGB format, avoiding potential color mismatches during image preprocessing.  
- 🚀 **Improved Compatibility**: Aligns with standard RGB image handling, making the inference process more robust for diverse datasets.  
- 🔧 **Developer-Friendly**: Simplifies debugging and reduces potential issues caused by inconsistent padding behavior.