### PR TITLE
Allow to specify custom name for images and labels directories

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -162,7 +162,7 @@ class YOLODataset(BaseDataset):
         Returns:
             (List[dict]): List of label dictionaries, each containing information about an image and its annotations.
         """
-        self.label_files = img2label_paths(self.im_files)
+        self.label_files = img2label_paths(self.im_files, self.data["images_folder"], self.data["labels_folder"])
         cache_path = Path(self.label_files[0]).parent.with_suffix(".cache")
         try:
             cache, exists = load_dataset_cache_file(cache_path), True  # attempt to load a *.cache file

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -162,7 +162,11 @@ class YOLODataset(BaseDataset):
         Returns:
             (List[dict]): List of label dictionaries, each containing information about an image and its annotations.
         """
-        self.label_files = img2label_paths(self.im_files, self.data["images_folder"], self.data["labels_folder"])
+
+        images_folder = self.data.get("images_folder", "images")
+        labels_folder = self.data.get("labels_folder", "labels")
+
+        self.label_files = img2label_paths(self.im_files, images_folder, labels_folder)
         cache_path = Path(self.label_files[0]).parent.with_suffix(".cache")
         try:
             cache, exists = load_dataset_cache_file(cache_path), True  # attempt to load a *.cache file

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -162,7 +162,6 @@ class YOLODataset(BaseDataset):
         Returns:
             (List[dict]): List of label dictionaries, each containing information about an image and its annotations.
         """
-
         images_folder = self.data.get("images_folder", "images")
         labels_folder = self.data.get("labels_folder", "labels")
 

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -41,9 +41,9 @@ PIN_MEMORY = str(os.getenv("PIN_MEMORY", True)).lower() == "true"  # global pin_
 FORMATS_HELP_MSG = f"Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID_FORMATS}"
 
 
-def img2label_paths(img_paths):
+def img2label_paths(img_paths, images_folder="images", labels_folder="labels"):
     """Define label paths as a function of image paths."""
-    sa, sb = f"{os.sep}images{os.sep}", f"{os.sep}labels{os.sep}"  # /images/, /labels/ substrings
+    sa, sb = f"{os.sep}{images_folder}{os.sep}", f"{os.sep}{labels_folder}{os.sep}"  # /images/, /labels/ substrings
     return [sb.join(x.rsplit(sa, 1)).rsplit(".", 1)[0] + ".txt" for x in img_paths]
 
 


### PR DESCRIPTION
Custom dataset may not respect either voc or coco folder structure. This PR let the user put images and annotations in folders named differently than `images` and `labels`, respectively.

The names can be specified inside the `data` yaml.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced dataset handling by allowing customizable folder names for images and labels. 🗂️✨  

### 📊 Key Changes  
- Updated `img2label_paths` function to accept `images_folder` and `labels_folder` as parameters, enabling flexibility in folder naming.  
- Modified `get_labels` method to use these customizable folder names when mapping image paths to label paths.  

### 🎯 Purpose & Impact  
- **Purpose**: To provide users with greater flexibility in organizing their datasets by allowing non-standard folder names for images and labels.  
- **Impact**: Simplifies dataset integration for users with custom folder structures, improving usability and reducing the need for manual adjustments. 🚀