### PR TITLE
Fix keypoints being clipped rather than hidden

### DIFF
--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -402,8 +402,14 @@ class Instances:
         self.segments[..., 0] = self.segments[..., 0].clip(0, w)
         self.segments[..., 1] = self.segments[..., 1].clip(0, h)
         if self.keypoints is not None:
-            self.keypoints[..., 0] = self.keypoints[..., 0].clip(0, w)
-            self.keypoints[..., 1] = self.keypoints[..., 1].clip(0, h)
+            self.keypoints[..., 2] = np.where(
+                (self.keypoints[..., 0] < 0)
+                | (self.keypoints[..., 0] > w)
+                | (self.keypoints[..., 1] < 0)
+                | (self.keypoints[..., 1] > h),
+                0.0,
+                self.keypoints[..., 2],
+            )
 
     def remove_zero_area_boxes(self):
         """

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -402,14 +402,11 @@ class Instances:
         self.segments[..., 0] = self.segments[..., 0].clip(0, w)
         self.segments[..., 1] = self.segments[..., 1].clip(0, h)
         if self.keypoints is not None:
-            self.keypoints[..., 2] = np.where(
-                (self.keypoints[..., 0] < 0)
+            # Set out of bounds visibility to zero
+            self.keypoints[..., 2][(self.keypoints[..., 0] < 0)
                 | (self.keypoints[..., 0] > w)
                 | (self.keypoints[..., 1] < 0)
-                | (self.keypoints[..., 1] > h),
-                0.0,
-                self.keypoints[..., 2],
-            )
+                | (self.keypoints[..., 1] > h)] = 0.0
 
     def remove_zero_area_boxes(self):
         """

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -403,10 +403,12 @@ class Instances:
         self.segments[..., 1] = self.segments[..., 1].clip(0, h)
         if self.keypoints is not None:
             # Set out of bounds visibility to zero
-            self.keypoints[..., 2][(self.keypoints[..., 0] < 0)
+            self.keypoints[..., 2][
+                (self.keypoints[..., 0] < 0)
                 | (self.keypoints[..., 0] > w)
                 | (self.keypoints[..., 1] < 0)
-                | (self.keypoints[..., 1] > h)] = 0.0
+                | (self.keypoints[..., 1] > h)
+            ] = 0.0
 
     def remove_zero_area_boxes(self):
         """


### PR DESCRIPTION
Fixes #19920 

When using augmentations when training pose models, the images are sometimes cut off. The expected behavior is that it hides the keypoints that are now outside the image, but instead, they are clipped. This causes the keypoints to be on the border of the image.

This pull requests fixes that by setting the visibility of keypoints outside image bounds to 0.0.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved handling of keypoints to ensure better accuracy and reliability in edge cases. 🛠️✨  

### 📊 Key Changes  
- Updated the `clip` method to set the visibility of out-of-bounds keypoints to zero instead of just clipping their coordinates.  
- Ensures keypoints outside the defined image boundaries are marked as invisible.  

### 🎯 Purpose & Impact  
- **Purpose**: Enhances the accuracy of keypoint visibility by explicitly marking out-of-bounds keypoints as invisible, improving data integrity.  
- **Impact**: Users working with keypoint detection will benefit from more reliable and realistic results, especially in scenarios involving edge cases or boundary conditions. 🚀