### PR TITLE
Enable `rect` option to predict mode

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -43,6 +43,9 @@
 34196005+fcakyon@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/34196005?v=4
   username: fcakyon
+36942973+JShengP@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/36942973?v=4
+  username: JShengP
 37276661+capjamesg@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/37276661?v=4
   username: capjamesg

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -534,7 +534,7 @@ class Model(torch.nn.Module):
             x in ARGV for x in ("predict", "track", "mode=predict", "mode=track")
         )
 
-        custom = {"conf": 0.25, "batch": 1, "save": is_cli, "mode": "predict"}  # method defaults
+        custom = {"conf": 0.25, "batch": 1, "save": is_cli, "mode": "predict", "rect": True}  # method defaults
         args = {**self.overrides, **custom, **kwargs}  # highest priority args on the right
         prompts = args.pop("prompts", None)  # for SAM-type models
 

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -184,8 +184,8 @@ class BasePredictor:
         letterbox = LetterBox(
             self.imgsz,
             auto=same_shapes
-            and (self.model.pt or (getattr(self.model, "dynamic", False) and not self.model.imx))
-            and self.args.rect,
+            and self.args.rect
+            and (self.model.pt or (getattr(self.model, "dynamic", False) and not self.model.imx)),
             stride=self.model.stride,
         )
         return [letterbox(image=x) for x in im]

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -183,7 +183,9 @@ class BasePredictor:
         same_shapes = len({x.shape for x in im}) == 1
         letterbox = LetterBox(
             self.imgsz,
-            auto=same_shapes and (self.model.pt or (getattr(self.model, "dynamic", False) and not self.model.imx)),
+            auto=same_shapes
+            and (self.model.pt or (getattr(self.model, "dynamic", False) and not self.model.imx))
+            and self.args.rect,
             stride=self.model.stride,
         )
         return [letterbox(image=x) for x in im]


### PR DESCRIPTION
Now users could disable the default rectangle setting of letterbox if they want, means with `rect=False` in inference the input images would be resized and pad to square shape.
```bash
yolo predict rect=False
```
```python
from ultralytics import YOLO
model = YOLO("yolo11n.pt")
model.predict()
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Enhanced prediction functionality with improved rectangular inference support and updated contributor details. 🚀  

### 📊 Key Changes  
- Added a new `rect` parameter (default: `True`) to the prediction method for better rectangular inference handling.  
- Updated the `pre_transform` function to utilize the `rect` parameter for more consistent image processing.  
- Included a new contributor (`JShengP`) in the documentation authors list.  

### 🎯 Purpose & Impact  
- **Improved Predictions**: The `rect` parameter enhances rectangular inference, leading to better performance and accuracy for certain image shapes. 📸  
- **Streamlined Processing**: Adjustments to `pre_transform` ensure more efficient and consistent handling of input images. ⚡  
- **Acknowledging Contributions**: Adding a new contributor highlights community involvement and collaboration. 🤝  

This update refines the prediction pipeline, benefiting both developers and users with more robust and accurate results. 🌟