### PR TITLE
YOLOE: Bypass source check when `source` is None

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -290,7 +290,7 @@ class YOLOE(Model):
 
         self.predictor.setup_model(model=self.model)
 
-        if refer_image is None:
+        if refer_image is None and source:
             dataset = load_inference_source(source)
             if dataset.mode in {"video", "stream"}:
                 # NOTE: set the first frame as refer image for videos/streams inference


### PR DESCRIPTION
To allow to use default ASSETS for predict when source=None
```python
from ultralytics import YOLO

model = YOLO("yoloe-v8l-seg-pf.pt")
model.predict()
```
or it'd fail with:
```bash
Traceback (most recent call last):
  File "/home/laughing/codes/ultralytics/runs/yoloe-stuff/tests/predict_pf.py", line 28, in <module>
    model.predict(save=True)
  File "/home/laughing/codes/ultralytics/ultralytics/models/yolo/model.py", line 294, in predict
    dataset = load_inference_source(source)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/laughing/codes/ultralytics/ultralytics/data/build.py", line 238, in load_inference_source
    source, stream, screenshot, from_img, in_memory, tensor = check_source(source)
                                                              ^^^^^^^^^^^^^^^^^^^^
  File "/home/laughing/codes/ultralytics/ultralytics/data/build.py", line 220, in check_source
    raise TypeError("Unsupported image type. For supported types see https://docs.ultralytics.com/modes/predict")
TypeError: Unsupported image type. For supported types see https://docs.ultralytics.com/modes/predict
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved handling of reference images during video and stream inference in YOLO models. 🎥✨  

### 📊 Key Changes  
- Updated the condition to check if a reference image is `None` and if a `source` is provided during inference.  
- Ensures the first frame of a video or stream is set as the reference image when applicable.  

### 🎯 Purpose & Impact  
- 🛠️ **Purpose**: Enhances the inference process for videos and streams by ensuring proper reference image setup.  
- 🚀 **Impact**: Improves accuracy and reliability of YOLO models when processing video or stream data, leading to better performance for users working with dynamic content.