### PR TITLE
`ultralytics 8.3.103` New RayTune `resume=True` functionality

### DIFF
--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -137,6 +137,32 @@ Here's how to define a search space and use the `model.tune()` method to utilize
         )
         ```
 
+## Resuming An Interrupted Hyperparameter Tuning Session
+
+You can resume an interrupted hyperparameter tuning session by passing `resume=True`. You can optionally pass the directory `name` used under `runs/{task}` to resume. Otherwise, it would resume the last interrupted session. You also need to provide all the previous training arguments including `data`, `epochs`, `iterations` and `space`.
+
+
+!!! example "Using `resume=True` with `model.tune()`"
+
+    ```python
+    from ultralytics import YOLO
+
+    # Define a YOLO model
+    model = YOLO("yolo11n.pt")
+
+    # Define search space
+    search_space = {
+        "lr0": (1e-5, 1e-1),
+        "degrees": (0.0, 45.0),
+    }
+
+    # Resume previous run
+    results = model.tune(data="coco8.yaml", epochs=50, iterations=300, space=search_space, resume=True)
+
+    # Resume tuning run with name 'tune_exp'
+    results = model.tune(data="coco8.yaml", epochs=50, iterations=300, space=search_space, name="tune_exp", resume=True)
+    ```
+
 ## Results
 
 After you've successfully completed the hyperparameter tuning process, you will obtain several files and directories that encapsulate the results of the tuning. The following describes each:

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -141,7 +141,6 @@ Here's how to define a search space and use the `model.tune()` method to utilize
 
 You can resume an interrupted hyperparameter tuning session by passing `resume=True`. You can optionally pass the directory `name` used under `runs/{task}` to resume. Otherwise, it would resume the last interrupted session. You also need to provide all the previous training arguments including `data`, `epochs`, `iterations` and `space`.
 
-
 !!! example "Using `resume=True` with `model.tune()`"
 
     ```python

--- a/docs/en/integrations/ray-tune.md
+++ b/docs/en/integrations/ray-tune.md
@@ -128,7 +128,7 @@ In the code snippet above, we create a YOLO model with the "yolo11n.pt" pretrain
 
 You can resume an interrupted Ray Tune session by passing `resume=True`. You can optionally pass the directory `name` used by Ray Tune under `runs/{task}` to resume. Otherwise, it would resume the last interrupted session. You don't need to provide the `iterations` and `space` again, but you need to provide the rest of the training arguments again including `data` and `epochs`.
 
-!!! example "Resuming an interrupted Ray Tune session"
+!!! example "Using `resume=True` with `model.tune()`"
 
     ```python
     from ultralytics import YOLO

--- a/docs/en/integrations/ray-tune.md
+++ b/docs/en/integrations/ray-tune.md
@@ -124,6 +124,26 @@ In this example, we demonstrate how to use a custom search space for hyperparame
 
 In the code snippet above, we create a YOLO model with the "yolo11n.pt" pretrained weights. Then, we call the `tune()` method, specifying the dataset configuration with "coco8.yaml". We provide a custom search space for the initial learning rate `lr0` using a dictionary with the key "lr0" and the value `tune.uniform(1e-5, 1e-1)`. Finally, we pass additional training arguments, such as the number of epochs directly to the tune method as `epochs=50`.
 
+## Resuming An Interrupted Hyperparameter Tuning Session With Ray Tune
+
+You can resume an interrupted Ray Tune session by passing `resume=True`. You can optionally pass the directory `name` used by Ray Tune under `runs/{task}` to resume. Otherwise, it would resume the last interrupted session. You don't need to provide the `iterations` and `space` again, but you need to provide the rest of the training arguments again including `data` and `epochs`. 
+
+!!! example "Resuming an interrupted Ray Tune session"
+
+    ```python
+
+    from ultralytics import YOLO
+
+    # Define a YOLO model
+    model = YOLO("yolo11n.pt")
+
+    # Resume previous run
+    results = model.tune(use_ray=True, data="coco8.yaml", epochs=50, resume=True)
+
+    # Resume Ray Tune run with name 'tune_exp_2'
+    results = model.tune(use_ray=True, data="coco8.yaml", epochs=50, name='tune_exp_2', resume=True)
+    ```
+
 ## Processing Ray Tune Results
 
 After running a hyperparameter tuning experiment with Ray Tune, you might want to perform various analyses on the obtained results. This guide will take you through common workflows for processing and analyzing these results.

--- a/docs/en/integrations/ray-tune.md
+++ b/docs/en/integrations/ray-tune.md
@@ -126,12 +126,11 @@ In the code snippet above, we create a YOLO model with the "yolo11n.pt" pretrain
 
 ## Resuming An Interrupted Hyperparameter Tuning Session With Ray Tune
 
-You can resume an interrupted Ray Tune session by passing `resume=True`. You can optionally pass the directory `name` used by Ray Tune under `runs/{task}` to resume. Otherwise, it would resume the last interrupted session. You don't need to provide the `iterations` and `space` again, but you need to provide the rest of the training arguments again including `data` and `epochs`. 
+You can resume an interrupted Ray Tune session by passing `resume=True`. You can optionally pass the directory `name` used by Ray Tune under `runs/{task}` to resume. Otherwise, it would resume the last interrupted session. You don't need to provide the `iterations` and `space` again, but you need to provide the rest of the training arguments again including `data` and `epochs`.
 
 !!! example "Resuming an interrupted Ray Tune session"
 
     ```python
-
     from ultralytics import YOLO
 
     # Define a YOLO model
@@ -141,7 +140,7 @@ You can resume an interrupted Ray Tune session by passing `resume=True`. You can
     results = model.tune(use_ray=True, data="coco8.yaml", epochs=50, resume=True)
 
     # Resume Ray Tune run with name 'tune_exp_2'
-    results = model.tune(use_ray=True, data="coco8.yaml", epochs=50, name='tune_exp_2', resume=True)
+    results = model.tune(use_ray=True, data="coco8.yaml", epochs=50, name="tune_exp_2", resume=True)
     ```
 
 ## Processing Ray Tune Results

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.102"
+__version__ = "8.3.103"
 
 import os
 

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from ultralytics.cfg import TASK2DATA, TASK2METRIC, get_cfg, get_save_dir
-from ultralytics.utils import DEFAULT_CFG, DEFAULT_CFG_DICT, LOGGER, NUM_THREADS, checks
+from ultralytics.utils import DEFAULT_CFG, DEFAULT_CFG_DICT, LOGGER, NUM_THREADS, checks, colorstr
 
 
 def run_ray_tune(

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -123,15 +123,23 @@ def run_ray_tune(
 
     # Create the Ray Tune hyperparameter search tuner
     tune_dir = get_save_dir(
-        get_cfg(DEFAULT_CFG, train_args), name=train_args.pop("name", "tune")
+        get_cfg(
+            DEFAULT_CFG,
+            {**train_args, **{"exist_ok": train_args.pop("resume", False)}},  # resume w/ same tune_dir
+        ),
+        name=train_args.pop("name", "tune"),  # runs/{task}/{tune_dir}
     ).resolve()  # must be absolute dir
     tune_dir.mkdir(parents=True, exist_ok=True)
-    tuner = tune.Tuner(
-        trainable_with_resources,
-        param_space=space,
-        tune_config=tune.TuneConfig(scheduler=asha_scheduler, num_samples=max_samples),
-        run_config=RunConfig(callbacks=tuner_callbacks, storage_path=tune_dir),
-    )
+    if tune.Tuner.can_restore(tune_dir):
+        LOGGER.info(f"{colorstr('Tuner: ')} Resuming tuning run {tune_dir}...")
+        tuner = tune.Tuner.restore(str(tune_dir), trainable=trainable_with_resources, resume_errored=True)
+    else:
+        tuner = tune.Tuner(
+            trainable_with_resources,
+            param_space=space,
+            tune_config=tune.TuneConfig(scheduler=asha_scheduler, num_samples=max_samples),
+            run_config=RunConfig(callbacks=tuner_callbacks, storage_path=tune_dir.parent, name=tune_dir.name),
+        )
 
     # Run the hyperparameter search
     tuner.fit()

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -95,7 +95,7 @@ def run_ray_tune(
         return results.results_dict
 
     # Get search space
-    if not space:
+    if not space and not train_args.get("resume"):
         space = default_space
         LOGGER.warning("WARNING ⚠️ search space not provided, using default search space.")
 


### PR DESCRIPTION
Closes #20033 
Resolves https://github.com/ultralytics/ultralytics/issues/5892
Resolves https://github.com/ultralytics/ultralytics/issues/18729
Resolves https://github.com/ultralytics/ultralytics/issues/6212

```python
In [6]: results = model.tune(iterations=5, epochs=10, use_ray=True, name="tune_exp", resume=True)
💡 Learn about RayTune at https://docs.ultralytics.com/integrations/ray-tune
2025-04-06 09:20:53,190 WARNING utils.py:596 -- Detecting docker specified CPUs. In previous versions of Ray, CPU detection in containers was incorrect. Please ensure that Ray has enough CPUs allocated. As a temporary workaround to revert to the prior behavior, set `RAY_USE_MULTIPROCESSING_CPU_COUNT=1` as an env var before starting Ray. Set the env var: `RAY_DISABLE_DOCKER_CPU_WARNING=1` to mute this warning.
2025-04-06 09:20:54,483 INFO worker.py:1852 -- Started a local Ray instance.
WARNING ⚠️ search space not provided, using default search space.
WARNING ⚠️ data not provided, using default "data=coco8.yaml".
Tuner:  Resuming tuning run /ultralytics/runs/detect/tune_exp...
```
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added the ability to resume interrupted hyperparameter tuning sessions for both standard and Ray Tune workflows.

### 📊 Key Changes
- **Resume Support for Tuning**: Introduced a `resume=True` option in `model.tune()` to continue interrupted hyperparameter tuning sessions.
  - Works for both standard and Ray Tune-based tuning.
  - Allows specifying a session name (`name`) to resume a specific run or defaults to the last interrupted session.
- **Documentation Updates**: Enhanced guides on hyperparameter tuning and Ray Tune integration to include examples of using the new `resume` functionality.
- **Code Enhancements**: Improved internal logic to handle resuming sessions, including iteration tracking and directory management.
- **Version Update**: Bumped version to `8.3.103`.

### 🎯 Purpose & Impact
- **Purpose**: To save time and resources by enabling users to pick up hyperparameter tuning from where it left off, avoiding the need to restart from scratch.
- **Impact**:
  - **For Users**: Simplifies workflows, especially for long-running tuning processes, and reduces frustration from interruptions. 🚀
  - **For Developers**: Provides a more robust and flexible tuning experience, making the platform more user-friendly. 💡