### PR TITLE
Apply stride to image lists

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -351,6 +351,11 @@ class LoadImagesAndVideos:
                 videos.append(f)
         ni, nv = len(images), len(videos)
 
+        if ni > 0:
+            # If images are present, apply the stride to the images list.
+            images = images[::vid_stride]
+            ni = len(images)  # update count to reflect reduced list
+
         self.files = images + videos
         self.nf = ni + nv  # number of files
         self.ni = ni  # number of images


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Apply vid_stride to image datasets in the loader to enable quick image subsampling and align behavior with video handling. 🚀

### 📊 Key Changes
- Images are now sliced by the vid_stride value (images = images[::vid_stride]) when present. 🖼️➡️⏭️
- Image count (ni) is updated after subsampling; total file count (nf) reflects the reduced list. 📉
- Behavior is consistent whether loading images, videos, or both. 🔄

### 🎯 Purpose & Impact
- Faster experiments and reduced I/O by skipping images when vid_stride > 1. ⚡
- Consistent and predictable use of vid_stride across images and videos. ✅
- Potentially smaller effective dataset size; results and metrics may change if vid_stride > 1—be mindful when training/evaluating. ⚠️
- No impact for default vid_stride = 1. 👍