### PR TITLE
`ultralytics 8.3.106` iOS14+ CoreML `mlmodel` and `mlpackage` joint support

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.105"
+__version__ = "8.3.106"
 
 import os
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -86,7 +86,6 @@ from ultralytics.utils import (
     LINUX,
     LOGGER,
     MACOS,
-    PYTHON_VERSION,
     RKNN_CHIPS,
     ROOT,
     WINDOWS,
@@ -820,9 +819,9 @@ class Exporter:
             model = self.model
         ts = torch.jit.trace(model.eval(), self.im, strict=False)  # TorchScript model
 
-        # Based on apple's documentation it is better to leave out the minimum_deployment target and let that get set 
+        # Based on apple's documentation it is better to leave out the minimum_deployment target and let that get set
         # Internally based on the model conversion and output type.
-        # Setting minimum_depoloyment_target >= iOS16 will require setting compute_precision=ct.precision.FLOAT32. 
+        # Setting minimum_depoloyment_target >= iOS16 will require setting compute_precision=ct.precision.FLOAT32.
         # iOS16 adds in better support for FP16, but none of the CoreML NMS specifications handle FP16 as input.
         ct_model = ct.convert(
             ts,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -795,7 +795,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """YOLO CoreML export."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools>=6.0,<=6.2" if mlmodel else "coremltools>=8.0")
+        check_requirements("coremltools>=8.0")
         import coremltools as ct  # noqa
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")
@@ -819,11 +819,15 @@ class Exporter:
                 # TODO CoreML Segment and Pose model pipelining
             model = self.model
         ts = torch.jit.trace(model.eval(), self.im, strict=False)  # TorchScript model
+
+        # Based on apple's documentation it is better to leave out the minimum_deployment target and let that get set 
+        # Internally based on the model conversion and output type.
+        # Setting minimum_depoloyment_target >= iOS16 will require setting compute_precision=ct.precision.FLOAT32. 
+        # iOS16 adds in better support for FP16, but none of the CoreML NMS specifications handle FP16 as input.
         ct_model = ct.convert(
             ts,
             inputs=[ct.ImageType("image", shape=self.im.shape, scale=scale, bias=bias)],  # expects ct.TensorType
             classifier_config=classifier_config,
-            minimum_deployment_target=ct.target.iOS15,  # warning: >=16 causes pipeline errors
             convert_to="neuralnetwork" if mlmodel else "mlprogram",
         )
         bits, mode = (8, "kmeans") if self.args.int8 else (16, "linear") if self.args.half else (32, None)
@@ -840,8 +844,6 @@ class Exporter:
                 ct_model = cto.palettize_weights(ct_model, config=config)
         if self.args.nms and self.model.task == "detect":
             if mlmodel:
-                # coremltools<=6.2 NMS export requires Python<3.11
-                check_version(PYTHON_VERSION, "<3.11", name="Python ", hard=True)
                 weights_dir = None
             else:
                 ct_model.save(str(f))  # save otherwise weights_dir does not exist
@@ -1469,7 +1471,7 @@ class Exporter:
 
         # 3. Create NMS protobuf
         nms_spec = ct.proto.Model_pb2.Model()
-        nms_spec.specificationVersion = 9
+        nms_spec.specificationVersion = spec.specificationVersion
         for i in range(2):
             decoder_output = model._spec.description.output[i].SerializeToString()
             nms_spec.description.input.add()
@@ -1522,7 +1524,7 @@ class Exporter:
         pipeline.spec.description.output[1].ParseFromString(nms_model._spec.description.output[1].SerializeToString())
 
         # Update metadata
-        pipeline.spec.specificationVersion = 9
+        pipeline.spec.specificationVersion = spec.specificationVersion
         pipeline.spec.description.metadata.userDefined.update(
             {"IoU threshold": str(nms.iouThreshold), "Confidence threshold": str(nms.confidenceThreshold)}
         )


### PR DESCRIPTION
This updates the detect model export to support iOS14 via the mlmodel type. It also cleans up the NMS export to set the specification version to match the version of the core model.

### Detailed Changes

This fix is linked to https://github.com/ultralytics/ultralytics/issues/20061  but does not fully resolve that particular issue.

- coremltools 8.x is capable of exporting both `mlmodel` and `mlpackage` CoreML types, thus the change to requiring that version. 
- The minimum iOS version parameter is being removed because Apple's documentation on conversion implies that it better to let coremltools set the minimum iOS version based on the export type and the elements within the model.
- I left in a comment about issues supporting higher versions of iOS than iOS15 as that is related to https://github.com/ultralytics/ultralytics/issues/19953
- The `specificationVersion` of the nms model is being set to match the specification version of the core model. It does not look like Apple has updated their nms model since 2020, thus it is probably wisest to match what the core YOLO model requires for a `specificationVersion`.

### Testing
I have tested both yolov8m and yolo11m base models exporting to both `mlmodel` and `mlpackage` types. I also tested with the parameter `half=` set to both `True` and `False`. All 8 base model exports worked, though it is interesting to note that the `half=False` parameter looks to be ignored in the `mlpackage` export as the resulting packages are sized identically.

Testing with my custom models shows that the `mlmodel` export works as expected but that the `mlpackage` export still exhibits the issues reported in https://github.com/ultralytics/ultralytics/issues/20061

### License Agreement
I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved CoreML export functionality with updated dependencies and streamlined configurations for better compatibility and performance. 🚀  

### 📊 Key Changes  
- Updated `coremltools` dependency to version 8.0 or higher, removing legacy version constraints.  
- Removed the explicit `minimum_deployment_target` setting for CoreML exports, allowing automatic configuration based on model and output type.  
- Adjusted CoreML pipeline specifications to dynamically match the model's specification version.  
- Cleaned up unused imports and redundant version checks for Python compatibility.  

### 🎯 Purpose & Impact  
- **Enhanced Compatibility**: Ensures smoother CoreML exports by aligning with the latest `coremltools` capabilities and removing outdated constraints.  
- **Improved Flexibility**: Automatic deployment target configuration simplifies the export process and reduces potential errors.  
- **Streamlined Code**: Removing unnecessary checks and imports makes the codebase cleaner and easier to maintain.  
- **User Benefit**: Users exporting models to CoreML will experience fewer compatibility issues and better support for modern iOS features. 🎉