### PR TITLE
Pin `typing-extensions<=4.13.1` to fix macOS export for OPENVINO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
     "requests>=2.23.0",
     "scipy>=1.4.1",
     "torch>=1.8.0",
+    "typing-extensions<=4.13.1",
     "torch>=1.8.0,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
     "torchvision>=0.9.0",
     "tqdm>=4.64.0", # progress bars


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added a version constraint for `typing-extensions` to improve compatibility and stability.  

### 📊 Key Changes  
- Included `typing-extensions<=4.13.1` in the dependencies list.  

### 🎯 Purpose & Impact  
- 🛠 Ensures compatibility with other dependencies and prevents potential issues caused by newer versions of `typing-extensions`.  
- 🚀 Improves stability and reliability for users running the software across different environments.  
- 🔧 Helps avoid unexpected errors, especially for developers working with specific configurations.