### PR TITLE
insert hash in the cache filename

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -164,11 +164,12 @@ class YOLODataset(BaseDataset):
             (List[dict]): List of label dictionaries, each containing information about an image and its annotations.
         """
         self.label_files = img2label_paths(self.im_files)
-        cache_path = Path(self.label_files[0]).parent.with_suffix(".cache")
+        cur_data_hash = get_hash(self.label_files + self.im_files)
+        cache_path = Path(self.label_files[0]).parent.with_suffix(f".{cur_data_hash}.cache")
         try:
             cache, exists = load_dataset_cache_file(cache_path), True  # attempt to load a *.cache file
             assert cache["version"] == DATASET_CACHE_VERSION  # matches current version
-            assert cache["hash"] == get_hash(self.label_files + self.im_files)  # identical hash
+            assert cache["hash"] == cur_data_hash  # identical hash
         except (FileNotFoundError, AssertionError, AttributeError):
             cache, exists = self.cache_labels(cache_path), False  # run cache ops
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    # I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Smarter, hash-based dataset caching now creates unique cache files per data state, reducing stale cache issues and improving reliability ⚡

### 📊 Key Changes
- Computes a current data hash from image and label files once and reuses it.
- Names cache files with the computed hash (e.g., .<hash>.cache) instead of a generic .cache.
- Validates the cache by comparing against the precomputed hash, avoiding duplicate hash calculations.
- Falls back to rebuilding the cache if the version or hash doesn’t match.

### 🎯 Purpose & Impact
- Minimizes stale or incorrect cache usage when datasets change 🧹
- Enables multiple dataset versions to coexist without cache conflicts 🗂️
- Slight performance win by avoiding redundant hash computation 🚀
- More predictable training and labeling behavior for users, especially when iterating on data ✅