### PR TITLE
Enable Solutions tests, except on `Linux (Python 3.11)` and `Raspberry PI` due to `--slow` test errors

### DIFF
--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -8,7 +8,7 @@ import pytest
 
 from tests import MODEL, TMP
 from ultralytics import solutions
-from ultralytics.utils import ASSETS_URL, checks
+from ultralytics.utils import ASSETS_URL, checks, LINUX
 from ultralytics.utils.downloads import safe_download
 
 # Pre-defined arguments values
@@ -152,7 +152,7 @@ def process_video(solution, video_path, needs_frame_count=False):
     cap.release()
 
 
-@pytest.mark.skipif(True, reason="Disabled for testing due to --slow test errors after YOLOE PR.")
+@pytest.mark.skipif(LINUX and checks.IS_PYTHON_3_11, reason="Disabled for testing due to --slow test errors after YOLOE PR.")
 @pytest.mark.parametrize("name, solution_class, needs_frame_count, video, kwargs", SOLUTIONS)
 def test_solution(name, solution_class, needs_frame_count, video, kwargs):
     """Test individual Ultralytics solution."""

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -8,7 +8,7 @@ import pytest
 
 from tests import MODEL, TMP
 from ultralytics import solutions
-from ultralytics.utils import ASSETS_URL, checks, LINUX, IS_RASPBERRYPI
+from ultralytics.utils import ASSETS_URL, IS_RASPBERRYPI, LINUX, checks
 from ultralytics.utils.downloads import safe_download
 
 # Pre-defined arguments values

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -152,8 +152,10 @@ def process_video(solution, video_path, needs_frame_count=False):
     cap.release()
 
 
-@pytest.mark.skipif((LINUX and checks.IS_PYTHON_3_11) or IS_RASPBERRYPI,
-                    reason="Disabled for testing due to --slow test errors after YOLOE PR.")
+@pytest.mark.skipif(
+    (LINUX and checks.IS_PYTHON_3_11) or IS_RASPBERRYPI,
+    reason="Disabled for testing due to --slow test errors after YOLOE PR.",
+)
 @pytest.mark.parametrize("name, solution_class, needs_frame_count, video, kwargs", SOLUTIONS)
 def test_solution(name, solution_class, needs_frame_count, video, kwargs):
     """Test individual Ultralytics solution."""

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -8,7 +8,7 @@ import pytest
 
 from tests import MODEL, TMP
 from ultralytics import solutions
-from ultralytics.utils import ASSETS_URL, checks, LINUX
+from ultralytics.utils import ASSETS_URL, checks, LINUX, IS_RASPBERRYPI
 from ultralytics.utils.downloads import safe_download
 
 # Pre-defined arguments values
@@ -152,7 +152,8 @@ def process_video(solution, video_path, needs_frame_count=False):
     cap.release()
 
 
-@pytest.mark.skipif(LINUX and checks.IS_PYTHON_3_11, reason="Disabled for testing due to --slow test errors after YOLOE PR.")
+@pytest.mark.skipif((LINUX and checks.IS_PYTHON_3_11) or IS_RASPBERRYPI,
+                    reason="Disabled for testing due to --slow test errors after YOLOE PR.")
 @pytest.mark.parametrize("name, solution_class, needs_frame_count, video, kwargs", SOLUTIONS)
 def test_solution(name, solution_class, needs_frame_count, video, kwargs):
     """Test individual Ultralytics solution."""

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -890,5 +890,6 @@ check_torchvision()  # check torch-torchvision compatibility
 
 # Define constants
 IS_PYTHON_MINIMUM_3_10 = check_python("3.10", hard=False)
+IS_PYTHON_3_11 = PYTHON_VERSION.startswith("3.11")
 IS_PYTHON_3_12 = PYTHON_VERSION.startswith("3.12")
 IS_PYTHON_3_13 = PYTHON_VERSION.startswith("3.13")


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved test handling by conditionally skipping certain solution tests on specific platforms and Python versions 🧪🚫

### 📊 Key Changes
- Updated test logic to skip slow solution tests on Linux with Python 3.11 or on Raspberry Pi devices.
- Added a new constant (`IS_PYTHON_3_11`) to easily detect Python 3.11 environments.

### 🎯 Purpose & Impact
- Prevents known test failures and errors on platforms where issues are expected, making automated testing more reliable.
- Saves developers time by avoiding unnecessary test runs on unsupported setups.
- Improves clarity and maintainability of test conditions for future updates.