### PR TITLE
Reduce trigger threshold to clear GPU memory to 50%

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -457,8 +457,8 @@ class BaseTrainer:
                 self.scheduler.last_epoch = self.epoch  # do not move
                 self.stop |= epoch >= self.epochs  # stop if exceeded epochs
             self.run_callbacks("on_fit_epoch_end")
-            if self._get_memory(fraction=True) > 0.9:
-                self._clear_memory()  # clear if memory utilization > 90%
+            if self._get_memory(fraction=True) > 0.5:
+                self._clear_memory()  # clear if memory utilization > 50%
 
             # Early Stopping
             if RANK != -1:  # if DDP training


### PR DESCRIPTION
Closes #19862 
https://community.ultralytics.com/t/gpu-memory-leak/967/16

Users have reported OOM issue.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved memory management during training by clearing memory more frequently.

### 📊 Key Changes  
- Adjusted the memory usage threshold for clearing memory from 90% to 50% during training.

### 🎯 Purpose & Impact  
- 🧹 Reduces the risk of running out of memory by freeing up resources earlier.
- 🚀 Helps ensure smoother and more stable training, especially on devices with limited memory.
- 👍 May prevent crashes or slowdowns during long training sessions.