### PR TITLE
RTDETR: Remove unused `preprocess_batch` function

### DIFF
--- a/ultralytics/models/rtdetr/train.py
+++ b/ultralytics/models/rtdetr/train.py
@@ -85,22 +85,3 @@ class RTDETRTrainer(DetectionTrainer):
         """Returns a DetectionValidator suitable for RT-DETR model validation."""
         self.loss_names = "giou_loss", "cls_loss", "l1_loss"
         return RTDETRValidator(self.test_loader, save_dir=self.save_dir, args=copy(self.args))
-
-    def preprocess_batch(self, batch):
-        """
-        Preprocess a batch of images by scaling and converting to float format.
-
-        Args:
-            batch (dict): Dictionary containing a batch of images, bboxes, and labels.
-
-        Returns:
-            (dict): Preprocessed batch with ground truth bounding boxes and classes separated by batch index.
-        """
-        batch = super().preprocess_batch(batch)
-        bs = len(batch["img"])
-        batch_idx = batch["batch_idx"]
-        gt_bbox, gt_class = [], []
-        for i in range(bs):
-            gt_bbox.append(batch["bboxes"][batch_idx == i].to(batch_idx.device))
-            gt_class.append(batch["cls"][batch_idx == i].to(device=batch_idx.device, dtype=torch.long))
-        return batch

--- a/ultralytics/models/rtdetr/train.py
+++ b/ultralytics/models/rtdetr/train.py
@@ -2,8 +2,6 @@
 
 from copy import copy
 
-import torch
-
 from ultralytics.models.yolo.detect import DetectionTrainer
 from ultralytics.nn.tasks import RTDETRDetectionModel
 from ultralytics.utils import RANK, colorstr


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified the RT-DETR training code by removing a redundant batch preprocessing method.

### 📊 Key Changes
- Removed the `preprocess_batch` function from the RT-DETR training script.

### 🎯 Purpose & Impact
- 🧹 Cleans up the codebase, making it easier to maintain and understand.
- 🚀 No change to model performance or user workflow—just a behind-the-scenes improvement.
- 👩‍💻 Developers will find the code less cluttered and easier to extend or debug.