### PR TITLE
`ultralytics 8.3.113` New DOTA8-Multispectral dataset

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.112"
+__version__ = "8.3.113"
 
 import os
 

--- a/ultralytics/cfg/datasets/dota8-multispectral.yaml
+++ b/ultralytics/cfg/datasets/dota8-multispectral.yaml
@@ -1,0 +1,38 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# DOTA8-Multispectral dataset (DOTA8 interpolated across 10 channels in the visual spectrum) by Ultralytics
+# Documentation: https://docs.ultralytics.com/datasets/obb/dota8/
+# Example usage: yolo train model=yolov8n-obb.pt data=dota8-multispectral.yaml
+# parent
+# ├── ultralytics
+# └── datasets
+#     └── dota8-multispectral  ← downloads here (1MB)
+
+# Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
+path: ../datasets/dota8-multispectral # dataset root dir
+train: images/train # train images (relative to 'path') 4 images
+val: images/val # val images (relative to 'path') 4 images
+
+# Number of multispectral image channels
+channels: 10
+
+# Classes for DOTA 1.0
+names:
+  0: plane
+  1: ship
+  2: storage tank
+  3: baseball diamond
+  4: tennis court
+  5: basketball court
+  6: ground track field
+  7: harbor
+  8: bridge
+  9: large vehicle
+  10: small vehicle
+  11: helicopter
+  12: roundabout
+  13: soccer ball field
+  14: swimming pool
+
+# Download script/URL (optional)
+download: https://github.com/ultralytics/assets/releases/download/v0.0.0/dota8-multispectral.zip

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -718,7 +718,9 @@ def convert_to_multispectral(path, n_channels=10, replace=False, zip=False):
 
     Examples:
         >>> # Convert a single image
-        >>> convert_to_multispectral("path/to/image.jpg", n_channels=12)
+        >>> convert_to_multispectral("path/to/image.jpg", n_channels=10)
+        >>> # Convert a dataset
+        >>> convert_to_multispectral("../datasets/coco8", n_channels=10)
     """
     from scipy.interpolate import interp1d
 


### PR DESCRIPTION
Create this dataset
```python
from ultralytics.data.converter import convert_to_multispectral
from ultralytics.utils.downloads import zip_directory

convert_to_multispectral("../datasets/coco8-pose", n_channels=10)

# Delete all jpgs and rename
zip_directory("../datasets/dota8-multispectral")
```

Train on this dataset:
```bash
yolo train data=dota8-multispectral.yaml model=yolo11n-obb.pt
```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added support for the DOTA8-Multispectral dataset and improved multispectral image conversion examples. 🚁🌈

### 📊 Key Changes
- Added a new configuration file for the DOTA8-Multispectral dataset, supporting 10-channel multispectral images.
- Updated example usage in the `convert_to_multispectral` function to reflect 10-channel support and dataset conversion.
- Bumped the Ultralytics package version to 8.3.113.

### 🎯 Purpose & Impact
- Enables users to train and evaluate models on the DOTA8-Multispectral dataset, expanding multispectral image support.
- Makes it easier for users to convert both single images and entire datasets to multispectral formats.
- Enhances documentation and usability for those working with advanced image data, especially in aerial and remote sensing applications.