### PR TITLE
`ultralytics 8.3.115` TIFF image RGB training and prediction support

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.114"
+__version__ = "8.3.115"
 
 import os
 

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -31,7 +31,8 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR):
     if filename.endswith((".tiff", ".tif")):
         success, frames = cv2.imdecodemulti(file_bytes, cv2.IMREAD_UNCHANGED)
         if success:
-            return np.stack(frames, axis=2)  # or np.asarray(frames).transpose(1,2,0)
+            # handle RGB images in tif/tiff format
+            return frames[0] if len(frames) == 1 and frames[0].ndim == 3 else np.stack(frames, axis=2)
         return None
     else:
         return cv2.imdecode(file_bytes, flags)


### PR DESCRIPTION
@glenn-jocher There's a user who seems have been using `tif/tiff` format for regular RGB images for the beginning and encountered error after our multi-channel training update.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved TIFF image handling for more reliable image loading in Ultralytics.

### 📊 Key Changes
- Enhanced the `imread` function to better handle TIFF/TIF images, especially single-frame RGB images.
- Updated the version number to 8.3.115.

### 🎯 Purpose & Impact
- 🖼️ Ensures TIFF images, including single-frame RGB files, are loaded correctly—reducing errors and improving compatibility.
- 🚀 Provides a smoother experience for users working with various image formats in Ultralytics projects.
- 🔄 The update is backward-compatible and should not affect existing workflows, but improves reliability for TIFF image processing.