### PR TITLE
Bug Fix: Incorrect Use of RANK in Distributed Context Manager

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1261,7 +1261,7 @@ class SettingsManager(JSONDict):
             "For help see https://docs.ultralytics.com/quickstart/#ultralytics-settings."
         )
 
-        with torch_distributed_zero_first(RANK):
+        with torch_distributed_zero_first(LOCAL_RANK):
             super().__init__(self.file)
 
             if not self.file.exists() or not self:  # Check if file doesn't exist or is empty


### PR DESCRIPTION
## Issue
When using YOLOv8 and any other models in a multi-GPU and multi-NODE (distributed) setting across multiple nodes, an error occurs related to device instantiation:
`device_id invalid ordinal`

## Root Cause
The problem lies in `ultralytics/utils/__init__.py`, where the `torch_distributed_zero_first` context manager is initialized with the global `RANK` instead of the `LOCAL_RANK`.

## Current (causes issues in multi-node setups)
```
with torch_distributed_zero_first(RANK):
    ...    
```
## Fix
Replace `RANK` with `LOCAL_RANK` to ensure proper behavior within each node during distributed execution:
```
with torch_distributed_zero_first(LOCAL_RANK):
    ...
```

This change prevents incorrect GPU ordinal assignment in multi-node setups.
---

I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved distributed training compatibility by refining rank handling in the settings initialization process. 🚀  

### 📊 Key Changes  
- Replaced `RANK` with `LOCAL_RANK` in the `torch_distributed_zero_first` context during settings initialization.  

### 🎯 Purpose & Impact  
- **Purpose**: Ensures better alignment with distributed training setups by using the correct rank variable (`LOCAL_RANK`).  
- **Impact**: Enhances reliability and compatibility for users running YOLO models in distributed environments, reducing potential errors. 🌐