### PR TITLE
Fix YOLOE usage in `model.py`

### DIFF
--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -323,7 +323,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         from ultralytics import YOLOE
 
         # Create a YOLOE model
-        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
+        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-11s/m-seg.pt for different sizes
 
         # Conduct model validation on the COCO128-seg example dataset
         metrics = model.val(data="coco128-seg.yaml")

--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -337,7 +337,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         from ultralytics import YOLOE
 
         # Create a YOLOE model
-        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
+        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-11s/m-seg.pt for different sizes
 
         # Conduct model validation on the COCO128-seg example dataset
         metrics = model.val(data="coco128-seg.yaml", load_vp=True)
@@ -350,7 +350,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         from ultralytics import YOLOE
 
         # Create a YOLOE model
-        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
+        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-11s/m-seg.pt for different sizes
 
         # Conduct model validation on the COCO128-seg example dataset
         metrics = model.val(data="coco128-seg.yaml", load_vp=True, refer_data="coco.yaml")
@@ -363,7 +363,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         from ultralytics import YOLOE
 
         # Create a YOLOE model
-        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
+        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-11s/m-seg.pt for different sizes
 
         # Conduct model validation on the COCO128-seg example dataset
         metrics = model.val(data="coco128-seg.yaml")
@@ -709,7 +709,7 @@ YOLOE integrates seamlessly with the [Ultralytics Python API](../usage/python.md
         from ultralytics import YOLO
 
         # Load pre-trained YOLOE model and train on custom data
-        model = YOLO("yoloe-11s.pt")
+        model = YOLO("yoloe-11s-seg.pt")
         model.train(data="path/to/data.yaml", epochs=50, imgsz=640)
 
         # Run inference using text prompts ("person", "bus")
@@ -724,10 +724,10 @@ YOLOE integrates seamlessly with the [Ultralytics Python API](../usage/python.md
 
         ```bash
         # Training YOLOE on custom dataset
-        yolo train model=yoloe-11s.pt data=path/to/data.yaml epochs=50 imgsz=640
+        yolo train model=yoloe-11s-seg.pt data=path/to/data.yaml epochs=50 imgsz=640
 
         # Inference with text prompts
-        yolo predict model=yoloe-11s.pt source="test_images/street.jpg" classes="person,bus"
+        yolo predict model=yoloe-11s-seg.pt source="test_images/street.jpg" classes="person,bus"
         ```
 
         CLI prompts (`classes`) guide YOLOE similarly to Python's `set_classes`. Visual prompting (image-based queries) currently requires the Python API.
@@ -762,7 +762,7 @@ Quickly set up YOLOE with Ultralytics by following these steps:
     - **Training**: Fine-tuning YOLOE on custom data typically requires just one GPU. Extensive open-vocabulary pre-training (LVIS/Objects365) used by authors required substantial compute (8× RTX 4090 GPUs).
 
 4. **Configuration**:
-   YOLOE configurations use standard Ultralytics YAML files. Default configs (e.g., `yoloe-s.yaml`) typically suffice, but you can modify backbone, classes, or image size as needed.
+   YOLOE configurations use standard Ultralytics YAML files. Default configs (e.g., `yoloe-11s-seg.yaml`) typically suffice, but you can modify backbone, classes, or image size as needed.
 
 5. **Running YOLOE**:
 

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -144,7 +144,7 @@ class YOLOWorld(Model):
 class YOLOE(Model):
     """YOLOE object detection and segmentation model."""
 
-    def __init__(self, model="yoloe-v8s-seg.pt", task=None, verbose=False) -> None:
+    def __init__(self, model="yoloe-11s-seg.pt", task=None, verbose=False) -> None:
         """
         Initialize YOLOE model with a pre-trained model file.
 
@@ -197,7 +197,7 @@ class YOLOE(Model):
             (torch.Tensor): Visual positional embeddings.
 
         Examples:
-            >>> model = YOLOE("yoloe-v8s.pt")
+            >>> model = YOLOE("yoloe-11s-seg.pt")
             >>> img = torch.rand(1, 3, 640, 640)
             >>> visual_features = model.model.backbone(img)
             >>> pe = model.get_visual_pe(img, visual_features)
@@ -220,7 +220,7 @@ class YOLOE(Model):
             AssertionError: If the model is not an instance of YOLOEModel.
 
         Examples:
-            >>> model = YOLOE("yoloe-v8s.pt")
+            >>> model = YOLOE("yoloe-11s-seg.pt")
             >>> model.set_vocab(["person", "car", "dog"], ["person", "car", "dog"])
         """
         assert isinstance(self.model, YOLOEModel)
@@ -304,7 +304,7 @@ class YOLOE(Model):
             (List | generator): List of Results objects or generator of Results objects if stream=True.
 
         Examples:
-            >>> model = YOLOE("yoloe-v8s-seg.pt")
+            >>> model = YOLOE("yoloe-11s-seg.pt")
             >>> results = model.predict("path/to/image.jpg")
             >>> # With visual prompts
             >>> prompts = {"bboxes": [[10, 20, 100, 200]], "cls": ["person"]}


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates YOLOE documentation and code examples to use the latest model naming conventions, ensuring clarity and consistency for users. 🚀

### 📊 Key Changes
- Updated all YOLOE model references from older names (like `yoloe-m/l-seg.pt` and `yoloe-v8s-seg.pt`) to the new format (e.g., `yoloe-11s-seg.pt`, `yoloe-11l-seg.pt`).
- Adjusted documentation and code snippets to reflect these new model file names and configuration files.
- Improved consistency across Python and CLI usage examples.

### 🎯 Purpose & Impact
- 📝 **Clarity:** Makes it easier for users to identify and use the correct YOLOE model files.
- 🛠️ **Consistency:** Reduces confusion by aligning documentation and code with the latest naming standards.
- 🚦 **User Experience:** Helps both new and existing users avoid errors when following guides or running code examples.

Overall, these updates make working with YOLOE models in Ultralytics smoother and more intuitive!