### PR TITLE
Add workflow-level CI permissions for security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@
 # YOLO Continuous Integration (CI) GitHub Actions tests
 
 name: Ultralytics CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@
 # YOLO Continuous Integration (CI) GitHub Actions tests
 
 name: Ultralytics CI
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@
 
 name: Publish Docker Images
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,6 +11,9 @@
 
 name: Check Broken links
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -6,6 +6,9 @@
 
 name: Mirror Repository
 
+permissions:
+  contents: read
+
 on:
   # push:
   #   branches:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub workflow security by explicitly setting read-only permissions for workflows.

### 📊 Key Changes
- Added `permissions: contents: read` to all main GitHub Actions workflows (CI, Docker, link checker, and mirror).

### 🎯 Purpose & Impact
- 🔒 Enhances security by limiting workflow access to read-only, reducing risk of unauthorized changes.
- ✅ Follows GitHub best practices for safer automation.
- 🚀 No impact on user-facing features or functionality; purely a behind-the-scenes improvement.