### PR TITLE
Fix box sizes for CoreML exports

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -384,7 +384,7 @@ class Exporter:
                 m.export = True
                 m.format = self.args.format
                 m.max_det = self.args.max_det
-                m.xyxy = self.args.nms
+                m.xyxy = self.args.nms and not coreml
             elif isinstance(m, C2f) and not is_tf_format:
                 # EdgeTPU does not support FlexSplitV while split provides cleaner ONNX graph
                 m.forward = m.forward_split


### PR DESCRIPTION
This fixes https://github.com/ultralytics/ultralytics/issues/20356. The flag appears to be incompatible with CoreML.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved export logic for better compatibility with CoreML and other formats. 🚀  

### 📊 Key Changes  
- Adjusted the `xyxy` parameter to ensure compatibility with CoreML by adding a condition to disable it when exporting to CoreML.  
- Maintained existing logic for other formats like ONNX and TensorFlow.  

### 🎯 Purpose & Impact  
- 🛠️ **Purpose**: Enhance export functionality by addressing specific compatibility issues with CoreML.  
- 🌍 **Impact**: Users exporting models to CoreML will experience smoother and more reliable performance, reducing potential errors during deployment.  
- 🔧 **Developer-Friendly**: Maintains clean and efficient logic for other export formats, ensuring no disruption to existing workflows.