### PR TITLE
Add `tests` directory to package for Conda builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,8 @@ ultralytics = "ultralytics.cfg:entrypoint"
 # Tools settings -------------------------------------------------------------------------------------------------------
 [tool.setuptools]  # configuration specific to the `setuptools` build backend.
 packages = { find = { where = ["."], include = ["ultralytics", "ultralytics.*"] } }
-package-data = { "ultralytics" = ["**/*.yaml", "**/*.sh"], "ultralytics.assets" = ["*.jpg"] }
+# Tests included below for checking Conda builds in https://github.com/conda-forge/ultralytics-feedstock
+package-data = { "ultralytics" = ["**/*.yaml", "**/*.sh", "../tests/*.py"], "ultralytics.assets" = ["*.jpg"] }
 
 [tool.setuptools.dynamic]
 version = { attr = "ultralytics.__version__" }


### PR DESCRIPTION
@Y-T-G reverts https://github.com/ultralytics/ultralytics/pull/20079 as we need the tests directory to test Conda builds.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved packaging to include test files for better Conda build checks. 🛠️

### 📊 Key Changes  
- Updated the packaging configuration to include test files (`../tests/*.py`) in the distributed package.

### 🎯 Purpose & Impact  
- Ensures test files are available during Conda builds, helping maintain package quality.  
- Facilitates easier and more reliable testing for users and maintainers using Conda.  
- No impact on regular users; mainly benefits developers and package maintainers.