### PR TITLE
Fix NMS box format comment from xyxy to xywh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ solutions = [
     "streamlit>=1.29.0,<1.44.0",    # for live inference on web browser, i.e `yolo streamlit-predict`
 ]
 logging = [
-    "wandb", # https://docs.ultralytics.com/integrations/comet/
+    "wandb", # https://docs.ultralytics.com/integrations/weights-biases/
     "tensorboard",  # https://docs.ultralytics.com/integrations/tensorboard/
     "mlflow",  # https://docs.ultralytics.com/integrations/mlflow/
 ]

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -213,7 +213,7 @@ def non_max_suppression(
         multi_label (bool): If True, each box may have multiple labels.
         labels (List[List[Union[int, float, torch.Tensor]]]): A list of lists, where each inner
             list contains the apriori labels for a given image. The list should be in the format
-            output by a dataloader, with each label being a tuple of (class_index, x1, y1, x2, y2).
+            output by a dataloader, with each label being a tuple of (class_index, x, y, w, h).
         max_det (int): The maximum number of boxes to keep after NMS.
         nc (int): The number of classes output by the model. Any indices after this will be considered masks.
         max_time_img (float): The maximum time (seconds) for processing one image.


### PR DESCRIPTION
 docs: correct labels parameter format from (cls,x1,y1,x2,y2) to (cls,x,y,w,h) #20372 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation updates for improved clarity and accuracy in Ultralytics code and links. 📝✨

### 📊 Key Changes
- Updated a comment link for the Weights & Biases integration to point to the correct documentation page.
- Clarified the format description for label tuples in the `non_max_suppression` function docstring.

### 🎯 Purpose & Impact
- Ensures users and developers are directed to the right integration documentation, reducing confusion.
- Improves code documentation accuracy, making it easier for contributors and users to understand how label data should be structured.
- No changes to core functionality—safe for all users! 🚀