### PR TITLE
Fix BOTSORT initialization with ReID set to False

### DIFF
--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -17,7 +17,7 @@ from .utils.kalman_filter import KalmanFilterXYWH
 
 class BOTrack(STrack):
     """
-    An extended version of the STrack class for YOLOv8, adding object tracking features.
+    An extended version of the STrack class for YOLO, adding object tracking features.
 
     This class extends the STrack class to include additional functionalities for object tracking, such as feature
     smoothing, Kalman filter prediction, and reactivation of tracks.
@@ -150,7 +150,7 @@ class BOTrack(STrack):
 
 class BOTSORT(BYTETracker):
     """
-    An extended version of the BYTETracker class for YOLOv8, designed for object tracking with ReID and GMC algorithm.
+    An extended version of the BYTETracker class for YOLO, designed for object tracking with ReID and GMC algorithm.
 
     Attributes:
         proximity_thresh (float): Threshold for spatial proximity (IoU) between tracks and detections.
@@ -163,7 +163,7 @@ class BOTSORT(BYTETracker):
         get_kalmanfilter: Return an instance of KalmanFilterXYWH for object tracking.
         init_track: Initialize track with detections, scores, and classes.
         get_dists: Get distances between tracks and detections using IoU and (optionally) ReID.
-        multi_predict: Predict and track multiple objects with YOLOv8 model.
+        multi_predict: Predict and track multiple objects with a YOLO model.
         reset: Reset the BOTSORT tracker to its initial state.
 
     Examples:
@@ -173,7 +173,7 @@ class BOTSORT(BYTETracker):
         >>> bot_sort.multi_predict(tracks)
 
     Note:
-        The class is designed to work with the YOLOv8 object detection model and supports ReID only if enabled via args.
+        The class is designed to work with a YOLO object detection model and supports ReID only if enabled via args.
     """
 
     def __init__(self, args, frame_rate=30):

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -195,13 +195,15 @@ class BOTSORT(BYTETracker):
         # ReID module
         self.proximity_thresh = args.proximity_thresh
         self.appearance_thresh = args.appearance_thresh
-        self.encoder = (
-            (lambda feats, s: [f.cpu().numpy() for f in feats])  # native features do not require any model
-            if self.args.model == "auto"
-            else ReID(args.model)
-            if args.with_reid
-            else None
-        )
+        if args.with_reid:
+            if args.model == "auto":
+                self.encoder = lambda feats, s: [
+                    f.cpu().numpy() for f in feats
+                ]  # native features do not require any model
+            else:
+                self.encoder = ReID(args.model)
+        else:
+            self.encoder = None
 
     def get_kalmanfilter(self):
         """Return an instance of KalmanFilterXYWH for predicting and updating object states in the tracking process."""

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -195,15 +195,13 @@ class BOTSORT(BYTETracker):
         # ReID module
         self.proximity_thresh = args.proximity_thresh
         self.appearance_thresh = args.appearance_thresh
-        if args.with_reid:
-            if args.model == "auto":
-                self.encoder = lambda feats, s: [
-                    f.cpu().numpy() for f in feats
-                ]  # native features do not require any model
-            else:
-                self.encoder = ReID(args.model)
-        else:
-            self.encoder = None
+        self.encoder = (
+            (lambda feats, s: [f.cpu().numpy() for f in feats])  # native features do not require any model
+            if self.args.model == "auto" and args.with_reid
+            else ReID(args.model)
+            if args.with_reid
+            else None
+                )
 
     def get_kalmanfilter(self):
         """Return an instance of KalmanFilterXYWH for predicting and updating object states in the tracking process."""

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -197,7 +197,7 @@ class BOTSORT(BYTETracker):
         self.appearance_thresh = args.appearance_thresh
         self.encoder = (
             (lambda feats, s: [f.cpu().numpy() for f in feats])  # native features do not require any model
-            if self.args.model == "auto" and args.with_reid
+            if args.with_reid and self.args.model == "auto"
             else ReID(args.model)
             if args.with_reid
             else None

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -201,7 +201,7 @@ class BOTSORT(BYTETracker):
             else ReID(args.model)
             if args.with_reid
             else None
-                )
+        )
 
     def get_kalmanfilter(self):
         """Return an instance of KalmanFilterXYWH for predicting and updating object states in the tracking process."""


### PR DESCRIPTION
Fix edge case when encoder was initialized even when with_reid was set to false.
Fixes #20391

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor updates to the BOTSORT tracker to generalize documentation and improve feature handling for YOLO models. 📝✨

### 📊 Key Changes
- Updated class docstrings to refer to "YOLO" models in general, instead of specifically "YOLOv8".
- Clarified that BOTSORT supports any YOLO object detection model, not just YOLOv8.
- Adjusted feature encoder logic to better handle ReID (Re-Identification) settings.

### 🎯 Purpose & Impact
- Makes the tracker documentation and code more accurate and inclusive for all YOLO versions, including upcoming releases like YOLO11 and YOLO12.
- Helps users understand that BOTSORT can be used with any YOLO model, increasing flexibility.
- Improves clarity and maintainability for both developers and users.