### PR TITLE
Adjust `track_high_thresh` for `conf<0.25`

### DIFF
--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -42,6 +42,7 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
     cfg = IterableSimpleNamespace(**yaml_load(tracker))
     if predictor.args.conf < 0.25:  # Set track_high_thresh = conf if conf < 0.25
         from ultralytics.utils import LOGGER
+
         LOGGER.warning("confidence threshold is below 0.25, track_high_thresh is set to match the confidence value.")
         cfg.track_high_thresh = predictor.args.conf
     if cfg.tracker_type not in {"bytetrack", "botsort"}:

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -40,7 +40,10 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
 
     tracker = check_yaml(predictor.args.tracker)
     cfg = IterableSimpleNamespace(**yaml_load(tracker))
-
+    if predictor.args.conf < 0.25:  # Set track_high_thresh = conf if conf < 0.25
+        from ultralytics.utils import LOGGER
+        LOGGER.warning("confidence threshold is below 0.25, track_high_thresh is set to match the confidence value.")
+        cfg.track_high_thresh = predictor.args.conf
     if cfg.tracker_type not in {"bytetrack", "botsort"}:
         raise AssertionError(f"Only 'bytetrack' and 'botsort' are supported for now, but got '{cfg.tracker_type}'")
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improves tracking reliability by adjusting a key threshold when using low confidence values in object tracking.

### 📊 Key Changes  
- Automatically sets `track_high_thresh` to match the confidence threshold if it is below 0.25.
- Adds a warning message to inform users when this adjustment occurs.

### 🎯 Purpose & Impact  
- Ensures more stable and accurate object tracking when users set low confidence thresholds.
- Helps prevent tracking issues that could arise from mismatched threshold settings.
- Provides clear feedback to users, making it easier to understand how configuration changes affect tracking behavior. 🚦