### PR TITLE
`ultralytics 8.3.122` Native Xcode preview of YOLO CoreML Classification models

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.121"
+__version__ = "8.3.122"
 
 import os
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -851,8 +851,9 @@ class Exporter:
         ct_model.license = m.pop("license")
         ct_model.version = m.pop("version")
         ct_model.user_defined_metadata.update({k: str(v) for k, v in m.items()})
-        if self.model.task == "classify": ct_model.user_defined_metadata.update({"com.apple.coreml.model.preview.type": "imageClassifier"}) 
-        
+        if self.model.task == "classify":
+            ct_model.user_defined_metadata.update({"com.apple.coreml.model.preview.type": "imageClassifier"})
+
         try:
             ct_model.save(str(f))  # save *.mlpackage
         except Exception as e:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -851,6 +851,7 @@ class Exporter:
         ct_model.license = m.pop("license")
         ct_model.version = m.pop("version")
         ct_model.user_defined_metadata.update({k: str(v) for k, v in m.items()})
+        if self.model.task == "classify": ct_model.user_defined_metadata.update({"com.apple.coreml.model.preview.type": "imageClassifier"}) 
         try:
             ct_model.save(str(f))  # save *.mlpackage
         except Exception as e:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -852,6 +852,7 @@ class Exporter:
         ct_model.version = m.pop("version")
         ct_model.user_defined_metadata.update({k: str(v) for k, v in m.items()})
         if self.model.task == "classify": ct_model.user_defined_metadata.update({"com.apple.coreml.model.preview.type": "imageClassifier"}) 
+        
         try:
             ct_model.save(str(f))  # save *.mlpackage
         except Exception as e:


### PR DESCRIPTION
When exporting a classification model to coreml, the native xcode preview functionality does not work. This is typically a good indicator that something went wrong during export. In this case, it's just due to missing metadata signaling the task type. 

https://apple.github.io/coremltools/docs-guides/source/xcode-model-preview-types.html

If your wondering why this smells, it's because it does. 🤷 👃 

> Some model architecture types, such as Neural Network Classifier, don’t require a model.preview.type, and some model preview types don’t require preview parameters.


    I have read the CLA Document and I sign the CLA




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves CoreML export for classification models by adding metadata for better compatibility and preview support. 🚀

### 📊 Key Changes
- Bumps Ultralytics version to 8.3.122.
- Updates the CoreML export process to include a specific metadata tag (`imageClassifier`) when exporting classification models.

### 🎯 Purpose & Impact
- Ensures exported classification models are correctly recognized as image classifiers by Apple devices and tools.
- Enhances user experience by enabling proper previews and integration in Apple’s ecosystem.
- No changes to model performance or training—this update only affects CoreML export and deployment workflows.