### PR TITLE
Docs on converting LabelMe to YOLO

### DIFF
--- a/docs/en/usage/simple-utilities.md
+++ b/docs/en/usage/simple-utilities.md
@@ -118,7 +118,6 @@ You can then train your model with:
 yolo task=detect mode=train model=yolov8n.pt data=dataset/data.yaml
 ```
 
-
 ### Get Bounding Box Dimensions
 
 ```python

--- a/docs/en/usage/simple-utilities.md
+++ b/docs/en/usage/simple-utilities.md
@@ -99,6 +99,26 @@ convert_coco(
 
 For additional information about the `convert_coco` function, [visit the reference page](../reference/data/converter.md#ultralytics.data.converter.convert_coco).
 
+### Convert LabelMe into YOLO Format
+
+If your annotations are in LabelMe JSON format, you can convert them to YOLO format using [labelme2yolo](https://pypi.org/project/labelme2yolo/).
+
+#### Example:
+
+```bash
+pip install labelme2yolo
+python labelme2yolo.py /path/to/labelme_dataset
+```
+
+This generates a YOLO-compatible directory with images/, labels/, and a data.yaml file.
+
+You can then train your model with:
+
+```bash
+yolo task=detect mode=train model=yolov8n.pt data=dataset/data.yaml
+```
+
+
 ### Get Bounding Box Dimensions
 
 ```python


### PR DESCRIPTION
This adds documentation for converting datasets annotated in the LabelMe JSON format into YOLO format. The new section is added to the docs/en/usage/simple-utilities.md file.

Changes Made:
Added a subsection explaining how to convert LabelMe JSON to YOLO format using LabelMe2YOLO.
Provided a usage example showing how to parse VIA JSON and convert annotations to YOLO format.

Related Issues:
N/A – this contribution was made proactively to address a common need among users unfamiliar with converting annotation formats.

CLA Agreement:
I have read the CLA Document and I sign the CLA.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added clear instructions for converting LabelMe annotations to YOLO format using the labelme2yolo tool. 📝➡️🦾

### 📊 Key Changes
- Added a new section in the documentation explaining how to convert LabelMe JSON annotations to YOLO format.
- Provided step-by-step example commands for installing and running the labelme2yolo tool.
- Clarified how to use the converted dataset for training with YOLO models.

### 🎯 Purpose & Impact
- Makes it easier for users with LabelMe-annotated datasets to switch to YOLO format and start training quickly.
- Reduces confusion and setup time for new users working with different annotation formats.
- Supports a smoother onboarding experience for users migrating datasets to Ultralytics workflows. 🚀