### PR TITLE
Fix Python version to downgrade `numpy` for TensorRT inference on JetPack 5

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -290,8 +290,8 @@ class AutoBackend(nn.Module):
         elif engine:
             LOGGER.info(f"Loading {w} for TensorRT inference...")
 
-            if IS_JETSON and check_version(PYTHON_VERSION, "<=3.8.0"):
-                # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 with Python <= 3.8.0
+            if IS_JETSON and check_version(PYTHON_VERSION, "<=3.8.10"):
+                # fix error: `np.bool` was a deprecated alias for the builtin `bool` for JetPack 4 and JetPack 5 with Python <= 3.8.10
                 check_requirements("numpy==1.23.5")
 
             try:  # https://developer.nvidia.com/nvidia-tensorrt-download


### PR DESCRIPTION
@glenn-jocher The existing implementation does not work because JetPack 4 uses Python 3.8 whereas JetPack 5 uses Python 3.8.10. This PR fixes that. Thanks!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved compatibility for TensorRT inference on NVIDIA Jetson devices with newer Python 3.8 versions. 🚀

### 📊 Key Changes
- Updated Python version check for Jetson devices from 3.8.0 to 3.8.10 when loading TensorRT models.
- Enhanced comment to clarify support for both JetPack 4 and JetPack 5 with Python up to 3.8.10.

### 🎯 Purpose & Impact
- Ensures smoother TensorRT model loading on Jetson devices running Python versions up to 3.8.10.
- Reduces potential errors related to deprecated NumPy types, improving reliability for edge device deployments.
- Makes Ultralytics models more robust and user-friendly for Jetson users. 🖥️✨