### PR TITLE
Add MINMAX_CALIBRATION info to TensorRT Doc

### DIFF
--- a/docs/en/integrations/tensorrt.md
+++ b/docs/en/integrations/tensorrt.md
@@ -142,7 +142,7 @@ When processing implicitly quantized networks TensorRT uses INT8 opportunistical
 
 #### Configuring INT8 Export
 
-The arguments provided when using [export](../modes/export.md) for an Ultralytics YOLO model will **greatly** influence the performance of the exported model. They will also need to be selected based on the device resources available, however the default arguments _should_ work for most [Ampere (or newer) NVIDIA discrete GPUs](https://developer.nvidia.com/blog/nvidia-ampere-architecture-in-depth/). The calibration algorithm used is `"ENTROPY_CALIBRATION_2"` and you can read more details about the options available [in the TensorRT Developer Guide](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#enable_int8_c). Ultralytics tests found that `"ENTROPY_CALIBRATION_2"` was the best choice and exports are fixed to using this algorithm.
+The arguments provided when using [export](../modes/export.md) for an Ultralytics YOLO model will **greatly** influence the performance of the exported model. They will also need to be selected based on the device resources available, however the default arguments _should_ work for most [Ampere (or newer) NVIDIA discrete GPUs](https://developer.nvidia.com/blog/nvidia-ampere-architecture-in-depth/). The calibration algorithm used is `"MINMAX_CALIBRATION"` and you can read more details about the options available [in the TensorRT Developer Guide](https://docs.nvidia.com/deeplearning/tensorrt/latest/_static/python-api/infer/Int8/MinMaxCalibrator.html). Ultralytics tests found that `"MINMAX_CALIBRATION"` was the best choice and exports are fixed to using this algorithm.
 
 - `workspace` : Controls the size (in GiB) of the device memory allocation while converting the model weights.
 


### PR DESCRIPTION
@glenn-jocher Updating docs to align with [this PR](https://github.com/ultralytics/ultralytics/pull/20345).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated TensorRT export documentation to recommend and use "MINMAX_CALIBRATION" for INT8 quantization in Ultralytics YOLO models.

### 📊 Key Changes
- Changed the recommended INT8 calibration algorithm from "ENTROPY_CALIBRATION_2" to "MINMAX_CALIBRATION" in the TensorRT integration docs.
- Updated related documentation links to point to the correct TensorRT Developer Guide section for "MINMAX_CALIBRATION".

### 🎯 Purpose & Impact
- Ensures users follow the latest and most effective calibration method based on Ultralytics testing, leading to better model performance and compatibility. 🚀
- Provides clearer guidance and accurate references, making the export process easier and more reliable for users working with NVIDIA GPUs. 💡