### PR TITLE
Skip `paddlepaddle` export on NVIDIA Jetson

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -93,6 +93,7 @@ from ultralytics.utils import (
     callbacks,
     colorstr,
     get_default_args,
+    IS_JETSON,
 )
 from ultralytics.utils.checks import (
     check_imgsz,
@@ -682,6 +683,7 @@ class Exporter:
     @try_export
     def export_paddle(self, prefix=colorstr("PaddlePaddle:")):
         """YOLO Paddle export."""
+        assert not IS_JETSON, "Jetson Paddle exports not supported yet"
         check_requirements(("paddlepaddle-gpu" if torch.cuda.is_available() else "paddlepaddle>=3.0.0", "x2paddle"))
         import x2paddle  # noqa
         from x2paddle.convert import pytorch2paddle  # noqa

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -82,6 +82,7 @@ from ultralytics.utils import (
     ARM64,
     DEFAULT_CFG,
     IS_COLAB,
+    IS_JETSON,
     LINUX,
     LOGGER,
     MACOS,
@@ -93,7 +94,6 @@ from ultralytics.utils import (
     callbacks,
     colorstr,
     get_default_args,
-    IS_JETSON,
 )
 from ultralytics.utils.checks import (
     check_imgsz,

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -40,7 +40,7 @@ import torch.cuda
 from ultralytics import YOLO, YOLOWorld
 from ultralytics.cfg import TASK2DATA, TASK2METRIC
 from ultralytics.engine.exporter import export_formats
-from ultralytics.utils import ARM64, ASSETS, LINUX, LOGGER, MACOS, TQDM, WEIGHTS_DIR, YAML
+from ultralytics.utils import ARM64, ASSETS, LINUX, LOGGER, MACOS, TQDM, WEIGHTS_DIR, YAML, IS_JETSON
 from ultralytics.utils.checks import IS_PYTHON_3_13, check_imgsz, check_requirements, check_yolo, is_rockchip
 from ultralytics.utils.downloads import safe_download
 from ultralytics.utils.files import file_size
@@ -126,7 +126,7 @@ def benchmark(
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 Paddle exports not supported yet"
                 assert model.task != "obb", "Paddle OBB bug https://github.com/PaddlePaddle/Paddle/issues/72024"
                 assert not is_end2end, "End-to-end models not supported by PaddlePaddle yet"
-                assert LINUX or MACOS, "Windows Paddle exports not supported yet"
+                assert (LINUX and not IS_JETSON) or MACOS, "Windows and Jetson Paddle exports not supported yet"
             if i == 12:  # MNN
                 assert not isinstance(model, YOLOWorld), "YOLOWorldv2 MNN exports not supported yet"
             if i == 13:  # NCNN

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -40,7 +40,7 @@ import torch.cuda
 from ultralytics import YOLO, YOLOWorld
 from ultralytics.cfg import TASK2DATA, TASK2METRIC
 from ultralytics.engine.exporter import export_formats
-from ultralytics.utils import ARM64, ASSETS, LINUX, LOGGER, MACOS, TQDM, WEIGHTS_DIR, YAML, IS_JETSON
+from ultralytics.utils import ARM64, ASSETS, IS_JETSON, LINUX, LOGGER, MACOS, TQDM, WEIGHTS_DIR, YAML
 from ultralytics.utils.checks import IS_PYTHON_3_13, check_imgsz, check_requirements, check_yolo, is_rockchip
 from ultralytics.utils.downloads import safe_download
 from ultralytics.utils.files import file_size


### PR DESCRIPTION
@glenn-jocher Currently there are no `aarch64` binaries for `paddlepaddle-gpu` on PyPi and therefore the `check_requirements` fail for Jetson.
https://pypi.org/project/paddlepaddle-gpu/#files

EDIT: I have opened an [issue here](https://github.com/PaddlePaddle/Paddle/issues/72578) to request for these binaries.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved export and benchmarking support by clearly blocking unsupported PaddlePaddle exports on Jetson devices. 🚫🤖

### 📊 Key Changes
- Added a check to prevent PaddlePaddle model exports on Jetson devices, with a clear error message.
- Updated benchmarking logic to block PaddlePaddle exports on both Windows and Jetson platforms.

### 🎯 Purpose & Impact
- Prevents users from attempting unsupported PaddlePaddle exports on Jetson, avoiding confusion and errors.
- Provides clearer guidance and error messages, improving the user experience for those working with Jetson devices.
- Ensures more robust and predictable export and benchmarking workflows across different hardware platforms.