### PR TITLE
Fix language switcher links

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -169,7 +169,7 @@ def update_docs_html():
     for html_file in tqdm(SITE.rglob("*.html"), desc="Updating bs4 soup", mininterval=1.0):
         with open(html_file, encoding="utf-8") as file:
             content = file.read()
-        updated_content = update_docs_soup(content)
+        updated_content = update_docs_soup(content, html_file=html_file)
         if updated_content != content:
             with open(html_file, "w", encoding="utf-8") as file:
                 file.write(updated_content)
@@ -188,7 +188,7 @@ def update_docs_html():
         shutil.rmtree(macros_dir)
 
 
-def update_docs_soup(content: str, max_title_length: int = 70) -> str:
+def update_docs_soup(content: str, html_file: Path = None, max_title_length: int = 70) -> str:
     """Convert plaintext links to HTML hyperlinks, truncate long meta titles, and remove code line hrefs."""
     soup = BeautifulSoup(content, "html.parser")
     modified = False
@@ -223,6 +223,42 @@ def update_docs_soup(content: str, max_title_length: int = 70) -> str:
         else:  # If it has no text
             a.replace_with(soup.new_tag("span"))  # Replace with an empty span
         modified = True
+
+    # Fix language switcher links
+    if html_file:
+        # Language codes from your site
+        lang_codes = ["zh", "ko", "ja", "ru", "de", "fr", "es", "pt", "it", "tr", "vi", "ar"]
+
+        # Get relative path from site root
+        file_path = "/" + str(html_file.relative_to(SITE)).replace("\\", "/")
+        if file_path.endswith("index.html"):
+            file_path = file_path[:-10]
+
+        # Find current language prefix if any
+        current_lang = None
+        for lang in lang_codes:
+            if file_path.startswith(f"/{lang}/"):
+                current_lang = lang
+                # Remove language prefix from path
+                current_path = file_path[len(f"/{lang}") :]
+                break
+        else:
+            current_path = file_path
+
+        # Update language switcher links
+        for link in soup.select(".md-select__link"):
+            href = link.get("href", "")
+            match = re.match(r"^\/([a-z]{2})\/?$", href)
+
+            if match:
+                # Language root link (e.g., /zh/)
+                link["href"] = f"/{match.group(1)}{current_path}"
+                modified = True
+            elif href == "/" or href == "":
+                # Default language link
+                link["href"] = current_path
+                modified = True
+
     return str(soup) if modified else content
 
 

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -235,10 +235,8 @@ def update_docs_soup(content: str, html_file: Path = None, max_title_length: int
             file_path = file_path[:-10]
 
         # Find current language prefix if any
-        current_lang = None
         for lang in lang_codes:
             if file_path.startswith(f"/{lang}/"):
-                current_lang = lang
                 # Remove language prefix from path
                 current_path = file_path[len(f"/{lang}") :]
                 break

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -226,27 +226,23 @@ def update_docs_soup(content: str, html_file: Path = None, max_title_length: int
 
     # Fix language switcher links
     if html_file:
-        # Language codes from your site
-        lang_codes = ["zh", "ko", "ja", "ru", "de", "fr", "es", "pt", "it", "tr", "vi", "ar"]
+        # Get page path without index.html
+        current_path = file_path = "/" + str(html_file.relative_to(SITE)).replace("\\", "/").replace("index.html", "")
 
-        # Get relative path from site root
-        file_path = "/" + str(html_file.relative_to(SITE)).replace("\\", "/")
-        if file_path.endswith("index.html"):
-            file_path = file_path[:-10]
+        # Get language links and extract language codes
+        lang_links = soup.select(".md-select__link")
+        lang_codes = [m.group(1) for link in lang_links if (m := re.match(r"^/([a-z]{2})/?$", link.get("href", "")))]
 
-        # Find current language prefix if any
+        # Find current language and path
         for lang in lang_codes:
             if file_path.startswith(f"/{lang}/"):
-                # Remove language prefix from path
                 current_path = file_path[len(f"/{lang}") :]
                 break
-        else:
-            current_path = file_path
 
-        # Update language switcher links
-        for link in soup.select(".md-select__link"):
+        # Update all language links
+        for link in lang_links:
             href = link.get("href", "")
-            match = re.match(r"^\/([a-z]{2})\/?$", href)
+            match = re.match(r"^/([a-z]{2})\/?$", href)
 
             if match:
                 # Language root link (e.g., /zh/)

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -242,7 +242,7 @@ def update_docs_soup(content: str, html_file: Path = None, max_title_length: int
         # Update all language links
         for link in lang_links:
             href = link.get("href", "")
-            match = re.match(r"^/([a-z]{2})\/?$", href)
+            match = re.match(r"^/([a-z]{2})/?$", href)
 
             if match:
                 # Language root link (e.g., /zh/)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the documentation build process by fixing language switcher links for a smoother multilingual experience. 🌐📚

### 📊 Key Changes
- Updated the documentation script to correctly handle language switcher links in HTML files.
- Ensured that language links now point to the corresponding page in each language, rather than just the language root.
- Minor code adjustments to support these improvements.

### 🎯 Purpose & Impact
- Enhances navigation for users reading the docs in different languages, making it easier to switch languages without losing your place.
- Provides a more professional and user-friendly documentation experience for the global Ultralytics community.
- Reduces confusion and improves accessibility for non-English users.