### PR TITLE
Add checks for multi-GPU training

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -71,8 +71,13 @@ def test_export_engine_matrix(task, dynamic, int8, half, batch):
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 def test_train():
     """Test model training on a minimal dataset using available CUDA devices."""
-    device = DEVICES if len(DEVICES) > 1 else DEVICES[0]
-    YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device)  # requires imgsz>=64
+    import os
+
+    device = tuple(DEVICES) if len(DEVICES) > 1 else DEVICES[0]
+    model = YOLO(MODEL)
+    model.train(data="coco8.yaml", imgsz=64, epochs=1, device=device)  # requires imgsz>=64
+    visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
+    assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
 
 
 @pytest.mark.slow

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -74,10 +74,10 @@ def test_train():
     import os
 
     device = tuple(DEVICES) if len(DEVICES) > 1 else DEVICES[0]
-    model = YOLO(MODEL)
-    model.train(data="coco8.yaml", imgsz=64, epochs=1, device=device)  # requires imgsz>=64
+    results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device)  # requires imgsz>=64
     visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
     assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
+    assert results is (None if len(DEVICES) > 1 else not None)  # DDP returns None, single-GPU returns metrics
 
 
 @pytest.mark.slow


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved CUDA device handling and validation in training tests for better reliability and accuracy. 🚀

### 📊 Key Changes  
- Updated the training test to handle multiple CUDA devices more robustly.
- Added checks to ensure the correct GPUs are used during training.
- Included assertions to verify expected training results depending on single or multi-GPU setups.

### 🎯 Purpose & Impact  
- Ensures that training uses the intended CUDA devices, preventing accidental misconfiguration. 🖥️
- Improves test reliability, especially for multi-GPU (Distributed Data Parallel) scenarios.
- Helps developers catch device assignment issues early, leading to smoother model training experiences. ✅