### PR TITLE
TensorRT: Bump default dynamic `max_shape` up to 1280

### DIFF
--- a/ultralytics/utils/export.py
+++ b/ultralytics/utils/export.py
@@ -138,7 +138,7 @@ def export_engine(
             LOGGER.warning(f"{prefix} 'dynamic=True' model requires max batch size, i.e. 'batch=16'")
         profile = builder.create_optimization_profile()
         min_shape = (1, shape[1], 32, 32)  # minimum input shape
-        max_shape = (*shape[:2], *(int(max(1, workspace or 1) * d) for d in shape[2:]))  # max input shape
+        max_shape = (*shape[:2], *(int(max(2, workspace or 2) * d) for d in shape[2:]))  # max input shape
         for inp in inputs:
             profile.set_shape(inp.name, min=min_shape, opt=shape, max=max_shape)
         config.add_optimization_profile(profile)


### PR DESCRIPTION
By default exported tensorrt int8 model is dynamic within max shape 640, but our default validation behavior has extra padding which ends up 672 image size which exceeds 640 hence produce warnings and incorrect results.
```bash
yolo export model=yolo11x.pt format=engine int8
yolo val task=detect model=weights/yolo11x.engine imgsz=640 data=coco128.yaml int8 verbose=False
```
![pic-250507-1520-21](https://github.com/user-attachments/assets/fde448b6-7c3e-451e-94e7-dc20e7fd901e)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved TensorRT export by increasing the maximum input shape for dynamic models.

### 📊 Key Changes  
- Increased the minimum multiplier for calculating the maximum input shape from 1 to 2 during TensorRT engine export.

### 🎯 Purpose & Impact  
- Ensures exported models can handle larger input sizes when using dynamic batching.
- Reduces the risk of errors or limitations when running inference on varied input sizes.
- Makes model deployment with TensorRT more robust and flexible for users. 🚀