### PR TITLE
Add `on_model_save` callback with Python example to Callbacks docs

### DIFF
--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -69,8 +69,8 @@ def on_model_save(model):
         f"Best fitness: {model.best_fitness}, "
         f"Loss names: {model.loss_names}, "  # List of loss names
         f"Metrics: {model.metrics}, "
-        f"Total loss: {model.tloss}"
-    )  # Total loss value
+        f"Total loss: {model.tloss}"  # Total loss value
+    )  
 
 
 if __name__ == "__main__":

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -74,7 +74,7 @@ def on_model_save(model):
 
 
 if __name__ == "__main__":
-    # Add on_train_epoch_end callback.
+    # Add on_model_save callback.
     model.add_callback("on_model_save", on_model_save)
 
     # Run model training on custom dataset.

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -70,7 +70,7 @@ def on_model_save(model):
         f"Loss names: {model.loss_names}, "  # List of loss names
         f"Metrics: {model.metrics}, "
         f"Total loss: {model.tloss}"  # Total loss value
-    )  
+    )
 
 
 if __name__ == "__main__":

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -130,12 +130,6 @@ Below are all the supported callbacks. For more details, refer to the callbacks 
 | `on_export_start` | Triggered when the export process starts. |
 | `on_export_end`   | Triggered when the export process ends.   |
 
-### Model Callbacks
-
-| Callback        | Description                                                                     |
-| --------------- | ------------------------------------------------------------------------------- |
-| `on_model_save` | Triggered at the end of each training epoch when the model checkpoint is saved. |
-
 ## FAQ
 
 ### What are Ultralytics callbacks and how can I use them?

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -55,7 +55,7 @@ for result, frame in model.predict():  # or model.track()
 
 In many research projects, model accuracy is crucial. Training for too many epochs can lead to overfitting, while too few may result in suboptimal performance. To address this, the `on_model_save` callback in Ultralytics allows you to run validation at the end of each epoch using the latest checkpoint.
 
-This approach helps you monitor accuracy and other metrics in real-time, saving time and offering clearer insights into model performance. It also provides per-epoch metrics that are essential for informed testing and optimization.
+This approach helps you monitor accuracy and other metrics in real-time, saving time and offering clearer insights into model performance.
 
 Below is an example of how to implement per-epoch validation using Ultralytics Callbacks.
 
@@ -64,15 +64,13 @@ from ultralytics import YOLO
 
 model = YOLO("yolo11n.pt")
 
-batch, imgsz, workers, epochs = 2, 640, 1, 3
-data, device = "coco8.yaml", "0"
+batch, imgsz, workers, epochs, data, device = 2, 640, 1, 3, "coco8.yaml", "0"
 
 def on_train_epoch_end(trainer):
-    print(f"\nRunning Validation {trainer.epoch+1}...")
-
     from pathlib import Path
     val_model = YOLO(Path(trainer.save_dir) / "weights" / "best.pt")
 
+    print(f"\nRunning Validation {trainer.epoch+1}...")
     validation_results = val_model.val(
         data=data,
         imgsz=imgsz,

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -66,27 +66,29 @@ model = YOLO("yolo11n.pt")
 
 batch, imgsz, workers, epochs, data, device = 2, 640, 1, 3, "coco8.yaml", "0"
 
+
 def on_train_epoch_end(trainer):
     from pathlib import Path
+
     val_model = YOLO(Path(trainer.save_dir) / "weights" / "best.pt")
 
-    print(f"\nRunning Validation {trainer.epoch+1}...")
+    print(f"\nRunning Validation {trainer.epoch + 1}...")
     validation_results = val_model.val(
         data=data,
         imgsz=imgsz,
         batch=batch * 2,  # validation with 2x batch required
         workers=workers,
-        device=device
+        device=device,
     )
     # print(validation_results)
+
 
 if __name__ == "__main__":
     # Add on_train_epoch_end callback.
     model.add_callback("on_model_save", on_train_epoch_end)
 
     # Run model training on custom dataset.
-    results = model.train(data=data, epochs=epochs, batch=batch,
-                          imgsz=imgsz, device=device, workers=workers)
+    results = model.train(data=data, epochs=epochs, batch=batch, imgsz=imgsz, device=device, workers=workers)
 ```
 
 ## All Callbacks
@@ -140,8 +142,8 @@ Below are all the supported callbacks. For more details, refer to the callbacks 
 
 ### Model Callbacks
 
-| Callback        | Description                                                             |
-|-----------------|-------------------------------------------------------------------------|
+| Callback        | Description                                                                     |
+| --------------- | ------------------------------------------------------------------------------- |
 | `on_model_save` | Triggered at the end of each training epoch when the model checkpoint is saved. |
 
 ## FAQ

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -51,44 +51,35 @@ for result, frame in model.predict():  # or model.track()
     pass
 ```
 
-### Perform Validation After Every Epoch Using the `on_model_save` Callback
+### Get Notifications After Each Epoch with `on_model_save` Callback
 
-In many research projects, model accuracy is crucial. Training for too many epochs can lead to overfitting, while too few may result in suboptimal performance. To address this, the `on_model_save` callback in Ultralytics allows you to run validation at the end of each epoch using the latest checkpoint.
+In deep learning workflows, staying updated on training progress can save time and help you stay focused. While Ultralytics' YOLO framework provides flexible callbacks, you can use the `on_model_save` callback to send desktop notifications automatically after each epoch when a model checkpoint is saved.
 
-This approach helps you monitor accuracy and other metrics in real-time, saving time and offering clearer insights into model performance.
-
-Below is an example of how to implement per-epoch validation using Ultralytics Callbacks.
+Below is an example of how you can implement this functionality using the Python `plyer` library.
 
 ```python
 from ultralytics import YOLO
 
+from ultralytics.utils.checks import check_requirements
+check_requirements("plyer")
+
 model = YOLO("yolo11n.pt")
 
-batch, imgsz, workers, epochs, data, device = 2, 640, 1, 3, "coco8.yaml", "0"
-
-
-def on_train_epoch_end(trainer):
-    from pathlib import Path
-
-    val_model = YOLO(Path(trainer.save_dir) / "weights" / "best.pt")
-
-    print(f"\nRunning Validation {trainer.epoch + 1}...")
-    validation_results = val_model.val(
-        data=data,
-        imgsz=imgsz,
-        batch=batch * 2,  # validation with 2x batch required
-        workers=workers,
-        device=device,
+def on_model_save(model):
+    """Send notification once after each iteration model checkpoint saved"""
+    from plyer import notification
+    notification.notify(
+        title="Ultralytics YOLO 🚀",
+        message=f"Epoch {model.epoch+1} is completed and model saved in the directory: {model.save_dir}",
+        timeout=5  # seconds
     )
-    # print(validation_results)
-
 
 if __name__ == "__main__":
     # Add on_train_epoch_end callback.
-    model.add_callback("on_model_save", on_train_epoch_end)
+    model.add_callback("on_model_save", on_model_save)
 
     # Run model training on custom dataset.
-    results = model.train(data=data, epochs=epochs, batch=batch, imgsz=imgsz, device=device, workers=workers)
+    results = model.train(data="coco8.yaml", epochs=3, workers=1)
 ```
 
 ## All Callbacks

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -61,13 +61,17 @@ from ultralytics.utils import LOGGER
 
 model = YOLO("yolo11n.pt")
 
+
 def on_model_save(model):
-    """Print model details after each epoch"""
-    LOGGER.info(f"Model details\n"
-                f"Best fitness: {model.best_fitness}, "
-                f"Loss names: {model.loss_names}, "  # List of loss names
-                f"Metrics: {model.metrics}, "
-                f"Total loss: {model.tloss}")  # Total loss value
+    """Print model details after each epoch."""
+    LOGGER.info(
+        f"Model details\n"
+        f"Best fitness: {model.best_fitness}, "
+        f"Loss names: {model.loss_names}, "  # List of loss names
+        f"Metrics: {model.metrics}, "
+        f"Total loss: {model.tloss}"
+    )  # Total loss value
+
 
 if __name__ == "__main__":
     # Add on_train_epoch_end callback.

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -53,7 +53,7 @@ for result, frame in model.predict():  # or model.track()
 
 ### Access Model metrics using the `on_model_save` callback
 
-This example shows how to retrieve training details, such as the best_fitness score, total_loss, and other metrics after each epoch using the `on_model_save` callback.
+This example shows how to retrieve training details, such as the best_fitness score, total_loss, and other metrics after a checkpoint is saved using the `on_model_save` callback.
 
 ```python
 from ultralytics import YOLO

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -59,20 +59,23 @@ Below is an example of how you can implement this functionality using the Python
 
 ```python
 from ultralytics import YOLO
-
 from ultralytics.utils.checks import check_requirements
+
 check_requirements("plyer")
 
 model = YOLO("yolo11n.pt")
 
+
 def on_model_save(model):
-    """Send notification once after each iteration model checkpoint saved"""
+    """Send notification once after each iteration model checkpoint saved."""
     from plyer import notification
+
     notification.notify(
         title="Ultralytics YOLO 🚀",
-        message=f"Epoch {model.epoch+1} is completed and model saved in the directory: {model.save_dir}",
-        timeout=5  # seconds
+        message=f"Epoch {model.epoch + 1} is completed and model saved in the directory: {model.save_dir}",
+        timeout=5,  # seconds
     )
+
 
 if __name__ == "__main__":
     # Add on_train_epoch_end callback.

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -53,7 +53,7 @@ for result, frame in model.predict():  # or model.track()
 
 ### Get Notifications After Each Epoch with `on_model_save` Callback
 
-In deep learning workflows, staying updated on training progress can save time and help you stay focused. While Ultralytics' YOLO framework provides flexible callbacks, you can use the `on_model_save` callback to send desktop notifications automatically after each epoch when a model checkpoint is saved.
+In deep learning workflows, staying updated on training progress can save time and help you stay focused. While Ultralytics YOLO framework provides flexible callbacks, you can use the `on_model_save` callback to send desktop notifications automatically after each epoch when a model checkpoint is saved.
 
 Below is an example of how you can implement this functionality using the Python `plyer` library.
 

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -51,31 +51,23 @@ for result, frame in model.predict():  # or model.track()
     pass
 ```
 
-### Get Notifications After Each Epoch with `on_model_save` Callback
+### Access Model metrics using the `on_model_save` callback
 
-In deep learning workflows, staying updated on training progress can save time and help you stay focused. While Ultralytics YOLO framework provides flexible callbacks, you can use the `on_model_save` callback to send desktop notifications automatically after each epoch when a model checkpoint is saved.
-
-Below is an example of how you can implement this functionality using the Python `plyer` library.
+This example shows how to retrieve training details, such as the best_fitness score, total_loss, and other metrics after each epoch using the `on_model_save` callback.
 
 ```python
 from ultralytics import YOLO
-from ultralytics.utils.checks import check_requirements
-
-check_requirements("plyer")
+from ultralytics.utils import LOGGER
 
 model = YOLO("yolo11n.pt")
 
-
 def on_model_save(model):
-    """Send notification once after each iteration model checkpoint saved."""
-    from plyer import notification
-
-    notification.notify(
-        title="Ultralytics YOLO 🚀",
-        message=f"Epoch {model.epoch + 1} is completed and model saved in the directory: {model.save_dir}",
-        timeout=5,  # seconds
-    )
-
+    """Print model details after each epoch"""
+    LOGGER.info(f"Model details\n"
+                f"Best fitness: {model.best_fitness}, "
+                f"Loss names: {model.loss_names}, "  # List of loss names
+                f"Metrics: {model.metrics}, "
+                f"Total loss: {model.tloss}")  # Total loss value
 
 if __name__ == "__main__":
     # Add on_train_epoch_end callback.

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -57,28 +57,28 @@ This example shows how to retrieve training details, such as the best_fitness sc
 
 ```python
 from ultralytics import YOLO
-from ultralytics.utils import LOGGER
 
+# Load a YOLO model
 model = YOLO("yolo11n.pt")
 
 
-def on_model_save(model):
-    """Print model details after each epoch."""
-    LOGGER.info(
+def print_checkpoint_metrics(trainer):
+    """Print trainer metrics and loss details after each checkpoint is saved."""
+    print(
         f"Model details\n"
-        f"Best fitness: {model.best_fitness}, "
-        f"Loss names: {model.loss_names}, "  # List of loss names
-        f"Metrics: {model.metrics}, "
-        f"Total loss: {model.tloss}"  # Total loss value
+        f"Best fitness: {trainer.best_fitness}, "
+        f"Loss names: {trainer.loss_names}, "  # List of loss names
+        f"Metrics: {trainer.metrics}, "
+        f"Total loss: {trainer.tloss}"  # Total loss value
     )
 
 
 if __name__ == "__main__":
     # Add on_model_save callback.
-    model.add_callback("on_model_save", on_model_save)
+    model.add_callback("on_model_save", print_checkpoint_metrics)
 
     # Run model training on custom dataset.
-    results = model.train(data="coco8.yaml", epochs=3, workers=1)
+    results = model.train(data="coco8.yaml", epochs=3)
 ```
 
 ## All Callbacks


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved documentation to show how to access model metrics using the `on_model_save` callback during training. 📈

### 📊 Key Changes
- Added a new example in the callbacks documentation demonstrating how to retrieve and print training metrics (like best fitness, total loss, and other details) after each model checkpoint is saved.

### 🎯 Purpose & Impact
- Makes it easier for users to monitor and log training progress by accessing key metrics at each checkpoint.
- Helps both beginners and advanced users better understand and utilize callbacks for custom training workflows.
- Enhances transparency and control over the training process, leading to more informed model development. 🚀