### PR TITLE
Fix benchmark note in docs

### DIFF
--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -577,7 +577,7 @@ To reproduce the above Ultralytics benchmarks on all export [formats](../modes/e
         yolo benchmark model=yolo11n.pt data=coco8.yaml imgsz=640
         ```
 
-    Note that benchmarking results might vary based on the exact hardware and software configuration of a system, as well as the current workload of the system at the time the benchmarks are run. For the most reliable results use a dataset with a large number of images, i.e. `data='coco8.yaml'` (4 val images), or `data='coco.yaml'` (5000 val images).
+    Note that benchmarking results might vary based on the exact hardware and software configuration of a system, as well as the current workload of the system at the time the benchmarks are run. For the most reliable results use a dataset with a large number of images, i.e. `data='coco128.yaml'` (128 val images), or `data='coco.yaml'` (5000 val images).
 
 ## Best Practices when using NVIDIA Jetson
 

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -211,7 +211,7 @@ To reproduce the above Ultralytics benchmarks on all [export formats](../modes/e
         yolo benchmark model=yolo11n.pt data=coco8.yaml imgsz=640
         ```
 
-    Note that benchmarking results might vary based on the exact hardware and software configuration of a system, as well as the current workload of the system at the time the benchmarks are run. For the most reliable results use a dataset with a large number of images, i.e. `data='coco8.yaml'` (4 val images), or `data='coco.yaml'` (5000 val images).
+    Note that benchmarking results might vary based on the exact hardware and software configuration of a system, as well as the current workload of the system at the time the benchmarks are run. For the most reliable results use a dataset with a large number of images, i.e. `data='coco128.yaml'` (128 val images), or `data='coco.yaml'` (5000 val images).
 
 ## Use Raspberry Pi Camera
 

--- a/docs/en/integrations/openvino.md
+++ b/docs/en/integrations/openvino.md
@@ -374,7 +374,7 @@ To reproduce the Ultralytics benchmarks above on all export [formats](../modes/e
         yolo benchmark model=yolov8n.pt data=coco8.yaml
         ```
 
-    Note that benchmarking results might vary based on the exact hardware and software configuration of a system, as well as the current workload of the system at the time the benchmarks are run. For the most reliable results use a dataset with a large number of images, i.e. `data='coco128.yaml' (128 val images), or `data='coco.yaml'` (5000 val images).
+    Note that benchmarking results might vary based on the exact hardware and software configuration of a system, as well as the current workload of the system at the time the benchmarks are run. For the most reliable results use a dataset with a large number of images, i.e. `data='coco128.yaml'` (128 val images), or `data='coco.yaml'` (5000 val images).
 
 ## Conclusion
 


### PR DESCRIPTION
@glenn-jocher FYI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation update to improve dataset recommendations for benchmarking on NVIDIA Jetson, Raspberry Pi, and OpenVINO guides. 📚✨

### 📊 Key Changes
- Updated recommended dataset for benchmarking from `coco8.yaml` (4 images) to `coco128.yaml` (128 images) in the NVIDIA Jetson and Raspberry Pi guides.
- Fixed a formatting issue in the OpenVINO guide for consistency in dataset references.

### 🎯 Purpose & Impact
- Ensures users are guided to use more representative datasets (`coco128.yaml` or `coco.yaml`) for reliable benchmarking results.
- Helps users obtain more accurate and meaningful performance metrics.
- Improves clarity and consistency across documentation, making it easier for both new and experienced users to follow best practices. 🚀