### PR TITLE
`ultralytics 8.3.132` Always transfer `Conv` layer pretrained weights

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.131"
+__version__ = "8.3.132"
 
 import os
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -285,8 +285,11 @@ class BaseModel(torch.nn.Module):
         self.load_state_dict(updated_csd, strict=False)  # load
         first_conv = "model.0.conv.weight"
         if first_conv not in updated_csd:
-            channel = min(self.state_dict()[first_conv].shape[1], csd[first_conv].shape[1])
-            self.state_dict()[first_conv][:, :channel] = csd[first_conv][:, :channel]
+            c1, c2, h, w = self.state_dict()[first_conv].shape
+            cc1, cc2, ch, cw = csd[first_conv].shape
+            if ch == h and cw == w:
+                c1, c2 = min(c1, cc1), min(c2, cc2)
+                self.state_dict()[first_conv][:c1, :c2] = csd[first_conv][:c1, :c2]
         if verbose:
             LOGGER.info(f"Transferred {len(csd)}/{len(self.model.state_dict())} items from pretrained weights")
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -283,6 +283,7 @@ class BaseModel(torch.nn.Module):
         csd = model.float().state_dict()  # checkpoint state_dict as FP32
         updated_csd = intersect_dicts(csd, self.state_dict())  # intersect
         self.load_state_dict(updated_csd, strict=False)  # load
+        len_updated_csd = len(updated_csd)
         first_conv = "model.0.conv.weight"
         if first_conv not in updated_csd:
             c1, c2, h, w = self.state_dict()[first_conv].shape
@@ -290,8 +291,9 @@ class BaseModel(torch.nn.Module):
             if ch == h and cw == w:
                 c1, c2 = min(c1, cc1), min(c2, cc2)
                 self.state_dict()[first_conv][:c1, :c2] = csd[first_conv][:c1, :c2]
+                len_updated_csd += 1
         if verbose:
-            LOGGER.info(f"Transferred {len(csd)}/{len(self.model.state_dict())} items from pretrained weights")
+            LOGGER.info(f"Transferred {len_updated_csd}/{len(self.model.state_dict())} items from pretrained weights")
 
     def loss(self, batch, preds=None):
         """

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -285,7 +285,7 @@ class BaseModel(torch.nn.Module):
         self.load_state_dict(updated_csd, strict=False)  # load
         len_updated_csd = len(updated_csd)
         first_conv = "model.0.conv.weight"
-        if first_conv not in updated_csd:
+        if first_conv not in updated_csd:  # mostly used to boost multi-channel training
             c1, c2, h, w = self.state_dict()[first_conv].shape
             cc1, cc2, ch, cw = csd[first_conv].shape
             if ch == h and cw == w:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model weight loading for better support of multi-channel training in Ultralytics models. 🚀

### 📊 Key Changes
- Enhanced the model weight loading process to better handle cases where the first convolutional layer's weights differ in channel size.
- Now attempts to partially load compatible weights for the first convolutional layer if full matching isn't possible.
- Updated logging to accurately reflect the number of weights transferred during loading.
- Bumped version to 8.3.132.

### 🎯 Purpose & Impact
- Makes it easier to use pretrained weights when training on datasets with different input channel numbers (e.g., multi-channel images).
- Reduces errors and manual intervention when adapting models to new data types.
- Provides clearer feedback to users about the weight transfer process.
- Overall, this update improves flexibility and user experience for custom training scenarios. 💡