### PR TITLE
Exempt TODO PRs from stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -51,4 +51,5 @@ jobs:
           days-before-pr-stale: 90
           days-before-pr-close: 30
           exempt-issue-labels: "documentation,tutorial,TODO"
+          exempt-pr-labels: "TODO"
           operations-per-run: 300 # The maximum number of operations per run, used to control rate limiting.

--- a/examples/YOLO11-Triton-CPP/inference.cpp
+++ b/examples/YOLO11-Triton-CPP/inference.cpp
@@ -1,3 +1,5 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 #include "inference.hpp"
 #include <immintrin.h>
 #include <iostream>

--- a/examples/YOLO11-Triton-CPP/inference.hpp
+++ b/examples/YOLO11-Triton-CPP/inference.hpp
@@ -1,3 +1,5 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 #pragma once
 
 #include <opencv2/opencv.hpp>

--- a/examples/YOLO11-Triton-CPP/main.cpp
+++ b/examples/YOLO11-Triton-CPP/main.cpp
@@ -1,3 +1,5 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 #include "inference.hpp"
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added license headers to YOLO11 Triton C++ example files and improved PR workflow label handling. 📝🔖

### 📊 Key Changes
- Added Ultralytics AGPL-3.0 license header to all YOLO11-Triton-CPP example source files.
- Updated GitHub workflow to exempt pull requests labeled "TODO" from being marked stale or auto-closed.

### 🎯 Purpose & Impact
- Ensures proper licensing and legal clarity for example code, making usage terms clear to all users.
- Prevents important PRs labeled "TODO" from being accidentally closed, helping maintainers and contributors keep track of ongoing work.
- Improves project transparency and workflow efficiency for both developers and users.