### PR TITLE
Allow image compression `>178.9M` pixels

### DIFF
--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -736,7 +736,10 @@ def compress_one_image(f, f_new=None, max_dim=1920, quality=50):
         >>>    compress_one_image(f)
     """
     try:  # use PIL
+        Image.MAX_IMAGE_PIXELS = None  # Fix DecompressionBombError, allow optimization of image > ~178.9 million pixels
         im = Image.open(f)
+        if im.mode in ("RGBA", "LA"):  # Convert to RGB if needed (for JPEG)
+            im = im.convert("RGB")
         r = max_dim / max(im.height, im.width)  # ratio
         if r < 1.0:  # image too large
             im = im.resize((int(im.width * r), int(im.height * r)))

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -738,7 +738,7 @@ def compress_one_image(f, f_new=None, max_dim=1920, quality=50):
     try:  # use PIL
         Image.MAX_IMAGE_PIXELS = None  # Fix DecompressionBombError, allow optimization of image > ~178.9 million pixels
         im = Image.open(f)
-        if im.mode in ("RGBA", "LA"):  # Convert to RGB if needed (for JPEG)
+        if im.mode in {"RGBA", "LA"}:  # Convert to RGB if needed (for JPEG)
             im = im.convert("RGB")
         r = max_dim / max(im.height, im.width)  # ratio
         if r < 1.0:  # image too large


### PR DESCRIPTION
@glenn-jocher Hi, while compressing some images with `compress_one_image` function, I encountered a `DecompressionBombError` due to [PIL's default pixel limit](https://stackoverflow.com/a/56174985) (~178.9M pixels). This PR addresses the issue by setting `Image.MAX_IMAGE_PIXELS = None`, which allows users to safely process high-resolution images.

Additionally, I noticed that images with an alpha channel (`RGBA` or `LA`) were causing errors, likely due to incompatible formats when saving (e.g., as JPEG). I've added a mode check and a conversion to RGB to ensure compatibility and prevent those failures. Thanks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image compression handling for very large images and images with transparency. 🖼️✨

### 📊 Key Changes
- Disabled the PIL image size limit to prevent errors when processing extremely large images.
- Automatically converts images with transparency (like PNGs with alpha channels) to standard RGB before saving as JPEG.

### 🎯 Purpose & Impact
- Users can now compress very large images without running into errors.
- Ensures images with transparency are handled correctly, preventing issues when saving as JPEG.
- Makes the image compression feature more robust and user-friendly, especially for diverse image types and sizes.