### PR TITLE
Remove YOLOv10 from Raspberry Pi Benchmarks CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,8 +283,6 @@ jobs:
         run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-pose.pt' imgsz=160 verbose=0.197
       - name: Benchmark OBBModel
         run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-obb.pt' imgsz=160 verbose=0.597
-      - name: Benchmark YOLOv10Model
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolov10n.pt' imgsz=160 verbose=0.205
       - name: Benchmark Summary
         run: |
           cat benchmarks.log


### PR DESCRIPTION
@glenn-jocher this is to align with our other Benchmarks CIs. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Removes the YOLOv10 model benchmark from the continuous integration (CI) workflow. 🚀

### 📊 Key Changes  
- Deleted the step that benchmarks the YOLOv10 model (`yolov10n.pt`) in the CI pipeline.

### 🎯 Purpose & Impact  
- Streamlines the CI process by focusing on newer models like YOLO11.
- Reduces maintenance and testing time for outdated models.
- Ensures CI resources are dedicated to the latest features and improvements, benefiting both developers and users with faster, more relevant testing. ⚡