### PR TITLE
Update error hint to reference `coco8.yaml` instead of `dota8.yaml`

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -674,7 +674,7 @@ class v8OBBLoss(v8DetectionLoss):
             raise TypeError(
                 "ERROR ❌ OBB dataset incorrectly formatted or not a OBB dataset.\n"
                 "This error can occur when incorrectly training a 'OBB' model on a 'detect' dataset, "
-                "i.e. 'yolo train model=yolo11n-obb.pt data=dota8.yaml'.\nVerify your dataset is a "
+                "i.e. 'yolo train model=yolo11n-obb.pt data=coco8.yaml'.\nVerify your dataset is a "
                 "correctly formatted 'OBB' dataset using 'data=dota8.yaml' "
                 "as an example.\nSee https://docs.ultralytics.com/datasets/obb/ for help."
             ) from e


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved error message for OBB dataset formatting issues to provide clearer guidance to users. 📝

### 📊 Key Changes  
- Updated the example in the error message to use a more relevant dataset name (`coco8.yaml` instead of `dota8.yaml`) when warning about incorrect OBB dataset formatting.

### 🎯 Purpose & Impact  
- Helps users more easily identify and fix dataset formatting mistakes when training OBB models.
- Reduces confusion by providing a clearer, more accurate example in error messages.
- Enhances the overall user experience, especially for those new to OBB datasets.