### PR TITLE
Prevent `fitness` from `nan` values

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -788,7 +788,7 @@ class Metric(SimpleClass):
     def fitness(self):
         """Return model fitness as a weighted combination of metrics."""
         w = [0.0, 0.0, 0.1, 0.9]  # weights for [P, R, mAP@0.5, mAP@0.5:0.95]
-        return (np.array(self.mean_results()) * w).sum()
+        return (np.nan_to_num(np.array(self.mean_results())) * w).sum()
 
     def update(self, results):
         """


### PR DESCRIPTION
@glenn-jocher I was doing some exps the other day and found one of the training was somehow early-stopped while mAP was still increasing every epoch. 
Then I went check the log and found somehow the first `P` was `nan` hence the following code does not work properly:
https://github.com/ultralytics/ultralytics/blob/d64b6f254809c41d18e76b32add15cd529a1e487/ultralytics/utils/torch_utils.py#L929-L929
![pic-250512-2002-16](https://github.com/user-attachments/assets/9ac15125-8fbf-404a-9c95-7bd8ff74e2d0)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model fitness calculation to handle missing or invalid metric values more robustly. 🛠️

### 📊 Key Changes
- Updated the fitness calculation to safely handle cases where metric results may be missing or invalid (NaN values).
- Uses `np.nan_to_num` to convert any NaN values in the metrics to zero before calculating the fitness score.

### 🎯 Purpose & Impact
- Prevents errors or misleading results during model evaluation when some metrics are unavailable.
- Ensures more stable and reliable fitness scores, especially in edge cases.
- Improves user experience by reducing unexpected crashes or issues during training and evaluation.