### PR TITLE
Use `boats.jpg` for obb `predict` with Python code example

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -529,7 +529,7 @@ class Model(torch.nn.Module):
             - For SAM-type models, 'prompts' can be passed as a keyword argument.
         """
         if source is None:
-            source = ASSETS
+            source = "https://ultralytics.com/images/boats.jpg" if self.task =="obb" else ASSETS
             LOGGER.warning(f"'source' is missing. Using 'source={source}'.")
 
         is_cli = (ARGV[0].endswith("yolo") or ARGV[0].endswith("ultralytics")) and any(

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -529,7 +529,7 @@ class Model(torch.nn.Module):
             - For SAM-type models, 'prompts' can be passed as a keyword argument.
         """
         if source is None:
-            source = "https://ultralytics.com/images/boats.jpg" if self.task =="obb" else ASSETS
+            source = "https://ultralytics.com/images/boats.jpg" if self.task == "obb" else ASSETS
             LOGGER.warning(f"'source' is missing. Using 'source={source}'.")
 
         is_cli = (ARGV[0].endswith("yolo") or ARGV[0].endswith("ultralytics")) and any(


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved default image selection for OBB predictions in Ultralytics models. 🖼️✨

### 📊 Key Changes
- Updated the default image used when no input is provided for OBB (Oriented Bounding Box) tasks.
- Now uses a specific sample image ("boats.jpg") for OBB predictions instead of the generic default.

### 🎯 Purpose & Impact
- Ensures OBB models have a relevant example image for predictions, improving user experience.
- Reduces confusion by providing a task-appropriate default image, making it easier for users to test OBB features out-of-the-box.