### PR TITLE
Attempt to use `onnx` and `onnx2tf` latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
     "mkdocs-macros-plugin>=1.0.5"  # duplicating content (i.e. export tables) in multiple places
 ]
 export = [
-    "onnx>=1.12.0,<1.18.0", # ONNX export
+    "onnx>=1.12.0", # ONNX export
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -555,7 +555,7 @@ class Exporter:
     @try_export
     def export_onnx(self, prefix=colorstr("ONNX:")):
         """YOLO ONNX export."""
-        requirements = ["onnx>=1.12.0,<1.18.0"]
+        requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
             requirements += ["onnxslim>=0.1.46", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
ONNX export support updated to allow newer ONNX versions for improved compatibility and flexibility. 🚀

### 📊 Key Changes
- Removed the upper version limit for the ONNX dependency (now requires ONNX 1.12.0 or higher, no maximum).
- Updated ONNX export logic to match the new dependency range.

### 🎯 Purpose & Impact
- ✅ Allows users to install and use the latest ONNX versions, ensuring better compatibility with new features and bug fixes.
- 🔄 Reduces potential installation issues caused by version conflicts with other libraries.
- 💡 Makes the export process more future-proof for users working with ONNX models.