### PR TITLE
Attempt to fix `tflite` export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
     "mkdocs-macros-plugin>=1.0.5"  # duplicating content (i.e. export tables) in multiple places
 ]
 export = [
-    "onnx>=1.12.0,<1.18.0", # ONNX export
+    "onnx>=1.12.0", # ONNX export
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -390,7 +390,7 @@ class Exporter:
                 m.format = self.args.format
                 m.max_det = self.args.max_det
                 m.xyxy = self.args.nms and not coreml
-            elif isinstance(m, C2f) and not is_tf_format:
+            elif isinstance(m, C2f):
                 # EdgeTPU does not support FlexSplitV while split provides cleaner ONNX graph
                 m.forward = m.forward_split
             if isinstance(m, Detect) and imx:
@@ -555,7 +555,7 @@ class Exporter:
     @try_export
     def export_onnx(self, prefix=colorstr("ONNX:")):
         """YOLO ONNX export."""
-        requirements = ["onnx>=1.12.0,<1.18.0"]
+        requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
             requirements += ["onnxslim>=0.1.46", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update removes the upper version limit for the ONNX dependency, allowing support for newer ONNX releases in Ultralytics exports. 🚀

### 📊 Key Changes
- Removed the ONNX version cap (`<1.18.0`) in both the `pyproject.toml` and exporter code.
- Now requires only `onnx>=1.12.0`, enabling compatibility with the latest ONNX versions.

### 🎯 Purpose & Impact
- 🆕 Allows users to work with the latest ONNX releases, ensuring better compatibility and access to new features.
- 🔧 Reduces potential installation issues caused by version conflicts.
- 📦 Makes Ultralytics exports more future-proof and flexible for diverse environments.