### PR TITLE
Use `defaultdict` for classwise object counting

### DIFF
--- a/ultralytics/solutions/heatmap.py
+++ b/ultralytics/solutions/heatmap.py
@@ -99,7 +99,6 @@ class Heatmap(ObjectCounter):
             if self.region is not None:
                 self.annotator.draw_region(reg_pts=self.region, color=(104, 0, 123), thickness=self.line_width * 2)
                 self.store_tracking_history(track_id, box)  # Store track history
-                self.store_classwise_counts(cls)  # Store classwise counts in dict
                 # Get previous position if available
                 prev_position = None
                 if len(self.track_history[track_id]) > 1:
@@ -123,6 +122,6 @@ class Heatmap(ObjectCounter):
             plot_im=plot_im,
             in_count=self.in_count,
             out_count=self.out_count,
-            classwise_count=self.classwise_counts,
+            classwise_count=dict(self.classwise_counts),
             total_tracks=len(self.track_ids),
         )

--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -2,6 +2,7 @@
 
 from ultralytics.solutions.solutions import BaseSolution, SolutionAnnotator, SolutionResults
 from ultralytics.utils.plotting import colors
+from collections import defaultdict
 
 
 class ObjectCounter(BaseSolution):
@@ -22,7 +23,6 @@ class ObjectCounter(BaseSolution):
 
     Methods:
         count_objects: Counts objects within a polygonal or linear region.
-        store_classwise_counts: Initializes class-wise counts if not already present.
         display_counts: Displays object counts on the frame.
         process: Processes input data (frames or object tracks) and updates counts.
 
@@ -40,7 +40,7 @@ class ObjectCounter(BaseSolution):
         self.in_count = 0  # Counter for objects moving inward
         self.out_count = 0  # Counter for objects moving outward
         self.counted_ids = []  # List of IDs of objects that have been counted
-        self.classwise_counts = {}  # Dictionary for counts, categorized by object class
+        self.classwise_counts = defaultdict(lambda: {"IN": 0, "OUT": 0})  # Dictionary for counts, categorized by class
         self.region_initialized = False  # Flag indicating whether the region has been initialized
 
         self.show_in = self.CFG["show_in"]
@@ -110,22 +110,6 @@ class ObjectCounter(BaseSolution):
                     self.classwise_counts[self.names[cls]]["OUT"] += 1
                 self.counted_ids.append(track_id)
 
-    def store_classwise_counts(self, cls):
-        """
-        Initialize class-wise counts for a specific object class if not already present.
-
-        Args:
-            cls (int): Class index for classwise count updates.
-
-        Examples:
-            >>> counter = ObjectCounter()
-            >>> counter.store_classwise_counts(0)  # Initialize counts for class index 0
-            >>> print(counter.classwise_counts)
-            {'person': {'IN': 0, 'OUT': 0}}
-        """
-        if self.names[cls] not in self.classwise_counts:
-            self.classwise_counts[self.names[cls]] = {"IN": 0, "OUT": 0}
-
     def display_counts(self, plot_im):
         """
         Display object counts on the input image or frame.
@@ -189,7 +173,6 @@ class ObjectCounter(BaseSolution):
                 box, label=self.adjust_box_label(cls, conf, track_id), color=colors(cls, True), rotated=is_obb
             )
             self.store_tracking_history(track_id, box, is_obb=is_obb)  # Store track history
-            self.store_classwise_counts(cls)  # Store classwise counts in dict
 
             # Store previous position of track for object counting
             prev_position = None
@@ -206,6 +189,6 @@ class ObjectCounter(BaseSolution):
             plot_im=plot_im,
             in_count=self.in_count,
             out_count=self.out_count,
-            classwise_count=self.classwise_counts,
+            classwise_count=dict(self.classwise_counts),
             total_tracks=len(self.track_ids),
         )

--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -1,8 +1,9 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+from collections import defaultdict
+
 from ultralytics.solutions.solutions import BaseSolution, SolutionAnnotator, SolutionResults
 from ultralytics.utils.plotting import colors
-from collections import defaultdict
 
 
 class ObjectCounter(BaseSolution):


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved object counting in heatmap and object counter solutions by simplifying class-wise counting logic and making results more consistent. 🚀

### 📊 Key Changes
- Removed the `store_classwise_counts` method and related calls from both heatmap and object counter modules.
- Replaced manual class-wise count initialization with Python's `defaultdict` for automatic handling.
- Ensured class-wise counts are always returned as regular dictionaries for compatibility.

### 🎯 Purpose & Impact
- 🧹 **Cleaner Code:** Reduces redundant code and simplifies how class-wise object counts are managed.
- ⚡ **More Reliable Counting:** Automatically initializes class counts, preventing errors if a new class appears.
- 🤝 **Consistent Output:** Guarantees that results are always in a standard dictionary format, making integration and usage easier for developers and users.