### PR TITLE
Add `to_sql` and `to_html` in pytests `test_results` method

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -271,10 +271,12 @@ def test_results(model):
         r = r.to(device="cpu", dtype=torch.float32)
         r.save_txt(txt_file=TMP / "runs/tests/label.txt", save_conf=True)
         r.save_crop(save_dir=TMP / "runs/tests/crops/")
-        r.to_json(normalize=True)
         r.to_df(decimals=3)
         r.to_csv()
         r.to_xml()
+        r.to_html()
+        r.to_json(normalize=True)
+        r.to_sql()
         r.plot(pil=True, save=True, filename=TMP / "results_plot_save.jpg")
         r.plot(conf=True, boxes=True)
         print(r, len(r), r.path)  # print after methods

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -271,7 +271,7 @@ def test_results(model):
         r = r.to(device="cpu", dtype=torch.float32)
         r.save_txt(txt_file=TMP / "runs/tests/label.txt", save_conf=True)
         r.save_crop(save_dir=TMP / "runs/tests/crops/")
-        r.to_df(decimals=3)
+        r.to_df(decimals=3)  # Align to_ methods: https://docs.ultralytics.com/modes/predict/#working-with-results
         r.to_csv()
         r.to_xml()
         r.to_html()


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Expanded test coverage for YOLO results export formats, ensuring more robust and versatile output options. 🧪✨

### 📊 Key Changes
- Added tests for new results export methods: `to_html()` and `to_sql()`.
- Adjusted the order of some export method tests for better alignment with documentation.
- Ensured all major export formats (CSV, XML, HTML, JSON, SQL) are tested.

### 🎯 Purpose & Impact
- Improves reliability by verifying that results can be exported in multiple formats, including HTML and SQL.
- Helps users confidently use different export options for their YOLO results.
- Keeps tests up-to-date with the latest features, supporting a smoother user experience and easier troubleshooting.