### PR TITLE
Fix `cv2.waitKey` in solutions for Docker tests

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -711,7 +711,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
 
         solution = getattr(solutions, SOLUTION_MAP[solution_name])(is_cli=True, **overrides)  # class i.e ObjectCounter
 
-                cap = cv2.VideoCapture(solution.CFG["source"])  # read the video file
+        cap = cv2.VideoCapture(solution.CFG["source"])  # read the video file
         if solution_name != "crop":
             # extract width, height and fps of the video file, create save directory and initialize video writer
             w, h, fps = (

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -733,9 +733,8 @@ def handle_yolo_solutions(args: List[str]) -> None:
                 results = solution(frame, f_n := f_n + 1) if solution_name == "analytics" else solution(frame)
                 if solution_name != "crop":
                     vw.write(results.plot_im)
-                if show:
-                    if cv2.waitKey(1) & 0xFF == ord("q"):
-                        break
+                if show and cv2.waitKey(1) & 0xFF == ord("q"):
+                    break
         finally:
             cap.release()
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -711,7 +711,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
 
         solution = getattr(solutions, SOLUTION_MAP[solution_name])(is_cli=True, **overrides)  # class i.e ObjectCounter
 
-        cap = cv2.VideoCapture(solution.CFG["source"])  # read the video file
+                cap = cv2.VideoCapture(solution.CFG["source"])  # read the video file
         if solution_name != "crop":
             # extract width, height and fps of the video file, create save directory and initialize video writer
             w, h, fps = (
@@ -732,8 +732,9 @@ def handle_yolo_solutions(args: List[str]) -> None:
                 results = solution(frame, f_n := f_n + 1) if solution_name == "analytics" else solution(frame)
                 if solution_name != "crop":
                     vw.write(results.plot_im)
-                if cv2.waitKey(1) & 0xFF == ord("q"):
-                    break
+                if solution.CFG["show"]:
+                    if cv2.waitKey(1) & 0xFF == ord("q"):
+                        break
         finally:
             cap.release()
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -723,6 +723,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
             save_dir.mkdir(parents=True)  # create the output directory i.e. runs/solutions/exp
             vw = cv2.VideoWriter(str(save_dir / f"{solution_name}.avi"), cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
 
+        show = solution.CFG["show"]
         try:  # Process video frames
             f_n = 0  # frame number, required for analytical graphs
             while cap.isOpened():
@@ -732,7 +733,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
                 results = solution(frame, f_n := f_n + 1) if solution_name == "analytics" else solution(frame)
                 if solution_name != "crop":
                     vw.write(results.plot_im)
-                if solution.CFG["show"]:
+                if show:
                     if cv2.waitKey(1) & 0xFF == ord("q"):
                         break
         finally:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -723,7 +723,6 @@ def handle_yolo_solutions(args: List[str]) -> None:
             save_dir.mkdir(parents=True)  # create the output directory i.e. runs/solutions/exp
             vw = cv2.VideoWriter(str(save_dir / f"{solution_name}.avi"), cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
 
-        show = solution.CFG["show"]
         try:  # Process video frames
             f_n = 0  # frame number, required for analytical graphs
             while cap.isOpened():
@@ -733,7 +732,7 @@ def handle_yolo_solutions(args: List[str]) -> None:
                 results = solution(frame, f_n := f_n + 1) if solution_name == "analytics" else solution(frame)
                 if solution_name != "crop":
                     vw.write(results.plot_im)
-                if show and cv2.waitKey(1) & 0xFF == ord("q"):
+                if solution.CFG["show"] and cv2.waitKey(1) & 0xFF == ord("q"):
                     break
         finally:
             cap.release()


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved video processing behavior in YOLO Solutions by making the quit option conditional on display settings. 🎬✨

### 📊 Key Changes  
- The ability to quit video processing with the "q" key now only works if the results are being displayed (`show` is enabled).

### 🎯 Purpose & Impact  
- Prevents unnecessary checks for user input when video display is off, making processing more efficient.
- Reduces potential confusion for users running headless or automated tasks, as the quit option is only available when relevant.
- Enhances overall user experience and resource management during video analysis.