### PR TITLE
Cache `check_font` result

### DIFF
--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -297,7 +297,7 @@ def check_pip_update_available():
 
 
 @ThreadingLocked()
-@functools.cache
+@functools.lru_cache
 def check_font(font="Arial.ttf"):
     """
     Find font locally or download to user's configuration directory if it does not already exist.

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -1,5 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import functools
 import glob
 import inspect
 import math
@@ -296,6 +297,7 @@ def check_pip_update_available():
 
 
 @ThreadingLocked()
+@functools.cache
 def check_font(font="Arial.ttf"):
     """
     Find font locally or download to user's configuration directory if it does not already exist.


### PR DESCRIPTION
When using `yolo predict`, > 90 % of time is spent in `check_font` on my machine. It also seems to have quadratic runtime.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved font checking performance by adding caching to the font lookup function. 🚀

### 📊 Key Changes
- Added caching (`lru_cache`) to the `check_font` function, which checks for and downloads fonts if needed.

### 🎯 Purpose & Impact
- ⚡ Speeds up repeated font checks by avoiding redundant file lookups and downloads.
- 🖼️ Enhances efficiency for users who frequently use features that require font validation.
- 💡 Results in a smoother and faster experience, especially in workflows involving multiple font operations.