### PR TITLE
Potential fixes for Actions code scanning alerts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: write # Modify code in PRs
+
 jobs:
   Docs:
     if: github.repository == 'ultralytics/ultralytics'

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -11,6 +11,9 @@ on:
   #   branches:
   #     - ${{ github.event.repository.default_branch }}
 
+permissions:
+  contents: write # Modify code in PRs
+
 jobs:
   Merge:
     if: github.repository == 'ultralytics/ultralytics'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,8 @@ jobs:
     needs: [check, publish]
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Extract PR Details


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/ultralytics/security/code-scanning/21](https://github.com/ultralytics/ultralytics/security/code-scanning/21)

To fix the issue, we will add a `permissions` block to the `notify` job. Since the job only needs to read repository contents and does not perform any write operations, we will set `contents: read` as the minimal required permission. This change ensures that the job has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub workflow permissions for better automation and security in the Ultralytics repository. 🚀🔒

### 📊 Key Changes
- Added explicit `contents: write` permissions to documentation and PR merge workflows.
- Set `contents: read` permission for the publish workflow.

### 🎯 Purpose & Impact
- Enhances security by specifying the minimum required permissions for each workflow.
- Ensures workflows can perform necessary actions, like updating docs or merging code, without granting excessive access.
- Reduces risk of unintended changes and aligns with GitHub best practices for workflow permissions.