### PR TITLE
Fix invalid task information on warning 

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -919,7 +919,7 @@ def entrypoint(debug: str = "") -> None:
         if task not in TASKS:
             if task == "track":
                 LOGGER.warning(
-                    "invalid 'task=track', setting 'task=detect' and 'mode=track'. Valid tasks are {TASKS}.\n{CLI_HELP_MSG}."
+                    f"invalid 'task=track', setting 'task=detect' and 'mode=track'. Valid tasks are {TASKS}.\n{CLI_HELP_MSG}."
                 )
                 task, mode = "detect", "track"
             else:


### PR DESCRIPTION
# PR Summary
This small PR fixes the warning message to evaluate and display the invalid task information.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved warning message formatting for invalid 'track' task selection in the CLI.

### 📊 Key Changes
- Fixed the warning message to correctly display the list of valid tasks and help text when users enter an invalid 'track' task.

### 🎯 Purpose & Impact
- Ensures users see accurate and helpful information if they mistakenly use 'track' as a task, making troubleshooting easier.
- Enhances the overall user experience by providing clearer guidance in the command-line interface. 🚀