### PR TITLE
Disable similarity search tests on RaspberryPI

### DIFF
--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -300,6 +300,7 @@ def test_streamlit_handle_video_upload_creates_file():
     os.remove("ultralytics.mp4")
 
 
+@pytest.mark.skipif(IS_RASPBERRYPI, reason="Disabled due to slow performance on Raspberry Pi.")
 def test_similarity_search_app_init():
     """Test SearchApp initializes with required attributes."""
     app = solutions.SearchApp(device="cpu")
@@ -307,6 +308,7 @@ def test_similarity_search_app_init():
     assert hasattr(app, "run")
 
 
+@pytest.mark.skipif(IS_RASPBERRYPI, reason="Disabled due to slow performance on Raspberry Pi.")
 def test_similarity_search_complete(tmp_path):
     """Test VisualAISearch end-to-end with sample image and query."""
     from PIL import Image


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves test reliability by skipping slow tests on Raspberry Pi devices. 🥧🚀

### 📊 Key Changes
- Added a condition to skip two specific tests when running on Raspberry Pi due to slow performance.

### 🎯 Purpose & Impact
- Ensures test runs are faster and more reliable on Raspberry Pi.
- Prevents unnecessary test failures or timeouts on slower hardware.
- Makes the development and testing process smoother for users working with Raspberry Pi devices.