### PR TITLE
Remove `IS_PYTHON_3_11` constant

### DIFF
--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -180,10 +180,7 @@ def process_video(solution, video_path, needs_frame_count=False):
     cap.release()
 
 
-@pytest.mark.skipif(
-    LINUX or IS_RASPBERRYPI,
-    reason="Disabled for testing due to --slow test errors after YOLOE PR.",
-)
+@pytest.mark.skipif(IS_RASPBERRYPI, reason="Disabled for testing due to --slow test errors after YOLOE PR.")
 @pytest.mark.parametrize("name, solution_class, needs_frame_count, video, kwargs", SOLUTIONS)
 def test_solution(name, solution_class, needs_frame_count, video, kwargs):
     """Test individual Ultralytics solution."""

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests import MODEL, TMP
 from ultralytics import solutions
-from ultralytics.utils import ASSETS_URL, IS_RASPBERRYPI, LINUX, checks
+from ultralytics.utils import ASSETS_URL, IS_RASPBERRYPI, checks
 from ultralytics.utils.downloads import safe_download
 
 # Pre-defined arguments values

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -181,7 +181,7 @@ def process_video(solution, video_path, needs_frame_count=False):
 
 
 @pytest.mark.skipif(
-    (LINUX and checks.IS_PYTHON_3_11) or IS_RASPBERRYPI,
+    LINUX or IS_RASPBERRYPI,
     reason="Disabled for testing due to --slow test errors after YOLOE PR.",
 )
 @pytest.mark.parametrize("name, solution_class, needs_frame_count, video, kwargs", SOLUTIONS)

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -901,7 +901,6 @@ check_torchvision()  # check torch-torchvision compatibility
 
 # Define constants
 IS_PYTHON_3_8 = PYTHON_VERSION.startswith("3.8")
-IS_PYTHON_3_11 = PYTHON_VERSION.startswith("3.11")
 IS_PYTHON_3_12 = PYTHON_VERSION.startswith("3.12")
 IS_PYTHON_3_13 = PYTHON_VERSION.startswith("3.13")
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplifies test conditions by removing a Python version check, making the test suite cleaner and easier to maintain. 🧹

### 📊 Key Changes
- Removed the `IS_PYTHON_3_11` constant from the codebase.
- Updated the test for Ultralytics solutions to skip only on Raspberry Pi, not specifically on Linux with Python 3.11.

### 🎯 Purpose & Impact
- **Easier Maintenance:** Reduces unnecessary complexity in test conditions, making the codebase simpler.
- **Broader Test Coverage:** Tests will now run on more Linux environments, including those using Python 3.11, unless on Raspberry Pi.
- **Fewer Skipped Tests:** Users and developers benefit from more comprehensive testing, helping catch issues earlier.