### PR TITLE
Handle legacy `CenterCrop` in Classify prediction

### DIFF
--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -57,7 +57,7 @@ class ClassificationPredictor(BasePredictor):
         super().setup_source(source)
         updated = (
             self.model.model.transforms.transforms[0].size != max(self.imgsz)
-            if hasattr(self.model.model, "transforms") and hasattr(self.model.model.transforms.transform[0], "size")
+            if hasattr(self.model.model, "transforms") and hasattr(self.model.model.transforms.transforms[0], "size")
             else True
         )
         self.transforms = self.model.model.transforms if not updated else classify_transforms(self.imgsz)

--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -57,7 +57,7 @@ class ClassificationPredictor(BasePredictor):
         super().setup_source(source)
         updated = (
             self.model.model.transforms.transforms[0].size != max(self.imgsz)
-            if hasattr(self.model.model, "transforms") and hasattr(self.model.model.transforms[0], "size")
+            if hasattr(self.model.model, "transforms") and hasattr(self.model.model.transforms.transform[0], "size")
             else True
         )
         self.transforms = self.model.model.transforms if not updated else classify_transforms(self.imgsz)

--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -57,7 +57,7 @@ class ClassificationPredictor(BasePredictor):
         super().setup_source(source)
         updated = (
             self.model.model.transforms.transforms[0].size != max(self.imgsz)
-            if hasattr(self.model.model, "transforms")
+            if hasattr(self.model.model, "transforms") and hasattr(self.model.model.transforms[0], "size")
             else True
         )
         self.transforms = self.model.model.transforms if not updated else classify_transforms(self.imgsz)


### PR DESCRIPTION
Closes #20697 

Seems like older checkpoints use the Ultralytics version of `CenterCrop`

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in image classification prediction by safely checking for transform size attributes. 🛡️

### 📊 Key Changes
- Enhanced the code to check if the image transform has a "size" attribute before accessing it, preventing potential errors.

### 🎯 Purpose & Impact
- Prevents crashes or unexpected behavior when certain image transforms lack a "size" attribute.
- Makes the classification prediction process more reliable and user-friendly, especially when using custom or varied models.