### PR TITLE
Add warning for `masks` is None

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -162,14 +162,6 @@ def test_predict_grey_and_4ch():
         f.unlink()  # cleanup
 
 
-def test_mask_is_none():
-    """Test instance segmentation model with no mask return."""
-    im = np.zeros((480, 640, 3), dtype=np.uint8)
-    model = YOLO("yolo11n-seg.pt")
-    results = model.predict(im, classes=0)  # Run predictions with class filter
-    assert results[0].masks is not None, "No masks returned, expected at least one mask."
-
-
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(is_github_action_running(), reason="No auth https://github.com/JuanBindez/pytubefix/issues/166")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -162,6 +162,14 @@ def test_predict_grey_and_4ch():
         f.unlink()  # cleanup
 
 
+def test_mask_is_none():
+    """Test instance segmentation model with no mask return"""
+    im = np.zeros((480, 640, 3), dtype=np.uint8)
+    model = YOLO("yolo11n-seg.pt")
+    results = model.predict(im, classes=0)  # Run predictions with class filter
+    assert results[0].masks is not None, "No masks returned, expected at least one mask."
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(is_github_action_running(), reason="No auth https://github.com/JuanBindez/pytubefix/issues/166")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -163,7 +163,7 @@ def test_predict_grey_and_4ch():
 
 
 def test_mask_is_none():
-    """Test instance segmentation model with no mask return"""
+    """Test instance segmentation model with no mask return."""
     im = np.zeros((480, 640, 3), dtype=np.uint8)
     model = YOLO("yolo11n-seg.pt")
     results = model.predict(im, classes=0)  # Run predictions with class filter

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -266,7 +266,15 @@ class Results(SimpleClass, DataExportMixin):
         self.orig_img = orig_img
         self.orig_shape = orig_img.shape[:2]
         self.boxes = Boxes(boxes, self.orig_shape) if boxes is not None else None  # native size boxes
-        self.masks = Masks(masks, self.orig_shape) if masks is not None else None  # native size or imgsz masks
+        if masks is not None:
+            self.masks = Masks(masks, self.orig_shape)  # native size or imgsz masks
+        else:
+            LOGGER.warning(
+                "No segmentation masks found. This usually occurs when using a detection model for inference,\n"
+                "e.g. `yolo segment predict model=yolo11n.pt`, or when the model can't segment the given class.\n"
+                "Accessing masks[0].xy or masks[0].xyn will not work in this case."
+            )
+            self.masks = None
         self.probs = Probs(probs) if probs is not None else None
         self.keypoints = Keypoints(keypoints, self.orig_shape) if keypoints is not None else None
         self.obb = OBB(obb, self.orig_shape) if obb is not None else None


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved handling and clearer warnings for missing segmentation masks during inference. 🛡️

### 📊 Key Changes
- Added a warning message when segmentation masks are missing during inference.
- Clarified why masks might be missing (e.g., using a detection model or unsupported classes).
- Ensured users are informed that accessing mask attributes will not work if masks are absent.

### 🎯 Purpose & Impact
- Helps users quickly understand why segmentation masks are missing, reducing confusion. 🤔
- Prevents errors by warning users before they try to access unavailable mask data.
- Improves overall user experience and debugging for segmentation tasks. 🚀