### PR TITLE
Remove broken link in `view-results-in-terminal.md`

### DIFF
--- a/docs/en/guides/view-results-in-terminal.md
+++ b/docs/en/guides/view-results-in-terminal.md
@@ -20,7 +20,7 @@ When connecting to a remote machine, normally visualizing image results is not p
 
     Only compatible with Linux and MacOS. Check the [VSCode repository](https://github.com/microsoft/vscode), check [Issue status](https://github.com/microsoft/vscode/issues/198622), or [documentation](https://code.visualstudio.com/docs) for updates about Windows support to view images in terminal with `sixel`.
 
-The VSCode compatible protocols for viewing images using the integrated terminal are [`sixel`](https://en.wikipedia.org/wiki/Sixel) and [`iTerm`](https://iterm2.com/documentation-images.html). This guide will demonstrate use of the `sixel` protocol.
+The VSCode compatible protocols for viewing images using the integrated terminal are [`sixel`](https://en.wikipedia.org/wiki/Sixel) and iTerm. This guide will demonstrate use of the `sixel` protocol.
 
 ## Process
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation update clarifying image viewing protocols in the terminal guide. 📝

### 📊 Key Changes
- Removed an unnecessary hyperlink from the mention of "iTerm" in the documentation about viewing results in the terminal.

### 🎯 Purpose & Impact
- Makes the documentation cleaner and more consistent.
- Reduces potential confusion for users by streamlining references.
- No impact on code or features—this is a documentation-only change.