### PR TITLE
Disable `setMouseCallback` where `imshow` not supported

### DIFF
--- a/ultralytics/solutions/distance_calculation.py
+++ b/ultralytics/solutions/distance_calculation.py
@@ -118,7 +118,8 @@ class DistanceCalculation(BaseSolution):
         self.centroids = []  # Reset centroids for next frame
         plot_im = annotator.result()
         self.display_output(plot_im)  # Display output with base class function
-        cv2.setMouseCallback("Ultralytics Solutions", self.mouse_event_for_distance)
+        if self.CFG.get("show") and self.env_check:
+            cv2.setMouseCallback("Ultralytics Solutions", self.mouse_event_for_distance)
 
         # Return SolutionResults with processed image and calculated metrics
         return SolutionResults(plot_im=plot_im, pixels_distance=pixels_distance, total_tracks=len(self.track_ids))


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved display logic for distance calculation by making mouse interaction conditional on display settings. 🖱️🖼️

### 📊 Key Changes
- Mouse event handling for distance measurement is now only enabled if display is active and the environment supports it.
- Prevents unnecessary mouse callbacks when output is not shown.

### 🎯 Purpose & Impact
- Reduces potential errors or unnecessary processing when running in headless or non-GUI environments.
- Makes the distance calculation solution more robust and user-friendly, especially for automated or server-side use cases.