### PR TITLE
Remove `is_obb` usage from `store_tracking_history`

### DIFF
--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -171,7 +171,7 @@ class ObjectCounter(BaseSolution):
         for box, track_id, cls, conf in zip(self.boxes, self.track_ids, self.clss, self.confs):
             # Draw bounding box and counting region
             self.annotator.box_label(box, label=self.adjust_box_label(cls, conf, track_id), color=colors(cls, True))
-            self.store_tracking_history(track_id, box, is_obb=is_obb)  # Store track history
+            self.store_tracking_history(track_id, box)  # Store track history
 
             # Store previous position of track for object counting
             prev_position = None

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -148,7 +148,7 @@ class BaseSolution:
             self.LOGGER.warning("no tracks found!")
             self.boxes, self.clss, self.track_ids, self.confs = [], [], [], []
 
-    def store_tracking_history(self, track_id, box, is_obb=False):
+    def store_tracking_history(self, track_id, box):
         """
         Stores the tracking history of an object.
 
@@ -158,7 +158,6 @@ class BaseSolution:
         Args:
             track_id (int): The unique identifier for the tracked object.
             box (List[float]): The bounding box coordinates of the object in the format [x1, y1, x2, y2].
-            is_obb (bool): True if OBB model is used (applies to object counting only).
 
         Examples:
             >>> solution = BaseSolution()
@@ -166,7 +165,7 @@ class BaseSolution:
         """
         # Store tracking history
         self.track_line = self.track_history[track_id]
-        self.track_line.append(tuple(box.mean(dim=0)) if is_obb else (box[:4:2].mean(), box[1:4:2].mean()))
+        self.track_line.append(tuple(box.mean(dim=0)) if box.numel() > 4 else (box[:4:2].mean(), box[1:4:2].mean()))
         if len(self.track_line) > 30:
             self.track_line.pop(0)
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved object tracking history logic in the object counter solution for more robust and flexible tracking. 🧮✨

### 📊 Key Changes
- Removed the `is_obb` parameter from the `store_tracking_history` method, simplifying its usage.
- Updated tracking history logic to automatically handle different box formats based on their size, making it more adaptable.
- Cleaned up related code and documentation for clarity.

### 🎯 Purpose & Impact
- **Easier Integration:** Developers no longer need to specify if a box is an oriented bounding box (OBB); the method now detects this automatically.
- **More Robust Tracking:** The solution is now better equipped to handle various bounding box types, reducing potential errors.
- **Cleaner Code:** Simplified method signatures and improved documentation make the codebase easier to maintain and understand.

This update makes object counting and tracking in Ultralytics solutions more user-friendly and reliable! 🚀