### PR TITLE
Clean up: use `{}` instead of `set([])`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,6 @@ def test_special_modes() -> None:
     run("yolo version")
     run("yolo settings reset")
     run("yolo cfg")
-    run("yolo benchmark model=yolo11n.pt data=coco8.yaml format=onnx")  # For functionality check only benchmark onnx.
 
 
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ def test_special_modes() -> None:
     run("yolo cfg")
     run("yolo benchmark model=yolo11n.pt data=coco8.yaml format=onnx")  # For functioonality check only benchmark onnx.
 
+
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)
 def test_train(task: str, model: str, data: str) -> None:
     """Test YOLO training for different tasks, models, and datasets."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def test_special_modes() -> None:
     run("yolo version")
     run("yolo settings reset")
     run("yolo cfg")
-    run("yolo benchmark model=yolo11n.pt data=coco8.yaml format=onnx")  # For functioonality check only benchmark onnx.
+    run("yolo benchmark model=yolo11n.pt data=coco8.yaml format=onnx")  # For functionality check only benchmark onnx.
 
 
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def test_special_modes() -> None:
     run("yolo version")
     run("yolo settings reset")
     run("yolo cfg")
-
+    run("yolo benchmark model=yolo11n.pt data=coco8.yaml format=onnx")  # For functioonality check only benchmark onnx.
 
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)
 def test_train(task: str, model: str, data: str) -> None:

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -674,7 +674,7 @@ class Model(torch.nn.Module):
         args = {**DEFAULT_CFG_DICT, **self.model.args, **custom, **kwargs, "mode": "benchmark"}
         fmts = export_formats()
         export_args = set(dict(zip(fmts["Argument"], fmts["Arguments"])).get(format, []))
-        export_kwargs = {k: v for k, v in args.items() if k in export_args - {"batch"}}
+        export_kwargs = {k: v for k, v in args.items() if k in export_args - set(["batch"])}
         return benchmark(
             model=self,
             data=data,  # if no 'data' argument passed set data=None for default datasets

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -673,8 +673,8 @@ class Model(torch.nn.Module):
         custom = {"verbose": False}  # method defaults
         args = {**DEFAULT_CFG_DICT, **self.model.args, **custom, **kwargs, "mode": "benchmark"}
         fmts = export_formats()
-        export_args = set(dict(zip(fmts["Argument"], fmts["Arguments"])).get(format, []))
-        export_kwargs = {k: v for k, v in args.items() if k in export_args - {"batch"}}
+        export_args = set(dict(zip(fmts["Argument"], fmts["Arguments"])).get(format, [])) - {"batch"}
+        export_kwargs = {k: v for k, v in args.items() if k in export_args}
         return benchmark(
             model=self,
             data=data,  # if no 'data' argument passed set data=None for default datasets

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -674,7 +674,7 @@ class Model(torch.nn.Module):
         args = {**DEFAULT_CFG_DICT, **self.model.args, **custom, **kwargs, "mode": "benchmark"}
         fmts = export_formats()
         export_args = set(dict(zip(fmts["Argument"], fmts["Arguments"])).get(format, []))
-        export_kwargs = {k: v for k, v in args.items() if k in export_args - set(["batch"])}
+        export_kwargs = {k: v for k, v in args.items() if k in export_args - {"batch"}}
         return benchmark(
             model=self,
             data=data,  # if no 'data' argument passed set data=None for default datasets


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the model benchmarking process by refining how export arguments are handled for different formats. ⚡

### 📊 Key Changes
- Adjusted the way export arguments are filtered during benchmarking to exclude the "batch" argument more cleanly.
- Simplified the logic for passing relevant arguments to the export function.

### 🎯 Purpose & Impact
- Ensures only valid arguments are passed during model export, reducing the risk of errors. ✅
- Makes the benchmarking process more robust and maintainable for users working with different export formats. 🛠️
- Enhances reliability when benchmarking models in YOLO11, YOLO12, and future versions. 🚀