### PR TITLE
Add optional `re_id` argument with `model.track` method

### DIFF
--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -183,12 +183,12 @@ By default, ReID is turned off to minimize performance overhead. Enabling it is 
 
         ```python
         from ultralytics import YOLO
-        
+
         # Load the model
         model = YOLO("yolo11n.pt")
-        
+
         # Enable re-identification with reid=True
-        results = model.track(source="https://youtu.be/LNwODJXcvt4", with_reid=True)  
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", with_reid=True)
         ```
 
 You can also customize the `model` used for ReID, allowing you to trade off accuracy and speed depending on your use case:

--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -175,7 +175,23 @@ The following table provides a description of each parameter:
 
 ### Enabling Re-Identification (ReID)
 
-By default, ReID is turned off to minimize performance overhead. Enabling it is simple—just set `with_reid: True` in the [tracker configuration](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/trackers/botsort.yaml). You can also customize the `model` used for ReID, allowing you to trade off accuracy and speed depending on your use case:
+By default, ReID is turned off to minimize performance overhead. Enabling it is simple—just set `with_reid: True` in the [tracker configuration](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/trackers/botsort.yaml) or you can use mentioned code to enable it.
+
+!!! example
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+        
+        # Load the model and run the tracker with a custom configuration file
+        model = YOLO("yolo11n.pt")
+        
+        # Enable re-identification with reid=True
+        results = model.track(source="https://youtu.be/LNwODJXcvt4", with_reid=True)  
+        ```
+
+You can also customize the `model` used for ReID, allowing you to trade off accuracy and speed depending on your use case:
 
 - **Native features (`model: auto`)**: This leverages features directly from the YOLO detector for ReID, adding minimal overhead. It's ideal when you need some level of ReID without significantly impacting performance. If the detector doesn't support native features, it automatically falls back to using `yolo11n-cls.pt`.
 - **YOLO classification models**: You can explicitly set a classification model (e.g. `yolo11n-cls.pt`) for ReID feature extraction. This provides more discriminative embeddings, but introduces additional latency due to the extra inference step.

--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -184,7 +184,7 @@ By default, ReID is turned off to minimize performance overhead. Enabling it is 
         ```python
         from ultralytics import YOLO
         
-        # Load the model and run the tracker with a custom configuration file
+        # Load the model
         model = YOLO("yolo11n.pt")
         
         # Enable re-identification with reid=True

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,6 +1,5 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-
 import contextlib
 import csv
 import urllib

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -38,141 +38,141 @@ from ultralytics.utils.torch_utils import TORCH_1_9
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 
 
-# def test_model_forward():
-#     """Test the forward pass of the YOLO model."""
-#     model = YOLO(CFG)
-#     model(source=None, imgsz=32, augment=True)  # also test no source and augment
-#
-#
-# def test_model_methods():
-#     """Test various methods and properties of the YOLO model to ensure correct functionality."""
-#     model = YOLO(MODEL)
-#
-#     # Model methods
-#     model.info(verbose=True, detailed=True)
-#     model = model.reset_weights()
-#     model = model.load(MODEL)
-#     model.to("cpu")
-#     model.fuse()
-#     model.clear_callback("on_train_start")
-#     model.reset_callbacks()
-#
-#     # Model properties
-#     _ = model.names
-#     _ = model.device
-#     _ = model.transforms
-#     _ = model.task_map
-#
-#
-# def test_model_profile():
-#     """Test profiling of the YOLO model with `profile=True` to assess performance and resource usage."""
-#     from ultralytics.nn.tasks import DetectionModel
-#
-#     model = DetectionModel()  # build model
-#     im = torch.randn(1, 3, 64, 64)  # requires min imgsz=64
-#     _ = model.predict(im, profile=True)
-#
-#
-# @pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
-# def test_predict_txt():
-#     """Test YOLO predictions with file, directory, and pattern sources listed in a text file."""
-#     file = TMP / "sources_multi_row.txt"
-#     with open(file, "w") as f:
-#         for src in SOURCES_LIST:
-#             f.write(f"{src}\n")
-#     results = YOLO(MODEL)(source=file, imgsz=32)
-#     assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
-#
-#
-# @pytest.mark.skipif(True, reason="disabled for testing")
-# @pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
-# def test_predict_csv_multi_row():
-#     """Test YOLO predictions with sources listed in multiple rows of a CSV file."""
-#     file = TMP / "sources_multi_row.csv"
-#     with open(file, "w", newline="") as f:
-#         writer = csv.writer(f)
-#         writer.writerow(["source"])
-#         writer.writerows([[src] for src in SOURCES_LIST])
-#     results = YOLO(MODEL)(source=file, imgsz=32)
-#     assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
-#
-#
-# @pytest.mark.skipif(True, reason="disabled for testing")
-# @pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
-# def test_predict_csv_single_row():
-#     """Test YOLO predictions with sources listed in a single row of a CSV file."""
-#     file = TMP / "sources_single_row.csv"
-#     with open(file, "w", newline="") as f:
-#         writer = csv.writer(f)
-#         writer.writerow(SOURCES_LIST)
-#     results = YOLO(MODEL)(source=file, imgsz=32)
-#     assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
-#
-#
-# @pytest.mark.parametrize("model_name", MODELS)
-# def test_predict_img(model_name):
-#     """Test YOLO model predictions on various image input types and sources, including online images."""
-#     model = YOLO(WEIGHTS_DIR / model_name)
-#     im = cv2.imread(str(SOURCE))  # uint8 numpy array
-#     assert len(model(source=Image.open(SOURCE), save=True, verbose=True, imgsz=32)) == 1  # PIL
-#     assert len(model(source=im, save=True, save_txt=True, imgsz=32)) == 1  # ndarray
-#     assert len(model(torch.rand((2, 3, 32, 32)), imgsz=32)) == 2  # batch-size 2 Tensor, FP32 0.0-1.0 RGB order
-#     assert len(model(source=[im, im], save=True, save_txt=True, imgsz=32)) == 2  # batch
-#     assert len(list(model(source=[im, im], save=True, stream=True, imgsz=32))) == 2  # stream
-#     assert len(model(torch.zeros(320, 640, 3).numpy().astype(np.uint8), imgsz=32)) == 1  # tensor to numpy
-#     batch = [
-#         str(SOURCE),  # filename
-#         Path(SOURCE),  # Path
-#         "https://github.com/ultralytics/assets/releases/download/v0.0.0/zidane.jpg" if ONLINE else SOURCE,  # URI
-#         cv2.imread(str(SOURCE)),  # OpenCV
-#         Image.open(SOURCE),  # PIL
-#         np.zeros((320, 640, 3), dtype=np.uint8),  # numpy
-#     ]
-#     assert len(model(batch, imgsz=32, classes=0)) == len(batch)  # multiple sources in a batch
-#
-#
-# @pytest.mark.parametrize("model", MODELS)
-# def test_predict_visualize(model):
-#     """Test model prediction methods with 'visualize=True' to generate and display prediction visualizations."""
-#     YOLO(WEIGHTS_DIR / model)(SOURCE, imgsz=32, visualize=True)
-#
-#
-# def test_predict_grey_and_4ch():
-#     """Test YOLO prediction on SOURCE converted to greyscale and 4-channel images with various filenames."""
-#     im = Image.open(SOURCE)
-#     directory = TMP / "im4"
-#     directory.mkdir(parents=True, exist_ok=True)
-#
-#     source_greyscale = directory / "greyscale.jpg"
-#     source_rgba = directory / "4ch.png"
-#     source_non_utf = directory / "non_UTF_测试文件_tést_image.jpg"
-#     source_spaces = directory / "image with spaces.jpg"
-#
-#     im.convert("L").save(source_greyscale)  # greyscale
-#     im.convert("RGBA").save(source_rgba)  # 4-ch PNG with alpha
-#     im.save(source_non_utf)  # non-UTF characters in filename
-#     im.save(source_spaces)  # spaces in filename
-#
-#     # Inference
-#     model = YOLO(MODEL)
-#     for f in source_rgba, source_greyscale, source_non_utf, source_spaces:
-#         for source in Image.open(f), cv2.imread(str(f)), f:
-#             results = model(source, save=True, verbose=True, imgsz=32)
-#             assert len(results) == 1  # verify that an image was run
-#         f.unlink()  # cleanup
-#
-#
-# @pytest.mark.slow
-# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
-# @pytest.mark.skipif(is_github_action_running(), reason="No auth https://github.com/JuanBindez/pytubefix/issues/166")
-# def test_youtube():
-#     """Test YOLO model on a YouTube video stream, handling potential network-related errors."""
-#     model = YOLO(MODEL)
-#     try:
-#         model.predict("https://youtu.be/G17sBkb38XQ", imgsz=96, save=True)
-#     # Handle internet connection errors and 'urllib.error.HTTPError: HTTP Error 429: Too Many Requests'
-#     except (urllib.error.HTTPError, ConnectionError) as e:
-#         LOGGER.error(f"YouTube Test Error: {e}")
+def test_model_forward():
+    """Test the forward pass of the YOLO model."""
+    model = YOLO(CFG)
+    model(source=None, imgsz=32, augment=True)  # also test no source and augment
+
+
+def test_model_methods():
+    """Test various methods and properties of the YOLO model to ensure correct functionality."""
+    model = YOLO(MODEL)
+
+    # Model methods
+    model.info(verbose=True, detailed=True)
+    model = model.reset_weights()
+    model = model.load(MODEL)
+    model.to("cpu")
+    model.fuse()
+    model.clear_callback("on_train_start")
+    model.reset_callbacks()
+
+    # Model properties
+    _ = model.names
+    _ = model.device
+    _ = model.transforms
+    _ = model.task_map
+
+
+def test_model_profile():
+    """Test profiling of the YOLO model with `profile=True` to assess performance and resource usage."""
+    from ultralytics.nn.tasks import DetectionModel
+
+    model = DetectionModel()  # build model
+    im = torch.randn(1, 3, 64, 64)  # requires min imgsz=64
+    _ = model.predict(im, profile=True)
+
+
+@pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
+def test_predict_txt():
+    """Test YOLO predictions with file, directory, and pattern sources listed in a text file."""
+    file = TMP / "sources_multi_row.txt"
+    with open(file, "w") as f:
+        for src in SOURCES_LIST:
+            f.write(f"{src}\n")
+    results = YOLO(MODEL)(source=file, imgsz=32)
+    assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
+
+
+@pytest.mark.skipif(True, reason="disabled for testing")
+@pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
+def test_predict_csv_multi_row():
+    """Test YOLO predictions with sources listed in multiple rows of a CSV file."""
+    file = TMP / "sources_multi_row.csv"
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["source"])
+        writer.writerows([[src] for src in SOURCES_LIST])
+    results = YOLO(MODEL)(source=file, imgsz=32)
+    assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
+
+
+@pytest.mark.skipif(True, reason="disabled for testing")
+@pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
+def test_predict_csv_single_row():
+    """Test YOLO predictions with sources listed in a single row of a CSV file."""
+    file = TMP / "sources_single_row.csv"
+    with open(file, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(SOURCES_LIST)
+    results = YOLO(MODEL)(source=file, imgsz=32)
+    assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_predict_img(model_name):
+    """Test YOLO model predictions on various image input types and sources, including online images."""
+    model = YOLO(WEIGHTS_DIR / model_name)
+    im = cv2.imread(str(SOURCE))  # uint8 numpy array
+    assert len(model(source=Image.open(SOURCE), save=True, verbose=True, imgsz=32)) == 1  # PIL
+    assert len(model(source=im, save=True, save_txt=True, imgsz=32)) == 1  # ndarray
+    assert len(model(torch.rand((2, 3, 32, 32)), imgsz=32)) == 2  # batch-size 2 Tensor, FP32 0.0-1.0 RGB order
+    assert len(model(source=[im, im], save=True, save_txt=True, imgsz=32)) == 2  # batch
+    assert len(list(model(source=[im, im], save=True, stream=True, imgsz=32))) == 2  # stream
+    assert len(model(torch.zeros(320, 640, 3).numpy().astype(np.uint8), imgsz=32)) == 1  # tensor to numpy
+    batch = [
+        str(SOURCE),  # filename
+        Path(SOURCE),  # Path
+        "https://github.com/ultralytics/assets/releases/download/v0.0.0/zidane.jpg" if ONLINE else SOURCE,  # URI
+        cv2.imread(str(SOURCE)),  # OpenCV
+        Image.open(SOURCE),  # PIL
+        np.zeros((320, 640, 3), dtype=np.uint8),  # numpy
+    ]
+    assert len(model(batch, imgsz=32, classes=0)) == len(batch)  # multiple sources in a batch
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_predict_visualize(model):
+    """Test model prediction methods with 'visualize=True' to generate and display prediction visualizations."""
+    YOLO(WEIGHTS_DIR / model)(SOURCE, imgsz=32, visualize=True)
+
+
+def test_predict_grey_and_4ch():
+    """Test YOLO prediction on SOURCE converted to greyscale and 4-channel images with various filenames."""
+    im = Image.open(SOURCE)
+    directory = TMP / "im4"
+    directory.mkdir(parents=True, exist_ok=True)
+
+    source_greyscale = directory / "greyscale.jpg"
+    source_rgba = directory / "4ch.png"
+    source_non_utf = directory / "non_UTF_测试文件_tést_image.jpg"
+    source_spaces = directory / "image with spaces.jpg"
+
+    im.convert("L").save(source_greyscale)  # greyscale
+    im.convert("RGBA").save(source_rgba)  # 4-ch PNG with alpha
+    im.save(source_non_utf)  # non-UTF characters in filename
+    im.save(source_spaces)  # spaces in filename
+
+    # Inference
+    model = YOLO(MODEL)
+    for f in source_rgba, source_greyscale, source_non_utf, source_spaces:
+        for source in Image.open(f), cv2.imread(str(f)), f:
+            results = model(source, save=True, verbose=True, imgsz=32)
+            assert len(results) == 1  # verify that an image was run
+        f.unlink()  # cleanup
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not ONLINE, reason="environment is offline")
+@pytest.mark.skipif(is_github_action_running(), reason="No auth https://github.com/JuanBindez/pytubefix/issues/166")
+def test_youtube():
+    """Test YOLO model on a YouTube video stream, handling potential network-related errors."""
+    model = YOLO(MODEL)
+    try:
+        model.predict("https://youtu.be/G17sBkb38XQ", imgsz=96, save=True)
+    # Handle internet connection errors and 'urllib.error.HTTPError: HTTP Error 429: Too Many Requests'
+    except (urllib.error.HTTPError, ConnectionError) as e:
+        LOGGER.error(f"YouTube Test Error: {e}")
 
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
@@ -196,506 +196,506 @@ def test_track_stream():
         model.track(video_url, imgsz=160, tracker=custom_yaml)
 
 
-# def test_val():
-#     """Test the validation mode of the YOLO model."""
-#     metrics = YOLO(MODEL).val(data="coco8.yaml", imgsz=32)
-#     metrics.to_df()
-#     metrics.to_csv()
-#     metrics.to_xml()
-#     metrics.to_html()
-#     metrics.to_json()
-#     metrics.to_sql()
-#
-#
-# def test_train_scratch():
-#     """Test training the YOLO model from scratch using the provided configuration."""
-#     model = YOLO(CFG)
-#     model.train(data="coco8.yaml", epochs=2, imgsz=32, cache="disk", batch=-1, close_mosaic=1, name="model")
-#     model(SOURCE)
-#
-#
-# @pytest.mark.parametrize("scls", [False, True])
-# def test_train_pretrained(scls):
-#     """Test training of the YOLO model starting from a pre-trained checkpoint."""
-#     model = YOLO(WEIGHTS_DIR / "yolo11n-seg.pt")
-#     model.train(
-#         data="coco8-seg.yaml", epochs=1, imgsz=32, cache="ram", copy_paste=0.5, mixup=0.5, name=0, single_cls=scls
-#     )
-#     model(SOURCE)
-#
-#
-# def test_all_model_yamls():
-#     """Test YOLO model creation for all available YAML configurations in the `cfg/models` directory."""
-#     for m in (ROOT / "cfg" / "models").rglob("*.yaml"):
-#         if "rtdetr" in m.name:
-#             if TORCH_1_9:  # torch<=1.8 issue - TypeError: __init__() got an unexpected keyword argument 'batch_first'
-#                 _ = RTDETR(m.name)(SOURCE, imgsz=640)  # must be 640
-#         else:
-#             YOLO(m.name)
-#
-#
-# @pytest.mark.skipif(WINDOWS, reason="Windows slow CI export bug https://github.com/ultralytics/ultralytics/pull/16003")
-# def test_workflow():
-#     """Test the complete workflow including training, validation, prediction, and exporting."""
-#     model = YOLO(MODEL)
-#     model.train(data="coco8.yaml", epochs=1, imgsz=32, optimizer="SGD")
-#     model.val(imgsz=32)
-#     model.predict(SOURCE, imgsz=32)
-#     model.export(format="torchscript")  # WARNING: Windows slow CI export bug
-#
-#
-# def test_predict_callback_and_setup():
-#     """Test callback functionality during YOLO prediction setup and execution."""
-#
-#     def on_predict_batch_end(predictor):
-#         """Callback function that handles operations at the end of a prediction batch."""
-#         path, im0s, _ = predictor.batch
-#         im0s = im0s if isinstance(im0s, list) else [im0s]
-#         bs = [predictor.dataset.bs for _ in range(len(path))]
-#         predictor.results = zip(predictor.results, im0s, bs)  # results is List[batch_size]
-#
-#     model = YOLO(MODEL)
-#     model.add_callback("on_predict_batch_end", on_predict_batch_end)
-#
-#     dataset = load_inference_source(source=SOURCE)
-#     bs = dataset.bs  # noqa access predictor properties
-#     results = model.predict(dataset, stream=True, imgsz=160)  # source already setup
-#     for r, im0, bs in results:
-#         print("test_callback", im0.shape)
-#         print("test_callback", bs)
-#         boxes = r.boxes  # Boxes object for bbox outputs
-#         print(boxes)
-#
-#
-# @pytest.mark.parametrize("model", MODELS)
-# def test_results(model):
-#     """Test YOLO model results processing and output in various formats."""
-#     temp_s = "https://ultralytics.com/images/boats.jpg" if model == "yolo11n-obb.pt" else SOURCE
-#     results = YOLO(WEIGHTS_DIR / model)([temp_s, temp_s], imgsz=160)
-#     for r in results:
-#         r = r.cpu().numpy()
-#         print(r, len(r), r.path)  # print numpy attributes
-#         r = r.to(device="cpu", dtype=torch.float32)
-#         r.save_txt(txt_file=TMP / "runs/tests/label.txt", save_conf=True)
-#         r.save_crop(save_dir=TMP / "runs/tests/crops/")
-#         r.to_df(decimals=3)  # Align to_ methods: https://docs.ultralytics.com/modes/predict/#working-with-results
-#         r.to_csv()
-#         r.to_xml()
-#         r.to_html()
-#         r.to_json(normalize=True)
-#         r.to_sql()
-#         r.plot(pil=True, save=True, filename=TMP / "results_plot_save.jpg")
-#         r.plot(conf=True, boxes=True)
-#         print(r, len(r), r.path)  # print after methods
-#
-#
-# def test_labels_and_crops():
-#     """Test output from prediction args for saving YOLO detection labels and crops."""
-#     imgs = [SOURCE, ASSETS / "zidane.jpg"]
-#     results = YOLO(WEIGHTS_DIR / "yolo11n.pt")(imgs, imgsz=160, save_txt=True, save_crop=True)
-#     save_path = Path(results[0].save_dir)
-#     for r in results:
-#         im_name = Path(r.path).stem
-#         cls_idxs = r.boxes.cls.int().tolist()
-#         # Check correct detections
-#         assert cls_idxs == ([0, 7, 0, 0] if r.path.endswith("bus.jpg") else [0, 0, 0])  # bus.jpg and zidane.jpg classes
-#         # Check label path
-#         labels = save_path / f"labels/{im_name}.txt"
-#         assert labels.exists()
-#         # Check detections match label count
-#         assert len(r.boxes.data) == len([line for line in labels.read_text().splitlines() if line])
-#         # Check crops path and files
-#         crop_dirs = list((save_path / "crops").iterdir())
-#         crop_files = [f for p in crop_dirs for f in p.glob("*")]
-#         # Crop directories match detections
-#         assert all(r.names.get(c) in {d.name for d in crop_dirs} for c in cls_idxs)
-#         # Same number of crops as detections
-#         assert len([f for f in crop_files if im_name in f.name]) == len(r.boxes.data)
-#
-#
-# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
-# def test_data_utils():
-#     """Test utility functions in ultralytics/data/utils.py, including dataset stats and auto-splitting."""
-#     from ultralytics.data.split import autosplit
-#     from ultralytics.data.utils import HUBDatasetStats
-#     from ultralytics.utils.downloads import zip_directory
-#
-#     # from ultralytics.utils.files import WorkingDirectory
-#     # with WorkingDirectory(ROOT.parent / 'tests'):
-#
-#     for task in TASKS:
-#         file = Path(TASK2DATA[task]).with_suffix(".zip")  # i.e. coco8.zip
-#         download(f"https://github.com/ultralytics/hub/raw/main/example_datasets/{file}", unzip=False, dir=TMP)
-#         stats = HUBDatasetStats(TMP / file, task=task)
-#         stats.get_json(save=True)
-#         stats.process_images()
-#
-#     autosplit(TMP / "coco8")
-#     zip_directory(TMP / "coco8/images/val")  # zip
-#
-#
-# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
-# def test_data_converter():
-#     """Test dataset conversion functions from COCO to YOLO format and class mappings."""
-#     from ultralytics.data.converter import coco80_to_coco91_class, convert_coco
-#
-#     file = "instances_val2017.json"
-#     download(f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{file}", dir=TMP)
-#     convert_coco(labels_dir=TMP, save_dir=TMP / "yolo_labels", use_segments=True, use_keypoints=False, cls91to80=True)
-#     coco80_to_coco91_class()
-#
-#
-# def test_data_annotator():
-#     """Test automatic annotation of data using detection and segmentation models."""
-#     from ultralytics.data.annotator import auto_annotate
-#
-#     auto_annotate(
-#         ASSETS,
-#         det_model=WEIGHTS_DIR / "yolo11n.pt",
-#         sam_model=WEIGHTS_DIR / "mobile_sam.pt",
-#         output_dir=TMP / "auto_annotate_labels",
-#     )
-#
-#
-# def test_events():
-#     """Test event sending functionality."""
-#     from ultralytics.hub.utils import Events
-#
-#     events = Events()
-#     events.enabled = True
-#     cfg = copy(DEFAULT_CFG)  # does not require deepcopy
-#     cfg.mode = "test"
-#     events(cfg)
-#
-#
-# def test_cfg_init():
-#     """Test configuration initialization utilities from the 'ultralytics.cfg' module."""
-#     from ultralytics.cfg import check_dict_alignment, copy_default_cfg, smart_value
-#
-#     with contextlib.suppress(SyntaxError):
-#         check_dict_alignment({"a": 1}, {"b": 2})
-#     copy_default_cfg()
-#     (Path.cwd() / DEFAULT_CFG_PATH.name.replace(".yaml", "_copy.yaml")).unlink(missing_ok=False)
-#     [smart_value(x) for x in ["none", "true", "false"]]
-#
-#
-# def test_utils_init():
-#     """Test initialization utilities in the Ultralytics library."""
-#     from ultralytics.utils import get_git_branch, get_git_origin_url, get_ubuntu_version, is_github_action_running
-#
-#     get_ubuntu_version()
-#     is_github_action_running()
-#     get_git_origin_url()
-#     get_git_branch()
-#
-#
-# def test_utils_checks():
-#     """Test various utility checks for filenames, git status, requirements, image sizes, and versions."""
-#     checks.check_yolov5u_filename("yolov5n.pt")
-#     checks.git_describe(ROOT)
-#     checks.check_requirements()  # check requirements.txt
-#     checks.check_imgsz([600, 600], max_dim=1)
-#     checks.check_imshow(warn=True)
-#     checks.check_version("ultralytics", "8.0.0")
-#     checks.print_args()
-#
-#
-# @pytest.mark.skipif(WINDOWS, reason="Windows profiling is extremely slow (cause unknown)")
-# def test_utils_benchmarks():
-#     """Benchmark model performance using 'ProfileModels' from 'ultralytics.utils.benchmarks'."""
-#     from ultralytics.utils.benchmarks import ProfileModels
-#
-#     ProfileModels(["yolo11n.yaml"], imgsz=32, min_time=1, num_timed_runs=3, num_warmup_runs=1).run()
-#
-#
-# def test_utils_torchutils():
-#     """Test Torch utility functions including profiling and FLOP calculations."""
-#     from ultralytics.nn.modules.conv import Conv
-#     from ultralytics.utils.torch_utils import get_flops_with_torch_profiler, profile_ops, time_sync
-#
-#     x = torch.randn(1, 64, 20, 20)
-#     m = Conv(64, 64, k=1, s=2)
-#
-#     profile_ops(x, [m], n=3)
-#     get_flops_with_torch_profiler(m)
-#     time_sync()
-#
-#
-# def test_utils_ops():
-#     """Test utility operations for coordinate transformations and normalizations."""
-#     from ultralytics.utils.ops import (
-#         ltwh2xywh,
-#         ltwh2xyxy,
-#         make_divisible,
-#         xywh2ltwh,
-#         xywh2xyxy,
-#         xywhn2xyxy,
-#         xywhr2xyxyxyxy,
-#         xyxy2ltwh,
-#         xyxy2xywh,
-#         xyxy2xywhn,
-#         xyxyxyxy2xywhr,
-#     )
-#
-#     make_divisible(17, torch.tensor([8]))
-#
-#     boxes = torch.rand(10, 4)  # xywh
-#     torch.allclose(boxes, xyxy2xywh(xywh2xyxy(boxes)))
-#     torch.allclose(boxes, xyxy2xywhn(xywhn2xyxy(boxes)))
-#     torch.allclose(boxes, ltwh2xywh(xywh2ltwh(boxes)))
-#     torch.allclose(boxes, xyxy2ltwh(ltwh2xyxy(boxes)))
-#
-#     boxes = torch.rand(10, 5)  # xywhr for OBB
-#     boxes[:, 4] = torch.randn(10) * 30
-#     torch.allclose(boxes, xyxyxyxy2xywhr(xywhr2xyxyxyxy(boxes)), rtol=1e-3)
-#
-#
-# def test_utils_files():
-#     """Test file handling utilities including file age, date, and paths with spaces."""
-#     from ultralytics.utils.files import file_age, file_date, get_latest_run, spaces_in_path
-#
-#     file_age(SOURCE)
-#     file_date(SOURCE)
-#     get_latest_run(ROOT / "runs")
-#
-#     path = TMP / "path/with spaces"
-#     path.mkdir(parents=True, exist_ok=True)
-#     with spaces_in_path(path) as new_path:
-#         print(new_path)
-#
-#
-# @pytest.mark.slow
-# def test_utils_patches_torch_save():
-#     """Test torch_save backoff when _torch_save raises RuntimeError."""
-#     from unittest.mock import MagicMock, patch
-#
-#     from ultralytics.utils.patches import torch_save
-#
-#     mock = MagicMock(side_effect=RuntimeError)
-#
-#     with patch("ultralytics.utils.patches._torch_save", new=mock):
-#         with pytest.raises(RuntimeError):
-#             torch_save(torch.zeros(1), TMP / "test.pt")
-#
-#     assert mock.call_count == 4, "torch_save was not attempted the expected number of times"
-#
-#
-# def test_nn_modules_conv():
-#     """Test Convolutional Neural Network modules including CBAM, Conv2, and ConvTranspose."""
-#     from ultralytics.nn.modules.conv import CBAM, Conv2, ConvTranspose, DWConvTranspose2d, Focus
-#
-#     c1, c2 = 8, 16  # input and output channels
-#     x = torch.zeros(4, c1, 10, 10)  # BCHW
-#
-#     # Run all modules not otherwise covered in tests
-#     DWConvTranspose2d(c1, c2)(x)
-#     ConvTranspose(c1, c2)(x)
-#     Focus(c1, c2)(x)
-#     CBAM(c1)(x)
-#
-#     # Fuse ops
-#     m = Conv2(c1, c2)
-#     m.fuse_convs()
-#     m(x)
-#
-#
-# def test_nn_modules_block():
-#     """Test various neural network block modules."""
-#     from ultralytics.nn.modules.block import C1, C3TR, BottleneckCSP, C3Ghost, C3x
-#
-#     c1, c2 = 8, 16  # input and output channels
-#     x = torch.zeros(4, c1, 10, 10)  # BCHW
-#
-#     # Run all modules not otherwise covered in tests
-#     C1(c1, c2)(x)
-#     C3x(c1, c2)(x)
-#     C3TR(c1, c2)(x)
-#     C3Ghost(c1, c2)(x)
-#     BottleneckCSP(c1, c2)(x)
-#
-#
-# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
-# def test_hub():
-#     """Test Ultralytics HUB functionalities."""
-#     from ultralytics.hub import export_fmts_hub, logout
-#     from ultralytics.hub.utils import smart_request
-#
-#     export_fmts_hub()
-#     logout()
-#     smart_request("GET", "https://github.com", progress=True)
-#
-#
-# @pytest.fixture
-# def image():
-#     """Load and return an image from a predefined source."""
-#     return cv2.imread(str(SOURCE))
-#
-#
-# @pytest.mark.parametrize(
-#     "auto_augment, erasing, force_color_jitter",
-#     [
-#         (None, 0.0, False),
-#         ("randaugment", 0.5, True),
-#         ("augmix", 0.2, False),
-#         ("autoaugment", 0.0, True),
-#     ],
-# )
-# def test_classify_transforms_train(image, auto_augment, erasing, force_color_jitter):
-#     """Test classification transforms during training with various augmentations."""
-#     from ultralytics.data.augment import classify_augmentations
-#
-#     transform = classify_augmentations(
-#         size=224,
-#         mean=(0.5, 0.5, 0.5),
-#         std=(0.5, 0.5, 0.5),
-#         scale=(0.08, 1.0),
-#         ratio=(3.0 / 4.0, 4.0 / 3.0),
-#         hflip=0.5,
-#         vflip=0.5,
-#         auto_augment=auto_augment,
-#         hsv_h=0.015,
-#         hsv_s=0.4,
-#         hsv_v=0.4,
-#         force_color_jitter=force_color_jitter,
-#         erasing=erasing,
-#     )
-#
-#     transformed_image = transform(Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB)))
-#
-#     assert transformed_image.shape == (3, 224, 224)
-#     assert torch.is_tensor(transformed_image)
-#     assert transformed_image.dtype == torch.float32
-#
-#
-# @pytest.mark.slow
-# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
-# def test_model_tune():
-#     """Tune YOLO model for performance improvement."""
-#     YOLO("yolo11n-pose.pt").tune(data="coco8-pose.yaml", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
-#     YOLO("yolo11n-cls.pt").tune(data="imagenet10", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
-#
-#
-# def test_model_embeddings():
-#     """Test YOLO model embeddings extraction functionality."""
-#     model_detect = YOLO(MODEL)
-#     model_segment = YOLO(WEIGHTS_DIR / "yolo11n-seg.pt")
-#
-#     for batch in [SOURCE], [SOURCE, SOURCE]:  # test batch size 1 and 2
-#         assert len(model_detect.embed(source=batch, imgsz=32)) == len(batch)
-#         assert len(model_segment.embed(source=batch, imgsz=32)) == len(batch)
-#
-#
-# @pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="YOLOWorld with CLIP is not supported in Python 3.12")
-# @pytest.mark.skipif(
-#     checks.IS_PYTHON_3_8 and LINUX and ARM64,
-#     reason="YOLOWorld with CLIP is not supported in Python 3.8 and aarch64 Linux",
-# )
-# def test_yolo_world():
-#     """Test YOLO world models with CLIP support."""
-#     model = YOLO(WEIGHTS_DIR / "yolov8s-world.pt")  # no YOLO11n-world model yet
-#     model.set_classes(["tree", "window"])
-#     model(SOURCE, conf=0.01)
-#
-#     model = YOLO(WEIGHTS_DIR / "yolov8s-worldv2.pt")  # no YOLO11n-world model yet
-#     # Training from a pretrained model. Eval is included at the final stage of training.
-#     # Use dota8.yaml which has fewer categories to reduce the inference time of CLIP model
-#     model.train(
-#         data="dota8.yaml",
-#         epochs=1,
-#         imgsz=32,
-#         cache="disk",
-#         close_mosaic=1,
-#     )
-#
-#     # test WorWorldTrainerFromScratch
-#     from ultralytics.models.yolo.world.train_world import WorldTrainerFromScratch
-#
-#     model = YOLO("yolov8s-worldv2.yaml")  # no YOLO11n-world model yet
-#     model.train(
-#         data={"train": {"yolo_data": ["dota8.yaml"]}, "val": {"yolo_data": ["dota8.yaml"]}},
-#         epochs=1,
-#         imgsz=32,
-#         cache="disk",
-#         close_mosaic=1,
-#         trainer=WorldTrainerFromScratch,
-#     )
-#
-#
-# @pytest.mark.skipif(checks.IS_PYTHON_3_12 or not TORCH_1_9, reason="YOLOE with CLIP is not supported in Python 3.12")
-# @pytest.mark.skipif(
-#     checks.IS_PYTHON_3_8 and LINUX and ARM64,
-#     reason="YOLOE with CLIP is not supported in Python 3.8 and aarch64 Linux",
-# )
-# def test_yoloe():
-#     """Test YOLOE models with MobileClip support."""
-#     # Predict
-#     # text-prompts
-#     model = YOLO(WEIGHTS_DIR / "yoloe-11s-seg.pt")
-#     names = ["person", "bus"]
-#     model.set_classes(names, model.get_text_pe(names))
-#     model(SOURCE, conf=0.01)
-#
-#     import numpy as np
-#
-#     from ultralytics import YOLOE
-#     from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
-#
-#     # visual-prompts
-#     visuals = dict(
-#         bboxes=np.array(
-#             [[221.52, 405.8, 344.98, 857.54], [120, 425, 160, 445]],
-#         ),
-#         cls=np.array([0, 1]),
-#     )
-#     model.predict(
-#         SOURCE,
-#         visual_prompts=visuals,
-#         predictor=YOLOEVPSegPredictor,
-#     )
-#
-#     # Val
-#     model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg.pt")
-#     # text prompts
-#     model.val(data="coco128-seg.yaml", imgsz=32)
-#     # visual prompts
-#     model.val(data="coco128-seg.yaml", load_vp=True, imgsz=32)
-#
-#     # Train, fine-tune
-#     from ultralytics.models.yolo.yoloe import YOLOEPESegTrainer
-#
-#     model = YOLOE("yoloe-11s-seg.pt")
-#     model.train(
-#         data="coco128-seg.yaml",
-#         epochs=1,
-#         close_mosaic=1,
-#         trainer=YOLOEPESegTrainer,
-#         imgsz=32,
-#     )
-#
-#     # prompt-free
-#     # predict
-#     model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg-pf.pt")
-#     model.predict(SOURCE)
-#     # val
-#     model = YOLOE("yoloe-11s-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
-#     model.val(data="coco128-seg.yaml", imgsz=32)
-#
-#
-# def test_yolov10():
-#     """Test YOLOv10 model training, validation, and prediction functionality."""
-#     model = YOLO("yolov10n.yaml")
-#     # train/val/predict
-#     model.train(data="coco8.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
-#     model.val(data="coco8.yaml", imgsz=32)
-#     model.predict(imgsz=32, save_txt=True, save_crop=True, augment=True)
-#     model(SOURCE)
-#
-#
-# def test_multichannel():
-#     """Test YOLO model multi-channel training, validation, and prediction functionality."""
-#     model = YOLO("yolo11n.pt")
-#     model.train(data="coco8-multispectral.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
-#     model.val(data="coco8-multispectral.yaml")
-#     im = np.zeros((32, 32, 10), dtype=np.uint8)
-#     model.predict(source=im, imgsz=32, save_txt=True, save_crop=True, augment=True)
-#     model.export(format="onnx")
+def test_val():
+    """Test the validation mode of the YOLO model."""
+    metrics = YOLO(MODEL).val(data="coco8.yaml", imgsz=32)
+    metrics.to_df()
+    metrics.to_csv()
+    metrics.to_xml()
+    metrics.to_html()
+    metrics.to_json()
+    metrics.to_sql()
+
+
+def test_train_scratch():
+    """Test training the YOLO model from scratch using the provided configuration."""
+    model = YOLO(CFG)
+    model.train(data="coco8.yaml", epochs=2, imgsz=32, cache="disk", batch=-1, close_mosaic=1, name="model")
+    model(SOURCE)
+
+
+@pytest.mark.parametrize("scls", [False, True])
+def test_train_pretrained(scls):
+    """Test training of the YOLO model starting from a pre-trained checkpoint."""
+    model = YOLO(WEIGHTS_DIR / "yolo11n-seg.pt")
+    model.train(
+        data="coco8-seg.yaml", epochs=1, imgsz=32, cache="ram", copy_paste=0.5, mixup=0.5, name=0, single_cls=scls
+    )
+    model(SOURCE)
+
+
+def test_all_model_yamls():
+    """Test YOLO model creation for all available YAML configurations in the `cfg/models` directory."""
+    for m in (ROOT / "cfg" / "models").rglob("*.yaml"):
+        if "rtdetr" in m.name:
+            if TORCH_1_9:  # torch<=1.8 issue - TypeError: __init__() got an unexpected keyword argument 'batch_first'
+                _ = RTDETR(m.name)(SOURCE, imgsz=640)  # must be 640
+        else:
+            YOLO(m.name)
+
+
+@pytest.mark.skipif(WINDOWS, reason="Windows slow CI export bug https://github.com/ultralytics/ultralytics/pull/16003")
+def test_workflow():
+    """Test the complete workflow including training, validation, prediction, and exporting."""
+    model = YOLO(MODEL)
+    model.train(data="coco8.yaml", epochs=1, imgsz=32, optimizer="SGD")
+    model.val(imgsz=32)
+    model.predict(SOURCE, imgsz=32)
+    model.export(format="torchscript")  # WARNING: Windows slow CI export bug
+
+
+def test_predict_callback_and_setup():
+    """Test callback functionality during YOLO prediction setup and execution."""
+
+    def on_predict_batch_end(predictor):
+        """Callback function that handles operations at the end of a prediction batch."""
+        path, im0s, _ = predictor.batch
+        im0s = im0s if isinstance(im0s, list) else [im0s]
+        bs = [predictor.dataset.bs for _ in range(len(path))]
+        predictor.results = zip(predictor.results, im0s, bs)  # results is List[batch_size]
+
+    model = YOLO(MODEL)
+    model.add_callback("on_predict_batch_end", on_predict_batch_end)
+
+    dataset = load_inference_source(source=SOURCE)
+    bs = dataset.bs  # noqa access predictor properties
+    results = model.predict(dataset, stream=True, imgsz=160)  # source already setup
+    for r, im0, bs in results:
+        print("test_callback", im0.shape)
+        print("test_callback", bs)
+        boxes = r.boxes  # Boxes object for bbox outputs
+        print(boxes)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_results(model):
+    """Test YOLO model results processing and output in various formats."""
+    temp_s = "https://ultralytics.com/images/boats.jpg" if model == "yolo11n-obb.pt" else SOURCE
+    results = YOLO(WEIGHTS_DIR / model)([temp_s, temp_s], imgsz=160)
+    for r in results:
+        r = r.cpu().numpy()
+        print(r, len(r), r.path)  # print numpy attributes
+        r = r.to(device="cpu", dtype=torch.float32)
+        r.save_txt(txt_file=TMP / "runs/tests/label.txt", save_conf=True)
+        r.save_crop(save_dir=TMP / "runs/tests/crops/")
+        r.to_df(decimals=3)  # Align to_ methods: https://docs.ultralytics.com/modes/predict/#working-with-results
+        r.to_csv()
+        r.to_xml()
+        r.to_html()
+        r.to_json(normalize=True)
+        r.to_sql()
+        r.plot(pil=True, save=True, filename=TMP / "results_plot_save.jpg")
+        r.plot(conf=True, boxes=True)
+        print(r, len(r), r.path)  # print after methods
+
+
+def test_labels_and_crops():
+    """Test output from prediction args for saving YOLO detection labels and crops."""
+    imgs = [SOURCE, ASSETS / "zidane.jpg"]
+    results = YOLO(WEIGHTS_DIR / "yolo11n.pt")(imgs, imgsz=160, save_txt=True, save_crop=True)
+    save_path = Path(results[0].save_dir)
+    for r in results:
+        im_name = Path(r.path).stem
+        cls_idxs = r.boxes.cls.int().tolist()
+        # Check correct detections
+        assert cls_idxs == ([0, 7, 0, 0] if r.path.endswith("bus.jpg") else [0, 0, 0])  # bus.jpg and zidane.jpg classes
+        # Check label path
+        labels = save_path / f"labels/{im_name}.txt"
+        assert labels.exists()
+        # Check detections match label count
+        assert len(r.boxes.data) == len([line for line in labels.read_text().splitlines() if line])
+        # Check crops path and files
+        crop_dirs = list((save_path / "crops").iterdir())
+        crop_files = [f for p in crop_dirs for f in p.glob("*")]
+        # Crop directories match detections
+        assert all(r.names.get(c) in {d.name for d in crop_dirs} for c in cls_idxs)
+        # Same number of crops as detections
+        assert len([f for f in crop_files if im_name in f.name]) == len(r.boxes.data)
+
+
+@pytest.mark.skipif(not ONLINE, reason="environment is offline")
+def test_data_utils():
+    """Test utility functions in ultralytics/data/utils.py, including dataset stats and auto-splitting."""
+    from ultralytics.data.split import autosplit
+    from ultralytics.data.utils import HUBDatasetStats
+    from ultralytics.utils.downloads import zip_directory
+
+    # from ultralytics.utils.files import WorkingDirectory
+    # with WorkingDirectory(ROOT.parent / 'tests'):
+
+    for task in TASKS:
+        file = Path(TASK2DATA[task]).with_suffix(".zip")  # i.e. coco8.zip
+        download(f"https://github.com/ultralytics/hub/raw/main/example_datasets/{file}", unzip=False, dir=TMP)
+        stats = HUBDatasetStats(TMP / file, task=task)
+        stats.get_json(save=True)
+        stats.process_images()
+
+    autosplit(TMP / "coco8")
+    zip_directory(TMP / "coco8/images/val")  # zip
+
+
+@pytest.mark.skipif(not ONLINE, reason="environment is offline")
+def test_data_converter():
+    """Test dataset conversion functions from COCO to YOLO format and class mappings."""
+    from ultralytics.data.converter import coco80_to_coco91_class, convert_coco
+
+    file = "instances_val2017.json"
+    download(f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{file}", dir=TMP)
+    convert_coco(labels_dir=TMP, save_dir=TMP / "yolo_labels", use_segments=True, use_keypoints=False, cls91to80=True)
+    coco80_to_coco91_class()
+
+
+def test_data_annotator():
+    """Test automatic annotation of data using detection and segmentation models."""
+    from ultralytics.data.annotator import auto_annotate
+
+    auto_annotate(
+        ASSETS,
+        det_model=WEIGHTS_DIR / "yolo11n.pt",
+        sam_model=WEIGHTS_DIR / "mobile_sam.pt",
+        output_dir=TMP / "auto_annotate_labels",
+    )
+
+
+def test_events():
+    """Test event sending functionality."""
+    from ultralytics.hub.utils import Events
+
+    events = Events()
+    events.enabled = True
+    cfg = copy(DEFAULT_CFG)  # does not require deepcopy
+    cfg.mode = "test"
+    events(cfg)
+
+
+def test_cfg_init():
+    """Test configuration initialization utilities from the 'ultralytics.cfg' module."""
+    from ultralytics.cfg import check_dict_alignment, copy_default_cfg, smart_value
+
+    with contextlib.suppress(SyntaxError):
+        check_dict_alignment({"a": 1}, {"b": 2})
+    copy_default_cfg()
+    (Path.cwd() / DEFAULT_CFG_PATH.name.replace(".yaml", "_copy.yaml")).unlink(missing_ok=False)
+    [smart_value(x) for x in ["none", "true", "false"]]
+
+
+def test_utils_init():
+    """Test initialization utilities in the Ultralytics library."""
+    from ultralytics.utils import get_git_branch, get_git_origin_url, get_ubuntu_version, is_github_action_running
+
+    get_ubuntu_version()
+    is_github_action_running()
+    get_git_origin_url()
+    get_git_branch()
+
+
+def test_utils_checks():
+    """Test various utility checks for filenames, git status, requirements, image sizes, and versions."""
+    checks.check_yolov5u_filename("yolov5n.pt")
+    checks.git_describe(ROOT)
+    checks.check_requirements()  # check requirements.txt
+    checks.check_imgsz([600, 600], max_dim=1)
+    checks.check_imshow(warn=True)
+    checks.check_version("ultralytics", "8.0.0")
+    checks.print_args()
+
+
+@pytest.mark.skipif(WINDOWS, reason="Windows profiling is extremely slow (cause unknown)")
+def test_utils_benchmarks():
+    """Benchmark model performance using 'ProfileModels' from 'ultralytics.utils.benchmarks'."""
+    from ultralytics.utils.benchmarks import ProfileModels
+
+    ProfileModels(["yolo11n.yaml"], imgsz=32, min_time=1, num_timed_runs=3, num_warmup_runs=1).run()
+
+
+def test_utils_torchutils():
+    """Test Torch utility functions including profiling and FLOP calculations."""
+    from ultralytics.nn.modules.conv import Conv
+    from ultralytics.utils.torch_utils import get_flops_with_torch_profiler, profile_ops, time_sync
+
+    x = torch.randn(1, 64, 20, 20)
+    m = Conv(64, 64, k=1, s=2)
+
+    profile_ops(x, [m], n=3)
+    get_flops_with_torch_profiler(m)
+    time_sync()
+
+
+def test_utils_ops():
+    """Test utility operations for coordinate transformations and normalizations."""
+    from ultralytics.utils.ops import (
+        ltwh2xywh,
+        ltwh2xyxy,
+        make_divisible,
+        xywh2ltwh,
+        xywh2xyxy,
+        xywhn2xyxy,
+        xywhr2xyxyxyxy,
+        xyxy2ltwh,
+        xyxy2xywh,
+        xyxy2xywhn,
+        xyxyxyxy2xywhr,
+    )
+
+    make_divisible(17, torch.tensor([8]))
+
+    boxes = torch.rand(10, 4)  # xywh
+    torch.allclose(boxes, xyxy2xywh(xywh2xyxy(boxes)))
+    torch.allclose(boxes, xyxy2xywhn(xywhn2xyxy(boxes)))
+    torch.allclose(boxes, ltwh2xywh(xywh2ltwh(boxes)))
+    torch.allclose(boxes, xyxy2ltwh(ltwh2xyxy(boxes)))
+
+    boxes = torch.rand(10, 5)  # xywhr for OBB
+    boxes[:, 4] = torch.randn(10) * 30
+    torch.allclose(boxes, xyxyxyxy2xywhr(xywhr2xyxyxyxy(boxes)), rtol=1e-3)
+
+
+def test_utils_files():
+    """Test file handling utilities including file age, date, and paths with spaces."""
+    from ultralytics.utils.files import file_age, file_date, get_latest_run, spaces_in_path
+
+    file_age(SOURCE)
+    file_date(SOURCE)
+    get_latest_run(ROOT / "runs")
+
+    path = TMP / "path/with spaces"
+    path.mkdir(parents=True, exist_ok=True)
+    with spaces_in_path(path) as new_path:
+        print(new_path)
+
+
+@pytest.mark.slow
+def test_utils_patches_torch_save():
+    """Test torch_save backoff when _torch_save raises RuntimeError."""
+    from unittest.mock import MagicMock, patch
+
+    from ultralytics.utils.patches import torch_save
+
+    mock = MagicMock(side_effect=RuntimeError)
+
+    with patch("ultralytics.utils.patches._torch_save", new=mock):
+        with pytest.raises(RuntimeError):
+            torch_save(torch.zeros(1), TMP / "test.pt")
+
+    assert mock.call_count == 4, "torch_save was not attempted the expected number of times"
+
+
+def test_nn_modules_conv():
+    """Test Convolutional Neural Network modules including CBAM, Conv2, and ConvTranspose."""
+    from ultralytics.nn.modules.conv import CBAM, Conv2, ConvTranspose, DWConvTranspose2d, Focus
+
+    c1, c2 = 8, 16  # input and output channels
+    x = torch.zeros(4, c1, 10, 10)  # BCHW
+
+    # Run all modules not otherwise covered in tests
+    DWConvTranspose2d(c1, c2)(x)
+    ConvTranspose(c1, c2)(x)
+    Focus(c1, c2)(x)
+    CBAM(c1)(x)
+
+    # Fuse ops
+    m = Conv2(c1, c2)
+    m.fuse_convs()
+    m(x)
+
+
+def test_nn_modules_block():
+    """Test various neural network block modules."""
+    from ultralytics.nn.modules.block import C1, C3TR, BottleneckCSP, C3Ghost, C3x
+
+    c1, c2 = 8, 16  # input and output channels
+    x = torch.zeros(4, c1, 10, 10)  # BCHW
+
+    # Run all modules not otherwise covered in tests
+    C1(c1, c2)(x)
+    C3x(c1, c2)(x)
+    C3TR(c1, c2)(x)
+    C3Ghost(c1, c2)(x)
+    BottleneckCSP(c1, c2)(x)
+
+
+@pytest.mark.skipif(not ONLINE, reason="environment is offline")
+def test_hub():
+    """Test Ultralytics HUB functionalities."""
+    from ultralytics.hub import export_fmts_hub, logout
+    from ultralytics.hub.utils import smart_request
+
+    export_fmts_hub()
+    logout()
+    smart_request("GET", "https://github.com", progress=True)
+
+
+@pytest.fixture
+def image():
+    """Load and return an image from a predefined source."""
+    return cv2.imread(str(SOURCE))
+
+
+@pytest.mark.parametrize(
+    "auto_augment, erasing, force_color_jitter",
+    [
+        (None, 0.0, False),
+        ("randaugment", 0.5, True),
+        ("augmix", 0.2, False),
+        ("autoaugment", 0.0, True),
+    ],
+)
+def test_classify_transforms_train(image, auto_augment, erasing, force_color_jitter):
+    """Test classification transforms during training with various augmentations."""
+    from ultralytics.data.augment import classify_augmentations
+
+    transform = classify_augmentations(
+        size=224,
+        mean=(0.5, 0.5, 0.5),
+        std=(0.5, 0.5, 0.5),
+        scale=(0.08, 1.0),
+        ratio=(3.0 / 4.0, 4.0 / 3.0),
+        hflip=0.5,
+        vflip=0.5,
+        auto_augment=auto_augment,
+        hsv_h=0.015,
+        hsv_s=0.4,
+        hsv_v=0.4,
+        force_color_jitter=force_color_jitter,
+        erasing=erasing,
+    )
+
+    transformed_image = transform(Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB)))
+
+    assert transformed_image.shape == (3, 224, 224)
+    assert torch.is_tensor(transformed_image)
+    assert transformed_image.dtype == torch.float32
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not ONLINE, reason="environment is offline")
+def test_model_tune():
+    """Tune YOLO model for performance improvement."""
+    YOLO("yolo11n-pose.pt").tune(data="coco8-pose.yaml", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
+    YOLO("yolo11n-cls.pt").tune(data="imagenet10", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
+
+
+def test_model_embeddings():
+    """Test YOLO model embeddings extraction functionality."""
+    model_detect = YOLO(MODEL)
+    model_segment = YOLO(WEIGHTS_DIR / "yolo11n-seg.pt")
+
+    for batch in [SOURCE], [SOURCE, SOURCE]:  # test batch size 1 and 2
+        assert len(model_detect.embed(source=batch, imgsz=32)) == len(batch)
+        assert len(model_segment.embed(source=batch, imgsz=32)) == len(batch)
+
+
+@pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="YOLOWorld with CLIP is not supported in Python 3.12")
+@pytest.mark.skipif(
+    checks.IS_PYTHON_3_8 and LINUX and ARM64,
+    reason="YOLOWorld with CLIP is not supported in Python 3.8 and aarch64 Linux",
+)
+def test_yolo_world():
+    """Test YOLO world models with CLIP support."""
+    model = YOLO(WEIGHTS_DIR / "yolov8s-world.pt")  # no YOLO11n-world model yet
+    model.set_classes(["tree", "window"])
+    model(SOURCE, conf=0.01)
+
+    model = YOLO(WEIGHTS_DIR / "yolov8s-worldv2.pt")  # no YOLO11n-world model yet
+    # Training from a pretrained model. Eval is included at the final stage of training.
+    # Use dota8.yaml which has fewer categories to reduce the inference time of CLIP model
+    model.train(
+        data="dota8.yaml",
+        epochs=1,
+        imgsz=32,
+        cache="disk",
+        close_mosaic=1,
+    )
+
+    # test WorWorldTrainerFromScratch
+    from ultralytics.models.yolo.world.train_world import WorldTrainerFromScratch
+
+    model = YOLO("yolov8s-worldv2.yaml")  # no YOLO11n-world model yet
+    model.train(
+        data={"train": {"yolo_data": ["dota8.yaml"]}, "val": {"yolo_data": ["dota8.yaml"]}},
+        epochs=1,
+        imgsz=32,
+        cache="disk",
+        close_mosaic=1,
+        trainer=WorldTrainerFromScratch,
+    )
+
+
+@pytest.mark.skipif(checks.IS_PYTHON_3_12 or not TORCH_1_9, reason="YOLOE with CLIP is not supported in Python 3.12")
+@pytest.mark.skipif(
+    checks.IS_PYTHON_3_8 and LINUX and ARM64,
+    reason="YOLOE with CLIP is not supported in Python 3.8 and aarch64 Linux",
+)
+def test_yoloe():
+    """Test YOLOE models with MobileClip support."""
+    # Predict
+    # text-prompts
+    model = YOLO(WEIGHTS_DIR / "yoloe-11s-seg.pt")
+    names = ["person", "bus"]
+    model.set_classes(names, model.get_text_pe(names))
+    model(SOURCE, conf=0.01)
+
+    import numpy as np
+
+    from ultralytics import YOLOE
+    from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
+
+    # visual-prompts
+    visuals = dict(
+        bboxes=np.array(
+            [[221.52, 405.8, 344.98, 857.54], [120, 425, 160, 445]],
+        ),
+        cls=np.array([0, 1]),
+    )
+    model.predict(
+        SOURCE,
+        visual_prompts=visuals,
+        predictor=YOLOEVPSegPredictor,
+    )
+
+    # Val
+    model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg.pt")
+    # text prompts
+    model.val(data="coco128-seg.yaml", imgsz=32)
+    # visual prompts
+    model.val(data="coco128-seg.yaml", load_vp=True, imgsz=32)
+
+    # Train, fine-tune
+    from ultralytics.models.yolo.yoloe import YOLOEPESegTrainer
+
+    model = YOLOE("yoloe-11s-seg.pt")
+    model.train(
+        data="coco128-seg.yaml",
+        epochs=1,
+        close_mosaic=1,
+        trainer=YOLOEPESegTrainer,
+        imgsz=32,
+    )
+
+    # prompt-free
+    # predict
+    model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg-pf.pt")
+    model.predict(SOURCE)
+    # val
+    model = YOLOE("yoloe-11s-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
+    model.val(data="coco128-seg.yaml", imgsz=32)
+
+
+def test_yolov10():
+    """Test YOLOv10 model training, validation, and prediction functionality."""
+    model = YOLO("yolov10n.yaml")
+    # train/val/predict
+    model.train(data="coco8.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
+    model.val(data="coco8.yaml", imgsz=32)
+    model.predict(imgsz=32, save_txt=True, save_crop=True, augment=True)
+    model(SOURCE)
+
+
+def test_multichannel():
+    """Test YOLO model multi-channel training, validation, and prediction functionality."""
+    model = YOLO("yolo11n.pt")
+    model.train(data="coco8-multispectral.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
+    model.val(data="coco8-multispectral.yaml")
+    im = np.zeros((32, 32, 10), dtype=np.uint8)
+    model.predict(source=im, imgsz=32, save_txt=True, save_crop=True, augment=True)
+    model.export(format="onnx")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,39 +1,16 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-import contextlib
-import csv
-import urllib
-from copy import copy
-from pathlib import Path
 
-import cv2
-import numpy as np
 import pytest
-import torch
-from PIL import Image
 
-from tests import CFG, MODEL, SOURCE, SOURCES_LIST, TMP
-from ultralytics import RTDETR, YOLO
-from ultralytics.cfg import MODELS, TASK2DATA, TASKS
-from ultralytics.data.build import load_inference_source
+from tests import MODEL, TMP
+from ultralytics import YOLO
 from ultralytics.utils import (
-    ARM64,
-    ASSETS,
-    DEFAULT_CFG,
-    DEFAULT_CFG_PATH,
-    LINUX,
-    LOGGER,
     ONLINE,
     ROOT,
-    WEIGHTS_DIR,
-    WINDOWS,
     YAML,
-    checks,
     is_dir_writeable,
-    is_github_action_running,
 )
-from ultralytics.utils.downloads import download
-from ultralytics.utils.torch_utils import TORCH_1_9
 
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -38,141 +38,141 @@ from ultralytics.utils.torch_utils import TORCH_1_9
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 
 
-def test_model_forward():
-    """Test the forward pass of the YOLO model."""
-    model = YOLO(CFG)
-    model(source=None, imgsz=32, augment=True)  # also test no source and augment
-
-
-def test_model_methods():
-    """Test various methods and properties of the YOLO model to ensure correct functionality."""
-    model = YOLO(MODEL)
-
-    # Model methods
-    model.info(verbose=True, detailed=True)
-    model = model.reset_weights()
-    model = model.load(MODEL)
-    model.to("cpu")
-    model.fuse()
-    model.clear_callback("on_train_start")
-    model.reset_callbacks()
-
-    # Model properties
-    _ = model.names
-    _ = model.device
-    _ = model.transforms
-    _ = model.task_map
-
-
-def test_model_profile():
-    """Test profiling of the YOLO model with `profile=True` to assess performance and resource usage."""
-    from ultralytics.nn.tasks import DetectionModel
-
-    model = DetectionModel()  # build model
-    im = torch.randn(1, 3, 64, 64)  # requires min imgsz=64
-    _ = model.predict(im, profile=True)
-
-
-@pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
-def test_predict_txt():
-    """Test YOLO predictions with file, directory, and pattern sources listed in a text file."""
-    file = TMP / "sources_multi_row.txt"
-    with open(file, "w") as f:
-        for src in SOURCES_LIST:
-            f.write(f"{src}\n")
-    results = YOLO(MODEL)(source=file, imgsz=32)
-    assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
-
-
-@pytest.mark.skipif(True, reason="disabled for testing")
-@pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
-def test_predict_csv_multi_row():
-    """Test YOLO predictions with sources listed in multiple rows of a CSV file."""
-    file = TMP / "sources_multi_row.csv"
-    with open(file, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(["source"])
-        writer.writerows([[src] for src in SOURCES_LIST])
-    results = YOLO(MODEL)(source=file, imgsz=32)
-    assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
-
-
-@pytest.mark.skipif(True, reason="disabled for testing")
-@pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
-def test_predict_csv_single_row():
-    """Test YOLO predictions with sources listed in a single row of a CSV file."""
-    file = TMP / "sources_single_row.csv"
-    with open(file, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(SOURCES_LIST)
-    results = YOLO(MODEL)(source=file, imgsz=32)
-    assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
-
-
-@pytest.mark.parametrize("model_name", MODELS)
-def test_predict_img(model_name):
-    """Test YOLO model predictions on various image input types and sources, including online images."""
-    model = YOLO(WEIGHTS_DIR / model_name)
-    im = cv2.imread(str(SOURCE))  # uint8 numpy array
-    assert len(model(source=Image.open(SOURCE), save=True, verbose=True, imgsz=32)) == 1  # PIL
-    assert len(model(source=im, save=True, save_txt=True, imgsz=32)) == 1  # ndarray
-    assert len(model(torch.rand((2, 3, 32, 32)), imgsz=32)) == 2  # batch-size 2 Tensor, FP32 0.0-1.0 RGB order
-    assert len(model(source=[im, im], save=True, save_txt=True, imgsz=32)) == 2  # batch
-    assert len(list(model(source=[im, im], save=True, stream=True, imgsz=32))) == 2  # stream
-    assert len(model(torch.zeros(320, 640, 3).numpy().astype(np.uint8), imgsz=32)) == 1  # tensor to numpy
-    batch = [
-        str(SOURCE),  # filename
-        Path(SOURCE),  # Path
-        "https://github.com/ultralytics/assets/releases/download/v0.0.0/zidane.jpg" if ONLINE else SOURCE,  # URI
-        cv2.imread(str(SOURCE)),  # OpenCV
-        Image.open(SOURCE),  # PIL
-        np.zeros((320, 640, 3), dtype=np.uint8),  # numpy
-    ]
-    assert len(model(batch, imgsz=32, classes=0)) == len(batch)  # multiple sources in a batch
-
-
-@pytest.mark.parametrize("model", MODELS)
-def test_predict_visualize(model):
-    """Test model prediction methods with 'visualize=True' to generate and display prediction visualizations."""
-    YOLO(WEIGHTS_DIR / model)(SOURCE, imgsz=32, visualize=True)
-
-
-def test_predict_grey_and_4ch():
-    """Test YOLO prediction on SOURCE converted to greyscale and 4-channel images with various filenames."""
-    im = Image.open(SOURCE)
-    directory = TMP / "im4"
-    directory.mkdir(parents=True, exist_ok=True)
-
-    source_greyscale = directory / "greyscale.jpg"
-    source_rgba = directory / "4ch.png"
-    source_non_utf = directory / "non_UTF_测试文件_tést_image.jpg"
-    source_spaces = directory / "image with spaces.jpg"
-
-    im.convert("L").save(source_greyscale)  # greyscale
-    im.convert("RGBA").save(source_rgba)  # 4-ch PNG with alpha
-    im.save(source_non_utf)  # non-UTF characters in filename
-    im.save(source_spaces)  # spaces in filename
-
-    # Inference
-    model = YOLO(MODEL)
-    for f in source_rgba, source_greyscale, source_non_utf, source_spaces:
-        for source in Image.open(f), cv2.imread(str(f)), f:
-            results = model(source, save=True, verbose=True, imgsz=32)
-            assert len(results) == 1  # verify that an image was run
-        f.unlink()  # cleanup
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(not ONLINE, reason="environment is offline")
-@pytest.mark.skipif(is_github_action_running(), reason="No auth https://github.com/JuanBindez/pytubefix/issues/166")
-def test_youtube():
-    """Test YOLO model on a YouTube video stream, handling potential network-related errors."""
-    model = YOLO(MODEL)
-    try:
-        model.predict("https://youtu.be/G17sBkb38XQ", imgsz=96, save=True)
-    # Handle internet connection errors and 'urllib.error.HTTPError: HTTP Error 429: Too Many Requests'
-    except (urllib.error.HTTPError, ConnectionError) as e:
-        LOGGER.error(f"YouTube Test Error: {e}")
+# def test_model_forward():
+#     """Test the forward pass of the YOLO model."""
+#     model = YOLO(CFG)
+#     model(source=None, imgsz=32, augment=True)  # also test no source and augment
+#
+#
+# def test_model_methods():
+#     """Test various methods and properties of the YOLO model to ensure correct functionality."""
+#     model = YOLO(MODEL)
+#
+#     # Model methods
+#     model.info(verbose=True, detailed=True)
+#     model = model.reset_weights()
+#     model = model.load(MODEL)
+#     model.to("cpu")
+#     model.fuse()
+#     model.clear_callback("on_train_start")
+#     model.reset_callbacks()
+#
+#     # Model properties
+#     _ = model.names
+#     _ = model.device
+#     _ = model.transforms
+#     _ = model.task_map
+#
+#
+# def test_model_profile():
+#     """Test profiling of the YOLO model with `profile=True` to assess performance and resource usage."""
+#     from ultralytics.nn.tasks import DetectionModel
+#
+#     model = DetectionModel()  # build model
+#     im = torch.randn(1, 3, 64, 64)  # requires min imgsz=64
+#     _ = model.predict(im, profile=True)
+#
+#
+# @pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
+# def test_predict_txt():
+#     """Test YOLO predictions with file, directory, and pattern sources listed in a text file."""
+#     file = TMP / "sources_multi_row.txt"
+#     with open(file, "w") as f:
+#         for src in SOURCES_LIST:
+#             f.write(f"{src}\n")
+#     results = YOLO(MODEL)(source=file, imgsz=32)
+#     assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
+#
+#
+# @pytest.mark.skipif(True, reason="disabled for testing")
+# @pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
+# def test_predict_csv_multi_row():
+#     """Test YOLO predictions with sources listed in multiple rows of a CSV file."""
+#     file = TMP / "sources_multi_row.csv"
+#     with open(file, "w", newline="") as f:
+#         writer = csv.writer(f)
+#         writer.writerow(["source"])
+#         writer.writerows([[src] for src in SOURCES_LIST])
+#     results = YOLO(MODEL)(source=file, imgsz=32)
+#     assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
+#
+#
+# @pytest.mark.skipif(True, reason="disabled for testing")
+# @pytest.mark.skipif(not IS_TMP_WRITEABLE, reason="directory is not writeable")
+# def test_predict_csv_single_row():
+#     """Test YOLO predictions with sources listed in a single row of a CSV file."""
+#     file = TMP / "sources_single_row.csv"
+#     with open(file, "w", newline="") as f:
+#         writer = csv.writer(f)
+#         writer.writerow(SOURCES_LIST)
+#     results = YOLO(MODEL)(source=file, imgsz=32)
+#     assert len(results) == 7  # 1 + 2 + 2 + 2 = 7 images
+#
+#
+# @pytest.mark.parametrize("model_name", MODELS)
+# def test_predict_img(model_name):
+#     """Test YOLO model predictions on various image input types and sources, including online images."""
+#     model = YOLO(WEIGHTS_DIR / model_name)
+#     im = cv2.imread(str(SOURCE))  # uint8 numpy array
+#     assert len(model(source=Image.open(SOURCE), save=True, verbose=True, imgsz=32)) == 1  # PIL
+#     assert len(model(source=im, save=True, save_txt=True, imgsz=32)) == 1  # ndarray
+#     assert len(model(torch.rand((2, 3, 32, 32)), imgsz=32)) == 2  # batch-size 2 Tensor, FP32 0.0-1.0 RGB order
+#     assert len(model(source=[im, im], save=True, save_txt=True, imgsz=32)) == 2  # batch
+#     assert len(list(model(source=[im, im], save=True, stream=True, imgsz=32))) == 2  # stream
+#     assert len(model(torch.zeros(320, 640, 3).numpy().astype(np.uint8), imgsz=32)) == 1  # tensor to numpy
+#     batch = [
+#         str(SOURCE),  # filename
+#         Path(SOURCE),  # Path
+#         "https://github.com/ultralytics/assets/releases/download/v0.0.0/zidane.jpg" if ONLINE else SOURCE,  # URI
+#         cv2.imread(str(SOURCE)),  # OpenCV
+#         Image.open(SOURCE),  # PIL
+#         np.zeros((320, 640, 3), dtype=np.uint8),  # numpy
+#     ]
+#     assert len(model(batch, imgsz=32, classes=0)) == len(batch)  # multiple sources in a batch
+#
+#
+# @pytest.mark.parametrize("model", MODELS)
+# def test_predict_visualize(model):
+#     """Test model prediction methods with 'visualize=True' to generate and display prediction visualizations."""
+#     YOLO(WEIGHTS_DIR / model)(SOURCE, imgsz=32, visualize=True)
+#
+#
+# def test_predict_grey_and_4ch():
+#     """Test YOLO prediction on SOURCE converted to greyscale and 4-channel images with various filenames."""
+#     im = Image.open(SOURCE)
+#     directory = TMP / "im4"
+#     directory.mkdir(parents=True, exist_ok=True)
+#
+#     source_greyscale = directory / "greyscale.jpg"
+#     source_rgba = directory / "4ch.png"
+#     source_non_utf = directory / "non_UTF_测试文件_tést_image.jpg"
+#     source_spaces = directory / "image with spaces.jpg"
+#
+#     im.convert("L").save(source_greyscale)  # greyscale
+#     im.convert("RGBA").save(source_rgba)  # 4-ch PNG with alpha
+#     im.save(source_non_utf)  # non-UTF characters in filename
+#     im.save(source_spaces)  # spaces in filename
+#
+#     # Inference
+#     model = YOLO(MODEL)
+#     for f in source_rgba, source_greyscale, source_non_utf, source_spaces:
+#         for source in Image.open(f), cv2.imread(str(f)), f:
+#             results = model(source, save=True, verbose=True, imgsz=32)
+#             assert len(results) == 1  # verify that an image was run
+#         f.unlink()  # cleanup
+#
+#
+# @pytest.mark.slow
+# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
+# @pytest.mark.skipif(is_github_action_running(), reason="No auth https://github.com/JuanBindez/pytubefix/issues/166")
+# def test_youtube():
+#     """Test YOLO model on a YouTube video stream, handling potential network-related errors."""
+#     model = YOLO(MODEL)
+#     try:
+#         model.predict("https://youtu.be/G17sBkb38XQ", imgsz=96, save=True)
+#     # Handle internet connection errors and 'urllib.error.HTTPError: HTTP Error 429: Too Many Requests'
+#     except (urllib.error.HTTPError, ConnectionError) as e:
+#         LOGGER.error(f"YouTube Test Error: {e}")
 
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
@@ -196,506 +196,506 @@ def test_track_stream():
         model.track(video_url, imgsz=160, tracker=custom_yaml)
 
 
-def test_val():
-    """Test the validation mode of the YOLO model."""
-    metrics = YOLO(MODEL).val(data="coco8.yaml", imgsz=32)
-    metrics.to_df()
-    metrics.to_csv()
-    metrics.to_xml()
-    metrics.to_html()
-    metrics.to_json()
-    metrics.to_sql()
-
-
-def test_train_scratch():
-    """Test training the YOLO model from scratch using the provided configuration."""
-    model = YOLO(CFG)
-    model.train(data="coco8.yaml", epochs=2, imgsz=32, cache="disk", batch=-1, close_mosaic=1, name="model")
-    model(SOURCE)
-
-
-@pytest.mark.parametrize("scls", [False, True])
-def test_train_pretrained(scls):
-    """Test training of the YOLO model starting from a pre-trained checkpoint."""
-    model = YOLO(WEIGHTS_DIR / "yolo11n-seg.pt")
-    model.train(
-        data="coco8-seg.yaml", epochs=1, imgsz=32, cache="ram", copy_paste=0.5, mixup=0.5, name=0, single_cls=scls
-    )
-    model(SOURCE)
-
-
-def test_all_model_yamls():
-    """Test YOLO model creation for all available YAML configurations in the `cfg/models` directory."""
-    for m in (ROOT / "cfg" / "models").rglob("*.yaml"):
-        if "rtdetr" in m.name:
-            if TORCH_1_9:  # torch<=1.8 issue - TypeError: __init__() got an unexpected keyword argument 'batch_first'
-                _ = RTDETR(m.name)(SOURCE, imgsz=640)  # must be 640
-        else:
-            YOLO(m.name)
-
-
-@pytest.mark.skipif(WINDOWS, reason="Windows slow CI export bug https://github.com/ultralytics/ultralytics/pull/16003")
-def test_workflow():
-    """Test the complete workflow including training, validation, prediction, and exporting."""
-    model = YOLO(MODEL)
-    model.train(data="coco8.yaml", epochs=1, imgsz=32, optimizer="SGD")
-    model.val(imgsz=32)
-    model.predict(SOURCE, imgsz=32)
-    model.export(format="torchscript")  # WARNING: Windows slow CI export bug
-
-
-def test_predict_callback_and_setup():
-    """Test callback functionality during YOLO prediction setup and execution."""
-
-    def on_predict_batch_end(predictor):
-        """Callback function that handles operations at the end of a prediction batch."""
-        path, im0s, _ = predictor.batch
-        im0s = im0s if isinstance(im0s, list) else [im0s]
-        bs = [predictor.dataset.bs for _ in range(len(path))]
-        predictor.results = zip(predictor.results, im0s, bs)  # results is List[batch_size]
-
-    model = YOLO(MODEL)
-    model.add_callback("on_predict_batch_end", on_predict_batch_end)
-
-    dataset = load_inference_source(source=SOURCE)
-    bs = dataset.bs  # noqa access predictor properties
-    results = model.predict(dataset, stream=True, imgsz=160)  # source already setup
-    for r, im0, bs in results:
-        print("test_callback", im0.shape)
-        print("test_callback", bs)
-        boxes = r.boxes  # Boxes object for bbox outputs
-        print(boxes)
-
-
-@pytest.mark.parametrize("model", MODELS)
-def test_results(model):
-    """Test YOLO model results processing and output in various formats."""
-    temp_s = "https://ultralytics.com/images/boats.jpg" if model == "yolo11n-obb.pt" else SOURCE
-    results = YOLO(WEIGHTS_DIR / model)([temp_s, temp_s], imgsz=160)
-    for r in results:
-        r = r.cpu().numpy()
-        print(r, len(r), r.path)  # print numpy attributes
-        r = r.to(device="cpu", dtype=torch.float32)
-        r.save_txt(txt_file=TMP / "runs/tests/label.txt", save_conf=True)
-        r.save_crop(save_dir=TMP / "runs/tests/crops/")
-        r.to_df(decimals=3)  # Align to_ methods: https://docs.ultralytics.com/modes/predict/#working-with-results
-        r.to_csv()
-        r.to_xml()
-        r.to_html()
-        r.to_json(normalize=True)
-        r.to_sql()
-        r.plot(pil=True, save=True, filename=TMP / "results_plot_save.jpg")
-        r.plot(conf=True, boxes=True)
-        print(r, len(r), r.path)  # print after methods
-
-
-def test_labels_and_crops():
-    """Test output from prediction args for saving YOLO detection labels and crops."""
-    imgs = [SOURCE, ASSETS / "zidane.jpg"]
-    results = YOLO(WEIGHTS_DIR / "yolo11n.pt")(imgs, imgsz=160, save_txt=True, save_crop=True)
-    save_path = Path(results[0].save_dir)
-    for r in results:
-        im_name = Path(r.path).stem
-        cls_idxs = r.boxes.cls.int().tolist()
-        # Check correct detections
-        assert cls_idxs == ([0, 7, 0, 0] if r.path.endswith("bus.jpg") else [0, 0, 0])  # bus.jpg and zidane.jpg classes
-        # Check label path
-        labels = save_path / f"labels/{im_name}.txt"
-        assert labels.exists()
-        # Check detections match label count
-        assert len(r.boxes.data) == len([line for line in labels.read_text().splitlines() if line])
-        # Check crops path and files
-        crop_dirs = list((save_path / "crops").iterdir())
-        crop_files = [f for p in crop_dirs for f in p.glob("*")]
-        # Crop directories match detections
-        assert all(r.names.get(c) in {d.name for d in crop_dirs} for c in cls_idxs)
-        # Same number of crops as detections
-        assert len([f for f in crop_files if im_name in f.name]) == len(r.boxes.data)
-
-
-@pytest.mark.skipif(not ONLINE, reason="environment is offline")
-def test_data_utils():
-    """Test utility functions in ultralytics/data/utils.py, including dataset stats and auto-splitting."""
-    from ultralytics.data.split import autosplit
-    from ultralytics.data.utils import HUBDatasetStats
-    from ultralytics.utils.downloads import zip_directory
-
-    # from ultralytics.utils.files import WorkingDirectory
-    # with WorkingDirectory(ROOT.parent / 'tests'):
-
-    for task in TASKS:
-        file = Path(TASK2DATA[task]).with_suffix(".zip")  # i.e. coco8.zip
-        download(f"https://github.com/ultralytics/hub/raw/main/example_datasets/{file}", unzip=False, dir=TMP)
-        stats = HUBDatasetStats(TMP / file, task=task)
-        stats.get_json(save=True)
-        stats.process_images()
-
-    autosplit(TMP / "coco8")
-    zip_directory(TMP / "coco8/images/val")  # zip
-
-
-@pytest.mark.skipif(not ONLINE, reason="environment is offline")
-def test_data_converter():
-    """Test dataset conversion functions from COCO to YOLO format and class mappings."""
-    from ultralytics.data.converter import coco80_to_coco91_class, convert_coco
-
-    file = "instances_val2017.json"
-    download(f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{file}", dir=TMP)
-    convert_coco(labels_dir=TMP, save_dir=TMP / "yolo_labels", use_segments=True, use_keypoints=False, cls91to80=True)
-    coco80_to_coco91_class()
-
-
-def test_data_annotator():
-    """Test automatic annotation of data using detection and segmentation models."""
-    from ultralytics.data.annotator import auto_annotate
-
-    auto_annotate(
-        ASSETS,
-        det_model=WEIGHTS_DIR / "yolo11n.pt",
-        sam_model=WEIGHTS_DIR / "mobile_sam.pt",
-        output_dir=TMP / "auto_annotate_labels",
-    )
-
-
-def test_events():
-    """Test event sending functionality."""
-    from ultralytics.hub.utils import Events
-
-    events = Events()
-    events.enabled = True
-    cfg = copy(DEFAULT_CFG)  # does not require deepcopy
-    cfg.mode = "test"
-    events(cfg)
-
-
-def test_cfg_init():
-    """Test configuration initialization utilities from the 'ultralytics.cfg' module."""
-    from ultralytics.cfg import check_dict_alignment, copy_default_cfg, smart_value
-
-    with contextlib.suppress(SyntaxError):
-        check_dict_alignment({"a": 1}, {"b": 2})
-    copy_default_cfg()
-    (Path.cwd() / DEFAULT_CFG_PATH.name.replace(".yaml", "_copy.yaml")).unlink(missing_ok=False)
-    [smart_value(x) for x in ["none", "true", "false"]]
-
-
-def test_utils_init():
-    """Test initialization utilities in the Ultralytics library."""
-    from ultralytics.utils import get_git_branch, get_git_origin_url, get_ubuntu_version, is_github_action_running
-
-    get_ubuntu_version()
-    is_github_action_running()
-    get_git_origin_url()
-    get_git_branch()
-
-
-def test_utils_checks():
-    """Test various utility checks for filenames, git status, requirements, image sizes, and versions."""
-    checks.check_yolov5u_filename("yolov5n.pt")
-    checks.git_describe(ROOT)
-    checks.check_requirements()  # check requirements.txt
-    checks.check_imgsz([600, 600], max_dim=1)
-    checks.check_imshow(warn=True)
-    checks.check_version("ultralytics", "8.0.0")
-    checks.print_args()
-
-
-@pytest.mark.skipif(WINDOWS, reason="Windows profiling is extremely slow (cause unknown)")
-def test_utils_benchmarks():
-    """Benchmark model performance using 'ProfileModels' from 'ultralytics.utils.benchmarks'."""
-    from ultralytics.utils.benchmarks import ProfileModels
-
-    ProfileModels(["yolo11n.yaml"], imgsz=32, min_time=1, num_timed_runs=3, num_warmup_runs=1).run()
-
-
-def test_utils_torchutils():
-    """Test Torch utility functions including profiling and FLOP calculations."""
-    from ultralytics.nn.modules.conv import Conv
-    from ultralytics.utils.torch_utils import get_flops_with_torch_profiler, profile_ops, time_sync
-
-    x = torch.randn(1, 64, 20, 20)
-    m = Conv(64, 64, k=1, s=2)
-
-    profile_ops(x, [m], n=3)
-    get_flops_with_torch_profiler(m)
-    time_sync()
-
-
-def test_utils_ops():
-    """Test utility operations for coordinate transformations and normalizations."""
-    from ultralytics.utils.ops import (
-        ltwh2xywh,
-        ltwh2xyxy,
-        make_divisible,
-        xywh2ltwh,
-        xywh2xyxy,
-        xywhn2xyxy,
-        xywhr2xyxyxyxy,
-        xyxy2ltwh,
-        xyxy2xywh,
-        xyxy2xywhn,
-        xyxyxyxy2xywhr,
-    )
-
-    make_divisible(17, torch.tensor([8]))
-
-    boxes = torch.rand(10, 4)  # xywh
-    torch.allclose(boxes, xyxy2xywh(xywh2xyxy(boxes)))
-    torch.allclose(boxes, xyxy2xywhn(xywhn2xyxy(boxes)))
-    torch.allclose(boxes, ltwh2xywh(xywh2ltwh(boxes)))
-    torch.allclose(boxes, xyxy2ltwh(ltwh2xyxy(boxes)))
-
-    boxes = torch.rand(10, 5)  # xywhr for OBB
-    boxes[:, 4] = torch.randn(10) * 30
-    torch.allclose(boxes, xyxyxyxy2xywhr(xywhr2xyxyxyxy(boxes)), rtol=1e-3)
-
-
-def test_utils_files():
-    """Test file handling utilities including file age, date, and paths with spaces."""
-    from ultralytics.utils.files import file_age, file_date, get_latest_run, spaces_in_path
-
-    file_age(SOURCE)
-    file_date(SOURCE)
-    get_latest_run(ROOT / "runs")
-
-    path = TMP / "path/with spaces"
-    path.mkdir(parents=True, exist_ok=True)
-    with spaces_in_path(path) as new_path:
-        print(new_path)
-
-
-@pytest.mark.slow
-def test_utils_patches_torch_save():
-    """Test torch_save backoff when _torch_save raises RuntimeError."""
-    from unittest.mock import MagicMock, patch
-
-    from ultralytics.utils.patches import torch_save
-
-    mock = MagicMock(side_effect=RuntimeError)
-
-    with patch("ultralytics.utils.patches._torch_save", new=mock):
-        with pytest.raises(RuntimeError):
-            torch_save(torch.zeros(1), TMP / "test.pt")
-
-    assert mock.call_count == 4, "torch_save was not attempted the expected number of times"
-
-
-def test_nn_modules_conv():
-    """Test Convolutional Neural Network modules including CBAM, Conv2, and ConvTranspose."""
-    from ultralytics.nn.modules.conv import CBAM, Conv2, ConvTranspose, DWConvTranspose2d, Focus
-
-    c1, c2 = 8, 16  # input and output channels
-    x = torch.zeros(4, c1, 10, 10)  # BCHW
-
-    # Run all modules not otherwise covered in tests
-    DWConvTranspose2d(c1, c2)(x)
-    ConvTranspose(c1, c2)(x)
-    Focus(c1, c2)(x)
-    CBAM(c1)(x)
-
-    # Fuse ops
-    m = Conv2(c1, c2)
-    m.fuse_convs()
-    m(x)
-
-
-def test_nn_modules_block():
-    """Test various neural network block modules."""
-    from ultralytics.nn.modules.block import C1, C3TR, BottleneckCSP, C3Ghost, C3x
-
-    c1, c2 = 8, 16  # input and output channels
-    x = torch.zeros(4, c1, 10, 10)  # BCHW
-
-    # Run all modules not otherwise covered in tests
-    C1(c1, c2)(x)
-    C3x(c1, c2)(x)
-    C3TR(c1, c2)(x)
-    C3Ghost(c1, c2)(x)
-    BottleneckCSP(c1, c2)(x)
-
-
-@pytest.mark.skipif(not ONLINE, reason="environment is offline")
-def test_hub():
-    """Test Ultralytics HUB functionalities."""
-    from ultralytics.hub import export_fmts_hub, logout
-    from ultralytics.hub.utils import smart_request
-
-    export_fmts_hub()
-    logout()
-    smart_request("GET", "https://github.com", progress=True)
-
-
-@pytest.fixture
-def image():
-    """Load and return an image from a predefined source."""
-    return cv2.imread(str(SOURCE))
-
-
-@pytest.mark.parametrize(
-    "auto_augment, erasing, force_color_jitter",
-    [
-        (None, 0.0, False),
-        ("randaugment", 0.5, True),
-        ("augmix", 0.2, False),
-        ("autoaugment", 0.0, True),
-    ],
-)
-def test_classify_transforms_train(image, auto_augment, erasing, force_color_jitter):
-    """Test classification transforms during training with various augmentations."""
-    from ultralytics.data.augment import classify_augmentations
-
-    transform = classify_augmentations(
-        size=224,
-        mean=(0.5, 0.5, 0.5),
-        std=(0.5, 0.5, 0.5),
-        scale=(0.08, 1.0),
-        ratio=(3.0 / 4.0, 4.0 / 3.0),
-        hflip=0.5,
-        vflip=0.5,
-        auto_augment=auto_augment,
-        hsv_h=0.015,
-        hsv_s=0.4,
-        hsv_v=0.4,
-        force_color_jitter=force_color_jitter,
-        erasing=erasing,
-    )
-
-    transformed_image = transform(Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB)))
-
-    assert transformed_image.shape == (3, 224, 224)
-    assert torch.is_tensor(transformed_image)
-    assert transformed_image.dtype == torch.float32
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(not ONLINE, reason="environment is offline")
-def test_model_tune():
-    """Tune YOLO model for performance improvement."""
-    YOLO("yolo11n-pose.pt").tune(data="coco8-pose.yaml", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
-    YOLO("yolo11n-cls.pt").tune(data="imagenet10", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
-
-
-def test_model_embeddings():
-    """Test YOLO model embeddings extraction functionality."""
-    model_detect = YOLO(MODEL)
-    model_segment = YOLO(WEIGHTS_DIR / "yolo11n-seg.pt")
-
-    for batch in [SOURCE], [SOURCE, SOURCE]:  # test batch size 1 and 2
-        assert len(model_detect.embed(source=batch, imgsz=32)) == len(batch)
-        assert len(model_segment.embed(source=batch, imgsz=32)) == len(batch)
-
-
-@pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="YOLOWorld with CLIP is not supported in Python 3.12")
-@pytest.mark.skipif(
-    checks.IS_PYTHON_3_8 and LINUX and ARM64,
-    reason="YOLOWorld with CLIP is not supported in Python 3.8 and aarch64 Linux",
-)
-def test_yolo_world():
-    """Test YOLO world models with CLIP support."""
-    model = YOLO(WEIGHTS_DIR / "yolov8s-world.pt")  # no YOLO11n-world model yet
-    model.set_classes(["tree", "window"])
-    model(SOURCE, conf=0.01)
-
-    model = YOLO(WEIGHTS_DIR / "yolov8s-worldv2.pt")  # no YOLO11n-world model yet
-    # Training from a pretrained model. Eval is included at the final stage of training.
-    # Use dota8.yaml which has fewer categories to reduce the inference time of CLIP model
-    model.train(
-        data="dota8.yaml",
-        epochs=1,
-        imgsz=32,
-        cache="disk",
-        close_mosaic=1,
-    )
-
-    # test WorWorldTrainerFromScratch
-    from ultralytics.models.yolo.world.train_world import WorldTrainerFromScratch
-
-    model = YOLO("yolov8s-worldv2.yaml")  # no YOLO11n-world model yet
-    model.train(
-        data={"train": {"yolo_data": ["dota8.yaml"]}, "val": {"yolo_data": ["dota8.yaml"]}},
-        epochs=1,
-        imgsz=32,
-        cache="disk",
-        close_mosaic=1,
-        trainer=WorldTrainerFromScratch,
-    )
-
-
-@pytest.mark.skipif(checks.IS_PYTHON_3_12 or not TORCH_1_9, reason="YOLOE with CLIP is not supported in Python 3.12")
-@pytest.mark.skipif(
-    checks.IS_PYTHON_3_8 and LINUX and ARM64,
-    reason="YOLOE with CLIP is not supported in Python 3.8 and aarch64 Linux",
-)
-def test_yoloe():
-    """Test YOLOE models with MobileClip support."""
-    # Predict
-    # text-prompts
-    model = YOLO(WEIGHTS_DIR / "yoloe-11s-seg.pt")
-    names = ["person", "bus"]
-    model.set_classes(names, model.get_text_pe(names))
-    model(SOURCE, conf=0.01)
-
-    import numpy as np
-
-    from ultralytics import YOLOE
-    from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
-
-    # visual-prompts
-    visuals = dict(
-        bboxes=np.array(
-            [[221.52, 405.8, 344.98, 857.54], [120, 425, 160, 445]],
-        ),
-        cls=np.array([0, 1]),
-    )
-    model.predict(
-        SOURCE,
-        visual_prompts=visuals,
-        predictor=YOLOEVPSegPredictor,
-    )
-
-    # Val
-    model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg.pt")
-    # text prompts
-    model.val(data="coco128-seg.yaml", imgsz=32)
-    # visual prompts
-    model.val(data="coco128-seg.yaml", load_vp=True, imgsz=32)
-
-    # Train, fine-tune
-    from ultralytics.models.yolo.yoloe import YOLOEPESegTrainer
-
-    model = YOLOE("yoloe-11s-seg.pt")
-    model.train(
-        data="coco128-seg.yaml",
-        epochs=1,
-        close_mosaic=1,
-        trainer=YOLOEPESegTrainer,
-        imgsz=32,
-    )
-
-    # prompt-free
-    # predict
-    model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg-pf.pt")
-    model.predict(SOURCE)
-    # val
-    model = YOLOE("yoloe-11s-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
-    model.val(data="coco128-seg.yaml", imgsz=32)
-
-
-def test_yolov10():
-    """Test YOLOv10 model training, validation, and prediction functionality."""
-    model = YOLO("yolov10n.yaml")
-    # train/val/predict
-    model.train(data="coco8.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
-    model.val(data="coco8.yaml", imgsz=32)
-    model.predict(imgsz=32, save_txt=True, save_crop=True, augment=True)
-    model(SOURCE)
-
-
-def test_multichannel():
-    """Test YOLO model multi-channel training, validation, and prediction functionality."""
-    model = YOLO("yolo11n.pt")
-    model.train(data="coco8-multispectral.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
-    model.val(data="coco8-multispectral.yaml")
-    im = np.zeros((32, 32, 10), dtype=np.uint8)
-    model.predict(source=im, imgsz=32, save_txt=True, save_crop=True, augment=True)
-    model.export(format="onnx")
+# def test_val():
+#     """Test the validation mode of the YOLO model."""
+#     metrics = YOLO(MODEL).val(data="coco8.yaml", imgsz=32)
+#     metrics.to_df()
+#     metrics.to_csv()
+#     metrics.to_xml()
+#     metrics.to_html()
+#     metrics.to_json()
+#     metrics.to_sql()
+#
+#
+# def test_train_scratch():
+#     """Test training the YOLO model from scratch using the provided configuration."""
+#     model = YOLO(CFG)
+#     model.train(data="coco8.yaml", epochs=2, imgsz=32, cache="disk", batch=-1, close_mosaic=1, name="model")
+#     model(SOURCE)
+#
+#
+# @pytest.mark.parametrize("scls", [False, True])
+# def test_train_pretrained(scls):
+#     """Test training of the YOLO model starting from a pre-trained checkpoint."""
+#     model = YOLO(WEIGHTS_DIR / "yolo11n-seg.pt")
+#     model.train(
+#         data="coco8-seg.yaml", epochs=1, imgsz=32, cache="ram", copy_paste=0.5, mixup=0.5, name=0, single_cls=scls
+#     )
+#     model(SOURCE)
+#
+#
+# def test_all_model_yamls():
+#     """Test YOLO model creation for all available YAML configurations in the `cfg/models` directory."""
+#     for m in (ROOT / "cfg" / "models").rglob("*.yaml"):
+#         if "rtdetr" in m.name:
+#             if TORCH_1_9:  # torch<=1.8 issue - TypeError: __init__() got an unexpected keyword argument 'batch_first'
+#                 _ = RTDETR(m.name)(SOURCE, imgsz=640)  # must be 640
+#         else:
+#             YOLO(m.name)
+#
+#
+# @pytest.mark.skipif(WINDOWS, reason="Windows slow CI export bug https://github.com/ultralytics/ultralytics/pull/16003")
+# def test_workflow():
+#     """Test the complete workflow including training, validation, prediction, and exporting."""
+#     model = YOLO(MODEL)
+#     model.train(data="coco8.yaml", epochs=1, imgsz=32, optimizer="SGD")
+#     model.val(imgsz=32)
+#     model.predict(SOURCE, imgsz=32)
+#     model.export(format="torchscript")  # WARNING: Windows slow CI export bug
+#
+#
+# def test_predict_callback_and_setup():
+#     """Test callback functionality during YOLO prediction setup and execution."""
+#
+#     def on_predict_batch_end(predictor):
+#         """Callback function that handles operations at the end of a prediction batch."""
+#         path, im0s, _ = predictor.batch
+#         im0s = im0s if isinstance(im0s, list) else [im0s]
+#         bs = [predictor.dataset.bs for _ in range(len(path))]
+#         predictor.results = zip(predictor.results, im0s, bs)  # results is List[batch_size]
+#
+#     model = YOLO(MODEL)
+#     model.add_callback("on_predict_batch_end", on_predict_batch_end)
+#
+#     dataset = load_inference_source(source=SOURCE)
+#     bs = dataset.bs  # noqa access predictor properties
+#     results = model.predict(dataset, stream=True, imgsz=160)  # source already setup
+#     for r, im0, bs in results:
+#         print("test_callback", im0.shape)
+#         print("test_callback", bs)
+#         boxes = r.boxes  # Boxes object for bbox outputs
+#         print(boxes)
+#
+#
+# @pytest.mark.parametrize("model", MODELS)
+# def test_results(model):
+#     """Test YOLO model results processing and output in various formats."""
+#     temp_s = "https://ultralytics.com/images/boats.jpg" if model == "yolo11n-obb.pt" else SOURCE
+#     results = YOLO(WEIGHTS_DIR / model)([temp_s, temp_s], imgsz=160)
+#     for r in results:
+#         r = r.cpu().numpy()
+#         print(r, len(r), r.path)  # print numpy attributes
+#         r = r.to(device="cpu", dtype=torch.float32)
+#         r.save_txt(txt_file=TMP / "runs/tests/label.txt", save_conf=True)
+#         r.save_crop(save_dir=TMP / "runs/tests/crops/")
+#         r.to_df(decimals=3)  # Align to_ methods: https://docs.ultralytics.com/modes/predict/#working-with-results
+#         r.to_csv()
+#         r.to_xml()
+#         r.to_html()
+#         r.to_json(normalize=True)
+#         r.to_sql()
+#         r.plot(pil=True, save=True, filename=TMP / "results_plot_save.jpg")
+#         r.plot(conf=True, boxes=True)
+#         print(r, len(r), r.path)  # print after methods
+#
+#
+# def test_labels_and_crops():
+#     """Test output from prediction args for saving YOLO detection labels and crops."""
+#     imgs = [SOURCE, ASSETS / "zidane.jpg"]
+#     results = YOLO(WEIGHTS_DIR / "yolo11n.pt")(imgs, imgsz=160, save_txt=True, save_crop=True)
+#     save_path = Path(results[0].save_dir)
+#     for r in results:
+#         im_name = Path(r.path).stem
+#         cls_idxs = r.boxes.cls.int().tolist()
+#         # Check correct detections
+#         assert cls_idxs == ([0, 7, 0, 0] if r.path.endswith("bus.jpg") else [0, 0, 0])  # bus.jpg and zidane.jpg classes
+#         # Check label path
+#         labels = save_path / f"labels/{im_name}.txt"
+#         assert labels.exists()
+#         # Check detections match label count
+#         assert len(r.boxes.data) == len([line for line in labels.read_text().splitlines() if line])
+#         # Check crops path and files
+#         crop_dirs = list((save_path / "crops").iterdir())
+#         crop_files = [f for p in crop_dirs for f in p.glob("*")]
+#         # Crop directories match detections
+#         assert all(r.names.get(c) in {d.name for d in crop_dirs} for c in cls_idxs)
+#         # Same number of crops as detections
+#         assert len([f for f in crop_files if im_name in f.name]) == len(r.boxes.data)
+#
+#
+# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
+# def test_data_utils():
+#     """Test utility functions in ultralytics/data/utils.py, including dataset stats and auto-splitting."""
+#     from ultralytics.data.split import autosplit
+#     from ultralytics.data.utils import HUBDatasetStats
+#     from ultralytics.utils.downloads import zip_directory
+#
+#     # from ultralytics.utils.files import WorkingDirectory
+#     # with WorkingDirectory(ROOT.parent / 'tests'):
+#
+#     for task in TASKS:
+#         file = Path(TASK2DATA[task]).with_suffix(".zip")  # i.e. coco8.zip
+#         download(f"https://github.com/ultralytics/hub/raw/main/example_datasets/{file}", unzip=False, dir=TMP)
+#         stats = HUBDatasetStats(TMP / file, task=task)
+#         stats.get_json(save=True)
+#         stats.process_images()
+#
+#     autosplit(TMP / "coco8")
+#     zip_directory(TMP / "coco8/images/val")  # zip
+#
+#
+# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
+# def test_data_converter():
+#     """Test dataset conversion functions from COCO to YOLO format and class mappings."""
+#     from ultralytics.data.converter import coco80_to_coco91_class, convert_coco
+#
+#     file = "instances_val2017.json"
+#     download(f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{file}", dir=TMP)
+#     convert_coco(labels_dir=TMP, save_dir=TMP / "yolo_labels", use_segments=True, use_keypoints=False, cls91to80=True)
+#     coco80_to_coco91_class()
+#
+#
+# def test_data_annotator():
+#     """Test automatic annotation of data using detection and segmentation models."""
+#     from ultralytics.data.annotator import auto_annotate
+#
+#     auto_annotate(
+#         ASSETS,
+#         det_model=WEIGHTS_DIR / "yolo11n.pt",
+#         sam_model=WEIGHTS_DIR / "mobile_sam.pt",
+#         output_dir=TMP / "auto_annotate_labels",
+#     )
+#
+#
+# def test_events():
+#     """Test event sending functionality."""
+#     from ultralytics.hub.utils import Events
+#
+#     events = Events()
+#     events.enabled = True
+#     cfg = copy(DEFAULT_CFG)  # does not require deepcopy
+#     cfg.mode = "test"
+#     events(cfg)
+#
+#
+# def test_cfg_init():
+#     """Test configuration initialization utilities from the 'ultralytics.cfg' module."""
+#     from ultralytics.cfg import check_dict_alignment, copy_default_cfg, smart_value
+#
+#     with contextlib.suppress(SyntaxError):
+#         check_dict_alignment({"a": 1}, {"b": 2})
+#     copy_default_cfg()
+#     (Path.cwd() / DEFAULT_CFG_PATH.name.replace(".yaml", "_copy.yaml")).unlink(missing_ok=False)
+#     [smart_value(x) for x in ["none", "true", "false"]]
+#
+#
+# def test_utils_init():
+#     """Test initialization utilities in the Ultralytics library."""
+#     from ultralytics.utils import get_git_branch, get_git_origin_url, get_ubuntu_version, is_github_action_running
+#
+#     get_ubuntu_version()
+#     is_github_action_running()
+#     get_git_origin_url()
+#     get_git_branch()
+#
+#
+# def test_utils_checks():
+#     """Test various utility checks for filenames, git status, requirements, image sizes, and versions."""
+#     checks.check_yolov5u_filename("yolov5n.pt")
+#     checks.git_describe(ROOT)
+#     checks.check_requirements()  # check requirements.txt
+#     checks.check_imgsz([600, 600], max_dim=1)
+#     checks.check_imshow(warn=True)
+#     checks.check_version("ultralytics", "8.0.0")
+#     checks.print_args()
+#
+#
+# @pytest.mark.skipif(WINDOWS, reason="Windows profiling is extremely slow (cause unknown)")
+# def test_utils_benchmarks():
+#     """Benchmark model performance using 'ProfileModels' from 'ultralytics.utils.benchmarks'."""
+#     from ultralytics.utils.benchmarks import ProfileModels
+#
+#     ProfileModels(["yolo11n.yaml"], imgsz=32, min_time=1, num_timed_runs=3, num_warmup_runs=1).run()
+#
+#
+# def test_utils_torchutils():
+#     """Test Torch utility functions including profiling and FLOP calculations."""
+#     from ultralytics.nn.modules.conv import Conv
+#     from ultralytics.utils.torch_utils import get_flops_with_torch_profiler, profile_ops, time_sync
+#
+#     x = torch.randn(1, 64, 20, 20)
+#     m = Conv(64, 64, k=1, s=2)
+#
+#     profile_ops(x, [m], n=3)
+#     get_flops_with_torch_profiler(m)
+#     time_sync()
+#
+#
+# def test_utils_ops():
+#     """Test utility operations for coordinate transformations and normalizations."""
+#     from ultralytics.utils.ops import (
+#         ltwh2xywh,
+#         ltwh2xyxy,
+#         make_divisible,
+#         xywh2ltwh,
+#         xywh2xyxy,
+#         xywhn2xyxy,
+#         xywhr2xyxyxyxy,
+#         xyxy2ltwh,
+#         xyxy2xywh,
+#         xyxy2xywhn,
+#         xyxyxyxy2xywhr,
+#     )
+#
+#     make_divisible(17, torch.tensor([8]))
+#
+#     boxes = torch.rand(10, 4)  # xywh
+#     torch.allclose(boxes, xyxy2xywh(xywh2xyxy(boxes)))
+#     torch.allclose(boxes, xyxy2xywhn(xywhn2xyxy(boxes)))
+#     torch.allclose(boxes, ltwh2xywh(xywh2ltwh(boxes)))
+#     torch.allclose(boxes, xyxy2ltwh(ltwh2xyxy(boxes)))
+#
+#     boxes = torch.rand(10, 5)  # xywhr for OBB
+#     boxes[:, 4] = torch.randn(10) * 30
+#     torch.allclose(boxes, xyxyxyxy2xywhr(xywhr2xyxyxyxy(boxes)), rtol=1e-3)
+#
+#
+# def test_utils_files():
+#     """Test file handling utilities including file age, date, and paths with spaces."""
+#     from ultralytics.utils.files import file_age, file_date, get_latest_run, spaces_in_path
+#
+#     file_age(SOURCE)
+#     file_date(SOURCE)
+#     get_latest_run(ROOT / "runs")
+#
+#     path = TMP / "path/with spaces"
+#     path.mkdir(parents=True, exist_ok=True)
+#     with spaces_in_path(path) as new_path:
+#         print(new_path)
+#
+#
+# @pytest.mark.slow
+# def test_utils_patches_torch_save():
+#     """Test torch_save backoff when _torch_save raises RuntimeError."""
+#     from unittest.mock import MagicMock, patch
+#
+#     from ultralytics.utils.patches import torch_save
+#
+#     mock = MagicMock(side_effect=RuntimeError)
+#
+#     with patch("ultralytics.utils.patches._torch_save", new=mock):
+#         with pytest.raises(RuntimeError):
+#             torch_save(torch.zeros(1), TMP / "test.pt")
+#
+#     assert mock.call_count == 4, "torch_save was not attempted the expected number of times"
+#
+#
+# def test_nn_modules_conv():
+#     """Test Convolutional Neural Network modules including CBAM, Conv2, and ConvTranspose."""
+#     from ultralytics.nn.modules.conv import CBAM, Conv2, ConvTranspose, DWConvTranspose2d, Focus
+#
+#     c1, c2 = 8, 16  # input and output channels
+#     x = torch.zeros(4, c1, 10, 10)  # BCHW
+#
+#     # Run all modules not otherwise covered in tests
+#     DWConvTranspose2d(c1, c2)(x)
+#     ConvTranspose(c1, c2)(x)
+#     Focus(c1, c2)(x)
+#     CBAM(c1)(x)
+#
+#     # Fuse ops
+#     m = Conv2(c1, c2)
+#     m.fuse_convs()
+#     m(x)
+#
+#
+# def test_nn_modules_block():
+#     """Test various neural network block modules."""
+#     from ultralytics.nn.modules.block import C1, C3TR, BottleneckCSP, C3Ghost, C3x
+#
+#     c1, c2 = 8, 16  # input and output channels
+#     x = torch.zeros(4, c1, 10, 10)  # BCHW
+#
+#     # Run all modules not otherwise covered in tests
+#     C1(c1, c2)(x)
+#     C3x(c1, c2)(x)
+#     C3TR(c1, c2)(x)
+#     C3Ghost(c1, c2)(x)
+#     BottleneckCSP(c1, c2)(x)
+#
+#
+# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
+# def test_hub():
+#     """Test Ultralytics HUB functionalities."""
+#     from ultralytics.hub import export_fmts_hub, logout
+#     from ultralytics.hub.utils import smart_request
+#
+#     export_fmts_hub()
+#     logout()
+#     smart_request("GET", "https://github.com", progress=True)
+#
+#
+# @pytest.fixture
+# def image():
+#     """Load and return an image from a predefined source."""
+#     return cv2.imread(str(SOURCE))
+#
+#
+# @pytest.mark.parametrize(
+#     "auto_augment, erasing, force_color_jitter",
+#     [
+#         (None, 0.0, False),
+#         ("randaugment", 0.5, True),
+#         ("augmix", 0.2, False),
+#         ("autoaugment", 0.0, True),
+#     ],
+# )
+# def test_classify_transforms_train(image, auto_augment, erasing, force_color_jitter):
+#     """Test classification transforms during training with various augmentations."""
+#     from ultralytics.data.augment import classify_augmentations
+#
+#     transform = classify_augmentations(
+#         size=224,
+#         mean=(0.5, 0.5, 0.5),
+#         std=(0.5, 0.5, 0.5),
+#         scale=(0.08, 1.0),
+#         ratio=(3.0 / 4.0, 4.0 / 3.0),
+#         hflip=0.5,
+#         vflip=0.5,
+#         auto_augment=auto_augment,
+#         hsv_h=0.015,
+#         hsv_s=0.4,
+#         hsv_v=0.4,
+#         force_color_jitter=force_color_jitter,
+#         erasing=erasing,
+#     )
+#
+#     transformed_image = transform(Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB)))
+#
+#     assert transformed_image.shape == (3, 224, 224)
+#     assert torch.is_tensor(transformed_image)
+#     assert transformed_image.dtype == torch.float32
+#
+#
+# @pytest.mark.slow
+# @pytest.mark.skipif(not ONLINE, reason="environment is offline")
+# def test_model_tune():
+#     """Tune YOLO model for performance improvement."""
+#     YOLO("yolo11n-pose.pt").tune(data="coco8-pose.yaml", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
+#     YOLO("yolo11n-cls.pt").tune(data="imagenet10", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
+#
+#
+# def test_model_embeddings():
+#     """Test YOLO model embeddings extraction functionality."""
+#     model_detect = YOLO(MODEL)
+#     model_segment = YOLO(WEIGHTS_DIR / "yolo11n-seg.pt")
+#
+#     for batch in [SOURCE], [SOURCE, SOURCE]:  # test batch size 1 and 2
+#         assert len(model_detect.embed(source=batch, imgsz=32)) == len(batch)
+#         assert len(model_segment.embed(source=batch, imgsz=32)) == len(batch)
+#
+#
+# @pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="YOLOWorld with CLIP is not supported in Python 3.12")
+# @pytest.mark.skipif(
+#     checks.IS_PYTHON_3_8 and LINUX and ARM64,
+#     reason="YOLOWorld with CLIP is not supported in Python 3.8 and aarch64 Linux",
+# )
+# def test_yolo_world():
+#     """Test YOLO world models with CLIP support."""
+#     model = YOLO(WEIGHTS_DIR / "yolov8s-world.pt")  # no YOLO11n-world model yet
+#     model.set_classes(["tree", "window"])
+#     model(SOURCE, conf=0.01)
+#
+#     model = YOLO(WEIGHTS_DIR / "yolov8s-worldv2.pt")  # no YOLO11n-world model yet
+#     # Training from a pretrained model. Eval is included at the final stage of training.
+#     # Use dota8.yaml which has fewer categories to reduce the inference time of CLIP model
+#     model.train(
+#         data="dota8.yaml",
+#         epochs=1,
+#         imgsz=32,
+#         cache="disk",
+#         close_mosaic=1,
+#     )
+#
+#     # test WorWorldTrainerFromScratch
+#     from ultralytics.models.yolo.world.train_world import WorldTrainerFromScratch
+#
+#     model = YOLO("yolov8s-worldv2.yaml")  # no YOLO11n-world model yet
+#     model.train(
+#         data={"train": {"yolo_data": ["dota8.yaml"]}, "val": {"yolo_data": ["dota8.yaml"]}},
+#         epochs=1,
+#         imgsz=32,
+#         cache="disk",
+#         close_mosaic=1,
+#         trainer=WorldTrainerFromScratch,
+#     )
+#
+#
+# @pytest.mark.skipif(checks.IS_PYTHON_3_12 or not TORCH_1_9, reason="YOLOE with CLIP is not supported in Python 3.12")
+# @pytest.mark.skipif(
+#     checks.IS_PYTHON_3_8 and LINUX and ARM64,
+#     reason="YOLOE with CLIP is not supported in Python 3.8 and aarch64 Linux",
+# )
+# def test_yoloe():
+#     """Test YOLOE models with MobileClip support."""
+#     # Predict
+#     # text-prompts
+#     model = YOLO(WEIGHTS_DIR / "yoloe-11s-seg.pt")
+#     names = ["person", "bus"]
+#     model.set_classes(names, model.get_text_pe(names))
+#     model(SOURCE, conf=0.01)
+#
+#     import numpy as np
+#
+#     from ultralytics import YOLOE
+#     from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
+#
+#     # visual-prompts
+#     visuals = dict(
+#         bboxes=np.array(
+#             [[221.52, 405.8, 344.98, 857.54], [120, 425, 160, 445]],
+#         ),
+#         cls=np.array([0, 1]),
+#     )
+#     model.predict(
+#         SOURCE,
+#         visual_prompts=visuals,
+#         predictor=YOLOEVPSegPredictor,
+#     )
+#
+#     # Val
+#     model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg.pt")
+#     # text prompts
+#     model.val(data="coco128-seg.yaml", imgsz=32)
+#     # visual prompts
+#     model.val(data="coco128-seg.yaml", load_vp=True, imgsz=32)
+#
+#     # Train, fine-tune
+#     from ultralytics.models.yolo.yoloe import YOLOEPESegTrainer
+#
+#     model = YOLOE("yoloe-11s-seg.pt")
+#     model.train(
+#         data="coco128-seg.yaml",
+#         epochs=1,
+#         close_mosaic=1,
+#         trainer=YOLOEPESegTrainer,
+#         imgsz=32,
+#     )
+#
+#     # prompt-free
+#     # predict
+#     model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg-pf.pt")
+#     model.predict(SOURCE)
+#     # val
+#     model = YOLOE("yoloe-11s-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
+#     model.val(data="coco128-seg.yaml", imgsz=32)
+#
+#
+# def test_yolov10():
+#     """Test YOLOv10 model training, validation, and prediction functionality."""
+#     model = YOLO("yolov10n.yaml")
+#     # train/val/predict
+#     model.train(data="coco8.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
+#     model.val(data="coco8.yaml", imgsz=32)
+#     model.predict(imgsz=32, save_txt=True, save_crop=True, augment=True)
+#     model(SOURCE)
+#
+#
+# def test_multichannel():
+#     """Test YOLO model multi-channel training, validation, and prediction functionality."""
+#     model = YOLO("yolo11n.pt")
+#     model.train(data="coco8-multispectral.yaml", epochs=1, imgsz=32, close_mosaic=1, cache="disk")
+#     model.val(data="coco8-multispectral.yaml")
+#     im = np.zeros((32, 32, 10), dtype=np.uint8)
+#     model.predict(source=im, imgsz=32, save_txt=True, save_crop=True, augment=True)
+#     model.export(format="onnx")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,16 +1,44 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 
-import pytest
+import contextlib
+import csv
+import urllib
+from copy import copy
+from pathlib import Path
 
+import cv2
+import numpy as np
+
+import pytest
+import torch
+from PIL import Image
+
+from tests import CFG, MODEL, SOURCE, SOURCES_LIST, TMP
+from ultralytics import RTDETR, YOLO
+from ultralytics.cfg import MODELS, TASK2DATA, TASKS
+from ultralytics.data.build import load_inference_source
 from tests import MODEL, TMP
 from ultralytics import YOLO
 from ultralytics.utils import (
+    ARM64,
+    ASSETS,
+    DEFAULT_CFG,
+    DEFAULT_CFG_PATH,
+    LINUX,
+    LOGGER,
     ONLINE,
     ROOT,
+    WEIGHTS_DIR,
+    WINDOWS,
     YAML,
+    checks,
     is_dir_writeable,
+    is_github_action_running,
 )
+from ultralytics.utils.downloads import download
+from ultralytics.utils.torch_utils import TORCH_1_9
+
 
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import cv2
 import numpy as np
-
 import pytest
 import torch
 from PIL import Image
@@ -18,8 +17,6 @@ from tests import CFG, MODEL, SOURCE, SOURCES_LIST, TMP
 from ultralytics import RTDETR, YOLO
 from ultralytics.cfg import MODELS, TASK2DATA, TASKS
 from ultralytics.data.build import load_inference_source
-from tests import MODEL, TMP
-from ultralytics import YOLO
 from ultralytics.utils import (
     ARM64,
     ASSETS,
@@ -38,7 +35,6 @@ from ultralytics.utils import (
 )
 from ultralytics.utils.downloads import download
 from ultralytics.utils.torch_utils import TORCH_1_9
-
 
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -39,7 +39,6 @@ from ultralytics.utils import (
 from ultralytics.utils.downloads import download
 from ultralytics.utils.torch_utils import TORCH_1_9
 
-
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -555,8 +555,9 @@ class Model(torch.nn.Module):
         return (
             self.predictor.predict_cli(source=source)
             if is_cli
-            else self.predictor(source=source, stream=stream,
-                                **({"with_reid": True} if kwargs.get("mode") == "track" else {}))  # for botsort reid
+            else self.predictor(
+                source=source, stream=stream, **({"with_reid": True} if kwargs.get("mode") == "track" else {})
+            )  # for botsort reid
         )
 
     def track(

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -542,7 +542,6 @@ class Model(torch.nn.Module):
         custom = {"conf": 0.25, "batch": 1, "save": is_cli, "mode": "predict", "rect": True}  # method defaults
         args = {**self.overrides, **custom, **kwargs}  # highest priority args on the right
         prompts = args.pop("prompts", None)  # for SAM-type models
-        with_reid = args.pop("with_reid", False)  # for botsort reidentification
 
         if not self.predictor:
             self.predictor = (predictor or self._smart_load("predictor"))(overrides=args, _callbacks=self.callbacks)
@@ -556,7 +555,8 @@ class Model(torch.nn.Module):
         return (
             self.predictor.predict_cli(source=source)
             if is_cli
-            else self.predictor(source=source, stream=stream, with_reid=with_reid)
+            else self.predictor(source=source, stream=stream,
+                                **({"with_reid": True} if kwargs.get("mode") == "track" else {}))  # for botsort reid
         )
 
     def track(

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -553,7 +553,11 @@ class Model(torch.nn.Module):
                 self.predictor.save_dir = get_save_dir(self.predictor.args)
         if prompts and hasattr(self.predictor, "set_prompts"):  # for SAM-type models
             self.predictor.set_prompts(prompts)
-        return self.predictor.predict_cli(source=source) if is_cli else self.predictor(source=source, stream=stream, with_reid=with_reid)
+        return (
+            self.predictor.predict_cli(source=source)
+            if is_cli
+            else self.predictor(source=source, stream=stream, with_reid=with_reid)
+        )
 
     def track(
         self,

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -542,6 +542,7 @@ class Model(torch.nn.Module):
         custom = {"conf": 0.25, "batch": 1, "save": is_cli, "mode": "predict", "rect": True}  # method defaults
         args = {**self.overrides, **custom, **kwargs}  # highest priority args on the right
         prompts = args.pop("prompts", None)  # for SAM-type models
+        with_reid = args.pop("with_reid", False)  # for botsort reidentification
 
         if not self.predictor:
             self.predictor = (predictor or self._smart_load("predictor"))(overrides=args, _callbacks=self.callbacks)
@@ -552,7 +553,7 @@ class Model(torch.nn.Module):
                 self.predictor.save_dir = get_save_dir(self.predictor.args)
         if prompts and hasattr(self.predictor, "set_prompts"):  # for SAM-type models
             self.predictor.set_prompts(prompts)
-        return self.predictor.predict_cli(source=source) if is_cli else self.predictor(source=source, stream=stream)
+        return self.predictor.predict_cli(source=source) if is_cli else self.predictor(source=source, stream=stream, with_reid=with_reid)
 
     def track(
         self,

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -542,6 +542,7 @@ class Model(torch.nn.Module):
         custom = {"conf": 0.25, "batch": 1, "save": is_cli, "mode": "predict", "rect": True}  # method defaults
         args = {**self.overrides, **custom, **kwargs}  # highest priority args on the right
         prompts = args.pop("prompts", None)  # for SAM-type models
+        with_reid = args.pop("with_reid", False)  # for botsort reidentification
 
         if not self.predictor:
             self.predictor = (predictor or self._smart_load("predictor"))(overrides=args, _callbacks=self.callbacks)
@@ -556,7 +557,7 @@ class Model(torch.nn.Module):
             self.predictor.predict_cli(source=source)
             if is_cli
             else self.predictor(
-                source=source, stream=stream, **({"with_reid": True} if kwargs.get("mode") == "track" else {})
+                source=source, stream=stream, **({"with_reid": with_reid} if kwargs.get("mode") == "track" else {})
             )  # for botsort reid
         )
 

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -317,7 +317,7 @@ class BasePredictor:
                 ops.Profile(device=self.device),
                 ops.Profile(device=self.device),
             )
-            self.args.with_reid = kwargs["with_reid"]
+            self.args.with_reid = kwargs["with_reid"]  # Call it before on_predict_start callback for usage in track.py
             self.run_callbacks("on_predict_start")
             for self.batch in self.dataset:
                 self.run_callbacks("on_predict_batch_start")

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -317,7 +317,7 @@ class BasePredictor:
                 ops.Profile(device=self.device),
                 ops.Profile(device=self.device),
             )
-            self.args.with_reid = kwargs["with_reid"]  # Call it before on_predict_start callback for usage in track.py
+            self.args.with_reid = kwargs.get("with_reid", False)
             self.run_callbacks("on_predict_start")
             for self.batch in self.dataset:
                 self.run_callbacks("on_predict_batch_start")

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -179,6 +179,7 @@ class BasePredictor:
             if self.args.visualize and (not self.source_type.tensor)
             else False
         )
+        kwargs.pop("with_reid", None)  # Remove this, as it's dynamic argument created to support re-id with track.
         return self.model(im, augment=self.args.augment, visualize=visualize, embed=self.args.embed, *args, **kwargs)
 
     def pre_transform(self, im: List[np.ndarray]) -> List[np.ndarray]:
@@ -316,6 +317,7 @@ class BasePredictor:
                 ops.Profile(device=self.device),
                 ops.Profile(device=self.device),
             )
+            self.args.with_reid = kwargs["with_reid"]
             self.run_callbacks("on_predict_start")
             for self.batch in self.dataset:
                 self.run_callbacks("on_predict_batch_start")

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -36,6 +36,7 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
 
     tracker = check_yaml(predictor.args.tracker)
     cfg = IterableSimpleNamespace(**YAML.load(tracker))
+    cfg.with_reid = predictor.args.with_reid
 
     if cfg.tracker_type not in {"bytetrack", "botsort"}:
         raise AssertionError(f"Only 'bytetrack' and 'botsort' are supported for now, but got '{cfg.tracker_type}'")
@@ -43,7 +44,7 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
     predictor._feats = None  # reset in case used earlier
     if hasattr(predictor, "_hook"):
         predictor._hook.remove()
-    if cfg.tracker_type == "botsort" and predictor.args.with_reid and cfg.model == "auto":
+    if cfg.tracker_type == "botsort" and cfg.with_reid and cfg.model == "auto":
         from ultralytics.nn.modules.head import Detect
 
         if not (

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -43,7 +43,7 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
     predictor._feats = None  # reset in case used earlier
     if hasattr(predictor, "_hook"):
         predictor._hook.remove()
-    if cfg.tracker_type == "botsort" and cfg.with_reid and cfg.model == "auto":
+    if cfg.tracker_type == "botsort" and predictor.args.with_reid is True and cfg.model == "auto":
         from ultralytics.nn.modules.head import Detect
 
         if not (

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -43,7 +43,7 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
     predictor._feats = None  # reset in case used earlier
     if hasattr(predictor, "_hook"):
         predictor._hook.remove()
-    if cfg.tracker_type == "botsort" and predictor.args.with_reid is True and cfg.model == "auto":
+    if cfg.tracker_type == "botsort" and predictor.args.with_reid and cfg.model == "auto":
         from ultralytics.nn.modules.head import Detect
 
         if not (


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update makes it easier to enable and use Re-Identification (ReID) in object tracking with YOLO models, adding clearer documentation and improved code support. 🚀

### 📊 Key Changes
- Added a Python code example in the documentation showing how to enable ReID during tracking.
- Improved the codebase to allow passing the `with_reid` parameter directly when calling the `track` method.
- Ensured the ReID setting is properly handled and passed through the prediction and tracking pipeline.

### 🎯 Purpose & Impact
- **Simplifies Usage:** Users can now easily enable ReID with a single parameter in their code, making advanced tracking features more accessible.
- **Clearer Documentation:** The new example helps users understand how to activate and use ReID in their own projects.
- **Better Flexibility:** Developers can more easily experiment with and customize tracking behavior, improving workflow efficiency and model performance for tasks that require object re-identification.