### PR TITLE
Remove duplicate warning in tracker docs

### DIFF
--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -56,10 +56,6 @@ The default tracker is BoT-SORT.
 
 ## Tracking
 
-!!! warning "Tracker Threshold Information"
-
-    If object confidence score will be low, i.e lower than [`track_high_thresh`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/trackers/bytetrack.yaml#L5), then there will be no tracks successfully returned and updated.
-
 To run the tracker on video streams, use a trained Detect, Segment or Pose model such as YOLO11n, YOLO11n-seg and YOLO11n-pose.
 
 !!! example


### PR DESCRIPTION
Same warning in two sections

https://docs.ultralytics.com/modes/track/#tracking
https://docs.ultralytics.com/modes/track/#tracker-arguments

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removed a warning about tracker threshold behavior from the tracking documentation. 📝

### 📊 Key Changes
- Deleted a warning note explaining that tracks are not returned if object confidence is below the `track_high_thresh` value.

### 🎯 Purpose & Impact
- Simplifies the tracking documentation, making it less cluttered for users.
- Reduces potential confusion by removing technical details that may not be essential for most users.
- Users will now see a cleaner guide when learning how to use tracking features in Ultralytics models.