### PR TITLE
Extend `Model` class with `count` method for one-line counting

### DIFF
--- a/docs/en/guides/object-counting.md
+++ b/docs/en/guides/object-counting.md
@@ -58,13 +58,13 @@ Object counting with [Ultralytics YOLO11](https://github.com/ultralytics/ultraly
 
         # Load an official or custom model
         model = YOLO("yolo11n.pt")  # Load an official Detect model
-        
+
         results = model.count(source="Path/to/video.mp4")
-        
+
         for result in results:
             print(result.out_count)
         ```
-    
+
     === "With video processing pipeline"
 
         ```python

--- a/docs/en/guides/object-counting.md
+++ b/docs/en/guides/object-counting.md
@@ -54,6 +54,20 @@ Object counting with [Ultralytics YOLO11](https://github.com/ultralytics/ultraly
     === "Python"
 
         ```python
+        from ultralytics import YOLO
+
+        # Load an official or custom model
+        model = YOLO("yolo11n.pt")  # Load an official Detect model
+        
+        results = model.count(source="Path/to/video.mp4")
+        
+        for result in results:
+            print(result.out_count)
+        ```
+    
+    === "With video processing pipeline"
+
+        ```python
         import cv2
 
         from ultralytics import solutions

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -199,6 +199,9 @@ def test_track_stream(model):
         YAML.save(custom_yaml, {**default_args, "gmc_method": gmc, "with_reid": True, "model": reidm})
         model.track(video_url, imgsz=160, tracker=custom_yaml)
 
+def test_count_stream():
+    _ = YOLO("yolo11n.pt").count()
+
 
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)
 def test_val(task: str, model: str, data: str) -> None:

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -199,6 +199,7 @@ def test_track_stream(model):
         YAML.save(custom_yaml, {**default_args, "gmc_method": gmc, "with_reid": True, "model": reidm})
         model.track(video_url, imgsz=160, tracker=custom_yaml)
 
+
 def test_count_stream():
     _ = YOLO("yolo11n.pt").count()
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -199,8 +199,8 @@ def test_track_stream(model):
         YAML.save(custom_yaml, {**default_args, "gmc_method": gmc, "with_reid": True, "model": reidm})
         model.track(video_url, imgsz=160, tracker=custom_yaml)
 
-
 def test_count_stream():
+    """Test for object counting."""
     _ = YOLO("yolo11n.pt").count()
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -199,6 +199,7 @@ def test_track_stream(model):
         YAML.save(custom_yaml, {**default_args, "gmc_method": gmc, "with_reid": True, "model": reidm})
         model.track(video_url, imgsz=160, tracker=custom_yaml)
 
+
 def test_count_stream():
     """Test for object counting."""
     _ = YOLO("yolo11n.pt").count()

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -601,10 +601,10 @@ class Model(torch.nn.Module):
         return self.predict(source=source, stream=stream, **kwargs)
 
     def count(
-            self,
-            source: Union[str, Path, int, list, tuple, np.ndarray, torch.Tensor] = None,
-            save=True,
-            **kwargs: Any,
+        self,
+        source: Union[str, Path, int, list, tuple, np.ndarray, torch.Tensor] = None,
+        save=True,
+        **kwargs: Any,
     ) -> List[dict]:
         """
         Perform object counting on the specified input source using the ObjectCounter solution.
@@ -652,10 +652,18 @@ class Model(torch.nn.Module):
                         from types import SimpleNamespace  # scope import for fast speed
 
                         import cv2  # scope import for fast speed
-                        suffix, fourcc = (".mp4", "avc1") if MACOS else (".avi", "WMV2") if WINDOWS else (".avi", "MJPG")
+
+                        suffix, fourcc = (
+                            (".mp4", "avc1") if MACOS else (".avi", "WMV2") if WINDOWS else (".avi", "MJPG")
+                        )
                         save_dir = get_save_dir(SimpleNamespace(project="runs/solutions", name="exp", exist_ok=False))
                         save_dir.mkdir(parents=True)
-                        vid_writer = cv2.VideoWriter(str(Path(save_dir/"output").with_suffix(suffix)), cv2.VideoWriter_fourcc(*fourcc), 30, im.shape[:2])
+                        vid_writer = cv2.VideoWriter(
+                            str(Path(save_dir / "output").with_suffix(suffix)),
+                            cv2.VideoWriter_fourcc(*fourcc),
+                            30,
+                            im.shape[:2],
+                        )
                     vid_writer.write(result.plot_im)
         return results
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -3,10 +3,10 @@
 import inspect
 from pathlib import Path
 from typing import Any, Dict, List, Union
-
 import numpy as np
 import torch
 from PIL import Image
+from line_profiler_pycharm import profile
 
 from ultralytics.cfg import TASK2DATA, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
@@ -21,6 +21,8 @@ from ultralytics.utils import (
     YAML,
     callbacks,
     checks,
+    MACOS,
+    WINDOWS
 )
 
 
@@ -597,6 +599,67 @@ class Model(torch.nn.Module):
         kwargs["batch"] = kwargs.get("batch") or 1  # batch-size 1 for tracking in videos
         kwargs["mode"] = "track"
         return self.predict(source=source, stream=stream, **kwargs)
+
+    @profile
+    def count(
+            self,
+            source: Union[str, Path, int, list, tuple, np.ndarray, torch.Tensor] = None,
+            save=True,
+            **kwargs: Any,
+    ) -> List[dict]:
+        """
+        Perform object counting on the specified input source using the ObjectCounter solution.
+
+        This method applies real-time object counting using the ObjectCounter class, which supports various input sources
+        such as video files, or image streams. It initializes the appropriate predictor and object counter,
+        processes each frame in the input source, and returns a list of results for each processed frame.
+
+        Args:
+            source (str | Path | int | List | Tuple | np.ndarray | torch.Tensor, optional): Input source for object
+                counting. Can be a file path, URL, camera index, or image/frame array.
+            save (bool): Save the processed video in the directory.
+            **kwargs (Any): Additional keyword arguments to configure the ObjectCounter solution.
+
+        Returns:
+            (List[dict]): A list of dictionaries containing object counting results for each frame.
+
+        Examples:
+            >>> model = YOLO("yolo11n.pt")
+            >>> results = model.count(source="path/to/video.mp4")
+            >>> for r in results:
+            ...     print(r.in_count)  # print in counts for video stream at specific video frame.
+
+        Notes:
+            - Automatically defaults to "solutions_ci_demo.mp4" if no source is provided.
+            - Uses the ObjectCounter solution from `ultralytics.solutions`.
+            - `region_points` for counting can be passed via kwargs to define counting regions.
+        """
+        self.predictor = (self._smart_load("predictor"))()
+        self.predictor.setup_model(model=self.model, verbose=False)
+
+        from ultralytics import solutions
+
+        counter = solutions.ObjectCounter(is_cli=True, source=source, **kwargs)
+
+        self.predictor.setup_source(source or "solutions_ci_demo.mp4")
+
+        vid_writer = None  # For video writing
+        results = []  # For results storage
+
+        for self.batch in self.predictor.dataset:
+            for im in self.batch[1]:
+                result = counter(im)
+                results.append(result)
+                if save:
+                    if vid_writer is None:
+                        import cv2  # scope import for fast speed
+                        from types import SimpleNamespace  # scope import for fast speed
+                        suffix, fourcc = (".mp4", "avc1") if MACOS else (".avi", "WMV2") if WINDOWS else (".avi", "MJPG")
+                        save_dir = get_save_dir(SimpleNamespace(project="runs/solutions", name="exp", exist_ok=False))
+                        save_dir.mkdir(parents=True)
+                        vid_writer = cv2.VideoWriter(str(Path(save_dir/"output").with_suffix(suffix)), cv2.VideoWriter_fourcc(*fourcc), 30, im.shape[:2])
+                    vid_writer.write(result.plot_im)
+        return results
 
     def val(
         self,

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -16,13 +16,13 @@ from ultralytics.utils import (
     ASSETS,
     DEFAULT_CFG_DICT,
     LOGGER,
+    MACOS,
     RANK,
     SETTINGS,
+    WINDOWS,
     YAML,
     callbacks,
     checks,
-    MACOS,
-    WINDOWS
 )
 
 
@@ -649,8 +649,9 @@ class Model(torch.nn.Module):
                 results.append(result)
                 if save:
                     if vid_writer is None:
-                        import cv2  # scope import for fast speed
                         from types import SimpleNamespace  # scope import for fast speed
+
+                        import cv2  # scope import for fast speed
                         suffix, fourcc = (".mp4", "avc1") if MACOS else (".avi", "WMV2") if WINDOWS else (".avi", "MJPG")
                         save_dir = get_save_dir(SimpleNamespace(project="runs/solutions", name="exp", exist_ok=False))
                         save_dir.mkdir(parents=True)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Union
 import numpy as np
 import torch
 from PIL import Image
-from line_profiler_pycharm import profile
 
 from ultralytics.cfg import TASK2DATA, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
@@ -600,7 +599,6 @@ class Model(torch.nn.Module):
         kwargs["mode"] = "track"
         return self.predict(source=source, stream=stream, **kwargs)
 
-    @profile
     def count(
             self,
             source: Union[str, Path, int, list, tuple, np.ndarray, torch.Tensor] = None,
@@ -611,12 +609,11 @@ class Model(torch.nn.Module):
         Perform object counting on the specified input source using the ObjectCounter solution.
 
         This method applies real-time object counting using the ObjectCounter class, which supports various input sources
-        such as video files, or image streams. It initializes the appropriate predictor and object counter,
+        such as video files, or streams. It initializes the appropriate predictor and object counter,
         processes each frame in the input source, and returns a list of results for each processed frame.
 
         Args:
-            source (str | Path | int | List | Tuple | np.ndarray | torch.Tensor, optional): Input source for object
-                counting. Can be a file path, URL, camera index, or image/frame array.
+            source (str | Path , optional): Input source for object counting. Can be a file path or stream URL.
             save (bool): Save the processed video in the directory.
             **kwargs (Any): Additional keyword arguments to configure the ObjectCounter solution.
 
@@ -631,8 +628,7 @@ class Model(torch.nn.Module):
 
         Notes:
             - Automatically defaults to "solutions_ci_demo.mp4" if no source is provided.
-            - Uses the ObjectCounter solution from `ultralytics.solutions`.
-            - `region_points` for counting can be passed via kwargs to define counting regions.
+            - `region` for counting can be passed via kwargs to define counting region.
         """
         self.predictor = (self._smart_load("predictor"))()
         self.predictor.setup_model(model=self.model, verbose=False)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -652,6 +652,7 @@ class Model(torch.nn.Module):
                         from types import SimpleNamespace  # scope import for fast speed
 
                         import cv2  # scope import for fast speed
+
                         h, w = im.shape[:2]
                         suffix, fourcc = (
                             (".mp4", "avc1") if MACOS else (".avi", "WMV2") if WINDOWS else (".avi", "MJPG")

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -652,7 +652,7 @@ class Model(torch.nn.Module):
                         from types import SimpleNamespace  # scope import for fast speed
 
                         import cv2  # scope import for fast speed
-
+                        h, w = im.shape[:2]
                         suffix, fourcc = (
                             (".mp4", "avc1") if MACOS else (".avi", "WMV2") if WINDOWS else (".avi", "MJPG")
                         )
@@ -662,7 +662,7 @@ class Model(torch.nn.Module):
                             str(Path(save_dir / "output").with_suffix(suffix)),
                             cv2.VideoWriter_fourcc(*fourcc),
                             30,
-                            im.shape[:2],
+                            (w, h),
                         )
                     vid_writer.write(result.plot_im)
         return results

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -3,6 +3,7 @@
 import inspect
 from pathlib import Path
 from typing import Any, Dict, List, Union
+
 import numpy as np
 import torch
 from PIL import Image


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds a new `count()` method to the YOLO model, enabling easy object counting in videos and streams directly from Python. 📊🎥

### 📊 Key Changes
- Introduced a `count()` method to the YOLO class for real-time object counting on various input sources (videos, streams, images).
- Updated documentation with clear Python usage examples for object counting.
- Added a test to ensure the new `count()` method works as expected.

### 🎯 Purpose & Impact
- **Simplifies Object Counting:** Users can now count objects in videos or streams with a single method call, making the process much more accessible.
- **Enhanced Usability:** The new method supports saving processed videos and customizing counting regions, offering flexibility for different use cases.
- **Improved Documentation:** Clear examples help users quickly understand and implement object counting in their projects.
- **Reliability:** Automated tests ensure the feature works correctly, increasing confidence for both developers and users.

This update makes object counting with Ultralytics YOLO models easier and more user-friendly for everyone! 🚀