### PR TITLE
Configurable oks

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -119,7 +119,7 @@ copy_paste: 0.0 # (float) segment copy-paste (probability)
 copy_paste_mode: "flip" # (str) the method to do copy_paste augmentation (flip, mixup)
 auto_augment: randaugment # (str) auto augmentation policy for classification (randaugment, autoaugment, augmix)
 erasing: 0.4 # (float) probability of random erasing during classification training (0-0.9), 0 means no erasing, must be less than 1.0.
-
+OKS_SIGMA: [.026, .025, .025, .035, .035, .079, .079, .072, .072, .062, .062, 0.107, .107, .087, .087, .089, .089] # (list) keypoints weight for OKS pose loss and metric. Numbers are optimized for coco keypoints
 # Custom config.yaml ---------------------------------------------------------------------------------------------------
 cfg: # (str, optional) for overriding defaults.yaml
 

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -100,6 +100,7 @@ cls: 0.5 # (float) cls loss gain (scale with pixels)
 dfl: 1.5 # (float) dfl loss gain
 pose: 12.0 # (float) pose loss gain
 kobj: 1.0 # (float) keypoint obj loss gain
+OKS_SIGMA: [.026, .025, .025, .035, .035, .079, .079, .072, .072, .062, .062, 0.107, .107, .087, .087, .089, .089] # (list) keypoints weight for OKS pose loss and metric. Numbers are optimized for coco keypoints
 nbs: 64 # (int) nominal batch size
 hsv_h: 0.015 # (float) image HSV-Hue augmentation (fraction)
 hsv_s: 0.7 # (float) image HSV-Saturation augmentation (fraction)
@@ -119,7 +120,6 @@ copy_paste: 0.0 # (float) segment copy-paste (probability)
 copy_paste_mode: "flip" # (str) the method to do copy_paste augmentation (flip, mixup)
 auto_augment: randaugment # (str) auto augmentation policy for classification (randaugment, autoaugment, augmix)
 erasing: 0.4 # (float) probability of random erasing during classification training (0-0.9), 0 means no erasing, must be less than 1.0.
-OKS_SIGMA: [.026, .025, .025, .035, .035, .079, .079, .072, .072, .062, .062, 0.107, .107, .087, .087, .089, .089] # (list) keypoints weight for OKS pose loss and metric. Numbers are optimized for coco keypoints
 # Custom config.yaml ---------------------------------------------------------------------------------------------------
 cfg: # (str, optional) for overriding defaults.yaml
 

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -9,7 +9,7 @@ import torch
 from ultralytics.models.yolo.detect import DetectionValidator
 from ultralytics.utils import LOGGER, ops
 from ultralytics.utils.checks import check_requirements
-from ultralytics.utils.metrics import OKS_SIGMA, PoseMetrics, box_iou, kpt_iou
+from ultralytics.utils.metrics import PoseMetrics, box_iou, kpt_iou
 from ultralytics.utils.plotting import output_to_target, plot_images
 
 
@@ -116,9 +116,9 @@ class PoseValidator(DetectionValidator):
         """
         super().init_metrics(model)
         self.kpt_shape = self.data["kpt_shape"]
-        is_pose = self.kpt_shape == [17, 3]
-        nkpt = self.kpt_shape[0]
-        self.sigma = OKS_SIGMA if is_pose else np.ones(nkpt) / nkpt
+        OKS_SIGMA = self.args.OKS_SIGMA
+        is_pose = len(OKS_SIGMA) == nkpt
+        self.sigma = np.array(OKS_SIGMA) if is_pose else np.ones(nkpt) / nkpt
         self.stats = dict(tp_p=[], tp=[], conf=[], pred_cls=[], target_cls=[], target_img=[])
 
     def _prepare_batch(self, si: int, batch: Dict[str, Any]) -> Dict[str, Any]:

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from ultralytics.utils.metrics import OKS_SIGMA
 from ultralytics.utils.ops import crop_mask, xywh2xyxy, xyxy2xywh
 from ultralytics.utils.tal import RotatedTaskAlignedAssigner, TaskAlignedAssigner, dist2bbox, dist2rbox, make_anchors
 from ultralytics.utils.torch_utils import autocast
@@ -488,9 +487,10 @@ class v8PoseLoss(v8DetectionLoss):
         super().__init__(model)
         self.kpt_shape = model.model[-1].kpt_shape
         self.bce_pose = nn.BCEWithLogitsLoss()
-        is_pose = self.kpt_shape == [17, 3]
         nkpt = self.kpt_shape[0]  # number of keypoints
-        sigmas = torch.from_numpy(OKS_SIGMA).to(self.device) if is_pose else torch.ones(nkpt, device=self.device) / nkpt
+        OKS_SIGMA = model.args.OKS_SIGMA
+        is_pose = len(OKS_SIGMA) == nkpt  # instead of is_pose = self.kpt_shape == [17, 3]
+        sigmas = torch.tensor(OKS_SIGMA).to(self.device) if is_pose else torch.ones(nkpt, device=self.device) / nkpt
         self.keypoint_loss = KeypointLoss(sigmas=sigmas)
 
     def __call__(self, preds: Any, batch: Dict[str, torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -11,10 +11,6 @@ import torch
 
 from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, plt_settings
 
-OKS_SIGMA = (
-    np.array([0.26, 0.25, 0.25, 0.35, 0.35, 0.79, 0.79, 0.72, 0.72, 0.62, 0.62, 1.07, 1.07, 0.87, 0.87, 0.89, 0.89])
-    / 10.0
-)
 
 
 def bbox_ioa(box1: np.ndarray, box2: np.ndarray, iou: bool = False, eps: float = 1e-7) -> np.ndarray:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
This pull request refactors the handling of the `OKS_SIGMA` constant, moving it from being hardcoded in `ultralytics/utils/metrics.py` to being configurable via the `ultralytics/cfg/default.yaml` file. It also updates the relevant modules to dynamically retrieve `OKS_SIGMA` from model arguments, improving flexibility and configurability.

### Configuration Updates:
* Added `OKS_SIGMA` as a configurable parameter in `ultralytics/cfg/default.yaml`, allowing users to specify keypoint weights for OKS pose loss and metrics.

### Code Refactoring:
* Removed the hardcoded `OKS_SIGMA` constant from `ultralytics/utils/metrics.py`.
* Updated `ultralytics/models/yolo/pose/val.py` to dynamically retrieve `OKS_SIGMA` from model arguments (`self.args.OKS_SIGMA`) instead of relying on the hardcoded constant.
* Updated `ultralytics/utils/loss.py` to use `model.args.OKS_SIGMA` for initializing keypoint loss, replacing the hardcoded constant.

### Import Cleanup:
* Removed unused imports of `OKS_SIGMA` in `ultralytics/models/yolo/pose/val.py` and `ultralytics/utils/loss.py`. [[1]](diffhunk://#diff-87c04c65554f867c15a5425248ea5642ba95c9ed23cca06db823a369d47d1d9fL12-R12) [[2]](diffhunk://#diff-d2ac3773214d5694c3286cf9534fc4914555f1a3f5c5ae4a99c6aff00c75892dL9)

I have read the CLA Document and I sign the CLA



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update makes the OKS_SIGMA keypoint weighting configurable for pose estimation, allowing users to easily adjust keypoint weights for different datasets or tasks. 🤸‍♂️🔧

### 📊 Key Changes
- Added `OKS_SIGMA` to the default configuration file, making keypoint weights for pose loss and metrics user-configurable.
- Updated pose validation and loss calculation code to use the configurable `OKS_SIGMA` instead of a hardcoded value.
- Removed the fixed `OKS_SIGMA` array from the metrics utility, relying on the new config-based approach.

### 🎯 Purpose & Impact
- **Greater Flexibility:** Users can now customize keypoint weighting for pose estimation tasks, improving adaptability to various datasets beyond COCO.
- **Easier Experimentation:** Adjusting OKS_SIGMA no longer requires code changes—just update the config file.
- **Improved Usability:** Makes pose model training and evaluation more transparent and user-friendly, especially for advanced users and researchers.