### PR TITLE
Configurable oks

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -119,7 +119,7 @@ copy_paste: 0.0 # (float) segment copy-paste (probability)
 copy_paste_mode: "flip" # (str) the method to do copy_paste augmentation (flip, mixup)
 auto_augment: randaugment # (str) auto augmentation policy for classification (randaugment, autoaugment, augmix)
 erasing: 0.4 # (float) probability of random erasing during classification training (0-0.9), 0 means no erasing, must be less than 1.0.
-
+OKS_SIGMA: [.026, .025, .025, .035, .035, .079, .079, .072, .072, .062, .062, 0.107, .107, .087, .087, .089, .089] # (list) keypoints weight for OKS pose loss and metric. Numbers are optimized for coco keypoints
 # Custom config.yaml ---------------------------------------------------------------------------------------------------
 cfg: # (str, optional) for overriding defaults.yaml
 

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -100,6 +100,7 @@ cls: 0.5 # (float) cls loss gain (scale with pixels)
 dfl: 1.5 # (float) dfl loss gain
 pose: 12.0 # (float) pose loss gain
 kobj: 1.0 # (float) keypoint obj loss gain
+OKS_SIGMA: [.026, .025, .025, .035, .035, .079, .079, .072, .072, .062, .062, 0.107, .107, .087, .087, .089, .089] # (list) keypoints weight for OKS pose loss and metric. Numbers are optimized for coco keypoints
 nbs: 64 # (int) nominal batch size
 hsv_h: 0.015 # (float) image HSV-Hue augmentation (fraction)
 hsv_s: 0.7 # (float) image HSV-Saturation augmentation (fraction)
@@ -119,7 +120,6 @@ copy_paste: 0.0 # (float) segment copy-paste (probability)
 copy_paste_mode: "flip" # (str) the method to do copy_paste augmentation (flip, mixup)
 auto_augment: randaugment # (str) auto augmentation policy for classification (randaugment, autoaugment, augmix)
 erasing: 0.4 # (float) probability of random erasing during classification training (0-0.9), 0 means no erasing, must be less than 1.0.
-OKS_SIGMA: [.026, .025, .025, .035, .035, .079, .079, .072, .072, .062, .062, 0.107, .107, .087, .087, .089, .089] # (list) keypoints weight for OKS pose loss and metric. Numbers are optimized for coco keypoints
 # Custom config.yaml ---------------------------------------------------------------------------------------------------
 cfg: # (str, optional) for overriding defaults.yaml
 

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -117,8 +117,8 @@ class PoseValidator(DetectionValidator):
         super().init_metrics(model)
         self.kpt_shape = self.data["kpt_shape"]
         OKS_SIGMA = self.args.OKS_SIGMA
-        is_pose = len(OKS_SIGMA) == nkpt
-        self.sigma = np.array(OKS_SIGMA) if is_pose else np.ones(nkpt) / nkpt
+        is_pose = len(OKS_SIGMA) == self.kpt_shape[0]
+        self.sigma = np.array(OKS_SIGMA) if is_pose else np.ones(self.kpt_shape[0]) / self.kpt_shape[0]
         self.stats = dict(tp_p=[], tp=[], conf=[], pred_cls=[], target_cls=[], target_img=[])
 
     def _prepare_batch(self, si: int, batch: Dict[str, Any]) -> Dict[str, Any]:

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -9,7 +9,7 @@ import torch
 from ultralytics.models.yolo.detect import DetectionValidator
 from ultralytics.utils import LOGGER, ops
 from ultralytics.utils.checks import check_requirements
-from ultralytics.utils.metrics import OKS_SIGMA, PoseMetrics, box_iou, kpt_iou
+from ultralytics.utils.metrics import PoseMetrics, box_iou, kpt_iou
 from ultralytics.utils.plotting import output_to_target, plot_images
 
 
@@ -116,9 +116,9 @@ class PoseValidator(DetectionValidator):
         """
         super().init_metrics(model)
         self.kpt_shape = self.data["kpt_shape"]
-        is_pose = self.kpt_shape == [17, 3]
-        nkpt = self.kpt_shape[0]
-        self.sigma = OKS_SIGMA if is_pose else np.ones(nkpt) / nkpt
+        OKS_SIGMA = self.args.OKS_SIGMA
+        is_pose = len(OKS_SIGMA) == nkpt
+        self.sigma = np.array(OKS_SIGMA) if is_pose else np.ones(nkpt) / nkpt
         self.stats = dict(tp_p=[], tp=[], conf=[], pred_cls=[], target_cls=[], target_img=[])
 
     def _prepare_batch(self, si: int, batch: Dict[str, Any]) -> Dict[str, Any]:

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from ultralytics.utils.metrics import OKS_SIGMA
 from ultralytics.utils.ops import crop_mask, xywh2xyxy, xyxy2xywh
 from ultralytics.utils.tal import RotatedTaskAlignedAssigner, TaskAlignedAssigner, dist2bbox, dist2rbox, make_anchors
 from ultralytics.utils.torch_utils import autocast
@@ -488,9 +487,10 @@ class v8PoseLoss(v8DetectionLoss):
         super().__init__(model)
         self.kpt_shape = model.model[-1].kpt_shape
         self.bce_pose = nn.BCEWithLogitsLoss()
-        is_pose = self.kpt_shape == [17, 3]
         nkpt = self.kpt_shape[0]  # number of keypoints
-        sigmas = torch.from_numpy(OKS_SIGMA).to(self.device) if is_pose else torch.ones(nkpt, device=self.device) / nkpt
+        OKS_SIGMA = model.args.OKS_SIGMA
+        is_pose = len(OKS_SIGMA) == nkpt  # instead of is_pose = self.kpt_shape == [17, 3]
+        sigmas = torch.tensor(OKS_SIGMA).to(self.device) if is_pose else torch.ones(nkpt, device=self.device) / nkpt
         self.keypoint_loss = KeypointLoss(sigmas=sigmas)
 
     def __call__(self, preds: Any, batch: Dict[str, torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -11,10 +11,6 @@ import torch
 
 from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, plt_settings
 
-OKS_SIGMA = (
-    np.array([0.26, 0.25, 0.25, 0.35, 0.35, 0.79, 0.79, 0.72, 0.72, 0.62, 0.62, 1.07, 1.07, 0.87, 0.87, 0.89, 0.89])
-    / 10.0
-)
 
 
 def bbox_ioa(box1: np.ndarray, box2: np.ndarray, iou: bool = False, eps: float = 1e-7) -> np.ndarray:


### PR DESCRIPTION
This pull request refactors the handling of the `OKS_SIGMA` constant across the codebase, moving it from being hardcoded in `ultralytics/utils/metrics.py` to being configurable via the `default.yaml` configuration file. This change improves flexibility and allows users to customize the keypoint weights for pose loss and metrics. Additionally, the code has been updated to dynamically retrieve `OKS_SIGMA` from the configuration in relevant modules.

### Configuration Updates:
* Added `OKS_SIGMA` as a configurable parameter in `ultralytics/cfg/default.yaml`. This parameter specifies keypoint weights for OKS pose loss and metrics.

### Code Refactoring:
* Removed the hardcoded `OKS_SIGMA` definition from `ultralytics/utils/metrics.py`. This constant is now dynamically retrieved from the configuration file.
* Updated `ultralytics/models/yolo/pose/val.py` to use `OKS_SIGMA` from the `args` configuration instead of relying on the removed hardcoded constant. Adjusted logic for determining `is_pose` and calculating `sigma`. [[1]](diffhunk://#diff-87c04c65554f867c15a5425248ea5642ba95c9ed23cca06db823a369d47d1d9fL12-R12) [[2]](diffhunk://#diff-87c04c65554f867c15a5425248ea5642ba95c9ed23cca06db823a369d47d1d9fL119-R121)
* Refactored `ultralytics/utils/loss.py` to dynamically fetch `OKS_SIGMA` from the `model.args` configuration. Simplified `is_pose` determination and updated `sigmas` initialization for keypoint loss calculation. [[1]](diffhunk://#diff-d2ac3773214d5694c3286cf9534fc4914555f1a3f5c5ae4a99c6aff00c75892dL9) [[2]](diffhunk://#diff-d2ac3773214d5694c3286cf9534fc4914555f1a3f5c5ae4a99c6aff00c75892dL491-R493)

### Minor Cleanup:
* Removed unused import of `OKS_SIGMA` in `ultralytics/utils/loss.py`.
* Removed unused import of `OKS_SIGMA` in `ultralytics/models/yolo/pose/val.py`.


I have read the CLA Document and I sign the CLA



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update makes the OKS_SIGMA keypoint weights for pose estimation configurable, allowing users to easily adjust them for different datasets or tasks. 🤸‍♂️🔧

### 📊 Key Changes
- Added `OKS_SIGMA` as a configurable parameter in the default settings (`default.yaml`), with values optimized for COCO keypoints.
- Updated pose validation and loss calculation code to use the `OKS_SIGMA` value from the configuration, rather than a hardcoded value.
- Removed the hardcoded `OKS_SIGMA` from the metrics utility file.

### 🎯 Purpose & Impact
- **Greater Flexibility:** Users can now customize keypoint weights for pose estimation directly in their config files, making it easier to adapt models to different datasets or keypoint layouts.
- **Improved Usability:** No need to modify code to change keypoint weights—just update the config!
- **Better Performance:** Enables fine-tuning of pose estimation metrics and loss calculations for improved accuracy on custom tasks.

This change is especially helpful for users working with pose estimation beyond the standard COCO dataset. 🚀