### PR TITLE
chore: split export dependencies into respective framework groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ export-tensorflow = [# tensorflow export on Windows and darwin is pretty broken,
     "tf_keras",  # required by 'onnx2tf' package
     "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
     "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
-    "ai-edge-litert>=1.2.0",  # required by 'onnx2tf' package
+    "ai-edge-litert>=1.2.0; python_version >='3.9' and platform_system != 'Windows'",  # required by 'onnx2tf' package, only available for python >= 3.9
     "onnx2tf>=1.26.3; python_version >='3.10'", # below 3.10 onnx2tf may not be resolvable on windows,
     # it will try to resolve this on runtime
     "onnxruntime", # in case a gpu is available the gpu version will be installed at runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,16 +90,26 @@ dev = [
 export-onnx = [
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
+    "onnxslim>=0.1.53",
 ]
 export-openvino = [
     "openvino>=2024.0.0",  # OpenVINO export
 ]
 export-tensorflow = [# tensorflow export on Windows and darwin is pretty broken, only use this on linux
+    "ultralytics[export-onnx]", # onnx is used as intermediary step before converting to tf
     "numpy<2.0.0", # TF 2.20 compatibility
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
+    "tf_keras",  # required by 'onnx2tf' package
+    "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
+    "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
+    "ai-edge-litert>=1.2.0",  # required by 'onnx2tf' package
+    "onnx2tf>=1.26.3; python_version >='3.10'", # below 3.10 onnx2tf may not be resolvable on windows,
+    # it will try to resolve this on runtime
+    "onnxruntime", # in case a gpu is available the gpu version will be installed at runtime
+    "protobuf>=5",
 ]
 export-coreml = [
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
@@ -108,7 +118,6 @@ export-coreml = [
 export = [
     "ultralytics[export-onnx,export-openvino,export-tensorflow,export-coreml]",
 ]
-
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching
     "streamlit>=1.29.0",    # for live inference on web browser, i.e `yolo streamlit-predict`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,18 +87,28 @@ dev = [
     "mkdocs-ultralytics-plugin>=0.2.3", # for meta descriptions and images, dates and authors
     "minijinja>=2.0.0", # render docs macros without mkdocs-macros-plugin
 ]
-export = [
-    "numpy<2.0.0", # TF 2.20 compatibility
+export-onnx = [
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
-    "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
-    "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
+]
+export-openvino = [
     "openvino>=2024.0.0",  # OpenVINO export
+]
+export-tensorflow = [# tensorflow export on Windows and darwin is pretty broken, only use this on linux
+    "numpy<2.0.0", # TF 2.20 compatibility
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
 ]
+export-coreml = [
+    "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
+    "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
+]
+export = [
+    "ultralytics[export-onnx,export-openvino,export-tensorflow,export-coreml]",
+]
+
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching
     "streamlit>=1.29.0",    # for live inference on web browser, i.e `yolo streamlit-predict`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ export-onnx = [
     "onnxslim>=0.1.53",
 ]
 export-openvino = [
+    "packaging>=23.2",
+    "nncf>=2.14.0; python_version >= '3.9'", # only supported on python >=3.9
     "openvino>=2024.0.0",  # OpenVINO export
 ]
 export-tensorflow = [# tensorflow export on Windows and darwin is pretty broken, only use this on linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ export-tensorflow = [# tensorflow export on Windows and darwin is pretty broken,
     "ultralytics[export-onnx]", # onnx is used as intermediary step before converting to tf
     "numpy<2.0.0", # TF 2.20 compatibility
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    # ^ this implicitly limits the max python version to 3.12
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release


### PR DESCRIPTION
### TLDR: No longer install 2 Gigs of TF deps when all you want is exporting to onnx.


This PR splits the dependencies for the different ML export Frameworks into different extra groups and adds a meta group for backwards compatibility, This simplifies downstream handling of the library, when only requiring specific exports, especially the TF and TF-lite related dependencies have made it annoying to install Those dependencies.

When using the previous dependencies with tools like UV installation of the export extra was not straightforward on Windows and maybe other systems as well, as `tensorflow-decision-forests` is not supported on windows. (There are Workarounds with OS specific version pinning, but those are cumbersome and fragile).

As The dependency trees of the different frameworks are mostly disjunct, besides some common reliance on ONNX This seems like a nice solution to me, where you get very decent behavior and dependency trees for every export use-case (or the old Linux ~only "export all at once" behavior if you choose to use the old extra).

This also adds the magic 'check_requirements' dependencies from the TFexporter directly to the pyproject.toml, which gives end-users more transparency about the things they are installing.

I did not add the dependencies for the completely hidden exporters (those which were not part of the old export requirements at all), if you want me to add them here as well I can do that.


    I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactors and organizes export-related dependencies into separate groups for ONNX, OpenVINO, TensorFlow, and CoreML, making export options more modular and manageable. 🛠️✨

### 📊 Key Changes
- Splits export dependencies into distinct groups: `export-onnx`, `export-openvino`, `export-tensorflow`, and `export-coreml`.
- Updates the main `export` group to include all these new sub-groups.
- Adds and clarifies several TensorFlow-related dependencies for improved compatibility and functionality.
- Improves platform and Python version checks for certain dependencies.

### 🎯 Purpose & Impact
- **Easier Installation:** Users can now install only the export dependencies they need, reducing unnecessary packages and potential conflicts.
- **Better Compatibility:** Fine-tuned dependency management ensures smoother exports across different platforms and Python versions.
- **Improved Maintainability:** Clearer structure makes it easier for developers to update or troubleshoot export dependencies in the future.

This update streamlines the export process, making it more flexible and reliable for all users! 🚀