### PR TITLE
Enable `normalize` and `decimals` support for confusion matrix export

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -505,7 +505,7 @@ class ConfusionMatrix(DataExportMixin):
         for i in range(self.matrix.shape[0]):
             LOGGER.info(" ".join(map(str, self.matrix[i])))
 
-    def summary(self, normalize: bool = False, decimals: int = 2) -> List[Dict[str, float]]:
+    def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, float]]:
         """
         Generate a summarized representation of the confusion matrix as a list of dictionaries, with optional normalization.
         This is useful for exporting the matrix to various formats such as CSV, XML, HTML, JSON, or SQL.

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -505,8 +505,25 @@ class ConfusionMatrix(DataExportMixin):
         for i in range(self.matrix.shape[0]):
             LOGGER.info(" ".join(map(str, self.matrix[i])))
 
-    def summary(self, **kwargs):
-        """Returns summary of the confusion matrix for export in different formats CSV, XML, HTML."""
+    def summary(self, normalize: bool = False, decimals: int = 2) -> List[Dict[str, Any]]:
+        """
+        Generate a summarized representation of the confusion matrix as a list of dictionaries, with optional normalization.
+
+        This is useful for exporting the matrix to various formats such as CSV, XML, HTML, JSON, or SQL.
+
+        Args:
+            normalize (bool): Whether to normalize the confusion matrix values.
+            decimals (int): Number of decimal places to round the output values to.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries, each representing one predicted class with corresponding values
+            for all actual classes.
+
+        Examples:
+            >>> results = model.val(data="coco.yaml", plots=True)
+            >>> cm_dicts = results.confusion_matrix.summary(normalize=True, decimals=5)
+            >>> print(cm_dicts)
+        """
         import re
 
         names = self.names if self.task == "classify" else self.names + ["background"]
@@ -520,6 +537,8 @@ class ConfusionMatrix(DataExportMixin):
                 counter += 1
             seen.add(clean_name.lower())
             clean_names.append(clean_name)
+        if normalize:
+            self.matrix = (self.matrix / (self.matrix.sum(0).reshape(1, -1) + 1e-9)).round(decimals)
         return [
             dict({"Predicted": clean_names[i]}, **{clean_names[j]: self.matrix[i, j] for j in range(len(clean_names))})
             for i in range(len(clean_names))

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -535,8 +535,7 @@ class ConfusionMatrix(DataExportMixin):
                 counter += 1
             seen.add(clean_name.lower())
             clean_names.append(clean_name)
-        if normalize:
-            self.matrix = (self.matrix / (self.matrix.sum(0).reshape(1, -1) + 1e-9)).round(decimals)
+        self.matrix = (self.matrix / ((self.matrix.sum(0).reshape(1, -1) + 1e-9) if normalize else 1)).round(decimals)
         return [
             dict({"Predicted": clean_names[i]}, **{clean_names[j]: self.matrix[i, j] for j in range(len(clean_names))})
             for i in range(len(clean_names))

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -515,7 +515,7 @@ class ConfusionMatrix(DataExportMixin):
             decimals (int): Number of decimal places to round the output values to.
 
         Returns:
-            List[Dict]: A list of dictionaries, each representing one predicted class with corresponding values for all actual classes.
+            List[Dict[str, float]]: A list of dictionaries, each representing one predicted class with corresponding values for all actual classes.
 
         Examples:
             >>> results = model.val(data="coco8.yaml", plots=True)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -519,8 +519,8 @@ class ConfusionMatrix(DataExportMixin):
 
         Examples:
             >>> results = model.val(data="coco.yaml", plots=True)
-            >>> cm_dicts = results.confusion_matrix.summary(normalize=True, decimals=5)
-            >>> print(cm_dicts)
+            >>> cm_dict = results.confusion_matrix.summary(normalize=True, decimals=5)
+            >>> print(cm_dict)
         """
         import re
 

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -535,9 +535,9 @@ class ConfusionMatrix(DataExportMixin):
                 counter += 1
             seen.add(clean_name.lower())
             clean_names.append(clean_name)
-        self.matrix = (self.matrix / ((self.matrix.sum(0).reshape(1, -1) + 1e-9) if normalize else 1)).round(decimals)
+        array = (self.matrix / ((self.matrix.sum(0).reshape(1, -1) + 1e-9) if normalize else 1)).round(decimals)
         return [
-            dict({"Predicted": clean_names[i]}, **{clean_names[j]: self.matrix[i, j] for j in range(len(clean_names))})
+            dict({"Predicted": clean_names[i]}, **{clean_names[j]: array[i, j] for j in range(len(clean_names))})
             for i in range(len(clean_names))
         ]
 

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -518,7 +518,7 @@ class ConfusionMatrix(DataExportMixin):
             List[Dict]: A list of dictionaries, each representing one predicted class with corresponding values for all actual classes.
 
         Examples:
-            >>> results = model.val(data="coco.yaml", plots=True)
+            >>> results = model.val(data="coco8.yaml", plots=True)
             >>> cm_dict = results.confusion_matrix.summary(normalize=True, decimals=5)
             >>> print(cm_dict)
         """

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -507,8 +507,8 @@ class ConfusionMatrix(DataExportMixin):
 
     def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, float]]:
         """
-        Generate a summarized representation of the confusion matrix as a list of dictionaries, with optional normalization.
-        This is useful for exporting the matrix to various formats such as CSV, XML, HTML, JSON, or SQL.
+        Generate a summarized representation of the confusion matrix as a list of dictionaries, with optional
+        normalization. This is useful for exporting the matrix to various formats such as CSV, XML, HTML, JSON, or SQL.
 
         Args:
             normalize (bool): Whether to normalize the confusion matrix values.

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -462,7 +462,7 @@ class ConfusionMatrix(DataExportMixin):
             warnings.simplefilter("ignore")  # suppress empty matrix RuntimeWarning: All-NaN slice encountered
             im = ax.imshow(array, cmap="Blues", vmin=0.0, interpolation="none")
             ax.xaxis.set_label_position("bottom")
-            if nc < 120:  # Add score for each cell of confusion matrix
+            if nc < 30:  # Add score for each cell of confusion matrix
                 for i, row in enumerate(array[:nc]):
                     for j, val in enumerate(row[:nc]):
                         val = array[i, j]

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -462,7 +462,7 @@ class ConfusionMatrix(DataExportMixin):
             warnings.simplefilter("ignore")  # suppress empty matrix RuntimeWarning: All-NaN slice encountered
             im = ax.imshow(array, cmap="Blues", vmin=0.0, interpolation="none")
             ax.xaxis.set_label_position("bottom")
-            if nc < 30:  # Add score for each cell of confusion matrix
+            if nc < 120:  # Add score for each cell of confusion matrix
                 for i, row in enumerate(array[:nc]):
                     for j, val in enumerate(row[:nc]):
                         val = array[i, j]
@@ -505,10 +505,9 @@ class ConfusionMatrix(DataExportMixin):
         for i in range(self.matrix.shape[0]):
             LOGGER.info(" ".join(map(str, self.matrix[i])))
 
-    def summary(self, normalize: bool = False, decimals: int = 2) -> List[Dict[str, Any]]:
+    def summary(self, normalize: bool = False, decimals: int = 2) -> List[Dict[str, float]]:
         """
         Generate a summarized representation of the confusion matrix as a list of dictionaries, with optional normalization.
-
         This is useful for exporting the matrix to various formats such as CSV, XML, HTML, JSON, or SQL.
 
         Args:
@@ -516,8 +515,7 @@ class ConfusionMatrix(DataExportMixin):
             decimals (int): Number of decimal places to round the output values to.
 
         Returns:
-            List[Dict[str, Any]]: A list of dictionaries, each representing one predicted class with corresponding values
-            for all actual classes.
+            List[Dict]: A list of dictionaries, each representing one predicted class with corresponding values for all actual classes.
 
         Examples:
             >>> results = model.val(data="coco.yaml", plots=True)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the confusion matrix summary function to support normalization and customizable decimal precision for easier export and analysis. 📊✨

### 📊 Key Changes
- Enhanced the `summary` method in the confusion matrix:
  - Added options to normalize values and set decimal precision.
  - Now returns results as a list of dictionaries, ready for export to formats like CSV, XML, HTML, JSON, or SQL.
- Updated documentation and usage examples for clarity.

### 🎯 Purpose & Impact
- Makes it easier for users to analyze and share confusion matrix results in various formats.
- Normalization and rounding options help users better interpret and present model performance.
- Supports more flexible and user-friendly reporting for both technical and non-technical audiences.