### PR TITLE
Move `waitKey()` and `destroyAllWindows()` to Predictor

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -186,7 +186,6 @@ class LoadStreams:
                 cap.release()  # release video capture
             except Exception as e:
                 LOGGER.warning(f"Could not release VideoCapture object: {e}")
-        cv2.destroyAllWindows()
 
     def __iter__(self):
         """Iterate through YOLO image feed and re-open unresponsive streams."""
@@ -201,7 +200,7 @@ class LoadStreams:
         for i, x in enumerate(self.imgs):
             # Wait until a frame is available in each buffer
             while not x:
-                if not self.threads[i].is_alive() or cv2.waitKey(1) == ord("q"):  # q to quit
+                if not self.threads[i].is_alive():
                     self.close()
                     raise StopIteration
                 time.sleep(1 / min(self.fps))

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -339,15 +339,18 @@ class BasePredictor:
 
                 # Visualize, save, write results
                 n = len(im0s)
-                for i in range(n):
-                    self.seen += 1
-                    self.results[i].speed = {
-                        "preprocess": profilers[0].dt * 1e3 / n,
-                        "inference": profilers[1].dt * 1e3 / n,
-                        "postprocess": profilers[2].dt * 1e3 / n,
-                    }
-                    if self.args.verbose or self.args.save or self.args.save_txt or self.args.show:
-                        s[i] += self.write_results(i, Path(paths[i]), im, s)
+                try:
+                    for i in range(n):
+                        self.seen += 1
+                        self.results[i].speed = {
+                            "preprocess": profilers[0].dt * 1e3 / n,
+                            "inference": profilers[1].dt * 1e3 / n,
+                            "postprocess": profilers[2].dt * 1e3 / n,
+                        }
+                        if self.args.verbose or self.args.save or self.args.save_txt or self.args.show:
+                            s[i] += self.write_results(i, Path(paths[i]), im, s)
+                except StopIteration:
+                    break
 
                 # Print batch results
                 if self.args.verbose:
@@ -362,7 +365,7 @@ class BasePredictor:
                 v.release()
 
         if self.args.show:
-            cv2.destroyAllWindows()
+            cv2.destroyAllWindows()  # close any open windows
 
         # Print final results
         if self.args.verbose and self.seen:

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -498,7 +498,7 @@ class BasePredictor:
             cv2.namedWindow(p, cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
             cv2.resizeWindow(p, im.shape[1], im.shape[0])  # (width, height)
         cv2.imshow(p, im)
-        if cv2.waitKey(300 if self.dataset.mode == "image" else 1) & 0xFF == ord("q"): # 300ms if image; else 1ms
+        if cv2.waitKey(300 if self.dataset.mode == "image" else 1) & 0xFF == ord("q"):  # 300ms if image; else 1ms
             raise StopIteration
 
     def run_callbacks(self, event: str):

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -361,6 +361,9 @@ class BasePredictor:
             if isinstance(v, cv2.VideoWriter):
                 v.release()
 
+        if self.args.show:
+            cv2.destroyAllWindows()
+
         # Print final results
         if self.args.verbose and self.seen:
             t = tuple(x.t / self.seen * 1e3 for x in profilers)  # speeds per image
@@ -492,7 +495,8 @@ class BasePredictor:
             cv2.namedWindow(p, cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
             cv2.resizeWindow(p, im.shape[1], im.shape[0])  # (width, height)
         cv2.imshow(p, im)
-        cv2.waitKey(300 if self.dataset.mode == "image" else 1)  # 1 millisecond
+        if cv2.waitKey(300 if self.dataset.mode == "image" else 1) & 0xFF == ord("q"):  # 1 millisecond
+            raise StopIteration
 
     def run_callbacks(self, event: str):
         """Run all registered callbacks for a specific event."""

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -498,7 +498,7 @@ class BasePredictor:
             cv2.namedWindow(p, cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
             cv2.resizeWindow(p, im.shape[1], im.shape[0])  # (width, height)
         cv2.imshow(p, im)
-        if cv2.waitKey(300 if self.dataset.mode == "image" else 1) & 0xFF == ord("q"):  # 1 millisecond
+        if cv2.waitKey(300 if self.dataset.mode == "image" else 1) & 0xFF == ord("q"): # 300ms if image; else 1ms
             raise StopIteration
 
     def run_callbacks(self, event: str):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves video stream handling and window management for a smoother user experience and more robust stream processing. 🎥🪟

### 📊 Key Changes
- Removed automatic closing of all OpenCV windows (`cv2.destroyAllWindows()`) from the data loader's `close()` method.
- Stopped using the "q" key to quit streams in the data loader; now only thread status is checked.
- Added error handling in the prediction stream to gracefully stop processing when streams end.
- Ensured OpenCV windows are properly closed after prediction if results are shown.
- Improved window display logic: pressing "q" while viewing results now cleanly stops the stream.

### 🎯 Purpose & Impact
- 🛠️ Prevents unwanted closure of unrelated OpenCV windows, making workflows with multiple windows more reliable.
- 🚫 Removes dependency on keyboard input ("q" key) for quitting, reducing accidental interruptions.
- 💪 Makes video stream processing more robust and less prone to crashes or hangs.
- 👀 Enhances user control and experience when viewing results, allowing for smoother exits.
- 👍 Overall, these changes make YOLO stream processing and visualization more stable and user-friendly.