### PR TITLE
Use `pytorch-cpu` for Conda CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,8 @@ jobs:
           conda config --set solver libmamba
       - name: Install Ultralytics package from conda-forge
         run: |
-          conda install -c pytorch -c conda-forge pytorch-cpu torchvision-cpu ultralytics openvino pillow=6.2.2
+          conda install -c pytorch -c conda-forge pytorch-cpu torchvision-cpu ultralytics openvino
+          conda install pillow=6.2.2 -c conda-forge
       - name: Install pip packages
         run: |
           pip install pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
           conda config --set solver libmamba
       - name: Install Ultralytics package from conda-forge
         run: |
-          conda install -c pytorch -c conda-forge pytorch torchvision ultralytics openvino
+          conda install -c pytorch -c conda-forge pytorch-cpu torchvision-cpu ultralytics openvino
       - name: Install pip packages
         run: |
           pip install pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,8 +374,7 @@ jobs:
           conda config --set solver libmamba
       - name: Install Ultralytics package from conda-forge
         run: |
-          conda install -c pytorch -c conda-forge pytorch-cpu torchvision-cpu ultralytics openvino
-          conda install pillow=6.2.2 -c conda-forge
+          conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino
       - name: Install pip packages
         run: |
           pip install pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
           conda config --set solver libmamba
       - name: Install Ultralytics package from conda-forge
         run: |
-          conda install -c pytorch -c conda-forge pytorch-cpu torchvision-cpu ultralytics openvino
+          conda install -c pytorch -c conda-forge pytorch-cpu torchvision-cpu ultralytics openvino pillow=6.2.2
       - name: Install pip packages
         run: |
           pip install pytest


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CI workflow by switching to CPU-only PyTorch installation for Conda builds. 🖥️⚡

### 📊 Key Changes
- Updated the CI configuration to install `pytorch-cpu` instead of the default `pytorch` package when setting up the Ultralytics environment with Conda.

### 🎯 Purpose & Impact
- Ensures that CI tests run reliably on machines without GPUs, reducing compatibility issues.
- Speeds up and simplifies testing by avoiding unnecessary GPU dependencies.
- Makes the build process more consistent and accessible for users working in CPU-only environments.