### PR TITLE
Fix  param description in classifier task for train, val methods

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -623,7 +623,7 @@ class Model(torch.nn.Module):
 
         Examples:
             >>> model = YOLO("yolo11n.pt")
-            >>> results = model.val(data="path/to/datset", imgsz=640)
+            >>> results = model.val(data="path/to/dataset", imgsz=640)
             >>> print(results.box.map)  # Print mAP50-95
         """
         custom = {"rect": True}  # method defaults

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -623,7 +623,7 @@ class Model(torch.nn.Module):
 
         Examples:
             >>> model = YOLO("yolo11n.pt")
-            >>> results = model.val(data="coco8.yaml", imgsz=640)
+            >>> results = model.val(data="path/to/datset", imgsz=640)
             >>> print(results.box.map)  # Print mAP50-95
         """
         custom = {"rect": True}  # method defaults
@@ -752,7 +752,7 @@ class Model(torch.nn.Module):
         Args:
             trainer (BaseTrainer, optional): Custom trainer instance for model training. If None, uses default.
             **kwargs (Any): Arbitrary keyword arguments for training configuration. Common options include:
-                data (str): Path to dataset configuration file.
+                data (str): Path to dataset.
                 epochs (int): Number of training epochs.
                 batch (int): Batch size for training.
                 imgsz (int): Input image size.
@@ -767,7 +767,7 @@ class Model(torch.nn.Module):
 
         Examples:
             >>> model = YOLO("yolo11n.pt")
-            >>> results = model.train(data="coco8.yaml", epochs=3)
+            >>> results = model.train(data="path/to/dataset", epochs=3)
         """
         self._check_is_pytorch_model()
         if hasattr(self.session, "model") and self.session.model.id:  # Ultralytics HUB session with loaded model


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
The current docs suggest that `data` should be a path to YAML config file, which is misleading.
Updated the documentation to reflect that `data` is a plain path to the dataset.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Docs-only tweak: clarifies that `data` should point to a dataset path (not just a YAML file) in `model.train()` and `model.val()` examples and argument descriptions. 🧭

### 📊 Key Changes
- Updated `model.val()` example from `data="coco8.yaml"` to `data="path/to/dataset"`.
- Updated `model.train()`:
  - Arg doc: `data` now described as “Path to dataset.”
  - Example changed from `data="coco8.yaml"` to `data="path/to/dataset"`.

### 🎯 Purpose & Impact
- Reduces confusion for users who think a YAML config is required. ✅
- Reflects current flexibility: users can pass a dataset directory or config, improving onboarding. 🚀
- No functional or API changes—safe update with zero risk to existing code. 🛡️

Example:
```python
from ultralytics import YOLO

model = YOLO("yolo11n.pt")
model.train(data="path/to/dataset", epochs=3)
model.val(data="path/to/dataset", imgsz=640)
```