### PR TITLE
`ultralytics 8.3.151` Add `decimals` argument to Metrics

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.150"
+__version__ = "8.3.151"
 
 import os
 

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1049,7 +1049,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
            decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-           (List[Dict]): A list of dictionaries, each representing one class with corresponding metric values.
+           (List[Dict[str, Union[str, float]]]): A list of dictionaries, each representing one class with corresponding metric values.
 
         Examples:
            >>> results = model.val(data="coco8.yaml")
@@ -1221,7 +1221,7 @@ class SegmentMetrics(SimpleClass, DataExportMixin):
             decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            (List[Dict]): A list of dictionaries, each representing one class with corresponding metric values.
+            (List[Dict[str, Union[str, float]]]): A list of dictionaries, each representing one class with corresponding metric values.
 
         Examples:
             >>> results = model.val(data="coco8-seg.yaml")
@@ -1399,7 +1399,7 @@ class PoseMetrics(SegmentMetrics):
             decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            (List[Dict]): A list of dictionaries, each representing one class with corresponding metric values.
+            (List[Dict[str, Union[str, float]]]): A list of dictionaries, each representing one class with corresponding metric values.
 
         Examples:
             >>> results = model.val(data="coco8-pose.yaml")
@@ -1493,7 +1493,7 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
             decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            (List[Dict]): A list with one dictionary containing Top-1 and Top-5 classification accuracy.
+            (List[Dict[str, float]]): A list with one dictionary containing Top-1 and Top-5 classification accuracy.
 
         Examples:
             >>> results = model.val(data="imagenet10")
@@ -1612,7 +1612,7 @@ class OBBMetrics(SimpleClass, DataExportMixin):
             decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            (List[Dict]): A list of dictionaries, each representing one class with detection metrics.
+            (List[Dict[str, Union[str, float]]]): A list of dictionaries, each representing one class with detection metrics.
 
         Examples:
             >>> results = model.val(data="dota8.yaml")

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1049,7 +1049,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
            decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-           List[Dict]: A list of dictionaries, each representing one class with corresponding metric values.
+           (List[Dict]): A list of dictionaries, each representing one class with corresponding metric values.
 
         Examples:
            >>> results = model.val(data="coco8.yaml")
@@ -1221,7 +1221,7 @@ class SegmentMetrics(SimpleClass, DataExportMixin):
             decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            List[Dict]: A list of dictionaries, each representing one class with corresponding metric values.
+            (List[Dict]): A list of dictionaries, each representing one class with corresponding metric values.
 
         Examples:
             >>> results = model.val(data="coco8-seg.yaml")
@@ -1399,7 +1399,7 @@ class PoseMetrics(SegmentMetrics):
             decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            List[Dict]: A list of dictionaries, each representing one class with corresponding metric values.
+            (List[Dict]): A list of dictionaries, each representing one class with corresponding metric values.
 
         Examples:
             >>> results = model.val(data="coco8-pose.yaml")
@@ -1493,7 +1493,7 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
             decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            List[Dict]: A list with one dictionary containing Top-1 and Top-5 classification accuracy.
+            (List[Dict]): A list with one dictionary containing Top-1 and Top-5 classification accuracy.
 
         Examples:
             >>> results = model.val(data="imagenet10")
@@ -1612,7 +1612,7 @@ class OBBMetrics(SimpleClass, DataExportMixin):
             decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            List[Dict]: A list of dictionaries, each representing one class with detection metrics.
+            (List[Dict]): A list of dictionaries, each representing one class with detection metrics.
 
         Examples:
             >>> results = model.val(data="dota8.yaml")

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1496,7 +1496,7 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
             List[Dict]: A list with one dictionary containing Top-1 and Top-5 classification accuracy.
 
         Examples:
-            >>> results = model.val(data="imagenet.yaml")
+            >>> results = model.val(data="imagenet10")
             >>> classify_summary = results.summary(decimals=4)
             >>> print(classify_summary)
         """
@@ -1615,7 +1615,7 @@ class OBBMetrics(SimpleClass, DataExportMixin):
             List[Dict]: A list of dictionaries, each representing one class with detection metrics.
 
         Examples:
-            >>> results = model.val(data="coco8.yaml")
+            >>> results = model.val(data="dota8.yaml")
             >>> detection_summary = results.summary(decimals=4)
             >>> print(detection_summary)
         """

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1496,9 +1496,27 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
         """Return a list of curves for accessing specific metrics curves."""
         return []
 
-    def summary(self, **kwargs) -> List[Dict[str, float]]:
-        """Return a single-row summary for classification metrics (top1/top5)."""
-        return [{"classify-top1": self.top1, "classify-top5": self.top5}]
+    def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, float]]:
+        """
+        Generate a single-row summary of classification metrics (Top-1 and Top-5 accuracy).
+        This format is useful for reporting or exporting classification results.
+
+        Args:
+            normalize (bool): For classification metrics, everything is normalized  by default [0-1].
+            decimals (int): Number of decimal places to round the output values to.
+
+        Returns:
+            List[Dict]: A list with one dictionary containing Top-1 and Top-5 classification accuracy.
+
+        Examples:
+            >>> results = model.val(data="imagenet.yaml")
+            >>> classify_summary = results.classify.summary(decimals=4)
+            >>> print(classify_summary)
+        """
+        return [{
+            "classify-top1": round(self.top1, decimals),
+            "classify-top5": round(self.top5, decimals)
+        }]
 
 
 class OBBMetrics(SimpleClass, DataExportMixin):

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1039,7 +1039,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
         """Return dictionary of computed performance metrics and statistics."""
         return self.box.curves_results
 
-    def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
+    def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
         Generate a summarized representation of per-class detection metrics as a list of dictionaries.
         Includes shared scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
@@ -1216,7 +1216,7 @@ class SegmentMetrics(SimpleClass, DataExportMixin):
         """Return dictionary of computed performance metrics and statistics."""
         return self.box.curves_results + self.seg.curves_results
 
-    def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
+    def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
         Generate a summarized representation of per-class segmentation metrics as a list of dictionaries.
         Includes both box and mask scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
@@ -1397,7 +1397,7 @@ class PoseMetrics(SegmentMetrics):
         """Return dictionary of computed performance metrics and statistics."""
         return self.box.curves_results + self.pose.curves_results
 
-    def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
+    def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
         Generate a summarized representation of per-class pose metrics as a list of dictionaries.
         Includes both box and pose scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1041,13 +1041,12 @@ class DetMetrics(SimpleClass, DataExportMixin):
 
     def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
-        Generate a summarized representation of per-class detection metrics as a list of dictionaries.
-        Includes shared scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
-        This format is useful for exporting evaluation metrics to formats such as CSV, JSON, or HTML.
+        Generate a summarized representation of per-class detection metrics as a list of dictionaries. Includes
+        shared scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
 
         Args:
            normalize (bool): For Detect metrics, everything is normalized  by default [0-1].
-           decimals (int): Number of decimal places to round the output values to.
+           decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
            List[Dict]: A list of dictionaries, each representing one class with corresponding metric values.
@@ -1218,12 +1217,12 @@ class SegmentMetrics(SimpleClass, DataExportMixin):
 
     def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
-        Generate a summarized representation of per-class segmentation metrics as a list of dictionaries.
-        Includes both box and mask scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
+        Generate a summarized representation of per-class segmentation metrics as a list of dictionaries. Includes both
+        box and mask scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
 
         Args:
             normalize (bool): For Segment metrics, everything is normalized  by default [0-1].
-            decimals (int): Number of decimal places to round the output values to.
+            decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
             List[Dict]: A list of dictionaries, each representing one class with corresponding metric values.
@@ -1399,12 +1398,12 @@ class PoseMetrics(SegmentMetrics):
 
     def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
-        Generate a summarized representation of per-class pose metrics as a list of dictionaries.
-        Includes both box and pose scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
+        Generate a summarized representation of per-class pose metrics as a list of dictionaries. Includes both box
+        and pose scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
 
         Args:
             normalize (bool): For Pose metrics, everything is normalized  by default [0-1].
-            decimals (int): Number of decimal places to round the output values to.
+            decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
             List[Dict]: A list of dictionaries, each representing one class with corresponding metric values.
@@ -1499,11 +1498,10 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
     def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, float]]:
         """
         Generate a single-row summary of classification metrics (Top-1 and Top-5 accuracy).
-        This format is useful for reporting or exporting classification results.
 
         Args:
             normalize (bool): For Classify metrics, everything is normalized  by default [0-1].
-            decimals (int): Number of decimal places to round the output values to.
+            decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
             List[Dict]: A list with one dictionary containing Top-1 and Top-5 classification accuracy.
@@ -1513,10 +1511,7 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
             >>> classify_summary = results.classify.summary(decimals=4)
             >>> print(classify_summary)
         """
-        return [{
-            "classify-top1": round(self.top1, decimals),
-            "classify-top5": round(self.top5, decimals)
-        }]
+        return [{"classify-top1": round(self.top1, decimals), "classify-top5": round(self.top5, decimals)}]
 
 
 class OBBMetrics(SimpleClass, DataExportMixin):
@@ -1620,15 +1615,15 @@ class OBBMetrics(SimpleClass, DataExportMixin):
 
     def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
-        Generate a summarized representation of per-class detection metrics as a list of dictionaries.
-        Includes shared scalar metrics (mAP, mAP50, mAP75) along with precision, recall, and F1-score for each class.
+        Generate a summarized representation of per-class detection metrics as a list of dictionaries. Includes shared
+        scalar metrics (mAP, mAP50, mAP75) along with precision, recall, and F1-score for each class.
 
         Args:
             normalize (bool): For OBB metrics, everything is normalized  by default [0-1].
-            decimals (int): Number of decimal places to round the output values to.
+            decimals (int): Number of decimal places to round the metrics values to.
 
         Returns:
-            List[Dict[str, float]]: A list of dictionaries, each representing one class with detection metrics.
+            List[Dict]: A list of dictionaries, each representing one class with detection metrics.
 
         Examples:
             >>> results = model.val(data="coco8.yaml")

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1039,12 +1039,28 @@ class DetMetrics(SimpleClass, DataExportMixin):
         """Return dictionary of computed performance metrics and statistics."""
         return self.box.curves_results
 
-    def summary(self, **kwargs) -> List[Dict[str, Union[str, float]]]:
-        """Return per-class detection metrics with shared scalar values included."""
+    def summary(self, normalize: bool = False, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
+        """
+        Generate a summarized representation of per-class detection metrics as a list of dictionaries.
+        Includes shared scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
+        This format is useful for exporting evaluation metrics to formats such as CSV, JSON, or HTML.
+
+        Args:
+           normalize (bool): For detection metrics, everything is normalized  by default [0-1].
+           decimals (int): Number of decimal places to round the output values to.
+
+        Returns:
+           List[Dict]: A list of dictionaries, each representing one class with corresponding metric values.
+
+        Examples:
+           >>> results = model.val(data="coco8.yaml")
+           >>> detection_summary = results.box.summary()
+           >>> print(detection_summary)
+       """
         scalars = {
-            "box-map": self.box.map,
-            "box-map50": self.box.map50,
-            "box-map75": self.box.map75,
+            "box-map": round(self.box.map, decimals),
+            "box-map50": round(self.box.map50, decimals),
+            "box-map75": round(self.box.map75, decimals),
         }
         per_class = {
             "box-p": self.box.p,
@@ -1054,7 +1070,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
         return [
             {
                 "class_name": self.names[i] if hasattr(self, "names") and i in self.names else str(i),
-                **{k: v[i] for k, v in per_class.items()},
+                **{k: round(v[i], decimals) for k, v in per_class.items()},
                 **scalars,
             }
             for i in range(len(next(iter(per_class.values()), [])))

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1053,7 +1053,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
 
         Examples:
            >>> results = model.val(data="coco8.yaml")
-           >>> detection_summary = results.box.summary()
+           >>> detection_summary = results.summary()
            >>> print(detection_summary)
         """
         scalars = {
@@ -1225,7 +1225,7 @@ class SegmentMetrics(SimpleClass, DataExportMixin):
 
         Examples:
             >>> results = model.val(data="coco8-seg.yaml")
-            >>> seg_summary = results.box.summary(decimals=4)
+            >>> seg_summary = results.summary(decimals=4)
             >>> print(seg_summary)
         """
         scalars = {
@@ -1403,7 +1403,7 @@ class PoseMetrics(SegmentMetrics):
 
         Examples:
             >>> results = model.val(data="coco8-pose.yaml")
-            >>> pose_summary = results.box.summary(decimals=4)
+            >>> pose_summary = results.summary(decimals=4)
             >>> print(pose_summary)
         """
         scalars = {
@@ -1497,7 +1497,7 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
 
         Examples:
             >>> results = model.val(data="imagenet.yaml")
-            >>> classify_summary = results.classify.summary(decimals=4)
+            >>> classify_summary = results.summary(decimals=4)
             >>> print(classify_summary)
         """
         return [{"classify-top1": round(self.top1, decimals), "classify-top5": round(self.top5, decimals)}]
@@ -1616,7 +1616,7 @@ class OBBMetrics(SimpleClass, DataExportMixin):
 
         Examples:
             >>> results = model.val(data="coco8.yaml")
-            >>> detection_summary = results.box.summary(decimals=4)
+            >>> detection_summary = results.summary(decimals=4)
             >>> print(detection_summary)
         """
         scalars = {

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1055,7 +1055,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
            >>> results = model.val(data="coco8.yaml")
            >>> detection_summary = results.box.summary()
            >>> print(detection_summary)
-       """
+        """
         scalars = {
             "box-map": round(self.box.map, decimals),
             "box-map50": round(self.box.map50, decimals),

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1067,11 +1067,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
             "box-f1": self.box.f1,
         }
         return [
-            {
-                "class_name": self.names[i] if hasattr(self, "names") and i in self.names else str(i),
-                **{k: round(v[i], decimals) for k, v in per_class.items()},
-                **scalars,
-            }
+            {"class_name": self.names[i], **{k: round(v[i], decimals) for k, v in per_class.items()}, **scalars}
             for i in range(len(next(iter(per_class.values()), [])))
         ]
 
@@ -1249,11 +1245,7 @@ class SegmentMetrics(SimpleClass, DataExportMixin):
             "mask-f1": self.seg.f1,
         }
         return [
-            {
-                "class_name": self.names[i] if hasattr(self, "names") and i in self.names else str(i),
-                **{k: round(v[i], decimals) for k, v in per_class.items()},
-                **scalars,
-            }
+            {"class_name": self.names[i], **{k: round(v[i], decimals) for k, v in per_class.items()}, **scalars}
             for i in range(len(next(iter(per_class.values()), [])))
         ]
 
@@ -1430,11 +1422,7 @@ class PoseMetrics(SegmentMetrics):
             "pose-f1": self.pose.f1,
         }
         return [
-            {
-                "class_name": self.names[i] if hasattr(self, "names") and i in self.names else str(i),
-                **{k: round(v[i], decimals) for k, v in per_class.items()},
-                **scalars,
-            }
+            {"class_name": self.names[i], **{k: round(v[i], decimals) for k, v in per_class.items()}, **scalars}
             for i in range(len(next(iter(per_class.values()), [])))
         ]
 
@@ -1637,10 +1625,6 @@ class OBBMetrics(SimpleClass, DataExportMixin):
         }
         per_class = {"box-p": self.box.p, "box-r": self.box.r, "box-f1": self.box.f1}
         return [
-            {
-                "class_name": self.names[i] if hasattr(self, "names") and i in self.names else str(i),
-                **{k: round(v[i], decimals) for k, v in per_class.items()},
-                **scalars,
-            }
+            {"class_name": self.names[i], **{k: round(v[i], decimals) for k, v in per_class.items()}, **scalars}
             for i in range(len(next(iter(per_class.values()), [])))
         ]

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -515,7 +515,7 @@ class ConfusionMatrix(DataExportMixin):
             decimals (int): Number of decimal places to round the output values to.
 
         Returns:
-            List[Dict[str, float]]: A list of dictionaries, each representing one predicted class with corresponding values for all actual classes.
+            (List[Dict[str, float]]): A list of dictionaries, each representing one predicted class with corresponding values for all actual classes.
 
         Examples:
             >>> results = model.val(data="coco8.yaml", plots=True)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1041,8 +1041,8 @@ class DetMetrics(SimpleClass, DataExportMixin):
 
     def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
-        Generate a summarized representation of per-class detection metrics as a list of dictionaries. Includes
-        shared scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
+        Generate a summarized representation of per-class detection metrics as a list of dictionaries. Includes shared
+        scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
 
         Args:
            normalize (bool): For Detect metrics, everything is normalized  by default [0-1].
@@ -1249,6 +1249,7 @@ class SegmentMetrics(SimpleClass, DataExportMixin):
             for i in range(len(next(iter(per_class.values()), [])))
         ]
 
+
 class PoseMetrics(SegmentMetrics):
     """
     Calculate and aggregate detection and pose metrics over a given set of classes.
@@ -1390,8 +1391,8 @@ class PoseMetrics(SegmentMetrics):
 
     def summary(self, normalize: bool = True, decimals: int = 5) -> List[Dict[str, Union[str, float]]]:
         """
-        Generate a summarized representation of per-class pose metrics as a list of dictionaries. Includes both box
-        and pose scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
+        Generate a summarized representation of per-class pose metrics as a list of dictionaries. Includes both box and
+        pose scalar metrics (mAP, mAP50, mAP75) alongside precision, recall, and F1-score for each class.
 
         Args:
             normalize (bool): For Pose metrics, everything is normalized  by default [0-1].


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the `summary()` metric reporting across detection, segmentation, pose, classification, and OBB tasks by adding rounding options, clearer documentation, and more consistent output formatting. 📝✨

### 📊 Key Changes
- Added `normalize` and `decimals` parameters to all `summary()` methods, allowing users to control output precision.
- All metric values in summaries are now rounded to the specified number of decimal places for cleaner, more readable results.
- Expanded and clarified docstrings for each `summary()` method, including usage examples.
- Ensured consistent output structure across detection, segmentation, pose, classification, and OBB metric summaries.
- Updated version to 8.3.151.

### 🎯 Purpose & Impact
- 📈 **Easier to Read Results:** Users get cleaner, more precise metric reports, making it simpler to interpret and share results.
- 🛠️ **Consistent API:** Developers benefit from a unified and predictable summary output across all tasks.
- 📚 **Better Documentation:** Enhanced docstrings and examples help both new and experienced users understand how to use and interpret metric summaries.
- 🎨 **Customization:** Users can now easily adjust the level of detail in their metric outputs to suit their needs.

Overall, this update makes metric reporting in Ultralytics models more user-friendly, customizable, and consistent! 🚀