### PR TITLE
`ultralytics 8.3.152` Optimize padding for Segment mask processing

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.151"
+__version__ = "8.3.152"
 
 import os
 

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -754,19 +754,18 @@ def scale_masks(masks, shape, padding: bool = True):
     Returns:
         (torch.Tensor): Rescaled masks.
     """
+    mh, mw = masks.shape[2:]
+    gain = min(mh / shape[0], mw / shape[1])  # gain  = old / new
+    pad = [mw - shape[1] * gain, mh - shape[0] * gain]  # wh padding
     if padding:
-        mh, mw = masks.shape[2:]
-        gain = min(mh / shape[0], mw / shape[1])  # gain  = old / new
-        pad = [mw - shape[1] * gain, mh - shape[0] * gain]  # wh padding
-
         pad[0] /= 2
         pad[1] /= 2
-        top, left = (int(round(pad[1] - 0.1)), int(round(pad[0] - 0.1)))
-        bottom, right = (
-            mh - int(round(pad[1] + 0.1)),
-            mw - int(round(pad[0] + 0.1)),
-        )
-        masks = masks[..., top:bottom, left:right]
+    top, left = (int(round(pad[1] - 0.1)), int(round(pad[0] - 0.1))) if padding else (0, 0)  # y, x
+    bottom, right = (
+        mh - int(round(pad[1] + 0.1)),
+        mw - int(round(pad[0] + 0.1)),
+    )
+    masks = masks[..., top:bottom, left:right]
 
     masks = F.interpolate(masks, shape, mode="bilinear", align_corners=False)  # NCHW
     return masks

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -404,8 +404,12 @@ def scale_image(masks, im0_shape, ratio_pad=None):
         pad = (im1_shape[1] - im0_shape[1] * gain) / 2, (im1_shape[0] - im0_shape[0] * gain) / 2  # wh padding
     else:
         pad = ratio_pad[1]
-    top, left = int(pad[1]), int(pad[0])  # y, x
-    bottom, right = int(im1_shape[0] - pad[1]), int(im1_shape[1] - pad[0])
+        
+    top, left = (int(round(pad[1] - 0.1)), int(round(pad[0] - 0.1)))
+    bottom, right = (
+            im1_shape[0] - int(round(pad[1] + 0.1)),
+            im1_shape[1] - int(round(pad[0] + 0.1)),
+        )
 
     if len(masks.shape) < 2:
         raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
@@ -750,15 +754,19 @@ def scale_masks(masks, shape, padding: bool = True):
     Returns:
         (torch.Tensor): Rescaled masks.
     """
-    mh, mw = masks.shape[2:]
-    gain = min(mh / shape[0], mw / shape[1])  # gain  = old / new
-    pad = [mw - shape[1] * gain, mh - shape[0] * gain]  # wh padding
     if padding:
+        mh, mw = masks.shape[2:]
+        gain = min(mh / shape[0], mw / shape[1])  # gain  = old / new
+        pad = [mw - shape[1] * gain, mh - shape[0] * gain]  # wh padding
+    
         pad[0] /= 2
         pad[1] /= 2
-    top, left = (int(pad[1]), int(pad[0])) if padding else (0, 0)  # y, x
-    bottom, right = (int(mh - pad[1]), int(mw - pad[0]))
-    masks = masks[..., top:bottom, left:right]
+        top, left = (int(round(pad[1] - 0.1)), int(round(pad[0] - 0.1)))
+        bottom, right = (
+                mh - int(round(pad[1] + 0.1)),
+                mw - int(round(pad[0] + 0.1)),
+            )
+        masks = masks[..., top:bottom, left:right]
 
     masks = F.interpolate(masks, shape, mode="bilinear", align_corners=False)  # NCHW
     return masks

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -404,12 +404,12 @@ def scale_image(masks, im0_shape, ratio_pad=None):
         pad = (im1_shape[1] - im0_shape[1] * gain) / 2, (im1_shape[0] - im0_shape[0] * gain) / 2  # wh padding
     else:
         pad = ratio_pad[1]
-        
+
     top, left = (int(round(pad[1] - 0.1)), int(round(pad[0] - 0.1)))
     bottom, right = (
-            im1_shape[0] - int(round(pad[1] + 0.1)),
-            im1_shape[1] - int(round(pad[0] + 0.1)),
-        )
+        im1_shape[0] - int(round(pad[1] + 0.1)),
+        im1_shape[1] - int(round(pad[0] + 0.1)),
+    )
 
     if len(masks.shape) < 2:
         raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
@@ -758,14 +758,14 @@ def scale_masks(masks, shape, padding: bool = True):
         mh, mw = masks.shape[2:]
         gain = min(mh / shape[0], mw / shape[1])  # gain  = old / new
         pad = [mw - shape[1] * gain, mh - shape[0] * gain]  # wh padding
-    
+
         pad[0] /= 2
         pad[1] /= 2
         top, left = (int(round(pad[1] - 0.1)), int(round(pad[0] - 0.1)))
         bottom, right = (
-                mh - int(round(pad[1] + 0.1)),
-                mw - int(round(pad[0] + 0.1)),
-            )
+            mh - int(round(pad[1] + 0.1)),
+            mw - int(round(pad[0] + 0.1)),
+        )
         masks = masks[..., top:bottom, left:right]
 
     masks = F.interpolate(masks, shape, mode="bilinear", align_corners=False)  # NCHW


### PR DESCRIPTION
Implementing code suggestion by @baptist as discussed here https://github.com/ultralytics/ultralytics/issues/20953#issuecomment-2944221416.

This fixes the offset that is introduced due to improper scaling of masks and images to their original resolution. See figure below and original discussion in issues. 


<img width="1306" alt="pr yolo" src="https://github.com/user-attachments/assets/d78398ee-d779-4705-9a87-d7af34fc2f7a" />


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved mask scaling accuracy in image processing functions for more precise results. 🖼️✨

### 📊 Key Changes
- Updated the logic for calculating padding and cropping in `scale_image` and `scale_masks` functions.
- Switched to using `round()` for more accurate boundary calculations when processing masks.
- Incremented the package version to 8.3.152.

### 🎯 Purpose & Impact
- Ensures more precise mask alignment and scaling, reducing potential off-by-one errors.
- Improves the quality of segmentation outputs, especially in edge cases.
- Users can expect more reliable and accurate results when working with masks in detection and segmentation tasks.