### PR TITLE
Clear memory if VRAM usage is high before validation.

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -456,6 +456,8 @@ class BaseTrainer:
 
                 # Validation
                 if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
+                    if self._get_memory(fraction=True) > 0.5:
+                        self._clear_memory()  # clear if memory utilization > 50%
                     self.metrics, self.fitness = self.validate()
                 self.save_metrics(metrics={**self.label_loss_items(self.tloss), **self.metrics, **self.lr})
                 self.stop |= self.stopper(epoch + 1, self.fitness) or final_epoch

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -529,7 +529,7 @@ class BaseTrainer:
         """Clear accelerator memory by calling garbage collector and emptying cache."""
         if threhold:
             assert 0 <= threhold <= 1, "Threshold must be between 0 and 1."
-            if self._get_memory(fraction=True) < threhold:
+            if self._get_memory(fraction=True) <= threhold:
                 return
         gc.collect()
         if self.device.type == "mps":

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -456,7 +456,7 @@ class BaseTrainer:
 
                 # Validation
                 if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
-                    self._clear_memory(threhold=0.5)  # prevent VRAM spike
+                    self._clear_memory(threshold=0.5)  # prevent VRAM spike
                     self.metrics, self.fitness = self.validate()
                 self.save_metrics(metrics={**self.label_loss_items(self.tloss), **self.metrics, **self.lr})
                 self.stop |= self.stopper(epoch + 1, self.fitness) or final_epoch
@@ -525,11 +525,11 @@ class BaseTrainer:
                 total = torch.cuda.get_device_properties(self.device).total_memory
         return ((memory / total) if total > 0 else 0) if fraction else (memory / 2**30)
 
-    def _clear_memory(self, threhold: float = None):
+    def _clear_memory(self, threshold: float = None):
         """Clear accelerator memory by calling garbage collector and emptying cache."""
-        if threhold:
-            assert 0 <= threhold <= 1, "Threshold must be between 0 and 1."
-            if self._get_memory(fraction=True) <= threhold:
+        if threshold:
+            assert 0 <= threshold <= 1, "Threshold must be between 0 and 1."
+            if self._get_memory(fraction=True) <= threshold:
                 return
         gc.collect()
         if self.device.type == "mps":

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -527,8 +527,12 @@ class BaseTrainer:
                 total = torch.cuda.get_device_properties(self.device).total_memory
         return ((memory / total) if total > 0 else 0) if fraction else (memory / 2**30)
 
-    def _clear_memory(self):
+    def _clear_memory(self, threhold: float = None):
         """Clear accelerator memory by calling garbage collector and emptying cache."""
+        if threhold is not None:
+            assert 0 <= threhold <= 1, "Threshold must be between 0 and 1."
+            if self._get_memory(fraction=True) < threhold:
+                return
         gc.collect()
         if self.device.type == "mps":
             torch.mps.empty_cache()


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/20958


The purpose of this PR is to prevent a VRAM spike during validation. This occurs because memory is not cleared between Train and Validation, which forces me (and undoubtedly many others) to resort to a lower batch size. Which often means I'm only using about 40-50% of the available VRAM, because increasing the batch size would lead to an OOM when validation starts.

This PR offers a simple fix. If memory consumption is above 50%, then the clear_memory() function will be called.

```
                # Validation
                if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
                    if self._get_memory(fraction=True) > 0.5:
                        self._clear_memory()  # clear if memory utilization > 50%
                    self.metrics, self.fitness = self.validate()
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved memory management during training to prevent VRAM spikes and optimize resource usage. 🚀

### 📊 Key Changes
- Added a memory threshold parameter to the `_clear_memory` method, allowing memory to be cleared only when usage exceeds a specified level.
- Integrated memory clearing before validation and at the end of each training epoch to prevent VRAM spikes.
- Refactored code to use the new threshold-based memory clearing consistently.

### 🎯 Purpose & Impact
- Reduces the risk of out-of-memory errors and VRAM spikes during training, especially on GPUs.
- Makes training more stable and efficient, particularly for users with limited hardware resources.
- Enhances overall reliability and performance of the training process in Ultralytics models. 💡