### PR TITLE
Fix incorrect task when loading saved checkpoint

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -293,7 +293,7 @@ class Model(torch.nn.Module):
 
         if str(weights).rpartition(".")[-1] == "pt":
             self.model, self.ckpt = attempt_load_one_weight(weights)
-            self.task = self.model.args["task"]
+            self.task = self.model.task
             self.overrides = self.model.args = self._reset_ckpt_args(self.model.args)
             self.ckpt_path = self.model.pt_path
         else:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1505,7 +1505,7 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
         # Model compatibility updates
         model.args = args  # attach args to model
         model.pt_path = w  # attach *.pt file path to model
-        model.task = guess_model_task(model)
+        model.task = getattr(model, "task", guess_model_task(model))
         if not hasattr(model, "stride"):
             model.stride = torch.tensor([32.0])
 
@@ -1553,7 +1553,7 @@ def attempt_load_one_weight(weight, device=None, inplace=True, fuse=False):
     # Model compatibility updates
     model.args = {k: v for k, v in args.items() if k in DEFAULT_CFG_KEYS}  # attach args to model
     model.pt_path = weight  # attach *.pt file path to model
-    model.task = guess_model_task(model)
+    model.task = getattr(model, "task", guess_model_task(model))
     if not hasattr(model, "stride"):
         model.stride = torch.tensor([32.0])
 


### PR DESCRIPTION
Closes #20570 

The `task` is stored as part of the checkpoint. Prioritize the `task` attribute in checkpoint before guessing.

**MRE**
```python
from ultralytics import YOLO
model = YOLO(model="yolo11s-seg.yaml")
model.save("saved-model.pt")
model = YOLO("saved-model.pt")
print(model.task)  # prints detect in main
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves how the model's task type is determined and stored when loading weights, making model loading more robust and compatible. 🚀

### 📊 Key Changes
- Updates the way the `task` attribute is set when loading models:
  - Now checks if the model already has a `task` attribute before trying to guess it.
- Adjusts how the `task` is accessed in the model loading process for better reliability.

### 🎯 Purpose & Impact
- Prevents overwriting an existing `task` attribute, which helps maintain custom or pre-set task types.
- Enhances compatibility with models that may already define their task, reducing potential errors during loading.
- Makes the model loading process more stable and user-friendly, especially when working with custom or previously saved models. 🛠️