### PR TITLE
Fixes #20895: Corrected handling of XYWH boxes.

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -130,14 +130,22 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = T
         gain = ratio_pad[0][0]
         pad = ratio_pad[1]
 
+    if xywh:
+        boxes = xywh2xyxy(boxes)  # convert to xyxy format as `clip_boxes` expects xyxy
+
     if padding:
-        boxes[..., 0] -= pad[0]  # x padding
-        boxes[..., 1] -= pad[1]  # y padding
-        if not xywh:
-            boxes[..., 2] -= pad[0]  # x padding
-            boxes[..., 3] -= pad[1]  # y padding
+        boxes[..., 0] -= pad[0]  # x1 - x padding
+        boxes[..., 1] -= pad[1]  # y1 - y padding
+        boxes[..., 2] -= pad[0]  # x2 - x padding
+        boxes[..., 3] -= pad[1]  # y2 - y padding
+
     boxes[..., :4] /= gain
-    return clip_boxes(boxes, img0_shape)
+    boxes = clip_boxes(boxes, img0_shape)
+
+    if xywh:
+        boxes = xyxy2xywh(boxes)
+
+    return boxes
 
 
 def make_divisible(x: int, divisor):

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -129,12 +129,12 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = T
     else:
         gain = ratio_pad[0][0]
         pad = ratio_pad[1]
-    
+
     if padding:
         boxes[..., 0] -= pad[0]  # x padding
         boxes[..., 1] -= pad[1]  # y padding
         if not xywh:
-            boxes[..., 2] -= pad[0]  # x padding  
+            boxes[..., 2] -= pad[0]  # x padding
             boxes[..., 3] -= pad[1]  # y padding
 
     boxes[..., :4] /= gain
@@ -143,13 +143,14 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = T
 
     if xywh and not is_obb:
         boxes = xywh2xyxy(boxes)  # convert to xyxy format as `clip_boxes` expects xyxy
-        
+
     boxes = clip_boxes(boxes, img0_shape)
 
     if xywh and not is_obb:
         boxes = xyxy2xywh(boxes)
 
     return boxes
+
 
 def make_divisible(x: int, divisor):
     """


### PR DESCRIPTION
Fixes #20895.

`scale_boxes` now converts `xywh` boxes to `xyxy` format before processing.

### Verification
Output of Minimal Reproducible Example provided in the issue:

Before:
```
Scaled XYXY: tensor([[ 20.,   0., 200., 120.]])
Scaled XYWH: tensor([[110.,  30., 180., 180.]])
Scaled XYWH -> XYXY: tensor([[ 20., -60., 200., 120.]])
```

Now:
```
Scaled XYXY: tensor([[ 20.,   0., 200., 120.]])
Scaled XYWH: tensor([[110.,  60., 180., 120.]])
Scaled XYWH -> XYXY: tensor([[ 20.,   0., 200., 120.]])
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds proper support for oriented bounding boxes (OBB, xywhr) and fixes clipping behavior for xywh boxes in `scale_boxes`, improving accuracy and consistency when rescaling boxes between image sizes. 🧭📦

### 📊 Key Changes
- `scale_boxes` now supports xyxy, xywh, and xywhr (OBB) formats.
- Updated docstrings to clearly document OBB handling and expected formats.
- Ensures correct clipping by:
  - Converting xywh → xyxy before clipping, then converting back to xywh.
  - Preserving OBB (xywhr) without unnecessary format conversions.
- Maintains angle (r) handling for OBBs while scaling and padding adjustments apply to x, y, w, h.

### 🎯 Purpose & Impact
- More reliable post-processing for OBB models (e.g., YOLO11 OBB variants) when resizing or letterboxing images. 🧰
- Fixes potential mis-clipping of xywh boxes, preventing distorted or out-of-bounds boxes. ✅
- Backward compatible for existing xyxy/xywh workflows—no user changes required.
- Leads to more accurate visualization and evaluation when moving predictions between image shapes, benefiting training, inference, and Ultralytics HUB integrations. 🚀

Example:
```python
from ultralytics.utils.ops import scale_boxes
# boxes_xywhr: tensor[N, 5] -> [x, y, w, h, r]
boxes_scaled = scale_boxes(img1_shape, boxes_xywhr, img0_shape, xywh=True)
```