### PR TITLE
Add support for `pinterest` video link inference

### DIFF
--- a/docs/en/reference/data/loaders.md
+++ b/docs/en/reference/data/loaders.md
@@ -39,6 +39,10 @@ keywords: Ultralytics, data loaders, SourceTypes, LoadStreams, LoadScreenshots, 
 
 <br><br><hr><br>
 
+## ::: ultralytics.data.loaders.download_pinterest_video
+
+<br><br><hr><br>
+
 ## ::: ultralytics.data.loaders.get_best_youtube_url
 
 <br><br>

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -279,6 +279,7 @@ def load_inference_source(source=None, batch: int = 1, vid_stride: int = 1, buff
     else:
         if is_pinterest:
             source = download_pinterest_video(source)
+            print(source)
         dataset = LoadImagesAndVideos(source, batch=batch, vid_stride=vid_stride, channels=channels)
 
     # Attach source types to the dataset

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -20,6 +20,7 @@ from ultralytics.data.loaders import (
     LoadTensor,
     SourceTypes,
     autocast_list,
+    download_pinterest_video,
 )
 from ultralytics.data.utils import IMG_FORMATS, PIN_MEMORY, VID_FORMATS
 from ultralytics.utils import RANK, colorstr
@@ -219,7 +220,8 @@ def check_source(source):
         source = str(source)
         source_lower = source.lower()
         is_file = source_lower.rpartition(".")[-1] in (IMG_FORMATS | VID_FORMATS)
-        is_url = source_lower.startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://"))
+        is_pinterest = "pinterest.com" in source_lower
+        is_url = source_lower.startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")) and not is_pinterest
         webcam = source.isnumeric() or source.endswith(".streams") or (is_url and not is_file)
         screenshot = source_lower == "screen"
         if is_url and is_file:
@@ -236,7 +238,7 @@ def check_source(source):
     else:
         raise TypeError("Unsupported image type. For supported types see https://docs.ultralytics.com/modes/predict")
 
-    return source, webcam, screenshot, from_img, in_memory, tensor
+    return source, webcam, screenshot, from_img, in_memory, tensor, is_pinterest
 
 
 def load_inference_source(source=None, batch: int = 1, vid_stride: int = 1, buffer: bool = False, channels: int = 3):
@@ -260,7 +262,7 @@ def load_inference_source(source=None, batch: int = 1, vid_stride: int = 1, buff
         Load a video stream source
         >>> dataset = load_inference_source("rtsp://example.com/stream", vid_stride=2)
     """
-    source, stream, screenshot, from_img, in_memory, tensor = check_source(source)
+    source, stream, screenshot, from_img, in_memory, tensor, is_pinterest = check_source(source)
     source_type = source.source_type if in_memory else SourceTypes(stream, screenshot, from_img, tensor)
 
     # Dataloader
@@ -275,6 +277,8 @@ def load_inference_source(source=None, batch: int = 1, vid_stride: int = 1, buff
     elif from_img:
         dataset = LoadPilAndNumpy(source, channels=channels)
     else:
+        if is_pinterest:
+            source = download_pinterest_video(source)
         dataset = LoadImagesAndVideos(source, batch=batch, vid_stride=vid_stride, channels=channels)
 
     # Attach source types to the dataset

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -20,8 +20,7 @@ from ultralytics.data.loaders import (
     LoadStreams,
     LoadTensor,
     SourceTypes,
-    autocast_list,
-    download_pinterest_video,
+    autocast_list, download_pinterest_video,
 )
 from ultralytics.data.utils import IMG_FORMATS, PIN_MEMORY, VID_FORMATS
 from ultralytics.utils import RANK, colorstr
@@ -211,17 +210,17 @@ def check_source(source):
 
     Examples:
         Check a file path source
-        >>> source, webcam, screenshot, from_img, in_memory, tensor = check_source("image.jpg")
+        >>> source, webcam, screenshot, from_img, in_memory, tensor, is_pinterest = check_source("image.jpg")
 
         Check a webcam source
-        >>> source, webcam, screenshot, from_img, in_memory, tensor = check_source(0)
+        >>> source, webcam, screenshot, from_img, in_memory, tensor, is_pinterest = check_source(0)
     """
     webcam, screenshot, from_img, in_memory, tensor, is_pinterest = False, False, False, False, False, False
     if isinstance(source, (str, int, Path)):  # int for local usb camera
         source = str(source)
         source_lower = source.lower()
         is_file = source_lower.rpartition(".")[-1] in (IMG_FORMATS | VID_FORMATS)
-        is_pinterest = urllib.parse.urlparse(source_lower).hostname == "in.pinterest.com"
+        is_pinterest = urllib.parse.urlparse(source_lower).hostname == "in.pinterest.com"  # for pintrest video predict.
         is_url = source_lower.startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")) and not is_pinterest
         webcam = source.isnumeric() or source.endswith(".streams") or (is_url and not is_file)
         screenshot = source_lower == "screen"
@@ -279,6 +278,8 @@ def load_inference_source(source=None, batch: int = 1, vid_stride: int = 1, buff
         dataset = LoadPilAndNumpy(source, channels=channels)
     else:
         if is_pinterest:
+            # Pinterest video usually is 5-15 second clip that work better with local download Unlike YouTube video
+            # (which stream well), it's URL expire quickly, downloading and then running inference is the best option.
             source = download_pinterest_video(source)
         dataset = LoadImagesAndVideos(source, batch=batch, vid_stride=vid_stride, channels=channels)
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -216,7 +216,7 @@ def check_source(source):
         Check a webcam source
         >>> source, webcam, screenshot, from_img, in_memory, tensor = check_source(0)
     """
-    webcam, screenshot, from_img, in_memory, tensor = False, False, False, False, False
+    webcam, screenshot, from_img, in_memory, tensor, is_pinterest = False, False, False, False, False, False
     if isinstance(source, (str, int, Path)):  # int for local usb camera
         source = str(source)
         source_lower = source.lower()

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -2,7 +2,6 @@
 
 import os
 import random
-import urllib.parse
 from pathlib import Path
 from typing import Any, Iterator
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -221,8 +221,7 @@ def check_source(source):
         source_lower = source.lower()
         is_file = source_lower.rpartition(".")[-1] in (IMG_FORMATS | VID_FORMATS)
         try:
-            parsed_url = urlparse(source_lower)
-            is_pinterest = parsed_url.hostname == "pinterest.com"
+            is_pinterest = urlparse(source_lower).hostname == "pinterest.com"
         except ValueError:
             is_pinterest = False
         is_url = source_lower.startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")) and not is_pinterest

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -220,7 +220,7 @@ def check_source(source):
         source = str(source)
         source_lower = source.lower()
         is_file = source_lower.rpartition(".")[-1] in (IMG_FORMATS | VID_FORMATS)
-        is_pinterest = source_lower.startswith("https://in.pinterest")
+        is_pinterest = source_lower.startswith("https://in.pinterest.com")
         is_url = source_lower.startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")) and not is_pinterest
         webcam = source.isnumeric() or source.endswith(".streams") or (is_url and not is_file)
         screenshot = source_lower == "screen"

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -4,6 +4,7 @@ import os
 import random
 from pathlib import Path
 from typing import Any, Iterator
+from urllib.parse import urlparse
 
 import numpy as np
 import torch
@@ -220,7 +221,7 @@ def check_source(source):
         source = str(source)
         source_lower = source.lower()
         is_file = source_lower.rpartition(".")[-1] in (IMG_FORMATS | VID_FORMATS)
-        is_pinterest = source_lower.startswith("https://in.pinterest.com")
+        is_pinterest = urllib.parse.urlparse(source_lower).hostname == "in.pinterest.com"
         is_url = source_lower.startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")) and not is_pinterest
         webcam = source.isnumeric() or source.endswith(".streams") or (is_url and not is_file)
         screenshot = source_lower == "screen"

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -4,7 +4,7 @@ import os
 import random
 from pathlib import Path
 from typing import Any, Iterator
-from urllib.parse import urlparse
+import urllib
 
 import numpy as np
 import torch

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -2,6 +2,7 @@
 
 import os
 import random
+import urllib.parse
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -220,10 +221,7 @@ def check_source(source):
         source = str(source)
         source_lower = source.lower()
         is_file = source_lower.rpartition(".")[-1] in (IMG_FORMATS | VID_FORMATS)
-        try:
-            is_pinterest = urlparse(source_lower).hostname == "pinterest.com"
-        except ValueError:
-            is_pinterest = False
+        is_pinterest = source_lower.startswith("https://in.pinterest")
         is_url = source_lower.startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")) and not is_pinterest
         webcam = source.isnumeric() or source.endswith(".streams") or (is_url and not is_file)
         screenshot = source_lower == "screen"

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -2,9 +2,9 @@
 
 import os
 import random
+import urllib
 from pathlib import Path
 from typing import Any, Iterator
-import urllib
 
 import numpy as np
 import torch

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -4,7 +4,6 @@ import os
 import random
 from pathlib import Path
 from typing import Any, Iterator
-from urllib.parse import urlparse
 
 import numpy as np
 import torch

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -20,7 +20,8 @@ from ultralytics.data.loaders import (
     LoadStreams,
     LoadTensor,
     SourceTypes,
-    autocast_list, download_pinterest_video,
+    autocast_list,
+    download_pinterest_video,
 )
 from ultralytics.data.utils import IMG_FORMATS, PIN_MEMORY, VID_FORMATS
 from ultralytics.utils import RANK, colorstr

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -282,7 +282,6 @@ def load_inference_source(source=None, batch: int = 1, vid_stride: int = 1, buff
     else:
         if is_pinterest:
             source = download_pinterest_video(source)
-            print(source)
         dataset = LoadImagesAndVideos(source, batch=batch, vid_stride=vid_stride, channels=channels)
 
     # Attach source types to the dataset

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -220,7 +220,11 @@ def check_source(source):
         source = str(source)
         source_lower = source.lower()
         is_file = source_lower.rpartition(".")[-1] in (IMG_FORMATS | VID_FORMATS)
-        is_pinterest = "pinterest.com" in source_lower
+        try:
+            parsed_url = urlparse(source_lower)
+            is_pinterest = parsed_url.hostname == "pinterest.com"
+        except ValueError:
+            is_pinterest = False
         is_url = source_lower.startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")) and not is_pinterest
         webcam = source.isnumeric() or source.endswith(".streams") or (is_url and not is_file)
         screenshot = source_lower == "screen"

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -657,10 +657,10 @@ def download_pinterest_video(url: str) -> Optional[str]:
     Downloads the best available MP4 video from a Pinterest link using yt-dlp.
 
     Args:
-        url (str): Pinterest video page URL.
+        url (str): Pinterest video page URL i.e. https://in.pinterest.com/pin/356980707982596275/
 
     Returns:
-        Optional[str]: Path to the downloaded video file, or None if download fails.
+        (str): Path to the downloaded video file, or None if download fails.
     """
     check_requirements("yt-dlp")
     from yt_dlp import YoutubeDL
@@ -672,8 +672,7 @@ def download_pinterest_video(url: str) -> Optional[str]:
     try:
         with YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=True)
-            ext = info.get("ext", "mp4")
-            downloaded_file = f"{pin_id}.{ext}"  # Do NOT double the extension
+            downloaded_file = f"{pin_id}.{info.get('ext', 'mp4')}"
             return downloaded_file if os.path.isfile(downloaded_file) else None
     except Exception as e:
         print(f"Download failed: {e}")

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -666,7 +666,7 @@ def download_pinterest_video(url: str) -> Optional[str]:
     from yt_dlp import YoutubeDL
 
     pin_id = urllib.parse.urlparse(url).path.strip("/").split("/")[-1]
-    ydl_opts = {"quiet": False, "outtmpl": f'{pin_id}.%(ext)s', "format": "best[ext=mp4]/best"}
+    ydl_opts = {"quiet": False, "outtmpl": f"{pin_id}.%(ext)s", "format": "best[ext=mp4]/best"}
 
     try:
         with YoutubeDL(ydl_opts) as ydl:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -124,8 +124,6 @@ class LoadStreams:
             if urllib.parse.urlparse(s).hostname in {"www.youtube.com", "youtube.com", "youtu.be"}:  # YouTube video
                 # YouTube format i.e. 'https://www.youtube.com/watch?v=Jsn8D3aC840' or 'https://youtu.be/Jsn8D3aC840'
                 s = get_best_youtube_url(s)
-            elif "pinterest.com" in hostname or "pinimg.com" in hostname:
-                s = download_and_return_path_from_url(s)  # NEW: Pinterest handler
             s = eval(s) if s.isnumeric() else s  # i.e. s = '0' local webcam
             if s == 0 and (IS_COLAB or IS_KAGGLE):
                 raise NotImplementedError(

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -660,35 +660,22 @@ def download_pinterest_video(url: str) -> Optional[str]:
 
     Args:
         url (str): Pinterest video page URL.
-        output_dir (str): Local directory to save the video. Defaults to "videos".
 
     Returns:
         Optional[str]: Path to the downloaded video file, or None if download fails.
-
-    Example:
-        >>> path = download_pinterest_video("https://in.pinterest.com/pin/2040762328456404")
-        >>> print(path)
-        2040762328456404.mp4
-
-    Notes:
-        - The returned file path can be used as input to Ultralytics: `yolo source=test.mp4`
     """
     check_requirements("yt-dlp")
-
     from yt_dlp import YoutubeDL
 
-    output_path = f"{urlparse(url).path.strip('/').split('/')[-1]}.%(ext)s"  # Extract PinID (last part of the URL)
-    ydl_opts = {
-        "quiet": False,
-        "outtmpl": output_path,
-        "format": "best[ext=mp4]/best"
-    }
+    pin_id = urllib.parse.urlparse(url).path.strip("/").split("/")[-1]
+    file_name = f"{pin_id}.%(ext)s"  # e.g., 2040762328456404.mp4
+    ydl_opts = {"quiet": False, "outtmpl": file_name, "format": "best[ext=mp4]/best"}
 
     try:
         with YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=True)
             ext = info.get("ext", "mp4")
-            downloaded_file = f"pinterest_video.{ext}"
+            downloaded_file = f"{pin_id}.{ext}"  # Do NOT double the extension
             return downloaded_file if os.path.isfile(downloaded_file) else None
     except Exception as e:
         print(f"Download failed: {e}")

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -670,8 +670,7 @@ def download_pinterest_video(url: str) -> Optional[str]:
 
     try:
         with YoutubeDL(ydl_opts) as ydl:
-            info = ydl.extract_info(url, download=True)
-            downloaded_file = f"{pin_id}.{info.get('ext', 'mp4')}"
+            downloaded_file = f"{pin_id}.{ydl.extract_info(url, download=True).get('ext', 'mp4')}"
             return downloaded_file if os.path.isfile(downloaded_file) else None
     except Exception as e:
         print(f"Download failed: {e}")

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -666,8 +666,7 @@ def download_pinterest_video(url: str) -> Optional[str]:
     from yt_dlp import YoutubeDL
 
     pin_id = urllib.parse.urlparse(url).path.strip("/").split("/")[-1]
-    file_name = f"{pin_id}.%(ext)s"  # e.g., 2040762328456404.mp4
-    ydl_opts = {"quiet": False, "outtmpl": file_name, "format": "best[ext=mp4]/best"}
+    ydl_opts = {"quiet": False, "outtmpl": f'{pin_id}.%(ext)s', "format": "best[ext=mp4]/best"}
 
     try:
         with YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Pinterest video links are now supported for direct download and inference in Ultralytics, making it easier to run models on Pinterest videos. 📹✨

### 📊 Key Changes
- Added a new `download_pinterest_video` function that downloads Pinterest videos using `yt-dlp`.
- Updated data loading logic to detect Pinterest video URLs and automatically download them before running inference.
- Improved documentation to include the new Pinterest video download feature.

### 🎯 Purpose & Impact
- Enables users to easily run YOLO models on Pinterest videos by handling the download process automatically.
- Improves reliability for Pinterest video inference, as these videos are now downloaded locally (avoiding issues with expiring URLs).
- Expands the range of supported video sources, making Ultralytics more versatile for content creators and researchers.