### PR TITLE
Fix COCO128 typo in `rockchip-rknn.md`

### DIFF
--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -182,7 +182,7 @@ YOLO11 benchmarks below were run by the Ultralytics team on Radxa Rock 5B based 
 
     !!! note
 
-        Validation for the above benchmarks were done using COCO18 dataset. Inference time does not include pre/ post-processing.
+        Validation for the above benchmarks were done using COCO128 dataset. Inference time does not include pre/ post-processing.
 
 ## Summary
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation fix: Corrected the dataset name in the YOLO11 benchmark notes for Rockchip RKNN integration. 📝

### 📊 Key Changes
- Updated the documentation to state that the YOLO11 benchmarks used the COCO128 dataset (instead of COCO18).

### 🎯 Purpose & Impact
- Ensures accuracy and clarity in the documentation for users referencing benchmark results.
- Helps users correctly understand the testing setup and results for Rockchip RKNN integration.