### PR TITLE
Revert `model.fuse()` to maintain NVIDIA JetPack 5 and below compatibility

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -285,6 +285,7 @@ def test_results(model: str):
     temp_s = "https://ultralytics.com/images/boats.jpg" if model == "yolo11n-obb.pt" else SOURCE
     results = YOLO(WEIGHTS_DIR / model)([temp_s, temp_s], imgsz=160)
     for r in results:
+        assert len(r), f"'{model}' results should not be empty!"
         r = r.cpu().numpy()
         print(r, len(r), r.path)  # print numpy attributes
         r = r.to(device="cpu", dtype=torch.float32)

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -196,7 +196,6 @@ class AutoBackend(nn.Module):
 
         # In-memory PyTorch model
         if nn_module:
-            # fuse on gpu for JetPack 5 and below
             model = weights.to(device)
             if fuse:
                 model = model.fuse(verbose=verbose)

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -197,13 +197,13 @@ class AutoBackend(nn.Module):
         # In-memory PyTorch model
         if nn_module:
             # fuse on gpu for JetPack 5 and below
-            if IS_JETSON and check_version(PYTHON_VERSION, "<=3.8.10"): 
+            if IS_JETSON and check_version(PYTHON_VERSION, "<=3.8.10"):
                 model = weights.to(device)
                 if fuse:
                     model = model.fuse(verbose=verbose)
             else:
                 if fuse:
-                    weights = weights.fuse(verbose=verbose) # fuse before move to gpu
+                    weights = weights.fuse(verbose=verbose)  # fuse before move to gpu
                 model = weights.to(device)
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -197,14 +197,9 @@ class AutoBackend(nn.Module):
         # In-memory PyTorch model
         if nn_module:
             # fuse on gpu for JetPack 5 and below
-            if IS_JETSON and check_version(PYTHON_VERSION, "<=3.8.10"):
-                model = weights.to(device)
-                if fuse:
-                    model = model.fuse(verbose=verbose)
-            else:
-                if fuse:
-                    weights = weights.fuse(verbose=verbose)  # fuse before move to gpu
-                model = weights.to(device)
+            model = weights.to(device)
+            if fuse:
+                model = model.fuse(verbose=verbose)
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only
             stride = max(int(model.stride.max()), 32)  # model stride


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved test reliability and optimized model loading for PyTorch in Ultralytics.

### 📊 Key Changes
- Added a check in tests to ensure model results are not empty.
- Adjusted the order of model fusion and device transfer for in-memory PyTorch models, fusing after moving the model to the desired device.

### 🎯 Purpose & Impact
- 🛡️ Ensures tests catch cases where models return no results, improving reliability.
- ⚡ Optimizes model loading by fusing models after device transfer, which can prevent errors and improve performance.
- 🚀 Users benefit from more robust testing and potentially smoother model deployment, especially when using custom or in-memory PyTorch models.