### PR TITLE
Fix `model.train` and `model.val` without `data` argument for YOLO11 models

### DIFF
--- a/docs/en/reference/utils/__init__.md
+++ b/docs/en/reference/utils/__init__.md
@@ -175,6 +175,10 @@ keywords: Ultralytics, utils, TQDM, Python, ML, Machine Learning utilities, YOLO
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.set_default_data_path
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.vscode_msg
 
 <br><br>

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -629,6 +629,7 @@ class Model(torch.nn.Module):
         """
         custom = {"rect": True}  # method defaults
         args = {**self.overrides, **custom, **kwargs, "mode": "val"}  # highest priority args on the right
+
         set_default_data_path(args, kwargs)  # set data.yaml for YOLO11 pretrained models if data is not provided
         validator = (validator or self._smart_load("validator"))(args=args, _callbacks=self.callbacks)
         validator(model=self.model)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -628,7 +628,15 @@ class Model(torch.nn.Module):
         """
         custom = {"rect": True}  # method defaults
         args = {**self.overrides, **custom, **kwargs, "mode": "val"}  # highest priority args on the right
-
+        if kwargs.get("data") is None:  # Fix hardcoded data.yaml in PyTorch files for YOLO11 models.
+            model = args["model"]
+            if model.startswith("yolo11") and model.endswith(".pt"):
+                if "-pose" in model:
+                    args["data"] = "coco-pose.yaml"
+                elif "-obb" in model:
+                    args["data"] = "DOTAv1.yaml"
+                else:
+                    args["data"] = "coco.yaml"
         validator = (validator or self._smart_load("validator"))(args=args, _callbacks=self.callbacks)
         validator(model=self.model)
         self.metrics = validator.metrics
@@ -784,6 +792,17 @@ class Model(torch.nn.Module):
             "model": self.overrides["model"],
             "task": self.task,
         }  # method defaults
+
+        if kwargs.get("data") is None:  # Fix hardcoded data.yaml in PyTorch files for YOLO11 models .
+            model = custom["model"]
+            if model.startswith("yolo11") and model.endswith(".pt"):
+                if "-pose" in model:
+                    kwargs["data"] = "coco-pose.yaml"
+                elif "-obb" in model:
+                    kwargs["data"] = "DOTAv1.yaml"
+                else:
+                    kwargs["data"] = "coco.yaml"
+
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
         if args.get("resume"):
             args["resume"] = self.ckpt_path

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -21,6 +21,7 @@ from ultralytics.utils import (
     YAML,
     callbacks,
     checks,
+    set_default_data_path,
 )
 
 
@@ -628,15 +629,7 @@ class Model(torch.nn.Module):
         """
         custom = {"rect": True}  # method defaults
         args = {**self.overrides, **custom, **kwargs, "mode": "val"}  # highest priority args on the right
-        if kwargs.get("data") is None:  # Fix hardcoded data.yaml in PyTorch files for YOLO11 models.
-            model = args["model"]
-            if model.startswith("yolo11") and model.endswith(".pt"):
-                if "-pose" in model:
-                    args["data"] = "coco-pose.yaml"
-                elif "-obb" in model:
-                    args["data"] = "DOTAv1.yaml"
-                else:
-                    args["data"] = "coco.yaml"
+        set_default_data_path(args, kwargs)  # set data.yaml for YOLO11 pretrained models if data is not provided
         validator = (validator or self._smart_load("validator"))(args=args, _callbacks=self.callbacks)
         validator(model=self.model)
         self.metrics = validator.metrics
@@ -793,17 +786,8 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
 
-        if kwargs.get("data") is None:  # Fix hardcoded data.yaml in PyTorch files for YOLO11 models .
-            model = custom["model"]
-            if model.startswith("yolo11") and model.endswith(".pt"):
-                if "-pose" in model:
-                    kwargs["data"] = "coco-pose.yaml"
-                elif "-obb" in model:
-                    kwargs["data"] = "DOTAv1.yaml"
-                else:
-                    kwargs["data"] = "coco.yaml"
-
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
+        set_default_data_path(args, kwargs)  # set data.yaml for YOLO11 pretrained models if data is not provided
         if args.get("resume"):
             args["resume"] = self.ckpt_path
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -786,7 +786,6 @@ class Model(torch.nn.Module):
             "model": self.overrides["model"],
             "task": self.task,
         }  # method defaults
-
         args = {**overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
         set_default_data_path(args, kwargs)  # set data.yaml for YOLO11 pretrained models if data is not provided
         if args.get("resume"):

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1577,7 +1577,6 @@ def set_default_data_path(args: dict, kwargs: dict) -> None:
         args (dict): The full argument dictionary constructed from overrides, custom settings, and kwargs.
         kwargs (dict): The original keyword arguments passed to the method or CLI.
     """
-
     if kwargs.get("data") is None:
         model = args.get("model", "")
         if model.startswith("yolo11") and model.endswith(".pt"):

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1565,8 +1565,8 @@ def url2file(url):
 
 def set_default_data_path(args: dict, kwargs: dict) -> None:
     """
-    Set the default 'data' field in `args` for Ultralytics YOLO11 models to avoid calling model.train and model.val without
-    data argument. This function modifies the `args` dictionary in-place. If 'data' is not present in `kwargs`,
+    Set the default 'data.yaml' path in `args` for Ultralytics YOLO11 models to avoid calling model.train and model.val
+    without data argument. It will directly modify the `args` dictionary in-place. If 'data' is not present in `kwargs`,
     and the model belongs to the YOLO11 family, it assigns a default dataset path based on the model type:
 
     - For detection and segmentation models: "coco.yaml"

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1563,6 +1563,31 @@ def url2file(url):
     return Path(clean_url(url)).name
 
 
+def set_default_data_path(args: dict, kwargs: dict) -> None:
+    """
+    Set the default 'data' field in `args` for Ultralytics YOLO11 models to avoid calling model.train and model.val without
+    data argument. This function modifies the `args` dictionary in-place. If 'data' is not present in `kwargs`,
+    and the model belongs to the YOLO11 family, it assigns a default dataset path based on the model type:
+
+    - For detection and segmentation models: "coco.yaml"
+    - For pose models (with '-pose' in name): "coco-pose.yaml"
+    - For oriented bounding box models (with '-obb' in name): "DOTAv1.yaml"
+
+    Args:
+        args (dict): The full argument dictionary constructed from overrides, custom settings, and kwargs.
+        kwargs (dict): The original keyword arguments passed to the method or CLI.
+    """
+    if kwargs.get("data") is None:
+        model = args.get("model", "")
+        if model.startswith("yolo11") and model.endswith(".pt"):
+            if "-pose" in model:
+                args["data"] = "coco-pose.yaml"
+            elif "-obb" in model:
+                args["data"] = "DOTAv1.yaml"
+            else:
+                args["data"] = "coco.yaml"
+
+
 def vscode_msg(ext="ultralytics.ultralytics-snippets") -> str:
     """Display a message to install Ultralytics-Snippets for VS Code if not already installed."""
     path = (USER_CONFIG_DIR.parents[2] if WINDOWS else USER_CONFIG_DIR.parents[1]) / ".vscode/extensions"

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1566,7 +1566,9 @@ def url2file(url):
 def set_default_data_path(args: dict, kwargs: dict) -> None:
     """
     Set the default 'data.yaml' path in `args` for Ultralytics YOLO11 models to avoid calling model.train and model.val
-    without data argument. It will directly modify the `args` dictionary in-place. If 'data' is not present in `kwargs`,
+    without data argument.
+
+    It will directly modify the `args` dictionary in-place. If 'data' is not present in `kwargs`,
     and the model belongs to the YOLO11 family, it assigns a default dataset path based on the model type:
 
     - For detection and segmentation models: "coco.yaml"

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1577,6 +1577,7 @@ def set_default_data_path(args: dict, kwargs: dict) -> None:
         args (dict): The full argument dictionary constructed from overrides, custom settings, and kwargs.
         kwargs (dict): The original keyword arguments passed to the method or CLI.
     """
+
     if kwargs.get("data") is None:
         model = args.get("model", "")
         if model.startswith("yolo11") and model.endswith(".pt"):


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Automatically sets a default dataset for YOLO11 pretrained models when training or validating, making it easier to use these models without specifying a data file.

### 📊 Key Changes
- Introduced a new utility function, `set_default_data_path`, to assign a default `data.yaml` path for YOLO11 models if none is provided.
- Updated the `train` and `val` methods to call this function, ensuring YOLO11 models always have a dataset specified.
- Documentation updated to include the new utility.

### 🎯 Purpose & Impact
- 🛠️ Simplifies the workflow for users working with YOLO11 pretrained models by removing the need to manually specify a dataset.
- 🚀 Reduces errors and confusion, especially for new users, by automatically selecting the appropriate dataset (e.g., COCO, COCO-Pose, DOTA) based on the model type.
- 📚 Improves documentation and code clarity for future development and user reference.