### PR TITLE
Update classification tip for `CustomizedValidator`

### DIFF
--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -166,6 +166,7 @@ Validate trained YOLO11n-cls model [accuracy](https://www.ultralytics.com/glossa
         yolo classify val model=yolo11n-cls.pt  # val official model
         yolo classify val model=path/to/best.pt # val custom model
         ```
+
 !!! tip
 
     Just like the [training step](#train), for images with extreme aspect ratios, consider creating a custom `ClassificationValidator` when calling the `val`() method:
@@ -177,6 +178,7 @@ Validate trained YOLO11n-cls model [accuracy](https://www.ultralytics.com/glossa
     from ultralytics import YOLO
     from ultralytics.data.dataset import ClassificationDataset
     from ultralytics.models.yolo.classify import ClassificationValidator
+
 
     class CustomizedDataset(ClassificationDataset):
         """A customized dataset class for image classification with enhanced data augmentation transforms."""
@@ -193,16 +195,17 @@ Validate trained YOLO11n-cls model [accuracy](https://www.ultralytics.com/glossa
             )
             self.torch_transforms = val_transforms
 
+
     class CustomizedValidator(ClassificationValidator):
         """A customized validator class for YOLO classification models with enhanced dataset handling."""
+
         def build_dataset(self, img_path: str, mode: str = "test", batch=None):
-            return CustomizedDataset(
-                root=img_path, args=self.args, augment=mode == "train", prefix=mode
-            )
+            return CustomizedDataset(root=img_path, args=self.args, augment=mode == "train", prefix=mode)
+
 
     model = YOLO("yolo11n-cls.pt")
     model.train(data="imagenet1000", epochs=10, imgsz=224, batch=64)
-    
+
     # Example: validate the model on the test split
     metrics = model.val(validator=CustomizedValidator, split="test")
     ```

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -75,11 +75,10 @@ Train YOLO11n-cls on the MNIST160 dataset for 100 [epochs](https://www.ultralyti
 !!! tip
 
     Ultralytics YOLO classification uses [`torchvision.transforms.RandomResizedCrop`](https://pytorch.org/vision/stable/generated/torchvision.transforms.RandomResizedCrop.html) for training and [`torchvision.transforms.CenterCrop`](https://pytorch.org/vision/stable/generated/torchvision.transforms.CenterCrop.html) for validation and inference.
-    These cropping-based transforms assume square inputs and may crop out important parts of images with extreme aspect ratios, resulting in loss of relevant content during training.
-    To preserve the full image while maintaining its proportions, consider using a letterbox-style resizing approach instead. This resizes the image while keeping its aspect ratio and adds padding as needed.
+    These cropping-based transforms assume square inputs and may inadvertently crop out important regions from images with extreme aspect ratios, potentially causing loss of critical visual information during training.
+    To preserve the full image while maintaining its proportions, consider using [torchvision.transforms.Resize](https://docs.pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) instead of cropping transforms.
 
-
-    To apply this, customize your augmentation pipeline using a custom `ClassificationDataset` and `ClassificationTrainer`. Refer to the training step code sample for implementation guidance.
+    You can implement this by customizing your augmentation pipeline through a custom `ClassificationDataset` and `ClassificationTrainer`.
 
 
     ```python
@@ -178,7 +177,7 @@ Validate trained YOLO11n-cls model [accuracy](https://www.ultralytics.com/glossa
 
 !!! tip
 
-    As mentioned in the [training step](#train), where a custom `ClassificationTrainer` is used to handle extreme aspect ratios, you can apply a similar approach during validation. Refer to the code sample in that section and consider using a custom `ClassificationValidator` when calling the `val()` method.
+    As mentioned in the [training section](#train), you can handle extreme aspect ratios during training by using a custom `ClassificationTrainer`. You can apply the same approach during validation by implementing a custom `ClassificationValidator` when calling the `val()` method. Refer to the complete code example in the training section for implementation details.
 
 ## Predict
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -168,7 +168,7 @@ Validate trained YOLO11n-cls model [accuracy](https://www.ultralytics.com/glossa
         ```
 !!! tip
 
-    Just like the [training step](#train), for images with extreme aspect ratios, consider creating a custom `ClassificationValidator` when using the `val`() method:
+    Just like the [training step](#train), for images with extreme aspect ratios, consider creating a custom `ClassificationValidator` when calling the `val`() method:
 
     ```python
     import torch
@@ -220,7 +220,7 @@ Use a trained YOLO11n-cls model to run predictions on images.
 
         # Load a model
         model = YOLO("yolo11n-cls.pt")  # load an official model
-        model = YOLO("path/to/best.pt")  # load a cuxstom model
+        model = YOLO("path/to/best.pt")  # load a custom model
 
         # Predict with the model
         results = model("https://ultralytics.com/images/bus.jpg")  # predict on an image

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -177,7 +177,7 @@ Validate trained YOLO11n-cls model [accuracy](https://www.ultralytics.com/glossa
 
 !!! tip
 
-    As mentioned in the [training section](#train), you can handle extreme aspect ratios during training by using a custom `ClassificationTrainer`. You can apply the same approach during validation by implementing a custom `ClassificationValidator` when calling the `val()` method. Refer to the complete code example in the training section for implementation details.
+    As mentioned in the [training section](#train), you can handle extreme aspect ratios during training by using a custom `ClassificationTrainer`. You need to apply the same approach for consistent validation results by implementing a custom `ClassificationValidator` when calling the `val()` method. Refer to the complete code example in the [training section](#train) for implementation details.
 
 ## Predict
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -77,10 +77,10 @@ Train YOLO11n-cls on the MNIST160 dataset for 100 [epochs](https://www.ultralyti
     Ultralytics YOLO classification uses [`torchvision.transforms.RandomResizedCrop`](https://pytorch.org/vision/stable/generated/torchvision.transforms.RandomResizedCrop.html) for training and [`torchvision.transforms.CenterCrop`](https://pytorch.org/vision/stable/generated/torchvision.transforms.CenterCrop.html) for validation and inference.
     These cropping-based transforms assume square inputs and may crop out important parts of images with extreme aspect ratios, resulting in loss of relevant content during training.
     To preserve the full image while maintaining its proportions, consider using a letterbox-style resizing approach instead. This resizes the image while keeping its aspect ratio and adds padding as needed.
-    
-    
+
+
     To apply this, customize your augmentation pipeline using a custom `ClassificationDataset` and `ClassificationTrainer`. Refer to the training step code sample for implementation guidance.
-    
+
 
     ```python
     import torch

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -76,7 +76,7 @@ Train YOLO11n-cls on the MNIST160 dataset for 100 [epochs](https://www.ultralyti
 
     Ultralytics YOLO classification uses [`torchvision.transforms.RandomResizedCrop`](https://pytorch.org/vision/stable/generated/torchvision.transforms.RandomResizedCrop.html) for training and [`torchvision.transforms.CenterCrop`](https://pytorch.org/vision/stable/generated/torchvision.transforms.CenterCrop.html) for validation and inference.
     These cropping-based transforms assume square inputs and may inadvertently crop out important regions from images with extreme aspect ratios, potentially causing loss of critical visual information during training.
-    To preserve the full image while maintaining its proportions, consider using [torchvision.transforms.Resize](https://docs.pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) instead of cropping transforms.
+    To preserve the full image while maintaining its proportions, consider using [`torchvision.transforms.Resize`](https://docs.pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) instead of cropping transforms.
 
     You can implement this by customizing your augmentation pipeline through a custom `ClassificationDataset` and `ClassificationTrainer`.
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -74,8 +74,13 @@ Train YOLO11n-cls on the MNIST160 dataset for 100 [epochs](https://www.ultralyti
 
 !!! tip
 
-    Ultralytics YOLO classification uses [torchvision.transforms.RandomResizedCrop](https://docs.pytorch.org/vision/stable/generated/torchvision.transforms.RandomResizedCrop.html) for training augmentation and [torchvision.transforms.CenterCrop](https://docs.pytorch.org/vision/stable/generated/torchvision.transforms.CenterCrop.html) for validation/inference.
-    For images with extreme aspect ratios, consider using [torchvision.transforms.Resize](https://docs.pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html) instead. The example below shows how to customize augmentations for classification training using a custom `ClassificationDataset` and `ClassificationTrainer`.
+    Ultralytics YOLO classification uses [`torchvision.transforms.RandomResizedCrop`](https://pytorch.org/vision/stable/generated/torchvision.transforms.RandomResizedCrop.html) for training and [`torchvision.transforms.CenterCrop`](https://pytorch.org/vision/stable/generated/torchvision.transforms.CenterCrop.html) for validation and inference.
+    These cropping-based transforms assume square inputs and may crop out important parts of images with extreme aspect ratios, resulting in loss of relevant content during training.
+    To preserve the full image while maintaining its proportions, consider using a letterbox-style resizing approach instead. This resizes the image while keeping its aspect ratio and adds padding as needed.
+    
+    
+    To apply this, customize your augmentation pipeline using a custom `ClassificationDataset` and `ClassificationTrainer`. Refer to the training step code sample for implementation guidance.
+    
 
     ```python
     import torch
@@ -92,6 +97,8 @@ Train YOLO11n-cls on the MNIST160 dataset for 100 [epochs](https://www.ultralyti
         def __init__(self, root: str, args, augment: bool = False, prefix: str = ""):
             """Initialize a customized classification dataset with enhanced data augmentation transforms."""
             super().__init__(root, args, augment, prefix)
+
+            # Add your custom training transforms here
             train_transforms = T.Compose(
                 [
                     T.Resize((args.imgsz, args.imgsz)),
@@ -104,6 +111,8 @@ Train YOLO11n-cls on the MNIST160 dataset for 100 [epochs](https://www.ultralyti
                     T.RandomErasing(p=args.erasing, inplace=True),
                 ]
             )
+
+            # Add your custom validation transforms here
             val_transforms = T.Compose(
                 [
                     T.Resize((args.imgsz, args.imgsz)),
@@ -169,46 +178,7 @@ Validate trained YOLO11n-cls model [accuracy](https://www.ultralytics.com/glossa
 
 !!! tip
 
-    Just like the [training step](#train), for images with extreme aspect ratios, consider creating a custom `ClassificationValidator` when calling the `val`() method:
-
-    ```python
-    import torch
-    import torchvision.transforms as T
-
-    from ultralytics import YOLO
-    from ultralytics.data.dataset import ClassificationDataset
-    from ultralytics.models.yolo.classify import ClassificationValidator
-
-
-    class CustomizedDataset(ClassificationDataset):
-        """A customized dataset class for image classification with enhanced data augmentation transforms."""
-
-        def __init__(self, root: str, args, augment: bool = False, prefix: str = ""):
-            """Initialize a customized classification dataset with enhanced data augmentation transforms."""
-            super().__init__(root, args, augment, prefix)
-            val_transforms = T.Compose(
-                [
-                    T.Resize((args.imgsz, args.imgsz)),
-                    T.ToTensor(),
-                    T.Normalize(mean=torch.tensor(0), std=torch.tensor(1)),
-                ]
-            )
-            self.torch_transforms = val_transforms
-
-
-    class CustomizedValidator(ClassificationValidator):
-        """A customized validator class for YOLO classification models with enhanced dataset handling."""
-
-        def build_dataset(self, img_path: str, mode: str = "test", batch=None):
-            return CustomizedDataset(root=img_path, args=self.args, augment=mode == "train", prefix=mode)
-
-
-    model = YOLO("yolo11n-cls.pt")
-    model.train(data="imagenet1000", epochs=10, imgsz=224, batch=64)
-
-    # Example: validate the model on the test split
-    metrics = model.val(validator=CustomizedValidator, split="test")
-    ```
+    As mentioned in the [training step](#train), where a custom `ClassificationTrainer` is used to handle extreme aspect ratios, you can apply a similar approach during validation. Refer to the code sample in that section and consider using a custom `ClassificationValidator` when calling the `val()` method.
 
 ## Predict
 


### PR DESCRIPTION
Like @Laughing-q did last time with [PR 20949](https://github.com/ultralytics/ultralytics/pull/20949/files), I added a similar example for the `val` method. Based on a client request the SE team had.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved YOLO classification documentation to better guide users on handling images with extreme aspect ratios during training and validation. 📚✨

### 📊 Key Changes
- Expanded explanation on how cropping-based transforms (like RandomResizedCrop and CenterCrop) may crop out important regions in images with unusual aspect ratios.
- Added clear guidance to use Resize transforms instead, preserving the full image and its proportions.
- Provided updated code examples for customizing training and validation augmentation pipelines using custom `ClassificationDataset` and `ClassificationTrainer`.
- Included a new tip on ensuring consistent handling of aspect ratios during validation by using a custom `ClassificationValidator`.

### 🎯 Purpose & Impact
- Helps users avoid losing important image content when training or validating with non-square images.
- Makes it easier for users to customize their data augmentation pipeline for better model performance on diverse datasets.
- Ensures more reliable and consistent results for classification tasks, especially with images that have extreme aspect ratios.
- Enhances the overall clarity and usefulness of the YOLO classification documentation for both new and experienced users.