### PR TITLE
Fix RTDETR onnx input height and input width

### DIFF
--- a/examples/RTDETR-ONNXRuntime-Python/main.py
+++ b/examples/RTDETR-ONNXRuntime-Python/main.py
@@ -97,8 +97,8 @@ class RTDETR:
         self.session = ort.InferenceSession(model_path, providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
 
         self.model_input = self.session.get_inputs()
-        self.input_width = self.model_input[0].shape[2]
-        self.input_height = self.model_input[0].shape[3]
+        self.input_height = self.model_input[0].shape[2]
+        self.input_width = self.model_input[0].shape[3]
 
         if self.classes is None:
             # Load class names from the COCO dataset YAML file


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes swapped input height/width parsing in the RTDETR ONNXRuntime Python example to ensure correct model input handling ✅

### 📊 Key Changes
- Corrects input shape indexing:
  - Previously: `input_width = shape[2]`, `input_height = shape[3]`
  - Now: `input_height = shape[2]`, `input_width = shape[3]` (matches NCHW format) 🧭
- Applies to `examples/RTDETR-ONNXRuntime-Python/main.py` using ONNXRuntime with CUDA/CPU providers

### 🎯 Purpose & Impact
- Ensures proper handling of model input dimensions, preventing mis-scaled or distorted detections on non-square images 📐
- Avoids potential inference errors and incorrect box scaling due to width/height confusion 🚫🐛
- Improves reliability of the RTDETR ONNXRuntime example without changing the public API or behavior elsewhere ✅