### PR TITLE
Pin `lxml<6.0.0` to fix Jetson `Jetpack4` and `Jetpack5` docker build

### DIFF
--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -54,7 +54,7 @@ RUN uv pip install --system \
     tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl
-RUN uv pip install --system -e ".[export]" lxml
+RUN uv pip install --system -e ".[export]" "lxml<6.0.0"
 
 # Remove extra build files
 RUN rm -rf *.whl /root/.config/Ultralytics/persistent_cache.json

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -54,6 +54,7 @@ RUN uv pip install --system \
     tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl
+# lxml latest version not supported: https://github.com/ultralytics/ultralytics/actions/runs/15919317342/job/44904645988
 RUN uv pip install --system -e ".[export]" "lxml<6.0.0"
 
 # Remove extra build files

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -54,7 +54,7 @@ RUN uv pip install --system \
     tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl
-RUN uv pip install --system -e ".[export]"
+RUN uv pip install --system -e ".[export]" lxml
 
 # Remove extra build files
 RUN rm -rf *.whl /root/.config/Ultralytics/persistent_cache.json

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -54,7 +54,7 @@ RUN uv pip install --system \
     tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl
-# lxml latest version not supported: https://github.com/ultralytics/ultralytics/actions/runs/15919317342/job/44904645988
+# lxml >= 6.0.0 error on jetpack4: https://github.com/ultralytics/ultralytics/actions/runs/15919317342/job/44904645988
 RUN uv pip install --system -e ".[export]" "lxml<6.0.0"
 
 # Remove extra build files

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -40,7 +40,7 @@ RUN uv pip install --system \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.18.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.2.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl
-# lxml latest version not supported: https://github.com/ultralytics/ultralytics/actions/runs/15919317342/job/44904645989
+# lxml >= 6.0.0 error on jetpack5: https://github.com/ultralytics/ultralytics/actions/runs/15919317342/job/44904645988
 RUN uv pip install --system -e ".[export]" "lxml<6.0.0"
 
 # Remove extra build files

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -40,7 +40,7 @@ RUN uv pip install --system \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.18.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.2.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl
-# lxml >= 6.0.0 error on jetpack5: https://github.com/ultralytics/ultralytics/actions/runs/15919317342/job/44904645988
+# lxml >= 6.0.0 error on jetpack5: https://github.com/ultralytics/ultralytics/actions/runs/15919317342/job/44904645989
 RUN uv pip install --system -e ".[export]" "lxml<6.0.0"
 
 # Remove extra build files

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -40,7 +40,7 @@ RUN uv pip install --system \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.18.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.2.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl
-RUN uv pip install --system -e ".[export]" lxml
+RUN uv pip install --system -e ".[export]" "lxml<6.0.0"
 
 # Remove extra build files
 RUN rm -rf *.whl /root/.config/Ultralytics/persistent_cache.json

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -40,6 +40,7 @@ RUN uv pip install --system \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.18.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.2.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl
+# lxml latest version not supported: https://github.com/ultralytics/ultralytics/actions/runs/15919317342/job/44904645989
 RUN uv pip install --system -e ".[export]" "lxml<6.0.0"
 
 # Remove extra build files

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -40,7 +40,7 @@ RUN uv pip install --system \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.18.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.2.0-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl
-RUN uv pip install --system -e ".[export]"
+RUN uv pip install --system -e ".[export]" lxml
 
 # Remove extra build files
 RUN rm -rf *.whl /root/.config/Ultralytics/persistent_cache.json


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes compatibility issues with lxml on Jetson JetPack 4 and 5 Docker images by restricting the lxml version.

### 📊 Key Changes
- Updates Dockerfiles for Jetson JetPack 4 and 5 to install lxml version below 6.0.0.
- Adds a comment explaining that lxml >= 6.0.0 causes errors on these platforms.

### 🎯 Purpose & Impact
- Prevents installation errors and build failures when setting up Ultralytics on NVIDIA Jetson devices 🚀.
- Ensures smoother, more reliable deployments for users working with Jetson hardware 🛠️.
- Saves users time by avoiding known compatibility issues with newer lxml versions.