### PR TITLE
Update Sony IMX Doc with COCO128 Benchmarks

### DIFF
--- a/docs/en/integrations/sony-imx500.md
+++ b/docs/en/integrations/sony-imx500.md
@@ -188,12 +188,12 @@ YOLOv8 and YOLO11n benchmarks below were run by the Ultralytics team on Raspberr
 
 | Model   | Format | Status | Size of `RPK` (MB) | mAP50-95(B) | Inference time (ms/im) |
 | ------- | ------ | ------ | ------------------ | ----------- | ---------------------- |
-| YOLOv8n | imx    | ✅     | 3.1                | 0.602       | 58.82                  |
-| YOLO11n | imx    | ✅     | 3.2                | 0.644       | 62.50                  |
+| YOLOv8n | imx    | ✅     | 3.1                | 0.433       | 58.82                  |
+| YOLO11n | imx    | ✅     | 3.2                | 0.492       | 62.50                  |
 
 !!! note
 
-    Validation for the above benchmark was done using coco8 dataset on a Raspberry Pi 5
+    Validation for the above benchmark was done using coco128 dataset on a Raspberry Pi 5
 
 ## What's Under the Hood?
 
@@ -307,9 +307,9 @@ Software:
 
 Based on Ultralytics benchmarks on Raspberry Pi AI Camera:
 
-- YOLO11n achieves 58.82ms inference time per image
-- mAP50-95 of 0.522 on COCO8 dataset
-- Model size of only 2.9MB after quantization
+- YOLO11n achieves 62.50ms inference time per image
+- mAP50-95 of 0.492 on COCO128 dataset
+- Model size of only 3.2MB after quantization
 
 This demonstrates that IMX500 format provides efficient real-time inference while maintaining good accuracy for edge AI applications.
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated Sony IMX500 integration docs with corrected YOLO11n and YOLOv8n benchmark results and dataset details. 📈

### 📊 Key Changes
- Updated mAP50-95 (accuracy) values for YOLOv8n and YOLO11n models in the benchmark table.
- Changed the validation dataset reference from "coco8" to "coco128".
- Adjusted YOLO11n's reported inference time, accuracy, and model size in the summary section.

### 🎯 Purpose & Impact
- Ensures users have accurate, up-to-date benchmark results for YOLOv8n and YOLO11n on Sony IMX500 devices.
- Clarifies which dataset was used for validation, improving transparency and reproducibility.
- Helps developers and users make informed decisions about model performance for edge AI applications. 🚀