### PR TITLE
Fix COCO128 capitalization in Sony IMX Doc

### DIFF
--- a/docs/en/integrations/sony-imx500.md
+++ b/docs/en/integrations/sony-imx500.md
@@ -193,7 +193,7 @@ YOLOv8 and YOLO11n benchmarks below were run by the Ultralytics team on Raspberr
 
 !!! note
 
-    Validation for the above benchmark was done using coco128 dataset on a Raspberry Pi 5
+    Validation for the above benchmark was done using COCO128 dataset on a Raspberry Pi 5
 
 ## What's Under the Hood?
 


### PR DESCRIPTION
@Laughing-q I missed this in the [previous PR](https://github.com/ultralytics/ultralytics/pull/21227). Just a small change to make the naming consistant.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor documentation update to clarify dataset naming in Sony IMX500 integration guide. 📝

### 📊 Key Changes
- Updated the dataset name from "coco128" to "COCO128" in the benchmark validation note.

### 🎯 Purpose & Impact
- Ensures consistency and clarity in documentation for users referencing the dataset.
- Helps avoid confusion, especially for new users following the integration guide.