### PR TITLE
Fix metrics plotting for `Pose` and `Segment` tasks

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1006,6 +1006,7 @@ class DetMetrics(SimpleClass, DataExportMixin):
             save_dir=save_dir,
             names=self.names,
             on_plot=on_plot,
+            prefix="Box",
         )[2:]
         self.box.nc = len(self.names)
         self.box.update(results)
@@ -1135,7 +1136,7 @@ class SegmentMetrics(DetMetrics):
         Returns:
             (Dict[str, np.ndarray]): Dictionary containing concatenated statistics arrays.
         """
-        stats = DetMetrics.process(self, on_plot=on_plot)  # process box stats
+        stats = DetMetrics.process(self, save_dir, plot, on_plot=on_plot)  # process box stats
         results_mask = ap_per_class(
             stats["tp_m"],
             stats["conf"],
@@ -1270,7 +1271,7 @@ class PoseMetrics(DetMetrics):
         Returns:
             (Dict[str, np.ndarray]): Dictionary containing concatenated statistics arrays.
         """
-        stats = DetMetrics.process(self, on_plot=on_plot)  # process box stats
+        stats = DetMetrics.process(self, save_dir, plot, on_plot=on_plot)  # process box stats
         results_pose = ap_per_class(
             stats["tp_p"],
             stats["conf"],


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved metric processing for detection, segmentation, and pose tasks by refining function calls and adding clearer labeling.

### 📊 Key Changes
- Added a "Box" prefix to metric plots for better clarity.
- Updated internal function calls to pass additional parameters (`save_dir`, `plot`) when processing detection, segmentation, and pose metrics.

### 🎯 Purpose & Impact
- 🏷️ Makes metric plots easier to understand by clearly labeling box-related results.
- 🛠️ Ensures more consistent and accurate metric processing across different tasks.
- 👩‍💻 Enhances the user experience when reviewing evaluation results, especially for those working with multiple task types.