### PR TITLE
Fix frame saving logic for video files with dots and align frame filenames with label naming convention

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -466,29 +466,35 @@ class BasePredictor:
         """
         im = self.plotted_img
 
+        video_stem = Path(save_path).stem  # filename without extension
+        frames_path = Path(save_path).parent / f"{video_stem}_frames"
+
         # Save videos and streams
         if self.dataset.mode in {"stream", "video"}:
             fps = self.dataset.fps if self.dataset.mode == "video" else 30
-            frames_path = f"{save_path.split('.', 1)[0]}_frames/"
+
             if save_path not in self.vid_writer:  # new video
                 if self.args.save_frames:
-                    Path(frames_path).mkdir(parents=True, exist_ok=True)
+                    frames_path.mkdir(parents=True, exist_ok=True)
                 suffix, fourcc = (".mp4", "avc1") if MACOS else (".avi", "WMV2") if WINDOWS else (".avi", "MJPG")
                 self.vid_writer[save_path] = cv2.VideoWriter(
                     filename=str(Path(save_path).with_suffix(suffix)),
                     fourcc=cv2.VideoWriter_fourcc(*fourcc),
-                    fps=fps,  # integer required, floats produce error in MP4 codec
-                    frameSize=(im.shape[1], im.shape[0]),  # (width, height)
+                    fps=fps,
+                    frameSize=(im.shape[1], im.shape[0]),
                 )
-
             # Save video
             self.vid_writer[save_path].write(im)
-            if self.args.save_frames:
-                cv2.imwrite(f"{frames_path}{frame}.jpg", im)
 
-        # Save images
+            if self.args.save_frames:
+                # Save frame image with full video_stem prefix
+                frame_filename = f"{video_stem}_{frame}.jpg"
+                cv2.imwrite(str(frames_path / frame_filename), im)
         else:
-            cv2.imwrite(str(Path(save_path).with_suffix(".jpg")), im)  # save to JPG for best support
+            # Save images: save in the same folder under frames_path with consistent naming
+            frames_path.mkdir(parents=True, exist_ok=True)
+            frame_filename = f"{video_stem}_{frame}.jpg"
+            cv2.imwrite(str(frames_path / frame_filename), im)
 
     def show(self, p: str = ""):
         """Display an image in a window."""


### PR DESCRIPTION
## PR Description:
### Summary
This PR addresses two key issues with frame-saving logic in the save_predicted_images() method in `engine/predictor.py`:

1. Incorrect folder names when video filenames contain multiple dots (e.g., IMG.0123.avi)
2. Inconsistent frame image names that make it difficult to pair with corresponding label files for downstream tasks like re-labeling, training, or evaluation.

## Problem

- The previous logic used `save_path.split('.', 1)[0]` to derive the frame directory and filename base. This fails when filenames contain multiple dots (e.g., IMG.0123.avi becomes IMG_frames/).
- Frame images were saved as 0.jpg, 1.jpg, etc., while corresponding labels used the full video name as prefix (e.g., IMG.0196_0.txt). This created a mismatch.
### Fix
Replaced fragile string-splitting with `Path(save_path).stem` to reliably extract the filename without extension.

- Frame images are now saved as:
IMG.0123_frames/IMG.0123_0.jpg, IMG.0123_1.jpg, etc.
- which aligns perfectly with label files like: labels/IMG.0196_0.txt, labels/IMG.0196_1.txt, etc.
Also ensures frame folder is created consistently regardless of mode.
### Benefits
Easy reuse of frames and labels with annotation tools like LabelImg 
Seamless integration into Ultralytics training pipelines without renaming or manual reformatting
More robust handling of video files with complex names (e.g., dash/dot separators)
Cleaner, consistent, and reproducible dataset structure

Below image shows Before i.e. predict and After i.e. predict2


![image](https://github.com/user-attachments/assets/7479619a-a771-420b-998c-ef77d6aa17d2)







## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves how predicted image frames are saved, ensuring more organized and consistent file naming and folder structure. 🗂️✨

### 📊 Key Changes
- Saves all predicted frames (from videos, streams, or images) into a dedicated folder named after the source file with a `_frames` suffix.
- Frame images are now named consistently using the source file's name and frame number (e.g., `video_12.jpg`).
- Ensures folders for frames are always created if needed, improving file organization.

### 🎯 Purpose & Impact
- Makes it easier for users to find and manage predicted frames, especially when working with multiple files or videos.
- Reduces confusion by using consistent and descriptive file and folder names.
- Enhances workflow for users who save individual frames, supporting better project organization and easier downstream processing.