### PR TITLE
Optimize the name of video file and frames when using `save_txt` and `save_frames`

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -452,16 +452,16 @@ class BasePredictor:
         if self.args.show:
             self.show(str(p))
         if self.args.save:
-            self.save_predicted_images(str(self.save_dir / p.name), frame)
+            self.save_predicted_images(self.save_dir / p.name, frame)
 
         return string
 
-    def save_predicted_images(self, save_path: str = "", frame: int = 0):
+    def save_predicted_images(self, save_path: Path = "", frame: int = 0):
         """
         Save video predictions as mp4 or images as jpg at specified path.
 
         Args:
-            save_path (str): Path to save the results.
+            save_path (Path): Path to save the results.
             frame (int): Frame number for video mode.
         """
         im = self.plotted_img
@@ -469,7 +469,7 @@ class BasePredictor:
         # Save videos and streams
         if self.dataset.mode in {"stream", "video"}:
             fps = self.dataset.fps if self.dataset.mode == "video" else 30
-            frames_path = f"{save_path.rsplit('.', 1)[0]}_frames/"
+            frames_path = self.save_dir / "frames"
             if save_path not in self.vid_writer:  # new video
                 if self.args.save_frames:
                     Path(frames_path).mkdir(parents=True, exist_ok=True)
@@ -484,11 +484,11 @@ class BasePredictor:
             # Save video
             self.vid_writer[save_path].write(im)
             if self.args.save_frames:
-                cv2.imwrite(f"{frames_path}{frame}.jpg", im)
+                cv2.imwrite(f"{frames_path}/{save_path.stem}_{frame}.jpg", im)
 
         # Save images
         else:
-            cv2.imwrite(str(Path(save_path).with_suffix(".jpg")), im)  # save to JPG for best support
+            cv2.imwrite(str(save_path.with_suffix(".jpg")), im)  # save to JPG for best support
 
     def show(self, p: str = ""):
         """Display an image in a window."""

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -456,7 +456,7 @@ class BasePredictor:
 
         return string
 
-    def save_predicted_images(self, save_path: Path = "", frame: int = 0):
+    def save_predicted_images(self, save_path: Path, frame: int = 0):
         """
         Save video predictions as mp4 or images as jpg at specified path.
 

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -469,7 +469,7 @@ class BasePredictor:
         # Save videos and streams
         if self.dataset.mode in {"stream", "video"}:
             fps = self.dataset.fps if self.dataset.mode == "video" else 30
-            frames_path = self.save_dir / "frames"
+            frames_path = self.save_dir / f"{save_path.stem}_frames"  # save frames to a separate directory
             if save_path not in self.vid_writer:  # new video
                 if self.args.save_frames:
                     Path(frames_path).mkdir(parents=True, exist_ok=True)

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -466,29 +466,35 @@ class BasePredictor:
         """
         im = self.plotted_img
 
+        video_stem = Path(save_path).stem  # filename without extension
+        frames_path = Path(save_path).parent / f"{video_stem}_frames"
+
         # Save videos and streams
         if self.dataset.mode in {"stream", "video"}:
             fps = self.dataset.fps if self.dataset.mode == "video" else 30
-            frames_path = f"{save_path.split('.', 1)[0]}_frames/"
+
             if save_path not in self.vid_writer:  # new video
                 if self.args.save_frames:
-                    Path(frames_path).mkdir(parents=True, exist_ok=True)
+                    frames_path.mkdir(parents=True, exist_ok=True)
                 suffix, fourcc = (".mp4", "avc1") if MACOS else (".avi", "WMV2") if WINDOWS else (".avi", "MJPG")
                 self.vid_writer[save_path] = cv2.VideoWriter(
                     filename=str(Path(save_path).with_suffix(suffix)),
                     fourcc=cv2.VideoWriter_fourcc(*fourcc),
-                    fps=fps,  # integer required, floats produce error in MP4 codec
-                    frameSize=(im.shape[1], im.shape[0]),  # (width, height)
+                    fps=fps,
+                    frameSize=(im.shape[1], im.shape[0]),
                 )
-
             # Save video
             self.vid_writer[save_path].write(im)
-            if self.args.save_frames:
-                cv2.imwrite(f"{frames_path}{frame}.jpg", im)
 
-        # Save images
+            if self.args.save_frames:
+                # Save frame image with full video_stem prefix
+                frame_filename = f"{video_stem}_{frame}.jpg"
+                cv2.imwrite(str(frames_path / frame_filename), im)
         else:
-            cv2.imwrite(str(Path(save_path).with_suffix(".jpg")), im)  # save to JPG for best support
+            # Save images: save in the same folder under frames_path with consistent naming
+            frames_path.mkdir(parents=True, exist_ok=True)
+            frame_filename = f"{video_stem}_{frame}.jpg"
+            cv2.imwrite(str(frames_path / frame_filename), im)
 
     def show(self, p: str = ""):
         """Display an image in a window."""


### PR DESCRIPTION
## PR Description:
### Summary
This PR addresses two key issues with frame-saving logic in the `save_predicted_images()` method in `engine/predictor.py:`

1. Incorrect folder names when video filenames contain multiple dots (e.g., IMG.0123.avi)
2. Inconsistent frame image names that make it difficult to pair with corresponding label files for downstream tasks like re-labeling, training, or evaluation.
### Problem

1. The previous logic used `save_path.split('.', 1)[0]` to derive the frame directory and filename base. This fails when filenames contain multiple dots (e.g., IMG.0123.avi becomes IMG_frames/).
2. Frame images were saved as 0.jpg, 1.jpg, etc., while corresponding labels used the full video name as prefix (e.g., IMG.0196_0.txt). This created a mismatch.
### Fix

- Replaced fragile string-splitting with `Path(save_path).stem` to reliably extract the filename without extension.
Frame images are now saved as:
IMG.0123_frames/IMG.0123_0.jpg, IMG.0123_1.jpg, etc.

- which aligns perfectly with label files like: labels/IMG.0196_0.txt, labels/IMG.0196_1.txt, etc.
- Also ensures frame folder is created consistently regardless of mode.
### Benefits

- Easy reuse of frames and labels with annotation tools like LabelImg
- Seamless integration into Ultralytics training pipelines without renaming or manual reformatting
- More robust handling of video files with complex names (e.g., dash/dot separators)
- Cleaner, consistent, and reproducible dataset structure

Below image shows Before i.e. predict and After i.e. predict2
![Screenshot 2025-07-03 160321](https://github.com/user-attachments/assets/346e42e5-43e4-47d8-8d8c-45bb234cf04d)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved how predicted images and video frames are saved, making file handling more robust and organized. 🗂️✨

### 📊 Key Changes
- Switched from using string paths to `Path` objects for saving predicted images and videos.
- Updated file and directory naming for saved video frames to be clearer and more consistent.
- Enhanced the way individual video frames are saved, including more descriptive filenames.

### 🎯 Purpose & Impact
- Reduces errors related to file paths, especially across different operating systems.
- Makes saved results easier to find and manage, especially when working with videos and frame extraction.
- Improves code maintainability and reliability for developers and users saving predictions.