### PR TITLE
Update JetPack test matrix to run all jobs regardless of failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         name: [JetPack6.2, JetPack5.1.2]
         include:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved CI workflow reliability for JetPack tests 🚦

### 📊 Key Changes  
- Disabled the "fail-fast" option in the GitHub Actions matrix for JetPack 6.2 and 5.1.2 tests.

### 🎯 Purpose & Impact  
- Ensures that if one JetPack test fails, the others will continue running instead of stopping immediately.
- Provides more complete test results, helping developers identify issues across different JetPack versions.
- Improves the stability and reliability of the continuous integration process for Ultralytics projects.