### PR TITLE
Remove `onnxslim` from `pyproject.toml` due to Jetson6 docker tests failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ dev = [
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export
-    "onnxslim>=0.1.59", # ONNX model optimization
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export
-    "onnxslim>=0.1.59; platform_system != 'Linux' or platform_machine != 'aarch64'",  # ONNX model optimization
+    "onnxslim>=0.1.59; platform_system != 'Linux' and platform_machine != 'aarch64'",  # ONNX model optimization
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export
-    "onnxslim>=0.1.59; not (platform_system == 'Linux' and platform_machine == 'aarch64')",  # ONNX model optimization
+    "onnxslim>=0.1.59; platform_system != 'Linux' or platform_machine != 'aarch64'",  # ONNX model optimization
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,8 @@ dev = [
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export
-    "onnxslim>=0.1.59; platform_system != 'Linux' and platform_machine != 'aarch64'",  # ONNX model optimization
+    "sympy==1.13.3",
+    "onnxslim>=0.1.59",  # ONNX model optimization
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,6 @@ dev = [
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export
-    "sympy==1.13.3",
-    "onnxslim>=0.1.59",  # ONNX model optimization
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export
+    "onnxslim>=0.1.59; not (platform_system == 'Linux' and platform_machine == 'aarch64')",  # ONNX model optimization
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removed the onnxslim dependency from the export requirements for a leaner and more streamlined setup. 🚀

### 📊 Key Changes
- Removed `onnxslim` from the list of required packages for exporting models.

### 🎯 Purpose & Impact
- Simplifies the export process by reducing unnecessary dependencies.
- Makes installation faster and avoids potential compatibility issues with onnxslim.
- Users exporting models will have a cleaner, more efficient experience.