### PR TITLE
Support `valid/` as fallback validation folder for classification datasets

### DIFF
--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -9,7 +9,7 @@ import zipfile
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from tarfile import is_tarfile
-from typing import Dict, List, Tuple, Union, Any
+from typing import Any, Dict, List, Tuple, Union
 
 import cv2
 import numpy as np

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -9,7 +9,7 @@ import zipfile
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from tarfile import is_tarfile
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Any
 
 import cv2
 import numpy as np
@@ -284,7 +284,7 @@ def visualize_image_annotations(image_path: str, txt_path: str, label_map: Dict[
             w = width * img_width
             h = height * img_height
             annotations.append((x, y, w, h, int(class_id)))
-    fig, ax = plt.subplots(1)  # Plot the image and annotations
+    _, ax = plt.subplots(1)  # Plot the image and annotations
     for x, y, w, h, label in annotations:
         color = tuple(c / 255 for c in colors(label, True))  # Get and normalize the RGB color
         rect = plt.Rectangle((x, y), w, h, linewidth=2, edgecolor=color, facecolor="none")  # Create a rectangle
@@ -384,7 +384,7 @@ def find_dataset_yaml(path: Path) -> Path:
     return files[0]
 
 
-def check_det_dataset(dataset: str, autodownload: bool = True) -> Dict:
+def check_det_dataset(dataset: str, autodownload: bool = True) -> Dict[str, Any]:
     """
     Download, verify, and/or unzip a dataset if not found locally.
 
@@ -397,7 +397,7 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> Dict:
         autodownload (bool, optional): Whether to automatically download the dataset if not found.
 
     Returns:
-        (Dict): Parsed dataset information and paths.
+        (Dict[str, Any]): Parsed dataset information and paths.
     """
     file = check_file(dataset)
 
@@ -479,7 +479,7 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> Dict:
     return data  # dictionary
 
 
-def check_cls_dataset(dataset: Union[str, Path], split: str = "") -> Dict:
+def check_cls_dataset(dataset: Union[str, Path], split: str = "") -> Dict[str, Any]:
     """
     Check a classification dataset such as Imagenet.
 
@@ -491,13 +491,13 @@ def check_cls_dataset(dataset: Union[str, Path], split: str = "") -> Dict:
         split (str, optional): The split of the dataset. Either 'val', 'test', or ''.
 
     Returns:
-        (Dict): A dictionary containing the following keys:
+        (Dict[str, Any]): A dictionary containing the following keys:
 
             - 'train' (Path): The directory path containing the training set of the dataset.
             - 'val' (Path): The directory path containing the validation set of the dataset.
             - 'test' (Path): The directory path containing the test set of the dataset.
             - 'nc' (int): The number of classes in the dataset.
-            - 'names' (Dict): A dictionary of class names in the dataset.
+            - 'names' (Dict[int, str]): A dictionary of class names in the dataset.
     """
     # Download (optional if dataset=https://file.zip is passed directly)
     if str(dataset).startswith(("http:/", "https:/")):

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -535,6 +535,8 @@ def check_cls_dataset(dataset: Union[str, Path], split: str = "") -> Dict:
         if (data_dir / "val").exists()
         else data_dir / "validation"
         if (data_dir / "validation").exists()
+        else data_dir / "valid"
+        if (data_dir / "valid").exists()
         else None
     )  # data/test or data/val
     test_set = data_dir / "test" if (data_dir / "test").exists() else None  # data/val or data/test


### PR DESCRIPTION
This feature would make the repo more compatible with Roboflow naming conventions for classification datasets exports. More specifically, it would work with Roboflow naming convention "valid" for the validation dataset.

When exporting a classification dataset from Roboflow, the folder structure created is:
train/
valid/
test/

However, the current Ultralytics code for classification datasets only checks for val/ and validation/ as the validation folder. Since valid/ does not match either val/ or validation/, the trainer skips it and instead uses test/ as the fallback. This happens even though valid/ is present and is the intended validation set, and Roboflow’s export structure seems to be quite common among users.

Proposed Change:
Expand the fallback logic to also support valid/, for example:

```
val_set = (
    data_dir / "val"
    if (data_dir / "val").exists()
    else data_dir / "validation"
    if (data_dir / "validation").exists()
    else data_dir / "valid"
    if (data_dir / "valid").exists()
    else None
)
```

You can replicate the issue by creating a dummy dataset with this structure:
```
train/
valid/
test/
```
Then run classification training:
`yolo classify train data=dataset model=yolov8n-cls.pt`

Before this change: `test/` is used as validation.
After this change: `valid/` is correctly picked up as validation.

Edit: This feature PR was proposed at #21311


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

    I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved dataset utility functions for better type clarity and enhanced support for different validation folder names. 🛠️📁

### 📊 Key Changes
- Updated type hints for dataset-checking functions to be more precise and descriptive.
- Enhanced classification dataset checks to recognize "valid" as a possible validation folder, in addition to "val" and "validation".
- Minor code cleanups for readability and consistency.

### 🎯 Purpose & Impact
- 🧑‍💻 **Developer Clarity:** Clearer type hints make the code easier to understand and maintain.
- 📂 **Better Dataset Compatibility:** Users with datasets using "valid" as a validation folder name are now supported out-of-the-box.
- 🔍 **Improved Reliability:** Reduces errors and confusion when working with various dataset structures, making the experience smoother for both new and experienced users.