### PR TITLE
Fix wrong error message in `classify_augmentations`

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2655,7 +2655,7 @@ def classify_augmentations(
     import torchvision.transforms as T  # scope for faster 'import ultralytics'
 
     if not isinstance(size, int):
-        raise TypeError(f"classify_transforms() size {size} must be integer, not (list, tuple)")
+        raise TypeError(f"classify_augmentations() size {size} must be integer, not (list, tuple)")
     scale = tuple(scale or (0.08, 1.0))  # default imagenet scale range
     ratio = tuple(ratio or (3.0 / 4.0, 4.0 / 3.0))  # default imagenet ratio range
     interpolation = getattr(T.InterpolationMode, interpolation)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
I was looking around the codebase and I noticed that classify_augmentations() contains this guard:

```
if not isinstance(size, int):
    raise TypeError(f"classify_transforms() size {size} must be integer, not (list, tuple)")
```
Unless I am wrong:

- Wrong function name in the message: the check is inside classify_augmentations(), but the error says “classify_transforms()”.
-   Misleading requirement: classify_transforms() actually does accept a tuple or list

So this PR is a quick fix

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor fix to error messaging in data augmentation for improved clarity. 🛠️

### 📊 Key Changes
- Corrected the function name in a TypeError message from `classify_transforms()` to `classify_augmentations()`.

### 🎯 Purpose & Impact
- Ensures error messages accurately reflect the function being used, reducing confusion for developers.
- Improves code clarity and maintainability with more precise messaging.