### PR TITLE
fix engine/predictor.py multiple image windows in image folder inference

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -499,7 +499,7 @@ class BasePredictor:
             for w in self.windows:
                 cv2.destroyWindow(w)
             self.windows.clear()
-            
+
         if platform.system() == "Linux" and p not in self.windows:
             self.windows.append(p)
             cv2.namedWindow(p, cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -493,6 +493,13 @@ class BasePredictor:
     def show(self, p: str = ""):
         """Display an image in a window."""
         im = self.plotted_img
+
+        # Close all previous windows in image mode to avoid multiple popups
+        if self.dataset.mode == "image":
+            for w in self.windows:
+                cv2.destroyWindow(w)
+            self.windows.clear()
+            
         if platform.system() == "Linux" and p not in self.windows:
             self.windows.append(p)
             cv2.namedWindow(p, cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)


### PR DESCRIPTION
## Problem Statement
When running inference in image mode on a folder of images with visualization enabled `show=True,` a new OpenCV window is created for each image. This leads to:

1. Window clutter when processing multiple images.
2. Poor user experience.
3. Extra resource overhead due to redundant window creation.
4. Ultimately leads to system crash.
<img width="1654" height="1000" alt="image (2)" src="https://github.com/user-attachments/assets/34129e30-922b-43e6-a5d3-604a267773a4" />


##  Improvement
This PR introduces window management cleanup in inference mode for folder of images, ensuring:

1. Only one window is shown at a time during image inference.
2. Previously opened windows are properly closed before the next image is displayed.

##  Why This Matters

1. Prevents UI clutter and improves usability across all supported platforms.
2. Reduces visual noise and system load in GUI environments.
3. Keeps show() behavior clean, consistent, and user-friendly.
4. No impact on behavior in video or stream modes, where persistent display is required.
5. Safe and Isolated Behavior
- The cleanup logic only affects OpenCV windows created by this process via `cv2.namedWindow(p)`.
- It iterates over `self.windows`, a scoped list managed internally by the class ; ensuring no impact on any other OpenCV instances or windows.
- This ensures full isolation, even if a user is running multiple OpenCV pipelines in parallel unlike `cv2.destroyAllWindows()`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image display by automatically closing previous windows to prevent multiple popups during predictions. 🖼️✨

### 📊 Key Changes
- Added logic to close all previously opened image windows before displaying a new one in image mode.
- Ensures the list of open windows is cleared after closing.

### 🎯 Purpose & Impact
- Prevents clutter from multiple popup windows when viewing predictions on images.
- Enhances user experience by keeping the display clean and manageable, especially during batch predictions.
- Makes the prediction workflow smoother and more intuitive for users working with images.