### PR TITLE
Switch `pillow_heif` to `pi_heif`

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -451,9 +451,9 @@ class LoadImagesAndVideos:
                 self.mode = "image"
                 if path.rpartition(".")[-1].lower() == "heic":
                     # Load HEIC image using Pillow with pillow-heif
-                    check_requirements("pillow-heif")
+                    check_requirements("pi-heif")
 
-                    from pillow_heif import register_heif_opener
+                    from pi_heif import register_heif_opener
 
                     register_heif_opener()  # Register HEIF opener with Pillow
                     with Image.open(path) as img:


### PR DESCRIPTION
After investigating our dependencies’ licenses, it turns out the dependency `pillow_heif` we use to open `.HEIC images` (i.e. iOS images) is licensed under the BSD 3-Clause License. However, its prebuilt binary wheels include components licensed under GPL-2.0, specifically for HEIC encoding via `x265`.

To simplify compliance, we’ve replaced `pillow_heif` with [pi-heif](https://github.com/bigcat88/pillow_heif/tree/master/pi-heif), a lightweight, decoder-only alternative. `pi-heif` is used solely to open and decode .HEIC images. It is licensed under permissive terms (BSD-3-Clause), though it does still rely on `libheif` (LGPL-3.0), which is compatible with AGPL-3 as stated [here](https://docs.shopware.com/en/shopware-5-en/tutorials-and-faq/agpl#compatibility-of-agplv3).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved HEIC image support by updating the required library for loading these images. 🖼️🔄

### 📊 Key Changes
- Changed the HEIC image loader dependency from `pillow-heif` to `pi-heif`.
- Updated the import statement to use `pi_heif` instead of `pillow_heif`.

### 🎯 Purpose & Impact
- Ensures better compatibility and reliability when loading HEIC images.
- Users working with HEIC image formats will experience smoother and more consistent image loading.
- Reduces potential issues related to library support and maintenance.