### PR TITLE
`ultralytics 8.3.165` Update datasets YAML's

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.164"
+__version__ = "8.3.165"
 
 import os
 

--- a/ultralytics/cfg/datasets/HomeObjects-3K.yaml
+++ b/ultralytics/cfg/datasets/HomeObjects-3K.yaml
@@ -10,9 +10,8 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: homeobjects-3K # dataset root dir
-train: train/images # train images (relative to 'path') 2285 images
-val: valid/images # val images (relative to 'path') 404 images
-test: # test images (relative to 'path')
+train: images/train # train images (relative to 'path') 2285 images
+val: images/val # val images (relative to 'path') 404 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/african-wildlife.yaml
+++ b/ultralytics/cfg/datasets/african-wildlife.yaml
@@ -10,9 +10,9 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: african-wildlife # dataset root dir
-train: train/images # train images (relative to 'path') 1052 images
-val: valid/images # val images (relative to 'path') 225 images
-test: test/images # test images (relative to 'path') 227 images
+train: images/train # train images (relative to 'path') 1052 images
+val: images/val # val images (relative to 'path') 225 images
+test: images/test # test images (relative to 'path') 227 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/brain-tumor.yaml
+++ b/ultralytics/cfg/datasets/brain-tumor.yaml
@@ -12,7 +12,6 @@
 path: brain-tumor # dataset root dir
 train: images/train # train images (relative to 'path') 893 images
 val: images/val # val images (relative to 'path') 223 images
-test: # test images (relative to 'path')
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/brain-tumor.yaml
+++ b/ultralytics/cfg/datasets/brain-tumor.yaml
@@ -6,12 +6,12 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── brain-tumor  ← downloads here (4.05 MB)
+#     └── brain-tumor  ← downloads here (4.21 MB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: brain-tumor # dataset root dir
-train: train/images # train images (relative to 'path') 893 images
-val: valid/images # val images (relative to 'path') 223 images
+train: images/train # train images (relative to 'path') 893 images
+val: images/val # val images (relative to 'path') 223 images
 test: # test images (relative to 'path')
 
 # Classes

--- a/ultralytics/cfg/datasets/carparts-seg.yaml
+++ b/ultralytics/cfg/datasets/carparts-seg.yaml
@@ -10,9 +10,9 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: carparts-seg # dataset root dir
-train: train/images # train images (relative to 'path') 3516 images
-val: valid/images # val images (relative to 'path') 276 images
-test: test/images # test images (relative to 'path') 401 images
+train: images/train # train images (relative to 'path') 3516 images
+val: images/val # val images (relative to 'path') 276 images
+test: images/test # test images (relative to 'path') 401 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/carparts-seg.yaml
+++ b/ultralytics/cfg/datasets/carparts-seg.yaml
@@ -6,7 +6,7 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── carparts-seg  ← downloads here (132 MB)
+#     └── carparts-seg  ← downloads here (133 MB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: carparts-seg # dataset root dir

--- a/ultralytics/cfg/datasets/crack-seg.yaml
+++ b/ultralytics/cfg/datasets/crack-seg.yaml
@@ -6,13 +6,13 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── crack-seg  ← downloads here (91.2 MB)
+#     └── crack-seg  ← downloads here (91.6 MB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: crack-seg # dataset root dir
-train: train/images # train images (relative to 'path') 3717 images
-val: valid/images # val images (relative to 'path') 112 images
-test: test/images # test images (relative to 'path') 200 images
+train: image/train # train images (relative to 'path') 3717 images
+val: images/val # val images (relative to 'path') 112 images
+test: images/test # test images (relative to 'path') 200 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/crack-seg.yaml
+++ b/ultralytics/cfg/datasets/crack-seg.yaml
@@ -10,7 +10,7 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: crack-seg # dataset root dir
-train: image/train # train images (relative to 'path') 3717 images
+train: images/train # train images (relative to 'path') 3717 images
 val: images/val # val images (relative to 'path') 112 images
 test: images/test # test images (relative to 'path') 200 images
 

--- a/ultralytics/cfg/datasets/dog-pose.yaml
+++ b/ultralytics/cfg/datasets/dog-pose.yaml
@@ -10,8 +10,8 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: dog-pose # dataset root dir
-train: train # train images (relative to 'path') 6773 images
-val: val # val images (relative to 'path') 1703 images
+train: images/train # train images (relative to 'path') 6773 images
+val: images/val # val images (relative to 'path') 1703 images
 
 # Keypoints
 kpt_shape: [24, 3] # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)

--- a/ultralytics/cfg/datasets/hand-keypoints.yaml
+++ b/ultralytics/cfg/datasets/hand-keypoints.yaml
@@ -10,8 +10,8 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: hand-keypoints # dataset root dir
-train: train # train images (relative to 'path') 18776 images
-val: val # val images (relative to 'path') 7992 images
+train: images/train # train images (relative to 'path') 18776 images
+val: images/val # val images (relative to 'path') 7992 images
 
 # Keypoints
 kpt_shape: [21, 3] # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)

--- a/ultralytics/cfg/datasets/medical-pills.yaml
+++ b/ultralytics/cfg/datasets/medical-pills.yaml
@@ -10,9 +10,8 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: medical-pills # dataset root dir
-train: train/images # train images (relative to 'path') 92 images
-val: valid/images # val images (relative to 'path') 23 images
-test: # test images (relative to 'path')
+train: images/train # train images (relative to 'path') 92 images
+val: images/val # val images (relative to 'path') 23 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/package-seg.yaml
+++ b/ultralytics/cfg/datasets/package-seg.yaml
@@ -6,13 +6,13 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── package-seg  ← downloads here (102 MB)
+#     └── package-seg  ← downloads here (103 MB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: package-seg # dataset root dir
-train: train/images # train images (relative to 'path') 1920 images
-val: valid/images # val images (relative to 'path') 89 images
-test: test/images # test images (relative to 'path') 188 images
+train: images/train # train images (relative to 'path') 1920 images
+val: images/val # val images (relative to 'path') 89 images
+test: images/test # test images (relative to 'path') 188 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/signature.yaml
+++ b/ultralytics/cfg/datasets/signature.yaml
@@ -6,12 +6,12 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── signature  ← downloads here (11.2 MB)
+#     └── signature  ← downloads here (11.3 MB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: signature # dataset root dir
-train: train/images # train images (relative to 'path') 143 images
-val: valid/images # val images (relative to 'path') 35 images
+train: images/train # train images (relative to 'path') 143 images
+val: images/val # val images (relative to 'path') 35 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/tiger-pose.yaml
+++ b/ultralytics/cfg/datasets/tiger-pose.yaml
@@ -6,12 +6,12 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── tiger-pose  ← downloads here (75.3 MB)
+#     └── tiger-pose  ← downloads here (22.8 MB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: tiger-pose # dataset root dir
-train: train # train images (relative to 'path') 210 images
-val: val # val images (relative to 'path') 53 images
+train: images/train # train images (relative to 'path') 210 images
+val: images/val # val images (relative to 'path') 53 images
 
 # Keypoints
 kpt_shape: [12, 2] # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update standardizes dataset folder structures in several YAML config files, making dataset paths more consistent and easier to use. 📁✨

### 📊 Key Changes
- Updated the version to 8.3.165.
- Changed dataset image paths in multiple YAML files to use a consistent `images/train`, `images/val`, and `images/test` structure.
- Adjusted dataset size comments to reflect minor changes in download sizes for some datasets.

### 🎯 Purpose & Impact
- 🧩 **Consistency:** All datasets now follow the same folder structure, reducing confusion and setup errors.
- 🚀 **Ease of Use:** Users can more easily switch between datasets or automate workflows without adjusting paths.
- 🛠️ **Better Maintenance:** Simplifies future updates and documentation, making the platform more user-friendly for both new and experienced users.