### PR TITLE
Fix `tiger-pose.yaml` download size

### DIFF
--- a/ultralytics/cfg/datasets/tiger-pose.yaml
+++ b/ultralytics/cfg/datasets/tiger-pose.yaml
@@ -6,7 +6,7 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── tiger-pose  ← downloads here (22.8 MB)
+#     └── tiger-pose  ← downloads here (49.8 MB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: tiger-pose # dataset root dir


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated the tiger-pose dataset configuration to reflect its new, larger file size.

### 📊 Key Changes  
- Changed the listed download size for the tiger-pose dataset from **22.8 MB** to **49.8 MB** in the configuration file.

### 🎯 Purpose & Impact  
- Ensures users have accurate information about the dataset size before downloading.  
- Helps prevent confusion or issues related to storage and download expectations.  
- Keeps documentation up to date for a smoother user experience. 🚀