### PR TITLE
YOLOE: Document ability to persist `visual_prompts` when running prediction with `refer_image`

### DIFF
--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -251,6 +251,15 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         results[0].show()
         ```
 
+        Using `refer_image` also sets the classes permanently, so you can run predictions without having to supply the same visual prompts again, and export the model while retaining the ability to still detect the same classes after export:
+        ```
+        # After making prediction with `refer_image`, you can run predictions without passing visual_prompts again and still get the same classes back
+        results = model("ultralytics/assets/bus.jpg")
+
+        # Or export it to a different format while retaining the classes
+        model.export(format="onnx")
+        ```
+
         You can also pass multiple target images to run prediction on:
 
         ```python

--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -252,7 +252,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         ```
 
         Using `refer_image` also sets the classes permanently, so you can run predictions without having to supply the same visual prompts again, and export the model while retaining the ability to still detect the same classes after export:
-        ```
+        ```python
         # After making prediction with `refer_image`, you can run predictions without passing visual_prompts again and still get the same classes back
         results = model("ultralytics/assets/bus.jpg")
 

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -287,7 +287,7 @@ class YOLOE(Model):
         Examples:
             >>> model = YOLOE("yoloe-11s-seg.pt")
             >>> img = torch.rand(1, 3, 640, 640)
-            >>> visual_features = model.model.backbone(img)
+            >>> visual_features = torch.rand(1, 1, 80, 80)
             >>> pe = model.get_visual_pe(img, visual_features)
         """
         assert isinstance(self.model, YOLOEModel)

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -243,10 +243,6 @@ class YOLOE(Model):
         """
         super().__init__(model=model, task=task, verbose=verbose)
 
-        # Assign default COCO class names when there are no custom names
-        if not hasattr(self.model, "names"):
-            self.model.names = YAML.load(ROOT / "cfg/datasets/coco8.yaml").get("names")
-
     @property
     def task_map(self) -> Dict[str, Dict[str, Any]]:
         """Map head to model, validator, and predictor classes."""


### PR DESCRIPTION
Resolves https://github.com/ultralytics/ultralytics/issues/20188
Closes https://github.com/ultralytics/ultralytics/issues/21361

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved YOLOE's visual prompting workflow by making class selection persistent and exportable, and updated documentation for clarity. 🚀

### 📊 Key Changes
- Updated documentation to explain that using `refer_image` sets classes permanently, allowing predictions and exports without re-supplying visual prompts.
- Added code examples showing how to predict and export models after setting classes with visual prompts.
- Removed redundant code that set default class names in the YOLO model initialization.
- Clarified a code example in the `get_visual_pe` method for better understanding.

### 🎯 Purpose & Impact
- Makes it easier for users to work with visual prompts: once set, classes remain fixed for future predictions and exports.
- Enhances model export: exported models retain the selected classes, improving deployment workflows.
- Documentation improvements help users understand and utilize these features more effectively.
- Cleaner codebase by removing unnecessary default class assignment logic.