### PR TITLE
Replace `path/to/bus.jpg` with `ASSETS/bus.jpg` and `ASSETS/zidane.jpg`

### DIFF
--- a/docs/en/guides/view-results-in-terminal.md
+++ b/docs/en/guides/view-results-in-terminal.md
@@ -44,13 +44,13 @@ The VSCode compatible protocols for viewing images using the integrated terminal
 3. Load a model and execute inference, then plot the results and store in a variable. See more about inference arguments and working with results on the [predict mode](../modes/predict.md) page.
 
     ```{ .py .annotate }
-    from ultralytics import YOLO
+    from ultralytics import YOLO, ASSETS
 
     # Load a model
     model = YOLO("yolo11n.pt")
 
     # Run inference on an image
-    results = model.predict(source="ultralytics/assets/bus.jpg")
+    results = model.predict(source=ASSETS / "bus.jpg")
 
     # Plot inference results
     plot = results[0].plot()  # (1)!
@@ -108,13 +108,13 @@ import io
 import cv2
 from sixel import SixelWriter
 
-from ultralytics import YOLO
+from ultralytics import YOLO, ASSETS
 
 # Load a model
 model = YOLO("yolo11n.pt")
 
 # Run inference on an image
-results = model.predict(source="ultralytics/assets/bus.jpg")
+results = model.predict(source=ASSETS / "bus.jpg")
 
 # Plot inference results
 plot = results[0].plot()  # (3)!

--- a/docs/en/guides/view-results-in-terminal.md
+++ b/docs/en/guides/view-results-in-terminal.md
@@ -44,7 +44,7 @@ The VSCode compatible protocols for viewing images using the integrated terminal
 3. Load a model and execute inference, then plot the results and store in a variable. See more about inference arguments and working with results on the [predict mode](../modes/predict.md) page.
 
     ```{ .py .annotate }
-    from ultralytics import YOLO, ASSETS
+    from ultralytics import ASSETS, YOLO
 
     # Load a model
     model = YOLO("yolo11n.pt")
@@ -108,7 +108,7 @@ import io
 import cv2
 from sixel import SixelWriter
 
-from ultralytics import YOLO, ASSETS
+from ultralytics import ASSETS, YOLO
 
 # Load a model
 model = YOLO("yolo11n.pt")

--- a/docs/en/models/fast-sam.md
+++ b/docs/en/models/fast-sam.md
@@ -108,7 +108,7 @@ To perform [object detection](https://www.ultralytics.com/glossary/object-detect
     === "Python"
 
         ```python
-        from ultralytics import FastSAM, ASSETS
+        from ultralytics import ASSETS, FastSAM
 
         # Define an inference source
         source = ASSETS / "bus.jpg"
@@ -327,7 +327,7 @@ Its ability to handle various user interaction prompts makes FastSAM adaptable a
 To use FastSAM for inference in Python, you can follow the example below:
 
 ```python
-from ultralytics import FastSAM, ASSETS
+from ultralytics import ASSETS, FastSAM
 
 # Define an inference source
 source = ASSETS / "bus.jpg"

--- a/docs/en/models/fast-sam.md
+++ b/docs/en/models/fast-sam.md
@@ -108,10 +108,10 @@ To perform [object detection](https://www.ultralytics.com/glossary/object-detect
     === "Python"
 
         ```python
-        from ultralytics import FastSAM
+        from ultralytics import FastSAM, ASSETS
 
         # Define an inference source
-        source = "path/to/bus.jpg"
+        source = ASSETS / "bus.jpg"
 
         # Create a FastSAM model
         model = FastSAM("FastSAM-s.pt")  # or FastSAM-x.pt
@@ -136,7 +136,7 @@ To perform [object detection](https://www.ultralytics.com/glossary/object-detect
 
         ```bash
         # Load a FastSAM model and segment everything with it
-        yolo segment predict model=FastSAM-s.pt source=path/to/bus.jpg imgsz=640
+        yolo segment predict model=FastSAM-s.pt source='https://ultralytics.com/images/bus.jpg' imgsz=640
         ```
 
 This snippet demonstrates the simplicity of loading a pre-trained model and running a prediction on an image.
@@ -148,6 +148,7 @@ This snippet demonstrates the simplicity of loading a pre-trained model and runn
     === "Prompt inference"
 
         ```python
+        from ultralytics import ASSETS
         from ultralytics.models.fastsam import FastSAMPredictor
 
         # Create FastSAMPredictor
@@ -155,7 +156,7 @@ This snippet demonstrates the simplicity of loading a pre-trained model and runn
         predictor = FastSAMPredictor(overrides=overrides)
 
         # Segment everything
-        everything_results = predictor("ultralytics/assets/bus.jpg")
+        everything_results = predictor(ASSETS / "bus.jpg")
 
         # Prompt inference
         bbox_results = predictor.prompt(everything_results, bboxes=[[200, 200, 300, 300]])
@@ -326,10 +327,10 @@ Its ability to handle various user interaction prompts makes FastSAM adaptable a
 To use FastSAM for inference in Python, you can follow the example below:
 
 ```python
-from ultralytics import FastSAM
+from ultralytics import FastSAM, ASSETS
 
 # Define an inference source
-source = "path/to/bus.jpg"
+source = ASSETS / "bus.jpg"
 
 # Create a FastSAM model
 model = FastSAM("FastSAM-s.pt")  # or FastSAM-x.pt

--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -56,7 +56,7 @@ Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for [ob
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()`, `SAM()`, `NAS()` and `RTDETR()` classes to create a model instance in Python:
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Load a COCO-pretrained YOLOv8n model
         model = YOLO("yolov8n.pt")

--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -56,7 +56,7 @@ Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for [ob
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()`, `SAM()`, `NAS()` and `RTDETR()` classes to create a model instance in Python:
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Load a COCO-pretrained YOLOv8n model
         model = YOLO("yolov8n.pt")
@@ -68,7 +68,7 @@ Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for [ob
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLOv8n model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -80,7 +80,7 @@ Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for [ob
         yolo train model=yolov8n.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained YOLOv8n model and run inference on the 'bus.jpg' image
-        yolo predict model=yolov8n.pt source=path/to/bus.jpg
+        yolo predict model=yolov8n.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Contributing New Models

--- a/docs/en/models/mobile-sam.md
+++ b/docs/en/models/mobile-sam.md
@@ -126,7 +126,7 @@ Download the MobileSAM pretrained weights from [Ultralytics assets](https://gith
     === "Python"
 
         ```python
-        from ultralytics import SAM, ASSETS
+        from ultralytics import ASSETS, SAM
 
         # Load the model
         model = SAM("mobile_sam.pt")
@@ -151,7 +151,7 @@ Download the MobileSAM pretrained weights from [Ultralytics assets](https://gith
     === "Python"
 
         ```python
-        from ultralytics import SAM, ASSETS
+        from ultralytics import ASSETS, SAM
 
         # Load the model
         model = SAM("mobile_sam.pt")
@@ -217,7 +217,7 @@ MobileSAM is a lightweight, fast [image segmentation](https://www.ultralytics.co
 Testing MobileSAM in Ultralytics is straightforward. You can use Point and Box prompts to predict segments. For example, using a Point prompt:
 
 ```python
-from ultralytics import SAM, ASSETS
+from ultralytics import ASSETS, SAM
 
 # Load the model
 model = SAM("mobile_sam.pt")

--- a/docs/en/models/mobile-sam.md
+++ b/docs/en/models/mobile-sam.md
@@ -126,22 +126,22 @@ Download the MobileSAM pretrained weights from [Ultralytics assets](https://gith
     === "Python"
 
         ```python
-        from ultralytics import SAM
+        from ultralytics import SAM, ASSETS
 
         # Load the model
         model = SAM("mobile_sam.pt")
 
         # Predict a segment based on a single point prompt
-        model.predict("ultralytics/assets/zidane.jpg", points=[900, 370], labels=[1])
+        model.predict(ASSETS / "zidane.jpg", points=[900, 370], labels=[1])
 
         # Predict multiple segments based on multiple points prompt
-        model.predict("ultralytics/assets/zidane.jpg", points=[[400, 370], [900, 370]], labels=[1, 1])
+        model.predict(ASSETS / "zidane.jpg", points=[[400, 370], [900, 370]], labels=[1, 1])
 
         # Predict a segment based on multiple points prompt per object
-        model.predict("ultralytics/assets/zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 1]])
+        model.predict(ASSETS / "zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 1]])
 
         # Predict a segment using both positive and negative prompts.
-        model.predict("ultralytics/assets/zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 0]])
+        model.predict(ASSETS / "zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 0]])
         ```
 
 ### Box Prompt
@@ -151,22 +151,22 @@ Download the MobileSAM pretrained weights from [Ultralytics assets](https://gith
     === "Python"
 
         ```python
-        from ultralytics import SAM
+        from ultralytics import SAM, ASSETS
 
         # Load the model
         model = SAM("mobile_sam.pt")
 
         # Predict a segment based on a single point prompt
-        model.predict("ultralytics/assets/zidane.jpg", points=[900, 370], labels=[1])
+        model.predict(ASSETS / "zidane.jpg", points=[900, 370], labels=[1])
 
         # Predict multiple segments based on multiple points prompt
-        model.predict("ultralytics/assets/zidane.jpg", points=[[400, 370], [900, 370]], labels=[1, 1])
+        model.predict(ASSETS / "zidane.jpg", points=[[400, 370], [900, 370]], labels=[1, 1])
 
         # Predict a segment based on multiple points prompt per object
-        model.predict("ultralytics/assets/zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 1]])
+        model.predict(ASSETS / "zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 1]])
 
         # Predict a segment using both positive and negative prompts.
-        model.predict("ultralytics/assets/zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 0]])
+        model.predict(ASSETS / "zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 0]])
         ```
 
 Both `MobileSAM` and `SAM` share the same API. For more usage details, see the [SAM documentation](sam.md).
@@ -217,13 +217,13 @@ MobileSAM is a lightweight, fast [image segmentation](https://www.ultralytics.co
 Testing MobileSAM in Ultralytics is straightforward. You can use Point and Box prompts to predict segments. For example, using a Point prompt:
 
 ```python
-from ultralytics import SAM
+from ultralytics import SAM, ASSETS
 
 # Load the model
 model = SAM("mobile_sam.pt")
 
 # Predict a segment based on a point prompt
-model.predict("ultralytics/assets/zidane.jpg", points=[900, 370], labels=[1])
+model.predict(ASSETS / "zidane.jpg", points=[900, 370], labels=[1])
 ```
 
 For more details, see the [Testing MobileSAM in Ultralytics](#testing-mobilesam-in-ultralytics) section.

--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -54,7 +54,7 @@ This example provides simple RT-DETR training and inference examples. For full d
     === "Python"
 
         ```python
-        from ultralytics import RTDETR
+        from ultralytics import RTDETR, ASSETS
 
         # Load a COCO-pretrained RT-DETR-l model
         model = RTDETR("rtdetr-l.pt")
@@ -66,7 +66,7 @@ This example provides simple RT-DETR training and inference examples. For full d
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the RT-DETR-l model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -76,7 +76,7 @@ This example provides simple RT-DETR training and inference examples. For full d
         yolo train model=rtdetr-l.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained RT-DETR-l model and run inference on the 'bus.jpg' image
-        yolo predict model=rtdetr-l.pt source=path/to/bus.jpg
+        yolo predict model=rtdetr-l.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Supported Tasks and Modes
@@ -151,7 +151,7 @@ You can leverage Ultralytics Python API to use pre-trained PaddlePaddle RT-DETR 
     === "Python"
 
         ```python
-        from ultralytics import RTDETR
+        from ultralytics import RTDETR, ASSETS
 
         # Load a COCO-pretrained RT-DETR-l model
         model = RTDETR("rtdetr-l.pt")
@@ -163,7 +163,7 @@ You can leverage Ultralytics Python API to use pre-trained PaddlePaddle RT-DETR 
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the RT-DETR-l model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -173,7 +173,7 @@ You can leverage Ultralytics Python API to use pre-trained PaddlePaddle RT-DETR 
         yolo train model=rtdetr-l.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained RT-DETR-l model and run inference on the 'bus.jpg' image
-        yolo predict model=rtdetr-l.pt source=path/to/bus.jpg
+        yolo predict model=rtdetr-l.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ### Why should I choose Baidu's RT-DETR over other real-time object detectors?

--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -54,7 +54,7 @@ This example provides simple RT-DETR training and inference examples. For full d
     === "Python"
 
         ```python
-        from ultralytics import RTDETR, ASSETS
+        from ultralytics import ASSETS, RTDETR
 
         # Load a COCO-pretrained RT-DETR-l model
         model = RTDETR("rtdetr-l.pt")
@@ -151,7 +151,7 @@ You can leverage Ultralytics Python API to use pre-trained PaddlePaddle RT-DETR 
     === "Python"
 
         ```python
-        from ultralytics import RTDETR, ASSETS
+        from ultralytics import ASSETS, RTDETR
 
         # Load a COCO-pretrained RT-DETR-l model
         model = RTDETR("rtdetr-l.pt")

--- a/docs/en/models/sam.md
+++ b/docs/en/models/sam.md
@@ -49,7 +49,7 @@ The Segment Anything Model can be employed for a multitude of downstream tasks t
     === "Python"
 
         ```python
-        from ultralytics import SAM
+        from ultralytics import SAM, ASSETS
 
         # Load a model
         model = SAM("sam_b.pt")
@@ -58,7 +58,7 @@ The Segment Anything Model can be employed for a multitude of downstream tasks t
         model.info()
 
         # Run inference with bboxes prompt
-        results = model("ultralytics/assets/zidane.jpg", bboxes=[439, 437, 524, 709])
+        results = model(ASSETS / "zidane.jpg", bboxes=[439, 437, 524, 709])
 
         # Run inference with single point
         results = model(points=[900, 370], labels=[1])
@@ -108,6 +108,7 @@ The Segment Anything Model can be employed for a multitude of downstream tasks t
     === "Prompt inference"
 
         ```python
+        from ultralytics import ASSETS
         from ultralytics.models.sam import Predictor as SAMPredictor
 
         # Create SAMPredictor
@@ -115,8 +116,8 @@ The Segment Anything Model can be employed for a multitude of downstream tasks t
         predictor = SAMPredictor(overrides=overrides)
 
         # Set image
-        predictor.set_image("ultralytics/assets/zidane.jpg")  # set with image file
-        predictor.set_image(cv2.imread("ultralytics/assets/zidane.jpg"))  # set with np.ndarray
+        predictor.set_image(ASSETS / "zidane.jpg")  # set with image file
+        predictor.set_image(cv2.imread(ASSETS / "zidane.jpg"))  # set with np.ndarray
         results = predictor(bboxes=[439, 437, 524, 709])
 
         # Run inference with single point prompt
@@ -137,6 +138,7 @@ The Segment Anything Model can be employed for a multitude of downstream tasks t
     === "Segment everything"
 
         ```python
+        from ultralytics import ASSETS
         from ultralytics.models.sam import Predictor as SAMPredictor
 
         # Create SAMPredictor
@@ -144,7 +146,7 @@ The Segment Anything Model can be employed for a multitude of downstream tasks t
         predictor = SAMPredictor(overrides=overrides)
 
         # Segment with additional args
-        results = predictor(source="ultralytics/assets/zidane.jpg", crop_n_layers=1, points_stride=64)
+        results = predictor(source=ASSETS / "zidane.jpg", crop_n_layers=1, points_stride=64)
         ```
 
 !!! note
@@ -250,25 +252,25 @@ The Segment Anything Model (SAM) by Ultralytics is a revolutionary image segment
 You can use the Segment Anything Model (SAM) for image segmentation by running inference with various prompts such as bounding boxes or points. Here's an example using Python:
 
 ```python
-from ultralytics import SAM
+from ultralytics import SAM, ASSETS
 
 # Load a model
 model = SAM("sam_b.pt")
 
 # Segment with bounding box prompt
-model("ultralytics/assets/zidane.jpg", bboxes=[439, 437, 524, 709])
+model(ASSETS / "zidane.jpg", bboxes=[439, 437, 524, 709])
 
 # Segment with points prompt
-model("ultralytics/assets/zidane.jpg", points=[900, 370], labels=[1])
+model(ASSETS / "zidane.jpg", points=[900, 370], labels=[1])
 
 # Segment with multiple points prompt
-model("ultralytics/assets/zidane.jpg", points=[[400, 370], [900, 370]], labels=[[1, 1]])
+model(ASSETS / "zidane.jpg", points=[[400, 370], [900, 370]], labels=[[1, 1]])
 
 # Segment with multiple points prompt per object
-model("ultralytics/assets/zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 1]])
+model(ASSETS / "zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 1]])
 
 # Segment with negative points prompt.
-model("ultralytics/assets/zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 0]])
+model(ASSETS / "zidane.jpg", points=[[[400, 370], [900, 370]]], labels=[[1, 0]])
 ```
 
 Alternatively, you can run inference with SAM in the command line interface (CLI):

--- a/docs/en/models/sam.md
+++ b/docs/en/models/sam.md
@@ -49,7 +49,7 @@ The Segment Anything Model can be employed for a multitude of downstream tasks t
     === "Python"
 
         ```python
-        from ultralytics import SAM, ASSETS
+        from ultralytics import ASSETS, SAM
 
         # Load a model
         model = SAM("sam_b.pt")
@@ -252,7 +252,7 @@ The Segment Anything Model (SAM) by Ultralytics is a revolutionary image segment
 You can use the Segment Anything Model (SAM) for image segmentation by running inference with various prompts such as bounding boxes or points. Here's an example using Python:
 
 ```python
-from ultralytics import SAM, ASSETS
+from ultralytics import ASSETS, SAM
 
 # Load a model
 model = SAM("sam_b.pt")

--- a/docs/en/models/yolo-nas.md
+++ b/docs/en/models/yolo-nas.md
@@ -60,7 +60,7 @@ In this example we validate YOLO-NAS-s on the COCO8 dataset.
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models files can be passed to the `NAS()` class to create a model instance in python:
 
         ```python
-        from ultralytics import NAS, ASSETS
+        from ultralytics import ASSETS, NAS
 
         # Load a COCO-pretrained YOLO-NAS-s model
         model = NAS("yolo_nas_s.pt")
@@ -136,7 +136,7 @@ YOLO-NAS, developed by Deci AI, is a state-of-the-art object detection model lev
 You can easily integrate YOLO-NAS models into your Python application using the `ultralytics` package. Here's a simple example of how to load a pre-trained YOLO-NAS model and perform inference:
 
 ```python
-from ultralytics import NAS, ASSETS
+from ultralytics import ASSETS, NAS
 
 # Load a COCO-pretrained YOLO-NAS-s model
 model = NAS("yolo_nas_s.pt")

--- a/docs/en/models/yolo-nas.md
+++ b/docs/en/models/yolo-nas.md
@@ -60,7 +60,7 @@ In this example we validate YOLO-NAS-s on the COCO8 dataset.
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models files can be passed to the `NAS()` class to create a model instance in python:
 
         ```python
-        from ultralytics import NAS
+        from ultralytics import NAS, ASSETS
 
         # Load a COCO-pretrained YOLO-NAS-s model
         model = NAS("yolo_nas_s.pt")
@@ -72,7 +72,7 @@ In this example we validate YOLO-NAS-s on the COCO8 dataset.
         results = model.val(data="coco8.yaml")
 
         # Run inference with the YOLO-NAS-s model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -84,7 +84,7 @@ In this example we validate YOLO-NAS-s on the COCO8 dataset.
         yolo val model=yolo_nas_s.pt data=coco8.yaml
 
         # Load a COCO-pretrained YOLO-NAS-s model and run inference on the 'bus.jpg' image
-        yolo predict model=yolo_nas_s.pt source=path/to/bus.jpg
+        yolo predict model=yolo_nas_s.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Supported Tasks and Modes
@@ -136,7 +136,7 @@ YOLO-NAS, developed by Deci AI, is a state-of-the-art object detection model lev
 You can easily integrate YOLO-NAS models into your Python application using the `ultralytics` package. Here's a simple example of how to load a pre-trained YOLO-NAS model and perform inference:
 
 ```python
-from ultralytics import NAS
+from ultralytics import NAS, ASSETS
 
 # Load a COCO-pretrained YOLO-NAS-s model
 model = NAS("yolo_nas_s.pt")
@@ -145,7 +145,7 @@ model = NAS("yolo_nas_s.pt")
 results = model.val(data="coco8.yaml")
 
 # Run inference with the YOLO-NAS-s model on the 'bus.jpg' image
-results = model("path/to/bus.jpg")
+results = model(ASSETS / "bus.jpg")
 ```
 
 For more information, refer to the [Inference and Validation Examples](#inference-and-validation-examples).

--- a/docs/en/models/yolo-world.md
+++ b/docs/en/models/yolo-world.md
@@ -94,7 +94,7 @@ The YOLO-World models are easy to integrate into your Python applications. Ultra
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLOWorld()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLOWorld
+        from ultralytics import YOLOWorld, ASSETS
 
         # Load a pretrained YOLOv8s-worldv2 model
         model = YOLOWorld("yolov8s-worldv2.pt")
@@ -103,7 +103,7 @@ The YOLO-World models are easy to integrate into your Python applications. Ultra
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLOv8n model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"

--- a/docs/en/models/yolo-world.md
+++ b/docs/en/models/yolo-world.md
@@ -94,7 +94,7 @@ The YOLO-World models are easy to integrate into your Python applications. Ultra
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLOWorld()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLOWorld, ASSETS
+        from ultralytics import ASSETS, YOLOWorld
 
         # Load a pretrained YOLOv8s-worldv2 model
         model = YOLOWorld("yolov8s-worldv2.pt")

--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -115,7 +115,7 @@ Note that the example below is for YOLO11 [Detect](../tasks/detect.md) models fo
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in Python:
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Load a COCO-pretrained YOLO11n model
         model = YOLO("yolo11n.pt")
@@ -124,7 +124,7 @@ Note that the example below is for YOLO11 [Detect](../tasks/detect.md) models fo
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLO11n model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -136,7 +136,7 @@ Note that the example below is for YOLO11 [Detect](../tasks/detect.md) models fo
         yolo train model=yolo11n.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained YOLO11n model and run inference on the 'bus.jpg' image
-        yolo predict model=yolo11n.pt source=path/to/bus.jpg
+        yolo predict model=yolo11n.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Citations and Acknowledgements

--- a/docs/en/models/yolo11.md
+++ b/docs/en/models/yolo11.md
@@ -115,7 +115,7 @@ Note that the example below is for YOLO11 [Detect](../tasks/detect.md) models fo
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in Python:
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Load a COCO-pretrained YOLO11n model
         model = YOLO("yolo11n.pt")

--- a/docs/en/models/yolo12.md
+++ b/docs/en/models/yolo12.md
@@ -86,7 +86,7 @@ The examples below focus on YOLO12 [Detect](../tasks/detect.md) models (for obje
         Pretrained `*.pt` models (using [PyTorch](https://pytorch.org/)) and configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in Python:
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Load a COCO-pretrained YOLO12n model
         model = YOLO("yolo12n.pt")
@@ -95,7 +95,7 @@ The examples below focus on YOLO12 [Detect](../tasks/detect.md) models (for obje
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLO12n model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -107,7 +107,7 @@ The examples below focus on YOLO12 [Detect](../tasks/detect.md) models (for obje
         yolo train model=yolo12n.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained YOLO12n model and run inference on the 'bus.jpg' image
-        yolo predict model=yolo12n.pt source=path/to/bus.jpg
+        yolo predict model=yolo12n.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Key Improvements

--- a/docs/en/models/yolo12.md
+++ b/docs/en/models/yolo12.md
@@ -86,7 +86,7 @@ The examples below focus on YOLO12 [Detect](../tasks/detect.md) models (for obje
         Pretrained `*.pt` models (using [PyTorch](https://pytorch.org/)) and configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in Python:
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Load a COCO-pretrained YOLO12n model
         model = YOLO("yolo12n.pt")

--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -184,7 +184,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         ```python
         import numpy as np
 
-        from ultralytics import YOLOE, ASSETS
+        from ultralytics import ASSETS, YOLOE
         from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
 
         # Initialize a YOLOE model
@@ -227,7 +227,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         ```python
         import numpy as np
 
-        from ultralytics import YOLOE, ASSETS
+        from ultralytics import ASSETS, YOLOE
         from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
 
         # Initialize a YOLOE model

--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -184,7 +184,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         ```python
         import numpy as np
 
-        from ultralytics import YOLOE
+        from ultralytics import YOLOE, ASSETS
         from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
 
         # Initialize a YOLOE model
@@ -209,7 +209,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
 
         # Run inference on an image, using the provided visual prompts as guidance
         results = model.predict(
-            "ultralytics/assets/bus.jpg",
+            ASSETS / "bus.jpg",
             visual_prompts=visual_prompts,
             predictor=YOLOEVPSegPredictor,
         )
@@ -227,7 +227,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         ```python
         import numpy as np
 
-        from ultralytics import YOLOE
+        from ultralytics import YOLOE, ASSETS
         from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
 
         # Initialize a YOLOE model
@@ -241,8 +241,8 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
 
         # Run prediction on a different image, using reference image to guide what to look for
         results = model.predict(
-            "ultralytics/assets/zidane.jpg",  # Target image for detection
-            refer_image="ultralytics/assets/bus.jpg",  # Reference image used to get visual prompts
+            ASSETS / "zidane.jpg",  # Target image for detection
+            refer_image=ASSETS / "bus.jpg",  # Reference image used to get visual prompts
             visual_prompts=visual_prompts,
             predictor=YOLOEVPSegPredictor,
         )
@@ -254,7 +254,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         Using `refer_image` also sets the classes permanently, so you can run predictions without having to supply the same visual prompts again, and export the model while retaining the ability to still detect the same classes after export:
         ```python
         # After making prediction with `refer_image`, you can run predictions without passing visual_prompts again and still get the same classes back
-        results = model("ultralytics/assets/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
 
         # Or export it to a different format while retaining the classes
         model.export(format="onnx")
@@ -296,7 +296,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
 
         # Run inference on multiple image, using the provided visual prompts as guidance
         results = model.predict(
-            ["ultralytics/assets/bus.jpg", "ultralytics/assets/zidane.jpg"],
+            [ASSETS / "bus.jpg", ASSETS / "zidane.jpg"],
             visual_prompts=visual_prompts,
             predictor=YOLOEVPSegPredictor,
         )

--- a/docs/en/models/yolov10.md
+++ b/docs/en/models/yolov10.md
@@ -174,7 +174,7 @@ For predicting new images with YOLOv10:
 
         ```bash
         # Load a COCO-pretrained YOLOv10n model and run inference on the 'bus.jpg' image
-        yolo detect predict model=yolov10n.pt source=path/to/bus.jpg
+        yolo detect predict model=yolov10n.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 For training YOLOv10 on a custom dataset:
@@ -200,7 +200,7 @@ For training YOLOv10 on a custom dataset:
         yolo train model=yolov10n.yaml data=coco8.yaml epochs=100 imgsz=640
 
         # Build a YOLOv10n model from scratch and run inference on the 'bus.jpg' image
-        yolo predict model=yolov10n.yaml source=path/to/bus.jpg
+        yolo predict model=yolov10n.yaml source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Supported Tasks and Modes

--- a/docs/en/models/yolov3.md
+++ b/docs/en/models/yolov3.md
@@ -47,7 +47,7 @@ This example provides simple YOLOv3 training and inference examples. For full do
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Load a COCO-pretrained YOLOv3u model
         model = YOLO("yolov3u.pt")
@@ -59,7 +59,7 @@ This example provides simple YOLOv3 training and inference examples. For full do
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLOv3u model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -71,7 +71,7 @@ This example provides simple YOLOv3 training and inference examples. For full do
         yolo train model=yolov3u.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained YOLOv3u model and run inference on the 'bus.jpg' image
-        yolo predict model=yolov3u.pt source=path/to/bus.jpg
+        yolo predict model=yolov3u.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Citations and Acknowledgements
@@ -139,20 +139,20 @@ You can perform inference using YOLOv3 models by either Python scripts or CLI co
     === "Python"
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Load a COCO-pretrained YOLOv3u model
         model = YOLO("yolov3u.pt")
 
         # Run inference with the YOLOv3u model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
 
         ```bash
         # Load a COCO-pretrained YOLOv3u model and run inference on the 'bus.jpg' image
-        yolo predict model=yolov3u.pt source=path/to/bus.jpg
+        yolo predict model=yolov3u.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 Refer to the [Inference mode documentation](../modes/predict.md) for more details on running YOLO models.

--- a/docs/en/models/yolov3.md
+++ b/docs/en/models/yolov3.md
@@ -47,7 +47,7 @@ This example provides simple YOLOv3 training and inference examples. For full do
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Load a COCO-pretrained YOLOv3u model
         model = YOLO("yolov3u.pt")
@@ -139,7 +139,7 @@ You can perform inference using YOLOv3 models by either Python scripts or CLI co
     === "Python"
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Load a COCO-pretrained YOLOv3u model
         model = YOLO("yolov3u.pt")

--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -68,7 +68,7 @@ This example provides simple YOLOv5 training and inference examples. For full do
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Load a COCO-pretrained YOLOv5n model
         model = YOLO("yolov5n.pt")

--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -68,7 +68,7 @@ This example provides simple YOLOv5 training and inference examples. For full do
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Load a COCO-pretrained YOLOv5n model
         model = YOLO("yolov5n.pt")
@@ -80,7 +80,7 @@ This example provides simple YOLOv5 training and inference examples. For full do
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLOv5n model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -92,7 +92,7 @@ This example provides simple YOLOv5 training and inference examples. For full do
         yolo train model=yolov5n.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained YOLOv5n model and run inference on the 'bus.jpg' image
-        yolo predict model=yolov5n.pt source=path/to/bus.jpg
+        yolo predict model=yolov5n.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Citations and Acknowledgements

--- a/docs/en/models/yolov6.md
+++ b/docs/en/models/yolov6.md
@@ -48,7 +48,7 @@ This example provides simple YOLOv6 training and inference examples. For full do
         YOLOv6 `*.yaml` files can be passed to the `YOLO()` class to build the corresponding model in Python:
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Build a YOLOv6n model from scratch
         model = YOLO("yolov6n.yaml")

--- a/docs/en/models/yolov6.md
+++ b/docs/en/models/yolov6.md
@@ -48,7 +48,7 @@ This example provides simple YOLOv6 training and inference examples. For full do
         YOLOv6 `*.yaml` files can be passed to the `YOLO()` class to build the corresponding model in Python:
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Build a YOLOv6n model from scratch
         model = YOLO("yolov6n.yaml")
@@ -60,7 +60,7 @@ This example provides simple YOLOv6 training and inference examples. For full do
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLOv6n model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -72,7 +72,7 @@ This example provides simple YOLOv6 training and inference examples. For full do
         yolo train model=yolov6n.yaml data=coco8.yaml epochs=100 imgsz=640
 
         # Build a YOLOv6n model from scratch and run inference on the 'bus.jpg' image
-        yolo predict model=yolov6n.yaml source=path/to/bus.jpg
+        yolo predict model=yolov6n.yaml source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Supported Tasks and Modes

--- a/docs/en/models/yolov8.md
+++ b/docs/en/models/yolov8.md
@@ -141,7 +141,7 @@ Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for obj
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Load a COCO-pretrained YOLOv8n model
         model = YOLO("yolov8n.pt")
@@ -153,7 +153,7 @@ Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for obj
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLOv8n model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -165,7 +165,7 @@ Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for obj
         yolo train model=yolov8n.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained YOLOv8n model and run inference on the 'bus.jpg' image
-        yolo predict model=yolov8n.pt source=path/to/bus.jpg
+        yolo predict model=yolov8n.pt source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Citations and Acknowledgements

--- a/docs/en/models/yolov8.md
+++ b/docs/en/models/yolov8.md
@@ -141,7 +141,7 @@ Note the below example is for YOLOv8 [Detect](../tasks/detect.md) models for obj
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Load a COCO-pretrained YOLOv8n model
         model = YOLO("yolov8n.pt")

--- a/docs/en/models/yolov9.md
+++ b/docs/en/models/yolov9.md
@@ -138,7 +138,7 @@ This example provides simple YOLOv9 training and inference examples. For full do
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         # Build a YOLOv9c model from scratch
         model = YOLO("yolov9c.yaml")

--- a/docs/en/models/yolov9.md
+++ b/docs/en/models/yolov9.md
@@ -138,7 +138,7 @@ This example provides simple YOLOv9 training and inference examples. For full do
         [PyTorch](https://www.ultralytics.com/glossary/pytorch) pretrained `*.pt` models as well as configuration `*.yaml` files can be passed to the `YOLO()` class to create a model instance in python:
 
         ```python
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         # Build a YOLOv9c model from scratch
         model = YOLO("yolov9c.yaml")
@@ -153,7 +153,7 @@ This example provides simple YOLOv9 training and inference examples. For full do
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
         # Run inference with the YOLOv9c model on the 'bus.jpg' image
-        results = model("path/to/bus.jpg")
+        results = model(ASSETS / "bus.jpg")
         ```
 
     === "CLI"
@@ -165,7 +165,7 @@ This example provides simple YOLOv9 training and inference examples. For full do
         yolo train model=yolov9c.yaml data=coco8.yaml epochs=100 imgsz=640
 
         # Build a YOLOv9c model from scratch and run inference on the 'bus.jpg' image
-        yolo predict model=yolov9c.yaml source=path/to/bus.jpg
+        yolo predict model=yolov9c.yaml source='https://ultralytics.com/images/bus.jpg'
         ```
 
 ## Supported Tasks and Modes

--- a/docs/en/usage/python.md
+++ b/docs/en/usage/python.md
@@ -128,7 +128,7 @@ For example, users can load a model, train it, evaluate its performance on a val
         import cv2
         from PIL import Image
 
-        from ultralytics import YOLO, ASSETS
+        from ultralytics import ASSETS, YOLO
 
         model = YOLO("model.pt")
         # accepts all formats - image/dir/Path/URL/video/PIL/ndarray. 0 for webcam

--- a/docs/en/usage/python.md
+++ b/docs/en/usage/python.md
@@ -128,7 +128,7 @@ For example, users can load a model, train it, evaluate its performance on a val
         import cv2
         from PIL import Image
 
-        from ultralytics import YOLO
+        from ultralytics import YOLO, ASSETS
 
         model = YOLO("model.pt")
         # accepts all formats - image/dir/Path/URL/video/PIL/ndarray. 0 for webcam
@@ -136,11 +136,11 @@ For example, users can load a model, train it, evaluate its performance on a val
         results = model.predict(source="folder", show=True)  # Display preds. Accepts all YOLO predict arguments
 
         # from PIL
-        im1 = Image.open("bus.jpg")
+        im1 = Image.open(ASSETS / "bus.jpg")
         results = model.predict(source=im1, save=True)  # save plotted images
 
         # from ndarray
-        im2 = cv2.imread("bus.jpg")
+        im2 = cv2.imread(ASSETS / "bus.jpg")
         results = model.predict(source=im2, save=True, save_txt=True)  # save predictions as labels
 
         # from list of PIL/ndarray

--- a/docs/en/usage/simple-utilities.md
+++ b/docs/en/usage/simple-utilities.md
@@ -285,10 +285,10 @@ When scaling an image up or down, you can appropriately scale corresponding boun
 ```python
 import cv2 as cv
 import numpy as np
-
+from ultralytics import ASSETS
 from ultralytics.utils.ops import scale_boxes
 
-image = cv.imread("ultralytics/assets/bus.jpg")
+image = cv.imread(ASSETS / "bus.jpg")
 h, w, c = image.shape
 resized = cv.resize(image, None, (), fx=1.2, fy=1.2)
 new_h, new_w, _ = resized.shape
@@ -484,7 +484,7 @@ Find additional details about the `sweep_annotator` method in our reference sect
 ```python
 import cv2 as cv
 import numpy as np
-
+from ultralytics import ASSETS
 from ultralytics.utils.plotting import Annotator, colors
 
 names = {
@@ -493,7 +493,7 @@ names = {
     11: "stop sign",
 }
 
-image = cv.imread("ultralytics/assets/bus.jpg")
+image = cv.imread(ASSETS / "bus.jpg")
 ann = Annotator(
     image,
     line_width=None,  # default auto-size

--- a/docs/en/usage/simple-utilities.md
+++ b/docs/en/usage/simple-utilities.md
@@ -285,6 +285,7 @@ When scaling an image up or down, you can appropriately scale corresponding boun
 ```python
 import cv2 as cv
 import numpy as np
+
 from ultralytics import ASSETS
 from ultralytics.utils.ops import scale_boxes
 
@@ -484,6 +485,7 @@ Find additional details about the `sweep_annotator` method in our reference sect
 ```python
 import cv2 as cv
 import numpy as np
+
 from ultralytics import ASSETS
 from ultralytics.utils.plotting import Annotator, colors
 

--- a/ultralytics/models/fastsam/model.py
+++ b/ultralytics/models/fastsam/model.py
@@ -26,9 +26,9 @@ class FastSAM(Model):
 
     Examples:
         Initialize FastSAM model and run prediction
-        >>> from ultralytics import FastSAM
+        >>> from ultralytics import FastSAM, ASSETS
         >>> model = FastSAM("FastSAM-x.pt")
-        >>> results = model.predict("ultralytics/assets/bus.jpg")
+        >>> results = model.predict(ASSETS / "bus.jpg")
 
         Run prediction with bounding box prompts
         >>> results = model.predict("image.jpg", bboxes=[[100, 100, 200, 200]])

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -32,9 +32,9 @@ class NAS(Model):
         info: Log model information and return model details.
 
     Examples:
-        >>> from ultralytics import NAS
+        >>> from ultralytics import NAS, ASSETS
         >>> model = NAS("yolo_nas_s")
-        >>> results = model.predict("ultralytics/assets/bus.jpg")
+        >>> results = model.predict(ASSETS / "bus.jpg")
 
     Notes:
         YOLO-NAS models only support pre-trained models. Do not provide YAML configuration files.


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates documentation and code examples across the Ultralytics repository to use the new `ASSETS` utility for referencing sample images, making code more robust and consistent. 🖼️✨

### 📊 Key Changes
- Replaces hardcoded image paths (like `"ultralytics/assets/bus.jpg"`) with `ASSETS / "bus.jpg"` in all Python and documentation examples.
- Updates CLI examples to use direct URLs (e.g., `'https://ultralytics.com/images/bus.jpg'`) for sample images.
- Adds `from ultralytics import ASSETS` to relevant code snippets and doc sections.
- Applies these changes across all model docs (YOLO11, YOLO12, YOLOv8, YOLOv5, YOLOv3, YOLOv10, YOLO-NAS, YOLO-World, YOLOE, FastSAM, MobileSAM, RT-DETR, SAM) and usage guides.
- Updates in-code docstrings for FastSAM and NAS models to use the new asset referencing method.

### 🎯 Purpose & Impact
- **Consistency:** Ensures all examples use a unified, reliable way to access sample assets, reducing confusion and potential errors. 🔗
- **Robustness:** Using the `ASSETS` utility makes code examples more portable and less dependent on local directory structures.
- **Clarity:** Improves documentation clarity for both new and experienced users, making it easier to follow and replicate examples. 📚
- **User Experience:** Simplifies onboarding and reduces friction for users running example code, especially in different environments or platforms.

Overall, this update streamlines the user experience and enhances the maintainability of Ultralytics documentation and code examples. 🚀