### PR TITLE
`ultralytics 8.3.167` Fix Sony IMX export `mct-quantizers>=1.6.0` dependency

### DIFF
--- a/docs/en/integrations/ibm-watsonx.md
+++ b/docs/en/integrations/ibm-watsonx.md
@@ -150,7 +150,7 @@ Fortunately, all labels in the marine litter data set are already formatted as Y
 But, YOLO models by default require separate images and labels in subdirectories within the train/val/test split. We need to reorganize the directory into the following structure:
 
 <p align="center">
-  <img width="400" src="https://github.com/ultralytics/docs/releases/download/0/yolo-directory-structure.avif" alt="Yolo Directory Structure">
+  <img width="400" src="https://github.com/ultralytics/docs/releases/download/0/yolo-directory-structure.avif" alt="YOLO Directory Structure">
 </p>
 
 To reorganize the data set directory, we can run the following script:

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.166"
+__version__ = "8.3.167"
 
 import os
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1171,7 +1171,9 @@ class Exporter:
             raise ValueError("IMX export is not supported for end2end models.")
         check_requirements(("model-compression-toolkit>=2.4.1", "sony-custom-layers>=0.3.0", "edge-mdt-tpc>=1.1.0"))
         check_requirements("imx500-converter[pt]>=3.16.1")  # Separate requirements for imx500-converter
-        check_requirements("mct-quantizers>=1.6.0") # Separate requirements for mct-quantizers for compatibility with model-compression-toolkit
+        check_requirements(
+            "mct-quantizers>=1.6.0"
+        )  # Separate requirements for mct-quantizers for compatibility with model-compression-toolkit
 
         import model_compression_toolkit as mct
         import onnx

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1171,9 +1171,7 @@ class Exporter:
             raise ValueError("IMX export is not supported for end2end models.")
         check_requirements(("model-compression-toolkit>=2.4.1", "sony-custom-layers>=0.3.0", "edge-mdt-tpc>=1.1.0"))
         check_requirements("imx500-converter[pt]>=3.16.1")  # Separate requirements for imx500-converter
-        check_requirements(
-            "mct-quantizers>=1.6.0"
-        )  # Separate requirements for mct-quantizers for compatibility with model-compression-toolkit
+        check_requirements("mct-quantizers>=1.6.0")  # Separate for compatibility with model-compression-toolkit
 
         import model_compression_toolkit as mct
         import onnx

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1171,6 +1171,7 @@ class Exporter:
             raise ValueError("IMX export is not supported for end2end models.")
         check_requirements(("model-compression-toolkit>=2.4.1", "sony-custom-layers>=0.3.0", "edge-mdt-tpc>=1.1.0"))
         check_requirements("imx500-converter[pt]>=3.16.1")  # Separate requirements for imx500-converter
+        check_requirements("mct-quantizers>=1.6.0") # Separate requirements for mct-quantizers for compatibility with model-compression-toolkit
 
         import model_compression_toolkit as mct
         import onnx


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor update improving export compatibility for IMX devices and documentation clarity. 🚀🛠️

### 📊 Key Changes
- Added a new dependency (`mct-quantizers>=1.6.0`) for IMX model export to ensure compatibility.
- Updated documentation image alt text for better clarity.
- Bumped the Ultralytics package version to 8.3.167.

### 🎯 Purpose & Impact
- Ensures smoother and more reliable model export to IMX devices by including all necessary dependencies.
- Improves documentation accessibility and clarity for users integrating with IBM watsonx.
- Users exporting models for IMX hardware will experience fewer compatibility issues.