### PR TITLE
Support for custom labels directory in dataset YAML configuration

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -164,7 +164,7 @@ class YOLODataset(BaseDataset):
         Returns:
             (List[dict]): List of label dictionaries, each containing information about an image and its annotations.
         """
-        self.label_files = img2label_paths(self.im_files)
+        self.label_files = img2label_paths(self.im_files, self.data.get("labels_path", "labels"))
         cache_path = Path(self.label_files[0]).parent.with_suffix(".cache")
         try:
             cache, exists = load_dataset_cache_file(cache_path), True  # attempt to load a *.cache file

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -42,7 +42,9 @@ FORMATS_HELP_MSG = f"Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID
 
 
 def img2label_paths(img_paths: List[str], labels_dir: str = "labels") -> List[str]:
-    """Convert image paths to label paths by replacing 'images' with custom labels directory and extension with '.txt'."""
+    """Convert image paths to label paths by replacing 'images' with custom labels directory and extension with
+    '.txt'.
+    """
     sa, sb = f"{os.sep}images{os.sep}", f"{os.sep}{labels_dir}{os.sep}"  # /images/, /labels_dir/ substrings
     return [sb.join(x.rsplit(sa, 1)).rsplit(".", 1)[0] + ".txt" for x in img_paths]
 

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -41,9 +41,9 @@ PIN_MEMORY = str(os.getenv("PIN_MEMORY", not MACOS)).lower() == "true"  # global
 FORMATS_HELP_MSG = f"Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID_FORMATS}"
 
 
-def img2label_paths(img_paths: List[str]) -> List[str]:
-    """Convert image paths to label paths by replacing 'images' with 'labels' and extension with '.txt'."""
-    sa, sb = f"{os.sep}images{os.sep}", f"{os.sep}labels{os.sep}"  # /images/, /labels/ substrings
+def img2label_paths(img_paths: List[str], labels_dir: str = "labels") -> List[str]:
+    """Convert image paths to label paths by replacing 'images' with custom labels directory and extension with '.txt'."""
+    sa, sb = f"{os.sep}images{os.sep}", f"{os.sep}{labels_dir}{os.sep}"  # /images/, /labels_dir/ substrings
     return [sb.join(x.rsplit(sa, 1)).rsplit(".", 1)[0] + ".txt" for x in img_paths]
 
 
@@ -431,6 +431,7 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> Dict[str, Any]
 
     data["names"] = check_class_names(data["names"])
     data["channels"] = data.get("channels", 3)  # get image channels, default to 3
+    data["labels_path"] = data.get("labels_path", "labels")  # get custom labels directory, default to 'labels'
 
     # Resolve paths
     path = Path(extract_dir or data.get("path") or Path(data.get("yaml_file", "")).parent)  # dataset root


### PR DESCRIPTION
# Add support for custom labels directory in dataset YAML configuration

## Summary
This PR adds the ability to specify a custom labels directory in dataset YAML files through a new `labels_path` key, allowing users to use non-standard label directory structures without reorganizing their datasets.

## Motivation
Currently, YOLO datasets must follow a strict directory structure where labels are always located in a `labels/` directory parallel to the `images/` directory. This limitation forces users to:
- Reorganize their existing datasets to match the expected structure
- Create symbolic links or copy files when experimenting with different label variants
- Maintain multiple dataset copies for different labeling approaches

## Changes Made

### 1. Enhanced `img2label_paths()` function
- **File**: `ultralytics/data/utils.py`
- **Change**: Added `labels_dir` parameter (default: `"labels"`) to allow custom label directory specification
- **Impact**: Core function now supports flexible label path generation

### 2. Updated `check_det_dataset()` function  
- **File**: `ultralytics/data/utils.py`
- **Change**: Added parsing of `labels_path` from dataset YAML with fallback to `"labels"`
- **Impact**: Dataset validation now recognizes and preserves custom label directory configuration

### 3. Modified `YOLODataset.get_labels()` method
- **File**: `ultralytics/data/dataset.py` 
- **Change**: Updated to use `self.data.get("labels_path", "labels")` when calling `img2label_paths()`
- **Impact**: Dataset loading pipeline now respects custom label directories

## Usage Example

Users can now specify a custom labels directory in their dataset YAML:

```yaml
# Standard structure (unchanged)
path: ../datasets/coco8
train: images/train
val: images/val

# NEW: Custom labels directory
labels_path: labels_variant1  # or any custom directory name

nc: 80
names: ['person', 'bicycle', ...]
```

This allows dataset structures like:
```
dataset/
├── images/
│   ├── train/
│   └── val/
├── labels_variant1/      # Custom labels directory
│   ├── train/
│   └── val/
└── labels_variant2/      # Alternative labels for experiments
    ├── train/
    └── val/
```

## Backward Compatibility
- ✅ **Fully backward compatible** - existing datasets continue to work without any changes
- ✅ **Default behavior unchanged** - when `labels_path` is not specified, defaults to `"labels"`
- ✅ **No breaking changes** - all existing functionality preserved

## Use Cases
1. **Multi-annotator workflows**: Compare labels from different annotators without dataset duplication
2. **Iterative labeling**: Maintain multiple label versions during annotation refinement  
3. **Legacy dataset integration**: Work with existing datasets that use non-standard directory names
4. **Experimental setups**: A/B test different labeling approaches on the same image set
5. **Collaborative projects**: Allow teams to use their preferred directory conventions

## Testing
- ✅ Tested with custom `labels_path` configuration
- ✅ Verified backward compatibility with existing datasets  
- ✅ Confirmed proper label file discovery and loading
- ✅ Validated training pipeline integration

## Files Modified
- `ultralytics/data/utils.py`: Enhanced `img2label_paths()` and `check_det_dataset()`
- `ultralytics/data/dataset.py`: Updated `YOLODataset.get_labels()` method

This enhancement provides users with greater flexibility in dataset organization while maintaining the robust, proven YOLO data loading pipeline.


Solves the following question:
https://github.com/orgs/ultralytics/discussions/21354#discussioncomment-13734444

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update adds support for custom label directories in datasets, making it easier to organize and use datasets with non-standard folder structures. 📁✨

### 📊 Key Changes
- Added the ability to specify a custom `labels_path` in dataset configurations.
- Updated internal functions to use the custom label directory instead of always defaulting to "labels".

### 🎯 Purpose & Impact
- **Greater Flexibility:** Users can now organize their datasets with label files in any directory, not just "labels".
- **Improved Compatibility:** Makes it easier to work with datasets that don't follow the default folder structure.
- **User-Friendly:** Reduces the need for manual dataset restructuring, saving time and effort for users.