### PR TITLE
Retain `predictor` args while getting model names

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -908,7 +908,7 @@ class Model(torch.nn.Module):
             return check_class_names(self.model.names)
         if not self.predictor:  # export formats will not have predictor defined until predict() is called
             predictor = self._smart_load("predictor")(overrides=self.overrides, _callbacks=self.callbacks)
-            predictor.setup_model(model=self.model, verbose=False)
+            predictor.setup_model(model=self.model, verbose=False)  # do not mess with self.predictor.model args
             return predictor.model.names
         return self.predictor.model.names
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -907,8 +907,9 @@ class Model(torch.nn.Module):
         if hasattr(self.model, "names"):
             return check_class_names(self.model.names)
         if not self.predictor:  # export formats will not have predictor defined until predict() is called
-            self.predictor = self._smart_load("predictor")(overrides=self.overrides, _callbacks=self.callbacks)
-            self.predictor.setup_model(model=self.model, verbose=False)
+            predictor = self._smart_load("predictor")(overrides=self.overrides, _callbacks=self.callbacks)
+            predictor.setup_model(model=self.model, verbose=False)
+            return predictor.model.names
         return self.predictor.model.names
 
     @property


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves how class names are retrieved from models, especially for exported formats. 🏷️

### 📊 Key Changes
- Refines the logic for accessing class names (`names`) in models.
- Ensures that when a predictor isn't initialized (common in exported models), a temporary predictor is used to fetch class names without altering the main model state.

### 🎯 Purpose & Impact
- Prevents unintended changes to the predictor when fetching class names, making the process safer and more reliable.
- Enhances compatibility and stability for exported models, reducing potential errors during inference or deployment.
- Users working with exported models or custom workflows will experience smoother and more predictable behavior when accessing class names. 🚀