### PR TITLE
Fix CLI syntax in docs example 

### DIFF
--- a/docs/en/guides/speed-estimation.md
+++ b/docs/en/guides/speed-estimation.md
@@ -173,7 +173,7 @@ Yes, YOLO11 can be integrated with other AI frameworks like TensorFlow and PyTor
 To export a YOLO11 model to ONNX format:
 
 ```bash
-yolo export --weights yolo11n.pt --include onnx
+yolo export model=yolo11n.pt format=onnx
 ```
 
 Learn more about exporting models in our [guide on export](../modes/export.md).


### PR DESCRIPTION
SyntaxError: 'weights' is not a valid YOLO argument.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor update to the speed estimation guide to reflect the latest YOLO11 model export command syntax. 🚀

### 📊 Key Changes
- Updated the ONNX export command example for YOLO11 to use the new argument format (`model=` and `format=`).

### 🎯 Purpose & Impact
- Ensures documentation matches the latest CLI syntax, reducing confusion for users.
- Helps users export YOLO11 models more easily and accurately.