### PR TITLE
Fix RT-DETR: Enforce `max_det` for inference

### DIFF
--- a/ultralytics/models/rtdetr/predict.py
+++ b/ultralytics/models/rtdetr/predict.py
@@ -64,14 +64,10 @@ class RTDETRPredictor(BasePredictor):
             bbox = ops.xywh2xyxy(bbox)
             max_score, cls = score.max(-1, keepdim=True)  # (300, 1)
             idx = max_score.squeeze(-1) > self.args.conf  # (300, )
-
             if self.args.classes is not None:
                 idx = (cls == torch.tensor(self.args.classes, device=cls.device)).any(1) & idx
-
             pred = torch.cat([bbox, max_score, cls], dim=-1)[idx]  # filter
-
-            if pred.shape[0] > 0:
-                pred = pred[pred[:, 4].argsort(descending=True)][: self.args.max_det]
+            pred = pred[pred[:, 4].argsort(descending=True)][: self.args.max_det]
 
             oh, ow = orig_img.shape[:2]
             pred[..., [0, 2]] *= ow  # scale x coordinates to original width

--- a/ultralytics/models/rtdetr/predict.py
+++ b/ultralytics/models/rtdetr/predict.py
@@ -50,20 +50,20 @@ class RTDETRPredictor(BasePredictor):
             results (List[Results]): A list of Results objects containing the post-processed bounding boxes,
                 confidence scores, and class labels.
         """
-        if not isinstance(preds, (list, tuple)):
+        if not isinstance(preds, (list, tuple)):  # list for PyTorch inference but list[0] Tensor for export inference
             preds = [preds, None]
 
         nd = preds[0].shape[-1]
         bboxes, scores = preds[0].split((4, nd - 4), dim=-1)
 
-        if not isinstance(orig_imgs, list):
+        if not isinstance(orig_imgs, list): # input images are a torch.Tensor, not a list
             orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
 
         results = []
-        for bbox, score, orig_img, img_path in zip(bboxes, scores, orig_imgs, self.batch[0]):
+        for bbox, score, orig_img, img_path in zip(bboxes, scores, orig_imgs, self.batch[0]): # (300, 4)
             bbox = ops.xywh2xyxy(bbox)
-            max_score, cls = score.max(-1, keepdim=True)
-            idx = max_score.squeeze(-1) > self.args.conf
+            max_score, cls = score.max(-1, keepdim=True) # (300, 1)
+            idx = max_score.squeeze(-1) > self.args.conf # (300, )
 
             if self.args.classes is not None:
                 idx = (cls == torch.tensor(self.args.classes, device=cls.device)).any(1) & idx

--- a/ultralytics/models/rtdetr/predict.py
+++ b/ultralytics/models/rtdetr/predict.py
@@ -68,7 +68,6 @@ class RTDETRPredictor(BasePredictor):
                 idx = (cls == torch.tensor(self.args.classes, device=cls.device)).any(1) & idx
             pred = torch.cat([bbox, max_score, cls], dim=-1)[idx]  # filter
             pred = pred[pred[:, 4].argsort(descending=True)][: self.args.max_det]
-
             oh, ow = orig_img.shape[:2]
             pred[..., [0, 2]] *= ow  # scale x coordinates to original width
             pred[..., [1, 3]] *= oh  # scale y coordinates to original height

--- a/ultralytics/models/rtdetr/predict.py
+++ b/ultralytics/models/rtdetr/predict.py
@@ -54,7 +54,7 @@ class RTDETRPredictor(BasePredictor):
             preds = [preds, None]
 
         nd = preds[0].shape[-1]
-        bboxes, scores = preds[0].split((4, nd - 4), dim=-1) 
+        bboxes, scores = preds[0].split((4, nd - 4), dim=-1)
 
         if not isinstance(orig_imgs, list):
             orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
@@ -62,8 +62,8 @@ class RTDETRPredictor(BasePredictor):
         results = []
         for bbox, score, orig_img, img_path in zip(bboxes, scores, orig_imgs, self.batch[0]):
             bbox = ops.xywh2xyxy(bbox)
-            max_score, cls = score.max(-1, keepdim=True) 
-            idx = max_score.squeeze(-1) > self.args.conf 
+            max_score, cls = score.max(-1, keepdim=True)
+            idx = max_score.squeeze(-1) > self.args.conf
 
             if self.args.classes is not None:
                 idx = (cls == torch.tensor(self.args.classes, device=cls.device)).any(1) & idx
@@ -71,7 +71,7 @@ class RTDETRPredictor(BasePredictor):
             pred = torch.cat([bbox, max_score, cls], dim=-1)[idx]  # filter
 
             if pred.shape[0] > 0:
-                pred = pred[pred[:, 4].argsort(descending=True)][:self.args.max_det]
+                pred = pred[pred[:, 4].argsort(descending=True)][: self.args.max_det]
 
             oh, ow = orig_img.shape[:2]
             pred[..., [0, 2]] *= ow  # scale x coordinates to original width

--- a/ultralytics/models/rtdetr/predict.py
+++ b/ultralytics/models/rtdetr/predict.py
@@ -56,14 +56,14 @@ class RTDETRPredictor(BasePredictor):
         nd = preds[0].shape[-1]
         bboxes, scores = preds[0].split((4, nd - 4), dim=-1)
 
-        if not isinstance(orig_imgs, list): # input images are a torch.Tensor, not a list
+        if not isinstance(orig_imgs, list):  # input images are a torch.Tensor, not a list
             orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
 
         results = []
-        for bbox, score, orig_img, img_path in zip(bboxes, scores, orig_imgs, self.batch[0]): # (300, 4)
+        for bbox, score, orig_img, img_path in zip(bboxes, scores, orig_imgs, self.batch[0]):  # (300, 4)
             bbox = ops.xywh2xyxy(bbox)
-            max_score, cls = score.max(-1, keepdim=True) # (300, 1)
-            idx = max_score.squeeze(-1) > self.args.conf # (300, )
+            max_score, cls = score.max(-1, keepdim=True)  # (300, 1)
+            idx = max_score.squeeze(-1) > self.args.conf  # (300, )
 
             if self.args.classes is not None:
                 idx = (cls == torch.tensor(self.args.classes, device=cls.device)).any(1) & idx


### PR DESCRIPTION
  ## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved RT-DETR prediction postprocessing to ensure only the top detections are kept, sorted by confidence. 🚀

### 📊 Key Changes  
- After filtering predictions, results are now sorted by confidence score.
- Only the top results (up to the `max_det` limit) are kept for each image.

### 🎯 Purpose & Impact  
- Ensures users receive the most confident and relevant detections first.
- Reduces clutter by limiting the number of detections per image.
- Improves consistency with how other Ultralytics models handle detection outputs.