### PR TITLE
`ultralytics 8.3.173` Fix ClearML logging for `metrics` and `val` categories

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.172"
+__version__ = "8.3.173"
 
 import os
 

--- a/ultralytics/utils/callbacks/clearml.py
+++ b/ultralytics/utils/callbacks/clearml.py
@@ -105,7 +105,10 @@ def on_fit_epoch_end(trainer) -> None:
             title="Epoch Time", series="Epoch Time", value=trainer.epoch_time, iteration=trainer.epoch
         )
         for k, v in trainer.metrics.items():
-            task.get_logger().report_scalar("val", k, v, iteration=trainer.epoch)
+            if k.startswith("metrics"):
+                task.get_logger().report_scalar("metrics", k, v, iteration=trainer.epoch)
+            elif k.startswith("val"):
+                task.get_logger().report_scalar("val", k, v, iteration=trainer.epoch)
         if trainer.epoch == 0:
             from ultralytics.utils.torch_utils import model_info_for_loggers
 

--- a/ultralytics/utils/callbacks/clearml.py
+++ b/ultralytics/utils/callbacks/clearml.py
@@ -105,10 +105,8 @@ def on_fit_epoch_end(trainer) -> None:
             title="Epoch Time", series="Epoch Time", value=trainer.epoch_time, iteration=trainer.epoch
         )
         for k, v in trainer.metrics.items():
-            if k.startswith("metrics"):
-                task.get_logger().report_scalar("metrics", k, v, iteration=trainer.epoch)
-            elif k.startswith("val"):
-                task.get_logger().report_scalar("val", k, v, iteration=trainer.epoch)
+            title = k.split("/")[0]
+            task.get_logger().report_scalar(title, k, v, iteration=trainer.epoch)
         if trainer.epoch == 0:
             from ultralytics.utils.torch_utils import model_info_for_loggers
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
Fix the chart issue in clearml https://github.com/ultralytics/ultralytics/issues/21524

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved how training metrics are logged to ClearML for better organization and clarity. 🚀

### 📊 Key Changes  
- Updated the version number to 8.3.173.
- Enhanced ClearML integration by grouping logged metrics under clearer titles, making logs more organized.

### 🎯 Purpose & Impact  
- Makes it easier for users to read and analyze training metrics in ClearML dashboards.
- Improves the overall user experience when tracking model performance during training.  
- No changes to model performance or training behavior—just better logging! 📈