### PR TITLE
Pin `click==8.2.1` to fix broken MkDocs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v6
       - name: Install Dependencies
-        run: uv pip install --system ruff black tqdm mkdocs-material "mkdocstrings[python]" mkdocs-ultralytics-plugin mkdocs-macros-plugin
+        run: uv pip install --system ruff black tqdm mkdocs-material "mkdocstrings[python]" mkdocs-ultralytics-plugin mkdocs-macros-plugin click==8.2.1
       - name: Ruff fixes
         continue-on-error: true
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
     "mkdocstrings[python]",
     "mkdocs-ultralytics-plugin>=0.1.26", # for meta descriptions and images, dates and authors
     "mkdocs-macros-plugin>=1.0.5"  # duplicating content (i.e. export tables) in multiple places
+    "click==8.2.1" # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
     "mkdocstrings[python]",
     "mkdocs-ultralytics-plugin>=0.1.26", # for meta descriptions and images, dates and authors
     "mkdocs-macros-plugin>=1.0.5"  # duplicating content (i.e. export tables) in multiple places
-    "click==8.2.1" # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
+    "click==8.2.1"  # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
     "mkdocstrings[python]",
     "mkdocs-ultralytics-plugin>=0.1.26", # for meta descriptions and images, dates and authors
     "mkdocs-macros-plugin>=1.0.5", # duplicating content (i.e. export tables) in multiple places
-    "click==8.2.1" # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
+    "click==8.2.1", # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,8 @@ dev = [
     "mkdocs-material>=9.5.9",
     "mkdocstrings[python]",
     "mkdocs-ultralytics-plugin>=0.1.26", # for meta descriptions and images, dates and authors
-    "mkdocs-macros-plugin>=1.0.5"  # duplicating content (i.e. export tables) in multiple places
-    "click<=8.2.1"  # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
+    "mkdocs-macros-plugin>=1.0.5", # duplicating content (i.e. export tables) in multiple places
+    "click==8.2.1" # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
     "mkdocstrings[python]",
     "mkdocs-ultralytics-plugin>=0.1.26", # for meta descriptions and images, dates and authors
     "mkdocs-macros-plugin>=1.0.5"  # duplicating content (i.e. export tables) in multiple places
-    "click==8.2.1"  # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
+    "click<=8.2.1"  # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export

--- a/ultralytics/models/fastsam/utils.py
+++ b/ultralytics/models/fastsam/utils.py
@@ -1,5 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+
 def adjust_bboxes_to_image_border(boxes, image_shape, threshold=20):
     """
     Adjust bounding boxes to stick to image border if they are within a certain threshold.

--- a/ultralytics/models/fastsam/utils.py
+++ b/ultralytics/models/fastsam/utils.py
@@ -1,6 +1,5 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-
 def adjust_bboxes_to_image_border(boxes, image_shape, threshold=20):
     """
     Adjust bounding boxes to stick to image border if they are within a certain threshold.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes a documentation build issue by pinning the Click library to version 8.2.1. 🛠️📚

### 📊 Key Changes
- Adds `click==8.2.1` to the documentation dependencies in both the GitHub Actions workflow and `pyproject.toml`.

### 🎯 Purpose & Impact
- Resolves a known bug with MkDocs when using Click 8.2.2, ensuring the documentation builds correctly.
- Improves reliability and stability of the documentation process for all contributors and users.