### PR TITLE
Remove libmamba from Conda CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,9 +370,6 @@ jobs:
           # Fix cv2 ImportError: 'libEGL.so.1: cannot open shared object file: No such file or directory'
           sudo apt-get update
           sudo apt-get install -y libegl1 libopengl0
-      - name: Install Libmamba
-        run: |
-          conda config --set solver libmamba
       - name: Install Ultralytics package from conda-forge
         run: |
           conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino


### PR DESCRIPTION
Recent versions of conda use libmamba by default

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Removed the step to install Libmamba in the CI workflow for a simpler and more streamlined setup. 🚀

### 📊 Key Changes  
- 🗑️ Removed the installation and configuration of Libmamba as the Conda solver in the CI process.

### 🎯 Purpose & Impact  
- ⚡ Simplifies the CI workflow, reducing unnecessary steps.
- 🛠️ May improve reliability and maintainability of the CI pipeline.
- 👩‍💻 No impact on end users; only affects internal development and testing processes.