### PR TITLE
Fix validator incorrectly set `batch_size` for TensorRT inference

### DIFF
--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -163,11 +163,9 @@ class BaseValidator:
             )
             self.device = model.device  # update device
             self.args.half = model.fp16  # update half
-            stride, pt, jit, engine = model.stride, model.pt, model.jit, model.engine
+            stride, pt, jit = model.stride, model.pt, model.jit
             imgsz = check_imgsz(self.args.imgsz, stride=stride)
-            if engine:
-                self.args.batch = model.batch_size
-            elif not (pt or jit or getattr(model, "dynamic", False)):
+            if not (pt or jit or getattr(model, "dynamic", False)):
                 self.args.batch = model.metadata.get("batch", 1)  # export.py models default to batch-size 1
                 LOGGER.info(f"Setting batch={self.args.batch} input of shape ({self.args.batch}, 3, {imgsz}, {imgsz})")
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -402,11 +402,6 @@ class AutoBackend(nn.Module):
                 bindings[name] = Binding(name, dtype, shape, im, int(im.data_ptr()))
             binding_addrs = OrderedDict((n, d.ptr) for n, d in bindings.items())
 
-            # patch
-            input_bindings = [v for k, v in bindings.items() if k not in output_names]
-            self.batch_size = input_bindings[0].shape[0] if input_bindings else 1
-            LOGGER.info(f"[TensorRT] Inferred batch size: {self.batch_size}")
-
         # CoreML
         elif coreml:
             LOGGER.info(f"Loading {w} for CoreML inference...")

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -402,6 +402,11 @@ class AutoBackend(nn.Module):
                 bindings[name] = Binding(name, dtype, shape, im, int(im.data_ptr()))
             binding_addrs = OrderedDict((n, d.ptr) for n, d in bindings.items())
 
+            # patch
+            input_bindings = [v for k, v in bindings.items() if k not in output_names]
+            self.batch_size = input_bindings[0].shape[0] if input_bindings else 1
+            LOGGER.info(f"[TensorRT] Inferred batch size: {self.batch_size}")
+
         # CoreML
         elif coreml:
             LOGGER.info(f"Loading {w} for CoreML inference...")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀!

1. Check for Existing Contributions: ✅ I searched PRs and issues using terms like "engine", "tensorrt", and "val" and found no matches.
2. Link Related Issues: ❌ Could not find any existing open issues that cover this.
3. Elaborate Your Changes: ✔️ See description below.
4. Ultralytics Contributor License Agreement (CLA): ✅ I have read the CLA Document and I sign the CLA.
-->


When using `yolo val` with a TensorRT `.engine` model, the process fails because `model.batch_size` is accessed in `validator.py` **only in the case of TensorRT inference**, but the `AutoBackend` class does not define a `batch_size` attribute for any backend.

This PR fixes the issue by setting `self.batch_size` inside the `AutoBackend `constructor during TensorRT engine loading. The value is inferred from the shape of the first input binding.

This ensures correct behavior during validation and other operations that rely on model.batch_size when using TensorRT models.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves how batch size is set during model validation for better consistency and clarity. 🛠️

### 📊 Key Changes
- Simplifies batch size assignment logic in the validator.
- Removes special handling for models with an "engine" attribute.
- Ensures batch size defaults to 1 for certain exported models, with clear logging.

### 🎯 Purpose & Impact
- Makes the code easier to maintain and understand.
- Reduces potential confusion or errors related to batch size when validating different model types.
- Users and developers benefit from more predictable validation behavior and clearer logs.