### PR TITLE
Fix missing imports in `sahi-tiled-inference` guide

### DIFF
--- a/docs/en/guides/sahi-tiled-inference.md
+++ b/docs/en/guides/sahi-tiled-inference.md
@@ -114,6 +114,7 @@ Perform standard inference using an image path or a numpy image.
 
 ```python
 from sahi.predict import get_prediction
+from sahi.utils.cv import read_image
 
 # With an image path
 result = get_prediction("demo_data/small-vehicles1.jpeg", detection_model)
@@ -127,6 +128,8 @@ result_with_np_image = get_prediction(read_image("demo_data/small-vehicles1.jpeg
 Export and visualize the predicted bounding boxes and masks:
 
 ```python
+from IPython.display import Image
+
 result.export_visuals(export_dir="demo_data/")
 Image("demo_data/prediction_visual.png")
 ```


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Documentation fix: SAHI tiled inference guide now includes missing imports so example code runs out-of-the-box. ✅

### 📊 Key Changes
- Added `from sahi.utils.cv import read_image` to the NumPy image example 🧩
- Added `from IPython.display import Image` to the visualization example 🖼️

### 🎯 Purpose & Impact
- Prevents NameError issues and makes examples copy‑paste ready ✂️➡️✅
- Improves user experience, especially in notebooks and quick-start scenarios 💻
- Documentation-only change; no impact on model behavior or APIs 🔒