### PR TITLE
refactor: 🚀 switch core data ops from `pandas` to `polars` (training, benchmarks, plotting, W&B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
           if [[ "${{ github.event_name }}" =~ ^(schedule|workflow_dispatch)$ ]]; then
               slow="faster-coco-eval mlflow"
           fi
-          uv pip install --system -e ".[export,solutions,database-export]" $torch $slow pytest-cov --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
+          uv pip install --system -e ".[export,solutions]" $torch $slow pytest-cov --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
       - name: Check environment
         run: |
           yolo checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
           if [[ "${{ github.event_name }}" =~ ^(schedule|workflow_dispatch)$ ]]; then
               slow="faster-coco-eval mlflow"
           fi
-          uv pip install --system -e ".[export,solutions]" $torch $slow pytest-cov --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
+          uv pip install --system -e ".[export,solutions,database-export]" $torch $slow pytest-cov --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
       - name: Check environment
         run: |
           yolo checks

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -516,7 +516,7 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 | `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.            |
 | `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                    |
 | `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.        |
-| `to_df()`     | `DataFrame`            | Converts detection results to a Pandas DataFrame.                                         |
+| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                         |
 | `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                 |
 | `to_xml()`    | `str`                  | Converts detection results to XML format.                                                 |
 | `to_html()`   | `str`                  | Converts detection results to HTML format.                                                |

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -518,10 +518,7 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 | `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.        |
 | `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                         |
 | `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                 |
-| `to_xml()`    | `str`                  | Converts detection results to XML format.                                                 |
-| `to_html()`   | `str`                  | Converts detection results to HTML format.                                                |
 | `to_json()`   | `str`                  | Converts detection results to JSON format.                                                |
-| `to_sql()`    | `None`                 | Converts detection results to SQL-compatible format and saves to database.                |
 
 For more details see the [`Results` class documentation](../reference/engine/results.md).
 

--- a/docs/en/modes/val.md
+++ b/docs/en/modes/val.md
@@ -93,7 +93,7 @@ Each of these settings plays a vital role in the validation process, allowing fo
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> How to Export Model Validation Results in CSV, JSON, SQL, Pandas DataFrame & More
+  <strong>Watch:</strong> How to Export Model Validation Results in CSV, JSON, SQL, Polars DataFrame & More
 </p>
 
 <a href="https://github.com/ultralytics/notebooks/blob/main/notebooks/how-to-export-the-validation-results-into-dataframe-csv-sql-and-other-formats.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Explore model validation and different export methods in Google Colab"></a>
@@ -136,7 +136,7 @@ The below examples showcase YOLO model validation with custom arguments in Pytho
 | Method      | Return Type            | Description                                                                      |
 | ----------- | ---------------------- | -------------------------------------------------------------------------------- |
 | `summary()` | `List[Dict[str, Any]]` | Converts validation results to a summarized dictionary.                          |
-| `to_df()`   | `DataFrame`            | Returns the validation results as a structured Pandas DataFrame.                 |
+| `to_df()`   | `DataFrame`            | Returns the validation results as a structured Polars DataFrame.                 |
 | `to_csv()`  | `str`                  | Exports the validation results in CSV format and returns the CSV string.         |
 | `to_xml()`  | `str`                  | Exports the validation results in XML format and returns the XML string.         |
 | `to_html()` | `str`                  | Exports the validation results in HTML table format and returns the HTML string. |

--- a/docs/en/modes/val.md
+++ b/docs/en/modes/val.md
@@ -133,15 +133,12 @@ The below examples showcase YOLO model validation with custom arguments in Pytho
     print(results.confusion_matrix.to_df())
     ```
 
-| Method      | Return Type            | Description                                                                      |
-| ----------- | ---------------------- | -------------------------------------------------------------------------------- |
-| `summary()` | `List[Dict[str, Any]]` | Converts validation results to a summarized dictionary.                          |
-| `to_df()`   | `DataFrame`            | Returns the validation results as a structured Polars DataFrame.                 |
-| `to_csv()`  | `str`                  | Exports the validation results in CSV format and returns the CSV string.         |
-| `to_xml()`  | `str`                  | Exports the validation results in XML format and returns the XML string.         |
-| `to_html()` | `str`                  | Exports the validation results in HTML table format and returns the HTML string. |
-| `to_json()` | `str`                  | Exports the validation results in JSON format and returns the JSON string.       |
-| `to_sql()`  | `str`                  | Exports the validation results in SQl database.                                  |
+| Method      | Return Type            | Description                                                                |
+| ----------- | ---------------------- | -------------------------------------------------------------------------- |
+| `summary()` | `List[Dict[str, Any]]` | Converts validation results to a summarized dictionary.                    |
+| `to_df()`   | `DataFrame`            | Returns the validation results as a structured Polars DataFrame.           |
+| `to_csv()`  | `str`                  | Exports the validation results in CSV format and returns the CSV string.   |
+| `to_json()` | `str`                  | Exports the validation results in JSON format and returns the JSON string. |
 
 For more details see the [`DataExportMixin` class documentation](../reference/utils/__init__.md/#ultralytics.utils.DataExportMixin).
 

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -167,7 +167,7 @@ While the standard installation methods cover most use cases, you might need a m
         2.  **Manually install dependencies:** You need to install all required packages listed in the `pyproject.toml` file, substituting or modifying versions as needed. For the headless OpenCV example:
             ```bash
             # Install other core dependencies
-            pip install torch torchvision numpy matplotlib pandas pyyaml pillow psutil requests scipy seaborn ultralytics-thop
+            pip install torch torchvision numpy matplotlib polars pyyaml pillow psutil requests scipy seaborn ultralytics-thop
 
             # Install headless OpenCV instead of the default
             pip install opencv-python-headless
@@ -237,7 +237,7 @@ While the standard installation methods cover most use cases, you might need a m
             # Core dependencies
             numpy
             matplotlib
-            pandas
+            polars
             pyyaml
             Pillow
             psutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "psutil", # system utilization
     "py-cpuinfo", # display CPU info
     "pandas>=1.1.4",
+    "polars",  # potential future replacement for pandas
     "ultralytics-thop>=2.0.0", # FLOPs computation https://github.com/ultralytics/thop
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ extra = [
     "faster-coco-eval>=1.6.7", # COCO mAP
 ]
 typing = [
-    "pandas-stubs",
     "scipy-stubs",
     "types-pillow",
     "types-psutil",
@@ -126,13 +125,7 @@ typing = [
     "types-requests",
     "types-shapely",
 ]
-database-export = [
-    "adbc-driver-manager>=1.2.0",
-    "adbc-driver-sqlite>=1.2.0",
-    "pandas>=1.1.4",
-    "pyarrow>=17.0.0",
-    "sqlalchemy>=2.0.43",
-]
+
 
 [project.urls]
 "Homepage" = "https://ultralytics.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ typing = [
     "types-shapely",
 ]
 
-
 [project.urls]
 "Homepage" = "https://ultralytics.com"
 "Source" = "https://github.com/ultralytics/ultralytics"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,7 @@ dependencies = [
     "torchvision>=0.9.0",
     "psutil", # system utilization
     "py-cpuinfo", # display CPU info
-    "pandas>=1.1.4",
-    "polars",  # potential future replacement for pandas
+    "polars",
     "ultralytics-thop>=2.0.0", # FLOPs computation https://github.com/ultralytics/thop
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,13 @@ typing = [
     "types-requests",
     "types-shapely",
 ]
+database-export = [
+    "adbc-driver-manager>=1.2.0",
+    "adbc-driver-sqlite>=1.2.0",
+    "pandas>=1.1.4",
+    "pyarrow>=17.0.0",
+    "sqlalchemy>=2.0.43",
+]
 
 [project.urls]
 "Homepage" = "https://ultralytics.com"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -209,16 +209,11 @@ def test_val(task: str, weight: str, data: str) -> None:
         metrics = model.val(data=data, imgsz=32, plots=plots)
         metrics.to_df()
         metrics.to_csv()
-        metrics.to_xml()
-        metrics.to_html()
         metrics.to_json()
-        metrics.to_sql()
-        metrics.confusion_matrix.to_df()  # Tests for confusion matrix export
+        # Tests for confusion matrix export
+        metrics.confusion_matrix.to_df()
         metrics.confusion_matrix.to_csv()
-        metrics.confusion_matrix.to_xml()
-        metrics.confusion_matrix.to_html()
         metrics.confusion_matrix.to_json()
-        metrics.confusion_matrix.to_sql()
 
 
 def test_train_scratch():
@@ -304,10 +299,7 @@ def test_results(model: str):
         r.save_crop(save_dir=TMP / "runs/tests/crops/")
         r.to_df(decimals=3)  # Align to_ methods: https://docs.ultralytics.com/modes/predict/#working-with-results
         r.to_csv()
-        r.to_xml()
-        r.to_html()
         r.to_json(normalize=True)
-        r.to_sql()
         r.plot(pil=True, save=True, filename=TMP / "results_plot_save.jpg")
         r.plot(conf=True, boxes=True)
         print(r, len(r), r.path)  # print after methods

--- a/ultralytics/cfg/datasets/SKU-110K.yaml
+++ b/ultralytics/cfg/datasets/SKU-110K.yaml
@@ -24,7 +24,7 @@ download: |
   from pathlib import Path
 
   import numpy as np
-  import pandas as pd
+  import polars as pl
 
   from ultralytics.utils import TQDM
   from ultralytics.utils.downloads import download
@@ -45,7 +45,7 @@ download: |
   # Convert labels
   names = "image", "x1", "y1", "x2", "y2", "class", "image_width", "image_height"  # column names
   for d in "annotations_train.csv", "annotations_val.csv", "annotations_test.csv":
-      x = pd.read_csv(dir / "annotations" / d, names=names).values  # annotations
+      x = pl.read_csv(dir / "annotations" / d, names=names).to_numpy()  # annotations
       images, unique_images = x[:, 0], np.unique(x[:, 0])
       with open((dir / d).with_suffix(".txt").__str__().replace("annotations_", ""), "w", encoding="utf-8") as f:
           f.writelines(f"./images/{s}\n" for s in unique_images)

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -222,7 +222,7 @@ class Results(SimpleClass, DataExportMixin):
         save_txt: Save detection results to a text file.
         save_crop: Save cropped detection images to specified directory.
         summary: Convert inference results to a summarized dictionary.
-        to_df: Convert detection results to a Pandas Dataframe.
+        to_df: Convert detection results to a Polars Dataframe.
         to_json: Convert detection results to JSON format.
         to_csv: Convert detection results to a CSV format.
         to_xml: Convert detection results to XML format.

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -225,9 +225,6 @@ class Results(SimpleClass, DataExportMixin):
         to_df: Convert detection results to a Polars Dataframe.
         to_json: Convert detection results to JSON format.
         to_csv: Convert detection results to a CSV format.
-        to_xml: Convert detection results to XML format.
-        to_html: Convert detection results to HTML format.
-        to_sql: Convert detection results to an SQL-compatible format.
 
     Examples:
         >>> results = model("path/to/image.jpg")

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -540,10 +540,10 @@ class BaseTrainer:
             torch.cuda.empty_cache()
 
     def read_results_csv(self):
-        """Read results.csv into a dictionary using pandas."""
-        import pandas as pd  # scope for faster 'import ultralytics'
+        """Read results.csv into a dictionary using polars."""
+        import polars as pl  # scope for faster 'import ultralytics'
 
-        return pd.read_csv(self.csv).to_dict(orient="list")
+        return pl.read_csv(self.csv).to_dict(as_series=False)
 
     def _model_train(self):
         """Set model in training mode."""

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -181,7 +181,6 @@ class DataExportMixin:
         Returns:
            (str): CSV content as string.
         """
-
         import polars as pl
 
         df = self.to_df(normalize=normalize, decimals=decimals)
@@ -212,7 +211,6 @@ class DataExportMixin:
             (str): XML string.
 
         """
-        
         df = self.to_df(normalize=normalize, decimals=decimals)
         if df.is_empty():
             return '<?xml version="1.0" encoding="utf-8"?>\n<root></root>'
@@ -251,7 +249,6 @@ class DataExportMixin:
         Returns:
             (str): HTML representation of the results.
         """
-        
         df = self.to_df(normalize=normalize, decimals=decimals)
         if df.is_empty():
             return "<table></table>"
@@ -307,7 +304,6 @@ class DataExportMixin:
         Returns:
             (str): JSON-formatted string of the results.
         """
-        
         return self.to_df(normalize=normalize, decimals=decimals).write_json()    
 
     def to_sql(self, normalize=False, decimals=5, table_name="results", db_path="sqlite:///results.db", if_table_exists="replace", engine="adbc"):
@@ -328,13 +324,12 @@ class DataExportMixin:
                 Options are "sqlalchemy" and "adbc".
 
 
-        Notes: 
+        Notes:
             For engine="sqlalchemy": requires sqlalchemy, pandas, and pyarrow packages.
             For engine="adbc": requires adbc_driver_manager and pyarrow packages.
         
 
         """
-        
         return self.to_df(normalize=normalize, decimals=decimals).write_database(
             table_name=table_name,
             connection=db_path,

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -363,9 +363,7 @@ class DataExportMixin:
 
                 def _to_sql_compatible(v):
                     """Convert complex types to SQL-compatible strings."""
-                    if v is None:
-                        return None
-                    elif isinstance(v, dict):
+                    if isinstance(v, dict):
                         return json.dumps(v)
                     elif isinstance(v, (list, tuple, set)):
                         return json.dumps(list(v))

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -149,7 +149,6 @@ class DataExportMixin:
         >>> df = results.to_df()
         >>> print(df)
         >>> csv_data = results.to_csv()
-        >>> results.to_sql(table_name="yolo_results")
     """
 
     def to_df(self, normalize=False, decimals=5):

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -196,7 +196,9 @@ class DataExportMixin:
                     return repr(v)
                 return str(v)
 
-            df_str = df.select([pl.col(c).map_elements(_to_str_simple, return_dtype=pl.String).alias(c) for c in df.columns])
+            df_str = df.select(
+                [pl.col(c).map_elements(_to_str_simple, return_dtype=pl.String).alias(c) for c in df.columns]
+            )
             return df_str.write_csv()
 
     def to_xml(self, normalize=False, decimals=5):
@@ -209,12 +211,11 @@ class DataExportMixin:
 
         Returns:
             (str): XML string.
-
         """
         df = self.to_df(normalize=normalize, decimals=decimals)
         if df.is_empty():
             return '<?xml version="1.0" encoding="utf-8"?>\n<root></root>'
-        
+
         def _to_xml_str_simple(v):
             """Convert basic types to XML-safe string."""
             if v is None:
@@ -222,20 +223,26 @@ class DataExportMixin:
             if isinstance(v, (dict, list, tuple, set)):
                 return str(v).replace("'", "&apos;").replace('"', "&quot;")
             if isinstance(v, str):
-                return v.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("'", "&apos;").replace('"', "&quot;")
+                return (
+                    v.replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;")
+                    .replace("'", "&apos;")
+                    .replace('"', "&quot;")
+                )
             return str(v)
 
-        xml_lines = ['<?xml version="1.0" encoding="utf-8"?>', '<root>']
-        
+        xml_lines = ['<?xml version="1.0" encoding="utf-8"?>', "<root>"]
+
         for row_dict in df.iter_rows(named=True):
-            xml_lines.append('  <row>')
+            xml_lines.append("  <row>")
             for col_name, value in row_dict.items():
                 xml_value = _to_xml_str_simple(value)
-                xml_lines.append(f'    <{col_name}>{xml_value}</{col_name}>')
-            xml_lines.append('  </row>')
-        
-        xml_lines.append('</root>')
-        return '\n'.join(xml_lines)
+                xml_lines.append(f"    <{col_name}>{xml_value}</{col_name}>")
+            xml_lines.append("  </row>")
+
+        xml_lines.append("</root>")
+        return "\n".join(xml_lines)
 
     def to_html(self, normalize=False, decimals=5, index=False):
         """
@@ -252,7 +259,7 @@ class DataExportMixin:
         df = self.to_df(normalize=normalize, decimals=decimals)
         if df.is_empty():
             return "<table></table>"
-        
+
         def _to_html_str_simple(v):
             """Convert basic types to HTML-safe string."""
             if v is None:
@@ -264,29 +271,29 @@ class DataExportMixin:
             return str(v)
 
         html_lines = ['<table border="1" class="dataframe">']
-        
-        html_lines.append('  <thead>')
+
+        html_lines.append("  <thead>")
         html_lines.append('    <tr style="text-align: right;">')
         if index:
-            html_lines.append('      <th></th>')
+            html_lines.append("      <th></th>")
         for col in df.columns:
-            html_lines.append(f'      <th>{col}</th>')
-        html_lines.append('    </tr>')
-        html_lines.append('  </thead>')
-        
-        html_lines.append('  <tbody>')
+            html_lines.append(f"      <th>{col}</th>")
+        html_lines.append("    </tr>")
+        html_lines.append("  </thead>")
+
+        html_lines.append("  <tbody>")
         for i, row_dict in enumerate(df.iter_rows(named=True)):
-            html_lines.append('    <tr>')
+            html_lines.append("    <tr>")
             if index:
-                html_lines.append(f'      <th>{i}</th>')
+                html_lines.append(f"      <th>{i}</th>")
             for _, value in row_dict.items():
                 html_value = _to_html_str_simple(value)
-                html_lines.append(f'      <td>{html_value}</td>')
-            html_lines.append('    </tr>')
-        html_lines.append('  </tbody>')
-        html_lines.append('</table>')
-        
-        return '\n'.join(html_lines)
+                html_lines.append(f"      <td>{html_value}</td>")
+            html_lines.append("    </tr>")
+        html_lines.append("  </tbody>")
+        html_lines.append("</table>")
+
+        return "\n".join(html_lines)
 
     def tojson(self, normalize=False, decimals=5):
         """Deprecated version of to_json()."""
@@ -304,9 +311,17 @@ class DataExportMixin:
         Returns:
             (str): JSON-formatted string of the results.
         """
-        return self.to_df(normalize=normalize, decimals=decimals).write_json()    
+        return self.to_df(normalize=normalize, decimals=decimals).write_json()
 
-    def to_sql(self, normalize=False, decimals=5, table_name="results", db_path="sqlite:///results.db", if_table_exists="replace", engine="adbc"):
+    def to_sql(
+        self,
+        normalize=False,
+        decimals=5,
+        table_name="results",
+        db_path="sqlite:///results.db",
+        if_table_exists="replace",
+        engine="adbc",
+    ):
         """
         Export results to an SQLite database.
 
@@ -327,16 +342,11 @@ class DataExportMixin:
         Notes:
             For engine="sqlalchemy": requires sqlalchemy, pandas, and pyarrow packages.
             For engine="adbc": requires adbc_driver_manager and pyarrow packages.
-        
-
         """
         return self.to_df(normalize=normalize, decimals=decimals).write_database(
-            table_name=table_name,
-            connection=db_path,
-            engine=engine,
-            if_table_exists=if_table_exists
+            table_name=table_name, connection=db_path, engine=engine, if_table_exists=if_table_exists
         )
-        
+
 
 class SimpleClass:
     """

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -135,16 +135,13 @@ class DataExportMixin:
 
     This class provides utilities to export performance metrics (e.g., mAP, precision, recall) or prediction results
     from classification, object detection, segmentation, or pose estimation tasks into various formats: Polars
-    DataFrame, CSV, XML, HTML, JSON and SQLite (SQL).
+    DataFrame, CSV and JSON.
 
     Methods:
         to_df: Convert summary to a Polars DataFrame.
         to_csv: Export results as a CSV string.
-        to_xml: Export results as an XML string.
-        to_html: Export results as an HTML table.
         to_json: Export results as a JSON string.
         tojson: Deprecated alias for `to_json()`.
-        to_sql: Export results to an SQLite database.
 
     Examples:
         >>> model = YOLO("yolo11n.pt")
@@ -201,105 +198,6 @@ class DataExportMixin:
             )
             return df_str.write_csv()
 
-    def to_xml(self, normalize=False, decimals=5):
-        """
-        Export results to XML format.
-
-        Args:
-            normalize (bool, optional): Normalize numeric values.
-            decimals (int, optional): Decimal precision.
-
-        Returns:
-            (str): XML string.
-        """
-        df = self.to_df(normalize=normalize, decimals=decimals)
-        if df.is_empty():
-            return '<?xml version="1.0" encoding="utf-8"?>\n<root></root>'
-
-        def _to_xml_str_simple(v):
-            """Convert basic types to XML-safe string."""
-            if v is None:
-                return ""
-            if isinstance(v, (dict, list, tuple, set)):
-                return str(v).replace("'", "&apos;").replace('"', "&quot;")
-            if isinstance(v, str):
-                return (
-                    v.replace("&", "&amp;")
-                    .replace("<", "&lt;")
-                    .replace(">", "&gt;")
-                    .replace("'", "&apos;")
-                    .replace('"', "&quot;")
-                )
-            return str(v)
-
-        xml_lines = ['<?xml version="1.0" encoding="utf-8"?>', "<root>"]
-
-        for row_dict in df.iter_rows(named=True):
-            xml_lines.append("  <row>")
-            for col_name, value in row_dict.items():
-                xml_value = _to_xml_str_simple(value)
-                xml_lines.append(f"    <{col_name}>{xml_value}</{col_name}>")
-            xml_lines.append("  </row>")
-
-        xml_lines.append("</root>")
-        return "\n".join(xml_lines)
-
-    def to_html(self, normalize=False, decimals=5, index=False):
-        """
-        Export results to HTML table format.
-
-        Args:
-            normalize (bool, optional): Normalize numeric values.
-            decimals (int, optional): Decimal precision.
-            index (bool, optional): Whether to include index column in the HTML table.
-
-        Returns:
-            (str): HTML representation of the results.
-        """
-        df = self.to_df(normalize=normalize, decimals=decimals)
-        if df.is_empty():
-            return "<table></table>"
-
-        def _to_html_str_simple(v):
-            """Convert basic types to HTML-safe string."""
-            if v is None:
-                return ""
-            if isinstance(v, (dict, list, tuple, set)):
-                return str(v).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-            if isinstance(v, str):
-                return v.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-            return str(v)
-
-        html_lines = ['<table border="1" class="dataframe">']
-
-        html_lines.append("  <thead>")
-        html_lines.append('    <tr style="text-align: right;">')
-        if index:
-            html_lines.append("      <th></th>")
-        for col in df.columns:
-            html_lines.append(f"      <th>{col}</th>")
-        html_lines.append("    </tr>")
-        html_lines.append("  </thead>")
-
-        html_lines.append("  <tbody>")
-        for i, row_dict in enumerate(df.iter_rows(named=True)):
-            html_lines.append("    <tr>")
-            if index:
-                html_lines.append(f"      <th>{i}</th>")
-            for _, value in row_dict.items():
-                html_value = _to_html_str_simple(value)
-                html_lines.append(f"      <td>{html_value}</td>")
-            html_lines.append("    </tr>")
-        html_lines.append("  </tbody>")
-        html_lines.append("</table>")
-
-        return "\n".join(html_lines)
-
-    def tojson(self, normalize=False, decimals=5):
-        """Deprecated version of to_json()."""
-        LOGGER.warning("'result.tojson()' is deprecated, replace with 'result.to_json()'.")
-        return self.to_json(normalize, decimals)
-
     def to_json(self, normalize=False, decimals=5):
         """
         Export results to JSON format.
@@ -312,77 +210,6 @@ class DataExportMixin:
             (str): JSON-formatted string of the results.
         """
         return self.to_df(normalize=normalize, decimals=decimals).write_json()
-
-    def to_sql(
-        self,
-        normalize=False,
-        decimals=5,
-        table_name="results",
-        db_path="sqlite:///results.db",
-        if_table_exists="replace",
-        engine="adbc",
-    ):
-        """
-        Export results to an SQLite database.
-
-        Args:
-            normalize (bool, optional): Normalize numeric values.
-            decimals (int, optional): Decimal precision.
-            table_name (str, optional): Name of the table to store data.
-            db_path (str, optional): Path to the database file. (PostgreSQL, SQLite, etc.)
-            if_table_exists (str, optional): Action to take if the table already exists.
-                Options are 'fail', 'replace', or 'append'.
-                - 'fail': Raise an error if the table exists.
-                - 'replace': Drop the table if it exists and create a new one.
-                - 'append': Append data to the existing table without dropping it.
-            engine (str, optional): Database engine to use.
-                Options are "sqlalchemy" and "adbc".
-
-
-        Notes:
-            For engine="sqlalchemy": requires sqlalchemy, pandas, and pyarrow packages.
-            For engine="adbc": requires adbc_driver_manager and pyarrow packages.
-        """
-        import polars as pl
-
-        df = self.to_df(normalize=normalize, decimals=decimals)
-
-        complex_columns = [
-            col for col in df.columns if df[col].dtype == pl.Object or isinstance(df[col].dtype, pl.Struct)
-        ]
-        if complex_columns:
-            struct_columns = [col for col in complex_columns if isinstance(df[col].dtype, pl.Struct)]
-            object_columns = [col for col in complex_columns if df[col].dtype == pl.Object]
-
-            conversion_exprs = []
-
-            if struct_columns:
-                conversion_exprs.extend([pl.col(col).struct.json_encode().alias(col) for col in struct_columns])
-
-            if object_columns:
-
-                def _to_sql_compatible(v):
-                    """Convert complex types to SQL-compatible strings."""
-                    if isinstance(v, dict):
-                        return json.dumps(v)
-                    elif isinstance(v, (list, tuple, set)):
-                        return json.dumps(list(v))
-                    else:
-                        return v
-
-                conversion_exprs.extend(
-                    [
-                        pl.col(col).map_elements(_to_sql_compatible, return_dtype=pl.String).alias(col)
-                        for col in object_columns
-                    ]
-                )
-
-            if conversion_exprs:
-                df = df.with_columns(conversion_exprs)
-
-        return df.write_database(
-            table_name=table_name, connection=db_path, engine=engine, if_table_exists=if_table_exists
-        )
 
 
 class SimpleClass:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -134,11 +134,11 @@ class DataExportMixin:
     Mixin class for exporting validation metrics or prediction results in various formats.
 
     This class provides utilities to export performance metrics (e.g., mAP, precision, recall) or prediction results
-    from classification, object detection, segmentation, or pose estimation tasks into various formats: Pandas
+    from classification, object detection, segmentation, or pose estimation tasks into various formats: Polars
     DataFrame, CSV, XML, HTML, JSON and SQLite (SQL).
 
     Methods:
-        to_df: Convert summary to a Pandas DataFrame.
+        to_df: Convert summary to a Polars DataFrame.
         to_csv: Export results as a CSV string.
         to_xml: Export results as an XML string.
         to_html: Export results as an HTML table.

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -166,9 +166,9 @@ class DataExportMixin:
         Returns:
             (DataFrame): DataFrame containing the summary data.
         """
-        import pandas as pd  # scope for faster 'import ultralytics'
+        import polars as pl  # scope for faster 'import ultralytics'
 
-        return pd.DataFrame(self.summary(normalize=normalize, decimals=decimals))
+        return pl.DataFrame(self.summary(normalize=normalize, decimals=decimals))
 
     def to_csv(self, normalize=False, decimals=5):
         """

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -77,7 +77,7 @@ def benchmark(
         **kwargs (Any): Additional keyword arguments for exporter.
 
     Returns:
-        (pandas.DataFrame): A pandas DataFrame with benchmark results for each format, including file size, metric,
+        (polars.DataFrame): A polars DataFrame with benchmark results for each format, including file size, metric,
             and inference time.
 
     Examples:

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -207,7 +207,7 @@ def benchmark(
     if verbose and isinstance(verbose, float):
         metrics = df[key].to_numpy()  # values to compare to floor
         floor = verbose  # minimum metric floor to pass, i.e. = 0.29 mAP for YOLOv5n
-        assert all(x > floor for x in metrics if x is not None), f"Benchmark failure: metric(s) < floor {floor}"
+        assert all(x > floor for x in metrics if not np.isnan(x)), f"Benchmark failure: metric(s) < floor {floor}"
 
     return df
 

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -92,6 +92,7 @@ def benchmark(
 
     pl.Config.set_tbl_cols(10)
     pl.Config.set_tbl_width_chars(120)
+    pl.Config.set_tbl_hide_dataframe_shape(True)
     device = select_device(device, verbose=False)
     if isinstance(model, (str, Path)):
         model = YOLO(model)

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -88,10 +88,10 @@ def benchmark(
     imgsz = check_imgsz(imgsz)
     assert imgsz[0] == imgsz[1] if isinstance(imgsz, list) else True, "benchmark() only supports square imgsz."
 
-    import pandas as pd  # scope for faster 'import ultralytics'
+    import polars as pl  # scope for faster 'import ultralytics'
 
-    pd.options.display.max_columns = 10
-    pd.options.display.width = 120
+    pl.Config.set_tbl_cols(10)
+    pl.Config.set_tbl_width_chars(120)
     device = select_device(device, verbose=False)
     if isinstance(model, (str, Path)):
         model = YOLO(model)
@@ -193,20 +193,20 @@ def benchmark(
 
     # Print results
     check_yolo(device=device)  # print system info
-    df = pd.DataFrame(y, columns=["Format", "Status❔", "Size (MB)", key, "Inference time (ms/im)", "FPS"])
+    df = pl.DataFrame(y, schema=["Format", "Status❔", "Size (MB)", key, "Inference time (ms/im)", "FPS"])
 
     name = model.model_name
     dt = time.time() - t0
     legend = "Benchmarks legend:  - ✅ Success  - ❎ Export passed but validation failed  - ❌️ Export failed"
-    s = f"\nBenchmarks complete for {name} on {data} at imgsz={imgsz} ({dt:.2f}s)\n{legend}\n{df.fillna('-')}\n"
+    s = f"\nBenchmarks complete for {name} on {data} at imgsz={imgsz} ({dt:.2f}s)\n{legend}\n{df.fill_null('-')}\n"
     LOGGER.info(s)
     with open("benchmarks.log", "a", errors="ignore", encoding="utf-8") as f:
         f.write(s)
 
     if verbose and isinstance(verbose, float):
-        metrics = df[key].array  # values to compare to floor
+        metrics = df[key].to_numpy()  # values to compare to floor
         floor = verbose  # minimum metric floor to pass, i.e. = 0.29 mAP for YOLOv5n
-        assert all(x > floor for x in metrics if pd.notna(x)), f"Benchmark failure: metric(s) < floor {floor}"
+        assert all(x > floor for x in metrics if x is not None), f"Benchmark failure: metric(s) < floor {floor}"
 
     return df
 

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -34,9 +34,9 @@ def _custom_table(x, y, classes, title="Precision Recall Curve", x_title="Recall
     Returns:
         (wandb.Object): A wandb object suitable for logging, showcasing the crafted metric visualization.
     """
-    import pandas  # scope for faster 'import ultralytics'
+    import polars  # scope for faster 'import ultralytics'
 
-    df = pandas.DataFrame({"class": classes, "y": y, "x": x}).round(3)
+    df = polars.DataFrame({"class": classes, "y": y, "x": x}).round(3)
     fields = {"x": "x", "y": "y", "class": "class"}
     string_fields = {"title": title, "x-axis-title": x_title, "y-axis-title": y_title}
     return wb.plot_table(

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -34,13 +34,20 @@ def _custom_table(x, y, classes, title="Precision Recall Curve", x_title="Recall
     Returns:
         (wandb.Object): A wandb object suitable for logging, showcasing the crafted metric visualization.
     """
-    import polars  # scope for faster 'import ultralytics'
+    import polars as pl  # scope for faster 'import ultralytics'
+    import polars.selectors as cs
 
-    df = polars.DataFrame({"class": classes, "y": y, "x": x}).round(3)
+    df = pl.DataFrame({"class": classes, "y": y, "x": x}).with_columns(cs.numeric().round(3))
+    data = df.select(["class", "y", "x"]).rows()
+
     fields = {"x": "x", "y": "y", "class": "class"}
     string_fields = {"title": title, "x-axis-title": x_title, "y-axis-title": y_title}
+
     return wb.plot_table(
-        "wandb/area-under-curve/v0", wb.Table(dataframe=df), fields=fields, string_fields=string_fields
+        "wandb/area-under-curve/v0",
+        wb.Table(data=data, columns=["class", "y", "x"]),
+        fields=fields,
+        string_fields=string_fields,
     )
 
 

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -42,7 +42,6 @@ def _custom_table(x, y, classes, title="Precision Recall Curve", x_title="Recall
 
     fields = {"x": "x", "y": "y", "class": "class"}
     string_fields = {"title": title, "x-axis-title": x_title, "y-axis-title": y_title}
-
     return wb.plot_table(
         "wandb/area-under-curve/v0",
         wb.Table(data=data, columns=["class", "y", "x"]),

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -557,7 +557,7 @@ class Annotator:
         return width, height, width * height
 
 
-@TryExcept()  # known issue https://github.com/ultralytics/yolov5/issues/5395
+@TryExcept()
 @plt_settings()
 def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     """
@@ -610,7 +610,7 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     boxes = np.column_stack([0.5 - boxes[:, 2:4] / 2, 0.5 + boxes[:, 2:4] / 2]) * 1000
     img = Image.fromarray(np.ones((1000, 1000, 3), dtype=np.uint8) * 255)
     for cls, box in zip(cls[:500], boxes[:500]):
-        ImageDraw.Draw(img).rectangle(box, width=1, outline=colors(cls))  # plot
+        ImageDraw.Draw(img).rectangle(box.tolist(), width=1, outline=colors(cls))  # plot
     ax[1].imshow(img)
     ax[1].axis("off")
 

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -584,24 +584,6 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     boxes = boxes[:1000000]  # limit to 1M boxes
     x = polars.DataFrame(boxes, schema=["x", "y", "width", "height"])
 
-    try:  # Seaborn correlogram
-        import pandas as pd
-        import seaborn
-
-        # NOTE: still use pandas dataframe here as seaborn does not support polars dataframe
-        seaborn.pairplot(
-            pd.DataFrame(x.to_numpy(), columns=x.columns),
-            corner=True,
-            diag_kind="auto",
-            kind="hist",
-            diag_kws=dict(bins=50),
-            plot_kws=dict(pmax=0.9),
-        )
-        plt.savefig(save_dir / "labels_correlogram.jpg", dpi=200)
-        plt.close()
-    except ImportError:
-        pass  # Skip if seaborn is not installed
-
     # Matplotlib labels
     subplot_3_4_color = LinearSegmentedColormap.from_list("white_blue", ["white", "blue"])
     ax = plt.subplots(2, 2, figsize=(8, 8), tight_layout=True)[1].ravel()

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -587,7 +587,9 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     try:  # Seaborn correlogram
         import seaborn
 
-        seaborn.pairplot(x.to_pandas(), corner=True, diag_kind="auto", kind="hist", diag_kws=dict(bins=50), plot_kws=dict(pmax=0.9))
+        seaborn.pairplot(
+            x.to_pandas(), corner=True, diag_kind="auto", kind="hist", diag_kws=dict(bins=50), plot_kws=dict(pmax=0.9)
+        )
         plt.savefig(save_dir / "labels_correlogram.jpg", dpi=200)
         plt.close()
     except ImportError:

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -585,8 +585,8 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     x = polars.DataFrame(boxes, schema=["x", "y", "width", "height"])
 
     try:  # Seaborn correlogram
-        import seaborn
         import pandas as pd
+        import seaborn
 
         # NOTE: still use pandas dataframe here as seaborn does not support polars dataframe
         seaborn.pairplot(

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -571,7 +571,7 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
         on_plot (Callable, optional): Function to call after plot is saved.
     """
     import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
-    import pandas
+    import polars
     from matplotlib.colors import LinearSegmentedColormap
 
     # Filter matplotlib>=3.7.2 warning
@@ -582,12 +582,12 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     LOGGER.info(f"Plotting labels to {save_dir / 'labels.jpg'}... ")
     nc = int(cls.max() + 1)  # number of classes
     boxes = boxes[:1000000]  # limit to 1M boxes
-    x = pandas.DataFrame(boxes, columns=["x", "y", "width", "height"])
+    x = polars.DataFrame(boxes, schema=["x", "y", "width", "height"])
 
     try:  # Seaborn correlogram
         import seaborn
 
-        seaborn.pairplot(x, corner=True, diag_kind="auto", kind="hist", diag_kws=dict(bins=50), plot_kws=dict(pmax=0.9))
+        seaborn.pairplot(x.to_pandas(), corner=True, diag_kind="auto", kind="hist", diag_kws=dict(bins=50), plot_kws=dict(pmax=0.9))
         plt.savefig(save_dir / "labels_correlogram.jpg", dpi=200)
         plt.close()
     except ImportError:

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -585,9 +585,10 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     x = polars.DataFrame(boxes, schema=["x", "y", "width", "height"])
 
     try:  # Seaborn correlogram
-        import pandas as pd
         import seaborn
+        import pandas as pd
 
+        # NOTE: still use pandas dataframe here as seaborn does not support polars dataframe
         seaborn.pairplot(
             pd.DataFrame(x.to_numpy(), columns=x.columns),
             corner=True,

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -585,10 +585,16 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     x = polars.DataFrame(boxes, schema=["x", "y", "width", "height"])
 
     try:  # Seaborn correlogram
+        import pandas as pd
         import seaborn
 
         seaborn.pairplot(
-            x.to_pandas(), corner=True, diag_kind="auto", kind="hist", diag_kws=dict(bins=50), plot_kws=dict(pmax=0.9)
+            pd.DataFrame(x.to_numpy(), columns=x.columns),
+            corner=True,
+            diag_kind="auto",
+            kind="hist",
+            diag_kws=dict(bins=50),
+            plot_kws=dict(pmax=0.9),
         )
         plt.savefig(save_dir / "labels_correlogram.jpg", dpi=200)
         plt.close()


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switch Ultralytics from Pandas to Polars for data exports and internal CSV handling, remove XML/HTML/SQL export helpers, and update docs/tests accordingly. 🚀

### 📊 Key Changes
- Replaced Pandas with Polars across the codebase:
  - `to_df()` now returns a Polars DataFrame for predictions and validation results.
  - CSV/JSON exports use Polars (`write_csv`, `write_json`) with safe fallbacks for complex types.
  - Training/benchmark utilities and plotting now read/write with Polars.
  - Dataset script (SKU-110K) uses `polars.read_csv(...).to_numpy()`.
- Removed export helpers: XML, HTML, and SQL (and related tests and docs).
- Updated dependencies:
  - Added `polars`, removed `pandas` and `pandas-stubs`.
  - Quickstart and requirements examples now reference `polars`.
- W&B callback refactor: builds tables from Polars data (no Pandas dependency).
- Minor plotting tweaks and cleanup (e.g., safer rectangle plotting, removed seaborn correlogram block).
- Docs updated to reflect Polars usage and removed XML/HTML/SQL options. 📚

### 🎯 Purpose & Impact
- Performance and footprint: Faster I/O and lower overhead with Polars; lighter dependency tree. ⚡
- Simpler, more consistent exports: CSV/JSON remain first-class, with robust handling of edge cases. 🧰
- Breaking changes to note:
  - DataFrames returned are now Polars, not Pandas. If you need Pandas, convert via `df.to_pandas()`.
  - Removed `to_xml()`, `to_html()`, and `to_sql()`; users should implement these externally if needed.
- Developer experience: Faster imports, cleaner tests, and clearer docs. ✅

See the Ultralytics Docs for details.