### PR TITLE
`ultralytics 8.3.178` new lighter `Dockerfile-python` images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ on:
         default: true
       Dockerfile-python:
         type: boolean
-        description: Dockerfile-python (+ jupyter, cpu)
+        description: Dockerfile-python (+ jupyter, cpu, python-export)
         default: true
       Dockerfile-arm64:
         type: boolean
@@ -66,7 +66,7 @@ jobs:
             tags: "latest-python"
             platforms: "linux/amd64"
             runs_on: "ubuntu-latest"
-            derivatives: "Dockerfile-jupyter,Dockerfile-cpu"
+            derivatives: "Dockerfile-jupyter,Dockerfile-cpu,Dockerfile-python-export"
           # Standalone base images
           - dockerfile: "Dockerfile-arm64"
             tags: "latest-arm64"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ on:
 jobs:
   docker:
     if: github.repository == 'ultralytics/ultralytics'
-    name: Build Images
+    name: Build
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ on:
 jobs:
   docker:
     if: github.repository == 'ultralytics/ultralytics'
-    name: Push Docker Images
+    name: Build Images
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -210,15 +210,15 @@ jobs:
 
       - name: Check Environment
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
+        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
 
       - name: Run Tests
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
+        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
 
       - name: Run Benchmarks
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
+        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
 
       - name: Push All Images
         if: github.event_name == 'push' || (github.event.inputs[matrix.dockerfile] == 'true' && github.event.inputs.push == 'true')

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Builds ultralytics/ultralytics:latest image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
-# Image is CUDA-optimized for YOLO11 single/multi-GPU training and inference
+# Image is CUDA-optimized for YOLO single/multi-GPU training and inference
 
 # Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch or nvcr.io/nvidia/pytorch:25.02-py3
 FROM pytorch/pytorch:2.7.0-cuda12.6-cudnn9-runtime

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Builds ultralytics/ultralytics:latest-jetson-jetpack4 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
-# Supports JetPack4.x for YOLO11 on Jetson Nano, TX2, Xavier NX, AGX Xavier
+# Supports JetPack4.x for YOLO on Jetson Nano, TX2, Xavier NX, AGX Xavier
 
 # Start FROM https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-cuda
 FROM nvcr.io/nvidia/l4t-cuda:10.2.460-runtime

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Builds ultralytics/ultralytics:jetson-jetpack4 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
+# Builds ultralytics/ultralytics:latest-jetson-jetpack4 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Supports JetPack4.x for YOLO11 on Jetson Nano, TX2, Xavier NX, AGX Xavier
 
 # Start FROM https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-cuda

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Builds ultralytics/ultralytics:latest-jetson-jetpack5 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
-# Supports JetPack5.1.2 for YOLO11 on Jetson Xavier NX, AGX Xavier, AGX Orin, Orin Nano and Orin NX
+# Supports JetPack5.1.2 for YOLO on Jetson Xavier NX, AGX Xavier, AGX Orin, Orin Nano and Orin NX
 
 # Start FROM https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-jetpack
 FROM nvcr.io/nvidia/l4t-jetpack:r35.4.1

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Builds ultralytics/ultralytics:jetson-jetpack5 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
+# Builds ultralytics/ultralytics:latest-jetson-jetpack5 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Supports JetPack5.1.2 for YOLO11 on Jetson Xavier NX, AGX Xavier, AGX Orin, Orin Nano and Orin NX
 
 # Start FROM https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-jetpack

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Builds ultralytics/ultralytics:jetson-jetpack6 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
+# Builds ultralytics/ultralytics:latest-jetson-jetpack6 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Supports JetPack6.1 for YOLO11 on Jetson AGX Orin, Orin NX and Orin Nano Series
 
 # Start FROM https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-jetpack

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Builds ultralytics/ultralytics:latest-jetson-jetpack6 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
-# Supports JetPack6.1 for YOLO11 on Jetson AGX Orin, Orin NX and Orin Nano Series
+# Supports JetPack6.1 for YOLO on Jetson AGX Orin, Orin NX and Orin Nano Series
 
 # Start FROM https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-jetpack
 FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0

--- a/docker/Dockerfile-python
+++ b/docker/Dockerfile-python
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Builds ultralytics/ultralytics:latest-python image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
-# Image is CPU-optimized for ONNX, OpenVINO and PyTorch YOLO11 deployments
+# Lightweight CPU image optimized for YOLO inference
 
 # Use official Python base image for reproducibility (3.11.10 for export and 3.12.10 for inference)
 FROM python:3.11.10-slim-bookworm
@@ -18,11 +18,9 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
     /root/.config/Ultralytics/
 
 # Install linux packages
-# gnupg required for Edge TPU install
-# Java runtime environment (default-jre-headless) required for Sony IMX export
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    python3-pip git zip unzip wget curl htop libgl1 libglib2.0-0 libpython3-dev gnupg default-jre-headless && \
+    python3-pip git zip unzip wget curl htop libgl1 libglib2.0-0 libpython3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Create working directory
@@ -34,18 +32,11 @@ RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
     sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
-# Install pip packages and run exports to AutoInstall packages
+# Install pip packages
 RUN pip install uv && \
-    uv pip install --system -e ".[export]" --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match && \
-    # Need lower version of 'numpy' for Sony IMX export
-    uv pip install --system numpy==1.26.4 && \
-    # Run exports to AutoInstall packages
-    yolo export model=tmp/yolo11n.pt format=edgetpu imgsz=32 && \
-    yolo export model=tmp/yolo11n.pt format=ncnn imgsz=32 && \
-    yolo export model=tmp/yolo11n.pt format=imx imgsz=32 && \
-    uv pip install --system paddlepaddle x2paddle && \
+    uv pip install --system -e . --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match && \
     # Remove extra build files
-    rm -rf tmp /root/.config/Ultralytics/persistent_cache.json
+    rm -rf tmp
 
 # Usage Examples -------------------------------------------------------------------------------------------------------
 

--- a/docker/Dockerfile-python
+++ b/docker/Dockerfile-python
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Builds ultralytics/ultralytics:latest-cpu image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
+# Builds ultralytics/ultralytics:latest-python image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Image is CPU-optimized for ONNX, OpenVINO and PyTorch YOLO11 deployments
 
 # Use official Python base image for reproducibility (3.11.10 for export and 3.12.10 for inference)

--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Builds ultralytics/ultralytics:latest-python-export image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
-# Full-featured image with export capabilities for ultralytics:latest-jetson model conversion
+# Full-featured image with export capabilities for YOLO model conversion
 
 # Build from lightweight Ultralytics Python image
 FROM ultralytics/ultralytics:latest-python

--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -9,7 +9,8 @@ FROM ultralytics/ultralytics:latest-python
 # Install export-specific system packages
 # gnupg required for Edge TPU install
 # Java runtime environment (default-jre-headless) required for Sony IMX export
-RUN apt-get install -y --no-install-recommends gnupg default-jre-headless && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gnupg default-jre-headless && \
     rm -rf /var/lib/apt/lists/*
 
 # Install export dependencies and run exports to AutoInstall packages

--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -1,0 +1,39 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Builds ultralytics/ultralytics:latest-python-export image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
+# Full-featured image with export capabilities for ultralytics:latest-jetson model conversion
+
+# Build from lightweight Ultralytics Python image
+FROM ultralytics/ultralytics:latest-python
+
+# Install export-specific system packages
+# gnupg required for Edge TPU install
+# Java runtime environment (default-jre-headless) required for Sony IMX export
+RUN apt-get install -y --no-install-recommends gnupg default-jre-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install export dependencies and run exports to AutoInstall packages
+RUN uv pip install --system -e ".[export]" && \
+    # Need lower version of 'numpy' for Sony IMX export
+    uv pip install --system numpy==1.26.4 && \
+    # Run exports to AutoInstall packages
+    yolo export model=yolo11n.pt format=edgetpu imgsz=32 && \
+    yolo export model=yolo11n.pt format=ncnn imgsz=32 && \
+    yolo export model=yolo11n.pt format=imx imgsz=32 && \
+    uv pip install --system paddlepaddle x2paddle && \
+    # Remove extra build files
+    rm -rf tmp /root/.config/Ultralytics/persistent_cache.json
+
+# Usage Examples -------------------------------------------------------------------------------------------------------
+
+# Build and Push
+# t=ultralytics/ultralytics:latest-python-export && sudo docker build -f docker/Dockerfile-python-export -t $t . && sudo docker push $t
+
+# Run
+# t=ultralytics/ultralytics:latest-python-export && sudo docker run -it --ipc=host $t
+
+# Pull and Run
+# t=ultralytics/ultralytics:latest-python-export && sudo docker pull $t && sudo docker run -it --ipc=host $t
+
+# Pull and Run with local volume mounted
+# t=ultralytics/ultralytics:latest-python-export && sudo docker pull $t && sudo docker run -it --ipc=host -v "$(pwd)"/shared/datasets:/datasets $t

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Builds GitHub actions CI runner image for deployment to DockerHub https://hub.docker.com/r/ultralytics/ultralytics
-# Image is CUDA-optimized for YOLO11 single/multi-GPU training and inference tests
+# Image is CUDA-optimized for YOLO single/multi-GPU training and inference tests
 
 # Start FROM Ultralytics GPU image
 FROM ultralytics/ultralytics:latest

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.177"
+__version__ = "8.3.178"
 
 import os
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactors Docker images by splitting a lightweight Python image from a full export-capable image, updating CI to build/test them appropriately, and polishing image descriptions and tags. 🚀

### 📊 Key Changes
- Introduced Dockerfile-python-export to provide a full-featured export image (latest-python-export) with Edge TPU, NCNN, IMX, and Paddle dependencies prepped. 🧰
- Slimmed Dockerfile-python into a lightweight CPU/inference image (latest-python) without export extras. ⚡
- CI workflow updates:
  - Renamed job to “Build” and added the new python-export derivative. 🏗️
  - Tests and checks use latest-python-export when matrix tag is latest-python. ✅
- Updated image descriptions/tagging for clarity across GPU and Jetson images (JetPack 4/5/6) and generalized “YOLO11” to “YOLO”. 🏷️
- Bumped package version to 8.3.178. 🔖

### 🎯 Purpose & Impact
- Faster pulls and quicker startup for users who only need Python-based YOLO inference. 🚀
- Clear separation of concerns: lightweight inference image vs. comprehensive export image, reducing bloat and build times. 📦
- More reliable CI by testing the correct image variant for export-related functionality. 🔍
- Improved discoverability and consistency on DockerHub through clearer tags and descriptions, including Jetson variants. 🧭
- Overall smoother deployment and better user experience for both inference and model conversion workflows. ✅