### PR TITLE
SBOM uv sync fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v6
-      - run: uv pip install --system click==8.2.1 && uv sync
+      - run: uv pip install -e .
         env:
           UV_PROJECT_ENVIRONMENT: sbom-env
       - uses: anchore/sbom-action@v0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,6 +104,7 @@ jobs:
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v6
+      - run: uv pip install --system click==8.2.1
       - run: uv sync
         env:
           UV_PROJECT_ENVIRONMENT: sbom-env

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,8 +104,7 @@ jobs:
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v6
-      - run: uv pip install --system click==8.2.1
-      - run: uv sync
+      - run: uv pip install --system click==8.2.1 && uv sync
         env:
           UV_PROJECT_ENVIRONMENT: sbom-env
       - uses: anchore/sbom-action@v0


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switches the SBOM generation step to install the package in editable mode with uv, improving dependency resolution during publishing workflows. 🚀

### 📊 Key Changes
- Replaces `uv sync` with `uv pip install -e .` in the GitHub Actions publish workflow for the SBOM job. 🛠️

### 🎯 Purpose & Impact
- Ensures the project is installed as an editable package before SBOM creation, leading to more accurate dependency capture. ✅
- Reduces potential mismatches between the build environment and what gets analyzed for the SBOM. 🔍
- Improves reliability of release metadata and supply-chain visibility without affecting end users’ runtime experience. 🔒