### PR TITLE
chore: remove `click` version lock as 8.2.2 was yanked

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ dev = [
     "mkdocstrings[python]",
     "mkdocs-ultralytics-plugin>=0.1.26", # for meta descriptions and images, dates and authors
     "mkdocs-macros-plugin>=1.0.5", # duplicating content (i.e. export tables) in multiple places
-    "click==8.2.1", # fix MkDocs use_directory_urls bug in 8.2.2 https://github.com/ultralytics/ultralytics/issues/21568
 ]
 export = [
     "onnx>=1.12.0,<1.18.0", # ONNX export


### PR DESCRIPTION

Based on the mkdocs maintainer’s comment ([link](https://github.com/mkdocs/mkdocs/pull/4015#issuecomment-3154128948)), since Click version 8.2.2 has been yanked, we can safely remove the version lock from the pyproject.toml while maintaining Python 3.8 compatibility.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removes a pinned Click dependency from dev requirements to restore default version behavior. 🔧

### 📊 Key Changes
- Deleted click==8.2.1 from the dev extras in pyproject.toml.

### 🎯 Purpose & Impact
- Resolves a temporary pin added to work around an MkDocs bug; now allows using the latest compatible Click version. ✅
- Simplifies dependency management and reduces maintenance overhead. 🧹
- Potentially brings bug fixes and improvements from newer Click releases to development workflows. 🚀
- Minor risk: developers may see changes in CLI behavior if newer Click versions introduce breaking changes, but standard compatibility is expected. ⚠️