### PR TITLE
FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -210,15 +210,15 @@ jobs:
 
       - name: Check Environment
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags == 'latest' && 'latest-export' || matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
+        run: docker run ultralytics/ultralytics:${{ (matrix.tags == 'latest-python' && 'latest-python-export') || (matrix.tags == 'latest' && 'latest-export') || matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
 
       - name: Run Tests
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags == 'latest' && 'latest-export' || matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
+        run: docker run ultralytics/ultralytics:${{ (matrix.tags == 'latest-python' && 'latest-python-export') || (matrix.tags == 'latest' && 'latest-export') || matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
 
       - name: Run Benchmarks
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags == 'latest' && 'latest-export' || matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
+        run: docker run ultralytics/ultralytics:${{ (matrix.tags == 'latest-python' && 'latest-python-export') || (matrix.tags == 'latest' && 'latest-export') || matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
 
       - name: Push All Images
         if: github.event_name == 'push' || (github.event.inputs[matrix.dockerfile] == 'true' && github.event.inputs.push == 'true')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
             tags: "latest"
             platforms: "linux/amd64"
             runs_on: "ubuntu-latest"
-            derivatives: "Dockerfile-runner"
+            derivatives: "Dockerfile-runner,Dockerfile-export"
           - dockerfile: "Dockerfile-python"
             tags: "latest-python"
             platforms: "linux/amd64"
@@ -210,15 +210,15 @@ jobs:
 
       - name: Check Environment
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
+        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags == 'latest' && 'latest-export' || matrix.tags }} /bin/bash -c "yolo checks && uv pip list"
 
       - name: Run Tests
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
+        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags == 'latest' && 'latest-export' || matrix.tags }} /bin/bash -c "pip install pytest && pytest tests"
 
       - name: Run Benchmarks
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
+        run: docker run ultralytics/ultralytics:${{ matrix.tags == 'latest-python' && 'latest-python-export' || matrix.tags == 'latest' && 'latest-export' || matrix.tags }} yolo benchmark model=yolo11n.pt imgsz=160 verbose=0.309
 
       - name: Push All Images
         if: github.event_name == 'push' || (github.event.inputs[matrix.dockerfile] == 'true' && github.event.inputs.push == 'true')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ on:
     inputs:
       Dockerfile:
         type: boolean
-        description: Dockerfile (+ runner)
+        description: Dockerfile (+ runner, export)
         default: true
       Dockerfile-python:
         type: boolean

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,14 +22,13 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.Unicode.ttf \
     /root/.config/Ultralytics/
 
-# Install linux packages and security updates
+# Install linux packages
 # gnupg required for Edge TPU install
 # libsm6 required by libqxcb to create QT-based windows for visualization; set 'QT_DEBUG_PLUGINS=1' to test in docker
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    gcc git zip unzip wget curl htop libgl1 libglib2.0-0 libpython3-dev gnupg libsm6 && \
-    # Security updates: https://security.snyk.io/vuln/SNYK-UBUNTU1804-OPENSSL-3314796
-    apt upgrade --no-install-recommends -y openssl tar && \
+    gcc git zip unzip wget curl htop libgl1 libglib2.0-0 gnupg libsm6 && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Create working directory

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # Image is CUDA-optimized for YOLO single/multi-GPU training and inference
 
 # Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch or nvcr.io/nvidia/pytorch:25.02-py3
-FROM pytorch/pytorch:2.7.0-cuda12.6-cudnn9-runtime
+FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime
 
 # Set environment variables
 # Avoid DDP error "MKL_THREADING_LAYER=INTEL is incompatible with libgomp.so.1 library"
@@ -22,13 +22,14 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.Unicode.ttf \
     /root/.config/Ultralytics/
 
-# Install linux packages
+# Install linux packages and security updates
 # gnupg required for Edge TPU install
 # libsm6 required by libqxcb to create QT-based windows for visualization; set 'QT_DEBUG_PLUGINS=1' to test in docker
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    gcc git zip unzip wget curl htop libgl1 libglib2.0-0 gnupg libsm6 && \
-    apt-get clean && \
+    gcc git zip unzip wget curl htop libgl1 libglib2.0-0 libpython3-dev gnupg libsm6 && \
+    # Security updates: https://security.snyk.io/vuln/SNYK-UBUNTU1804-OPENSSL-3314796
+    apt upgrade --no-install-recommends -y openssl tar && \
     rm -rf /var/lib/apt/lists/*
 
 # Create working directory

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,14 +40,10 @@ RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
     sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
-# Install pip packages and run exports to AutoInstall packages
+# Install pip packages
 RUN pip install uv && \
-    uv pip install --system -e ".[export]" albumentations faster-coco-eval "onnxruntime-gpu" tensorrt wandb && \
-    # Run exports to AutoInstall packages
-    yolo export model=tmp/yolo11n.pt format=edgetpu imgsz=32 && \
-    yolo export model=tmp/yolo11n.pt format=ncnn imgsz=32 && \
-    uv pip install --system paddlepaddle x2paddle && \
-    # Remove extra build files
+    uv pip install --system -e "." albumentations faster-coco-eval wandb && \
+    # Remove extra build files \
     rm -rf tmp /root/.config/Ultralytics/persistent_cache.json
 
 # Usage Examples -------------------------------------------------------------------------------------------------------

--- a/docker/Dockerfile-export
+++ b/docker/Dockerfile-export
@@ -1,0 +1,14 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Export-optimized derivative of ultralytics/ultralytics:latest for testing and benchmarks
+# Includes all export format dependencies and pre-installed export packages
+
+FROM ultralytics/ultralytics:latest
+
+# Install export dependencies and run exports to AutoInstall packages
+RUN uv pip install --system -e ".[export]" "onnxruntime-gpu" tensorrt paddlepaddle x2paddle && \
+    # Run exports to AutoInstall packages \
+    yolo export model=yolo11n.pt format=edgetpu imgsz=32 && \
+    yolo export model=yolo11n.pt format=ncnn imgsz=32 && \
+    # Remove temporary files \
+    rm -rf tmp /root/.config/Ultralytics/persistent_cache.json

--- a/docker/Dockerfile-export
+++ b/docker/Dockerfile-export
@@ -6,7 +6,8 @@
 FROM ultralytics/ultralytics:latest
 
 # Install export dependencies and run exports to AutoInstall packages
-RUN uv pip install --system -e ".[export]" "onnxruntime-gpu" tensorrt paddlepaddle x2paddle && \
+# Numpy 1.26.4 required due to TF export bug with torch 2.8
+RUN uv pip install --system -e ".[export]" "onnxruntime-gpu" tensorrt paddlepaddle x2paddle numpy==1.26.4 && \
     # Run exports to AutoInstall packages \
     yolo export model=yolo11n.pt format=edgetpu imgsz=32 && \
     yolo export model=yolo11n.pt format=ncnn imgsz=32 && \

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -7,11 +7,7 @@
 FROM ultralytics/ultralytics:latest
 
 # Set additional environment variables for runner
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_BREAK_SYSTEM_PACKAGES=1 \
-    RUNNER_ALLOW_RUNASROOT=1 \
+ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive
 
 # Set the working directory


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds a new export-focused Docker image, updates base dependencies, and refines CI to test/export with the correct tags—improving reliability, performance, and clarity of Ultralytics Docker workflows. 🚀

### 📊 Key Changes
- Docker CI workflow
  - Clarifies input description to “Dockerfile (+ runner, export)” 📝
  - Builds derivatives for both runner and new export images: Dockerfile-runner, Dockerfile-export 🧱
  - Uses export-tagged images in checks/tests/benchmarks for both latest and latest-python (e.g., latest-export, latest-python-export) ✅
- Base Docker image
  - Upgrades base to pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime for newer CUDA/cuDNN support 🔧
  - Streamlines default image to install core packages only (drops export-time installs and heavy extras) 🧹
- New Dockerfile-export
  - Introduces an export-optimized image layering on ultralytics:latest 🧪
  - Pre-installs all export dependencies (onnxruntime-gpu, TensorRT, Paddle, etc.) and runs small exports to trigger AutoInstall 📦
  - Pins numpy==1.26.4 to avoid a TF export issue with PyTorch 2.8 🩹
- Runner image cleanup
  - Simplifies environment variables in Dockerfile-runner (keeps RUNNER_ALLOW_RUNASROOT) 🔧

### 🎯 Purpose & Impact
- Clear separation of concerns: smaller, cleaner “latest” image for general use; dedicated export image for conversion workflows ⚖️
- More reliable CI: tests run against the correct export-tagged images, reducing false failures and ensuring export coverage ✅
- Performance and compatibility: newer PyTorch/CUDA stack and targeted dependency pinning improve stability for training and export tasks ⚡
- Developer productivity: faster builds, fewer unnecessary dependencies in the base image, and easier maintenance of Docker variants 🧭