### PR TITLE
Disable GPU CI for server upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,8 @@ jobs:
         run: uv cache prune --ci
 
   GPU:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
+    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'workflow_dispatch' && github.event.inputs.gpu == 'true')
     timeout-minutes: 360
     runs-on: gpu-latest
     steps:


### PR DESCRIPTION
Server upgrades in progress

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Restricts GPU CI jobs to run only when manually triggered with the GPU option enabled, reducing unintended GPU usage in CI. ⚙️🚀

### 📊 Key Changes
- Updated CI condition for the GPU job:
  - Previously: GPU job ran by default except when workflow_dispatch was used without GPU=true.
  - Now: GPU job runs only on workflow_dispatch with gpu == 'true'.
- Commented out the old condition for clarity/reference.

### 🎯 Purpose & Impact
- Saves GPU resources and CI minutes by preventing automatic GPU runs. 💸
- Gives maintainers explicit control over when GPU tests run (manual trigger only). 🧭
- Reduces queue times and flakiness for contributors who don’t need GPU tests. ⏱️
- No impact on CPU-based CI; regular checks continue to run as before. ✅