### PR TITLE
Remove unreachable code in `get_save_dir()`

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -388,7 +388,7 @@ def get_save_dir(args: SimpleNamespace, name: str = None) -> Path:
 
     Args:
         args (SimpleNamespace): Namespace object containing configurations such as 'project', 'name', 'task',
-            'mode', and 'save_dir'.
+            and 'mode'.
         name (str | None): Optional name for the output directory. If not provided, it defaults to 'args.name'
             or the 'args.mode'.
 
@@ -402,14 +402,11 @@ def get_save_dir(args: SimpleNamespace, name: str = None) -> Path:
         >>> print(save_dir)
         my_project/detect/train
     """
-    if getattr(args, "save_dir", None):
-        save_dir = args.save_dir
-    else:
-        from ultralytics.utils.files import increment_path
+    from ultralytics.utils.files import increment_path
 
-        project = args.project or (ROOT.parent / "tests/tmp/runs" if TESTS_RUNNING else RUNS_DIR) / args.task
-        name = name or args.name or f"{args.mode}"
-        save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True)
+    project = args.project or (ROOT.parent / "tests/tmp/runs" if TESTS_RUNNING else RUNS_DIR) / args.task
+    name = name or args.name or f"{args.mode}"
+    save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True)
 
     return Path(save_dir)
 


### PR DESCRIPTION
`save_dir` isn't a valid argument, so we never have `save_dir` in `args`

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplifies how output save directories are determined by always using a consistent path-generation flow, removing a special-case override.

### 📊 Key Changes
- Streamlined get_save_dir logic to always compute the save path using increment_path.
- Removed reliance on a pre-set args.save_dir override.
- Minor docstring cleanup (removed mention of 'save_dir' from args description).

### 🎯 Purpose & Impact
- More predictable run directory structure across tasks and modes ✅
- Reduces edge cases and potential confusion from manually provided save_dir values 🧹
- Ensures consistent behavior in distributed and testing environments 🧪
- Potential breaking change for users who relied on args.save_dir being respected; they may need to adjust workflows 🔧