### PR TITLE
`ultralytics 8.3.180` new `inference_features` method for SAM models

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.179"
+__version__ = "8.3.180"
 
 import os
 

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -647,6 +647,7 @@ class Predictor(BasePredictor):
 
         return new_masks[keep].to(device=masks.device, dtype=masks.dtype), keep
 
+    @smart_inference_mode()
     def inference_features(
         self,
         features,

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -252,6 +252,7 @@ class Predictor(BasePredictor):
             masks (List[np.ndarray] | np.ndarray | None): Masks for the objects, where each mask is a 2D array.
             multimask_output (bool): Flag to return multiple masks for ambiguous prompts.
             img_idx (int): Index of the image in the batch to process.
+
         Returns:
             pred_masks (torch.Tensor): Output masks with shape (C, H, W), where C is the number of generated masks.
             pred_scores (torch.Tensor): Quality scores for each mask, with length C.
@@ -815,6 +816,7 @@ class SAM2Predictor(Predictor):
             masks (List[np.ndarray] | np.ndarray | None): Masks for the objects, where each mask is a 2D array.
             multimask_output (bool): Flag to return multiple masks for ambiguous prompts.
             img_idx (int): Index of the image in the batch to process.
+
         Returns:
             pred_masks (torch.Tensor): Output masks with shape (C, H, W), where C is the number of generated masks.
             pred_scores (torch.Tensor): Quality scores for each mask, with length C.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -242,7 +242,8 @@ class Predictor(BasePredictor):
         masks=None,
         multimask_output=False,
     ):
-        """Perform inference on image features using the SAM model.
+        """
+        Perform inference on image features using the SAM model.
 
         Args:
             features (dict): Extracted image features from the SAM2 model.
@@ -807,7 +808,8 @@ class SAM2Predictor(Predictor):
         multimask_output=False,
         img_idx=-1,
     ):
-        """Perform inference on image features using the SAM2 model.
+        """
+        Perform inference on image features using the SAM2 model.
 
         Args:
             features (dict): Extracted image features from the SAM2 model.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -246,7 +246,7 @@ class Predictor(BasePredictor):
         Perform inference on image features using the SAM model.
 
         Args:
-            features (dict): Extracted image features from the SAM2 model.
+            features (torch.Tensor): Extracted image features with shape (B, C, H, W) from the SAM model image encoder.
             bboxes (np.ndarray | List[List[float]] | None): Bounding boxes in XYXY format with shape (N, 4).
             points (np.ndarray | List[List[float]] | None): Object location points with shape (N, 2), in pixels.
             labels (np.ndarray | List[int] | None): Point prompt labels with shape (N,). 1 = foreground, 0 = background.
@@ -813,7 +813,9 @@ class SAM2Predictor(Predictor):
         Perform inference on image features using the SAM2 model.
 
         Args:
-            features (dict): Extracted image features from the SAM2 model.
+            features (Dict[str, Any]): Extracted image information from the SAM2 model image encoder, it's a dictionary including:
+                image_embed (torch.Tensor): Image embedding with shape (B, C, H, W).
+                high_res_feats (List[torch.Tensor]): List of high-resolution feature maps from the backbone, each with shape (B, C, H, W).
             points (np.ndarray | List[List[float]] | None): Object location points with shape (N, 2), in pixels.
             labels (np.ndarray | List[int] | None): Point prompt labels with shape (N,). 1 = foreground, 0 = background.
             masks (List[np.ndarray] | np.ndarray | None): Masks for the objects, where each mask is a 2D array.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -279,8 +279,8 @@ class Predictor(BasePredictor):
         Prepare and transform the input prompts for processing based on the destination shape.
 
         Args:
-            dst_shape (tuple): The target shape (height, width) for the prompts.
-            src_shape (tuple): The source shape (height, width) of the input image.
+            dst_shape (Tuple[int, int]): The target shape (height, width) for the prompts.
+            src_shape (Tuple[int, int]): The source shape (height, width) of the input image.
             bboxes (np.ndarray | List | None): Bounding boxes in XYXY format with shape (N, 4).
             points (np.ndarray | List | None): Points indicating object locations with shape (N, 2) or (N, num_points, 2), in pixels.
             labels (np.ndarray | List | None): Point prompt labels with shape (N) or (N, num_points). 1 for foreground, 0 for background.
@@ -663,8 +663,8 @@ class Predictor(BasePredictor):
 
         Args:
             features (torch.Tensor | Dict[str, Any]): Extracted image features from the SAM/SAM2 model image encoder.
-            src_shape (Tuple(int, int)): The source shape (height, width) of the input image.
-            dst_shape (Tuple(int, int) | None): The target shape (height, width) for the prompts. If None, defaults to (imgsz, imgsz).
+            src_shape (Tuple[int, int]): The source shape (height, width) of the input image.
+            dst_shape (Tuple[int, int] | None): The target shape (height, width) for the prompts. If None, defaults to (imgsz, imgsz).
             bboxes (np.ndarray | List[List[float]] | None): Bounding boxes in xyxy format with shape (N, 4).
             points (np.ndarray | List[List[float]] | None): Points indicating object locations with shape (N, 2), in pixels.
             labels (np.ndarray | List[int] | None): Point prompt labels with shape (N, ).
@@ -741,8 +741,8 @@ class SAM2Predictor(Predictor):
         Prepare and transform the input prompts for processing based on the destination shape.
 
         Args:
-            dst_shape (tuple): The target shape (height, width) for the prompts.
-            src_shape (tuple): The source shape (height, width) of the input image.
+            dst_shape (Tuple[int, int]): The target shape (height, width) for the prompts.
+            src_shape (Tuple[int, int]): The source shape (height, width) of the input image.
             bboxes (np.ndarray | List | None): Bounding boxes in XYXY format with shape (N, 4).
             points (np.ndarray | List | None): Points indicating object locations with shape (N, 2) or (N, num_points, 2), in pixels.
             labels (np.ndarray | List | None): Point prompt labels with shape (N,) or (N, num_points). 1 for foreground, 0 for background.
@@ -1022,7 +1022,7 @@ class SAM2VideoPredictor(SAM2Predictor):
         the masks do not overlap, which can be useful for certain applications.
 
         Args:
-            preds (tuple): The predictions from the model.
+            preds (Tuple[torch.Tensor, torch.Tensor]): The predicted masks and scores from the model.
             img (torch.Tensor): The processed image tensor.
             orig_imgs (List[np.ndarray]): The original images before processing.
 

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -659,7 +659,20 @@ class Predictor(BasePredictor):
         masks=None,
         multimask_output=False,
     ):
-        """Perform prompts preprocessing and inference on provided image features using the SAM model."""
+        """Perform prompts preprocessing and inference on provided image features using the SAM model.
+
+        Args:
+            features (torch.Tensor | Dict[str, Any]): Extracted image features from the SAM/SAM2 model image encoder.
+            src_shape (Tuple(int, int)): The source shape (height, width) of the input image.
+            dst_shape (Tuple(int, int) | None): The target shape (height, width) for the prompts. If None, defaults to (imgsz, imgsz).
+            bboxes (np.ndarray | List[List[float]] | None): Bounding boxes in xyxy format with shape (N, 4).
+            points (np.ndarray | List[List[float]] | None): Points indicating object locations with shape (N, 2), in pixels.
+            labels (np.ndarray | List[int] | None): Point prompt labels with shape (N, ).
+            masks (List[np.ndarray] | np.ndarray | None): Masks for the objects, where each mask is a 2D array.
+            multimask_output (bool): Flag to return multiple masks for ambiguous prompts.
+        Notes:
+            features is a torch.Tensor of shape (B, C, H, W) if performing on SAM, or a Dict[str, Any] if performing on SAM2.
+        """
         dst_shape = dst_shape or (self.args.imgsz, self.args.imgsz)
         prompts = self._prepare_prompts(dst_shape, src_shape, bboxes, points, labels, masks)
         pred_masks, pred_scores = self._inference_features(features, *prompts, multimask_output)

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -182,9 +182,8 @@ class Predictor(BasePredictor):
             **kwargs (Any): Additional keyword arguments.
 
         Returns:
-            pred_masks (np.ndarray): The output masks in shape (C, H, W), where C is the number of generated masks.
-            pred_scores (np.ndarray): An array of length C containing quality scores predicted by the model for each mask.
-            pred_logits (np.ndarray): Low-resolution logits of shape (C, H, W) for subsequent inference, where H=W=256.
+            pred_masks (torch.Tensor): The output masks in shape (C, H, W), where C is the number of generated masks.
+            pred_scores (torch.Tensor): An array of length C containing quality scores predicted by the model for each mask.
 
         Examples:
             >>> predictor = Predictor()
@@ -219,8 +218,8 @@ class Predictor(BasePredictor):
             multimask_output (bool): Flag to return multiple masks for ambiguous prompts.
 
         Returns:
-            pred_masks (np.ndarray): Output masks with shape (C, H, W), where C is the number of generated masks.
-            pred_scores (np.ndarray): Quality scores predicted by the model for each mask, with length C.
+            pred_masks (torch.Tensor): Output masks with shape (C, H, W), where C is the number of generated masks.
+            pred_scores (torch.Tensor): Quality scores predicted by the model for each mask, with length C.
 
         Examples:
             >>> predictor = Predictor()
@@ -955,8 +954,8 @@ class SAM2VideoPredictor(SAM2Predictor):
             masks (np.ndarray, optional): Low-resolution masks from previous predictions shape (N,H,W). For SAM H=W=256.
 
         Returns:
-            pred_masks (np.ndarray): The output masks in shape CxHxW, where C is the number of generated masks.
-            pred_scores (np.ndarray): An array of length C containing quality scores predicted by the model for each mask.
+            pred_masks (torch.Tensor): The output masks in shape CxHxW, where C is the number of generated masks.
+            pred_scores (torch.Tensor): An array of length C containing quality scores predicted by the model for each mask.
         """
         # Override prompts if any stored in self.prompts
         bboxes = self.prompts.pop("bboxes", bboxes)

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -670,8 +670,14 @@ class Predictor(BasePredictor):
             labels (np.ndarray | List[int] | None): Point prompt labels with shape (N, ).
             masks (List[np.ndarray] | np.ndarray | None): Masks for the objects, where each mask is a 2D array.
             multimask_output (bool): Flag to return multiple masks for ambiguous prompts.
+
+        Returns:
+            pred_masks (torch.Tensor): The output masks in shape (C, H, W), where C is the number of generated masks.
+            pred_bboxes (torch.Tensor): Bounding boxes for each mask with shape (N, 6), where N is the number of boxes.
+                Each box is in xyxy format with additional columns for score and class.
+
         Notes:
-            features is a torch.Tensor of shape (B, C, H, W) if performing on SAM, or a Dict[str, Any] if performing on SAM2.
+            - The input features is a torch.Tensor of shape (B, C, H, W) if performing on SAM, or a Dict[str, Any] if performing on SAM2.
         """
         dst_shape = dst_shape or (self.args.imgsz, self.args.imgsz)
         prompts = self._prepare_prompts(dst_shape, src_shape, bboxes, points, labels, masks)

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -659,7 +659,8 @@ class Predictor(BasePredictor):
         masks=None,
         multimask_output=False,
     ):
-        """Perform prompts preprocessing and inference on provided image features using the SAM model.
+        """
+        Perform prompts preprocessing and inference on provided image features using the SAM model.
 
         Args:
             features (torch.Tensor | Dict[str, Any]): Extracted image features from the SAM/SAM2 model image encoder.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactors SAM/SAM2 predictors to support direct feature-based inference, standardizes tensor outputs, and improves prompt scaling and API clarity. 🚀

### 📊 Key Changes
- Version bump to 8.3.180.
- Standardized return types: masks and scores now return torch.Tensor instead of numpy arrays.
- New feature-based inference APIs:
  - Added _inference_features for SAM and SAM2 to run decoding directly from image features.
  - Added public inference_features method to preprocess prompts, run inference on features, and output masks and xyxy boxes with scores.
- Prompt preparation enhanced:
  - _prepare_prompts now takes both src_shape and dst_shape for accurate scaling.
  - Call sites updated to pass source and destination shapes explicitly.
- SAM2 cleanup and consistency:
  - Removed SAM2Predictor.prompt_inference duplicate path; logic moved into shared feature-based method.
  - Unified postprocess type hints and documentation.
- Output enhancements:
  - inference_features scales masks back to source image size, binarizes by mask threshold, and derives bounding boxes with scores.
  - Adds placeholder class indices for consistency in box outputs.

### 🎯 Purpose & Impact
- More flexible pipelines: Users can compute features once and run multiple prompt inferences efficiently, enabling advanced workflows and lower latency for interactive segmentation. ⚡
- Consistent, PyTorch-friendly outputs: Easier integration with downstream torch-based code and batched processing.
- More accurate prompt handling: Explicit src/dst shape handling ensures correct scaling across different image sizes. 🎯
- Cleaner API surface: Reduced duplication between SAM and SAM2, clearer method responsibilities, and improved docs.
- Better post-processing: Ready-to-use masks and boxes (with scores) simplify application integration and visualization. 🧰