### PR TITLE
Ensure independent tracker IDs for multiple trackers

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -125,3 +125,4 @@ cfg: # (str, optional) for overriding defaults.yaml
 
 # Tracker settings ------------------------------------------------------------------------------------------------------
 tracker: botsort.yaml # (str) tracker type, choices=[botsort.yaml, bytetrack.yaml]
+independent_trackers: False # (bool) whether to use independent track mode, which enables separate track ids for different trackers

--- a/ultralytics/cfg/trackers/botsort.yaml
+++ b/ultralytics/cfg/trackers/botsort.yaml
@@ -20,3 +20,4 @@ proximity_thresh: 0.5 # minimum IoU for valid match with ReID
 appearance_thresh: 0.8 # minimum appearance similarity for ReID
 with_reid: False
 model: auto # uses native features if detector is YOLO else yolo11n-cls.pt
+independent_trackers: False # whether to use independent track mode, which enables separate track ids for different trackers

--- a/ultralytics/cfg/trackers/bytetrack.yaml
+++ b/ultralytics/cfg/trackers/bytetrack.yaml
@@ -11,4 +11,5 @@ new_track_thresh: 0.25 # threshold for init new track if the detection does not 
 track_buffer: 30 # buffer to calculate the time when to remove tracks
 match_thresh: 0.8 # threshold for matching tracks
 fuse_score: True # Whether to fuse confidence scores with the iou distances before matching
+independent_trackers: False # whether to use independent track mode, which enables separate track ids for different trackers
 # min_box_area: 10  # threshold for min box areas(for tracker evaluation, not used for now)

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -102,11 +102,11 @@ class BOTrack(STrack):
 
         self.mean, self.covariance = self.kalman_filter.predict(mean_state, self.covariance)
 
-    def re_activate(self, new_track: "BOTrack", frame_id: int, new_id: bool = False) -> None:
+    def re_activate(self, new_track: "BOTrack", frame_id: int, track_id_count: int, new_id: bool = False) -> None:
         """Reactivate a track with updated features and optionally assign a new ID."""
         if new_track.curr_feat is not None:
             self.update_features(new_track.curr_feat)
-        super().re_activate(new_track, frame_id, new_id)
+        super().re_activate(new_track, frame_id, track_id_count, new_id)
 
     def update(self, new_track: "BOTrack", frame_id: int) -> None:
         """Update the track with new detection information and the current frame ID."""

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -122,10 +122,13 @@ class STrack(BaseTrack):
                 stracks[i].mean = mean
                 stracks[i].covariance = cov
 
-    def activate(self, kalman_filter: KalmanFilterXYAH, frame_id: int):
+    def activate(self, kalman_filter: KalmanFilterXYAH, frame_id: int, track_id_count: int):
         """Activate a new tracklet using the provided Kalman filter and initialize its state and covariance."""
         self.kalman_filter = kalman_filter
-        self.track_id = self.next_id()
+        if track_id_count is None:
+            self.track_id = self.next_id()
+        else:
+            self.track_id = track_id_count
         self.mean, self.covariance = self.kalman_filter.initiate(self.convert_coords(self._tlwh))
 
         self.tracklet_len = 0
@@ -135,7 +138,7 @@ class STrack(BaseTrack):
         self.frame_id = frame_id
         self.start_frame = frame_id
 
-    def re_activate(self, new_track: "STrack", frame_id: int, new_id: bool = False):
+    def re_activate(self, new_track: "STrack", frame_id: int, track_id_count: int, new_id: bool = False):
         """Reactivate a previously lost track using new detection data and update its state and attributes."""
         self.mean, self.covariance = self.kalman_filter.update(
             self.mean, self.covariance, self.convert_coords(new_track.tlwh)
@@ -145,7 +148,10 @@ class STrack(BaseTrack):
         self.is_activated = True
         self.frame_id = frame_id
         if new_id:
-            self.track_id = self.next_id()
+            if track_id_count is None:
+                self.track_id = self.next_id()
+            else:
+                self.track_id = track_id_count
         self.score = new_track.score
         self.cls = new_track.cls
         self.angle = new_track.angle
@@ -251,6 +257,7 @@ class BYTETracker:
         args (Namespace): Command-line arguments.
         max_time_lost (int): The maximum frames for a track to be considered as 'lost'.
         kalman_filter (KalmanFilterXYAH): Kalman Filter object.
+        track_id_count (Optional[int]): Counter for unique track IDs, None if independent_trackers are not used.
 
     Methods:
         update: Update object tracker with new detections.
@@ -292,7 +299,11 @@ class BYTETracker:
         self.args = args
         self.max_time_lost = int(frame_rate / 30.0 * args.track_buffer)
         self.kalman_filter = self.get_kalmanfilter()
-        self.reset_id()
+        if not args.independent_trackers:
+            self.reset_id()
+            self.track_id_count = None
+        else:
+            self.track_id_count = 0
 
     def update(self, results, img: Optional[np.ndarray] = None, feats: Optional[np.ndarray] = None) -> np.ndarray:
         """Update the tracker with new detections and return the current list of tracked objects."""
@@ -347,7 +358,7 @@ class BYTETracker:
                 track.update(det, self.frame_id)
                 activated_stracks.append(track)
             else:
-                track.re_activate(det, self.frame_id, new_id=False)
+                track.re_activate(det, self.frame_id, self.track_id_count, new_id=False)
                 refind_stracks.append(track)
         # Step 3: Second association, with low score detection boxes association the untrack to the low score detections
         detections_second = self.init_track(results_second, feats_second)
@@ -362,7 +373,7 @@ class BYTETracker:
                 track.update(det, self.frame_id)
                 activated_stracks.append(track)
             else:
-                track.re_activate(det, self.frame_id, new_id=False)
+                track.re_activate(det, self.frame_id, self.track_id_count, new_id=False)
                 refind_stracks.append(track)
 
         for it in u_track:
@@ -386,7 +397,9 @@ class BYTETracker:
             track = detections[inew]
             if track.score < self.args.new_track_thresh:
                 continue
-            track.activate(self.kalman_filter, self.frame_id)
+            if self.track_id_count is not None:
+                self.track_id_count += 1
+            track.activate(self.kalman_filter, self.frame_id, self.track_id_count)
             activated_stracks.append(track)
         # Step 5: Update state
         for track in self.lost_stracks:

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -40,6 +40,8 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
     if cfg.tracker_type not in {"bytetrack", "botsort"}:
         raise AssertionError(f"Only 'bytetrack' and 'botsort' are supported for now, but got '{cfg.tracker_type}'")
 
+    cfg.independent_trackers = predictor.args.independent_trackers
+
     predictor._feats = None  # reset in case used earlier
     if hasattr(predictor, "_hook"):
         predictor._hook.remove()


### PR DESCRIPTION
Problem:
The current .track() implementation has two issues when multiple models or trackers are used concurrently:

When two models are loaded and .track() is called for each, the track_id of one model affects the other. For example,if two models are loaded and suppose if the first model reaches track_id=50 and then the second model begins to get trackable objects, a new object in the second model will incorrectly receive track_id=51 instead of 1.

If a second model is loaded after some time while the first model’s .track() is running, the shared reset_id in BaseTrack can reset the first model’s IDs, causing unexpected behavior.

Solution:
Each tracker now maintains a separate track_id counter. A new flag, independent_trackers, allows users to choose the behavior:

True → Each tracker uses its own ID counter, ensuring independent tracking across models.

False → Follows the old behavior, where IDs continue globally across trackers.

This preserves backward compatibility while enabling truly independent multi-model tracking.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds an “independent trackers” mode to BYTETracker and BoT-SORT, enabling separate, per-tracker ID sequences for multi-tracker setups.

### 📊 Key Changes
- New config option: independent_trackers in default.yaml and tracker YAMLs (botsort.yaml, bytetrack.yaml), default False.
- BYTETracker updated to manage ID assignment:
  - track_id_count introduced to control ID sequences.
  - activate/re_activate now accept track_id_count to set IDs deterministically when independent mode is on.
  - When independent_trackers is True, IDs increment locally per tracker; otherwise, legacy global ID behavior remains.
- BoT-SORT re_activate signature updated to pass through track_id_count.
- Tracker init wires predictor args to tracker config for independent mode.

### 🎯 Purpose & Impact
- Better multi-tracker workflows 🚦: Each tracker can maintain its own ID space, preventing cross-tracker ID collisions.
- Backward compatible ✅: Defaults preserve current behavior; no changes needed unless you opt in.
- More predictable ID management 🔢: Useful for applications merging results from different trackers or running parallel trackers on separate streams.