### PR TITLE
YOLOE: Fix visual prompt `predictor` not switching after initialization

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,8 +406,9 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            if not self.predictor or type(self.predictor) is not (predictor or yolo.yoloe.YOLOEVPDetectPredictor):
-                self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
+            predictor = predictor or yolo.yoloe.YOLOEVPDetectPredictor
+            if type(self.predictor) is not predictor:
+                self.predictor = predictor(
                     overrides={
                         "task": self.model.task,
                         "mode": "predict",

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,9 +406,7 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            if type(self.predictor) is not (
-                predictor or type(self.predictor) if self.predictor else yolo.yoloe.YOLOEVPDetectPredictor
-            ):
+            if not (type(self.predictor) and type(self.predictor) is (predictor or yolo.yoloe.YOLOEVPDetectPredictor)):
                 self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
                     overrides={
                         "task": self.model.task,

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,7 +406,7 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            if not (self.predictor and type(self.predictor) is (predictor or yolo.yoloe.YOLOEVPDetectPredictor)):
+            if not self.predictor or type(self.predictor) is not (predictor or yolo.yoloe.YOLOEVPDetectPredictor):
                 self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
                     overrides={
                         "task": self.model.task,

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,7 +406,7 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            if not isinstance(self.predictor, yolo.yoloe.YOLOEVPDetectPredictor):
+            if not isinstance(self.predictor, (predictor or yolo.yoloe.YOLOEVPDetectPredictor)):
                 self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
                     overrides={
                         "task": self.model.task,

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,7 +406,11 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            predictor = type(self.predictor) if isinstance(predictor, yolo.yoloe.YOLOEVPDetectPredictor) else yolo.yoloe.YOLOEVPDetectPredictor
+            predictor = (
+                type(self.predictor)
+                if isinstance(predictor, yolo.yoloe.YOLOEVPDetectPredictor)
+                else yolo.yoloe.YOLOEVPDetectPredictor
+            )
             if type(self.predictor) is not predictor:
                 self.predictor = predictor(
                     overrides={

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,7 +406,7 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            if not (type(self.predictor) and type(self.predictor) is (predictor or yolo.yoloe.YOLOEVPDetectPredictor)):
+            if not (self.predictor and type(self.predictor) is (predictor or yolo.yoloe.YOLOEVPDetectPredictor)):
                 self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
                     overrides={
                         "task": self.model.task,

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -370,7 +370,7 @@ class YOLOE(Model):
         stream: bool = False,
         visual_prompts: Dict[str, List] = {},
         refer_image=None,
-        predictor=None,
+        predictor=yolo.yoloe.YOLOEVPDetectPredictor,
         **kwargs,
     ):
         """
@@ -406,7 +406,6 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            predictor = predictor or yolo.yoloe.YOLOEVPDetectPredictor
             if type(self.predictor) is not predictor:
                 self.predictor = predictor(
                     overrides={

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,8 +406,9 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            if type(self.predictor) is not (predictor or yolo.yoloe.YOLOEVPDetectPredictor):
-                self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
+            predictor = type(self.predictor) if isinstance(predictor, yolo.yoloe.YOLOEVPDetectPredictor) else yolo.yoloe.YOLOEVPDetectPredictor
+            if type(self.predictor) is not predictor:
+                self.predictor = predictor(
                     overrides={
                         "task": self.model.task,
                         "mode": "predict",

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,7 +406,7 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            if not isinstance(self.predictor, (predictor or yolo.yoloe.YOLOEVPDetectPredictor)):
+            if type(self.predictor) is not (predictor or yolo.yoloe.YOLOEVPDetectPredictor):
                 self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
                     overrides={
                         "task": self.model.task,

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,7 +406,9 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            if type(self.predictor) is not (predictor or type(self.predictor) if self.predictor else yolo.yoloe.YOLOEVPDetectPredictor):
+            if type(self.predictor) is not (
+                predictor or type(self.predictor) if self.predictor else yolo.yoloe.YOLOEVPDetectPredictor
+            ):
                 self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
                     overrides={
                         "task": self.model.task,

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -406,13 +406,8 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
-            predictor = (
-                type(self.predictor)
-                if isinstance(predictor, yolo.yoloe.YOLOEVPDetectPredictor)
-                else yolo.yoloe.YOLOEVPDetectPredictor
-            )
-            if type(self.predictor) is not predictor:
-                self.predictor = predictor(
+            if type(self.predictor) is not (predictor or type(self.predictor) if self.predictor else yolo.yoloe.YOLOEVPDetectPredictor):
+                self.predictor = (predictor or yolo.yoloe.YOLOEVPDetectPredictor)(
                     overrides={
                         "task": self.model.task,
                         "mode": "predict",


### PR DESCRIPTION
Reported at https://github.com/ultralytics/ultralytics/issues/21581#issuecomment-3197854471

**MRE**
```python
import numpy as np

from ultralytics import YOLOE
from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor, YOLOEVPDetectPredictor

# Initialize a YOLOE model
model = YOLOE("yoloe-11l-seg.pt")

# Define visual prompts using bounding boxes and their corresponding class IDs.
# Each box highlights an example of the object you want the model to detect.
visual_prompts = dict(
    bboxes=np.array(
        [
            [221.52, 405.8, 344.98, 857.54],  # Box enclosing person
            [120, 425, 160, 445],  # Box enclosing glasses
        ],
    ),
    cls=np.array(
        [
            0,  # ID to be assigned for person
            1,  # ID to be assigned for glassses
        ]
    ),
)

# Run inference on an image, using the provided visual prompts as guidance
results = model.predict(
    "ultralytics/assets/bus.jpg",
    visual_prompts=visual_prompts,
    predictor=YOLOEVPSegPredictor,
)

results = model.predict(
    "ultralytics/assets/bus.jpg",
    visual_prompts=visual_prompts,
    predictor=YOLOEVPDetectPredictor,
)

assert type(model.predictor) is YOLOEVPDetectPredictor, f"Passed YOLOEVPDetectPredictor, but model.predictor is {type(model.predictor)}"

# Check if the predictor gets reinitialized
p = model.predictor
results = model.predict(
    "ultralytics/assets/bus.jpg",
    visual_prompts=visual_prompts,
    predictor=YOLOEVPDetectPredictor,
)
assert model.predictor is p, f"Passed same predictor type as last run, but model.predictor was reintialized"
```


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Default and selection logic updated for the visual-prompt detection predictor to ensure the correct predictor is used consistently ✅

### 📊 Key Changes
- Sets the default predictor to yolo.yoloe.YOLOEVPDetectPredictor for predict() when using visual prompts.
- Simplifies the predictor initialization check from isinstance to a direct type comparison, and always instantiates using the provided predictor class.

### 🎯 Purpose & Impact
- Ensures the correct visual-prompt detection predictor is used by default, reducing misconfiguration issues 🛠️
- Provides more predictable behavior by consistently re-instantiating the specified predictor class 🔁
- Likely improves stability and correctness in visual-prompt workflows, benefiting users leveraging visual prompts in YOLO models 🎯