### PR TITLE
Fix YOLOE prompt-free validation example in docs

### DIFF
--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -448,10 +448,10 @@ Model validation on a dataset is streamlined as follows:
         from ultralytics import YOLOE
 
         # Create a YOLOE model
-        model = YOLOE("yoloe-11l-seg.pt")  # or select yoloe-11s/m-seg.pt for different sizes
+        model = YOLOE("yoloe-11l-seg-pf.pt")  # or select yoloe-11s/m-seg-pf.pt for different sizes
 
         # Conduct model validation on the COCO128-seg example dataset
-        metrics = model.val(data="coco128-seg.yaml")
+        metrics = model.val(data="coco128-seg.yaml",single_cls=True)
         ```
 
 ### Export Usage

--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -451,7 +451,7 @@ Model validation on a dataset is streamlined as follows:
         model = YOLOE("yoloe-11l-seg-pf.pt")  # or select yoloe-11s/m-seg-pf.pt for different sizes
 
         # Conduct model validation on the COCO128-seg example dataset
-        metrics = model.val(data="coco128-seg.yaml",single_cls=True)
+        metrics = model.val(data="coco128-seg.yaml", single_cls=True)
         ```
 
 ### Export Usage

--- a/ultralytics/models/yolo/yoloe/val.py
+++ b/ultralytics/models/yolo/yoloe/val.py
@@ -181,7 +181,7 @@ class YOLOEDetectValidator(DetectionValidator):
         else:
             if refer_data is not None:
                 assert load_vp, "Refer data is only used for visual prompt validation."
-            self.device = select_device(self.args.device)
+            self.device = select_device(self.args.device, verbose=False)
 
             if isinstance(model, (str, Path)):
                 from ultralytics.nn.tasks import attempt_load_weights


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Docs and minor code tweaks for YOLOE: correct model checkpoints, clearer validation example, and quieter device selection logging. ✅

### 📊 Key Changes
- Updated docs to use the correct YOLOE segmentation weights: `yoloe-11l-seg-pf.pt` (and `yoloe-11s/m-seg-pf.pt`). 📚
- Validation example now includes `single_cls=True` for class-agnostic evaluation in the snippet. 🧪
- Suppressed device selection logs in YOLOE validation by calling `select_device(..., verbose=False)`. 🤫

### 🎯 Purpose & Impact
- Ensures users load the right pretrained weights, reducing confusion and errors. 🔒
- Provides a more accurate, ready-to-run validation example for common setups. 🚀
- Produces cleaner console/CI output during validation runs, improving usability and readability. 🧹

See the Ultralytics Docs for details.