### PR TITLE
Fix TensorFlow export with `onnx>=1.18.0`

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -208,6 +208,9 @@ priytosh.revolution@live.com:
 rulosanti@gmail.com:
   avatar: null
   username: null
+shuai.lyu@foxmail.com:
+  avatar: https://avatars.githubusercontent.com/u/31230805?v=4
+  username: ShuaiLYU
 shuizhuyuanluo@126.com:
   avatar: https://avatars.githubusercontent.com/u/171016?v=4
   username: nihui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ export = [
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
-    "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflow>=2.0.0,<=2.19.1", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
 export = [
     "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
-    "onnx>=1.12.0,<1.19.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
+    "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,8 @@ dev = [
 ]
 export = [
     "numpy<2.0.0", # TF 2.20 compatibility
-    "onnx>=1.12.0", # ONNX export
+    "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
+    "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,7 @@ dev = [
 ]
 export = [
     "numpy<2.0.0", # TF 2.20 compatibility
-    "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
-    "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",
+    "onnx>=1.12.0", # ONNX export
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
 ]
 export = [
     "numpy<2.0.0", # TF 2.20 compatibility
-    "onnx>=1.12.0,<1.18.0", # ONNX export
+    "onnx>=1.12.0", # ONNX export
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,7 @@ dev = [
 ]
 export = [
     "numpy<2.0.0", # TF 2.20 compatibility
-    "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
-    "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",
+    "onnx>=1.12.0", # ONNX export
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ export = [
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
-    "tensorflow>=2.0.0,<=2.19.1", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
 export = [
     "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
-    "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
+    "onnx>=1.12.0,<1.19.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
 ]
 export = [
     "numpy<2.0.0", # TF 2.20 compatibility
-    "onnx>=1.12.0", # ONNX export
+    "onnx>=1.12.0,<1.18.0", # ONNX export
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,8 @@ dev = [
 ]
 export = [
     "numpy<2.0.0", # TF 2.20 compatibility
-    "onnx>=1.12.0", # ONNX export
+    "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
+    "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1004,12 +1004,13 @@ class Exporter:
                 np_data = [["images", tmp_file, [[[[0, 0, 0]]]], [[[[255, 255, 255]]]]]]
 
         import onnx2tf  # scoped for after ONNX export for reduced conflict during import
+        import onnx
 
         LOGGER.info(f"{prefix} starting TFLite export with onnx2tf {onnx2tf.__version__}...")
         keras_model = onnx2tf.convert(
             input_onnx_file_path=f_onnx,
             output_folder_path=str(f),
-            not_use_onnxsim=True,
+            not_use_onnxsim=False if check_version(onnx.__version__, "1.18.0") else True,  # export error with onnx==1.18.0
             verbosity="error",  # note INT8-FP16 activation bug https://github.com/ultralytics/ultralytics/issues/15873
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -582,7 +582,7 @@ class Exporter:
     @try_export
     def export_onnx(self, prefix=colorstr("ONNX:")):
         """Export YOLO model to ONNX format."""
-        requirements = ["onnx>=1.12.0,<1.18.0"]
+        requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
             requirements += ["onnxslim>=0.1.59", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1009,7 +1009,7 @@ class Exporter:
         keras_model = onnx2tf.convert(
             input_onnx_file_path=f_onnx,
             output_folder_path=str(f),
-            not_use_onnxsim=True,
+            not_use_onnxsim=False if MACOS else True,
             verbosity="error",  # note INT8-FP16 activation bug https://github.com/ultralytics/ultralytics/issues/15873
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1010,9 +1010,7 @@ class Exporter:
         keras_model = onnx2tf.convert(
             input_onnx_file_path=f_onnx,
             output_folder_path=str(f),
-            not_use_onnxsim=False
-            if check_version(onnx.__version__, "1.18.0")
-            else True,  # export error with onnx==1.18.0
+            not_use_onnxsim=not check_version(onnx.__version__, "1.18.0"),  # export error with onnx==1.18.0
             verbosity="error",  # note INT8-FP16 activation bug https://github.com/ultralytics/ultralytics/issues/15873
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -584,7 +584,7 @@ class Exporter:
         """Export YOLO model to ONNX format."""
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
-            requirements += ["onnxslim>=0.1.59", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
+            requirements += ["onnxslim>=0.1.65", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
         import onnx  # noqa
 
@@ -962,7 +962,7 @@ class Exporter:
                 "ai-edge-litert>=1.2.0,<1.4.0",  # required by 'onnx2tf' package
                 "onnx>=1.12.0",
                 "onnx2tf>=1.26.3",
-                "onnxslim>=0.1.59",
+                "onnxslim>=0.1.65",
                 "onnxruntime-gpu" if cuda else "onnxruntime",
                 "protobuf>=5",
             ),
@@ -1003,14 +1003,13 @@ class Exporter:
                 np.save(str(tmp_file), images.numpy().astype(np.float32))  # BHWC
                 np_data = [["images", tmp_file, [[[[0, 0, 0]]]], [[[[255, 255, 255]]]]]]
 
-        import onnx
         import onnx2tf  # scoped for after ONNX export for reduced conflict during import
 
         LOGGER.info(f"{prefix} starting TFLite export with onnx2tf {onnx2tf.__version__}...")
         keras_model = onnx2tf.convert(
             input_onnx_file_path=f_onnx,
             output_folder_path=str(f),
-            not_use_onnxsim=not check_version(onnx.__version__, "1.18.0"),  # export error with onnx==1.18.0
+            not_use_onnxsim=True,
             verbosity="error",  # note INT8-FP16 activation bug https://github.com/ultralytics/ultralytics/issues/15873
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -960,7 +960,7 @@ class Exporter:
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "ai-edge-litert>=1.2.0,<1.4.0",  # required by 'onnx2tf' package
-                "onnx>=1.12.0,<1.18.0",
+                "onnx>=1.12.0",
                 "onnx2tf>=1.26.3",
                 "onnxslim>=0.1.59",
                 "onnxruntime-gpu" if cuda else "onnxruntime",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1010,7 +1010,9 @@ class Exporter:
         keras_model = onnx2tf.convert(
             input_onnx_file_path=f_onnx,
             output_folder_path=str(f),
-            not_use_onnxsim=False if check_version(onnx.__version__, "1.18.0") else True,  # export error with onnx==1.18.0
+            not_use_onnxsim=False
+            if check_version(onnx.__version__, "1.18.0")
+            else True,  # export error with onnx==1.18.0
             verbosity="error",  # note INT8-FP16 activation bug https://github.com/ultralytics/ultralytics/issues/15873
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1003,8 +1003,8 @@ class Exporter:
                 np.save(str(tmp_file), images.numpy().astype(np.float32))  # BHWC
                 np_data = [["images", tmp_file, [[[[0, 0, 0]]]], [[[[255, 255, 255]]]]]]
 
-        import onnx2tf  # scoped for after ONNX export for reduced conflict during import
         import onnx
+        import onnx2tf  # scoped for after ONNX export for reduced conflict during import
 
         LOGGER.info(f"{prefix} starting TFLite export with onnx2tf {onnx2tf.__version__}...")
         keras_model = onnx2tf.convert(

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1009,7 +1009,7 @@ class Exporter:
         keras_model = onnx2tf.convert(
             input_onnx_file_path=f_onnx,
             output_folder_path=str(f),
-            not_use_onnxsim=False if MACOS else True,
+            not_use_onnxsim=True,
             verbosity="error",  # note INT8-FP16 activation bug https://github.com/ultralytics/ultralytics/issues/15873
             output_integer_quantized_tflite=self.args.int8,
             quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)


### PR DESCRIPTION
ONNX>=1.18 required for Python 3.13

https://community.ultralytics.com/t/speed-up-inference-time-for-the-model-trained-with-yolo12x/1384/19?u=toxite


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Eases ONNX version restrictions across platforms (except macOS) and updates ONNX simplification tooling for more reliable exports and fewer dependency conflicts. 🚀

### 📊 Key Changes
- Relaxed ONNX requirement:
  - General: `onnx>=1.12.0` (removed `<1.18.0` upper bound)
  - macOS (Darwin) only: kept `onnx<1.18.0` due to TensorFlow inference hangs
- Updated ONNX simplification dependencies:
  - Bumped `onnxslim` from `>=0.1.59` to `>=0.1.65`
  - `onnxruntime` selection remains GPU/CPU-aware based on CUDA availability
- Applied the same ONNX and `onnxslim` updates to both ONNX and TensorFlow SavedModel export paths

### 🎯 Purpose & Impact
- Fewer install conflicts on Linux/Windows by allowing newer ONNX versions ✅
- Maintains stability on macOS by pinning ONNX to avoid TF inference hangs 🛡️
- Improved export/simplify reliability and potential performance gains with newer `onnxslim` 🔧
- Smoother export workflows for YOLO models across platforms with minimal user changes 💼