### PR TITLE
Fix missing `async` functions in Docs bug

### DIFF
--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -29,9 +29,11 @@ MKDOCS_YAML = PACKAGE_DIR.parent / "mkdocs.yml"
 
 
 def extract_classes_and_functions(filepath: Path) -> tuple[list[str], list[str]]:
-    """Extract class and function names from a given Python file."""
+    """Extract top-level class and (a)sync function names from a Python file."""
     content = filepath.read_text()
-    return (re.findall(r"(?:^|\n)class\s(\w+)(?:\(|:)", content), re.findall(r"(?:^|\n)def\s(\w+)\(", content))
+    classes = re.findall(r"(?:^|\n)class\s(\w+)(?:\(|:)", content)
+    functions = re.findall(r"(?:^|\n)(?:async\s+)?def\s(\w+)\(", content)
+    return classes, functions
 
 
 def create_markdown(py_filepath: Path, module_path: str, classes: list[str], functions: list[str]) -> Path:

--- a/docs/en/reference/data/converter.md
+++ b/docs/en/reference/data/converter.md
@@ -49,4 +49,8 @@ keywords: Ultralytics, data conversion, YOLO models, COCO, DOTA, YOLO bbox2segme
 
 ## ::: ultralytics.data.converter.convert_to_multispectral
 
+<br><br><hr><br>
+
+## ::: ultralytics.data.converter.convert_ndjson_to_yolo
+
 <br><br>


### PR DESCRIPTION
Discovered by @yogendrasinghx 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves docs generation by capturing async functions in API refs and adds documentation for a new NDJSON-to-YOLO data conversion utility. 📚⚙️

### 📊 Key Changes
- Updated docs builder to extract top-level class and both sync/async function names from Python files.
- Clarified docstring for the extraction function to reflect async support.
- Added API reference entry for `ultralytics.data.converter.convert_ndjson_to_yolo` in the data converter docs.

### 🎯 Purpose & Impact
- More complete and accurate API documentation, especially for modules using `async def`. ✅
- Users can discover and reference the new NDJSON-to-YOLO conversion tool directly in the docs. 🔍
- Purely documentation-oriented changes; no runtime behavior affected. Safe upgrade. 🛡️

See the Ultralytics Docs for details.