### PR TITLE
Support reloading packages with `check_requirements()`

### DIFF
--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -356,7 +356,7 @@ def check_python(minimum: str = "3.8.0", hard: bool = True, verbose: bool = Fals
 
 
 @TryExcept()
-def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=(), install=True, cmds=""):
+def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=(), install=True, cmds="", reload=False):
     """
     Check if installed dependencies meet Ultralytics YOLO models requirements and attempt to auto-update if needed.
 
@@ -366,6 +366,7 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         exclude (tuple): Tuple of package names to exclude from checking.
         install (bool): If True, attempt to auto-update packages that don't meet requirements.
         cmds (str): Additional commands to pass to the pip install command when auto-updating.
+        reload (bool): Reload the package(s) after installation. May not work correctly for some packages.
 
     Examples:
         >>> from ultralytics.utils.checks import check_requirements
@@ -424,9 +425,15 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
                 LOGGER.info(attempt_install(s, cmds, use_uv=not ARM64 and check_uv()))
                 dt = time.time() - t
                 LOGGER.info(f"{prefix} AutoUpdate success ✅ {dt:.1f}s")
-                LOGGER.warning(
-                    f"{prefix} {colorstr('bold', 'Restart runtime or rerun command for updates to take effect')}\n"
-                )
+                if reload:
+                    import sys
+
+                    for m in pkgs:
+                        sys.modules.pop(m, None)
+                else:
+                    LOGGER.warning(
+                        f"{prefix} {colorstr('bold', 'Restart runtime or rerun command for updates to take effect')}\n"
+                    )
             except Exception as e:
                 LOGGER.warning(f"{prefix} ❌ {e}")
                 return False


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds an optional reload capability to dependency checks so newly installed packages can take effect immediately without a full restart in many cases. ⚡

### 📊 Key Changes
- New parameter: `reload` added to `check_requirements(...)`.
- When `reload=True`, the function will remove updated packages from `sys.modules` after auto-install, prompting a fresh import next use.
- If `reload=False` (default), behavior is unchanged and a restart/rerun warning is shown as before.

Minimal example:
```python
from ultralytics.utils.checks import check_requirements

# Auto-install missing/older deps and attempt in-session reload
check_requirements(reload=True)
```

### 🎯 Purpose & Impact
- Smoother workflows in notebooks and long-running sessions 🚀 — reduces the need to restart runtimes after auto-installing dependencies.
- Backward compatible ✅ — default behavior stays the same unless you opt in.
- Caveat: In-session reload may not work for all packages or complex import trees; some environments might still require a restart.  
- Overall, improves developer and user experience with faster iteration and fewer interruptions.

See the Ultralytics Docs for details: https://docs.ultralytics.com