### PR TITLE
Fix data loading in `yolo_bbox2segment`

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -613,7 +613,7 @@ def yolo_bbox2segment(
     from ultralytics.utils.ops import xywh2xyxy
 
     # NOTE: add placeholder to pass class index check
-    dataset = YOLODataset(im_dir, data=dict(names=list(range(1000))))
+    dataset = YOLODataset(im_dir, data=dict(names=list(range(1000)), channels=3))
     if len(dataset.labels[0]["segments"]) > 0:  # if it's segment data
         LOGGER.info("Segmentation labels detected, no need to generate new ones!")
         return

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -85,7 +85,7 @@ class YOLODataset(BaseDataset):
         self.use_obb = task == "obb"
         self.data = data
         assert not (self.use_segments and self.use_keypoints), "Can not use both segments and keypoints."
-        super().__init__(*args, channels=self.data["channels"], **kwargs)
+        super().__init__(*args, channels=self.data.get("channels", 3), **kwargs)
 
     def cache_labels(self, path: Path = Path("./labels.cache")) -> Dict:
         """


### PR DESCRIPTION
Closes #21771 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes dataset initialization by providing a safe default for image channels (RGB) and updates a converter utility to pass this info explicitly, preventing errors during label processing. ✅

### 📊 Key Changes
- YOLODataset now defaults to 3 channels if not specified: `channels=self.data.get("channels", 3)` 🧩
- `yolo_bbox2segment()` creates the dataset with `channels=3` in its placeholder data to avoid missing-key issues 🛠️

### 🎯 Purpose & Impact
- Prevents KeyError crashes when `data["channels"]` isn’t provided, making dataset loading more robust 👍
- Assumes RGB images by default, simplifying common use cases
- Maintains flexibility: custom datasets with non-RGB images can still specify `channels` explicitly
- Improves reliability of the bbox-to-segmentation conversion workflow

For more details, see the Ultralytics Docs.