### PR TITLE
Cleaner TQDM progress bars in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
           if [[ "${{ github.event_name }}" =~ ^(schedule|workflow_dispatch)$ ]]; then
               slow="faster-coco-eval mlflow"
           fi
-          uv pip install --system -e ".[export,solutions]" $torch $slow pytest-cov --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
+          uv pip install --system -e ".[export,solutions]" rich $torch $slow pytest-cov --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
       - name: Check environment
         run: |
           yolo checks
@@ -203,7 +203,7 @@ jobs:
           if [[ "${{ github.event_name }}" =~ ^(schedule|workflow_dispatch)$ ]]; then
               slow="--slow"
           fi
-          pytest $slow --cov=ultralytics/ --cov-report xml tests/
+          YOLO_TQDM_RICH=true pytest $slow --cov=ultralytics/ --cov-report xml tests/
       - name: Upload Coverage Reports to CodeCov
         if: github.repository == 'ultralytics/ultralytics' # && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Install requirements
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          pip install -e . pytest-cov pynvml
+          pip install -e . pytest-cov pynvml rich
           if [[ "${{ github.event_name }}" =~ ^(schedule|workflow_dispatch)$ ]]; then
             pip install tensorrt onnxruntime-gpu
           fi
@@ -241,7 +241,7 @@ jobs:
           if [[ "${{ github.event_name }}" =~ ^(schedule|workflow_dispatch)$ ]]; then
             slow="--slow"
           fi
-          pytest $slow --cov=ultralytics/ --cov-report xml tests/test_cuda.py -sv
+          YOLO_TQDM_RICH=true pytest $slow --cov=ultralytics/ --cov-report xml tests/test_cuda.py -sv
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Upload Coverage Reports to CodeCov


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enable rich-rendered progress output in CI by installing the `rich` package and toggling rich tqdm via an environment variable, improving test logs without affecting runtime behavior. ✨

### 📊 Key Changes
- Add `rich` to CI installs for both CPU and CUDA jobs.
- Run tests with `YOLO_TQDM_RICH=true` to enable rich-based tqdm output in pytest runs.
- No test logic changes; only CI workflow updates.

### 🎯 Purpose & Impact
- Clearer, more readable CI logs with rich-formatted progress bars 📈
- Consistent log formatting across CPU/GPU test jobs 🧩
- Zero impact on users or model performance; changes are CI-only ✅
- Slightly improved developer experience when reviewing CI output 🛠️