### PR TITLE
Remove `neuralmagic` blog redirect from `integration` page

### DIFF
--- a/docs/en/integrations/index.md
+++ b/docs/en/integrations/index.md
@@ -129,7 +129,7 @@ Yes, you can. Integrating [MLFlow](https://mlflow.org/) with Ultralytics models 
 
 ### What are the benefits of using Neural Magic for YOLO11 model optimization?
 
-[Neural Magic](https://neuralmagic.com/) optimizes YOLO11 models by leveraging techniques like Quantization Aware Training (QAT) and pruning, resulting in highly efficient, smaller models that perform better on resource-limited hardware. Check out the [Neural Magic](neural-magic.md) integration page to learn how to implement these optimizations for superior performance and leaner models. This is especially beneficial for deployment on edge devices where computational resources are constrained. Neural Magic's DeepSparse engine can deliver up to 6x faster inference on CPUs, making it possible to run complex models without specialized hardware.
+[Neural Magic](neural-magic.md) optimizes YOLO11 models by leveraging techniques like Quantization Aware Training (QAT) and pruning, resulting in highly efficient, smaller models that perform better on resource-limited hardware. Check out the [Neural Magic](neural-magic.md) integration page to learn how to implement these optimizations for superior performance and leaner models. This is especially beneficial for deployment on edge devices where computational resources are constrained. Neural Magic's DeepSparse engine can deliver up to 6x faster inference on CPUs, making it possible to run complex models without specialized hardware.
 
 ### How do I deploy Ultralytics YOLO models with Gradio for interactive demos?
 

--- a/docs/en/integrations/neural-magic.md
+++ b/docs/en/integrations/neural-magic.md
@@ -58,8 +58,6 @@ Neural Magic's Deep Sparse technology is inspired by the human brain's efficienc
   <img width="640" src="https://github.com/ultralytics/docs/releases/download/0/neural-magic-deepsparse-technology.avif" alt="How Neural Magic's DeepSparse Technology Works ">
 </p>
 
-For more details on how Neural Magic's DeepSparse technology works, check out [their blog post](https://neuralmagic.com/blog/how-neural-magics-deep-sparse-technology-works/).
-
 ## Creating A Sparse Version of YOLO11 Trained on a Custom Dataset
 
 [SparseZoo](https://github.com/neuralmagic/sparsezoo/blob/main/README.md), an open-source model repository by Neural Magic, offers [a collection of pre-sparsified YOLO11 model checkpoints](https://github.com/neuralmagic/sparsezoo/blob/main/README.md). With [SparseML](https://github.com/neuralmagic/sparseml), seamlessly integrated with Ultralytics, users can effortlessly fine-tune these sparse checkpoints on their specific datasets using a straightforward command-line interface.


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Docs cleanup to streamline the Neural Magic integration pages: internalized links and removed an external blog reference for a smoother reading experience. 🧭✨

### 📊 Key Changes
- Updated the first “Neural Magic” link in the Integrations FAQ to point to the internal `neural-magic.md` page instead of the external site.
- Removed an external blog link from the Neural Magic integration page to keep guidance within Ultralytics Docs.

### 🎯 Purpose & Impact
- Improves navigation and keeps users within the Ultralytics Docs for a consistent experience. 🚀
- Reduces reliance on external links that may change or break, lowering maintenance overhead. 🔧
- No changes to models, APIs, or training workflows—purely documentation polish. ✅

See the Ultralytics Docs for details: https://docs.ultralytics.com