### PR TITLE
Fix TQDM Rich bars to 10 width

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.184"
+__version__ = "8.3.185"
 
 import os
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -133,29 +133,17 @@ os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output
 if TQDM_RICH := str(os.getenv("YOLO_TQDM_RICH", False)).lower() == "true":
     from tqdm import rich
     
-    # Patch Rich Console and BarColumn for consistent behavior
+    # Patch Rich Console and BarColumn for fixed widths
     try:
         from rich.console import Console
         from rich.progress import BarColumn
         
-        # Patch Console to always use width=200
-        original_console_init = Console.__init__
+        # Force Console width=200 and BarColumn bar_width=10
+        _console_init = Console.__init__
+        _bar_init = BarColumn.__init__
         
-        def patched_console_init(self, *args, **kwargs):
-            """Patched Console.__init__ that forces width to 200."""
-            kwargs['width'] = 200
-            return original_console_init(self, *args, **kwargs)
-        
-        Console.__init__ = patched_console_init
-        
-        # Patch BarColumn to use fixed bar_width of 10
-        original_bar_column_init = BarColumn.__init__
-        
-        def patched_bar_column_init(self, bar_width=None, *args, **kwargs):
-            """Patched BarColumn.__init__ that forces bar_width to 10."""
-            return original_bar_column_init(self, bar_width=10, *args, **kwargs)
-        
-        BarColumn.__init__ = patched_bar_column_init
+        Console.__init__ = lambda self, *a, **k: _console_init(self, *a, **{**k, 'width': 200})
+        BarColumn.__init__ = lambda self, bar_width=None, *a, **k: _bar_init(self, 10, *a, **k)
         
     except ImportError:
         pass

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -133,21 +133,16 @@ os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output
 if TQDM_RICH := str(os.getenv("YOLO_TQDM_RICH", False)).lower() == "true":
     from tqdm import rich
 
-    # Patch Rich Console and BarColumn for fixed widths
-    try:
-        from rich.console import Console
-        from rich.progress import BarColumn
+    # Patch Rich Console and BarColumn for fixed widths to solve width=80 bug
+    from rich.console import Console
+    from rich.progress import BarColumn
 
-        # Force Console width=200 and BarColumn bar_width=10
-        _console_init = Console.__init__
-        _bar_init = BarColumn.__init__
+    # Force Console width=200 and BarColumn bar_width=10
+    _console_init = Console.__init__
+    _bar_init = BarColumn.__init__
 
-        Console.__init__ = lambda self, *a, **k: _console_init(self, *a, **{**k, "width": 200})
-        BarColumn.__init__ = lambda self, bar_width=None, *a, **k: _bar_init(self, 10, *a, **k)
-
-    except ImportError:
-        pass
-
+    Console.__init__ = lambda self, *a, **k: _console_init(self, *a, **{**k, "width": 200})
+    BarColumn.__init__ = lambda self, bar_width=None, *a, **k: _bar_init(self, 10, *a, **k)
 
 class TQDM(rich.tqdm if TQDM_RICH else tqdm.tqdm):
     """

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -132,6 +132,23 @@ os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output
 
 if TQDM_RICH := str(os.getenv("YOLO_TQDM_RICH", False)).lower() == "true":
     from tqdm import rich
+    
+    # Patch Rich BarColumn to use fixed bar_width of 10
+    try:
+        from rich.progress import BarColumn
+        
+        # Store original BarColumn __init__
+        original_bar_column_init = BarColumn.__init__
+        
+        def patched_bar_column_init(self, bar_width=None, *args, **kwargs):
+            """Patched BarColumn.__init__ that forces bar_width to 10."""
+            return original_bar_column_init(self, bar_width=10, *args, **kwargs)
+        
+        # Replace BarColumn.__init__ with our patched version
+        BarColumn.__init__ = patched_bar_column_init
+        
+    except ImportError:
+        pass
 
 
 class TQDM(rich.tqdm if TQDM_RICH else tqdm.tqdm):

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -133,18 +133,28 @@ os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output
 if TQDM_RICH := str(os.getenv("YOLO_TQDM_RICH", False)).lower() == "true":
     from tqdm import rich
     
-    # Patch Rich BarColumn to use fixed bar_width of 10
+    # Patch Rich Console and BarColumn for consistent behavior
     try:
+        from rich.console import Console
         from rich.progress import BarColumn
         
-        # Store original BarColumn __init__
+        # Patch Console to always use width=200
+        original_console_init = Console.__init__
+        
+        def patched_console_init(self, *args, **kwargs):
+            """Patched Console.__init__ that forces width to 200."""
+            kwargs['width'] = 200
+            return original_console_init(self, *args, **kwargs)
+        
+        Console.__init__ = patched_console_init
+        
+        # Patch BarColumn to use fixed bar_width of 10
         original_bar_column_init = BarColumn.__init__
         
         def patched_bar_column_init(self, bar_width=None, *args, **kwargs):
             """Patched BarColumn.__init__ that forces bar_width to 10."""
             return original_bar_column_init(self, bar_width=10, *args, **kwargs)
         
-        # Replace BarColumn.__init__ with our patched version
         BarColumn.__init__ = patched_bar_column_init
         
     except ImportError:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -143,6 +143,7 @@ if TQDM_RICH := str(os.getenv("YOLO_TQDM_RICH", False)).lower() == "true":
     Console.__init__ = lambda self, *a, **k: _console_init(self, *a, **{**k, "width": 200})
     BarColumn.__init__ = lambda self, bar_width=None, *a, **k: _bar_init(self, 10, *a, **k)
 
+
 class TQDM(rich.tqdm if TQDM_RICH else tqdm.tqdm):
     """
     A custom TQDM progress bar class that extends the original tqdm functionality.

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -131,15 +131,13 @@ os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not in
 os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output when computing FLOPs
 
 if TQDM_RICH := str(os.getenv("YOLO_TQDM_RICH", False)).lower() == "true":
-    # Patch Rich Console and BarColumn for fixed widths to solve width=80 bug
     from rich.console import Console
     from rich.progress import BarColumn
     from tqdm import rich
 
-    # Force Console width=200 and BarColumn bar_width=10
+    # Patch Rich Console width=200 and BarColumn bar_width=10 to solve width=80 missing bars bug
     _console_init = Console.__init__
     _bar_init = BarColumn.__init__
-
     Console.__init__ = lambda self, *a, **k: _console_init(self, *a, **{**k, "width": 200})
     BarColumn.__init__ = lambda self, bar_width=None, *a, **k: _bar_init(self, 10, *a, **k)
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -132,19 +132,19 @@ os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output
 
 if TQDM_RICH := str(os.getenv("YOLO_TQDM_RICH", False)).lower() == "true":
     from tqdm import rich
-    
+
     # Patch Rich Console and BarColumn for fixed widths
     try:
         from rich.console import Console
         from rich.progress import BarColumn
-        
+
         # Force Console width=200 and BarColumn bar_width=10
         _console_init = Console.__init__
         _bar_init = BarColumn.__init__
-        
-        Console.__init__ = lambda self, *a, **k: _console_init(self, *a, **{**k, 'width': 200})
+
+        Console.__init__ = lambda self, *a, **k: _console_init(self, *a, **{**k, "width": 200})
         BarColumn.__init__ = lambda self, bar_width=None, *a, **k: _bar_init(self, 10, *a, **k)
-        
+
     except ImportError:
         pass
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -131,11 +131,10 @@ os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not in
 os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output when computing FLOPs
 
 if TQDM_RICH := str(os.getenv("YOLO_TQDM_RICH", False)).lower() == "true":
-    from tqdm import rich
-
     # Patch Rich Console and BarColumn for fixed widths to solve width=80 bug
     from rich.console import Console
     from rich.progress import BarColumn
+    from tqdm import rich
 
     # Force Console width=200 and BarColumn bar_width=10
     _console_init = Console.__init__


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves progress bar visibility when using Rich-based TQDM, preventing missing/truncated bars, and bumps version to 8.3.185. 🎛️✨

### 📊 Key Changes
- Version bump: `8.3.184` ➜ `8.3.185`.
- When `YOLO_TQDM_RICH=true`:
  - Patches `rich.Console` to use a fixed width of 200.
  - Patches `rich.progress.BarColumn` to use a fixed bar width of 10.
  - Addresses a bug where progress bars could disappear or truncate at width 80 in some environments.

### 🎯 Purpose & Impact
- More reliable, readable progress bars in terminals and notebooks when Rich TQDM is enabled. ✅
- No change for default users; only affects setups with `YOLO_TQDM_RICH=true`. 🔧
- Minor layout change: wider console might alter line wrapping; improves UX in most terminals/CI/Colab. 📈

Enable Rich progress bars:
- CLI: `YOLO_TQDM_RICH=true yolo train ...`
- Python:
```python
import os
os.environ["YOLO_TQDM_RICH"] = "true"
from ultralytics import YOLO
``` 
See the Ultralytics Docs for details: https://docs.ultralytics.com