### PR TITLE
Remove `click==8.2.1` from docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v6
       - name: Install Dependencies
-        run: uv pip install --system ruff black tqdm mkdocs-material "mkdocstrings[python]" mkdocs-ultralytics-plugin mkdocs-macros-plugin click==8.2.1
+        run: uv pip install --system ruff black tqdm mkdocs-material "mkdocstrings[python]" mkdocs-ultralytics-plugin mkdocs-macros-plugin
       - name: Ruff fixes
         continue-on-error: true
         run: |


### PR DESCRIPTION
@onuralpszr I guess we missed this one

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Docs CI workflow updated to simplify dependencies by removing a pinned package, improving reliability and maintenance. 🔧📚

### 📊 Key Changes
- Removed `click==8.2.1` from the docs build dependencies in `.github/workflows/docs.yml`.
- Docs build now installs `ruff`, `black`, `tqdm`, `mkdocs-material`, `mkdocstrings[python]`, `mkdocs-ultralytics-plugin`, and `mkdocs-macros-plugin` without explicitly pinning `click`.

### 🎯 Purpose & Impact
- Reduces dependency pinning to avoid version conflicts and ease maintenance. ✅
- Allows using the latest compatible `click` version for better compatibility and security updates. 🔒
- Improves CI robustness and potentially speeds up docs builds. 🚀
- No user-facing changes; only affects internal documentation workflow. 🙌