### PR TITLE
Fix  `coreml` export `device` bug on `macOS` and `linux`

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1481,8 +1481,9 @@ class IOSDetectModel(torch.nn.Module):
             self.normalize = 1.0 / w  # scalar
         else:
             self.normalize = torch.tensor(
-                [1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h], device=device
-            )  # broadcast (slower, smaller)
+                [1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h],  # broadcast (slower, smaller)
+                device=device
+            )
 
     def forward(self, x):
         """Normalize predictions of object detection model with input size-dependent factors."""

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1464,7 +1464,7 @@ class Exporter:
 class IOSDetectModel(torch.nn.Module):
     """Wrap an Ultralytics YOLO model for Apple iOS CoreML export."""
 
-    def __init__(self, model, im, device: torch.device=None):
+    def __init__(self, model, im, device: torch.device = None):
         """
         Initialize the IOSDetectModel class with a YOLO model and example image.
 
@@ -1480,8 +1480,10 @@ class IOSDetectModel(torch.nn.Module):
         if w == h:
             self.normalize = 1.0 / w  # scalar
         else:
-            self.normalize = torch.tensor([1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h],  # broadcast (slower, smaller)
-                                          device=device)
+            self.normalize = torch.tensor(
+                [1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h],  # broadcast (slower, smaller)
+                device=device,
+            )
 
     def forward(self, x):
         """Normalize predictions of object detection model with input size-dependent factors."""

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1471,7 +1471,7 @@ class IOSDetectModel(torch.nn.Module):
         Args:
             model (torch.nn.Module): The YOLO model to wrap.
             im (torch.Tensor): Example input tensor with shape (B, C, H, W).
-            device (torch.device): Device to load the model and export it (e.g. 'cpu', 'cuda', 'mps').
+            device (torch.device): Device to export the model (e.g. 'cpu', 'cuda', 'mps').
         """
         super().__init__()
         _, _, h, w = im.shape  # batch, channel, height, width

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1482,7 +1482,8 @@ class IOSDetectModel(torch.nn.Module):
         else:
             self.normalize = torch.tensor(
                 [1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h],  # broadcast (slower, smaller)
-                device=device)
+                device=device,
+            )
 
     def forward(self, x):
         """Normalize predictions of object detection model with input size-dependent factors."""

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1464,14 +1464,14 @@ class Exporter:
 class IOSDetectModel(torch.nn.Module):
     """Wrap an Ultralytics YOLO model for Apple iOS CoreML export."""
 
-    def __init__(self, model, im, device: str = None):
+    def __init__(self, model, im, device: torch.device):
         """
         Initialize the IOSDetectModel class with a YOLO model and example image.
 
         Args:
             model (torch.nn.Module): The YOLO model to wrap.
             im (torch.Tensor): Example input tensor with shape (B, C, H, W).
-            device (str, optional): Device to run inference on (e.g. 'cpu', 'cuda', 'mps').
+            device (torch.device): Device to load the model and export it (e.g. 'cpu', 'cuda', 'mps').
         """
         super().__init__()
         _, _, h, w = im.shape  # batch, channel, height, width

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -851,7 +851,7 @@ class Exporter:
             classifier_config = ct.ClassifierConfig(list(self.model.names.values()))
             model = self.model
         elif self.model.task == "detect":
-            model = IOSDetectModel(self.model, self.im) if self.args.nms else self.model
+            model = IOSDetectModel(self.model, self.im, self.device) if self.args.nms else self.model
         else:
             if self.args.nms:
                 LOGGER.warning(f"{prefix} 'nms=True' is only available for Detect models like 'yolo11n.pt'.")
@@ -1464,13 +1464,14 @@ class Exporter:
 class IOSDetectModel(torch.nn.Module):
     """Wrap an Ultralytics YOLO model for Apple iOS CoreML export."""
 
-    def __init__(self, model, im):
+    def __init__(self, model, im, device: str = None):
         """
         Initialize the IOSDetectModel class with a YOLO model and example image.
 
         Args:
             model (torch.nn.Module): The YOLO model to wrap.
             im (torch.Tensor): Example input tensor with shape (B, C, H, W).
+            device (str, optional): Device to run inference on (e.g. 'cpu', 'cuda', 'mps').
         """
         super().__init__()
         _, _, h, w = im.shape  # batch, channel, height, width
@@ -1479,7 +1480,7 @@ class IOSDetectModel(torch.nn.Module):
         if w == h:
             self.normalize = 1.0 / w  # scalar
         else:
-            self.normalize = torch.tensor([1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h])  # broadcast (slower, smaller)
+            self.normalize = torch.tensor([1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h], device=device)  # broadcast (slower, smaller)
 
     def forward(self, x):
         """Normalize predictions of object detection model with input size-dependent factors."""

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -851,7 +851,7 @@ class Exporter:
             classifier_config = ct.ClassifierConfig(list(self.model.names.values()))
             model = self.model
         elif self.model.task == "detect":
-            model = IOSDetectModel(self.model, self.im, self.device) if self.args.nms else self.model
+            model = IOSDetectModel(self.model, self.im) if self.args.nms else self.model
         else:
             if self.args.nms:
                 LOGGER.warning(f"{prefix} 'nms=True' is only available for Detect models like 'yolo11n.pt'.")
@@ -1464,14 +1464,13 @@ class Exporter:
 class IOSDetectModel(torch.nn.Module):
     """Wrap an Ultralytics YOLO model for Apple iOS CoreML export."""
 
-    def __init__(self, model, im, device: torch.device = None):
+    def __init__(self, model, im):
         """
         Initialize the IOSDetectModel class with a YOLO model and example image.
 
         Args:
             model (torch.nn.Module): The YOLO model to wrap.
             im (torch.Tensor): Example input tensor with shape (B, C, H, W).
-            device (torch.device): Device to export the model (e.g. 'cpu', 'cuda', 'mps').
         """
         super().__init__()
         _, _, h, w = im.shape  # batch, channel, height, width
@@ -1482,7 +1481,7 @@ class IOSDetectModel(torch.nn.Module):
         else:
             self.normalize = torch.tensor(
                 [1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h],  # broadcast (slower, smaller)
-                device=device,
+                device=next(model.parameters()).device,
             )
 
     def forward(self, x):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1482,8 +1482,7 @@ class IOSDetectModel(torch.nn.Module):
         else:
             self.normalize = torch.tensor(
                 [1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h],  # broadcast (slower, smaller)
-                device=device
-            )
+                device=device)
 
     def forward(self, x):
         """Normalize predictions of object detection model with input size-dependent factors."""

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1480,7 +1480,9 @@ class IOSDetectModel(torch.nn.Module):
         if w == h:
             self.normalize = 1.0 / w  # scalar
         else:
-            self.normalize = torch.tensor([1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h], device=device)  # broadcast (slower, smaller)
+            self.normalize = torch.tensor(
+                [1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h], device=device
+            )  # broadcast (slower, smaller)
 
     def forward(self, x):
         """Normalize predictions of object detection model with input size-dependent factors."""

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -851,7 +851,7 @@ class Exporter:
             classifier_config = ct.ClassifierConfig(list(self.model.names.values()))
             model = self.model
         elif self.model.task == "detect":
-            model = IOSDetectModel(self.model.to(self.device), self.im) if self.args.nms else self.model
+            model = IOSDetectModel(self.model, self.im, self.device) if self.args.nms else self.model
         else:
             if self.args.nms:
                 LOGGER.warning(f"{prefix} 'nms=True' is only available for Detect models like 'yolo11n.pt'.")
@@ -1464,13 +1464,14 @@ class Exporter:
 class IOSDetectModel(torch.nn.Module):
     """Wrap an Ultralytics YOLO model for Apple iOS CoreML export."""
 
-    def __init__(self, model, im):
+    def __init__(self, model, im, device: torch.device=None):
         """
         Initialize the IOSDetectModel class with a YOLO model and example image.
 
         Args:
             model (torch.nn.Module): The YOLO model to wrap.
             im (torch.Tensor): Example input tensor with shape (B, C, H, W).
+            device (torch.device): Device to export the model (e.g. 'cpu', 'cuda', 'mps').
         """
         super().__init__()
         _, _, h, w = im.shape  # batch, channel, height, width
@@ -1479,7 +1480,8 @@ class IOSDetectModel(torch.nn.Module):
         if w == h:
             self.normalize = 1.0 / w  # scalar
         else:
-            self.normalize = torch.tensor([1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h])  # broadcast (slower, smaller)
+            self.normalize = torch.tensor([1.0 / w, 1.0 / h, 1.0 / w, 1.0 / h],  # broadcast (slower, smaller)
+                                          device=device)
 
     def forward(self, x):
         """Normalize predictions of object detection model with input size-dependent factors."""


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ensure normalization tensor is created on the same device as the model during export to prevent device mismatch errors and improve stability ⚙️✅

### 📊 Key Changes
- Set the normalization tensor’s device to match the model’s device in `ultralytics/engine/exporter.py`:
  - `torch.tensor([...], device=next(model.parameters()).device)`

### 🎯 Purpose & Impact
- Prevents device mismatch errors (e.g., CPU vs. CUDA) during export/inference 🚫💥
- Improves reliability across GPU/CPU environments without changing the API 🔁
- Minor performance win by avoiding implicit tensor device transfers ⚡
- Transparent to users—no configuration changes needed 🙌