### PR TITLE
Fix `region` visualization in `zone-counting` solution

### DIFF
--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -117,7 +117,7 @@ class RegionCounter(BaseSolution):
         for region in self.counting_regions:
             poly = region["polygon"]
             pts = list(map(tuple, np.array(poly.exterior.coords, dtype=np.int32)))
-            (x1, y1), (x2, y2) = [(int(poly.centroid.x), int(poly.centroid.y))]*2
+            (x1, y1), (x2, y2) = [(int(poly.centroid.x), int(poly.centroid.y))] * 2
             annotator.draw_region(pts, region["region_color"], self.line_width * 2)
             annotator.adaptive_label(
                 [x1, y1, x2, y2],

--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -115,8 +115,9 @@ class RegionCounter(BaseSolution):
 
         # Display region counts
         for region in self.counting_regions:
-            x1, y1, x2, y2 = map(int, region["polygon"].bounds)
-            pts = [(x1, y1), (x2, y1), (x2, y2), (x1, y2)]
+            poly = region["polygon"]
+            pts = list(map(tuple, np.array(poly.exterior.coords, dtype=np.int32)))
+            (x1, y1), (x2, y2) = [(int(poly.centroid.x), int(poly.centroid.y))]*2
             annotator.draw_region(pts, region["region_color"], self.line_width * 2)
             annotator.adaptive_label(
                 [x1, y1, x2, y2],


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves region visualization in region-based counting by drawing true polygon shapes and centering labels at the polygon centroid for clearer, more accurate overlays. 🧭🖊️

### 📊 Key Changes
- Draws regions using the actual polygon exterior coordinates instead of a rectangular bounding box.
- Places the region label at the polygon’s centroid (using a point), improving label positioning.
- Converts coordinates to int32 for robust rendering with the annotator.

### 🎯 Purpose & Impact
- More accurate and visually faithful region rendering, especially for non-rectangular/complex polygons. 🎨
- Cleaner, more intuitive labeling—labels now appear centered within regions. 🏷️
- No API changes; purely a visualization improvement with negligible performance impact. ✅