### PR TITLE
Add OBB angle limitation note to Docs

### DIFF
--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -52,7 +52,8 @@ YOLO11 pretrained OBB models are shown here, which are pretrained on the [DOTAv1
 Train YOLO11n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
 !!! note
-OBB angles are constrained to the range **0–90 degrees** (exclusive of 90). Angles of 90 degrees or greater are not supported.
+
+    OBB angles are constrained to the range **0–90 degrees** (exclusive of 90). Angles of 90 degrees or greater are not supported.
 
 !!! example
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -52,7 +52,7 @@ YOLO11 pretrained OBB models are shown here, which are pretrained on the [DOTAv1
 Train YOLO11n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
 !!! note
-    OBB angles are limited to the range **0–90 degrees**, exclusive of 90. Angles equal to or greater than 90 degrees are not supported.
+    OBB angles are constrained to the range **0–90 degrees** (exclusive of 90). Angles of 90 degrees or greater are not supported.
 
 !!! example
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -51,6 +51,9 @@ YOLO11 pretrained OBB models are shown here, which are pretrained on the [DOTAv1
 
 Train YOLO11n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
+!!! note
+    OBB angles are limited to the range **0–90 degrees**, exclusive of 90. Angles equal to or greater than 90 degrees are not supported.
+
 !!! example
 
     === "Python"

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -52,7 +52,7 @@ YOLO11 pretrained OBB models are shown here, which are pretrained on the [DOTAv1
 Train YOLO11n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
 !!! note
-OBB angles are limited to the range **0–90 degrees**, exclusive of 90. Angles equal to or greater than 90 degrees are not supported.
+    OBB angles are limited to the range **0–90 degrees**, exclusive of 90. Angles equal to or greater than 90 degrees are not supported.
 
 !!! example
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -52,7 +52,7 @@ YOLO11 pretrained OBB models are shown here, which are pretrained on the [DOTAv1
 Train YOLO11n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
 !!! note
-    OBB angles are constrained to the range **0–90 degrees** (exclusive of 90). Angles of 90 degrees or greater are not supported.
+OBB angles are constrained to the range **0–90 degrees** (exclusive of 90). Angles of 90 degrees or greater are not supported.
 
 !!! example
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -52,7 +52,7 @@ YOLO11 pretrained OBB models are shown here, which are pretrained on the [DOTAv1
 Train YOLO11n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
 !!! note
-    OBB angles are limited to the range **0–90 degrees**, exclusive of 90. Angles equal to or greater than 90 degrees are not supported.
+OBB angles are limited to the range **0–90 degrees**, exclusive of 90. Angles equal to or greater than 90 degrees are not supported.
 
 !!! example
 


### PR DESCRIPTION
Closes #21814 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Clarifies that YOLO11 OBB (Oriented Bounding Box) angles must be within 0–90 degrees (90 excluded) to ensure consistent training and inference. 🧭

### 📊 Key Changes
- Adds a note to the OBB task docs stating: OBB angles are constrained to 0–90 degrees (exclusive of 90). 📘
- Highlights that angles of 90 degrees or greater are not supported.

### 🎯 Purpose & Impact
- Prevents confusion and errors by clearly defining the supported angle range for OBB labels. ✅
- Helps users prepare/convert datasets correctly; labels at 90° or >90° should be normalized to within [0, 90). 🛠️
- Improves model stability and consistency in training/inference across OBB tasks. 📈

See the Ultralytics Docs for details.