### PR TITLE
Add `plt_settings` decorator to `plot_tune_results` for `agg` backend

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -32,7 +32,6 @@ from ultralytics.utils import (
     checks,
     is_dir_writeable,
     is_github_action_running,
-    plt_settings,
 )
 from ultralytics.utils.downloads import download
 from ultralytics.utils.torch_utils import TORCH_1_9
@@ -586,7 +585,6 @@ def test_classify_transforms_train(image, auto_augment, erasing, force_color_jit
 
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
-@plt_settings()
 def test_model_tune():
     """Tune YOLO model for performance improvement."""
     YOLO("yolo11n-pose.pt").tune(data="coco8-pose.yaml", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -32,6 +32,7 @@ from ultralytics.utils import (
     checks,
     is_dir_writeable,
     is_github_action_running,
+    plt_settings,
 )
 from ultralytics.utils.downloads import download
 from ultralytics.utils.torch_utils import TORCH_1_9
@@ -585,6 +586,7 @@ def test_classify_transforms_train(image, auto_augment, erasing, force_color_jit
 
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
+@plt_settings()
 def test_model_tune():
     """Tune YOLO model for performance improvement."""
     YOLO("yolo11n-pose.pt").tune(data="coco8-pose.yaml", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -944,6 +944,7 @@ def plt_color_scatter(v, f, bins: int = 20, cmap: str = "viridis", alpha: float 
     plt.scatter(v, f, c=colors, cmap=cmap, alpha=alpha, edgecolors=edgecolors)
 
 
+@plt_settings()
 def plot_tune_results(csv_file: str = "tune_results.csv"):
     """
     Plot the evolution results stored in a 'tune_results.csv' file. The function generates a scatter plot for each key


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds consistent Matplotlib styling to `plot_tune_results()` for cleaner, more reliable tuning result plots 🎨📈

### 📊 Key Changes
- Applied the `@plt_settings()` decorator to `plot_tune_results()` to standardize plot configuration.
- Ensures consistent backend, style, and figure handling across environments (scripts, notebooks, headless servers).

### 🎯 Purpose & Impact
- More consistent, professional-looking tuning plots out of the box ✅
- Fewer plotting side effects (e.g., interactive mode issues, backend mismatches) and reduced boilerplate for users 🧼
- Improves reliability when generating plots in automated or headless workflows (CI, servers) 🖥️
- No breaking changes; usage stays the same:
  ```python
  from ultralytics.utils.plotting import plot_tune_results
  plot_tune_results("tune_results.csv")
  ```

See the Ultralytics Docs for details.