### PR TITLE
fix issue #21783: initialize empty buffer with ram caching

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -741,25 +741,18 @@ def test_grayscale(task: str, model: str, data: str) -> None:
     model = YOLO(export_model, task=task)
     model.predict(source=im, imgsz=32)
 
+
 @pytest.mark.parametrize("cache", ["ram"])
 def test_deterministic_ram_caching(cache):
     """Test that deterministic=True with cache='ram' produces identical results across runs."""
-    
-    model1 = YOLO("yolo11n.pt")  
+    model1 = YOLO("yolo11n.pt")
     model2 = YOLO("yolo11n.pt")
-    
+
     # first training run
     results1 = model1.train(
-        data="coco8.yaml",
-        epochs=1,
-        cache=cache,
-        seed=42,
-        deterministic=True,
-        imgsz=32,
-        batch=2,
-        verbose=False
+        data="coco8.yaml", epochs=1, cache=cache, seed=42, deterministic=True, imgsz=32, batch=2, verbose=False
     )
-    
+
     # second training run with same parameters
     results2 = model2.train(
         data="coco8.yaml",
@@ -769,16 +762,17 @@ def test_deterministic_ram_caching(cache):
         deterministic=True,
         imgsz=32,
         batch=2,
-        verbose=False
+        verbose=False,
     )
-    
+
     assert abs(results1.box.map - results2.box.map) < 1e-6, "mAP should be identical with deterministic=True"
     assert abs(results1.box.map50 - results2.box.map50) < 1e-6, "mAP50 should be identical with deterministic=True"
 
+
 def test_ram_cache_buffer_cleared_when_deterministic():
     """Test that dataset.buffer is empty after caching when deterministic=True and cache='ram'."""
-    from ultralytics.models.yolo.detect import DetectionTrainer
     from ultralytics.cfg import get_cfg
+    from ultralytics.models.yolo.detect import DetectionTrainer
 
     overrides = dict(
         model="yolo11n.pt",
@@ -793,7 +787,7 @@ def test_ram_cache_buffer_cleared_when_deterministic():
     cfg = get_cfg(overrides=overrides)
 
     trainer = DetectionTrainer(cfg)
-    trainer._setup_train(world_size=1) 
+    trainer._setup_train(world_size=1)
 
     dataset = trainer.train_loader.dataset
     assert hasattr(dataset, "buffer")

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -120,7 +120,8 @@ class BaseDataset(Dataset):
         self.batch_size = batch_size
         self.stride = stride
         self.pad = pad
-        self.deterministic = hyp.deterministic
+        self.deterministic = bool(getattr(hyp, "deterministic", False))
+        
         if self.rect:
             assert self.batch_size is not None
             self.set_rectangle()

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -120,6 +120,7 @@ class BaseDataset(Dataset):
         self.batch_size = batch_size
         self.stride = stride
         self.pad = pad
+        self.deterministic = hyp.deterministic
         if self.rect:
             assert self.batch_size is not None
             self.set_rectangle()
@@ -276,6 +277,9 @@ class BaseDataset(Dataset):
                     b += self.ims[i].nbytes
                 pbar.desc = f"{self.prefix}Caching images ({b / gb:.1f}GB {storage})"
             pbar.close()
+
+        if self.cache == "ram" and self.deterministic:
+            self.buffer = []  # initialize empty buffer, since disk caching does the same
 
     def cache_images_to_disk(self, i: int) -> None:
         """Save an image as an *.npy file for faster loading."""

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -121,7 +121,7 @@ class BaseDataset(Dataset):
         self.stride = stride
         self.pad = pad
         self.deterministic = bool(getattr(hyp, "deterministic", False))
-        
+
         if self.rect:
             assert self.batch_size is not None
             self.set_rectangle()


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

Fixed deterministic caching on RAM as discussed in #21783. The problem was that the buffer was undeterministically filled during RAM caching, while it started as an empty list while using disk caching. Reinitializing the buffer as an empty list (after initialization and right before training) while using RAM caching fixes the issue.

Example of two runs after the fix:
1)
```
> yolo train model=yolo11n.pt data=signature.yaml epochs=1 cache=disk seed=42

Ultralytics 8.3.186 🚀 Python-3.9.23 torch-2.8.0+cu128 CUDA:0 (NVIDIA A100-SXM4-40GB, 40326MiB)
engine/trainer: agnostic_nms=False, amp=True, augment=False, auto_augment=randaugment, batch=16, bgr=0.0, box=7.5, cache=disk, cfg=None, classes=None, close_mosaic=10, cls=0.5, conf=None, copy_paste=0.0, copy_paste_mode=flip, cos_lr=False, cutmix=0.0, data=signature.yaml, degrees=0.0, deterministic=True, device=None, dfl=1.5, dnn=False, dropout=0.0, dynamic=False, embed=None, epochs=1, erasing=0.4, exist_ok=False, fliplr=0.5, flipud=0.0, format=torchscript, fraction=1.0, freeze=None, half=False, hsv_h=0.015, hsv_s=0.7, hsv_v=0.4, imgsz=640, int8=False, iou=0.7, keras=False, kobj=1.0, line_width=None, lr0=0.01, lrf=0.01, mask_ratio=4, max_det=300, mixup=0.0, mode=train, model=yolo11n.pt, momentum=0.937, mosaic=1.0, multi_scale=False, name=train32, nbs=64, nms=False, opset=None, optimize=False, optimizer=auto, overlap_mask=True, patience=100, perspective=0.0, plots=True, pose=12.0, pretrained=True, profile=False, project=None, rect=False, resume=False, retina_masks=False, save=True, save_conf=False, save_crop=False, save_dir=runs/detect/train32, save_frames=False, save_json=False, save_period=-1, save_txt=False, scale=0.5, seed=42, shear=0.0, show=False, show_boxes=True, show_conf=True, show_labels=True, simplify=True, single_cls=False, source=None, split=val, stream_buffer=False, task=detect, time=None, tracker=botsort.yaml, translate=0.1, val=True, verbose=True, vid_stride=1, visualize=False, warmup_bias_lr=0.1, warmup_epochs=3.0, warmup_momentum=0.8, weight_decay=0.0005, workers=8, workspace=None
Overriding model.yaml nc=80 with nc=1

                   from  n    params  module                                       arguments                     
  0                  -1  1       464  ultralytics.nn.modules.conv.Conv             [3, 16, 3, 2]                 
  1                  -1  1      4672  ultralytics.nn.modules.conv.Conv             [16, 32, 3, 2]                
  2                  -1  1      6640  ultralytics.nn.modules.block.C3k2            [32, 64, 1, False, 0.25]      
  3                  -1  1     36992  ultralytics.nn.modules.conv.Conv             [64, 64, 3, 2]                
  4                  -1  1     26080  ultralytics.nn.modules.block.C3k2            [64, 128, 1, False, 0.25]     
  5                  -1  1    147712  ultralytics.nn.modules.conv.Conv             [128, 128, 3, 2]              
  6                  -1  1     87040  ultralytics.nn.modules.block.C3k2            [128, 128, 1, True]           
  7                  -1  1    295424  ultralytics.nn.modules.conv.Conv             [128, 256, 3, 2]              
  8                  -1  1    346112  ultralytics.nn.modules.block.C3k2            [256, 256, 1, True]           
  9                  -1  1    164608  ultralytics.nn.modules.block.SPPF            [256, 256, 5]                 
 10                  -1  1    249728  ultralytics.nn.modules.block.C2PSA           [256, 256, 1]                 
 11                  -1  1         0  torch.nn.modules.upsampling.Upsample         [None, 2, 'nearest']          
 12             [-1, 6]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           
 13                  -1  1    111296  ultralytics.nn.modules.block.C3k2            [384, 128, 1, False]          
 14                  -1  1         0  torch.nn.modules.upsampling.Upsample         [None, 2, 'nearest']          
 15             [-1, 4]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           
 16                  -1  1     32096  ultralytics.nn.modules.block.C3k2            [256, 64, 1, False]           
 17                  -1  1     36992  ultralytics.nn.modules.conv.Conv             [64, 64, 3, 2]                
 18            [-1, 13]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           
 19                  -1  1     86720  ultralytics.nn.modules.block.C3k2            [192, 128, 1, False]          
 20                  -1  1    147712  ultralytics.nn.modules.conv.Conv             [128, 128, 3, 2]              
 21            [-1, 10]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           
 22                  -1  1    378880  ultralytics.nn.modules.block.C3k2            [384, 256, 1, True]           
 23        [16, 19, 22]  1    430867  ultralytics.nn.modules.head.Detect           [1, [64, 128, 256]]           
YOLO11n summary: 181 layers, 2,590,035 parameters, 2,590,019 gradients, 6.4 GFLOPs

Transferred 448/499 items from pretrained weights
Freezing layer 'model.23.dfl.conv.weight'
AMP: running Automatic Mixed Precision (AMP) checks...
AMP: checks passed ✅
train: Fast image access ✅ (ping: 0.0±0.0 ms, read: 1962.2±727.2 MB/s, size: 68.9 KB)
train: Scanning /home/singh/yolo/datasets/signature/labels/train.cache... 143 images, 0 backgrounds, 0 corrupt: 100% ━━━━━━━━━━━━ 143/143 29989273.6it/s 0.
train: Scanning /home/singh/yolo/datasets/signature/labels/train.cache... 143 images, 0 backgrounds, 0 corrupt: 100% ━━━━━━━━━━━━ 143/143 2280553.1it/s 0.0s
train: Caching images (0.8GB Disk): 100% ━━━━━━━━━━━━ 143/143 31812.1it/s 0.0s
val: Fast image access ✅ (ping: 0.0±0.0 ms, read: 735.2±482.8 MB/s, size: 68.2 KB)
val: Scanning /home/singh/yolo/datasets/signature/labels/val.cache... 35 images, 0 backgrounds, 0 corrupt: 100% ━━━━━━━━━━━━ 35/35 204742.9it/s 0.0s
val: Caching images (0.2GB Disk): 100% ━━━━━━━━━━━━ 35/35 15882.4it/s 0.0s
Plotting labels to runs/detect/train32/labels.jpg... 
optimizer: 'optimizer=auto' found, ignoring 'lr0=0.01' and 'momentum=0.937' and determining best 'optimizer', 'lr0' and 'momentum' automatically... 
optimizer: AdamW(lr=0.002, momentum=0.9) with parameter groups 81 weight(decay=0.0), 88 weight(decay=0.0005), 87 bias(decay=0.0)
Image sizes 640 train, 640 val
Using 8 dataloader workers
Logging results to runs/detect/train32
Starting training for 1 epochs...

      Epoch    GPU_mem   box_loss   cls_loss   dfl_loss  Instances       Size
        1/1       2.3G      1.129      3.198      1.332         41        640: 100% ━━━━━━━━━━━━ 9/9 0.44it/s 20.3s
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100% ━━━━━━━━━━━━ 2/2 0.34it/s 5.9s
                   all         35         35    0.00314      0.943      0.854      0.797

1 epochs completed in 0.008 hours.
Optimizer stripped from runs/detect/train32/weights/last.pt, 5.4MB
Optimizer stripped from runs/detect/train32/weights/best.pt, 5.4MB

Validating runs/detect/train32/weights/best.pt...
Ultralytics 8.3.186 🚀 Python-3.9.23 torch-2.8.0+cu128 CUDA:0 (NVIDIA A100-SXM4-40GB, 40326MiB)
YOLO11n summary (fused): 100 layers, 2,582,347 parameters, 0 gradients, 6.3 GFLOPs
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100% ━━━━━━━━━━━━ 2/2 11.2it/s 0.2s
                   all         35         35    0.00314      0.943      0.862      0.793
Speed: 0.1ms preprocess, 1.3ms inference, 0.0ms loss, 1.3ms postprocess per image
Results saved to runs/detect/train32
💡 Learn more at https://docs.ultralytics.com/modes/train
VS Code: view Ultralytics VS Code Extension ⚡ at https://docs.ultralytics.com/integrations/vscode
```

2)
```
> yolo train model=yolo11n.pt data=signature.yaml epochs=1 cache=disk seed=42

Ultralytics 8.3.186 🚀 Python-3.9.23 torch-2.8.0+cu128 CUDA:0 (NVIDIA A100-SXM4-40GB, 40326MiB)
engine/trainer: agnostic_nms=False, amp=True, augment=False, auto_augment=randaugment, batch=16, bgr=0.0, box=7.5, cache=disk, cfg=None, classes=None, close_mosaic=10, cls=0.5, conf=None, copy_paste=0.0, copy_paste_mode=flip, cos_lr=False, cutmix=0.0, data=signature.yaml, degrees=0.0, deterministic=True, device=None, dfl=1.5, dnn=False, dropout=0.0, dynamic=False, embed=None, epochs=1, erasing=0.4, exist_ok=False, fliplr=0.5, flipud=0.0, format=torchscript, fraction=1.0, freeze=None, half=False, hsv_h=0.015, hsv_s=0.7, hsv_v=0.4, imgsz=640, int8=False, iou=0.7, keras=False, kobj=1.0, line_width=None, lr0=0.01, lrf=0.01, mask_ratio=4, max_det=300, mixup=0.0, mode=train, model=yolo11n.pt, momentum=0.937, mosaic=1.0, multi_scale=False, name=train33, nbs=64, nms=False, opset=None, optimize=False, optimizer=auto, overlap_mask=True, patience=100, perspective=0.0, plots=True, pose=12.0, pretrained=True, profile=False, project=None, rect=False, resume=False, retina_masks=False, save=True, save_conf=False, save_crop=False, save_dir=runs/detect/train33, save_frames=False, save_json=False, save_period=-1, save_txt=False, scale=0.5, seed=42, shear=0.0, show=False, show_boxes=True, show_conf=True, show_labels=True, simplify=True, single_cls=False, source=None, split=val, stream_buffer=False, task=detect, time=None, tracker=botsort.yaml, translate=0.1, val=True, verbose=True, vid_stride=1, visualize=False, warmup_bias_lr=0.1, warmup_epochs=3.0, warmup_momentum=0.8, weight_decay=0.0005, workers=8, workspace=None
Overriding model.yaml nc=80 with nc=1

                   from  n    params  module                                       arguments                     
  0                  -1  1       464  ultralytics.nn.modules.conv.Conv             [3, 16, 3, 2]                 
  1                  -1  1      4672  ultralytics.nn.modules.conv.Conv             [16, 32, 3, 2]                
  2                  -1  1      6640  ultralytics.nn.modules.block.C3k2            [32, 64, 1, False, 0.25]      
  3                  -1  1     36992  ultralytics.nn.modules.conv.Conv             [64, 64, 3, 2]                
  4                  -1  1     26080  ultralytics.nn.modules.block.C3k2            [64, 128, 1, False, 0.25]     
  5                  -1  1    147712  ultralytics.nn.modules.conv.Conv             [128, 128, 3, 2]              
  6                  -1  1     87040  ultralytics.nn.modules.block.C3k2            [128, 128, 1, True]           
  7                  -1  1    295424  ultralytics.nn.modules.conv.Conv             [128, 256, 3, 2]              
  8                  -1  1    346112  ultralytics.nn.modules.block.C3k2            [256, 256, 1, True]           
  9                  -1  1    164608  ultralytics.nn.modules.block.SPPF            [256, 256, 5]                 
 10                  -1  1    249728  ultralytics.nn.modules.block.C2PSA           [256, 256, 1]                 
 11                  -1  1         0  torch.nn.modules.upsampling.Upsample         [None, 2, 'nearest']          
 12             [-1, 6]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           
 13                  -1  1    111296  ultralytics.nn.modules.block.C3k2            [384, 128, 1, False]          
 14                  -1  1         0  torch.nn.modules.upsampling.Upsample         [None, 2, 'nearest']          
 15             [-1, 4]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           
 16                  -1  1     32096  ultralytics.nn.modules.block.C3k2            [256, 64, 1, False]           
 17                  -1  1     36992  ultralytics.nn.modules.conv.Conv             [64, 64, 3, 2]                
 18            [-1, 13]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           
 19                  -1  1     86720  ultralytics.nn.modules.block.C3k2            [192, 128, 1, False]          
 20                  -1  1    147712  ultralytics.nn.modules.conv.Conv             [128, 128, 3, 2]              
 21            [-1, 10]  1         0  ultralytics.nn.modules.conv.Concat           [1]                           
 22                  -1  1    378880  ultralytics.nn.modules.block.C3k2            [384, 256, 1, True]           
 23        [16, 19, 22]  1    430867  ultralytics.nn.modules.head.Detect           [1, [64, 128, 256]]           
YOLO11n summary: 181 layers, 2,590,035 parameters, 2,590,019 gradients, 6.4 GFLOPs

Transferred 448/499 items from pretrained weights
Freezing layer 'model.23.dfl.conv.weight'
AMP: running Automatic Mixed Precision (AMP) checks...
AMP: checks passed ✅
train: Fast image access ✅ (ping: 0.0±0.0 ms, read: 2112.4±774.4 MB/s, size: 68.9 KB)
train: Scanning /home/singh/yolo/datasets/signature/labels/train.cache... 143 images, 0 backgrounds, 0 corrupt: 100% ━━━━━━━━━━━━ 143/143 33321415.1it/s 0.
train: Scanning /home/singh/yolo/datasets/signature/labels/train.cache... 143 images, 0 backgrounds, 0 corrupt: 100% ━━━━━━━━━━━━ 143/143 2333795.6it/s 0.0s
train: Caching images (0.8GB Disk): 100% ━━━━━━━━━━━━ 143/143 40175.9it/s 0.0s
val: Fast image access ✅ (ping: 0.0±0.0 ms, read: 873.6±696.8 MB/s, size: 68.2 KB)
val: Scanning /home/singh/yolo/datasets/signature/labels/val.cache... 35 images, 0 backgrounds, 0 corrupt: 100% ━━━━━━━━━━━━ 35/35 218453.3it/s 0.0s
val: Caching images (0.2GB Disk): 100% ━━━━━━━━━━━━ 35/35 14388.0it/s 0.0s
Plotting labels to runs/detect/train33/labels.jpg... 
optimizer: 'optimizer=auto' found, ignoring 'lr0=0.01' and 'momentum=0.937' and determining best 'optimizer', 'lr0' and 'momentum' automatically... 
optimizer: AdamW(lr=0.002, momentum=0.9) with parameter groups 81 weight(decay=0.0), 88 weight(decay=0.0005), 87 bias(decay=0.0)
Image sizes 640 train, 640 val
Using 8 dataloader workers
Logging results to runs/detect/train33
Starting training for 1 epochs...

      Epoch    GPU_mem   box_loss   cls_loss   dfl_loss  Instances       Size
        1/1       2.3G      1.129      3.198      1.332         41        640: 100% ━━━━━━━━━━━━ 9/9 0.44it/s 20.4s
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100% ━━━━━━━━━━━━ 2/2 0.34it/s 5.9s
                   all         35         35    0.00314      0.943      0.854      0.797

1 epochs completed in 0.008 hours.
Optimizer stripped from runs/detect/train33/weights/last.pt, 5.4MB
Optimizer stripped from runs/detect/train33/weights/best.pt, 5.4MB

Validating runs/detect/train33/weights/best.pt...
Ultralytics 8.3.186 🚀 Python-3.9.23 torch-2.8.0+cu128 CUDA:0 (NVIDIA A100-SXM4-40GB, 40326MiB)
YOLO11n summary (fused): 100 layers, 2,582,347 parameters, 0 gradients, 6.3 GFLOPs
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100% ━━━━━━━━━━━━ 2/2 11.4it/s 0.2s
                   all         35         35    0.00314      0.943      0.862      0.793
Speed: 0.1ms preprocess, 1.3ms inference, 0.0ms loss, 1.3ms postprocess per image
Results saved to runs/detect/train33
💡 Learn more at https://docs.ultralytics.com/modes/train
VS Code: view Ultralytics VS Code Extension ⚡ at https://docs.ultralytics.com/integrations/vscode
```

The model training results are identical now, as expected

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds a deterministic mode hook to the dataloader and aligns RAM caching behavior for reproducible runs and consistent memory use. ✅

### 📊 Key Changes
- Introduced `self.deterministic = hyp.deterministic` in the base dataset class.
- When `cache='ram'` and `deterministic=True`, the in-memory image buffer is cleared after caching (mirrors disk caching behavior).

### 🎯 Purpose & Impact
- Ensures reproducible training/evaluation by making RAM and disk caching behave consistently under deterministic settings. 🔁
- Reduces memory usage in deterministic runs by not retaining the RAM cache buffer. 💾
- Potential trade-off: slightly reduced data loading speed when `cache='ram'` and `deterministic=True`, since images aren’t kept in memory. ⏳
- Clearer control for users who need consistent benchmarks or repeatable experiments.

Tip: Enable deterministic runs via your config or CLI, e.g., `deterministic=True` (CLI: `--deterministic True`). See the Ultralytics Docs for details.