### PR TITLE
Add `file_name` field to `predictions.json` for better image-annotation alignment

### DIFF
--- a/ultralytics/models/rtdetr/val.py
+++ b/ultralytics/models/rtdetr/val.py
@@ -198,7 +198,6 @@ class RTDETRValidator(DetectionValidator):
         """
         path = Path(pbatch["im_file"])
         stem = path.stem
-        filename = path.name
         image_id = int(stem) if stem.isnumeric() else stem
         box = predn["bboxes"].clone()
         box[..., [0, 2]] *= pbatch["ori_shape"][1] / self.args.imgsz  # native-space pred
@@ -209,7 +208,7 @@ class RTDETRValidator(DetectionValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
-                    "filename": filename,
+                    "filename": path.name,
                     "category_id": self.class_map[int(c)],
                     "bbox": [round(x, 3) for x in b],
                     "score": round(s, 5),

--- a/ultralytics/models/rtdetr/val.py
+++ b/ultralytics/models/rtdetr/val.py
@@ -196,7 +196,9 @@ class RTDETRValidator(DetectionValidator):
                 with bounding box coordinates, confidence scores, and class predictions.
             pbatch (Dict[str, Any]): Batch dictionary containing 'imgsz', 'ori_shape', 'ratio_pad', and 'im_file'.
         """
-        stem = Path(pbatch["im_file"]).stem
+        path = Path(pbatch["im_file"])
+        stem = path.stem
+        filename = path.name
         image_id = int(stem) if stem.isnumeric() else stem
         box = predn["bboxes"].clone()
         box[..., [0, 2]] *= pbatch["ori_shape"][1] / self.args.imgsz  # native-space pred
@@ -207,6 +209,7 @@ class RTDETRValidator(DetectionValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
+                    "filename": filename,
                     "category_id": self.class_map[int(c)],
                     "bbox": [round(x, 3) for x in b],
                     "score": round(s, 5),

--- a/ultralytics/models/rtdetr/val.py
+++ b/ultralytics/models/rtdetr/val.py
@@ -208,7 +208,7 @@ class RTDETRValidator(DetectionValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
-                    "filename": path.name,
+                    "file_name": path.name,
                     "category_id": self.class_map[int(c)],
                     "bbox": [round(x, 3) for x in b],
                     "score": round(s, 5),

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -373,7 +373,9 @@ class DetectionValidator(BaseValidator):
                 with bounding box coordinates, confidence scores, and class predictions.
             pbatch (Dict[str, Any]): Batch dictionary containing 'imgsz', 'ori_shape', 'ratio_pad', and 'im_file'.
         """
-        stem = Path(pbatch["im_file"]).stem
+        path = Path(pbatch["im_file"])
+        stem = path.stem
+        filename = path.name
         image_id = int(stem) if stem.isnumeric() else stem
         box = ops.xyxy2xywh(predn["bboxes"])  # xywh
         box[:, :2] -= box[:, 2:] / 2  # xy center to top-left corner
@@ -381,6 +383,7 @@ class DetectionValidator(BaseValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
+                    "filename": filename,
                     "category_id": self.class_map[int(c)],
                     "bbox": [round(x, 3) for x in b],
                     "score": round(s, 5),

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -372,10 +372,18 @@ class DetectionValidator(BaseValidator):
             predn (Dict[str, torch.Tensor]): Predictions dictionary containing 'bboxes', 'conf', and 'cls' keys
                 with bounding box coordinates, confidence scores, and class predictions.
             pbatch (Dict[str, Any]): Batch dictionary containing 'imgsz', 'ori_shape', 'ratio_pad', and 'im_file'.
+
+        Examples:
+             >>> result = {
+             ...     "image_id": 42,
+             ...     "filename": "42.jpg",
+             ...     "category_id": 18,
+             ...     "bbox": [258.15, 41.29, 348.26, 243.78],
+             ...     "score": 0.236,
+             ... }
         """
         path = Path(pbatch["im_file"])
         stem = path.stem
-        filename = path.name
         image_id = int(stem) if stem.isnumeric() else stem
         box = ops.xyxy2xywh(predn["bboxes"])  # xywh
         box[:, :2] -= box[:, 2:] / 2  # xy center to top-left corner
@@ -383,7 +391,7 @@ class DetectionValidator(BaseValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
-                    "filename": filename,
+                    "filename": path.name,
                     "category_id": self.class_map[int(c)],
                     "bbox": [round(x, 3) for x in b],
                     "score": round(s, 5),

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -376,7 +376,7 @@ class DetectionValidator(BaseValidator):
         Examples:
              >>> result = {
              ...     "image_id": 42,
-             ...     "filename": "42.jpg",
+             ...     "file_name": "42.jpg",
              ...     "category_id": 18,
              ...     "bbox": [258.15, 41.29, 348.26, 243.78],
              ...     "score": 0.236,
@@ -391,7 +391,7 @@ class DetectionValidator(BaseValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
-                    "filename": path.name,
+                    "file_name": path.name,
                     "category_id": self.class_map[int(c)],
                     "bbox": [round(x, 3) for x in b],
                     "score": round(s, 5),

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -185,7 +185,7 @@ class OBBValidator(DetectionValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
-                    "filename": path.name,
+                    "file_name": path.name,
                     "category_id": self.class_map[int(c)],
                     "score": round(s, 5),
                     "rbox": [round(x, 3) for x in r],

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -178,7 +178,6 @@ class OBBValidator(DetectionValidator):
         """
         path = Path(pbatch["im_file"])
         stem = path.stem
-        filename = path.name
         image_id = int(stem) if stem.isnumeric() else stem
         rbox = predn["bboxes"]
         poly = ops.xywhr2xyxyxyxy(rbox).view(-1, 8)
@@ -186,7 +185,7 @@ class OBBValidator(DetectionValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
-                    "filename": filename,
+                    "filename": path.name,
                     "category_id": self.class_map[int(c)],
                     "score": round(s, 5),
                     "rbox": [round(x, 3) for x in r],

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -176,7 +176,9 @@ class OBBValidator(DetectionValidator):
             (x, y, w, h, angle) and polygon format (x1, y1, x2, y2, x3, y3, x4, y4) before adding them
             to the JSON dictionary.
         """
-        stem = Path(pbatch["im_file"]).stem
+        path = Path(pbatch["im_file"])
+        stem = path.stem
+        filename = path.name
         image_id = int(stem) if stem.isnumeric() else stem
         rbox = predn["bboxes"]
         poly = ops.xywhr2xyxyxyxy(rbox).view(-1, 8)
@@ -184,6 +186,7 @@ class OBBValidator(DetectionValidator):
             self.jdict.append(
                 {
                     "image_id": image_id,
+                    "filename": filename,
                     "category_id": self.class_map[int(c)],
                     "score": round(s, 5),
                     "rbox": [round(x, 3) for x in r],

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -219,7 +219,7 @@ class SegmentationValidator(DetectionValidator):
             pbatch (Dict[str, Any]): Batch dictionary containing 'imgsz', 'ori_shape', 'ratio_pad', and 'im_file'.
 
         Examples:
-             >>> result = {"image_id": 42, "category_id": 18, "bbox": [258.15, 41.29, 348.26, 243.78], "score": 0.236}
+             >>> result = {"image_id": 42, "filename": "42.jpg", "category_id": 18, "bbox": [258.15, 41.29, 348.26, 243.78], "score": 0.236}
         """
         from faster_coco_eval.core.mask import encode  # noqa
 

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -219,7 +219,13 @@ class SegmentationValidator(DetectionValidator):
             pbatch (Dict[str, Any]): Batch dictionary containing 'imgsz', 'ori_shape', 'ratio_pad', and 'im_file'.
 
         Examples:
-             >>> result = {"image_id": 42, "filename": "42.jpg", "category_id": 18, "bbox": [258.15, 41.29, 348.26, 243.78], "score": 0.236}
+             >>> result = {
+             ...     "image_id": 42,
+             ...     "filename": "42.jpg",
+             ...     "category_id": 18,
+             ...     "bbox": [258.15, 41.29, 348.26, 243.78],
+             ...     "score": 0.236,
+             ... }
         """
         from faster_coco_eval.core.mask import encode  # noqa
 

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -217,15 +217,6 @@ class SegmentationValidator(DetectionValidator):
         Args:
             predn (Dict[str, torch.Tensor]): Predictions containing bboxes, masks, confidence scores, and classes.
             pbatch (Dict[str, Any]): Batch dictionary containing 'imgsz', 'ori_shape', 'ratio_pad', and 'im_file'.
-
-        Examples:
-             >>> result = {
-             ...     "image_id": 42,
-             ...     "filename": "42.jpg",
-             ...     "category_id": 18,
-             ...     "bbox": [258.15, 41.29, 348.26, 243.78],
-             ...     "score": 0.236,
-             ... }
         """
         from faster_coco_eval.core.mask import encode  # noqa
 


### PR DESCRIPTION
fix #21557 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds file_name to JSON predictions across validators and improves docs/examples, making results easier to trace back to source images without changing model behavior. 📄✅

### 📊 Key Changes
- RT-DETR, YOLO Detect, and YOLO OBB validators now include "file_name" in JSON outputs alongside image_id. 🏷️
- Refactored path handling to use path = Path(pbatch["im_file"]) and stem = path.stem for consistency. 🔧
- YOLO Detect: enhanced docstring with a clear JSON result example. 📘
- YOLO Segment: removed an outdated inline example for cleaner docs. 🧹

### 🎯 Purpose & Impact
- Easier traceability: "file_name" helps map predictions back to original files, especially when image_id isn’t numeric or unique. 🔍
- Better interoperability: Some downstream tools and pipelines expect or benefit from file_name in results. 🔗
- Non-breaking change: COCO evaluators typically ignore extra keys, so existing workflows should continue to work; update any strict parsers if they assume a fixed key set. 🧩
- No performance impact or training/inference changes. ⚡

See the Ultralytics Docs for details: https://docs.ultralytics.com