### PR TITLE
Use `torch.long` dtype for classes in `non_max_suppression`

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -246,6 +246,7 @@ def non_max_suppression(
         prediction = prediction[0]  # select only inference output
     if classes is not None:
         classes = torch.tensor(classes, device=prediction.device, dtype=torch.long)
+
     if prediction.shape[-1] == 6 or end2end:  # end-to-end model (BNC, i.e. 1,300,6)
         output = [pred[pred[:, 4] > conf_thres][:max_det] for pred in prediction]
         if classes is not None:

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -245,8 +245,7 @@ def non_max_suppression(
     if isinstance(prediction, (list, tuple)):  # YOLOv8 model in validation model, output = (inference_out, loss_out)
         prediction = prediction[0]  # select only inference output
     if classes is not None:
-        classes = torch.tensor(classes, device=prediction.device)
-
+        classes = torch.tensor(classes, device=prediction.device, dtype=torch.long)
     if prediction.shape[-1] == 6 or end2end:  # end-to-end model (BNC, i.e. 1,300,6)
         output = [pred[pred[:, 4] > conf_thres][:max_det] for pred in prediction]
         if classes is not None:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ensures class filtering in non_max_suppression uses integer dtype to prevent type-related bugs and make filtering more reliable. ✅

### 📊 Key Changes
- Forces `classes` to be a `torch.long` tensor: `torch.tensor(classes, device=prediction.device, dtype=torch.long)` in `non_max_suppression`. 🛠️

### 🎯 Purpose & Impact
- Prevents dtype mismatches and runtime errors when users pass class IDs as floats or mixed types. 🧰
- Improves robustness across devices and pipelines (e.g., CPU/GPU, validation, exports). 🔒
- No API changes; negligible performance impact. Smooths class-based filtering for all YOLO models. ⚡