### PR TITLE
Refactor HUB root URLs for speed

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -20,7 +20,7 @@ from ultralytics.utils import (
     SETTINGS,
     YAML,
     callbacks,
-    checks,
+    checks, HUB_WEB_ROOT,
 )
 
 
@@ -229,7 +229,6 @@ class Model(torch.nn.Module):
             >>> Model.is_hub_model("yolo11n.pt")
             False
         """
-        from ultralytics.hub import HUB_WEB_ROOT
 
         return model.startswith(f"{HUB_WEB_ROOT}/models/")
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -15,12 +15,13 @@ from ultralytics.utils import (
     ARGV,
     ASSETS,
     DEFAULT_CFG_DICT,
+    HUB_WEB_ROOT,
     LOGGER,
     RANK,
     SETTINGS,
     YAML,
     callbacks,
-    checks, HUB_WEB_ROOT,
+    checks,
 )
 
 
@@ -229,7 +230,6 @@ class Model(torch.nn.Module):
             >>> Model.is_hub_model("yolo11n.pt")
             False
         """
-
         return model.startswith(f"{HUB_WEB_ROOT}/models/")
 
     def _new(self, cfg: str, task=None, model=None, verbose=False) -> None:

--- a/ultralytics/hub/__init__.py
+++ b/ultralytics/hub/__init__.py
@@ -5,12 +5,11 @@ import requests
 from ultralytics.data.utils import HUBDatasetStats
 from ultralytics.hub.auth import Auth
 from ultralytics.hub.session import HUBTrainingSession
-from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT, PREFIX, events
-from ultralytics.utils import LOGGER, SETTINGS, checks
+from ultralytics.hub.utils import PREFIX, events
+from ultralytics.utils import LOGGER, SETTINGS, checks, HUB_API_ROOT, HUB_WEB_ROOT
 
 __all__ = (
     "PREFIX",
-    "HUB_WEB_ROOT",
     "HUBTrainingSession",
     "login",
     "logout",

--- a/ultralytics/hub/__init__.py
+++ b/ultralytics/hub/__init__.py
@@ -6,7 +6,7 @@ from ultralytics.data.utils import HUBDatasetStats
 from ultralytics.hub.auth import Auth
 from ultralytics.hub.session import HUBTrainingSession
 from ultralytics.hub.utils import PREFIX, events
-from ultralytics.utils import LOGGER, SETTINGS, checks, HUB_API_ROOT, HUB_WEB_ROOT
+from ultralytics.utils import HUB_API_ROOT, HUB_WEB_ROOT, LOGGER, SETTINGS, checks
 
 __all__ = (
     "PREFIX",

--- a/ultralytics/hub/auth.py
+++ b/ultralytics/hub/auth.py
@@ -2,8 +2,8 @@
 
 import requests
 
-from ultralytics.hub.utils import HUB_API_ROOT, HUB_WEB_ROOT, PREFIX, request_with_credentials
-from ultralytics.utils import IS_COLAB, LOGGER, SETTINGS, emojis
+from ultralytics.hub.utils import PREFIX, request_with_credentials
+from ultralytics.utils import IS_COLAB, LOGGER, SETTINGS, emojis, HUB_API_ROOT, HUB_WEB_ROOT
 
 API_KEY_URL = f"{HUB_WEB_ROOT}/settings?tab=api+keys"
 

--- a/ultralytics/hub/auth.py
+++ b/ultralytics/hub/auth.py
@@ -3,7 +3,7 @@
 import requests
 
 from ultralytics.hub.utils import PREFIX, request_with_credentials
-from ultralytics.utils import IS_COLAB, LOGGER, SETTINGS, emojis, HUB_API_ROOT, HUB_WEB_ROOT
+from ultralytics.utils import HUB_API_ROOT, HUB_WEB_ROOT, IS_COLAB, LOGGER, SETTINGS, emojis
 
 API_KEY_URL = f"{HUB_WEB_ROOT}/settings?tab=api+keys"
 

--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -12,7 +12,7 @@ import requests
 
 from ultralytics import __version__
 from ultralytics.hub.utils import HELP_MSG, PREFIX
-from ultralytics.utils import IS_COLAB, LOGGER, SETTINGS, TQDM, checks, emojis, HUB_WEB_ROOT
+from ultralytics.utils import HUB_WEB_ROOT, IS_COLAB, LOGGER, SETTINGS, TQDM, checks, emojis
 from ultralytics.utils.errors import HUBModelError
 
 AGENT_NAME = f"python-{__version__}-colab" if IS_COLAB else f"python-{__version__}-local"

--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -11,8 +11,8 @@ from urllib.parse import parse_qs, urlparse
 import requests
 
 from ultralytics import __version__
-from ultralytics.hub.utils import HELP_MSG, HUB_WEB_ROOT, PREFIX
-from ultralytics.utils import IS_COLAB, LOGGER, SETTINGS, TQDM, checks, emojis
+from ultralytics.hub.utils import HELP_MSG, PREFIX
+from ultralytics.utils import IS_COLAB, LOGGER, SETTINGS, TQDM, checks, emojis, HUB_WEB_ROOT
 from ultralytics.utils.errors import HUBModelError
 
 AGENT_NAME = f"python-{__version__}-colab" if IS_COLAB else f"python-{__version__}-local"

--- a/ultralytics/hub/utils.py
+++ b/ultralytics/hub/utils.py
@@ -1,6 +1,5 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-import os
 import random
 import threading
 import time
@@ -29,9 +28,6 @@ from ultralytics.utils import (
 )
 from ultralytics.utils.downloads import GITHUB_ASSETS_NAMES
 from ultralytics.utils.torch_utils import get_cpu_info
-
-HUB_API_ROOT = os.environ.get("ULTRALYTICS_HUB_API", "https://api.ultralytics.com")
-HUB_WEB_ROOT = os.environ.get("ULTRALYTICS_HUB_WEB", "https://hub.ultralytics.com")
 
 PREFIX = colorstr("Ultralytics HUB: ")
 HELP_MSG = "If this issue persists please visit https://github.com/ultralytics/hub/issues for assistance."

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -48,6 +48,8 @@ PYTHON_VERSION = platform.python_version()
 TORCH_VERSION = torch.__version__
 TORCHVISION_VERSION = importlib.metadata.version("torchvision")  # faster than importing torchvision
 IS_VSCODE = os.environ.get("TERM_PROGRAM", False) == "vscode"
+HUB_API_ROOT = os.environ.get("ULTRALYTICS_HUB_API", "https://api.ultralytics.com")
+HUB_WEB_ROOT = os.environ.get("ULTRALYTICS_HUB_WEB", "https://hub.ultralytics.com")
 RKNN_CHIPS = frozenset(
     {
         "rk3588",
@@ -1471,5 +1473,3 @@ torch.save = torch_save
 if WINDOWS:
     # Apply cv2 patches for non-ASCII and non-UTF characters in image paths
     cv2.imread, cv2.imwrite, cv2.imshow = imread, imwrite, imshow
-HUB_API_ROOT = os.environ.get("ULTRALYTICS_HUB_API", "https://api.ultralytics.com")
-HUB_WEB_ROOT = os.environ.get("ULTRALYTICS_HUB_WEB", "https://hub.ultralytics.com")

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1471,3 +1471,5 @@ torch.save = torch_save
 if WINDOWS:
     # Apply cv2 patches for non-ASCII and non-UTF characters in image paths
     cv2.imread, cv2.imwrite, cv2.imshow = imread, imwrite, imshow
+HUB_API_ROOT = os.environ.get("ULTRALYTICS_HUB_API", "https://api.ultralytics.com")
+HUB_WEB_ROOT = os.environ.get("ULTRALYTICS_HUB_WEB", "https://hub.ultralytics.com")

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -3,8 +3,8 @@
 import json
 from time import time
 
-from ultralytics.hub import HUB_WEB_ROOT, PREFIX, HUBTrainingSession, events
-from ultralytics.utils import LOGGER, RANK, SETTINGS
+from ultralytics.hub import PREFIX, HUBTrainingSession, events
+from ultralytics.utils import LOGGER, RANK, SETTINGS, HUB_WEB_ROOT
 
 
 def on_pretrain_routine_start(trainer):

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -4,7 +4,7 @@ import json
 from time import time
 
 from ultralytics.hub import PREFIX, HUBTrainingSession, events
-from ultralytics.utils import LOGGER, RANK, SETTINGS, HUB_WEB_ROOT
+from ultralytics.utils import HUB_WEB_ROOT, LOGGER, RANK, SETTINGS
 
 
 def on_pretrain_routine_start(trainer):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Consolidates Ultralytics HUB endpoint constants into a single location and updates imports across the codebase for cleaner, more reliable HUB integrations. 🔧

### 📊 Key Changes
- Moved `HUB_API_ROOT` and `HUB_WEB_ROOT` definitions from `ultralytics.hub.utils` to `ultralytics.utils`.
- Updated all imports to use `ultralytics.utils.HUB_API_ROOT` and `ultralytics.utils.HUB_WEB_ROOT`.
- Removed `HUB_WEB_ROOT` from `ultralytics.hub.__init__.__all__`.
- Simplified `Model.is_hub_model()` by using a module-level import of `HUB_WEB_ROOT` (no more inline import).
- Preserved environment variable overrides:
  - `ULTRALYTICS_HUB_API` → `HUB_API_ROOT`
  - `ULTRALYTICS_HUB_WEB` → `HUB_WEB_ROOT`

### 🎯 Purpose & Impact
- Reduces circular imports and improves code reliability and maintainability. 🧹
- Centralizes HUB configuration, making it easier to manage and test. 🧭
- Minor performance improvement by removing function-level imports. ⚡
- Potential breaking change for anyone importing from old paths:
  - Before: `from ultralytics.hub.utils import HUB_WEB_ROOT`
  - Now: `from ultralytics.utils import HUB_WEB_ROOT`
- No changes to user-facing behavior; existing env var customization continues to work. ✅

Example update:
```python
# New import path
from ultralytics.utils import HUB_WEB_ROOT, HUB_API_ROOT
```