### PR TITLE
Autobackend `model.fuse()` order of operations speedup

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -194,9 +194,10 @@ class AutoBackend(nn.Module):
 
         # In-memory PyTorch model
         if nn_module:
-            model = weights.to(device)
             if fuse:
-                model = model.fuse(verbose=verbose)
+                model = (
+                    weights.to(device).fuse(verbose=verbose) if IS_JETSON else weights.fuse(verbose=verbose).to(device)
+                )
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only
             stride = max(int(model.stride.max()), 32)  # model stride

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -196,7 +196,9 @@ class AutoBackend(nn.Module):
         if nn_module:
             if fuse:
                 # Handle Jetson Jetpack5 fuse bug https://github.com/ultralytics/ultralytics/pull/21028
-                weights = weights.to(device).fuse(verbose=verbose) if is_jetson(jetpack=5) else weights.fuse(verbose=verbose)
+                weights = (
+                    weights.to(device).fuse(verbose=verbose) if is_jetson(jetpack=5) else weights.fuse(verbose=verbose)
+                )
             model = weights.to(device)
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -195,10 +195,10 @@ class AutoBackend(nn.Module):
         # In-memory PyTorch model
         if nn_module:
             if fuse:
-                # Handle Jetson Jetpack5 fuse bug https://github.com/ultralytics/ultralytics/pull/21028
-                weights = (
-                    weights.to(device).fuse(verbose=verbose) if is_jetson(jetpack=5) else weights.fuse(verbose=verbose)
-                )
+                if IS_JETSON and is_jetson(jetpack=5):
+                    # Jetson Jetpack5 requires device before fuse https://github.com/ultralytics/ultralytics/pull/21028
+                    weights = weights.to(device)
+                weights = weights.fuse(verbose=verbose)
             model = weights.to(device)
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -195,9 +195,8 @@ class AutoBackend(nn.Module):
         # In-memory PyTorch model
         if nn_module:
             if fuse:
-                model = (
-                    weights.to(device).fuse(verbose=verbose) if IS_JETSON else weights.fuse(verbose=verbose).to(device)
-                )
+                weights = weights.to(device).fuse(verbose=verbose) if IS_JETSON else weights.fuse(verbose=verbose)
+            model = weights.to(device)
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only
             stride = max(int(model.stride.max()), 32)  # model stride

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -14,7 +14,7 @@ import torch
 import torch.nn as nn
 from PIL import Image
 
-from ultralytics.utils import ARM64, IS_JETSON, LINUX, LOGGER, PYTHON_VERSION, ROOT, YAML
+from ultralytics.utils import ARM64, IS_JETSON, LINUX, LOGGER, PYTHON_VERSION, ROOT, YAML, is_jetson
 from ultralytics.utils.checks import check_requirements, check_suffix, check_version, check_yaml, is_rockchip
 from ultralytics.utils.downloads import attempt_download_asset, is_url
 
@@ -195,7 +195,8 @@ class AutoBackend(nn.Module):
         # In-memory PyTorch model
         if nn_module:
             if fuse:
-                weights = weights.to(device).fuse(verbose=verbose) if IS_JETSON else weights.fuse(verbose=verbose)
+                # Handle Jetson Jetpack5 fuse bug https://github.com/ultralytics/ultralytics/pull/21028
+                weights = weights.to(device).fuse(verbose=verbose) if is_jetson(jetpack=5) else weights.fuse(verbose=verbose)
             model = weights.to(device)
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1500,7 +1500,7 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt, w = torch_safe_load(w)  # load ckpt
         args = {**DEFAULT_CFG_DICT, **ckpt["train_args"]} if "train_args" in ckpt else None  # combined args
-        model = (ckpt.get("ema") or ckpt["model"]).to(device).float()  # FP32 model
+        model = (ckpt.get("ema") or ckpt["model"]).float()  # FP32 model
 
         # Model compatibility updates
         model.args = args  # attach args to model
@@ -1510,7 +1510,9 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
             model.stride = torch.tensor([32.0])
 
         # Append
-        ensemble.append(model.fuse().eval() if fuse and hasattr(model, "fuse") else model.eval())  # model in eval mode
+        ensemble.append(
+            (model.fuse().eval() if fuse and hasattr(model, "fuse") else model.eval()).to(device)
+        )  # model in eval mode
 
     # Module updates
     for m in ensemble.modules():

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1510,9 +1510,7 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
             model.stride = torch.tensor([32.0])
 
         # Append
-        ensemble.append(
-            (model.fuse().eval() if fuse and hasattr(model, "fuse") else model.eval()).to(device)
-        )  # model in eval mode
+        ensemble.append((model.fuse().eval() if fuse and hasattr(model, "fuse") else model.eval()).to(device))
 
     # Module updates
     for m in ensemble.modules():

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import threading
 import time
+from functools import lru_cache
 from pathlib import Path
 from threading import Lock
 from types import SimpleNamespace
@@ -727,6 +728,7 @@ def is_raspberrypi() -> bool:
     return "rpi" in DEVICE_MODEL
 
 
+@lru_cache(maxsize=3)
 def is_jetson(jetpack=None) -> bool:
     """
     Determine if the Python environment is running on an NVIDIA Jetson device.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves model device placement and fusion order for broader hardware compatibility—especially NVIDIA Jetson JetPack 5—while adding a small performance optimization 🛠️⚡

### 📊 Key Changes
- Adjusted fusion/device order in autobackend:
  - On Jetson with JetPack 5, move model to device before `fuse()` to avoid runtime issues.
  - For other devices, fuse first, then move to the target device.
- Updated weight loading (`attempt_load_weights`):
  - Perform `fuse()` and `.eval()` before moving the model to the device, then call `.to(device)` once at the end for consistency.
- Exported and used `is_jetson` in autobackend, with `@lru_cache(maxsize=3)` to cache Jetson detection for faster repeated checks.

### 🎯 Purpose & Impact
- Better Jetson stability ✅: Fixes fusion-related errors on NVIDIA Jetson JetPack 5 devices, improving reliability for edge deployments.
- Consistent device handling 🔁: Reduces device mismatch and unnecessary transfers by standardizing when models are moved to devices.
- Minor performance boost 🚀: Caching `is_jetson()` avoids repeated system checks, slightly speeding up startup and environment detection.
- Transparent for most users 👌: No API changes; behavior is unchanged on non-Jetson systems except for safer, more consistent device moves.