### PR TITLE
Update `TQDM` progress bar to display remaining time

### DIFF
--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -258,9 +258,8 @@ class TQDM:
 
         # Calculate remaining time
         remaining_str = ""
-        if self.total and self.n > 0 and self.n < self.total:
-            if rate > 0:
-                remaining_str = self._format_time((self.total - self.n) / rate)
+        if self.total and 0 < self.n < self.total and rate > 0:
+            remaining_str = self._format_time((self.total - self.n) / rate)
 
         # Build progress components
         if self.total:

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -140,7 +140,9 @@ class TQDM:
 
         # Set bar format based on whether we have a total
         if self.total is not None:
-            self.bar_format = bar_format or "{desc}: {percentage:3.0f}% {bar} {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]"
+            self.bar_format = (
+                bar_format or "{desc}: {percentage:3.0f}% {bar} {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]"
+            )
         else:
             self.bar_format = bar_format or "{desc}: {bar} {n_fmt} {rate_fmt} {elapsed}"
 

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -139,7 +139,7 @@ class TQDM:
         self.initial = initial
 
         # Set bar format based on whether we have a total
-        if self.total is not None:
+        if self.total:
             self.bar_format = bar_format or "{desc}: {percent:3.0f}% {bar} {n}/{total} {rate} {elapsed}<{remaining}"
         else:
             self.bar_format = bar_format or "{desc}: {bar} {n} {rate} {elapsed}"
@@ -155,7 +155,7 @@ class TQDM:
         self.closed = False
 
         # Display initial bar if we have total and not disabled
-        if not self.disable and self.total is not None and not self.noninteractive:
+        if not self.disable and self.total and not self.noninteractive:
             self._display()
 
     def _format_rate(self, rate: float) -> str:
@@ -218,7 +218,7 @@ class TQDM:
         if self.noninteractive:
             return False
 
-        if self.total is not None and self.n >= self.total:
+        if self.total and self.n >= self.total:
             return True
 
         return dt >= self.mininterval
@@ -258,12 +258,12 @@ class TQDM:
 
         # Calculate remaining time
         remaining_str = ""
-        if self.total is not None and self.n > 0 and self.n < self.total:
+        if self.total and self.n > 0 and self.n < self.total:
             if rate > 0:
                 remaining_str = self._format_time((self.total - self.n) / rate)
 
         # Build progress components
-        if self.total is not None:
+        if self.total:
             percent = (self.n / self.total) * 100
             # For bytes with unit scaling, avoid repeating units: show "5.4/5.4MB" not "5.4MB/5.4MB"
             n = self._format_num(self.n)
@@ -278,7 +278,7 @@ class TQDM:
         elapsed_str = self._format_time(elapsed)
 
         # Use different format for completion
-        if self.total is not None and self.n >= self.total:
+        if self.total and self.n >= self.total:
             format_str = self.bar_format.replace("<{remaining}", "")
         else:
             format_str = self.bar_format
@@ -407,7 +407,7 @@ if __name__ == "__main__":
     import time
 
     print("1. Basic progress bar with known total:")
-    for i in TQDM(range(0), desc="Known total"):
+    for i in TQDM(range(3), desc="Known total"):
         time.sleep(0.05)
 
     print("\n2. Manual updates with known total:")

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -260,8 +260,7 @@ class TQDM:
         remaining_str = ""
         if self.total is not None and self.n > 0 and self.n < self.total:
             if rate > 0:
-                remaining = (self.total - self.n) / rate
-                remaining_str = self._format_time(remaining)
+                remaining_str = self._format_time((self.total - self.n) / rate)
 
         # Build progress components
         if self.total is not None:

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -140,7 +140,7 @@ class TQDM:
 
         # Set bar format based on whether we have a total
         if self.total is not None:
-            self.bar_format = bar_format or "{desc}: {percentage:3.0f}% {bar} {n_fmt}/{total_fmt} {rate_fmt} {elapsed}"
+            self.bar_format = bar_format or "{desc}: {percentage:3.0f}% {bar} {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]"
         else:
             self.bar_format = bar_format or "{desc}: {bar} {n_fmt} {rate_fmt} {elapsed}"
 
@@ -262,14 +262,17 @@ class TQDM:
             # For bytes with unit scaling, avoid repeating units: show "5.4/5.4MB" not "5.4MB/5.4MB"
             n_fmt = self._format_num(self.n)
             total_fmt = self._format_num(self.total)
+            remaining = (self.total - self.n) / rate if rate > 0 else 0
             if self.unit_scale and self.unit in ("B", "bytes"):
                 n_fmt = n_fmt.rstrip("KMGTPB")  # Remove unit suffix from current
         else:
             percentage = 0
             n_fmt = self._format_num(self.n)
             total_fmt = "?"
+            remaining = 0
 
         elapsed_str = self._format_time(elapsed)
+        remaining_str = self._format_time(remaining)
         rate_fmt = self._format_rate(rate) or (self._format_rate(self.n / elapsed) if elapsed > 0 else "")
 
         # Format progress string
@@ -280,6 +283,7 @@ class TQDM:
             n_fmt=n_fmt,
             total_fmt=total_fmt,
             rate_fmt=rate_fmt,
+            remaining=remaining_str,
             elapsed=elapsed_str,
             unit=self.unit,
         )

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -140,7 +140,7 @@ class TQDM:
 
         # Set bar format based on whether we have a total
         if self.total:
-            self.bar_format = bar_format or "{desc}: {percent:3.0f}% {bar} {n}/{total} {rate} {elapsed}<{remaining}"
+            self.bar_format = bar_format or "{desc}: {percent:.0f}% {bar} {n}/{total} {rate} {elapsed}<{remaining}"
         else:
             self.bar_format = bar_format or "{desc}: {bar} {n} {rate} {elapsed}"
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves Ultralytics’ custom TQDM progress bar with cleaner formatting, ETA display, and clearer completion handling for a more informative and user-friendly experience. ⏳✅

### 📊 Key Changes
- Updated default bar format:
  - Shows percent, counts, rate, elapsed time, and ETA: `{percent:.0f}% {bar} {n}/{total} {rate} {elapsed}<{remaining}`
  - When total is unknown: `{bar} {n} {rate} {elapsed}`
  - Hides the ETA once complete.
- Added ETA (remaining time) when total is known and progress is in-flight.
- Simplified and standardized format fields:
  - Replaced `percentage`, `n_fmt`, `total_fmt`, `rate_fmt` with `percent`, `n`, `total`, `rate`, `remaining`.
- Smarter rate display: falls back to average rate if instantaneous rate isn’t available.
- Improved unit handling for bytes with scaling (avoids duplicated units like `5.4MB/5.4MB` → `5.4/5.4MB`).
- Safer “known total” checks by using truthiness of `total` in multiple places.
- Demo updates: example loops now show visible progress (e.g., `range(3)`, total `300`). 

### 🎯 Purpose & Impact
- Better UX: Clearer progress info with ETA helps users gauge completion time. 📈
- Cleaner output on completion: Removes redundant “<remaining” once done. 🎉
- More consistent API: Standardized format keys reduce confusion for contributors and extensions. 🧩
- Practical demos: Examples now visibly demonstrate the progress bar behavior out-of-the-box. 🧪

Tip: If you customize `bar_format`, use the new keys: `percent`, `bar`, `n`, `total`, `rate`, `elapsed`, `remaining`.