### PR TITLE
Eliminate duplicate ops indexing

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -389,16 +389,16 @@ def scale_image(masks, im0_shape, ratio_pad=None):
 
     Args:
         masks (np.ndarray): Resized and padded masks with shape [H, W, N] or [H, W, 3].
-        im0_shape (tuple): Original image shape as (height, width, channels).
+        im0_shape (tuple): Original image shape as HWC or HW (supports both).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
 
     Returns:
         (np.ndarray): Rescaled masks with shape [H, W, N] matching original image dimensions.
     """
     # Rescale coordinates (xyxy) from im1_shape to im0_shape
-    im0_h, im0_w, _ = im0_shape
+    im0_h, im0_w = im0_shape[:2]  # supports both HWC or HW shapes
     im1_h, im1_w, _ = masks.shape
-    if (im1_h, im1_w) == im0_shape:
+    if im1_h == im0_h and im1_w == im0_w:
         return masks
 
     if ratio_pad is None:  # calculate from im0_shape
@@ -790,7 +790,7 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     """
     img0_h, img0_w = img0_shape[:2]  # supports both HWC or HW shapes
     if ratio_pad is None:  # calculate from img0_shape
-        img1_h, img1_w = img1_shape[:2]  # # supports both HWC or HW shapes
+        img1_h, img1_w = img1_shape[:2]  # supports both HWC or HW shapes
         gain = min(img1_h / img0_h, img1_w / img0_w)  # gain  = old / new
         pad = (img1_w - img0_w * gain) / 2, (img1_h - img0_h * gain) / 2  # wh padding
     else:

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -370,7 +370,7 @@ def clip_coords(coords, shape):
     Returns:
         (torch.Tensor | np.ndarray): Clipped coordinates.
     """
-    h, w, _ = shape
+    h, w = shape
     if isinstance(coords, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
         coords[..., 0] = coords[..., 0].clamp(0, w)  # x
         coords[..., 1] = coords[..., 1].clamp(0, h)  # y
@@ -397,7 +397,7 @@ def scale_image(masks, im0_shape, ratio_pad=None):
     """
     # Rescale coordinates (xyxy) from im1_shape to im0_shape
     im0_h, im0_w = im0_shape
-    im1_h, im1_w = masks.shape[:2]
+    im1_h, im1_w, _ = masks.shape
     if (im1_h, im1_w) == im0_shape:
         return masks
 
@@ -778,9 +778,9 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Rescale segment coordinates from img1_shape to img0_shape.
 
     Args:
-        img1_shape (tuple): Shape of the source image.
+        img1_shape (tuple): Source image shape as (height, width).
         coords (torch.Tensor): Coordinates to scale with shape (N, 2).
-        img0_shape (tuple): Shape of the target image.
+        img0_shape (tuple): Image 0 shape as (height, width).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
         normalize (bool): Whether to normalize coordinates to range [0, 1].
         padding (bool): Whether coordinates are based on YOLO-style augmented images with padding.

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -342,12 +342,12 @@ def clip_boxes(boxes, shape):
 
     Args:
         boxes (torch.Tensor | np.ndarray): Bounding boxes to clip.
-        shape (tuple): Image shape as (height, width, channels) or (height, width).
+        shape (tuple): Image shape as HWC or HW (supports both).
 
     Returns:
         (torch.Tensor | np.ndarray): Clipped bounding boxes.
     """
-    h, w = shape[:2]  # note can be HWC or HW
+    h, w = shape[:2]  # supports both HWC or HW shapes
     if isinstance(boxes, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
         boxes[..., 0] = boxes[..., 0].clamp(0, w)  # x1
         boxes[..., 1] = boxes[..., 1].clamp(0, h)  # y1
@@ -365,12 +365,12 @@ def clip_coords(coords, shape):
 
     Args:
         coords (torch.Tensor | np.ndarray): Line coordinates to clip.
-        shape (tuple): Image shape as (height, width, channels).
+        shape (tuple): Image shape as HWC or HW (supports both).
 
     Returns:
         (torch.Tensor | np.ndarray): Clipped coordinates.
     """
-    h, w, _ = shape
+    h, w = shape[:2]  # supports both HWC or HW shapes
     if isinstance(coords, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
         coords[..., 0] = coords[..., 0].clamp(0, w)  # x
         coords[..., 1] = coords[..., 1].clamp(0, h)  # y
@@ -778,9 +778,9 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Rescale segment coordinates from img1_shape to img0_shape.
 
     Args:
-        img1_shape (tuple): Source image shape as (height, width).
+        img1_shape (tuple): Source image shape as HWC or HW (supports both).
         coords (torch.Tensor): Coordinates to scale with shape (N, 2).
-        img0_shape (tuple): Image 0 shape as (height, width, channels).
+        img0_shape (tuple): Image 0 shape as HWC or HW (supports both).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
         normalize (bool): Whether to normalize coordinates to range [0, 1].
         padding (bool): Whether coordinates are based on YOLO-style augmented images with padding.
@@ -788,9 +788,9 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Returns:
         (torch.Tensor): Scaled coordinates.
     """
-    img0_h, img0_w, _ = img0_shape
+    img0_h, img0_w = img0_shape[:2]  # supports both HWC or HW shapes
     if ratio_pad is None:  # calculate from img0_shape
-        img1_h, img1_w = img1_shape
+        img1_h, img1_w = img1_shape[:2]  # # supports both HWC or HW shapes
         gain = min(img1_h / img0_h, img1_w / img0_w)  # gain  = old / new
         pad = (img1_w - img0_w * gain) / 2, (img1_h - img0_h * gain) / 2  # wh padding
     else:

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -365,12 +365,12 @@ def clip_coords(coords, shape):
 
     Args:
         coords (torch.Tensor | np.ndarray): Line coordinates to clip.
-        shape (tuple): Image shape as (height, width).
+        shape (tuple): Image shape as (height, width, channels).
 
     Returns:
         (torch.Tensor | np.ndarray): Clipped coordinates.
     """
-    h, w = shape
+    h, w, _ = shape
     if isinstance(coords, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
         coords[..., 0] = coords[..., 0].clamp(0, w)  # x
         coords[..., 1] = coords[..., 1].clamp(0, h)  # y
@@ -389,14 +389,14 @@ def scale_image(masks, im0_shape, ratio_pad=None):
 
     Args:
         masks (np.ndarray): Resized and padded masks with shape [H, W, N] or [H, W, 3].
-        im0_shape (tuple): Original image shape as (height, width).
+        im0_shape (tuple): Original image shape as (height, width, channels).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
 
     Returns:
         (np.ndarray): Rescaled masks with shape [H, W, N] matching original image dimensions.
     """
     # Rescale coordinates (xyxy) from im1_shape to im0_shape
-    im0_h, im0_w = im0_shape
+    im0_h, im0_w, _ = im0_shape
     im1_h, im1_w, _ = masks.shape
     if (im1_h, im1_w) == im0_shape:
         return masks
@@ -780,7 +780,7 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Args:
         img1_shape (tuple): Source image shape as (height, width).
         coords (torch.Tensor): Coordinates to scale with shape (N, 2).
-        img0_shape (tuple): Image 0 shape as (height, width).
+        img0_shape (tuple): Image 0 shape as (height, width, channels).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
         normalize (bool): Whether to normalize coordinates to range [0, 1].
         padding (bool): Whether coordinates are based on YOLO-style augmented images with padding.
@@ -788,7 +788,7 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Returns:
         (torch.Tensor): Scaled coordinates.
     """
-    img0_h, img0_w = img0_shape
+    img0_h, img0_w, _ = img0_shape
     if ratio_pad is None:  # calculate from img0_shape
         img1_h, img1_w = img1_shape
         gain = min(img1_h / img0_h, img1_w / img0_w)  # gain  = old / new


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactors core geometry utilities to robustly handle both HW and HWC shapes, improving reliability of box, mask, and coordinate scaling and clipping across pipelines. 🧭✨

### 📊 Key Changes
- Added universal shape handling using shape[:2] in:
  - clip_boxes, clip_coords, scale_image, scale_coords
- Clarified and standardized padding variables:
  - Replaced tuple indexing with explicit pad_x/pad_y and pad_w/pad_h for readability and correctness
- Improved masking and scaling logic:
  - scale_masks: cleaner slicing and interpolation flow; reduced temporary variables
  - scale_image: corrected width/height pad ordering and shape extraction
- Minor performance/readability tweaks:
  - Local variable unpacking (x1, y1, x2, y2 / xc, yc, etc.) to reduce repeated indexing
- Updated docstrings to state support for both HW and HWC formats

### 🎯 Purpose & Impact
- Fewer shape-related bugs when passing images with channels (HWC) or without (HW) ✅
- More accurate box/mask placement after letterboxing and padding 🧩
- Clearer, more maintainable code that’s easier to reason about for contributors 🛠️
- Backwards compatible for most users; improves reliability across NumPy and PyTorch flows 🚀