### PR TITLE
Reintroduce inplace `.clamp_()` and `.sigmoid_()` ops

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.init import constant_, xavier_uniform_
 
-from ultralytics.utils import MACOS14
+from ultralytics.utils import NOT_MACOS14
 from ultralytics.utils.tal import TORCH_1_10, dist2bbox, dist2rbox, make_anchors
 from ultralytics.utils.torch_utils import fuse_conv_and_bn, smart_inference_mode
 
@@ -409,7 +409,7 @@ class Pose(Detect):
         else:
             y = kpts.clone()
             if ndim == 3:
-                if not MACOS14:
+                if NOT_MACOS14:
                     y[:, 2::ndim].sigmoid_()
                 else: # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
                     y[:, 2::ndim] = y[:, 2::ndim].sigmoid()

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.init import constant_, xavier_uniform_
 
+from ultralytics.utils import MACOS14
 from ultralytics.utils.tal import TORCH_1_10, dist2bbox, dist2rbox, make_anchors
 from ultralytics.utils.torch_utils import fuse_conv_and_bn, smart_inference_mode
 
@@ -408,7 +409,10 @@ class Pose(Detect):
         else:
             y = kpts.clone()
             if ndim == 3:
-                y[:, 2::ndim].sigmoid_()
+                if not MACOS14:
+                    y[:, 2::ndim].sigmoid_()
+                else: # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
+                    y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
             y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
             y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
             return y

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -408,7 +408,7 @@ class Pose(Detect):
         else:
             y = kpts.clone()
             if ndim == 3:
-                y[:, 2::ndim] = y[:, 2::ndim].sigmoid()  # sigmoid (WARNING: inplace .sigmoid_() Apple MPS bug)
+                y[:, 2::ndim].sigmoid_()
             y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
             y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
             return y

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -411,7 +411,7 @@ class Pose(Detect):
             if ndim == 3:
                 if not MACOS14:
                     y[:, 2::ndim].sigmoid_()
-                else: # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
+                else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
                     y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
             y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
             y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -44,7 +44,7 @@ VERBOSE = str(os.getenv("YOLO_VERBOSE", True)).lower() == "true"  # global verbo
 LOGGING_NAME = "ultralytics"
 MACOS, LINUX, WINDOWS = (platform.system() == x for x in ["Darwin", "Linux", "Windows"])  # environment booleans
 MACOS_VERSION = platform.mac_ver()[0] if MACOS else None
-MACOS14 = MACOS and MACOS_VERSION.startswith("14.")
+NOT_MACOS14 = MACOS and not MACOS_VERSION.startswith("14.")
 ARM64 = platform.machine() in {"arm64", "aarch64"}  # ARM64 booleans
 PYTHON_VERSION = platform.python_version()
 TORCH_VERSION = torch.__version__

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -44,7 +44,7 @@ VERBOSE = str(os.getenv("YOLO_VERBOSE", True)).lower() == "true"  # global verbo
 LOGGING_NAME = "ultralytics"
 MACOS, LINUX, WINDOWS = (platform.system() == x for x in ["Darwin", "Linux", "Windows"])  # environment booleans
 MACOS_VERSION = platform.mac_ver()[0] if MACOS else None
-NOT_MACOS14 = MACOS and not MACOS_VERSION.startswith("14.")
+NOT_MACOS14 = not (MACOS and MACOS_VERSION.startswith("14."))
 ARM64 = platform.machine() in {"arm64", "aarch64"}  # ARM64 booleans
 PYTHON_VERSION = platform.python_version()
 TORCH_VERSION = torch.__version__

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -11,7 +11,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from ultralytics.utils import LOGGER, MACOS14
+from ultralytics.utils import LOGGER, NOT_MACOS14
 from ultralytics.utils.metrics import batch_probiou
 
 
@@ -349,7 +349,7 @@ def clip_boxes(boxes, shape):
     """
     h, w = shape[:2]  # supports both HWC or HW shapes
     if isinstance(boxes, torch.Tensor):  # faster individually
-        if not MACOS14:
+        if NOT_MACOS14:
             boxes[..., 0].clamp_(0, w)  # x1
             boxes[..., 1].clamp_(0, h)  # y1
             boxes[..., 2].clamp_(0, w)  # x2
@@ -378,7 +378,7 @@ def clip_coords(coords, shape):
     """
     h, w = shape[:2]  # supports both HWC or HW shapes
     if isinstance(coords, torch.Tensor):
-        if not MACOS14:
+        if NOT_MACOS14:
             coords[..., 0].clamp_(0, w)  # x
             coords[..., 1].clamp_(0, h)  # y
         else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -389,16 +389,16 @@ def scale_image(masks, im0_shape, ratio_pad=None):
 
     Args:
         masks (np.ndarray): Resized and padded masks with shape [H, W, N] or [H, W, 3].
-        im0_shape (tuple): Original image shape as (height, width, channels).
+        im0_shape (tuple): Original image shape as HWC or HW (supports both).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
 
     Returns:
         (np.ndarray): Rescaled masks with shape [H, W, N] matching original image dimensions.
     """
     # Rescale coordinates (xyxy) from im1_shape to im0_shape
-    im0_h, im0_w, _ = im0_shape
+    im0_h, im0_w = im0_shape[:2]  # supports both HWC or HW shapes
     im1_h, im1_w, _ = masks.shape
-    if (im1_h, im1_w) == im0_shape:
+    if im1_h == im0_h and im1_w == im0_w:
         return masks
 
     if ratio_pad is None:  # calculate from im0_shape
@@ -790,7 +790,7 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     """
     img0_h, img0_w = img0_shape[:2]  # supports both HWC or HW shapes
     if ratio_pad is None:  # calculate from img0_shape
-        img1_h, img1_w = img1_shape[:2]  # # supports both HWC or HW shapes
+        img1_h, img1_w = img1_shape[:2]  # supports both HWC or HW shapes
         gain = min(img1_h / img0_h, img1_w / img0_w)  # gain  = old / new
         pad = (img1_w - img0_w * gain) / 2, (img1_h - img0_h * gain) / 2  # wh padding
     else:

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -370,7 +370,7 @@ def clip_coords(coords, shape):
     Returns:
         (torch.Tensor | np.ndarray): Clipped coordinates.
     """
-    h, w, _ = shape
+    h, w = shape
     if isinstance(coords, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
         coords[..., 0] = coords[..., 0].clamp(0, w)  # x
         coords[..., 1] = coords[..., 1].clamp(0, h)  # y
@@ -397,7 +397,7 @@ def scale_image(masks, im0_shape, ratio_pad=None):
     """
     # Rescale coordinates (xyxy) from im1_shape to im0_shape
     im0_h, im0_w = im0_shape
-    im1_h, im1_w = masks.shape[:2]
+    im1_h, im1_w, _ = masks.shape
     if (im1_h, im1_w) == im0_shape:
         return masks
 
@@ -778,9 +778,9 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Rescale segment coordinates from img1_shape to img0_shape.
 
     Args:
-        img1_shape (tuple): Shape of the source image.
+        img1_shape (tuple): Source image shape as (height, width).
         coords (torch.Tensor): Coordinates to scale with shape (N, 2).
-        img0_shape (tuple): Shape of the target image.
+        img0_shape (tuple): Image 0 shape as (height, width).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
         normalize (bool): Whether to normalize coordinates to range [0, 1].
         padding (bool): Whether coordinates are based on YOLO-style augmented images with padding.

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -354,7 +354,7 @@ def clip_boxes(boxes, shape):
             boxes[..., 1].clamp_(0, h)  # y1
             boxes[..., 2].clamp_(0, w)  # x2
             boxes[..., 3].clamp_(0, h)  # y2
-        else: # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
+        else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
             boxes[..., 0] = boxes[..., 0].clamp(0, w)
             boxes[..., 1] = boxes[..., 1].clamp(0, h)
             boxes[..., 2] = boxes[..., 2].clamp(0, w)

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -371,10 +371,10 @@ def clip_coords(coords, shape):
         (torch.Tensor | np.ndarray): Clipped coordinates.
     """
     h, w = shape[:2]  # supports both HWC or HW shapes
-    if isinstance(coords, torch.Tensor):  # faster individually
+    if isinstance(coords, torch.Tensor):
         coords[..., 0].clamp_(0, w)  # x
         coords[..., 1].clamp_(0, h)  # y
-    else:  # np.array (faster grouped)
+    else:  # np.array
         coords[..., 0] = coords[..., 0].clip(0, w)  # x
         coords[..., 1] = coords[..., 1].clip(0, h)  # y
     return coords

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -348,11 +348,11 @@ def clip_boxes(boxes, shape):
         (torch.Tensor | np.ndarray): Clipped bounding boxes.
     """
     h, w, _ = shape
-    if isinstance(boxes, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
-        boxes[..., 0] = boxes[..., 0].clamp(0, w)  # x1
-        boxes[..., 1] = boxes[..., 1].clamp(0, h)  # y1
-        boxes[..., 2] = boxes[..., 2].clamp(0, w)  # x2
-        boxes[..., 3] = boxes[..., 3].clamp(0, h)  # y2
+    if isinstance(boxes, torch.Tensor):  # faster individually
+        boxes[..., 0].clamp_(0, w)  # x1
+        boxes[..., 1].clamp_(0, h)  # y1
+        boxes[..., 2].clamp_(0, w)  # x2
+        boxes[..., 3].clamp_(0, h)  # y2
     else:  # np.array (faster grouped)
         boxes[..., [0, 2]] = boxes[..., [0, 2]].clip(0, w)  # x1, x2
         boxes[..., [1, 3]] = boxes[..., [1, 3]].clip(0, h)  # y1, y2
@@ -371,9 +371,9 @@ def clip_coords(coords, shape):
         (torch.Tensor | np.ndarray): Clipped coordinates.
     """
     h, w, _ = shape
-    if isinstance(coords, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
-        coords[..., 0] = coords[..., 0].clamp(0, w)  # x
-        coords[..., 1] = coords[..., 1].clamp(0, h)  # y
+    if isinstance(coords, torch.Tensor):  # faster individually
+        coords[..., 0].clamp_(0, w)  # x
+        coords[..., 1].clamp_(0, h)  # y
     else:  # np.array (faster grouped)
         coords[..., 0] = coords[..., 0].clip(0, w)  # x
         coords[..., 1] = coords[..., 1].clip(0, h)  # y

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -342,12 +342,12 @@ def clip_boxes(boxes, shape):
 
     Args:
         boxes (torch.Tensor | np.ndarray): Bounding boxes to clip.
-        shape (tuple): Image shape as (height, width, channels) or (height, width).
+        shape (tuple): Image shape as HWC or HW (supports both).
 
     Returns:
         (torch.Tensor | np.ndarray): Clipped bounding boxes.
     """
-    h, w = shape[:2]  # note can be HWC or HW
+    h, w = shape[:2]  # supports both HWC or HW shapes
     if isinstance(boxes, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
         boxes[..., 0] = boxes[..., 0].clamp(0, w)  # x1
         boxes[..., 1] = boxes[..., 1].clamp(0, h)  # y1
@@ -365,12 +365,12 @@ def clip_coords(coords, shape):
 
     Args:
         coords (torch.Tensor | np.ndarray): Line coordinates to clip.
-        shape (tuple): Image shape as (height, width, channels).
+        shape (tuple): Image shape as HWC or HW (supports both).
 
     Returns:
         (torch.Tensor | np.ndarray): Clipped coordinates.
     """
-    h, w, _ = shape
+    h, w = shape[:2]  # supports both HWC or HW shapes
     if isinstance(coords, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
         coords[..., 0] = coords[..., 0].clamp(0, w)  # x
         coords[..., 1] = coords[..., 1].clamp(0, h)  # y
@@ -778,9 +778,9 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Rescale segment coordinates from img1_shape to img0_shape.
 
     Args:
-        img1_shape (tuple): Source image shape as (height, width).
+        img1_shape (tuple): Source image shape as HWC or HW (supports both).
         coords (torch.Tensor): Coordinates to scale with shape (N, 2).
-        img0_shape (tuple): Image 0 shape as (height, width, channels).
+        img0_shape (tuple): Image 0 shape as HWC or HW (supports both).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
         normalize (bool): Whether to normalize coordinates to range [0, 1].
         padding (bool): Whether coordinates are based on YOLO-style augmented images with padding.
@@ -788,9 +788,9 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Returns:
         (torch.Tensor): Scaled coordinates.
     """
-    img0_h, img0_w, _ = img0_shape
+    img0_h, img0_w = img0_shape[:2]  # supports both HWC or HW shapes
     if ratio_pad is None:  # calculate from img0_shape
-        img1_h, img1_w = img1_shape
+        img1_h, img1_w = img1_shape[:2]  # # supports both HWC or HW shapes
         gain = min(img1_h / img0_h, img1_w / img0_w)  # gain  = old / new
         pad = (img1_w - img0_w * gain) / 2, (img1_h - img0_h * gain) / 2  # wh padding
     else:

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -365,12 +365,12 @@ def clip_coords(coords, shape):
 
     Args:
         coords (torch.Tensor | np.ndarray): Line coordinates to clip.
-        shape (tuple): Image shape as (height, width).
+        shape (tuple): Image shape as (height, width, channels).
 
     Returns:
         (torch.Tensor | np.ndarray): Clipped coordinates.
     """
-    h, w = shape
+    h, w, _ = shape
     if isinstance(coords, torch.Tensor):  # faster individually (WARNING: inplace .clamp_() Apple MPS bug)
         coords[..., 0] = coords[..., 0].clamp(0, w)  # x
         coords[..., 1] = coords[..., 1].clamp(0, h)  # y
@@ -389,14 +389,14 @@ def scale_image(masks, im0_shape, ratio_pad=None):
 
     Args:
         masks (np.ndarray): Resized and padded masks with shape [H, W, N] or [H, W, 3].
-        im0_shape (tuple): Original image shape as (height, width).
+        im0_shape (tuple): Original image shape as (height, width, channels).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
 
     Returns:
         (np.ndarray): Rescaled masks with shape [H, W, N] matching original image dimensions.
     """
     # Rescale coordinates (xyxy) from im1_shape to im0_shape
-    im0_h, im0_w = im0_shape
+    im0_h, im0_w, _ = im0_shape
     im1_h, im1_w, _ = masks.shape
     if (im1_h, im1_w) == im0_shape:
         return masks
@@ -780,7 +780,7 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Args:
         img1_shape (tuple): Source image shape as (height, width).
         coords (torch.Tensor): Coordinates to scale with shape (N, 2).
-        img0_shape (tuple): Image 0 shape as (height, width).
+        img0_shape (tuple): Image 0 shape as (height, width, channels).
         ratio_pad (tuple, optional): Ratio and padding values as ((ratio_h, ratio_w), (pad_h, pad_w)).
         normalize (bool): Whether to normalize coordinates to range [0, 1].
         padding (bool): Whether coordinates are based on YOLO-style augmented images with padding.
@@ -788,7 +788,7 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     Returns:
         (torch.Tensor): Scaled coordinates.
     """
-    img0_h, img0_w = img0_shape
+    img0_h, img0_w, _ = img0_shape
     if ratio_pad is None:  # calculate from img0_shape
         img1_h, img1_w = img1_shape
         gain = min(img1_h / img0_h, img1_w / img0_w)  # gain  = old / new


### PR DESCRIPTION
MPS bug appears resolved. @Y-T-G what do think?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Platform-safe speedups: enable in-place ops for most users while avoiding known macOS 14 MPS bugs, improving performance without changing results. 🚀🛡️

### 📊 Key Changes
- Introduced `NOT_MACOS14` flag in `ultralytics.utils` and replaced previous `MACOS14` usage.
- Enabled in-place operations where safe:
  - `sigmoid_()` in keypoint decoding (`head.py`) for non-macOS 14.
  - `clamp_()` in `clip_boxes` and `clip_coords` (`ops.py`) for non-macOS 14.
- Fallback to non-in-place ops on macOS 14 to avoid MPS-related crashes or errors.
- Updated imports to use the new `NOT_MACOS14` constant.

### 🎯 Purpose & Impact
- Performance boost for most users: in-place ops are faster and more memory-efficient. ⚡
- Stability on macOS 14: avoids known MPS in-place operation bugs; see the related macOS 14 MPS issue discussion.  
  [View the discussion](https://github.com/ultralytics/ultralytics/pull/21878) 🧯
- No changes to model outputs or accuracy—this is purely a runtime optimization/safety fix. ✅
- Potential minor breaking change only if you directly imported `MACOS14`; switch to `NOT_MACOS14`.