### PR TITLE
Rename Autobackend() `weights` to `model`

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -389,7 +389,7 @@ class BasePredictor:
             verbose (bool): Whether to print verbose output.
         """
         self.model = AutoBackend(
-            weights=model or self.args.model,
+            model=model or self.args.model,
             device=select_device(self.args.device, verbose=verbose),
             dnn=self.args.dnn,
             data=self.args.data,

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -155,7 +155,7 @@ class BaseValidator:
                 LOGGER.warning("validating an untrained model YAML will result in 0 mAP.")
             callbacks.add_integration_callbacks(self)
             model = AutoBackend(
-                weights=model or self.args.model,
+                model=model or self.args.model,
                 device=select_device(self.args.device, self.args.batch),
                 dnn=self.args.dnn,
                 data=self.args.data,

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -204,10 +204,11 @@ class AutoBackend(nn.Module):
                 model = model.to(device)
             else:  # pt file
                 from ultralytics.nn.tasks import attempt_load_weights
+
                 model = attempt_load_weights(
                     model if isinstance(model, list) else w, device=device, inplace=True, fuse=fuse
                 )
-            
+
             # Common PyTorch model processing
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -127,14 +127,14 @@ class AutoBackend(nn.Module):
         _model_type: Determine the model type from file path.
 
     Examples:
-        >>> model = AutoBackend(weights="yolo11n.pt", device="cuda")
+        >>> model = AutoBackend(model="yolo11n.pt", device="cuda")
         >>> results = model(img)
     """
 
     @torch.no_grad()
     def __init__(
         self,
-        weights: Union[str, List[str], torch.nn.Module] = "yolo11n.pt",
+        model: Union[str, List[str], torch.nn.Module] = "yolo11n.pt",
         device: torch.device = torch.device("cpu"),
         dnn: bool = False,
         data: Optional[Union[str, Path]] = None,
@@ -146,7 +146,7 @@ class AutoBackend(nn.Module):
         Initialize the AutoBackend for inference.
 
         Args:
-            weights (str | List[str] | torch.nn.Module): Path to the model weights file or a module instance.
+            model (str | List[str] | torch.nn.Module): Path to the model weights file or a module instance.
             device (torch.device): Device to run the model on.
             dnn (bool): Use OpenCV DNN module for ONNX inference.
             data (str | Path, optional): Path to the additional data.yaml file containing class names.
@@ -155,8 +155,8 @@ class AutoBackend(nn.Module):
             verbose (bool): Enable verbose logging.
         """
         super().__init__()
-        w = str(weights[0] if isinstance(weights, list) else weights)
-        nn_module = isinstance(weights, torch.nn.Module)
+        w = str(model[0] if isinstance(model, list) else model)
+        nn_module = isinstance(model, torch.nn.Module)
         (
             pt,
             jit,
@@ -180,7 +180,7 @@ class AutoBackend(nn.Module):
         nhwc = coreml or saved_model or pb or tflite or edgetpu or rknn  # BHWC formats (vs torch BCWH)
         stride, ch = 32, 3  # default stride and channels
         end2end, dynamic = False, False
-        model, metadata, task = None, None, None
+        metadata, task = None, None
 
         # Set device
         cuda = isinstance(device, torch.device) and torch.cuda.is_available() and device.type != "cpu"  # use CUDA
@@ -194,27 +194,29 @@ class AutoBackend(nn.Module):
 
         # In-memory PyTorch model
         if nn_module:
+            pt = True
             if fuse:
                 if IS_JETSON and is_jetson(jetpack=5):
                     # Jetson Jetpack5 requires device before fuse https://github.com/ultralytics/ultralytics/pull/21028
-                    weights = weights.to(device)
-                weights = weights.fuse(verbose=verbose)
-            model = weights.to(device)
+                    model = model.to(device)
+                model = model.fuse(verbose=verbose)
+            model = model.to(device)
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only
             stride = max(int(model.stride.max()), 32)  # model stride
             names = model.module.names if hasattr(model, "module") else model.names  # get class names
             model.half() if fp16 else model.float()
             ch = model.yaml.get("channels", 3)
+            for p in model.parameters():
+                p.requires_grad = False
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
-            pt = True
 
         # PyTorch
         elif pt:
             from ultralytics.nn.tasks import attempt_load_weights
 
             model = attempt_load_weights(
-                weights if isinstance(weights, list) else w, device=device, inplace=True, fuse=fuse
+                model if isinstance(model, list) else w, device=device, inplace=True, fuse=fuse
             )
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only
@@ -222,6 +224,8 @@ class AutoBackend(nn.Module):
             names = model.module.names if hasattr(model, "module") else model.names  # get class names
             model.half() if fp16 else model.float()
             ch = model.yaml.get("channels", 3)
+            for p in model.parameters():
+                p.requires_grad = False
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
 
         # TorchScript
@@ -602,17 +606,12 @@ class AutoBackend(nn.Module):
             dynamic = metadata.get("args", {}).get("dynamic", dynamic)
             ch = metadata.get("channels", 3)
         elif not (pt or triton or nn_module):
-            LOGGER.warning(f"Metadata not found for 'model={weights}'")
+            LOGGER.warning(f"Metadata not found for 'model={model}'")
 
         # Check names
         if "names" not in locals():  # names missing
             names = default_class_names(data)
         names = check_class_names(names)
-
-        # Disable gradients
-        if pt:
-            for p in model.parameters():
-                p.requires_grad = False
 
         self.__dict__.update(locals())  # assign all variables to self
 
@@ -879,7 +878,7 @@ class AutoBackend(nn.Module):
             (List[bool]): List of booleans indicating the model type.
 
         Examples:
-            >>> model = AutoBackend(weights="path/to/model.onnx")
+            >>> model = AutoBackend(model="path/to/model.onnx")
             >>> model_type = model._model_type()  # returns "onnx"
         """
         from ultralytics.engine.exporter import export_formats

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -597,7 +597,7 @@ class AutoBackend(nn.Module):
             dynamic = metadata.get("args", {}).get("dynamic", dynamic)
             ch = metadata.get("channels", 3)
         elif not (pt or triton or nn_module):
-            LOGGER.warning(f"Metadata not found for 'model={model}'")
+            LOGGER.warning(f"Metadata not found for 'model={w}'")
 
         # Check names
         if "names" not in locals():  # names missing

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -192,32 +192,23 @@ class AutoBackend(nn.Module):
         if not (pt or triton or nn_module):
             w = attempt_download_asset(w)
 
-        # In-memory PyTorch model
-        if nn_module:
-            pt = True
-            if fuse:
-                if IS_JETSON and is_jetson(jetpack=5):
-                    # Jetson Jetpack5 requires device before fuse https://github.com/ultralytics/ultralytics/pull/21028
-                    model = model.to(device)
-                model = model.fuse(verbose=verbose)
-            model = model.to(device)
-            if hasattr(model, "kpt_shape"):
-                kpt_shape = model.kpt_shape  # pose-only
-            stride = max(int(model.stride.max()), 32)  # model stride
-            names = model.module.names if hasattr(model, "module") else model.names  # get class names
-            model.half() if fp16 else model.float()
-            ch = model.yaml.get("channels", 3)
-            for p in model.parameters():
-                p.requires_grad = False
-            self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
-
-        # PyTorch
-        elif pt:
-            from ultralytics.nn.tasks import attempt_load_weights
-
-            model = attempt_load_weights(
-                model if isinstance(model, list) else w, device=device, inplace=True, fuse=fuse
-            )
+        # PyTorch (in-memory or file)
+        if nn_module or pt:
+            if nn_module:
+                pt = True
+                if fuse:
+                    if IS_JETSON and is_jetson(jetpack=5):
+                        # Jetson Jetpack5 requires device before fuse https://github.com/ultralytics/ultralytics/pull/21028
+                        model = model.to(device)
+                    model = model.fuse(verbose=verbose)
+                model = model.to(device)
+            else:  # pt file
+                from ultralytics.nn.tasks import attempt_load_weights
+                model = attempt_load_weights(
+                    model if isinstance(model, list) else w, device=device, inplace=True, fuse=fuse
+                )
+            
+            # Common PyTorch model processing
             if hasattr(model, "kpt_shape"):
                 kpt_shape = model.kpt_shape  # pose-only
             stride = max(int(model.stride.max()), 32)  # model stride


### PR DESCRIPTION
@ultralytics/yolo may eliminate duplicate weights in memory


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactors AutoBackend to use a consistent model parameter, unifies PyTorch model loading paths, and improves safety/perf by disabling gradients for PyTorch models. 🚀

### 📊 Key Changes
- Replaced weights= with model= across:
  - AutoBackend signature and docstrings
  - Predictor.setup_model() and Validator.__call__() instantiations
- Unified PyTorch handling:
  - Merged in-memory torch.nn.Module and .pt file logic into one path
  - Ensures proper device placement and optional layer fusion (with Jetson-specific ordering)
  - Disables gradients for all PyTorch models by default (p.requires_grad = False)
- Cleanups and fixes:
  - Avoids shadowing the model parameter by not reassigning it to None
  - Clearer warning message when metadata is missing
  - Updated examples to use model="..."

Minimal usage example:
```python
from ultralytics.nn.autobackend import AutoBackend
model = AutoBackend(model="yolo11n.pt", device="cuda")
```

### 🎯 Purpose & Impact
- Consistent API 🧭: Standardizes on model=, reducing confusion between “weights” vs “model” across the codebase.
- More robust PyTorch loading 🧱: Single code path lowers maintenance overhead and edge-case bugs (especially with in-memory models).
- Safer and faster inference ⚡: Gradients are disabled by default for PyTorch models, reducing memory and improving runtime.
- Jetson reliability 🤖: Maintains correct fuse/device order for JetPack 5 devices, improving compatibility.
- Minor migration note 🔁: If you instantiate AutoBackend directly, switch from weights= to model=. Positional use remains unaffected.