### PR TITLE
Use `subprocess.run()` for improved dataset autodownloads

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -124,6 +124,9 @@
 91465467+lalayants@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/91465467?v=4
   username: lalayants
+Bovey0809@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/10627971?v=4
+  username: Bovey0809
 Francesco.mttl@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/3855193?v=4
   username: ambitious-octopus

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -464,7 +464,7 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> Dict[str, Any]
                 safe_download(url=s, dir=DATASETS_DIR, delete=True)
             elif s.startswith("bash "):  # bash script
                 LOGGER.info(f"Running {s} ...")
-                r = os.system(s)
+                subprocess.run(s.split(), check=True)
             else:  # python script
                 exec(s, {"yaml": data})
             dt = f"({round(time.time() - t, 1)}s)"
@@ -509,7 +509,7 @@ def check_cls_dataset(dataset: Union[str, Path], split: str = "") -> Dict[str, A
         LOGGER.warning(f"Dataset not found, missing path {data_dir}, attempting download...")
         t = time.time()
         if str(dataset) == "imagenet":
-            subprocess.run(f"bash {ROOT / 'data/scripts/get_imagenet.sh'}", shell=True, check=True)
+            subprocess.run(["bash", str(ROOT / "data/scripts/get_imagenet.sh")], check=True)
         else:
             url = f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{dataset}.zip"
             download(url, dir=data_dir.parent)

--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -9,12 +9,12 @@ Examples:
     Visualize a module with Netron
     >>> from ultralytics.nn.modules import *
     >>> import torch
-    >>> import os
+    >>> import subprocess
     >>> x = torch.ones(1, 128, 40, 40)
     >>> m = Conv(128, 128)
     >>> f = f"{m._get_name()}.onnx"
     >>> torch.onnx.export(m, x, f)
-    >>> os.system(f"onnxslim {f} {f} && open {f}")  # pip install onnxslim
+    >>> subprocess.run(f"onnxslim {f} {f} && open {f}", shell=True, check=True)  # pip install onnxslim
 """
 
 from .block import (

--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -7,7 +7,7 @@ blocks, attention mechanisms, transformer components, and detection/segmentation
 
 Examples:
     Visualize a module with Netron
-    >>> from ultralytics.nn.modules import *
+    >>> from ultralytics.nn.modules import Conv
     >>> import torch
     >>> import subprocess
     >>> x = torch.ones(1, 128, 40, 40)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Replaces unsafe command execution with `subprocess.run` and improves module example imports for safer, more robust behavior across datasets and docs. 🛡️⚙️

### 📊 Key Changes
- Switched from `os.system(...)` to `subprocess.run(...)` in dataset utilities:
  - Detection dataset scripts: `subprocess.run(s.split(), check=True)` replaces `os.system(s)`
  - ImageNet script: `subprocess.run(["bash", str(ROOT / "data/scripts/get_imagenet.sh")], check=True)` removes `shell=True`
- Updated `ultralytics.nn.modules` docstring example:
  - Use explicit import `from ultralytics.nn.modules import Conv` instead of `import *`
  - Use `subprocess.run(..., shell=True, check=True)` instead of `os.system(...)` for ONNX slimming and opening

### 🎯 Purpose & Impact
- Better security and reliability by avoiding `os.system` and removing `shell=True` where not needed 🔒
- Clearer errors with `check=True`—failures surface immediately and are easier to debug 🚨
- Improved cross-platform compatibility and argument handling 🧰
- Cleaner, more explicit examples that encourage best practices and reduce namespace pollution 📘