### PR TITLE
Actions Concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@
 
 name: Ultralytics CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true  # on new commit, cancel previous runs for same branch
+
 permissions:
   contents: read
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

This pull request introduces a concurrency configuration to the GitHub Actions CI workflow. This ensures that only the latest workflow run for a given branch is executed, and any previous runs are automatically cancelled when a new commit is pushed. This will free up runners and prevent use of unnecessary compute.

GitHub Docs Reference: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds GitHub Actions concurrency to the Ultralytics CI workflow to auto-cancel older runs when new commits arrive on the same branch 🚦

### 📊 Key Changes
- Introduces a GitHub Actions `concurrency` block:
  - Groups runs by `workflow + ref` (branch/PR)
  - `cancel-in-progress: true` cancels previous in-progress runs when a new commit is pushed

### 🎯 Purpose & Impact
- Speeds up feedback by avoiding duplicate CI runs on rapid commits ⏩
- Reduces CI queue time and resource usage 💸
- Minimizes flaky race conditions between overlapping runs ✅
- No changes to user-facing code; impact is limited to CI behavior only 🔧
- Note: Long-running jobs may be canceled on new commits; re-run if needed 🔁