### PR TITLE
Add warning that legacy YOLOv5 models are not compatible with Ultralytics

### DIFF
--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -12,6 +12,9 @@ YOLOv5u represents an advancement in [object detection](https://www.ultralytics.
 
 ![Ultralytics YOLOv5](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov5-splash.avif)
 
+!!! warning "YOLOv5 models trained with `ultralytics/yolov5` are not compatible with the Ultralytics library"
+    Ultralytics provides an anchor-free variant of YOLOv5 model. Models trained with the [original YOLOv5 repo](https://github.com/ultralytics/yolov5) cannot be used with the Ultralytics library.
+
 ## Key Features
 
 - **Anchor-free Split Ultralytics Head:** Traditional object detection models rely on predefined anchor boxes to predict object locations. However, YOLOv5u modernizes this approach. By adopting an anchor-free split Ultralytics head, it ensures a more flexible and adaptive detection mechanism, consequently enhancing the performance in diverse scenarios.

--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -12,9 +12,9 @@ YOLOv5u represents an advancement in [object detection](https://www.ultralytics.
 
 ![Ultralytics YOLOv5](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov5-splash.avif)
 
-!!! warning "YOLOv5 models trained with `ultralytics/yolov5` are not compatible with the Ultralytics library"
+!!! warning "YOLOv5 models trained by `ultralytics/yolov5` are not compatible with the Ultralytics library"
 
-    Ultralytics provides an anchor-free variant of YOLOv5 model. Models trained with the [original YOLOv5 repo](https://github.com/ultralytics/yolov5) cannot be used with the Ultralytics library.
+    Ultralytics provides an [anchor-free variant of YOLOv5 model](#performance-metrics). Models trained with the [original YOLOv5 repo](https://github.com/ultralytics/yolov5) cannot be used with the Ultralytics library.
 
 ## Key Features
 

--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -12,7 +12,7 @@ YOLOv5u represents an advancement in [object detection](https://www.ultralytics.
 
 ![Ultralytics YOLOv5](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov5-splash.avif)
 
-!!! warning "YOLOv5 models trained by `ultralytics/yolov5` are not compatible with the Ultralytics library"
+!!! warning "YOLOv5 models trained by [ultralytics/yolov5](https://github.com/ultralytics/yolov5) are not compatible with [ultralytics/ultralytics](https://github.com/ultralytics/ultralytics) library"
 
     Ultralytics provides an [anchor-free variant of YOLOv5 model](#performance-metrics). Models trained with the [original YOLOv5 repo](https://github.com/ultralytics/yolov5) cannot be used with the Ultralytics library.
 

--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -13,6 +13,7 @@ YOLOv5u represents an advancement in [object detection](https://www.ultralytics.
 ![Ultralytics YOLOv5](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov5-splash.avif)
 
 !!! warning "YOLOv5 models trained with `ultralytics/yolov5` are not compatible with the Ultralytics library"
+
     Ultralytics provides an anchor-free variant of YOLOv5 model. Models trained with the [original YOLOv5 repo](https://github.com/ultralytics/yolov5) cannot be used with the Ultralytics library.
 
 ## Key Features


### PR DESCRIPTION
Closes #21914 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds a clear compatibility warning to the YOLOv5 docs: models trained in ultralytics/yolov5 are not compatible with the ultralytics/ultralytics library due to the anchor-free YOLOv5u design. ⚠️

### 📊 Key Changes
- Introduces a prominent docs warning that YOLOv5 models from the [ultralytics/yolov5 repository](https://github.com/ultralytics/yolov5) cannot be used with the [ultralytics/ultralytics library](https://github.com/ultralytics/ultralytics).  
- Clarifies that Ultralytics’ YOLOv5u is an anchor-free variant, which differs from the original YOLOv5 model architecture.

### 🎯 Purpose & Impact
- Reduces confusion and loading errors by explicitly stating cross-repo model incompatibility. 🙌  
- Guides users to train/use YOLOv5u models within the ultralytics/ultralytics ecosystem for seamless usage.  
- Helps teams plan migrations: existing weights from ultralytics/yolov5 may need retraining or conversion strategies before use in ultralytics/ultralytics.  

Tip: To use YOLOv5u weights with the Ultralytics library:
```python
from ultralytics import YOLO

model = YOLO('yolov5u.pt')  # use anchor-free YOLOv5u weights compatible with ultralytics/ultralytics
results = model('image.jpg')
```