### PR TITLE
Update docs.yml for Python 3.9 ruff format target

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,7 @@ jobs:
           --fix \
           --unsafe-fixes \
           --extend-select I,D,UP \
-          --target-version py38 \
+          --target-version py39 \
           --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413 \
           .
       - name: Update Docs Reference Section and Push Changes
@@ -81,7 +81,7 @@ jobs:
         run: |
           ruff check \
           --extend-select I,D,UP \
-          --target-version py38 \
+          --target-version py39 \
           --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413 \
           .
       - name: Build Docs and Check for Warnings


### PR DESCRIPTION
@onuralpszr paired with https://github.com/ultralytics/actions/pull/512

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update docs CI linting to target Python 3.9 instead of 3.8, aligning tooling with current project Python support. ✅

### 📊 Key Changes
- Bump Ruff `--target-version` from `py38` to `py39` in the docs workflow:
  - Applies to both “fix” and “check” linting steps in `.github/workflows/docs.yml`.

### 🎯 Purpose & Impact
- Aligns CI linting with the project’s minimum Python version (3.9), ensuring consistent style and rules. 🔧
- Enables Python 3.9-aware linting (e.g., newer syntax and typing features), reducing false positives. 🧠
- No runtime or user-facing changes; primarily affects contributors and CI. 🛠️
- Contributors should ensure local linting uses Python 3.9+ for parity with CI. 💻