### PR TITLE
Display resolved `save_dir`

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -413,7 +413,7 @@ def get_save_dir(args: SimpleNamespace, name: str = None) -> Path:
         name = name or args.name or f"{args.mode}"
         save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True)
 
-    return Path(save_dir)
+    return Path(save_dir).resolve()  # resolve to display full path in console
 
 
 def _handle_deprecation(custom: dict) -> dict:

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -129,7 +129,7 @@ def run_ray_tune(
             {**train_args, **{"exist_ok": train_args.pop("resume", False)}},  # resume w/ same tune_dir
         ),
         name=train_args.pop("name", "tune"),  # runs/{task}/{tune_dir}
-    ).resolve()  # must be absolute dir
+    )  # must be absolute dir
     tune_dir.mkdir(parents=True, exist_ok=True)
     if tune.Tuner.can_restore(tune_dir):
         LOGGER.info(f"{colorstr('Tuner: ')} Resuming tuning run {tune_dir}...")


### PR DESCRIPTION
For clearer path introspection.

<img width="988" height="396" alt="Screenshot 2025-09-03 at 17 05 02" src="https://github.com/user-attachments/assets/acd7c5cc-ee36-4647-9024-50d3ec242dde" />



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ensures save directories are always shown as absolute paths in logs and removes redundant path resolution in the tuner for cleaner, consistent path handling. 🗂️✅

### 📊 Key Changes
- get_save_dir now returns `Path(save_dir).resolve()` to display full (absolute) paths in the console.
- Removed an extra `.resolve()` call in the tuner when creating `tune_dir`, since get_save_dir now handles resolution.

### 🎯 Purpose & Impact
- Clearer logging: Users see the complete, absolute save path in outputs, reducing confusion about where runs and artifacts are stored. 🧭
- Consistency across platforms: More predictable path behavior on Windows, macOS, and Linux. 🖥️
- Cleaner code: Avoids redundant path resolution in the tuner while keeping absolute paths guaranteed. 🧹
- Minimal behavioral change: File locations remain the same; only console display and internal handling become more robust. Potential minor impact if any external scripts relied on relative paths in logs. ℹ️