### PR TITLE
Remove TQDM duplicate filesize info on completion

### DIFF
--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -284,6 +284,9 @@ class TQDM:
         # Use different format for completion
         if self.total and self.n >= self.total:
             format_str = self.bar_format.replace("<{remaining}", "")
+            # For completed downloads, show only final size
+            if self.unit_scale and self.unit in ("B", "bytes"):
+                format_str = format_str.replace("{n}/{total}", "{total}")
         else:
             format_str = self.bar_format
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves completed download progress bars to show only the final size (e.g., “12.3 MB” instead of “12.3/12.3 MB”) for cleaner, more readable output. ✅

### 📊 Key Changes
- Updates `ultralytics/utils/tqdm.py` `_display()` to:
  - On completion, and when using byte units with scaling, replace `{n}/{total}` with `{total}` so only the final size is shown.
  - Keeps existing behavior for all other cases.

### 🎯 Purpose & Impact
- Enhances readability of download logs (e.g., weights, assets) in CLI and Ultralytics HUB integrations. 📦
- Reduces visual noise in completed progress bars—more professional, concise output. 🧹
- Purely cosmetic; no changes to training or download logic/performance. 🔒
- Minor consideration: tools that parse the exact progress bar string may need to account for the new completion format. ⚠️