### PR TITLE
Fix `autosplit` import in `xView.yaml`

### DIFF
--- a/ultralytics/cfg/datasets/xView.yaml
+++ b/ultralytics/cfg/datasets/xView.yaml
@@ -87,7 +87,7 @@ download: |
   from PIL import Image
 
   from ultralytics.utils import TQDM
-  from ultralytics.data.utils import autosplit
+  from ultralytics.data.split import autosplit
   from ultralytics.utils.ops import xyxy2xywhn
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes a broken import in the xView dataset config by updating the `autosplit` import path to the new module location 🔧

### 📊 Key Changes
- Updated import in `ultralytics/cfg/datasets/xView.yaml`:
  - From: `from ultralytics.data.utils import autosplit`
  - To: `from ultralytics.data.split import autosplit`

### 🎯 Purpose & Impact
- Prevents ImportError when downloading/preparing the xView dataset ✅
- Aligns with internal module refactor (moving `autosplit` to `ultralytics.data.split`) for cleaner organization 🧹
- Ensures dataset auto-splitting works out of the box for users working with xView 📦

Minimal example if you import directly:
```python
from ultralytics.data.split import autosplit
```