### PR TITLE
Pin `onnxslim==0.1.65`

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -586,7 +586,7 @@ class Exporter:
         """Export YOLO model to ONNX format."""
         requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
-            requirements += ["onnxslim>=0.1.65", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
+            requirements += ["onnxslim==0.1.65", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
         import onnx  # noqa
 
@@ -964,7 +964,7 @@ class Exporter:
                 "ai-edge-litert>=1.2.0,<1.4.0",  # required by 'onnx2tf' package
                 "onnx>=1.12.0",
                 "onnx2tf>=1.26.3",
-                "onnxslim>=0.1.65",
+                "onnxslim==0.1.65",
                 "onnxruntime-gpu" if cuda else "onnxruntime",
                 "protobuf>=5",
             ),


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Pin onnxslim to version 0.1.65 for export workflows to ensure stable, reproducible ONNX and TensorFlow SavedModel exports. 🔒📦

### 📊 Key Changes
- Updated dependency in `ultralytics/engine/exporter.py`:
  - ONNX export: `onnxslim>=0.1.65` → `onnxslim==0.1.65`
  - TensorFlow SavedModel export: `onnxslim>=0.1.65` → `onnxslim==0.1.65`
- Keeps existing logic to install `onnxruntime` or `onnxruntime-gpu` based on CUDA availability.

### 🎯 Purpose & Impact
- Improve stability and reproducibility of exports by avoiding unexpected breaking changes in newer `onnxslim` releases. ✅
- Reduce export failures in CI and user environments for ONNX and TF SavedModel pipelines. 🛠️
- No API changes; only affects dependency resolution during export. Users with newer `onnxslim` may be prompted to downgrade to 0.1.65. ℹ️