### PR TITLE
Fix dataset directory structure information in docs

### DIFF
--- a/docs/en/datasets/index.md
+++ b/docs/en/datasets/index.md
@@ -115,16 +115,16 @@ Contributing a new dataset involves several steps to ensure that it aligns well 
 1. **Collect Images**: Gather the images that belong to the dataset. These could be collected from various sources, such as public databases or your own collection.
 2. **Annotate Images**: Annotate these images with bounding boxes, segments, or keypoints, depending on the task.
 3. **Export Annotations**: Convert these annotations into the YOLO `*.txt` file format which Ultralytics supports.
-4. **Organize Dataset**: Arrange your dataset into the correct folder structure. You should have `train/` and `val/` top-level directories, and within each, an `images/` and `labels/` subdirectory.
+4. **Organize Dataset**: Arrange your dataset into the correct folder structure. You should have `images/` and `labels/` top-level directories, and within each, a `train/` and `val/` subdirectory.
 
     ```
     dataset/
-    ├── train/
-    │   ├── images/
-    │   └── labels/
-    └── val/
-        ├── images/
-        └── labels/
+    ├── images/
+    │   ├── train/
+    │   └── val/
+    └── labels/
+        ├── train/
+        └── val/
     ```
 
 5. **Create a `data.yaml` File**: In your dataset's root directory, create a `data.yaml` file that describes the dataset, classes, and other necessary information.


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Docs update clarifies the recommended YOLO dataset folder structure by placing `images/` and `labels/` at the top level with `train/` and `val/` inside. 📁✨

### 📊 Key Changes
- Updated dataset organization guidance:
  - From: top-level `train/` and `val/` folders each containing `images/` and `labels/`
  - To: top-level `images/` and `labels/` folders each containing `train/` and `val/`
- Adjusted example directory tree to reflect the new structure
- No code changes—documentation only

See the updated guidance in the Ultralytics [dataset docs](https://docs.ultralytics.com/datasets/). 📚

### 🎯 Purpose & Impact
- ✅ Clearer, standardized structure reduces confusion when preparing datasets for YOLO training
- 🚫 Helps prevent common path/loader errors caused by mismatched folder layouts
- 🚀 Smoother onboarding for new users and more consistent setups across projects using YOLO models and Ultralytics HUB