### PR TITLE
fix: split large channel masks to handle `cv2.resize` 512 limitations

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -244,6 +244,7 @@ def scale_image(masks, im0_shape, ratio_pad=None):
     if len(masks.shape) < 2:
         raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
     masks = masks[top:bottom, left:right]
+    # handle the cv2.resize 512 channels limitation: https://github.com/ultralytics/ultralytics/pull/21947
     masks = [cv2.resize(array, (im0_w, im0_h)) for array in np.array_split(masks, masks.shape[-1] // 512 + 1, axis=-1)]
     masks = np.concatenate(masks, axis=-1) if len(masks) > 1 else masks[0]
     if len(masks.shape) == 2:

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -244,7 +244,8 @@ def scale_image(masks, im0_shape, ratio_pad=None):
     if len(masks.shape) < 2:
         raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
     masks = masks[top:bottom, left:right]
-    masks = cv2.resize(masks, (im0_w, im0_h))
+    masks = [cv2.resize(array, (im0_w, im0_h)) for array in np.array_split(masks, masks.shape[-1] // 512 + 1, axis=-1)]
+    masks = np.concatenate(masks, axis=-1) if len(masks) > 1 else masks[0]
     if len(masks.shape) == 2:
         masks = masks[:, :, None]
 


### PR DESCRIPTION
- Add batch processing for masks with >512 channels to avoid cv2.resize limitation
- Process masks in batches of 512 channels and concatenate results
- Fixes Error when max_det>512 causes wong result returned

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes a bug in mask resizing by handling OpenCV’s 512-channel limit, ensuring large multi-channel masks resize reliably without errors. ✅

### 📊 Key Changes
- Updated `scale_image` in `ultralytics/utils/ops.py` to:
  - Split mask arrays into chunks of ≤512 channels.
  - Resize each chunk with `cv2.resize` and concatenate the results.
- Added an inline comment referencing the limitation and related discussion in the PR [Handle cv2.resize 512-channel limit](https://github.com/ultralytics/ultralytics/pull/21947).

### 🎯 Purpose & Impact
- Prevents crashes or errors when resizing masks with many channels (e.g., large-class segmentation outputs). 🛡️
- Improves robustness for advanced segmentation workflows and large models. 🚀
- No API changes; behavior is transparent to users and backwards compatible. 🔄
- Slight, negligible performance overhead from chunking and concatenation. ⏱️