### PR TITLE
Support CoreML inference with NMS embedded models

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -120,14 +120,14 @@ def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms):
 @pytest.mark.skipif(not TORCH_1_9, reason="CoreML>=7.2 not supported with PyTorch<=1.8")
 @pytest.mark.skipif(checks.IS_PYTHON_3_13, reason="CoreML not supported in Python 3.13")
 @pytest.mark.parametrize(
-    "task, dynamic, int8, half, batch",
+    "task, dynamic, int8, half, nms, batch",
     [  # generate all combinations except for exclusion cases
-        (task, dynamic, int8, half, batch)
-        for task, dynamic, int8, half, batch in product(TASKS, [False], [True, False], [True, False], [1])
-        if not (int8 and half)
+        (task, dynamic, int8, half, nms, batch)
+        for task, dynamic, int8, half, nms, batch in product(TASKS, [False], [True, False], [True, False], [True, False], [1])
+        if not (int8 and half) and not (task != "detect" and nms)
     ],
 )
-def test_export_coreml_matrix(task, dynamic, int8, half, batch):
+def test_export_coreml_matrix(task, dynamic, int8, half, nms, batch):
     """Test YOLO export to CoreML format with various parameter configurations."""
     file = YOLO(TASK2MODEL[task]).export(
         format="coreml",
@@ -136,6 +136,7 @@ def test_export_coreml_matrix(task, dynamic, int8, half, batch):
         int8=int8,
         half=half,
         batch=batch,
+        nms=nms,
     )
     YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
     shutil.rmtree(file)  # cleanup

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -123,7 +123,9 @@ def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms):
     "task, dynamic, int8, half, nms, batch",
     [  # generate all combinations except for exclusion cases
         (task, dynamic, int8, half, nms, batch)
-        for task, dynamic, int8, half, nms, batch in product(TASKS, [False], [True, False], [True, False], [True, False], [1])
+        for task, dynamic, int8, half, nms, batch in product(
+            TASKS, [False], [True, False], [True, False], [True, False], [1]
+        )
         if not (int8 and half) and not (task != "detect" and nms)
     ],
 )

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -729,7 +729,7 @@ class AutoBackend(nn.Module):
 
                 box = xywh2xyxy(y["coordinates"] * [[w, h, w, h]])  # xyxy pixels
                 cls = y["confidence"].argmax(1, keepdims=True)
-                y = np.concatenate((box, np.take_along_axis(y["confidence"], cls), cls), 1)[None]
+                y = np.concatenate((box, np.take_along_axis(y["confidence"], cls, axis=1), cls), 1)[None]
             else:
                 y = list(y.values())
             if len(y) == 2 and len(y[1].shape) != 4:  # segmentation model

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -726,9 +726,10 @@ class AutoBackend(nn.Module):
             y = self.model.predict({"image": im_pil})  # coordinates are xywh normalized
             if "confidence" in y:  # NMS included
                 from ultralytics.utils.ops import xywh2xyxy
-                box = xywh2xyxy(y['coordinates'] * [[w, h, w, h]])  # xyxy pixels
-                cls = y['confidence'].argmax(1, keepdims=True)
-                y = np.concatenate((box, np.take_along_axis(y['confidence'], cls), cls), 1)[None]
+
+                box = xywh2xyxy(y["coordinates"] * [[w, h, w, h]])  # xyxy pixels
+                cls = y["confidence"].argmax(1, keepdims=True)
+                y = np.concatenate((box, np.take_along_axis(y["confidence"], cls), cls), 1)[None]
             else:
                 y = list(y.values())
             if len(y) == 2 and len(y[1].shape) != 4:  # segmentation model

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -724,17 +724,13 @@ class AutoBackend(nn.Module):
             im_pil = Image.fromarray((im * 255).astype("uint8"))
             # im = im.resize((192, 320), Image.BILINEAR)
             y = self.model.predict({"image": im_pil})  # coordinates are xywh normalized
-            if "confidence" in y:
-                raise TypeError(
-                    "Ultralytics only supports inference of non-pipelined CoreML models exported with "
-                    f"'nms=False', but 'model={w}' has an NMS pipeline created by an 'nms=True' export."
-                )
-                # TODO: CoreML NMS inference handling
-                # from ultralytics.utils.ops import xywh2xyxy
-                # box = xywh2xyxy(y['coordinates'] * [[w, h, w, h]])  # xyxy pixels
-                # conf, cls = y['confidence'].max(1), y['confidence'].argmax(1).astype(np.float32)
-                # y = np.concatenate((box, conf.reshape(-1, 1), cls.reshape(-1, 1)), 1)
-            y = list(y.values())
+            if "confidence" in y:  # NMS included
+                from ultralytics.utils.ops import xywh2xyxy
+                box = xywh2xyxy(y['coordinates'] * [[w, h, w, h]])  # xyxy pixels
+                cls = y['confidence'].argmax(1, keepdims=True)
+                y = np.concatenate((box, np.take_along_axis(y['confidence'], cls), cls), 1)[None]
+            else:
+                y = list(y.values())
             if len(y) == 2 and len(y[1].shape) != 4:  # segmentation model
                 y = list(reversed(y))  # reversed for segmentation models (pred, proto)
 


### PR DESCRIPTION
`yolo export model=yolo11n.pt format=coreml nms`
`yolo predict model=yolo11n.mlpackage`

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
CoreML now supports inference for YOLO models exported with NMS enabled, and tests are updated to cover this — making Apple-platform workflows smoother and more robust. 🍎⚙️

### 📊 Key Changes
- Added NMS option to CoreML export test matrix and export call.
- Enabled inference for CoreML models that include NMS by parsing `coordinates` and `confidence` outputs in `autobackend`.
- Excluded NMS tests for non-detection tasks to avoid unsupported cases.

### 🎯 Purpose & Impact
- Seamless Apple integration: Users can now export with `nms=True` and run inference without errors in Python. 🚀
- Better reliability: Expanded test coverage ensures CoreML export/inference works across common configurations.
- Backward-compatible: Non-NMS CoreML models continue to work as before; detection with NMS is now first-class.

Example:
```python
from ultralytics import YOLO

# Export to CoreML with NMS enabled
coreml_model = YOLO('yolo11n.pt').export(format='coreml', nms=True)

# Run inference
YOLO(coreml_model)('image.jpg')
```