### PR TITLE
Pin `tf_keras<=2.19.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,13 +91,12 @@ dev = [
     "mkdocs-macros-plugin>=1.0.5", # duplicating content (i.e. export tables) in multiple places
 ]
 export = [
-    "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
-    "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,12 +91,13 @@ dev = [
     "mkdocs-macros-plugin>=1.0.5", # duplicating content (i.e. export tables) in multiple places
 ]
 export = [
+    "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
     "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
-    "tensorflow>=2.0.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -955,11 +955,11 @@ class Exporter:
         try:
             import tensorflow as tf  # noqa
         except ImportError:
-            check_requirements("tensorflow>=2.0.0")
+            check_requirements("tensorflow>=2.0.0,<=2.19.0")
             import tensorflow as tf  # noqa
         check_requirements(
             (
-                "tf_keras",  # required by 'onnx2tf' package
+                "tf_keras<=2.19.0",  # required by 'onnx2tf' package
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "ai-edge-litert>=1.2.0,<1.4.0",  # required by 'onnx2tf' package


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Pins TensorFlow and tf-keras versions for TensorFlow SavedModel export to avoid compatibility issues with the ONNX-to-TensorFlow toolchain. ✅

### 📊 Key Changes
- Restricts TensorFlow to `>=2.0.0, <=2.19.0` during export.
- Restricts `tf_keras` to `<=2.19.0` (required by `onnx2tf`).
- Keeps existing dependencies for the export pipeline (e.g., `sng4onnx`, `onnx_graphsurgeon`, `ai-edge-litert`) unchanged.

### 🎯 Purpose & Impact
- Improves stability of TensorFlow SavedModel exports by aligning with versions supported by `onnx2tf`. 🧩
- Prevents import/runtime errors caused by newer TensorFlow releases (e.g., 2.20+) that are incompatible with the current export stack. 🛡️
- Users with TensorFlow > 2.19 will be prompted to downgrade for export; training/inference in other formats remains unaffected. 🔁
- Smoother, more predictable export experience from Ultralytics to TensorFlow ecosystems. 🚀