### PR TITLE
Disable box clipping for OBB predictions

### DIFF
--- a/ultralytics/models/yolo/obb/predict.py
+++ b/ultralytics/models/yolo/obb/predict.py
@@ -60,6 +60,6 @@ class OBBPredictor(DetectionPredictor):
                 boxes.
         """
         rboxes = ops.regularize_rboxes(torch.cat([pred[:, :4], pred[:, -1:]], dim=-1))
-        rboxes[:, :4] = ops.scale_boxes(img.shape[2:], rboxes[:, :4], orig_img.shape, xywh=True)
+        rboxes[:, :4] = ops.scale_boxes(img.shape[2:], rboxes[:, :4], orig_img.shape, xywh=True, clip=False)
         obb = torch.cat([rboxes, pred[:, 4:6]], dim=-1)
         return Results(orig_img, path=img_path, names=self.model.names, obb=obb)

--- a/ultralytics/models/yolo/obb/predict.py
+++ b/ultralytics/models/yolo/obb/predict.py
@@ -60,6 +60,6 @@ class OBBPredictor(DetectionPredictor):
                 boxes.
         """
         rboxes = ops.regularize_rboxes(torch.cat([pred[:, :4], pred[:, -1:]], dim=-1))
-        rboxes[:, :4] = ops.scale_boxes(img.shape[2:], rboxes[:, :4], orig_img.shape, xywh=True, clip=False)
+        rboxes[:, :4] = ops.scale_boxes(img.shape[2:], rboxes[:, :4], orig_img.shape, xywh=True)
         obb = torch.cat([rboxes, pred[:, 4:6]], dim=-1)
         return Results(orig_img, path=img_path, names=self.model.names, obb=obb)

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -102,9 +102,7 @@ def segment2box(segment, width: int = 640, height: int = 640):
     )  # xyxy
 
 
-def scale_boxes(
-    img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = True, xywh: bool = False, clip: bool = True
-):
+def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = True, xywh: bool = False):
     """
     Rescale bounding boxes from one image shape to another.
 
@@ -118,7 +116,6 @@ def scale_boxes(
         ratio_pad (tuple, optional): Tuple of (ratio, pad) for scaling. If None, calculated from image shapes.
         padding (bool): Whether boxes are based on YOLO-style augmented images with padding.
         xywh (bool): Whether box format is xywh (True) or xyxy (False).
-        clip (bool): Whether to clip the box coordinates to image boundaries.
 
     Returns:
         (torch.Tensor): Rescaled bounding boxes in the same format as input.
@@ -138,7 +135,7 @@ def scale_boxes(
             boxes[..., 2] -= pad_x  # x padding
             boxes[..., 3] -= pad_y  # y padding
     boxes[..., :4] /= gain
-    return clip_boxes(boxes, img0_shape) if clip else boxes
+    return boxes if xywh else clip_boxes(boxes, img0_shape)
 
 
 def make_divisible(x: int, divisor):

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -102,7 +102,7 @@ def segment2box(segment, width: int = 640, height: int = 640):
     )  # xyxy
 
 
-def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = True, xywh: bool = False):
+def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = True, xywh: bool = False, clip: bool = True):
     """
     Rescale bounding boxes from one image shape to another.
 
@@ -116,6 +116,7 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = T
         ratio_pad (tuple, optional): Tuple of (ratio, pad) for scaling. If None, calculated from image shapes.
         padding (bool): Whether boxes are based on YOLO-style augmented images with padding.
         xywh (bool): Whether box format is xywh (True) or xyxy (False).
+        clip (bool): Whether to clip the box coordinates to image boundaries.
 
     Returns:
         (torch.Tensor): Rescaled bounding boxes in the same format as input.
@@ -135,7 +136,7 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = T
             boxes[..., 2] -= pad_x  # x padding
             boxes[..., 3] -= pad_y  # y padding
     boxes[..., :4] /= gain
-    return clip_boxes(boxes, img0_shape)
+    return clip_boxes(boxes, img0_shape) if clip else boxes
 
 
 def make_divisible(x: int, divisor):

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -102,7 +102,9 @@ def segment2box(segment, width: int = 640, height: int = 640):
     )  # xyxy
 
 
-def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = True, xywh: bool = False, clip: bool = True):
+def scale_boxes(
+    img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = True, xywh: bool = False, clip: bool = True
+):
     """
     Rescale bounding boxes from one image shape to another.
 


### PR DESCRIPTION
Fixes #21471

`clip_boxes` expects `xyxy`.

**MRE**
```python
import numpy as np
boxes = np.array([[0.5, 0.5, 1.0, 1.0]]) * 640
from ultralytics.utils.ops import scale_boxes
print(scale_boxes((480,640), boxes, (480,640), xywh=True))
```

We can either disable clipping for OBB, or extend `clip_boxes` to support `xywh`. But for OBB `xywh` aren't the exact boundaries since the actual boundaries are found after rotation, so maybe it's better to disable it.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes a bug in `scale_boxes` to correctly handle xywh-format boxes by skipping inappropriate clipping ✅

### 📊 Key Changes
- Updated `scale_boxes` in `ultralytics/utils/ops.py` to:
  - Return unclipped boxes when `xywh=True`
  - Continue clipping only for xyxy-format boxes

### 🎯 Purpose & Impact
- Prevents incorrect modification of width/height when scaling xywh boxes 🚫✂️
- Improves accuracy for workflows that use xywh format (e.g., certain post-processing or exports) 🎯
- No API changes; behavior is safer and more consistent for xywh users ✅
- Minor performance improvement by avoiding unnecessary clipping when not applicable ⚡