### PR TITLE
Fix `SAM2DynamicInteractivePredictor` example in docs

### DIFF
--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -260,7 +260,7 @@ It offers three significant enhancements:
         predictor = SAM2DynamicInteractivePredictor(overrides=overrides, max_obj_num=10)
 
         # Define a category by box prompt
-        predictor.inference(img="image1.jpg", bboxes=[[100, 100, 200, 200]], obj_ids=[1], update_memory=True)
+        predictor(source="image1.jpg", bboxes=[[100, 100, 200, 200]], obj_ids=[1], update_memory=True)
 
         # Detect this particular object in a new image
         results = predictor(source="image2.jpg")
@@ -273,7 +273,7 @@ It offers three significant enhancements:
             update_memory=True,  # Add to memory
         )
         # Perform inference
-        results = predictor.inference(img="image5.jpg")
+        results = predictor(source="image5.jpg")
 
         # Add refinement prompts to the same category to boost performance
         # This helps when object appearance changes significantly

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -1761,7 +1761,7 @@ class SAM2DynamicInteractivePredictor(SAM2Predictor):
     @smart_inference_mode()
     def inference(
         self,
-        img: torch.Tensor | np.ndarray,
+        im: torch.Tensor | np.ndarray,
         bboxes: list[list[float]] | None = None,
         masks: torch.Tensor | np.ndarray | None = None,
         points: list[list[float]] | None = None,
@@ -1777,7 +1777,7 @@ class SAM2DynamicInteractivePredictor(SAM2Predictor):
         When update_memory is False, it will only run inference on the provided image without updating the memory.
 
         Args:
-            img (torch.Tensor | np.ndarray): The input image tensor or numpy array.
+            im (torch.Tensor | np.ndarray): The input image tensor or numpy array.
             bboxes (List[List[float]] | None): Optional list of bounding boxes to update the memory.
             masks (List[torch.Tensor | np.ndarray] | None): Optional masks to update the memory.
             points (List[List[float]] | None): Optional list of points to update the memory, each point is [x, y].
@@ -1789,7 +1789,7 @@ class SAM2DynamicInteractivePredictor(SAM2Predictor):
             res_masks (torch.Tensor): The output masks in shape (C, H, W)
             object_score_logits (torch.Tensor): Quality scores for each mask
         """
-        self.get_im_features(img)
+        self.get_im_features(im)
         points, labels, masks = self._prepare_prompts(
             dst_shape=self.imgsz,
             src_shape=self.batch[1][0].shape[:2],


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/21953#issuecomment-3257313922

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Aligns SAM-2 predictor API and docs: renames an inference parameter and fixes examples to use the standard `source` interface for consistency and clarity. ✅

### 📊 Key Changes
- Renamed `inference` method parameter from `img` to `im` in `ultralytics/models/sam/predict.py`.
- Updated internal usage to match the new `im` parameter.
- Fixed documentation examples to:
  - Call the predictor directly with `source=...` instead of `predictor.inference(img=...)`.
  - Use `predictor(source="imageX.jpg")` consistently in SAM-2 examples.

### 🎯 Purpose & Impact
- Improves API consistency across Ultralytics predictors by standardizing on `source` for inputs and `im` internally. 🔧
- Prevents confusion and errors in examples; docs now reflect working usage patterns. 📘
- Potential minor breaking change: code using `inference(img=...)` as a keyword argument should update to `inference(im=...)` or prefer `predictor(source=...)`. ⚠️
- Smoother onboarding for users working with SAM-2 dynamic interactive workflows. 🚀