### PR TITLE
Feature/simultaneous text visual prompting

### DIFF
--- a/docs/en/reference/utils/fusion.md
+++ b/docs/en/reference/utils/fusion.md
@@ -1,0 +1,20 @@
+---
+description: Fusion utilities for combining text and visual prompt embeddings in YOLO-E models with support for concat, sum, and attention-based fusion methods.
+keywords: Ultralytics, YOLO-E, prompt fusion, text embeddings, visual embeddings, attention, machine learning
+---
+
+# Reference for `ultralytics/utils/fusion.py`
+
+This module provides utilities for fusing text prompt embeddings (TPE) and visual prompt embeddings (VPE) in YOLO-E models. It supports multiple fusion strategies including concatenation, element-wise addition, and cross-attention based fusion.
+
+## ::: ultralytics.utils.fusion.PromptEmbeddingFusion
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.fusion.CrossAttentionFusion
+
+<br><br><hr><br>
+
+## ::: ultralytics.utils.fusion.fuse_prompt_embeddings
+
+<br><br>

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -1,0 +1,203 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+"""
+Test fusion utilities for text and visual prompt embeddings.
+"""
+
+import torch
+
+from ultralytics.utils.fusion import (
+    PromptEmbeddingFusion,
+    CrossAttentionFusion, 
+    fuse_prompt_embeddings
+)
+
+
+class TestPromptEmbeddingFusion:
+    """Test the PromptEmbeddingFusion class."""
+
+    def test_concat_fusion(self):
+        """Test concatenation fusion method."""
+        print("Testing concat fusion...")
+        fusion = PromptEmbeddingFusion('concat')
+        
+        tpe = torch.randn(2, 10, 512)
+        vpe = torch.randn(2, 5, 512)
+        
+        result = fusion(tpe, vpe)
+        assert result.shape == (2, 15, 512)
+        
+        # Test with only TPE
+        result_tpe = fusion(tpe, None)
+        assert torch.equal(result_tpe, tpe)
+        
+        # Test with only VPE
+        result_vpe = fusion(None, vpe)
+        assert torch.equal(result_vpe, vpe)
+        print("✓ Concat fusion tests passed")
+
+    def test_sum_fusion(self):
+        """Test sum fusion method."""
+        print("Testing sum fusion...")
+        fusion = PromptEmbeddingFusion('sum')
+        
+        tpe = torch.randn(2, 10, 512)
+        vpe = torch.randn(2, 10, 512)  # Same sequence length
+        
+        result = fusion(tpe, vpe)
+        assert result.shape == (2, 10, 512)
+        assert torch.allclose(result, tpe + vpe)
+        
+        # Test error case with different sequence lengths
+        vpe_diff = torch.randn(2, 5, 512)
+        try:
+            fusion(tpe, vpe_diff)
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "same sequence length" in str(e)
+        print("✓ Sum fusion tests passed")
+
+    def test_attention_fusion(self):
+        """Test attention fusion method."""
+        print("Testing attention fusion...")
+        fusion = PromptEmbeddingFusion('attention', embed_dim=512)
+        
+        tpe = torch.randn(2, 10, 512)
+        vpe = torch.randn(2, 5, 512)
+        
+        result = fusion(tpe, vpe)
+        assert result.shape == (2, 10, 512)  # Same as TPE (queries)
+        
+        # Should be different from input due to attention
+        assert not torch.allclose(result, tpe)
+        print("✓ Attention fusion tests passed")
+
+    def test_invalid_method(self):
+        """Test error handling for invalid fusion method."""
+        print("Testing invalid method...")
+        try:
+            PromptEmbeddingFusion('invalid')
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "Unsupported fusion method" in str(e)
+        print("✓ Invalid method test passed")
+
+    def test_no_embeddings(self):
+        """Test error handling when no embeddings provided."""
+        print("Testing no embeddings...")
+        fusion = PromptEmbeddingFusion('concat')
+        try:
+            fusion(None, None)
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "At least one of TPE or VPE" in str(e)
+        print("✓ No embeddings test passed")
+
+    def test_shape_validation(self):
+        """Test input shape validation."""
+        print("Testing shape validation...")
+        fusion = PromptEmbeddingFusion('concat')
+        
+        # Test wrong number of dimensions
+        tpe_2d = torch.randn(10, 512)  # Missing batch dimension
+        vpe = torch.randn(2, 5, 512)
+        try:
+            fusion(tpe_2d, vpe)
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "3D tensors" in str(e)
+        
+        # Test mismatched batch sizes
+        tpe = torch.randn(2, 10, 512)
+        vpe_diff_batch = torch.randn(3, 5, 512)
+        try:
+            fusion(tpe, vpe_diff_batch)
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "same batch size" in str(e)
+        
+        # Test mismatched embedding dimensions
+        tpe = torch.randn(2, 10, 512)
+        vpe_diff_embed = torch.randn(2, 5, 256)
+        try:
+            fusion(tpe, vpe_diff_embed)
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "same embedding dimension" in str(e)
+        print("✓ Shape validation tests passed")
+
+
+class TestCrossAttentionFusion:
+    """Test the CrossAttentionFusion module."""
+
+    def test_forward(self):
+        """Test forward pass."""
+        print("Testing cross attention forward...")
+        attention_fusion = CrossAttentionFusion(embed_dim=512, num_heads=8)
+        
+        tpe = torch.randn(2, 10, 512)
+        vpe = torch.randn(2, 5, 512)
+        
+        result = attention_fusion(tpe, vpe)
+        assert result.shape == (2, 10, 512)
+        
+        # Should be different from input due to attention
+        assert not torch.allclose(result, tpe)
+        print("✓ Cross attention tests passed")
+
+    def test_invalid_embed_dim(self):
+        """Test error handling for invalid embedding dimension."""
+        print("Testing invalid embed dim...")
+        try:
+            CrossAttentionFusion(embed_dim=511, num_heads=8)  # Not divisible by num_heads
+            assert False, "Should have raised AssertionError"
+        except AssertionError:
+            pass
+        print("✓ Invalid embed dim test passed")
+
+
+def test_fuse_prompt_embeddings_function():
+    """Test the convenience function."""
+    print("Testing convenience function...")
+    tpe = torch.randn(2, 10, 512)
+    vpe = torch.randn(2, 5, 512)
+    
+    # Test concat method
+    result_concat = fuse_prompt_embeddings(tpe, vpe, method='concat')
+    assert result_concat.shape == (2, 15, 512)
+    
+    # Test sum method (need same sequence length)
+    vpe_same_len = torch.randn(2, 10, 512)
+    result_sum = fuse_prompt_embeddings(tpe, vpe_same_len, method='sum')
+    assert result_sum.shape == (2, 10, 512)
+    assert torch.allclose(result_sum, tpe + vpe_same_len)
+    
+    # Test attention method
+    result_attn = fuse_prompt_embeddings(tpe, vpe, method='attention', embed_dim=512)
+    assert result_attn.shape == (2, 10, 512)
+    print("✓ Convenience function tests passed")
+
+
+def main():
+    """Run all tests."""
+    print("Running prompt embedding fusion tests...\n")
+    
+    test_suite = TestPromptEmbeddingFusion()
+    test_suite.test_concat_fusion()
+    test_suite.test_sum_fusion()
+    test_suite.test_attention_fusion()
+    test_suite.test_invalid_method()
+    test_suite.test_no_embeddings()
+    test_suite.test_shape_validation()
+    
+    test_cross_attn = TestCrossAttentionFusion()
+    test_cross_attn.test_forward()
+    test_cross_attn.test_invalid_embed_dim()
+    
+    test_fuse_prompt_embeddings_function()
+    
+    print("\n🎉 All tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -1,16 +1,9 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
-
-"""
-Test fusion utilities for text and visual prompt embeddings.
-"""
+"""Test fusion utilities for text and visual prompt embeddings."""
 
 import torch
 
-from ultralytics.utils.fusion import (
-    PromptEmbeddingFusion,
-    CrossAttentionFusion, 
-    fuse_prompt_embeddings
-)
+from ultralytics.utils.fusion import CrossAttentionFusion, PromptEmbeddingFusion, fuse_prompt_embeddings
 
 
 class TestPromptEmbeddingFusion:
@@ -19,18 +12,18 @@ class TestPromptEmbeddingFusion:
     def test_concat_fusion(self):
         """Test concatenation fusion method."""
         print("Testing concat fusion...")
-        fusion = PromptEmbeddingFusion('concat')
-        
+        fusion = PromptEmbeddingFusion("concat")
+
         tpe = torch.randn(2, 10, 512)
         vpe = torch.randn(2, 5, 512)
-        
+
         result = fusion(tpe, vpe)
         assert result.shape == (2, 15, 512)
-        
+
         # Test with only TPE
         result_tpe = fusion(tpe, None)
         assert torch.equal(result_tpe, tpe)
-        
+
         # Test with only VPE
         result_vpe = fusion(None, vpe)
         assert torch.equal(result_vpe, vpe)
@@ -39,15 +32,15 @@ class TestPromptEmbeddingFusion:
     def test_sum_fusion(self):
         """Test sum fusion method."""
         print("Testing sum fusion...")
-        fusion = PromptEmbeddingFusion('sum')
-        
+        fusion = PromptEmbeddingFusion("sum")
+
         tpe = torch.randn(2, 10, 512)
         vpe = torch.randn(2, 10, 512)  # Same sequence length
-        
+
         result = fusion(tpe, vpe)
         assert result.shape == (2, 10, 512)
         assert torch.allclose(result, tpe + vpe)
-        
+
         # Test error case with different sequence lengths
         vpe_diff = torch.randn(2, 5, 512)
         try:
@@ -60,14 +53,14 @@ class TestPromptEmbeddingFusion:
     def test_attention_fusion(self):
         """Test attention fusion method."""
         print("Testing attention fusion...")
-        fusion = PromptEmbeddingFusion('attention', embed_dim=512)
-        
+        fusion = PromptEmbeddingFusion("attention", embed_dim=512)
+
         tpe = torch.randn(2, 10, 512)
         vpe = torch.randn(2, 5, 512)
-        
+
         result = fusion(tpe, vpe)
         assert result.shape == (2, 10, 512)  # Same as TPE (queries)
-        
+
         # Should be different from input due to attention
         assert not torch.allclose(result, tpe)
         print("✓ Attention fusion tests passed")
@@ -76,7 +69,7 @@ class TestPromptEmbeddingFusion:
         """Test error handling for invalid fusion method."""
         print("Testing invalid method...")
         try:
-            PromptEmbeddingFusion('invalid')
+            PromptEmbeddingFusion("invalid")
             assert False, "Should have raised ValueError"
         except ValueError as e:
             assert "Unsupported fusion method" in str(e)
@@ -85,7 +78,7 @@ class TestPromptEmbeddingFusion:
     def test_no_embeddings(self):
         """Test error handling when no embeddings provided."""
         print("Testing no embeddings...")
-        fusion = PromptEmbeddingFusion('concat')
+        fusion = PromptEmbeddingFusion("concat")
         try:
             fusion(None, None)
             assert False, "Should have raised ValueError"
@@ -96,8 +89,8 @@ class TestPromptEmbeddingFusion:
     def test_shape_validation(self):
         """Test input shape validation."""
         print("Testing shape validation...")
-        fusion = PromptEmbeddingFusion('concat')
-        
+        fusion = PromptEmbeddingFusion("concat")
+
         # Test wrong number of dimensions
         tpe_2d = torch.randn(10, 512)  # Missing batch dimension
         vpe = torch.randn(2, 5, 512)
@@ -106,7 +99,7 @@ class TestPromptEmbeddingFusion:
             assert False, "Should have raised ValueError"
         except ValueError as e:
             assert "3D tensors" in str(e)
-        
+
         # Test mismatched batch sizes
         tpe = torch.randn(2, 10, 512)
         vpe_diff_batch = torch.randn(3, 5, 512)
@@ -115,7 +108,7 @@ class TestPromptEmbeddingFusion:
             assert False, "Should have raised ValueError"
         except ValueError as e:
             assert "same batch size" in str(e)
-        
+
         # Test mismatched embedding dimensions
         tpe = torch.randn(2, 10, 512)
         vpe_diff_embed = torch.randn(2, 5, 256)
@@ -134,13 +127,13 @@ class TestCrossAttentionFusion:
         """Test forward pass."""
         print("Testing cross attention forward...")
         attention_fusion = CrossAttentionFusion(embed_dim=512, num_heads=8)
-        
+
         tpe = torch.randn(2, 10, 512)
         vpe = torch.randn(2, 5, 512)
-        
+
         result = attention_fusion(tpe, vpe)
         assert result.shape == (2, 10, 512)
-        
+
         # Should be different from input due to attention
         assert not torch.allclose(result, tpe)
         print("✓ Cross attention tests passed")
@@ -161,19 +154,19 @@ def test_fuse_prompt_embeddings_function():
     print("Testing convenience function...")
     tpe = torch.randn(2, 10, 512)
     vpe = torch.randn(2, 5, 512)
-    
+
     # Test concat method
-    result_concat = fuse_prompt_embeddings(tpe, vpe, method='concat')
+    result_concat = fuse_prompt_embeddings(tpe, vpe, method="concat")
     assert result_concat.shape == (2, 15, 512)
-    
+
     # Test sum method (need same sequence length)
     vpe_same_len = torch.randn(2, 10, 512)
-    result_sum = fuse_prompt_embeddings(tpe, vpe_same_len, method='sum')
+    result_sum = fuse_prompt_embeddings(tpe, vpe_same_len, method="sum")
     assert result_sum.shape == (2, 10, 512)
     assert torch.allclose(result_sum, tpe + vpe_same_len)
-    
+
     # Test attention method
-    result_attn = fuse_prompt_embeddings(tpe, vpe, method='attention', embed_dim=512)
+    result_attn = fuse_prompt_embeddings(tpe, vpe, method="attention", embed_dim=512)
     assert result_attn.shape == (2, 10, 512)
     print("✓ Convenience function tests passed")
 
@@ -181,7 +174,7 @@ def test_fuse_prompt_embeddings_function():
 def main():
     """Run all tests."""
     print("Running prompt embedding fusion tests...\n")
-    
+
     test_suite = TestPromptEmbeddingFusion()
     test_suite.test_concat_fusion()
     test_suite.test_sum_fusion()
@@ -189,13 +182,13 @@ def main():
     test_suite.test_invalid_method()
     test_suite.test_no_embeddings()
     test_suite.test_shape_validation()
-    
+
     test_cross_attn = TestCrossAttentionFusion()
     test_cross_attn.test_forward()
     test_cross_attn.test_invalid_embed_dim()
-    
+
     test_fuse_prompt_embeddings_function()
-    
+
     print("\n🎉 All tests passed!")
 
 

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -370,7 +370,7 @@ class YOLOE(Model):
         stream: bool = False,
         visual_prompts: dict[str, list] = {},
         text_prompts: torch.Tensor | None = None,
-        fusion_method: str = 'concat',
+        fusion_method: str = "concat",
         cls_pe: torch.Tensor | None = None,
         refer_image=None,
         predictor=yolo.yoloe.YOLOEVPDetectPredictor,
@@ -407,14 +407,15 @@ class YOLOE(Model):
             >>> text_emb = torch.randn(1, 10, 512)  # Example text embeddings
             >>> results = model.predict("path/to/image.jpg", text_prompts=text_emb)
             >>> # With both text and visual prompts
-            >>> results = model.predict("path/to/image.jpg", visual_prompts=prompts, 
-            ...                        text_prompts=text_emb, fusion_method='attention')
+            >>> results = model.predict(
+            ...     "path/to/image.jpg", visual_prompts=prompts, text_prompts=text_emb, fusion_method="attention"
+            ... )
         """
         # Handle the case where we have prompts (visual, text, or both) or cls_pe override
         has_visual_prompts = len(visual_prompts) > 0
         has_text_prompts = text_prompts is not None
         has_cls_pe_override = cls_pe is not None
-        
+
         if has_visual_prompts or has_text_prompts or has_cls_pe_override:
             # Validate visual prompts if provided
             if has_visual_prompts:
@@ -425,7 +426,7 @@ class YOLOE(Model):
                     f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                     f"{len(visual_prompts['cls'])} respectively"
                 )
-            
+
             # Setup predictor if needed
             if type(self.predictor) is not predictor:
                 self.predictor = predictor(
@@ -451,16 +452,16 @@ class YOLOE(Model):
                 self.model.model[-1].nc = num_cls
                 self.model.names = [f"object{i}" for i in range(num_cls)]
                 self.predictor.set_prompts(visual_prompts.copy())
-            
+
             # Setup text prompts and fusion method
             if has_text_prompts:
                 self.predictor.set_text_prompts(text_prompts)
                 self.predictor.set_fusion_method(fusion_method)
-            
+
             # Setup cls_pe override if provided
             if has_cls_pe_override:
                 self.predictor.set_cls_pe_override(cls_pe)
-            
+
             self.predictor.setup_model(model=self.model)
 
             # Handle reference image for visual prompts

--- a/ultralytics/models/yolo/yoloe/predict.py
+++ b/ultralytics/models/yolo/yoloe/predict.py
@@ -47,7 +47,7 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
         self.done_warmup = True
         # Initialize prompt-related attributes
         self.text_prompts = None
-        self.fusion_method = 'concat'  # Default fusion method
+        self.fusion_method = "concat"  # Default fusion method
         self.cls_pe_override = None
 
     def set_prompts(self, prompts):
@@ -76,7 +76,7 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
         Args:
             method (str): Fusion method - 'concat', 'sum', or 'attention'.
         """
-        if method not in ['concat', 'sum', 'attention']:
+        if method not in ["concat", "sum", "attention"]:
             raise ValueError(f"Unsupported fusion method: {method}. Supported: 'concat', 'sum', 'attention'")
         self.fusion_method = method
 
@@ -185,7 +185,7 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
         # Handle cls_pe override if provided
         if self.cls_pe_override is not None:
             return super().inference(im, cls_pe=self.cls_pe_override, *args, **kwargs)
-        
+
         # Get fused embeddings for inference
         cls_pe = self.get_fused_embeddings(im)
         if cls_pe is not None:
@@ -224,26 +224,26 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
         """
         tpe = None
         vpe = None
-        
+
         # Get text prompt embeddings
         if self.text_prompts is not None:
             tpe = self.model.model[-1].get_tpe(self.text_prompts)
-        
+
         # Get visual prompt embeddings
-        if hasattr(self, 'prompts') and self.prompts is not None:
+        if hasattr(self, "prompts") and self.prompts is not None:
             # Use existing VPE processing from model
             vpe = self.model.model[-1].get_vpe([im], self.prompts)
-        
+
         # Return None if no embeddings available
         if tpe is None and vpe is None:
             return None
-        
+
         # Use fusion utility to combine embeddings
         try:
-            embed_dim = getattr(self.model.model[-1], 'embed', 512)
+            embed_dim = getattr(self.model.model[-1], "embed", 512)
             fused = fuse_prompt_embeddings(tpe, vpe, method=self.fusion_method, embed_dim=embed_dim)
             return fused
-        except Exception as e:
+        except Exception:
             # Fallback to basic concatenation if fusion fails
             if tpe is not None and vpe is not None:
                 return torch.cat([tpe, vpe], dim=1)

--- a/ultralytics/utils/fusion.py
+++ b/ultralytics/utils/fusion.py
@@ -1,0 +1,202 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+"""
+Utility functions for fusing text prompt embeddings (TPE) and visual prompt embeddings (VPE).
+
+This module provides various methods to combine text and visual embeddings for enhanced prompting
+in YOLO-E models, supporting backward compatibility while enabling new fusion strategies.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class PromptEmbeddingFusion:
+    """
+    Utility class for fusing text prompt embeddings (TPE) and visual prompt embeddings (VPE).
+    
+    Supports multiple fusion strategies:
+    - 'concat': Simple concatenation along the sequence dimension
+    - 'sum': Element-wise addition (requires same dimensions)
+    - 'attention': Cross-attention based fusion
+    
+    Args:
+        method (str): Fusion method - 'concat', 'sum', or 'attention'
+        embed_dim (int): Embedding dimension, required for attention-based fusion
+        
+    Examples:
+        >>> fusion = PromptEmbeddingFusion('concat')
+        >>> tpe = torch.randn(1, 10, 512)  # Text prompt embeddings
+        >>> vpe = torch.randn(1, 5, 512)   # Visual prompt embeddings  
+        >>> fused = fusion(tpe, vpe)
+        >>> print(fused.shape)  # torch.Size([1, 15, 512])
+        
+        >>> fusion = PromptEmbeddingFusion('attention', embed_dim=512)
+        >>> fused = fusion(tpe, vpe)
+        >>> print(fused.shape)  # torch.Size([1, 10, 512])
+    """
+    
+    def __init__(self, method: str = 'concat', embed_dim: int = 512):
+        """Initialize the fusion utility."""
+        self.method = method.lower()
+        self.embed_dim = embed_dim
+        
+        if self.method not in ['concat', 'sum', 'attention']:
+            raise ValueError(f"Unsupported fusion method: {method}. Supported: 'concat', 'sum', 'attention'")
+            
+        # Initialize attention module for attention-based fusion
+        if self.method == 'attention':
+            self.attention = CrossAttentionFusion(embed_dim)
+    
+    def __call__(self, tpe: torch.Tensor | None, vpe: torch.Tensor | None) -> torch.Tensor:
+        """
+        Fuse text and visual prompt embeddings.
+        
+        Args:
+            tpe (torch.Tensor, optional): Text prompt embeddings with shape (B, N_t, D)
+            vpe (torch.Tensor, optional): Visual prompt embeddings with shape (B, N_v, D)
+            
+        Returns:
+            torch.Tensor: Fused embeddings
+        """
+        return self.fuse(tpe, vpe)
+    
+    def fuse(self, tpe: torch.Tensor | None, vpe: torch.Tensor | None) -> torch.Tensor:
+        """
+        Fuse text and visual prompt embeddings using the specified method.
+        
+        Args:
+            tpe (torch.Tensor, optional): Text prompt embeddings with shape (B, N_t, D)
+            vpe (torch.Tensor, optional): Visual prompt embeddings with shape (B, N_v, D)
+            
+        Returns:
+            torch.Tensor: Fused embeddings
+            
+        Raises:
+            ValueError: If no embeddings provided or incompatible shapes for sum fusion
+        """
+        # Handle case where only one type of embedding is provided
+        if tpe is None and vpe is None:
+            raise ValueError("At least one of TPE or VPE must be provided")
+        elif tpe is None:
+            return vpe
+        elif vpe is None:
+            return tpe
+            
+        # Validate input shapes
+        if tpe.ndim != 3 or vpe.ndim != 3:
+            raise ValueError("TPE and VPE must be 3D tensors with shape (B, N, D)")
+        if tpe.shape[0] != vpe.shape[0]:
+            raise ValueError("TPE and VPE must have the same batch size")
+        if tpe.shape[2] != vpe.shape[2]:
+            raise ValueError("TPE and VPE must have the same embedding dimension")
+            
+        # Apply fusion method
+        if self.method == 'concat':
+            return self._concat_fusion(tpe, vpe)
+        elif self.method == 'sum':
+            return self._sum_fusion(tpe, vpe)
+        elif self.method == 'attention':
+            return self._attention_fusion(tpe, vpe)
+    
+    def _concat_fusion(self, tpe: torch.Tensor, vpe: torch.Tensor) -> torch.Tensor:
+        """Concatenate TPE and VPE along sequence dimension."""
+        return torch.cat([tpe, vpe], dim=1)
+    
+    def _sum_fusion(self, tpe: torch.Tensor, vpe: torch.Tensor) -> torch.Tensor:
+        """Element-wise addition of TPE and VPE (requires same sequence length)."""
+        if tpe.shape[1] != vpe.shape[1]:
+            raise ValueError(f"For sum fusion, TPE and VPE must have same sequence length. "
+                           f"Got TPE: {tpe.shape[1]}, VPE: {vpe.shape[1]}")
+        return tpe + vpe
+    
+    def _attention_fusion(self, tpe: torch.Tensor, vpe: torch.Tensor) -> torch.Tensor:
+        """Cross-attention based fusion using TPE as queries and VPE as keys/values."""
+        return self.attention(tpe, vpe)
+
+
+class CrossAttentionFusion(nn.Module):
+    """
+    Cross-attention module for fusing text and visual prompt embeddings.
+    
+    Uses text embeddings as queries and visual embeddings as keys and values,
+    producing attended text embeddings that incorporate visual information.
+    
+    Args:
+        embed_dim (int): Embedding dimension
+        num_heads (int): Number of attention heads
+        dropout (float): Dropout probability
+    """
+    
+    def __init__(self, embed_dim: int = 512, num_heads: int = 8, dropout: float = 0.1):
+        """Initialize cross-attention fusion module."""
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.dropout = dropout
+        
+        assert embed_dim % num_heads == 0, f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})"
+        
+        self.multihead_attn = nn.MultiheadAttention(
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+            batch_first=True
+        )
+        
+        # Layer normalization for residual connection
+        self.layer_norm = nn.LayerNorm(embed_dim)
+        
+    def forward(self, tpe: torch.Tensor, vpe: torch.Tensor) -> torch.Tensor:
+        """
+        Apply cross-attention fusion.
+        
+        Args:
+            tpe (torch.Tensor): Text prompt embeddings (B, N_t, D) - used as queries
+            vpe (torch.Tensor): Visual prompt embeddings (B, N_v, D) - used as keys/values
+            
+        Returns:
+            torch.Tensor: Attended text embeddings (B, N_t, D)
+        """
+        # Cross-attention: TPE as queries, VPE as keys and values
+        attended_tpe, _ = self.multihead_attn(
+            query=tpe,
+            key=vpe, 
+            value=vpe
+        )
+        
+        # Residual connection with layer norm
+        fused = self.layer_norm(tpe + attended_tpe)
+        
+        return fused
+
+
+def fuse_prompt_embeddings(
+    tpe: torch.Tensor | None,
+    vpe: torch.Tensor | None, 
+    method: str = 'concat',
+    embed_dim: int = 512
+) -> torch.Tensor:
+    """
+    Convenience function to fuse text and visual prompt embeddings.
+    
+    Args:
+        tpe (torch.Tensor, optional): Text prompt embeddings with shape (B, N_t, D)
+        vpe (torch.Tensor, optional): Visual prompt embeddings with shape (B, N_v, D)
+        method (str): Fusion method - 'concat', 'sum', or 'attention'
+        embed_dim (int): Embedding dimension, required for attention-based fusion
+        
+    Returns:
+        torch.Tensor: Fused embeddings
+        
+    Examples:
+        >>> tpe = torch.randn(1, 10, 512)
+        >>> vpe = torch.randn(1, 5, 512)
+        >>> fused = fuse_prompt_embeddings(tpe, vpe, method='concat')
+        >>> print(fused.shape)  # torch.Size([1, 15, 512])
+    """
+    fusion = PromptEmbeddingFusion(method=method, embed_dim=embed_dim)
+    return fusion.fuse(tpe, vpe)

--- a/ultralytics/utils/fusion.py
+++ b/ultralytics/utils/fusion.py
@@ -1,80 +1,78 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
-
 """
 Utility functions for fusing text prompt embeddings (TPE) and visual prompt embeddings (VPE).
 
-This module provides various methods to combine text and visual embeddings for enhanced prompting
-in YOLO-E models, supporting backward compatibility while enabling new fusion strategies.
+This module provides various methods to combine text and visual embeddings for enhanced prompting in YOLO-E models,
+supporting backward compatibility while enabling new fusion strategies.
 """
 
 from __future__ import annotations
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 
 class PromptEmbeddingFusion:
     """
     Utility class for fusing text prompt embeddings (TPE) and visual prompt embeddings (VPE).
-    
+
     Supports multiple fusion strategies:
     - 'concat': Simple concatenation along the sequence dimension
     - 'sum': Element-wise addition (requires same dimensions)
     - 'attention': Cross-attention based fusion
-    
+
     Args:
         method (str): Fusion method - 'concat', 'sum', or 'attention'
         embed_dim (int): Embedding dimension, required for attention-based fusion
-        
+
     Examples:
-        >>> fusion = PromptEmbeddingFusion('concat')
+        >>> fusion = PromptEmbeddingFusion("concat")
         >>> tpe = torch.randn(1, 10, 512)  # Text prompt embeddings
-        >>> vpe = torch.randn(1, 5, 512)   # Visual prompt embeddings  
+        >>> vpe = torch.randn(1, 5, 512)  # Visual prompt embeddings
         >>> fused = fusion(tpe, vpe)
         >>> print(fused.shape)  # torch.Size([1, 15, 512])
-        
-        >>> fusion = PromptEmbeddingFusion('attention', embed_dim=512)
+
+        >>> fusion = PromptEmbeddingFusion("attention", embed_dim=512)
         >>> fused = fusion(tpe, vpe)
         >>> print(fused.shape)  # torch.Size([1, 10, 512])
     """
-    
-    def __init__(self, method: str = 'concat', embed_dim: int = 512):
+
+    def __init__(self, method: str = "concat", embed_dim: int = 512):
         """Initialize the fusion utility."""
         self.method = method.lower()
         self.embed_dim = embed_dim
-        
-        if self.method not in ['concat', 'sum', 'attention']:
+
+        if self.method not in ["concat", "sum", "attention"]:
             raise ValueError(f"Unsupported fusion method: {method}. Supported: 'concat', 'sum', 'attention'")
-            
+
         # Initialize attention module for attention-based fusion
-        if self.method == 'attention':
+        if self.method == "attention":
             self.attention = CrossAttentionFusion(embed_dim)
-    
+
     def __call__(self, tpe: torch.Tensor | None, vpe: torch.Tensor | None) -> torch.Tensor:
         """
         Fuse text and visual prompt embeddings.
-        
+
         Args:
             tpe (torch.Tensor, optional): Text prompt embeddings with shape (B, N_t, D)
             vpe (torch.Tensor, optional): Visual prompt embeddings with shape (B, N_v, D)
-            
+
         Returns:
             torch.Tensor: Fused embeddings
         """
         return self.fuse(tpe, vpe)
-    
+
     def fuse(self, tpe: torch.Tensor | None, vpe: torch.Tensor | None) -> torch.Tensor:
         """
         Fuse text and visual prompt embeddings using the specified method.
-        
+
         Args:
             tpe (torch.Tensor, optional): Text prompt embeddings with shape (B, N_t, D)
             vpe (torch.Tensor, optional): Visual prompt embeddings with shape (B, N_v, D)
-            
+
         Returns:
             torch.Tensor: Fused embeddings
-            
+
         Raises:
             ValueError: If no embeddings provided or incompatible shapes for sum fusion
         """
@@ -85,7 +83,7 @@ class PromptEmbeddingFusion:
             return vpe
         elif vpe is None:
             return tpe
-            
+
         # Validate input shapes
         if tpe.ndim != 3 or vpe.ndim != 3:
             raise ValueError("TPE and VPE must be 3D tensors with shape (B, N, D)")
@@ -93,26 +91,28 @@ class PromptEmbeddingFusion:
             raise ValueError("TPE and VPE must have the same batch size")
         if tpe.shape[2] != vpe.shape[2]:
             raise ValueError("TPE and VPE must have the same embedding dimension")
-            
+
         # Apply fusion method
-        if self.method == 'concat':
+        if self.method == "concat":
             return self._concat_fusion(tpe, vpe)
-        elif self.method == 'sum':
+        elif self.method == "sum":
             return self._sum_fusion(tpe, vpe)
-        elif self.method == 'attention':
+        elif self.method == "attention":
             return self._attention_fusion(tpe, vpe)
-    
+
     def _concat_fusion(self, tpe: torch.Tensor, vpe: torch.Tensor) -> torch.Tensor:
         """Concatenate TPE and VPE along sequence dimension."""
         return torch.cat([tpe, vpe], dim=1)
-    
+
     def _sum_fusion(self, tpe: torch.Tensor, vpe: torch.Tensor) -> torch.Tensor:
         """Element-wise addition of TPE and VPE (requires same sequence length)."""
         if tpe.shape[1] != vpe.shape[1]:
-            raise ValueError(f"For sum fusion, TPE and VPE must have same sequence length. "
-                           f"Got TPE: {tpe.shape[1]}, VPE: {vpe.shape[1]}")
+            raise ValueError(
+                f"For sum fusion, TPE and VPE must have same sequence length. "
+                f"Got TPE: {tpe.shape[1]}, VPE: {vpe.shape[1]}"
+            )
         return tpe + vpe
-    
+
     def _attention_fusion(self, tpe: torch.Tensor, vpe: torch.Tensor) -> torch.Tensor:
         """Cross-attention based fusion using TPE as queries and VPE as keys/values."""
         return self.attention(tpe, vpe)
@@ -121,81 +121,71 @@ class PromptEmbeddingFusion:
 class CrossAttentionFusion(nn.Module):
     """
     Cross-attention module for fusing text and visual prompt embeddings.
-    
+
     Uses text embeddings as queries and visual embeddings as keys and values,
     producing attended text embeddings that incorporate visual information.
-    
+
     Args:
         embed_dim (int): Embedding dimension
         num_heads (int): Number of attention heads
         dropout (float): Dropout probability
     """
-    
+
     def __init__(self, embed_dim: int = 512, num_heads: int = 8, dropout: float = 0.1):
         """Initialize cross-attention fusion module."""
         super().__init__()
         self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.dropout = dropout
-        
+
         assert embed_dim % num_heads == 0, f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})"
-        
+
         self.multihead_attn = nn.MultiheadAttention(
-            embed_dim=embed_dim,
-            num_heads=num_heads,
-            dropout=dropout,
-            batch_first=True
+            embed_dim=embed_dim, num_heads=num_heads, dropout=dropout, batch_first=True
         )
-        
+
         # Layer normalization for residual connection
         self.layer_norm = nn.LayerNorm(embed_dim)
-        
+
     def forward(self, tpe: torch.Tensor, vpe: torch.Tensor) -> torch.Tensor:
         """
         Apply cross-attention fusion.
-        
+
         Args:
             tpe (torch.Tensor): Text prompt embeddings (B, N_t, D) - used as queries
             vpe (torch.Tensor): Visual prompt embeddings (B, N_v, D) - used as keys/values
-            
+
         Returns:
             torch.Tensor: Attended text embeddings (B, N_t, D)
         """
         # Cross-attention: TPE as queries, VPE as keys and values
-        attended_tpe, _ = self.multihead_attn(
-            query=tpe,
-            key=vpe, 
-            value=vpe
-        )
-        
+        attended_tpe, _ = self.multihead_attn(query=tpe, key=vpe, value=vpe)
+
         # Residual connection with layer norm
         fused = self.layer_norm(tpe + attended_tpe)
-        
+
         return fused
 
 
 def fuse_prompt_embeddings(
-    tpe: torch.Tensor | None,
-    vpe: torch.Tensor | None, 
-    method: str = 'concat',
-    embed_dim: int = 512
+    tpe: torch.Tensor | None, vpe: torch.Tensor | None, method: str = "concat", embed_dim: int = 512
 ) -> torch.Tensor:
     """
     Convenience function to fuse text and visual prompt embeddings.
-    
+
     Args:
         tpe (torch.Tensor, optional): Text prompt embeddings with shape (B, N_t, D)
         vpe (torch.Tensor, optional): Visual prompt embeddings with shape (B, N_v, D)
         method (str): Fusion method - 'concat', 'sum', or 'attention'
         embed_dim (int): Embedding dimension, required for attention-based fusion
-        
+
     Returns:
         torch.Tensor: Fused embeddings
-        
+
     Examples:
         >>> tpe = torch.randn(1, 10, 512)
         >>> vpe = torch.randn(1, 5, 512)
-        >>> fused = fuse_prompt_embeddings(tpe, vpe, method='concat')
+        >>> fused = fuse_prompt_embeddings(tpe, vpe, method="concat")
         >>> print(fused.shape)  # torch.Size([1, 15, 512])
     """
     fusion = PromptEmbeddingFusion(method=method, embed_dim=embed_dim)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds flexible fusion of text and visual prompts to YOLO-E, enabling concat/sum/attention strategies, new predict() args, comprehensive tests, and docs. 🚀

### 📊 Key Changes
- New fusion utilities:
  - `PromptEmbeddingFusion` with 'concat', 'sum', and 'attention' methods
  - `CrossAttentionFusion` (multi-head attention with residual + layer norm)
  - `fuse_prompt_embeddings` convenience function
- YOLO-E predictors updated to handle text prompts and fusion:
  - New methods: `set_text_prompts`, `set_fusion_method`, `set_cls_pe_override`, and `get_fused_embeddings`
  - Inference now supports text-only, visual-only, fused, or explicit `cls_pe` override
  - Backward-compatible fallback to VPE-only when no text prompts provided
- YOLO model API updates:
  - `model.predict(...)` adds `text_prompts`, `fusion_method`, and `cls_pe`
  - Visual prompt validation and predictor lifecycle refined
- Documentation:
  - New reference page for fusion utilities: Fusion utilities documentation
- Tests:
  - Extensive unit tests for concat/sum/attention, shape validation, error cases, and convenience function

### 🎯 Purpose & Impact
- More powerful prompting: Combine text and visual prompts for better guidance and flexibility in YOLO-E. 🧠👀
- Easy to use: Simple API with sensible defaults and clear error messages.
- Backward compatible: Existing visual prompt workflows continue to work unchanged.
- Configurable performance/quality trade-offs:
  - Concat for simplicity and speed
  - Sum for aligned sequences
  - Attention for richer cross-modal interaction (slightly higher compute)
- Reliability: Comprehensive tests ensure correctness across fusion modes and edge cases.

Example usage:
```python
from ultralytics import YOLO
import torch

model = YOLO("yoloe.pt")

# Visual prompts
prompts = {"bboxes": [[10, 20, 100, 200]], "cls": ["person"]}

# Text prompts (embeddings)
text_emb = torch.randn(1, 10, 512)

# Use attention fusion
results = model.predict(
    "image.jpg",
    visual_prompts=prompts,
    text_prompts=text_emb,
    fusion_method="attention",
)
```

Notes:
- Shapes must be (B, N, D); 'sum' requires same N.
- Attention requires `embed_dim` divisible by the number of heads.
- You can directly override class embeddings via `cls_pe` if needed.