### PR TITLE
Prevent long-running billed GPU CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
 
   GPU:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
-    timeout-minutes: 360
+    timeout-minutes: 20
     runs-on: github-linux-gpu-t4-4-core
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Prevent runaway billing on stalled GPU CI like https://github.com/ultralytics/ultralytics/actions/runs/17502843399/job/49719616168?pr=21959

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Reduce GPU CI job timeout from 6 hours to 20 minutes to speed up feedback and save resources ⏱️⚡

### 📊 Key Changes
- GPU job timeout in `.github/workflows/ci.yml` lowered from 360 minutes to 20 minutes.
- Applies to the GPU runner `github-linux-gpu-t4-4-core` under existing conditions.

### 🎯 Purpose & Impact
- Faster CI feedback by automatically stopping long-running or stuck GPU jobs 🚀
- Reduced resource usage and CI costs by capping GPU job duration 💸
- Encourages leaner, quicker GPU tests; may require optimizing or splitting longer tests to avoid unintended timeouts 📉
- Potential risk: legitimate long-running GPU tests could fail due to timeout and may need adjustment ✅