### PR TITLE
Fix `keypoints` typo in `verify_image_label`

### DIFF
--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -235,7 +235,7 @@ def verify_image_label(args: tuple) -> list:
                 lb = np.zeros((0, (5 + nkpt * ndim) if keypoint else 5), dtype=np.float32)
         else:
             nm = 1  # label missing
-            lb = np.zeros((0, (5 + nkpt * ndim) if keypoints else 5), dtype=np.float32)
+            lb = np.zeros((0, (5 + nkpt * ndim) if keypoint else 5), dtype=np.float32)
         if keypoint:
             keypoints = lb[:, 5:].reshape(-1, nkpt, ndim)
             if ndim == 2:


### PR DESCRIPTION
##  Description
I have read the CLA Document and I sign the CLA.

This PR fixes a bug in `verify_image_label` where the undefined variable `keypoints` was mistakenly used instead of the function parameter `keypoint`.

### Before
``` python
lb = np.zeros((0, (5 + nkpt * ndim) if keypoints else 5), dtype=np.float32)
```

### After
``` python
lb = np.zeros((0, (5 + nkpt * ndim) if keypoint else 5), dtype=np.float32)
```

## Why
- Prevents shape errors and potential crashes when verifying pose datasets.
- Ensures the correct logic is applied by using the keypoint argument.
- Non-pose datasets remain unaffected.

##  Related Issue
Closes #21964

##  Notes
- This is a minimal bug fix with no breaking changes.
- Improves dataset verification reliability.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes a variable name typo in image/label verification that could crash or mis-shape labels, especially for keypoint tasks 🛠️

### 📊 Key Changes
- Corrects a conditional from `keypoints` to `keypoint` in `ultralytics/data/utils.py` when initializing empty labels for missing annotations.
- Ensures the label tensor shape is computed consistently as `(5 + nkpt * ndim)` for keypoint tasks, or `5` otherwise.

### 🎯 Purpose & Impact
- Prevents runtime errors (NameError) during dataset verification when labels are missing, particularly in keypoint workflows ✅
- Ensures correct label shapes, avoiding downstream reshape issues and improving training/validation stability 🧩
- Improves robustness of data loading for all users, with notable reliability gains for keypoint datasets 👌