### PR TITLE
Restore all arguments on checkpoint load

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -69,7 +69,7 @@ from ultralytics.nn.modules import (
     YOLOESegment,
     v10Detect,
 )
-from ultralytics.utils import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER, YAML, colorstr, emojis
+from ultralytics.utils import DEFAULT_CFG_DICT, LOGGER, YAML, colorstr, emojis
 from ultralytics.utils.checks import check_requirements, check_suffix, check_yaml
 from ultralytics.utils.loss import (
     E2EDetectLoss,

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1502,7 +1502,7 @@ def load_checkpoint(weight, device=None, inplace=True, fuse=False):
     model = (ckpt.get("ema") or ckpt["model"]).float()  # FP32 model
 
     # Model compatibility updates
-    model.args = {k: v for k, v in args.items() if k in DEFAULT_CFG_KEYS}  # attach args to model
+    model.args = args # attach args to model
     model.pt_path = weight  # attach *.pt file path to model
     model.task = getattr(model, "task", guess_model_task(model))
     if not hasattr(model, "stride"):

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1502,7 +1502,7 @@ def load_checkpoint(weight, device=None, inplace=True, fuse=False):
     model = (ckpt.get("ema") or ckpt["model"]).float()  # FP32 model
 
     # Model compatibility updates
-    model.args = args # attach args to model
+    model.args = args  # attach args to model
     model.pt_path = weight  # attach *.pt file path to model
     model.task = getattr(model, "task", guess_model_task(model))
     if not hasattr(model, "stride"):


### PR DESCRIPTION
Closes #21963 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ensure all checkpoint args are preserved when loading models, improving compatibility and custom config support ✅

### 📊 Key Changes
- Removed filtering of checkpoint arguments: `model.args` now stores the full `args` dict instead of only keys in `DEFAULT_CFG_KEYS`.
- Cleaned up import by dropping unused `DEFAULT_CFG_KEYS`.

### 🎯 Purpose & Impact
- Better compatibility with custom configurations and future options—no more missing or silently dropped args 🚀
- More reliable behavior across tools and workflows (e.g., training resumption, exports, Ultralytics HUB integrations) since all metadata is retained 📦
- Minor behavior change: consumers of `model.args` may now see additional keys; ensure downstream code handles unexpected keys gracefully ⚠️