### PR TITLE
Cleanup CoreML NMS pipeline code

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1358,6 +1358,10 @@ class Exporter:
         spec = model.get_spec()
         outs = list(iter(spec.description.output))
 
+        if self.args.format == "mlmodel":  # mlmodel doesn't infer shapes automatically
+            outs[0].type.multiArrayType.shape[:] = self.output_shape[2], self.output_shape[1] - 4
+            outs[1].type.multiArrayType.shape[:] = self.output_shape[2], 4
+
         # Checks
         names = self.metadata["names"]
         nx, ny = spec.description.input[0].type.imageType.width, spec.description.input[0].type.imageType.height

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1402,7 +1402,6 @@ class Exporter:
         nms.confidenceThreshold = self.args.conf
         nms.pickTop.perClass = True
         nms.stringClassLabels.vector.extend(names.values())
-        nms.int64ClassLabels.vector.extend(names.keys())
         nms_model = ct.models.MLModel(nms_spec)
 
         # Pipeline models together

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1376,7 +1376,7 @@ class Exporter:
             nms_spec.description.input[i].ParseFromString(decoder_output)
             nms_spec.description.output.add()
             nms_spec.description.output[i].ParseFromString(decoder_output)
-        
+
         output_names = ["confidence", "coordinates"]
         for i, name in enumerate(output_names):
             nms_spec.description.output[i].name = name

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1357,7 +1357,6 @@ class Exporter:
         # Output shapes
         spec = model.get_spec()
         outs = list(iter(spec.description.output))
-
         if self.args.format == "mlmodel":  # mlmodel doesn't infer shapes automatically
             outs[0].type.multiArrayType.shape[:] = self.output_shape[2], self.output_shape[1] - 4
             outs[1].type.multiArrayType.shape[:] = self.output_shape[2], 4

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1417,7 +1417,7 @@ class Exporter:
         pipeline.add_model(model)
         pipeline.add_model(nms_model)
 
-        # Copy descriptions
+        # Correct datatypes
         pipeline.spec.description.input[0].ParseFromString(model._spec.description.input[0].SerializeToString())
         pipeline.spec.description.output[0].ParseFromString(nms_model._spec.description.output[0].SerializeToString())
         pipeline.spec.description.output[1].ParseFromString(nms_model._spec.description.output[1].SerializeToString())


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves CoreML export pipeline by removing runtime shape inference, setting output shapes more robustly, and simplifying NMS wiring—leading to more reliable exports across macOS, Linux, and Windows. 🚀

### 📊 Key Changes
- Reworked CoreML output handling:
  - Uses spec outputs directly (`outs`) instead of calling `model.predict()` to infer shapes.
  - Sets output shapes only when exporting to `mlmodel` format.
  - Derives class count (`nc`) from the CoreML spec output shape.
- Simplified and standardized NMS configuration:
  - Centralized output names via `output_names = ["confidence", "coordinates"]`.
  - Dynamically sets NMS input/output shapes and names based on spec outputs.
- Cleaned up pipeline assembly:
  - Uses `output_names` consistently for pipeline outputs.
  - Removed platform-specific prediction path (no more PIL image creation on macOS).

### 🎯 Purpose & Impact
- Reliability: Avoids `model.predict()` during export, preventing platform issues and crashes on Linux/Windows. 🛡️
- Correctness: Ensures output shapes and NMS dimensions are accurate and consistent with the model spec. ✅
- Maintainability: Cleaner, less platform-specific code that’s easier to extend and debug. 🧹
- User experience: More consistent CoreML export behavior across environments, reducing friction for deployment. 🌐