### PR TITLE
Fix empty predictions with OBB NMS export

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1560,7 +1560,7 @@ class NMSModel(torch.nn.Module):
                         or (self.args.format == "openvino" and self.args.int8)  # OpenVINO int8 error with triu
                     ),
                     iou_func=batch_probiou,
-                    exit_early=True,
+                    exit_early=False,
                 )
                 if self.obb
                 else nms

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1572,6 +1572,7 @@ class NMSModel(torch.nn.Module):
                         or (self.args.format == "openvino" and self.args.int8)  # OpenVINO int8 error with triu
                     ),
                     iou_func=batch_probiou,
+                    trace=True,
                 )
                 if self.obb
                 else nms

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1560,7 +1560,7 @@ class NMSModel(torch.nn.Module):
                         or (self.args.format == "openvino" and self.args.int8)  # OpenVINO int8 error with triu
                     ),
                     iou_func=batch_probiou,
-                    trace=True,
+                    exit_early=True,
                 )
                 if self.obb
                 else nms

--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -192,7 +192,7 @@ class TorchNMS:
         iou_threshold: float,
         use_triu: bool = True,
         iou_func=box_iou,
-        exit_early=True,
+        exit_early: bool = True,
     ) -> torch.Tensor:
         """
         Fast-NMS implementation from https://arxiv.org/pdf/1904.02689 using upper triangular matrix operations.

--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -192,7 +192,7 @@ class TorchNMS:
         iou_threshold: float,
         use_triu: bool = True,
         iou_func=box_iou,
-        trace=False,
+        exit_early=False,
     ) -> torch.Tensor:
         """
         Fast-NMS implementation from https://arxiv.org/pdf/1904.02689 using upper triangular matrix operations.
@@ -203,7 +203,7 @@ class TorchNMS:
             iou_threshold (float): IoU threshold for suppression.
             use_triu (bool): Whether to use torch.triu operator for upper triangular matrix operations.
             iou_func (callable): Function to compute IoU between boxes.
-            trace (bool): Whether to run in tracing mode, avoiding early exit.
+            exit_early (bool): Whether to exit early if there are no boxes.
 
         Returns:
             (torch.Tensor): Indices of boxes to keep after NMS.
@@ -214,7 +214,7 @@ class TorchNMS:
             >>> scores = torch.tensor([0.9, 0.8])
             >>> keep = TorchNMS.nms(boxes, scores, 0.5)
         """
-        if boxes.numel() == 0 and not trace:
+        if boxes.numel() == 0 and not exit_early:
             return torch.empty((0,), dtype=torch.int64, device=boxes.device)
 
         sorted_idx = torch.argsort(scores, descending=True)

--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -214,7 +214,7 @@ class TorchNMS:
             >>> scores = torch.tensor([0.9, 0.8])
             >>> keep = TorchNMS.nms(boxes, scores, 0.5)
         """
-        if boxes.numel() == 0 and not exit_early:
+        if boxes.numel() == 0 and exit_early:
             return torch.empty((0,), dtype=torch.int64, device=boxes.device)
 
         sorted_idx = torch.argsort(scores, descending=True)

--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -192,6 +192,7 @@ class TorchNMS:
         iou_threshold: float,
         use_triu: bool = True,
         iou_func=box_iou,
+        trace=False,
     ) -> torch.Tensor:
         """
         Fast-NMS implementation from https://arxiv.org/pdf/1904.02689 using upper triangular matrix operations.
@@ -202,6 +203,7 @@ class TorchNMS:
             iou_threshold (float): IoU threshold for suppression.
             use_triu (bool): Whether to use torch.triu operator for upper triangular matrix operations.
             iou_func (callable): Function to compute IoU between boxes.
+            trace (bool): Whether to run in tracing mode, avoiding early exit.
 
         Returns:
             (torch.Tensor): Indices of boxes to keep after NMS.
@@ -212,7 +214,7 @@ class TorchNMS:
             >>> scores = torch.tensor([0.9, 0.8])
             >>> keep = TorchNMS.nms(boxes, scores, 0.5)
         """
-        if boxes.numel() == 0:
+        if boxes.numel() == 0 and not trace:
             return torch.empty((0,), dtype=torch.int64, device=boxes.device)
 
         sorted_idx = torch.argsort(scores, descending=True)

--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -192,7 +192,7 @@ class TorchNMS:
         iou_threshold: float,
         use_triu: bool = True,
         iou_func=box_iou,
-        exit_early=False,
+        exit_early=True,
     ) -> torch.Tensor:
         """
         Fast-NMS implementation from https://arxiv.org/pdf/1904.02689 using upper triangular matrix operations.


### PR DESCRIPTION
```bash
yolo export model=yolo11n-obb.pt format=onnx nms
yolo val model=yolo11n-obb.onnx data=dota8.yaml exist_ok imgsz=1024
```

Tracing breaks if we exit early based on empty boxes.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds an optional exit_early switch to Fast-NMS and uses it during export to improve compatibility and stability across export backends, especially for OBB and certain INT8 pipelines. 🚀

### 📊 Key Changes
- Introduced `exit_early` parameter to `fast_nms` in `ultralytics/utils/nms.py` (default: `True`).
- During export, `fast_nms` is now called with `exit_early=False` (and `iou_func=batch_probiou`) for OBB flows in `ultralytics/engine/exporter.py`.
- Maintains default behavior in normal runtime; only export paths are adjusted.

Minimal usage example:
```python
from ultralytics.utils.nms import fast_nms

keep = fast_nms(boxes, scores, iou_threshold=0.5, exit_early=False)
```

### 🎯 Purpose & Impact
- Improves export reliability across backends (e.g., ONNX, CoreML, OpenVINO INT8) by avoiding early-return control flow that can break tracing/shape inference. ✅
- Enhances OBB export stability by pairing `fast_nms` with `batch_probiou` and disabling early exits. 📦
- Backward compatible: no change for existing users unless they opt into the new parameter. 🔧
- Minor overhead when no boxes are present during export, but negligible in practice. ⚖️