### PR TITLE
Fix overly verbose USER_CONFIG_DIR checks

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -857,7 +857,7 @@ def get_ubuntu_version():
 
 def get_user_config_dir(sub_dir="Ultralytics"):
     """
-    Return a writable config dir, preferring YOLO_CONFIG_DIR and being Docker-aware.
+    Return a writable config dir, preferring YOLO_CONFIG_DIR and being OS-aware.
 
     Args:
         sub_dir (str): The name of the subdirectory to create.

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -857,35 +857,48 @@ def get_ubuntu_version():
 
 def get_user_config_dir(sub_dir="Ultralytics"):
     """
-    Return the appropriate config directory based on the environment operating system.
-
+    Return a writable config dir, preferring YOLO_CONFIG_DIR and being Docker-aware.
+    
     Args:
         sub_dir (str): The name of the subdirectory to create.
 
     Returns:
         (Path): The path to the user config directory.
     """
-    if WINDOWS:
-        path = Path.home() / "AppData" / "Roaming" / sub_dir
-    elif MACOS:  # macOS
-        path = Path.home() / "Library" / "Application Support" / sub_dir
+    # Primary (env override → OS default)
+    env_dir = os.getenv("YOLO_CONFIG_DIR")
+    if env_dir:
+        p = Path(env_dir).expanduser() / sub_dir
     elif LINUX:
-        path = Path.home() / ".config" / sub_dir
+        p = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config")) / sub_dir
+    elif WINDOWS:
+        p = Path.home() / "AppData" / "Roaming" / sub_dir
+    elif MACOS:
+        p = Path.home() / "Library" / "Application Support" / sub_dir
     else:
         raise ValueError(f"Unsupported operating system: {platform.system()}")
 
-    # GCP and AWS lambda fix, only /tmp is writeable
-    if not is_dir_writeable(path.parent):
-        LOGGER.warning(
-            f"user config directory '{path}' is not writeable, defaulting to '/tmp' or CWD. "
-            "Alternatively you can define a YOLO_CONFIG_DIR environment variable for this path."
-        )
-        path = Path("/tmp") / sub_dir if is_dir_writeable("/tmp") else Path().cwd() / sub_dir
+    if p.exists():  # already created → trust it
+        return p
+    if is_dir_writeable(p.parent):  # create if possible
+        p.mkdir(parents=True, exist_ok=True)
+        return p
 
-    # Create the subdirectory if it does not exist
-    path.mkdir(parents=True, exist_ok=True)
+    # Fallbacks for Docker, GCP/AWS functions where only /tmp is writeable
+    for alt in [Path("/tmp") / sub_dir, Path.cwd() / sub_dir]:
+        if alt.exists():
+            return alt
+        if is_dir_writeable(alt.parent):
+            alt.mkdir(parents=True, exist_ok=True)
+            LOGGER.warning(
+                f"user config directory '{p}' is not writeable, using '{alt}'. Set YOLO_CONFIG_DIR to override."
+            )
+            return alt
 
-    return path
+    # Last fallback → CWD
+    p = Path.cwd() / sub_dir
+    p.mkdir(parents=True, exist_ok=True)
+    return p
 
 
 # Define constants (required below)
@@ -899,7 +912,7 @@ IS_JUPYTER = is_jupyter()
 IS_PIP_PACKAGE = is_pip_package()
 IS_RASPBERRYPI = is_raspberrypi()
 GIT = GitRepo()
-USER_CONFIG_DIR = Path(os.getenv("YOLO_CONFIG_DIR") or get_user_config_dir())  # Ultralytics settings dir
+USER_CONFIG_DIR = get_user_config_dir()  # Ultralytics settings dir
 SETTINGS_FILE = USER_CONFIG_DIR / "settings.json"
 
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -865,9 +865,7 @@ def get_user_config_dir(sub_dir="Ultralytics"):
     Returns:
         (Path): The path to the user config directory.
     """
-    # Primary (env override → OS default)
-    env_dir = os.getenv("YOLO_CONFIG_DIR")
-    if env_dir:
+    if env_dir := os.getenv("YOLO_CONFIG_DIR"):
         p = Path(env_dir).expanduser() / sub_dir
     elif LINUX:
         p = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config")) / sub_dir

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -858,7 +858,7 @@ def get_ubuntu_version():
 def get_user_config_dir(sub_dir="Ultralytics"):
     """
     Return a writable config dir, preferring YOLO_CONFIG_DIR and being Docker-aware.
-    
+
     Args:
         sub_dir (str): The name of the subdirectory to create.
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
More robust, OS-aware config directory resolution with better fallbacks and a unified approach to honoring `YOLO_CONFIG_DIR` 🌐🛠️

### 📊 Key Changes
- get_user_config_dir now:
  - Prefers `YOLO_CONFIG_DIR` (expands `~`) and always appends the subdirectory (default: `Ultralytics`).
  - Uses XDG on Linux (`$XDG_CONFIG_HOME` or `~/.config`), standard paths on macOS and Windows.
  - Creates the directory if writable; otherwise falls back to `/tmp/Ultralytics` or `./Ultralytics` with a clear warning.
  - Returns early if the target directory already exists.
- Centralized env handling: `USER_CONFIG_DIR` is now always derived from `get_user_config_dir()` (no direct `os.getenv` shortcut).

### 🎯 Purpose & Impact
- Fewer permission issues in containers and serverless (GCP/AWS) by automatically using writable fallbacks ✅
- Better Linux compliance via XDG paths, improving cross-platform consistency 🐧
- Clearer, predictable behavior for `YOLO_CONFIG_DIR`:
  - Set it as a base config directory; the tool will create/use `<YOLO_CONFIG_DIR>/Ultralytics` by default.
- Reduced edge cases and more consistent behavior across environments by avoiding split logic at import time 🔧

Tip: To customize the config location, set:
- macOS/Linux: `export YOLO_CONFIG_DIR=~/.config`
- Windows (PowerShell): `$env:YOLO_CONFIG_DIR="$HOME\.config"`