### PR TITLE
Use `torch.backends.cudnn.benchmark=True`

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -618,7 +618,7 @@ def init_seeds(seed=0, deterministic=False):
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)  # for Multi-GPU, exception safe
-    # torch.backends.cudnn.benchmark = True  # AutoBatch problem https://github.com/ultralytics/yolov5/issues/9287
+    torch.backends.cudnn.benchmark = True  # AutoBatch problem https://github.com/ultralytics/yolov5/issues/9287
     if deterministic:
         if TORCH_2_0:
             torch.use_deterministic_algorithms(True, warn_only=True)  # warn if deterministic is not possible


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enables cuDNN benchmarking by default in PyTorch seed initialization to improve GPU performance during training and inference. ⚡

### 📊 Key Changes
- Turned on `torch.backends.cudnn.benchmark = True` in `init_seeds()` within `ultralytics/utils/torch_utils.py`.

### 🎯 Purpose & Impact
- Faster runtime on NVIDIA GPUs for most workloads, especially with fixed input sizes (common in YOLO11, YOLO12, etc.). 🚀
- Helps mitigate an AutoBatch performance issue noted in the past; see the related [AutoBatch issue discussion (#9287)](https://github.com/ultralytics/yolov5/issues/9287). 🛠️
- Potential trade-off: cuDNN benchmarking can introduce minor variability and may re-benchmark when input shapes change, slightly affecting timing consistency. ⏱️
- Reproducibility: If you require strict determinism, set `deterministic=True` in Ultralytics settings (the code uses `torch.use_deterministic_algorithms(True)` when requested), though absolute reproducibility can still depend on CUDA/cuDNN constraints. 🔒