### PR TITLE
Fix typo in `deprecation_warn` method

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1394,7 +1394,7 @@ class SettingsManager(JSONDict):
 
 def deprecation_warn(arg, new_arg=None):
     """Issue a deprecation warning when a deprecated argument is used, suggesting an updated argument."""
-    msg = f"'{arg}' is deprecated and will be removed in in the future."
+    msg = f"'{arg}' is deprecated and will be removed in the future."
     if new_arg is not None:
         msg += f" Use '{new_arg}' instead."
     LOGGER.warning(msg)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor typo fix in a deprecation warning message to improve log clarity and professionalism. ✨

### 📊 Key Changes
- Corrected a duplicated word in `deprecation_warn()` message: “removed in in the future” → “removed in the future”. 🧹

### 🎯 Purpose & Impact
- Improves readability and polish of user-facing warnings. 📝
- No functional, API, or performance changes—safe and backward compatible. ✅
- Helps maintain a professional developer experience across logs and CLI output. 💼