### PR TITLE
Increase instance plotting limit for segmentation to `max_det`

### DIFF
--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -187,10 +187,10 @@ class SegmentationValidator(DetectionValidator):
         """
         for p in preds:
             masks = p["masks"]
-            if masks.shape[0] > 50:
-                LOGGER.warning("Limiting validation plots to first 50 items per image for speed...")
-            p["masks"] = torch.as_tensor(masks[:50], dtype=torch.uint8).cpu()
-        super().plot_predictions(batch, preds, ni, max_det=50)  # plot bboxes
+            if masks.shape[0] > self.args.max_det:
+                LOGGER.warning(f"Limiting validation plots to first {self.args.max_det} items per image for speed...")
+            p["masks"] = torch.as_tensor(masks[:self.args.max_det], dtype=torch.uint8).cpu()
+        super().plot_predictions(batch, preds, ni, max_det=self.args.max_det)  # plot bboxes
 
     def save_one_txt(self, predn: torch.Tensor, save_conf: bool, shape: tuple[int, int], file: Path) -> None:
         """

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -189,7 +189,7 @@ class SegmentationValidator(DetectionValidator):
             masks = p["masks"]
             if masks.shape[0] > self.args.max_det:
                 LOGGER.warning(f"Limiting validation plots to first {self.args.max_det} items per image for speed...")
-            p["masks"] = torch.as_tensor(masks[:self.args.max_det], dtype=torch.uint8).cpu()
+            p["masks"] = torch.as_tensor(masks[: self.args.max_det], dtype=torch.uint8).cpu()
         super().plot_predictions(batch, preds, ni, max_det=self.args.max_det)  # plot bboxes
 
     def save_one_txt(self, predn: torch.Tensor, save_conf: bool, shape: tuple[int, int], file: Path) -> None:

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -188,7 +188,7 @@ class SegmentationValidator(DetectionValidator):
         for p in preds:
             masks = p["masks"]
             if masks.shape[0] > self.args.max_det:
-                LOGGER.warning(f"Limiting validation plots to first {self.args.max_det} items per image for speed...")
+                LOGGER.warning(f"Limiting validation plots to 'max_det={self.args.max_det}' items.")
             p["masks"] = torch.as_tensor(masks[: self.args.max_det], dtype=torch.uint8).cpu()
         super().plot_predictions(batch, preds, ni, max_det=self.args.max_det)  # plot bboxes
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Validation plots for YOLO segmentation now respect the configurable `max_det` setting instead of using a hard-coded limit of 50 masks. 🎛️

### 📊 Key Changes
- Replaced fixed mask plot limit (50) with `self.args.max_det` in `plot_predictions`.
- Updated warning message to reflect the active `max_det` value.
- Passed `max_det=self.args.max_det` to the superclass plotting call for consistency.

### 🎯 Purpose & Impact
- Configurability: Users can now control how many masks are visualized during validation via `max_det`, aligning plots with detection limits. ⚙️
- Consistency: Plotting behavior matches the broader evaluation settings, reducing surprises. ✅
- Performance considerations: If your default `max_det` is higher than 50, more masks may be plotted by default, which could slow down validation plotting. Adjust `max_det` to balance detail vs. speed. 🚀

Example:
- CLI: `yolo task=segment mode=val model=yolo11n-seg.pt data=coco8-seg.yaml max_det=50`
- Python:
  ```python
  from ultralytics import YOLO

  model = YOLO("yolo11n-seg.pt")
  model.val(data="coco8-seg.yaml", max_det=50)
  ```