### PR TITLE
Fix metrics logging to HUB

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -797,7 +797,7 @@ class Model(torch.nn.Module):
             self.trainer.model = self.trainer.get_model(weights=self.model if self.ckpt else None, cfg=self.model.yaml)
             self.model = self.trainer.model
 
-        self.trainer.hub_session = self.session  # attach optional HUB session
+        self.trainer.hub_session = self.trainer.hub_session or self.session  # attach optional HUB session
         self.trainer.train()
         # Update model and cfg after training
         if RANK in {-1, 0}:

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -788,7 +788,7 @@ class Model(torch.nn.Module):
             "model": self.overrides["model"],
             "task": self.task,
         }  # method defaults
-        args = {**overrides, **custom, **kwargs, "mode": "train"}  # highest priority args on the right
+        args = {**overrides, **custom, **kwargs, "mode": "train", "session": self.session}  # prioritizes rightmost args
         if args.get("resume"):
             args["resume"] = self.ckpt_path
 
@@ -797,7 +797,6 @@ class Model(torch.nn.Module):
             self.trainer.model = self.trainer.get_model(weights=self.model if self.ckpt else None, cfg=self.model.yaml)
             self.model = self.trainer.model
 
-        self.trainer.hub_session = self.trainer.hub_session or self.session  # attach optional HUB session
         self.trainer.train()
         # Update model and cfg after training
         if RANK in {-1, 0}:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -119,7 +119,7 @@ class BaseTrainer:
             overrides (dict, optional): Configuration overrides.
             _callbacks (list, optional): List of callback functions.
         """
-        self.hub_session = overrides.pop("session")  # HUB
+        self.hub_session = overrides.pop("session", None)  # HUB
         self.args = get_cfg(cfg, overrides)
         self.check_resume(overrides)
         self.device = select_device(self.args.device, self.args.batch)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -119,6 +119,7 @@ class BaseTrainer:
             overrides (dict, optional): Configuration overrides.
             _callbacks (list, optional): List of callback functions.
         """
+        self.hub_session = overrides.pop("session") # HUB
         self.args = get_cfg(cfg, overrides)
         self.check_resume(overrides)
         self.device = select_device(self.args.device, self.args.batch)
@@ -169,9 +170,6 @@ class BaseTrainer:
         self.loss_names = ["Loss"]
         self.csv = self.save_dir / "results.csv"
         self.plot_idx = [0, 1, 2]
-
-        # HUB
-        self.hub_session = None
 
         # Callbacks
         self.callbacks = _callbacks or callbacks.get_default_callbacks()

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -119,7 +119,7 @@ class BaseTrainer:
             overrides (dict, optional): Configuration overrides.
             _callbacks (list, optional): List of callback functions.
         """
-        self.hub_session = overrides.pop("session") # HUB
+        self.hub_session = overrides.pop("session")  # HUB
         self.args = get_cfg(cfg, overrides)
         self.check_resume(overrides)
         self.device = select_device(self.args.device, self.args.batch)

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -6,11 +6,18 @@ from time import time
 from ultralytics.hub import HUB_WEB_ROOT, PREFIX, HUBTrainingSession
 from ultralytics.utils import LOGGER, RANK, SETTINGS
 from ultralytics.utils.events import events
+from ultralytics.engine.model import Model
 
 
 def on_pretrain_routine_start(trainer):
     """Create a remote Ultralytics HUB session to log local model training."""
-    if RANK in {-1, 0} and SETTINGS["hub"] is True and SETTINGS["api_key"] and trainer.hub_session is None:
+    if (
+        RANK in {-1, 0}
+        and SETTINGS["hub"] is True
+        and SETTINGS["api_key"]
+        and trainer.hub_session is None
+        and not Model.is_hub_model(trainer.model)
+    ):
         trainer.hub_session = HUBTrainingSession.create_session(trainer.args.model, trainer.args)
 
 

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -11,13 +11,7 @@ from ultralytics.utils.events import events
 
 def on_pretrain_routine_start(trainer):
     """Create a remote Ultralytics HUB session to log local model training."""
-    if (
-        RANK in {-1, 0}
-        and SETTINGS["hub"] is True
-        and SETTINGS["api_key"]
-        and trainer.hub_session is None
-        and not Model.is_hub_model(trainer.model)
-    ):
+    if RANK in {-1, 0} and SETTINGS["hub"] is True and SETTINGS["api_key"] and trainer.hub_session is None:
         trainer.hub_session = HUBTrainingSession.create_session(trainer.args.model, trainer.args)
 
 

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -3,7 +3,6 @@
 import json
 from time import time
 
-from ultralytics.engine.model import Model
 from ultralytics.hub import HUB_WEB_ROOT, PREFIX, HUBTrainingSession
 from ultralytics.utils import LOGGER, RANK, SETTINGS
 from ultralytics.utils.events import events

--- a/ultralytics/utils/callbacks/hub.py
+++ b/ultralytics/utils/callbacks/hub.py
@@ -3,10 +3,10 @@
 import json
 from time import time
 
+from ultralytics.engine.model import Model
 from ultralytics.hub import HUB_WEB_ROOT, PREFIX, HUBTrainingSession
 from ultralytics.utils import LOGGER, RANK, SETTINGS
 from ultralytics.utils.events import events
-from ultralytics.engine.model import Model
 
 
 def on_pretrain_routine_start(trainer):


### PR DESCRIPTION
Closes #21990 
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlines how Ultralytics HUB sessions are passed into training by routing the session through Trainer initialization, improving reliability and reducing side effects. 🔧✨

### 📊 Key Changes
- Passes the HUB session via the training args: `args = {..., "mode": "train", "session": self.session}` instead of setting `trainer.hub_session` later.
- Trainer now extracts the HUB session early: `self.hub_session = overrides.pop("session", None)`.
- Removes redundant `self.hub_session = None` default and late assignment in Trainer.
- Minor comment cleanup to clarify argument priority behavior.

### 🎯 Purpose & Impact
- Ensures the HUB session is available as soon as the Trainer is constructed, improving logging, syncing, and callback behavior with Ultralytics HUB. 📡
- Reduces hidden side effects by using a single, consistent path for session propagation. 🧩
- Improves code clarity and maintainability; no public API changes expected for most users. ✅
- Potential minor impact: the `session` key in overrides is now reserved for HUB sessions.