### PR TITLE
Remove `disable_dynamo` wrapper around `Detect.inference()` and loss calculation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,10 +31,10 @@ on:
         type: boolean
         description: Dockerfile-jetson-jetpack6
         default: true
-      # Dockerfile-jetson-jetpack5:
-      #   type: boolean
-      #   description: Dockerfile-jetson-jetpack5
-      #   default: true
+      Dockerfile-jetson-jetpack5:
+        type: boolean
+        description: Dockerfile-jetson-jetpack5
+        default: true
       Dockerfile-jetson-jetpack4:
         type: boolean
         description: Dockerfile-jetson-jetpack4
@@ -78,11 +78,11 @@ jobs:
             platforms: "linux/arm64"
             runs_on: "ubuntu-24.04-arm"
             derivatives: ""
-          # - dockerfile: "Dockerfile-jetson-jetpack5"
-          #   tags: "latest-jetson-jetpack5"
-          #   platforms: "linux/arm64"
-          #   runs_on: "ubuntu-24.04-arm"
-          #   derivatives: ""
+          - dockerfile: "Dockerfile-jetson-jetpack5"
+            tags: "latest-jetson-jetpack5"
+            platforms: "linux/arm64"
+            runs_on: "ubuntu-24.04-arm"
+            derivatives: ""
           - dockerfile: "Dockerfile-jetson-jetpack4"
             tags: "latest-jetson-jetpack4"
             platforms: "linux/arm64"

--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -139,10 +139,6 @@ keywords: Ultralytics, torch utils, model optimization, device selection, infere
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.torch_utils.disable_dynamo
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.torch_utils.attempt_compile
 
 <br><br>

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -112,7 +112,7 @@ from ultralytics.utils.metrics import batch_probiou
 from ultralytics.utils.nms import TorchNMS
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.patches import arange_patch
-from ultralytics.utils.torch_utils import TORCH_1_13, get_latest_opset, select_device, unwrap_model
+from ultralytics.utils.torch_utils import TORCH_1_13, get_latest_opset, select_device
 
 
 def export_formats():
@@ -270,7 +270,6 @@ class Exporter:
 
     def __call__(self, model=None) -> str:
         """Return list of exported files/dirs after running callbacks."""
-        model = unwrap_model(model)
         t = time.time()
         fmt = self.args.format.lower()  # to lowercase
         if fmt in {"tensorrt", "trt"}:  # 'engine' aliases

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -64,7 +64,6 @@ class DetectionTrainer(BaseTrainer):
             _callbacks (list, optional): List of callback functions to be executed during training.
         """
         super().__init__(cfg, overrides, _callbacks)
-        self.dynamic_tensors = ["batch_idx", "cls", "bboxes"]
 
     def build_dataset(self, img_path: str, mode: str = "train", batch: int | None = None):
         """
@@ -138,10 +137,6 @@ class DetectionTrainer(BaseTrainer):
                 ]  # new shape (stretched to gs-multiple)
                 imgs = nn.functional.interpolate(imgs, size=ns, mode="bilinear", align_corners=False)
             batch["img"] = imgs
-
-        if self.args.compile:
-            for k in self.dynamic_tensors:
-                torch._dynamo.maybe_mark_dynamic(batch[k], 0)
         return batch
 
     def set_model_attributes(self):

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -57,7 +57,6 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
             overrides = {}
         overrides["task"] = "pose"
         super().__init__(cfg, overrides, _callbacks)
-        self.dynamic_tensors = ["batch_idx", "cls", "bboxes", "keypoints"]
 
         if isinstance(self.args.device, str) and self.args.device.lower() == "mps":
             LOGGER.warning(

--- a/ultralytics/models/yolo/segment/train.py
+++ b/ultralytics/models/yolo/segment/train.py
@@ -41,7 +41,6 @@ class SegmentationTrainer(yolo.detect.DetectionTrainer):
             overrides = {}
         overrides["task"] = "segment"
         super().__init__(cfg, overrides, _callbacks)
-        self.dynamic_tensors = ["batch_idx", "cls", "bboxes", "masks"]
 
     def get_model(self, cfg: dict | str | None = None, weights: str | Path | None = None, verbose: bool = True):
         """

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -149,7 +149,6 @@ class Detect(nn.Module):
         y = self.postprocess(y.permute(0, 2, 1), self.max_det, self.nc)
         return y if self.export else (y, {"one2many": x, "one2one": one2one})
 
-    @disable_dynamo
     def _inference(self, x: list[torch.Tensor]) -> torch.Tensor:
         """
         Decode predicted bounding boxes and class probabilities based on multiple-level feature maps.

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -13,7 +13,7 @@ from torch.nn.init import constant_, xavier_uniform_
 
 from ultralytics.utils import NOT_MACOS14
 from ultralytics.utils.tal import TORCH_1_10, dist2bbox, dist2rbox, make_anchors
-from ultralytics.utils.torch_utils import disable_dynamo, fuse_conv_and_bn, smart_inference_mode
+from ultralytics.utils.torch_utils import fuse_conv_and_bn, smart_inference_mode
 
 from .block import DFL, SAVPE, BNContrastiveHead, ContrastiveHead, Proto, Residual, SwiGLUFFN
 from .conv import Conv, DWConv

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -215,7 +215,7 @@ class v8DetectionLoss:
         self.assigner = TaskAlignedAssigner(topk=tal_topk, num_classes=self.nc, alpha=0.5, beta=6.0)
         self.bbox_loss = BboxLoss(m.reg_max).to(device)
         self.proj = torch.arange(m.reg_max, dtype=torch.float, device=device)
-        disable_dynamo(self.__class__)  # exclude from compile
+        # disable_dynamo(self.__class__)  # exclude from compile
 
     def preprocess(self, targets: torch.Tensor, batch_size: int, scale_tensor: torch.Tensor) -> torch.Tensor:
         """Preprocess targets by converting to tensor format and scaling coordinates."""

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from ultralytics.utils.metrics import OKS_SIGMA
 from ultralytics.utils.ops import crop_mask, xywh2xyxy, xyxy2xywh
 from ultralytics.utils.tal import RotatedTaskAlignedAssigner, TaskAlignedAssigner, dist2bbox, dist2rbox, make_anchors
-from ultralytics.utils.torch_utils import autocast, disable_dynamo
+from ultralytics.utils.torch_utils import autocast
 
 from .metrics import bbox_iou, probiou
 from .tal import bbox2dist
@@ -215,7 +215,6 @@ class v8DetectionLoss:
         self.assigner = TaskAlignedAssigner(topk=tal_topk, num_classes=self.nc, alpha=0.5, beta=6.0)
         self.bbox_loss = BboxLoss(m.reg_max).to(device)
         self.proj = torch.arange(m.reg_max, dtype=torch.float, device=device)
-        # disable_dynamo(self.__class__)  # exclude from compile
 
     def preprocess(self, targets: torch.Tensor, batch_size: int, scale_tensor: torch.Tensor) -> torch.Tensor:
         """Preprocess targets by converting to tensor format and scaling coordinates."""

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1006,28 +1006,6 @@ class FXModel(nn.Module):
         return x
 
 
-def disable_dynamo(func: Any) -> Any:
-    """
-    Disable torch.compile/dynamo for a callable when available.
-
-    Args:
-        func (Any): Callable object to wrap. Could be a function, method, or class.
-
-    Returns:
-        func (Any): Same callable, wrapped by torch._dynamo.disable when available, otherwise unchanged.
-
-    Examples:
-        >>> @disable_dynamo
-        ... def fn(x):
-        ...     return x + 1
-        >>> # Works even if torch._dynamo is not available
-        >>> _ = fn(1)
-    """
-    if hasattr(torch, "_dynamo"):
-        return torch._dynamo.disable(func)
-    return func
-
-
 def attempt_compile(
     model: torch.nn.Module,
     device: torch.device,


### PR DESCRIPTION
@glenn-jocher I was using this to get validation to work with `rect=True` and compiled model. But it doesn't seem like validation works well anyway with `rect=True`.

Removing it to fix https://github.com/ultralytics/ultralytics/actions/runs/17549657383/job/49846504093

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves torch.compile compatibility and simplifies training/execution paths while re-enabling JetPack 5 Docker builds for NVIDIA Jetson users. 🚀🐳

### 📊 Key Changes
- Docker:
  - Re-enables Jetson JetPack 5 image builds in CI with `Dockerfile-jetson-jetpack5` (arm64, Ubuntu 24.04 ARM runner). 🧱
- Training pipeline:
  - Decouples forward and loss: now runs `preds = model(batch["img"])` and `loss, items = model.loss(batch, preds)` for cleaner torch.compile integration.
  - Removes dynamic tensor marking and related metadata popping/merging in training loops for detect/pose/segment tasks.
- Torch Dynamo/compile cleanups:
  - Removes `disable_dynamo` utility and its usage across the codebase (docs, heads, loss).
  - Drops `unwrap_model(model)` call during export.
- Docs:
  - Removes the reference page section for `disable_dynamo`.

Minimal example (new training step):
```python
with autocast(self.amp):
    batch = self.preprocess_batch(batch)
    preds = self.model(batch["img"])
    loss, self.loss_items = self.model.loss(batch, preds)
```

### 🎯 Purpose & Impact
- Better torch.compile support: Cleaner separation of inference and loss improves compile success rate and stability, potentially boosting training speed. ⚡
- Simpler, more maintainable code: Removing `disable_dynamo` and dynamic tensor hooks reduces complexity and risk of Dynamo-related issues.
- Improved Jetson support: JetPack 5 Docker images are now built again, making it easier for Jetson users to deploy and test. 🤖
- Export reliability: Removing model unwrapping simplifies exporter behavior with fewer edge cases.
- Documentation clarity: Eliminates references to a deprecated utility, reducing confusion.