### PR TITLE
Fix Slack notifications on scheduled CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,11 +419,7 @@ jobs:
     if: always()
     steps:
       - name: Check for failure and notify
-        if: >
-          github.repository == 'ultralytics/ultralytics' &&
-          (github.event_name == 'schedule' || github.event_name == 'push') &&
-          github.run_attempt == '1' &&
-          (failure() || cancelled())
+        if: (needs.HUB.result == 'failure' || needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.GPU.result == 'failure' || needs.RaspberryPi.result == 'failure' || needs.NVIDIA_Jetson.result == 'failure' || needs.Conda.result == 'failure' ) && github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
         uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook-type: incoming-webhook


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refines CI Slack notifications to trigger only when specific jobs fail, reducing noise and improving signal in alerts. 🔔✅

### 📊 Key Changes
- Replaced the generic `failure() || cancelled()` condition with explicit checks for failed jobs:
  - `HUB`, `Benchmarks`, `Tests`, `GPU`, `RaspberryPi`, `NVIDIA_Jetson`, `Conda`
- Maintains existing constraints:
  - Only for `ultralytics/ultralytics` on `schedule` or `push` events
  - Only on the first run attempt
- Uses `needs.<job>.result == 'failure'` to precisely target failures

### 🎯 Purpose & Impact
- Reduces false-positive Slack alerts from cancelled or unrelated failures 🚫🔕
- Ensures the team is alerted only for meaningful CI breakages across critical jobs 🎯
- Improves CI signal-to-noise, speeding up response to real issues and minimizing distraction ⚡
- No impact on end users or runtime behavior; CI-only change 🛠️