### PR TITLE
Unwrap DDP model before loss calculation

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -413,7 +413,7 @@ class BaseTrainer:
                     batch = self.preprocess_batch(batch)
                     # decouple inference and loss calculations for torch.compile convenience
                     preds = self.model(batch["img"])
-                    loss, self.loss_items = unwrap_model(self.model.loss)(batch, preds)
+                    loss, self.loss_items = unwrap_model(self.model).loss(batch, preds)
                     self.loss = loss.sum()
                     if RANK != -1:
                         self.loss *= world_size

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -413,7 +413,7 @@ class BaseTrainer:
                     batch = self.preprocess_batch(batch)
                     # decouple inference and loss calculations for torch.compile convenience
                     preds = self.model(batch["img"])
-                    loss, self.loss_items = self.model.loss(batch, preds)
+                    loss, self.loss_items = unwrap_model(self.model.loss)(batch, preds)
                     self.loss = loss.sum()
                     if RANK != -1:
                         self.loss *= world_size


### PR DESCRIPTION
Closes #22015 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ensures loss is computed on the underlying model by unwrapping any wrappers, improving compatibility with torch.compile and other training wrappers. ✅

### 📊 Key Changes
- Replaced `self.model.loss(...)` with `unwrap_model(self.model).loss(...)` during training loss computation.

### 🎯 Purpose & Impact
- Improves compatibility with torch.compile and other wrappers (e.g., DDP/EMA) that may hide or alter `.loss` on the wrapped model. 🧩
- Reduces runtime errors and edge cases when using compiled or wrapped models, leading to more reliable training. 🚀
- No expected change to training results or user-facing APIs—behavior remains the same, just more robust. 🔒