### PR TITLE
Revise detection boxes argument documentation

### DIFF
--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -900,7 +900,7 @@ class Boxes(BaseTensor):
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array with detection boxes of shape
                 (num_boxes, 6) or (num_boxes, 7). Columns should contain
-                [x1, y1, x2, y2, confidence, class, (optional) track_id].
+                [x1, y1, x2, y2, (optional) track_id, confidence, class].
             orig_shape (tuple[int, int]): The original image shape as (height, width). Used for normalization.
 
         Attributes:


### PR DESCRIPTION
Updated the order of columns in the detection boxes description to properly reflect the expected order. Tracking ID was in the last index when it should be in the third last index when it is present.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Docs-only fix: clarifies the expected column order for detection boxes, placing track_id before confidence and class. ✅

### 📊 Key Changes
- Updated docstring in `ultralytics/engine/results.py` to specify boxes should be ordered as:
  - `[x1, y1, x2, y2, (optional) track_id, confidence, class]` (previously had confidence and class before track_id)

### 🎯 Purpose & Impact
- Reduces confusion for users creating custom box tensors/arrays, especially when integrating trackers. 🧭
- No functional/runtime changes; models and APIs behave the same. 🛡️
- If you manually construct boxes, ensure the new documented order to avoid misalignment. 🔧

Example:
```python
# [x1, y1, x2, y2, track_id, confidence, class]
boxes = np.array([
    [10, 20, 100, 200, 5, 0.92, 1],
    [15, 25, 110, 210, 6, 0.88, 0],
])
```