### PR TITLE
Fix `imx` object detection export outputs

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1306,7 +1306,7 @@ class Exporter:
                     kpts = outputs[2]  # (bs, max_detections, kpts 17*3)
                     out_kpts = torch.gather(kpts, 1, nms_outputs.indices.unsqueeze(-1).expand(-1, -1, kpts.size(-1)))
                     return nms_outputs.boxes, nms_outputs.scores, nms_outputs.labels, out_kpts
-                return nms_outputs
+                return nms_outputs.boxes, nms_outputs.scores, nms_outputs.labels, nms_outputs.n_valid
 
         quant_model = NMSWrapper(
             model=quant_model,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Standardizes the NMS wrapper output during quantized export to always return simple tensors (boxes, scores, labels, count), improving consistency and downstream compatibility. ✅

### 📊 Key Changes
- Exporter’s NMSWrapper now returns a tuple `(boxes, scores, labels, n_valid)` instead of a custom `nms_outputs` object for non-keypoint tasks.
- For keypoint tasks, it continues to return `(boxes, scores, labels, out_kpts)` as before.
- Result: unified, unpackable outputs across export paths, especially for quantized models.

### 🎯 Purpose & Impact
- Improves compatibility with exporters and backends that expect plain tensor outputs (e.g., ONNX/TensorRT pipelines). 🔗
- Reduces errors from object-type returns during tracing/quantization and simplifies integration in deployment code. 🧩
- Minor behavioral note: if any custom code relied on the `nms_outputs` object directly in the quantized export path, it should switch to tuple unpacking. Otherwise, most users see smoother exports with no changes needed. 🚀

Example (post-change):
```python
boxes, scores, labels, n_valid = model(images)
# or for keypoints:
boxes, scores, labels, kpts = model(images)
```