### PR TITLE
Exclude zero-fitness points from Tuner plots

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -934,7 +934,7 @@ def plt_color_scatter(v, f, bins: int = 20, cmap: str = "viridis", alpha: float 
 
 
 @plt_settings()
-def plot_tune_results(csv_file: str = "tune_results.csv"):
+def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_points: bool = True):
     """
     Plot the evolution results stored in a 'tune_results.csv' file. The function generates a scatter plot for each key
     in the CSV, color-coded based on fitness scores. The best-performing configurations are highlighted on the plots.
@@ -962,8 +962,9 @@ def plot_tune_results(csv_file: str = "tune_results.csv"):
     keys = [x.strip() for x in data.columns][num_metrics_columns:]
     x = data.to_numpy()
     fitness = x[:, 0]  # fitness
-    mask = fitness > 0  # exclude zero-fitness points
-    x, fitness = x[mask], fitness[mask]
+    if exclude_zero_fitness_points
+        mask = fitness > 0  # exclude zero-fitness points
+        x, fitness = x[mask], fitness[mask]
     j = np.argmax(fitness)  # max fitness index
     n = math.ceil(len(keys) ** 0.5)  # columns and rows in plot
     plt.figure(figsize=(10, 10), tight_layout=True)

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -962,7 +962,7 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
     keys = [x.strip() for x in data.columns][num_metrics_columns:]
     x = data.to_numpy()
     fitness = x[:, 0]  # fitness
-    if exclude_zero_fitness_points
+    if exclude_zero_fitness_points:
         mask = fitness > 0  # exclude zero-fitness points
         x, fitness = x[mask], fitness[mask]
     j = np.argmax(fitness)  # max fitness index

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -941,6 +941,7 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
 
     Args:
         csv_file (str, optional): Path to the CSV file containing the tuning results.
+        exclude_zero_fitness_points (bool, optional): Don't include points with zero fitness in tuning plots.
 
     Examples:
         >>> plot_tune_results("path/to/tune_results.csv")

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -962,6 +962,8 @@ def plot_tune_results(csv_file: str = "tune_results.csv"):
     keys = [x.strip() for x in data.columns][num_metrics_columns:]
     x = data.to_numpy()
     fitness = x[:, 0]  # fitness
+    mask = fitness > 0  # exclude zero-fitness points
+    x, fitness = x[mask], fitness[mask]
     j = np.argmax(fitness)  # max fitness index
     n = math.ceil(len(keys) ** 0.5)  # columns and rows in plot
     plt.figure(figsize=(10, 10), tight_layout=True)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds an option to hide zero-fitness results in tuning plots for clearer, more meaningful visualizations. 🎯

### 📊 Key Changes
- Introduces `exclude_zero_fitness_points: bool = True` to `plot_tune_results(...)`.
- Filters out rows with zero fitness before plotting when enabled.
- Updates docstring to document the new parameter.

### 🎯 Purpose & Impact
- Cleaner plots by removing failed/invalid runs with zero fitness, reducing noise. 🧹
- Makes it easier to spot high-performing configurations and trends. 📈
- Slight behavior change: zero-fitness points are excluded by default; set `exclude_zero_fitness_points=False` to retain prior behavior. ⚙️
- Minor performance improvement from plotting fewer points; no breaking API changes. 🚀

Example:
```python
from ultralytics.utils.plotting import plot_tune_results

# New default: zero-fitness points are excluded
plot_tune_results("tune_results.csv")

# Previous behavior (include all points)
plot_tune_results("tune_results.csv", exclude_zero_fitness_points=False)
```