### PR TITLE
Update ci.yml for A100 GPU DDP runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
   GPU:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
     timeout-minutes: 20
-    runs-on: github-linux-gpu-t4-4-core
+    runs-on: gpu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
@ultralytics/yolo

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switches the CI GPU runner to a generic “gpu-latest” label to modernize and future-proof GPU testing infrastructure. 🚀

### 📊 Key Changes
- Updates GitHub Actions workflow: `runs-on` changed from `github-linux-gpu-t4-4-core` to `gpu-latest` for the GPU CI job.

### 🎯 Purpose & Impact
- Improves reliability and availability by using the latest maintained GPU runner pool. 🔧
- Reduces maintenance overhead and future-proofs CI against deprecated runner labels. 🛡️
- May speed up CI with newer hardware or better provisioning. ⏱️
- Minor risk of variability in test performance due to changing GPU hardware under the generic label. ⚠️
- No user-facing changes to YOLO11/YOLO12 or Ultralytics HUB—this only affects CI infrastructure. ✅