### PR TITLE
Fix undefined variable error in `parse_model()`

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1543,8 +1543,8 @@ def parse_model(d, ch, verbose=True):
     max_channels = float("inf")
     nc, act, scales = (d.get(x) for x in ("nc", "activation", "scales"))
     depth, width, kpt_shape = (d.get(x, 1.0) for x in ("depth_multiple", "width_multiple", "kpt_shape"))
+    scale = d.get("scale")
     if scales:
-        scale = d.get("scale")
         if not scale:
             scale = tuple(scales.keys())[0]
             LOGGER.warning(f"no model scale passed. Assuming scale='{scale}'.")


### PR DESCRIPTION
Fixes ULTRALYTICS-1YBP

**MRE**
```yaml
#custom.yaml
nc: 1
 backbone:
  - [-1, 1, Conv, [64, 3, 2]]
  - [-1, 1, Conv, [128, 3, 2]]
  - [-1, 2, C3k2, [256, False, 0.25]]
head:
  - [-1, nn.Identity, []]
```
```python
from ultralytics import YOLO
model = YOLO("custom.yaml", task="detect")
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplifies and hardens model parsing by initializing `scale` earlier, preventing potential errors when `scales` isn’t provided. ✅

### 📊 Key Changes
- Moved `scale = d.get("scale")` outside the `if scales:` block, so `scale` is always defined.
- Removed redundant retrieval of `scale` inside the conditional.
- Preserved existing warning behavior when no `scale` is passed.

### 🎯 Purpose & Impact
- Improves robustness: avoids potential runtime errors (e.g., undefined `scale`) when `scales` is missing. 🛡️
- Cleaner logic: reduces duplication and makes `parse_model` easier to read and maintain. 🧹
- Backward compatible: no user-facing API changes; existing configs continue to work as before. 🔄