### PR TITLE
Specify CUDA version during TensorRT installation

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -922,7 +922,8 @@ class Exporter:
             import tensorrt as trt  # noqa
         except ImportError:
             if LINUX:
-                check_requirements("tensorrt>7.0.0,!=10.1.0")
+                cuda_version = torch.version.cuda.split('.')[0]
+                check_requirements(f"tensorrt-cu{cuda_version}>7.0.0,!=10.1.0")
             import tensorrt as trt  # noqa
         check_version(trt.__version__, ">=7.0.0", hard=True)
         check_version(trt.__version__, "!=10.1.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -922,7 +922,7 @@ class Exporter:
             import tensorrt as trt  # noqa
         except ImportError:
             if LINUX:
-                cuda_version = torch.version.cuda.split('.')[0]
+                cuda_version = torch.version.cuda.split(".")[0]
                 check_requirements(f"tensorrt-cu{cuda_version}>7.0.0,!=10.1.0")
             import tensorrt as trt  # noqa
         check_version(trt.__version__, ">=7.0.0", hard=True)


### PR DESCRIPTION
Closes #22058 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves TensorRT export on Linux by auto-selecting the correct CUDA-specific TensorRT package for your environment. ✅

### 📊 Key Changes
- Updates TensorRT dependency resolution in `export_engine`:
  - When TensorRT isn’t installed on Linux, it now installs `tensorrt-cu{CUDA_MAJOR}` (e.g., `tensorrt-cu12`) instead of the generic `tensorrt`.
  - Continues to enforce `>7.0.0` and exclude problematic `10.1.0`.
- Dynamically detects CUDA major version using `torch.version.cuda`.

### 🎯 Purpose & Impact
- Smoother installs on Linux 🎉: Ensures the correct TensorRT wheel is installed for your CUDA version, reducing setup errors.
- Better compatibility 🔧: Aligns with NVIDIA’s CUDA-specific TensorRT packaging (e.g., `tensorrt-cu12`), improving export reliability.
- Fewer surprises 🚫: Still blocks known-bad TensorRT version `10.1.0`.
- Note for edge cases: Requires a valid CUDA version from PyTorch; CPU-only environments won’t benefit from this path.