### PR TITLE
Re-enable TensorRT export in GPU tests

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -68,7 +68,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         half=half,
         batch=batch,
         simplify=simplify,
-        nms=nms and task != "obb",  # disable NMS for OBB task for now on T4 instance
+        nms=nms,
         device=DEVICES[0],
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
@@ -76,7 +76,6 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(True, reason="CUDA export tests disabled pending additional Ultralytics GPU server availability")
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch",
@@ -164,7 +163,7 @@ def test_autobatch():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(True, reason="Skip for now since T4 instance does not support TensorRT > 10.0")
+@pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 def test_utils_benchmarks():
     """Profile YOLO models for performance benchmarks."""
     from ultralytics.utils.benchmarks import ProfileModels


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enable full CUDA test and benchmark coverage, including NMS in ONNX export for OBB, by removing unconditional skips and running when GPUs are available. 🚀

### 📊 Key Changes
- Re-enabled NMS during ONNX export for OBB tasks (`nms` no longer force-disabled for OBB). ✅
- Removed unconditional skip for CUDA export tests; they now run when CUDA devices are available. 🧪
- Enabled performance benchmark tests to run on any available CUDA device (no longer tied to T4/TensorRT limitations). 📈

### 🎯 Purpose & Impact
- Improve test coverage across GPU environments, increasing reliability and catching regressions earlier. 🛡️
- Validate ONNX export pipelines with NMS for OBB, ensuring broader compatibility and correctness. 📦
- Provide GPU performance signals via benchmarks when hardware is present, aiding optimization and CI visibility. 🔍
- Note: Changes are test-only; no user-facing API or behavior changes in runtime code. Minimal risk, with potential for longer CI times on GPU runners. ⏱️