### PR TITLE
Fix `KeyError` when `close_mosaic` not part of search space

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -341,7 +341,8 @@ class Tuner:
             hyp[k] = round(min(max(hyp[k], bounds[0]), bounds[1]), 5)
 
         # Update types
-        hyp["close_mosaic"] = int(round(hyp["close_mosaic"]))
+        if "close_mosaic" in hyp:
+            hyp["close_mosaic"] = int(round(hyp["close_mosaic"]))
 
         return hyp
 


### PR DESCRIPTION
Closes #22065 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Makes hyperparameter tuning more robust by safely handling the optional `close_mosaic` parameter in the tuner. ✅

### 📊 Key Changes
- Updated `tuner._mutate()` to only cast `hyp["close_mosaic"]` to `int` if the key exists.
  - Previously: always attempted to cast, risking a KeyError.
  - Now: guarded with `if "close_mosaic" in hyp:`.

### 🎯 Purpose & Impact
- Prevents crashes during hyperparameter evolution when `close_mosaic` isn’t included (e.g., certain tasks or custom configs). 🛡️
- No behavior change for users who already define `close_mosaic`; purely a safety improvement. 🔒
- Improves compatibility across tasks and custom hyperparameter sets, leading to smoother tuning runs. 🚀