### PR TITLE
Revert "Specify CUDA version during TensorRT installation"

### DIFF
--- a/docs/en/datasets/explorer/api.md
+++ b/docs/en/datasets/explorer/api.md
@@ -150,8 +150,9 @@ Note: This works using LLMs under the hood so the results are probabilistic and 
 !!! example "Ask AI"
 
     ```python
-    from ultralytics import Explorer
     from ultralytics.data.explorer import plot_query_result
+
+    from ultralytics import Explorer
 
     # create an Explorer object
     exp = Explorer(data="coco128.yaml", model="yolo11n.pt")

--- a/docs/en/datasets/explorer/explorer.md
+++ b/docs/en/datasets/explorer/explorer.md
@@ -116,7 +116,6 @@ Image.fromarray(plt)
 ```python
 # plot
 from PIL import Image
-
 from ultralytics.data.explorer import plot_query_result
 
 plt = plot_query_result(exp.ask_ai("show me 10 images containing exactly 2 persons"))

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -205,6 +205,9 @@ makei05@outlook.de:
 matthewnoyce@icloud.com:
   avatar: https://avatars.githubusercontent.com/u/131261051?v=4
   username: MatthewNoyce
+miles@ultralytics.com:
+  avatar: null
+  username: null
 muhammadravi251001@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/78993021?v=4
   username: muhammadravi251001

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -922,8 +922,7 @@ class Exporter:
             import tensorrt as trt  # noqa
         except ImportError:
             if LINUX:
-                cuda_version = torch.version.cuda.split(".")[0]
-                check_requirements(f"tensorrt-cu{cuda_version}>7.0.0,!=10.1.0")
+                check_requirements("tensorrt>7.0.0,!=10.1.0")
             import tensorrt as trt  # noqa
         check_version(trt.__version__, ">=7.0.0", hard=True)
         check_version(trt.__version__, "!=10.1.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")


### PR DESCRIPTION
Reverts ultralytics/ultralytics#22060

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlines TensorRT dependency handling for engine export on Linux and tidies Explorer docs, making exports and examples smoother 🚀

### 📊 Key Changes
- TensorRT install logic simplified in exporter:
  - Replaces CUDA-version-specific requirement (`tensorrt-cuXX`) with generic `tensorrt>7.0.0,!=10.1.0` on Linux.
  - Still enforces version checks and blocks the known-bad TensorRT 10.1.0 release (see the related PR note: [TensorRT 10.1.0 exclusion](https://github.com/ultralytics/ultralytics/pull/14239)).
- Docs cleanup for Dataset Explorer examples:
  - Standardized import order and removed a stray blank line for clearer examples using `Explorer` and `plot_query_result`.
- Docs metadata update:
  - Added a new author entry to `mkdocs_github_authors.yaml`.

### 🎯 Purpose & Impact
- Easier installs on Linux ✅
  - Avoids CUDA-specific TensorRT package resolution issues, reducing friction when exporting to TensorRT from YOLO11/YOLO12 models.
- More robust exports 🔒
  - Maintains strict version checks to prevent incompatible TensorRT versions from breaking exports.
- Cleaner, more readable docs 📚
  - Improves user experience when following Dataset Explorer examples.
- Minor docs metadata maintenance 👥
  - Keeps contributor information up to date.