### PR TITLE
Revert "Re-enable TensorRT export in GPU tests"

### DIFF
--- a/docs/en/datasets/explorer/api.md
+++ b/docs/en/datasets/explorer/api.md
@@ -150,8 +150,9 @@ Note: This works using LLMs under the hood so the results are probabilistic and 
 !!! example "Ask AI"
 
     ```python
-    from ultralytics import Explorer
     from ultralytics.data.explorer import plot_query_result
+
+    from ultralytics import Explorer
 
     # create an Explorer object
     exp = Explorer(data="coco128.yaml", model="yolo11n.pt")

--- a/docs/en/datasets/explorer/explorer.md
+++ b/docs/en/datasets/explorer/explorer.md
@@ -116,7 +116,6 @@ Image.fromarray(plt)
 ```python
 # plot
 from PIL import Image
-
 from ultralytics.data.explorer import plot_query_result
 
 plt = plot_query_result(exp.ask_ai("show me 10 images containing exactly 2 persons"))

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -68,7 +68,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         half=half,
         batch=batch,
         simplify=simplify,
-        nms=nms,
+        nms=nms and task != "obb",  # disable NMS for OBB task for now on T4 instance
         device=DEVICES[0],
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
@@ -76,6 +76,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(True, reason="CUDA export tests disabled pending additional Ultralytics GPU server availability")
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch",
@@ -163,7 +164,7 @@ def test_autobatch():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
+@pytest.mark.skipif(True, reason="Skip for now since T4 instance does not support TensorRT > 10.0")
 def test_utils_benchmarks():
     """Profile YOLO models for performance benchmarks."""
     from ultralytics.utils.benchmarks import ProfileModels

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -164,7 +164,7 @@ def test_autobatch():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(True, reason="Skip for now since T4 instance does not support TensorRT > 10.0")
+@pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 def test_utils_benchmarks():
     """Profile YOLO models for performance benchmarks."""
     from ultralytics.utils.benchmarks import ProfileModels

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -68,7 +68,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         half=half,
         batch=batch,
         simplify=simplify,
-        nms=nms and task != "obb",  # disable NMS for OBB task for now on T4 instance
+        nms=nms and task != "obb",  # WARNING: Failing NMS with OBB
         device=DEVICES[0],
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
@@ -76,7 +76,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(True, reason="CUDA export tests disabled pending additional Ultralytics GPU server availability")
+@pytest.mark.skipif(True, reason="WARNING: Failing TensorRT export tests")
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch",


### PR DESCRIPTION
Reverts ultralytics/ultralytics#22062

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Stabilizes CI by skipping flaky TensorRT export tests and adjusting ONNX export behavior for OBB, plus minor docs cleanup for Dataset Explorer examples. ✅

### 📊 Key Changes
- 🧪 Tests:
  - Disabled NMS during ONNX export for OBB tasks: `nms=nms and task != "obb"` to avoid failures.
  - Marked all TensorRT export tests as skipped with a clear warning: `@pytest.mark.skipif(True, reason="WARNING: Failing TensorRT export tests")`.
- 📚 Docs:
  - Cleaned up import order and formatting in Dataset Explorer examples for clarity and consistency.

### 🎯 Purpose & Impact
- 💡 Improves CI reliability by avoiding known failing paths (OBB NMS in ONNX and TensorRT exports).
- 🔍 Provides clearer signals to contributors about current export limitations and known issues.
- 🧭 Documentation tweaks make Explorer examples easier to follow, with no behavioral changes for users.
- 🧑‍💻 Net effect: smoother development and PR verification; end users see no runtime changes except more stable exports in supported paths.