### PR TITLE
Fix ONNX `RuntimeError` for OBB models exported with NMS

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -206,8 +206,8 @@ matthewnoyce@icloud.com:
   avatar: https://avatars.githubusercontent.com/u/131261051?v=4
   username: MatthewNoyce
 miles@ultralytics.com:
-  avatar: null
-  username: null
+  avatar: https://avatars.githubusercontent.com/u/231651492?v=4
+  username: miles-deans-ultralytics
 muhammadravi251001@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/78993021?v=4
   username: muhammadravi251001

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -205,6 +205,9 @@ makei05@outlook.de:
 matthewnoyce@icloud.com:
   avatar: https://avatars.githubusercontent.com/u/131261051?v=4
   username: MatthewNoyce
+miles@ultralytics.com:
+  avatar: null
+  username: null
 muhammadravi251001@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/78993021?v=4
   username: muhammadravi251001

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -68,7 +68,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         half=half,
         batch=batch,
         simplify=simplify,
-        nms=nms and task != "obb",  # WARNING: Failing NMS with OBB
+        nms=nms,
         device=DEVICES[0],
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1531,7 +1531,7 @@ class NMSModel(torch.nn.Module):
         for i in range(bs):
             box, cls, score, extra = boxes[i], classes[i], scores[i], extras[i]
             mask = score > self.args.conf
-            if self.is_tf:
+            if self.is_tf or (self.args.format == "onnx" and self.obb):
                 # TFLite GatherND error if mask is empty
                 score *= mask
                 # Explicit length otherwise reshape error, hardcoded to `self.args.max_det * 5`


### PR DESCRIPTION
```
yolo export model=yolo11n-obb.pt nms
yolo predict model=yolo11n-obb.onnx device=0
```

Fix for GPU CI error: https://github.com/ultralytics/ultralytics/actions/runs/17708412646/job/50323622561#step:6:3713

I just came across my own report about this on a PyTorch issue which I had forgotten about:
https://github.com/pytorch/pytorch/issues/66200#issuecomment-2849090692

This error only occurs when you run the ONNX model on CUDAExecutionProvider. The workaround is not to filter out all the boxes so that there are some remaining for NMS.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes ONNX export and inference for OBB models by safely handling NMS edge cases, and re-enables corresponding tests ✅

### 📊 Key Changes
- Tests: Always pass `nms=nms` in ONNX export tests, including for OBB tasks (previously disabled) 🧪
- Exporter: Extends the safety check for empty NMS masks to ONNX when using OBB, not just TensorFlow/TFLite:
  - Applies masking logic to avoid errors when no detections pass the confidence threshold 🛡️

### 🎯 Purpose & Impact
- Improves robustness of ONNX exports with OBB + NMS, preventing crashes in edge cases (e.g., no detections) 🧷
- Restores CI coverage for OBB NMS in ONNX, catching regressions earlier ✅
- No API changes; users exporting OBB models to ONNX can now rely on stable, built-in NMS behavior 🚀