### PR TITLE
Improve export error message for `pt` format

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -205,6 +205,9 @@ makei05@outlook.de:
 matthewnoyce@icloud.com:
   avatar: https://avatars.githubusercontent.com/u/131261051?v=4
   username: MatthewNoyce
+miles@ultralytics.com:
+  avatar: null
+  username: null
 muhammadravi251001@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/78993021?v=4
   username: muhammadravi251001

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -284,7 +284,8 @@ class Exporter:
             # Get the closest match if format is invalid
             matches = difflib.get_close_matches(fmt, fmts, n=1, cutoff=0.6)  # 60% similarity required to match
             if not matches:
-                raise ValueError(f"Invalid export format='{fmt}'. Valid formats are {fmts}")
+                msg = "Model is already in PyTorch format." if format == "pt" else f"Invalid export format='{fmt}'."
+                raise ValueError(f"{msg} Valid formats are {fmts}")
             LOGGER.warning(f"Invalid export format='{fmt}', updating to format='{matches[0]}'")
             fmt = matches[0]
         flags = [x == fmt for x in fmts]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -284,7 +284,7 @@ class Exporter:
             # Get the closest match if format is invalid
             matches = difflib.get_close_matches(fmt, fmts, n=1, cutoff=0.6)  # 60% similarity required to match
             if not matches:
-                msg = "Model is already in PyTorch format." if format == "pt" else f"Invalid export format='{fmt}'."
+                msg = "Model is already in PyTorch format." if fmt == "pt" else f"Invalid export format='{fmt}'."
                 raise ValueError(f"{msg} Valid formats are {fmts}")
             LOGGER.warning(f"Invalid export format='{fmt}', updating to format='{matches[0]}'")
             fmt = matches[0]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves export error messaging by clearly indicating when a user tries to "export" to PyTorch format, which the model already is. 🧭

### 📊 Key Changes
- Enhances the exporter's error message when an invalid format is provided.
- Adds a specific message for `fmt == "pt"`: “Model is already in PyTorch format.”
- Keeps the list of valid export formats in the error for quick reference.

### 🎯 Purpose & Impact
- Reduces confusion for users attempting to export to `pt` by clarifying that no export is needed. ✅
- Improves developer experience with clearer, more actionable errors. 🛠️
- No behavioral or performance changes; fully backward compatible. 🚀