### PR TITLE
Fix CSV read error in SKU-110K.yaml download script

### DIFF
--- a/ultralytics/cfg/datasets/SKU-110K.yaml
+++ b/ultralytics/cfg/datasets/SKU-110K.yaml
@@ -45,7 +45,7 @@ download: |
   # Convert labels
   names = "image", "x1", "y1", "x2", "y2", "class", "image_width", "image_height"  # column names
   for d in "annotations_train.csv", "annotations_val.csv", "annotations_test.csv":
-      x = pl.read_csv(dir / "annotations" / d, names=names, infer_schema_length=None).to_numpy()  # annotations
+      x = pl.read_csv(dir / "annotations" / d, has_header=False, new_columns=names, infer_schema_length=None).to_numpy()  # annotations
       images, unique_images = x[:, 0], np.unique(x[:, 0])
       with open((dir / d).with_suffix(".txt").__str__().replace("annotations_", ""), "w", encoding="utf-8") as f:
           f.writelines(f"./images/{s}\n" for s in unique_images)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes CSV parsing for the SKU-110K dataset conversion to ensure annotations load correctly and consistently ✅

### 📊 Key Changes
- Updated Polars `read_csv` call in `SKU-110K.yaml`:
  - Replaced `names=names` with `has_header=False, new_columns=names`
  - Ensures CSVs without headers are read with the correct column names

### 🎯 Purpose & Impact
- Prevents misaligned columns and parsing issues during SKU-110K dataset download/processing 🧹
- Improves compatibility with newer Polars behavior/APIs 📦
- Makes dataset setup more reliable; no impact on other datasets or training workflows 🚀