### PR TITLE
Export in Dockerfile `/tmp` dir

### DIFF
--- a/docker/Dockerfile-export
+++ b/docker/Dockerfile-export
@@ -10,7 +10,7 @@ FROM ultralytics/ultralytics:latest
 # Note tensorrt installed on-demand as depends on runtime environment CUDA version
 RUN uv pip install --system -e ".[export]" "onnxruntime-gpu" paddlepaddle x2paddle numpy==1.26.4 && \
     # Run exports to AutoInstall packages \
-    yolo export model=yolo11n.pt format=edgetpu imgsz=32 && \
-    yolo export model=yolo11n.pt format=ncnn imgsz=32 && \
+    yolo export model=tmp/yolo11n.pt format=edgetpu imgsz=32 && \
+    yolo export model=tmp/yolo11n.pt format=ncnn imgsz=32 && \
     # Remove temporary files \
     rm -rf tmp /root/.config/Ultralytics/persistent_cache.json

--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -19,9 +19,9 @@ RUN uv pip install --system -e ".[export]" && \
     # Need lower version of 'numpy' for Sony IMX export
     uv pip install --system numpy==1.26.4 && \
     # Run exports to AutoInstall packages
-    yolo export model=yolo11n.pt format=edgetpu imgsz=32 && \
-    yolo export model=yolo11n.pt format=ncnn imgsz=32 && \
-    yolo export model=yolo11n.pt format=imx imgsz=32 && \
+    yolo export model=tmp/yolo11n.pt format=edgetpu imgsz=32 && \
+    yolo export model=tmp/yolo11n.pt format=ncnn imgsz=32 && \
+    yolo export model=tmp/yolo11n.pt format=imx imgsz=32 && \
     uv pip install --system paddlepaddle x2paddle && \
     # Remove extra build files
     rm -rf tmp /root/.config/Ultralytics/persistent_cache.json


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updates export Dockerfiles to use a local temp model path for export steps, improving reliability and consistency during Docker builds. 🚀

### 📊 Key Changes
- Switched export commands to use `tmp/yolo11n.pt` instead of `yolo11n.pt` in:
  - `docker/Dockerfile-export` (for EdgeTPU and NCNN)
  - `docker/Dockerfile-python-export` (for EdgeTPU, NCNN, and IMX)
- Keeps the cleanup step to remove `tmp` and Ultralytics cache after exports.

### 🎯 Purpose & Impact
- More reliable builds: Uses a known local model path, reducing reliance on network downloads or remote resolution. ✅
- Faster and deterministic: Avoids re-downloading models, improving build speed and reproducibility. ⚡
- Cleaner images: Temporary files still removed at the end, keeping Docker layers lean. 🧹
- Smoother CI/CD: Minimizes flaky builds due to connectivity or path issues. 🔧