### PR TITLE
ci: 👷 Update CI workflow to run on macOS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         # Temporarily disable windows-latest due to https://github.com/ultralytics/ultralytics/actions/runs/13020330819/job/36319338854?pr=18921
-        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest, macos-26, ubuntu-24.04-arm]
         python-version: ["3.12"]
         model: [yolo11n]
     steps:
@@ -166,7 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest, macos-26, windows-latest, ubuntu-24.04-arm]
         python-version: ["3.12"]
         torch: [latest]
         include:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Pin CI to the macOS 26 runner to improve reliability and reproducibility across workflows 🚦

### 📊 Key Changes
- Replaced `macos-latest` with `macos-26` in CI job matrices.
- No other OS matrix changes: Ubuntu and ARM remain; Windows stays included in one matrix and intentionally excluded in another as noted.

### 🎯 Purpose & Impact
- Boosts CI stability by avoiding unexpected macOS runner changes 👍
- Ensures reproducible builds and easier debugging for contributors 🔧
- No user-facing code changes; YOLO models and Ultralytics HUB workflows remain unaffected 🚀