### PR TITLE
Start distributed Tuner mutation if Mongo collection exists

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -309,7 +309,7 @@ class Tuner:
                 # MongoDB already sorted by fitness DESC, so results[0] is best
                 x = np.array([[r["fitness"]] + [r["hyperparameters"][k] for k in self.space.keys()] for r in results])
             elif self.collection.name in self.collection.database.list_collection_names():  # Tuner started elsewhere
-                x = np.array([0.0] + [getattr(self.args, k) for k in self.space.keys()])
+                x = np.array([[0.0] + [getattr(self.args, k) for k in self.space.keys()]])
 
         # Fall back to CSV if MongoDB unavailable or empty
         if x is None and self.tune_csv.exists():

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -308,6 +308,8 @@ class Tuner:
             if results:
                 # MongoDB already sorted by fitness DESC, so results[0] is best
                 x = np.array([[r["fitness"]] + [r["hyperparameters"][k] for k in self.space.keys()] for r in results])
+            elif self.collection.name in self.collection.database.list_collection_names():  # Tuner started elsewhere
+                x = np.array([0.0] + [getattr(self.args, k) for k in self.space.keys()])
 
         # Fall back to CSV if MongoDB unavailable or empty
         if x is None and self.tune_csv.exists():


### PR DESCRIPTION
Don't wait to mutate, Tuning started on another instance.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves the hyperparameter tuner’s MongoDB startup logic to handle empty collections gracefully, enabling smoother distributed or resumed tuning runs. 🚀

### 📊 Key Changes
- Adds a fallback path in `Tuner._mutate()` when:
  - MongoDB is reachable and the target collection exists, but has no results yet.
  - In this case, initializes the search with the current `args` as a seed (fitness set to 0.0) instead of falling back to CSV.

### 🎯 Purpose & Impact
- Ensures tuning can start immediately in distributed setups (e.g., multiple workers) even if the MongoDB collection is empty. 🤝
- Improves robustness when joining an existing tuning session started elsewhere.
- Reduces cold-start issues and avoids unnecessary CSV fallback logic. 🧹
- No breaking changes; behavior is transparent to users and benefits YOLO hyperparameter tuning across local, cloud, and Ultralytics HUB workflows.