### PR TITLE
Use performance mode while quantizing model to OpenVINO

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -683,7 +683,7 @@ class Exporter:
             quantized_ov_model = nncf.quantize(
                 model=ov_model,
                 calibration_dataset=nncf.Dataset(self.get_int8_calibration_dataloader(prefix), transform_fn),
-                preset=nncf.QuantizationPreset.PERFORMANCE
+                preset=nncf.QuantizationPreset.PERFORMANCE,
             )
             serialize(quantized_ov_model, fq_ov)
             return fq


### PR DESCRIPTION
@ambitious-octopus option number 1


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switches OpenVINO INT8 export to NNCF’s PERFORMANCE preset and removes custom “ignored scope” logic for detection heads, simplifying quantization and aiming for faster, more consistent exports. 🚀

### 📊 Key Changes
- Replaced `nncf.QuantizationPreset.MIXED` with `nncf.QuantizationPreset.PERFORMANCE`.
- Removed custom `ignored_scope` rules that skipped quantizing specific head ops (e.g., Add/Sub/Mul/Div, DFL, Sigmoid) for Detect-family models.

### 🎯 Purpose & Impact
- Faster, more aggressive INT8 quantization by default, potentially improving inference speed and reducing model size. ⚡
- More robust and maintainable export pipeline by relying on NNCF defaults instead of model-specific patterns. 🧩
- Broader compatibility across heads (Detect, Segment, Pose, OBB, WorldDetect, YOLOE) without brittle exclusions. ✅
- Possible accuracy changes vs. previous exports; users should re-evaluate accuracy on INT8 OpenVINO models. 📏

Tip: To export with OpenVINO INT8 quantization:
- CLI: `yolo export model=yolo11n.pt format=openvino int8=True`
- Python:
```python
from ultralytics import YOLO

YOLO("yolo11n.pt").export(format="openvino", int8=True)
```