### PR TITLE
`ultralytics 8.3.202` TFLite `per-channel` INT8 quantization fix

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.201"
+__version__ = "8.3.202"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1011,9 +1011,8 @@ class Exporter:
             not_use_onnxsim=True,
             verbosity="error",  # note INT8-FP16 activation bug https://github.com/ultralytics/ultralytics/issues/15873
             output_integer_quantized_tflite=self.args.int8,
-            quant_type="per-tensor",  # "per-tensor" (faster) or "per-channel" (slower but more accurate)
             custom_input_op_name_np_data_path=np_data,
-            enable_batchmatmul_unfold=True,  # fix lower no. of detected objects on GPU delegate
+            enable_batchmatmul_unfold=True and not self.args.int8,  # fix lower no. of detected objects on GPU delegate
             output_signaturedefs=True,  # fix error with Attention block group convolution
             disable_group_convolution=self.args.format in {"tfjs", "edgetpu"},  # fix error with group convolution
         )


### PR DESCRIPTION
Closes #21030 

Also disabled `batchmul_unfold` for INT8 because it makes `integer_quant` files huge:
```
ls -lh yolo11n_saved_model/
-rw-r--r-- 1 root root 5.5M Sep 18 07:55 yolo11n_float16.tflite
-rw-r--r-- 1 root root  11M Sep 18 07:55 yolo11n_float32.tflite
-rw-r--r-- 1 root root  27M Sep 18 07:55 yolo11n_full_integer_quant.tflite
-rw-r--r-- 1 root root 3.2M Sep 18 07:55 yolo11n_int8.tflite
-rw-r--r-- 1 root root  27M Sep 18 07:55 yolo11n_integer_quant.tflite
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Version bump to 8.3.202 with a targeted fix to TensorFlow/TFLite export behavior to improve reliability, especially around INT8 quantization and GPU delegate execution. 🚀

### 📊 Key Changes
- Bumped package version to 8.3.202.
- Adjusted TFLite export settings:
  - Removed explicit `quant_type` argument (previously “per-tensor”) to avoid potential incompatibilities.
  - Made `enable_batchmatmul_unfold` conditional: enabled for non-INT8 exports, disabled when `--int8` is used.

### 🎯 Purpose & Impact
- Improves stability of TFLite exports by avoiding known INT8 activation issues (see the related discussion in the Ultralytics issue: [INT8-FP16 activation bug](https://github.com/ultralytics/ultralytics/issues/15873)) 🛠️
- Prevents reduced detection counts on GPU delegates by unfolding BatchMatMul when appropriate, while avoiding conflicts during INT8 quantization ✅
- Provides safer defaults for broader device compatibility across TensorFlow/TFLite targets, including TFJS and EdgeTPU exports 🌐