### PR TITLE
Fix Tuner missing `best_save_dir`

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -435,7 +435,7 @@ class Tuner:
                 best_metrics = {k: round(v, 5) for k, v in metrics.items()}
                 for ckpt in weights_dir.glob("*.pt"):
                     shutil.copy2(ckpt, self.tune_dir / "weights")
-            elif cleanup:
+            elif cleanup and best_save_dir:
                 shutil.rmtree(best_save_dir, ignore_errors=True)  # remove iteration dirs to reduce storage space
 
             # Plot tune results


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Makes hyperparameter tuning cleanup safer by only deleting directories when a valid path exists, preventing rare crashes during tuning. ✅

### 📊 Key Changes
- Updates cleanup condition in `engine/tuner.py` to `elif cleanup and best_save_dir:` instead of just `elif cleanup:`
- Ensures `shutil.rmtree` is only called when `best_save_dir` is defined/truthy

### 🎯 Purpose & Impact
- Prevents errors caused by attempting to delete a non-existent or undefined directory during tuning cleanup 🛡️
- Improves robustness of the tuning workflow with no API changes or performance impact ⚙️
- Reduces risk of unintended file operations, leading to smoother, more reliable hyperparameter tuning runs 🚀