### PR TITLE
`ultralytics 8.3.203` Future-proof ONNX `opset` selection

### DIFF
--- a/docs/en/reference/engine/exporter.md
+++ b/docs/en/reference/engine/exporter.md
@@ -27,7 +27,7 @@ keywords: YOLOv8, export formats, ONNX, TensorRT, CoreML, machine learning model
 
 <br><br><hr><br>
 
-## ::: ultralytics.engine.exporter.max_supported_onnx_opset
+## ::: ultralytics.engine.exporter.best_onnx_opset
 
 <br><br><hr><br>
 

--- a/docs/en/reference/engine/exporter.md
+++ b/docs/en/reference/engine/exporter.md
@@ -27,6 +27,10 @@ keywords: YOLOv8, export formats, ONNX, TensorRT, CoreML, machine learning model
 
 <br><br><hr><br>
 
+## ::: ultralytics.engine.exporter.max_supported_onnx_opset
+
+<br><br><hr><br>
+
 ## ::: ultralytics.engine.exporter.validate_args
 
 <br><br><hr><br>

--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -91,10 +91,6 @@ keywords: Ultralytics, torch utils, model optimization, device selection, infere
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.torch_utils.get_latest_opset
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.torch_utils.intersect_dicts
 
 <br><br><hr><br>

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -633,6 +633,11 @@ class Exporter:
             meta = model_onnx.metadata_props.add()
             meta.key, meta.value = k, str(v)
 
+        # IR version
+        if model_onnx.ir_version >= 10:
+            LOGGER.info(f"{prefix} limiting IR version {model_onnx.ir_version} to 10 for ONNXRuntime compatibility...")
+            model_onnx.ir_version = 10
+
         onnx.save(model_onnx, f)
         return f
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -634,7 +634,7 @@ class Exporter:
             meta.key, meta.value = k, str(v)
 
         # IR version
-        if model_onnx.ir_version >= 10:
+        if getattr(model_onnx, "ir_version", 0) >= 10:
             LOGGER.info(f"{prefix} limiting IR version {model_onnx.ir_version} to 10 for ONNXRuntime compatibility...")
             model_onnx.ir_version = 10
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -173,7 +173,7 @@ def best_onnx_opset(onnx) -> int:
             "2.6": 20,
             "2.7": 20,
             "2.8": 23,
-        }.get(".".join(TORCH_VERSION.split(".")[:2]), 12)
+        }.get(".".join(TORCH_VERSION.split(".")[:2]), 12) - 1
     return min(opset, onnx.defs.onnx_opset_version()) - 1  # use second-latest version for safety
 
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -634,7 +634,7 @@ class Exporter:
             meta.key, meta.value = k, str(v)
 
         # IR version
-        if getattr(model_onnx, "ir_version", 0) >= 10:
+        if getattr(model_onnx, "ir_version", 0) > 10:
             LOGGER.info(f"{prefix} limiting IR version {model_onnx.ir_version} to 10 for ONNXRuntime compatibility...")
             model_onnx.ir_version = 10
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -586,7 +586,7 @@ class Exporter:
         check_requirements(requirements)
         import onnx  # noqa
 
-        opset_version = self.args.opset or (onnx.defs.onnx_opset_version() - 1)  # default to second-most recent
+        opset_version = self.args.opset or (onnx.defs.onnx_opset_version() - 2)  # default to third-most recent
         LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__} opset {opset_version}...")
         f = str(self.file.with_suffix(".onnx"))
         output_names = ["output0", "output1"] if isinstance(self.model, SegmentationModel) else ["output0"]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -173,7 +173,7 @@ def best_onnx_opset(onnx) -> int:
             "2.6": 20,
             "2.7": 20,
             "2.8": 23,
-        }.get(".".join(TORCH_VERSION.split(".")[:2]), 12) 
+        }.get(".".join(TORCH_VERSION.split(".")[:2]), 12)
     return min(opset, onnx.defs.onnx_opset_version())
 
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -153,7 +153,7 @@ def export_formats():
 
 
 def max_supported_onnx_opset(onnx) -> int:
-    """Return max ONNX opset for this torch version, floored at 12 with ONNX fallback."""
+    """Return max ONNX opset for this torch version with ONNX fallback."""
     table = {
         "1.8": 12,
         "1.9": 12,
@@ -173,9 +173,8 @@ def max_supported_onnx_opset(onnx) -> int:
     }
     m = re.match(r"(\d+\.\d+)", torch.__version__)
     key = m.group(1) if m else torch.__version__
-    max_opset = onnx.defs.onnx_opset_version() - 2
-    opset = table.get(key, max_opset)
-    return min(max(12, opset), max_opset)
+    opset = table.get(key, onnx.defs.onnx_opset_version() - 2)
+    return min(max(12, opset), 22)  # Ceiling at 22 for ONNXRuntime compatibility
 
 
 def validate_args(format, passed_args, valid_args):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -155,7 +155,7 @@ def export_formats():
 def best_onnx_opset(onnx) -> int:
     """Return max ONNX opset for this torch version with ONNX fallback."""
     if hasattr(torch.onnx.utils, "_constants"):  # not supported in torch 1.8
-        opset = torch.onnx.utils._constants.ONNX_MAX_OPSET
+        opset = torch.onnx.utils._constants.ONNX_MAX_OPSET - 1  # use second-latest version for safety
     else:
         opset = {
             "1.8": 12,
@@ -173,8 +173,8 @@ def best_onnx_opset(onnx) -> int:
             "2.6": 20,
             "2.7": 20,
             "2.8": 23,
-        }.get(".".join(TORCH_VERSION.split(".")[:2]), 12) - 2
-    return min(opset, onnx.defs.onnx_opset_version()) - 1  # use second-latest version for safety
+        }.get(".".join(TORCH_VERSION.split(".")[:2]), 12) 
+    return min(opset, onnx.defs.onnx_opset_version())
 
 
 def validate_args(format, passed_args, valid_args):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -173,7 +173,7 @@ def best_onnx_opset(onnx) -> int:
             "2.6": 20,
             "2.7": 20,
             "2.8": 23,
-        }.get(".".join(TORCH_VERSION.split(".")[:2]), 12) - 1
+        }.get(".".join(TORCH_VERSION.split(".")[:2]), 12) - 2
     return min(opset, onnx.defs.onnx_opset_version()) - 1  # use second-latest version for safety
 
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -612,7 +612,7 @@ class Exporter:
         import onnx  # noqa
 
         opset = self.args.opset or (torch.onnx.utils._constants.ONNX_MAX_OPSET - 1)
-        opset = min(max(opset, torch.onnx.utils._constants.ONNX_MIN_OPSET, torch.onnx.utils._constants.ONNX_MAX_OPSET)
+        opset = min(max(opset, torch.onnx.utils._constants.ONNX_MIN_OPSET), torch.onnx.utils._constants.ONNX_MAX_OPSET)
         LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__} opset {opset}...")
         f = str(self.file.with_suffix(".onnx"))
         output_names = ["output0", "output1"] if isinstance(self.model, SegmentationModel) else ["output0"]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -112,7 +112,7 @@ from ultralytics.utils.metrics import batch_probiou
 from ultralytics.utils.nms import TorchNMS
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.patches import arange_patch
-from ultralytics.utils.torch_utils import TORCH_1_13, get_latest_opset, select_device
+from ultralytics.utils.torch_utils import TORCH_1_13, select_device
 
 
 def export_formats():
@@ -586,7 +586,7 @@ class Exporter:
         check_requirements(requirements)
         import onnx  # noqa
 
-        opset_version = self.args.opset or get_latest_opset()
+        opset_version = self.args.opset or (onnx.defs.onnx_opset_version() - 1)  # default to second-most recent
         LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__} opset {opset_version}...")
         f = str(self.file.with_suffix(".onnx"))
         output_names = ["output0", "output1"] if isinstance(self.model, SegmentationModel) else ["output0"]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -151,29 +151,31 @@ def export_formats():
     ]
     return dict(zip(["Format", "Argument", "Suffix", "CPU", "GPU", "Arguments"], zip(*x)))
 
+
 def max_supported_onnx_opset() -> int:
     """Return max ONNX opset for this torch version, floored at 12 with ONNX fallback."""
     table = {
-        "1.8":  12,
-        "1.9":  12,
+        "1.8": 12,
+        "1.9": 12,
         "1.10": 13,
         "1.11": 14,
         "1.12": 15,
         "1.13": 17,
-        "2.0":  18,
-        "2.1":  19,
-        "2.2":  19,
-        "2.3":  19,
-        "2.4":  20,
-        "2.5":  20,
-        "2.6":  20,
-        "2.7":  20,
-        "2.8":  23,
+        "2.0": 18,
+        "2.1": 19,
+        "2.2": 19,
+        "2.3": 19,
+        "2.4": 20,
+        "2.5": 20,
+        "2.6": 20,
+        "2.7": 20,
+        "2.8": 23,
     }
     m = re.match(r"(\d+\.\d+)", torch.__version__)
     key = m.group(1) if m else torch.__version__
     opset = table.get(key, onnx.defs.onnx_opset_version() - 2)
     return max(12, opset)
+
 
 def validate_args(format, passed_args, valid_args):
     """

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -152,7 +152,7 @@ def export_formats():
     return dict(zip(["Format", "Argument", "Suffix", "CPU", "GPU", "Arguments"], zip(*x)))
 
 
-def max_supported_onnx_opset() -> int:
+def max_supported_onnx_opset(onnx) -> int:
     """Return max ONNX opset for this torch version, floored at 12 with ONNX fallback."""
     table = {
         "1.8": 12,
@@ -611,7 +611,7 @@ class Exporter:
         check_requirements(requirements)
         import onnx  # noqa
 
-        opset_version = self.args.opset or max_supported_onnx_opset()
+        opset_version = self.args.opset or max_supported_onnx_opset(onnx)
         LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__} opset {opset_version}...")
         f = str(self.file.with_suffix(".onnx"))
         output_names = ["output0", "output1"] if isinstance(self.model, SegmentationModel) else ["output0"]

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -173,8 +173,9 @@ def max_supported_onnx_opset(onnx) -> int:
     }
     m = re.match(r"(\d+\.\d+)", torch.__version__)
     key = m.group(1) if m else torch.__version__
-    opset = table.get(key, onnx.defs.onnx_opset_version() - 2)
-    return max(12, opset)
+    max_opset = onnx.defs.onnx_opset_version() - 2
+    opset = table.get(key, max_opset)
+    return min(max(12, opset), max_opset)
 
 
 def validate_args(format, passed_args, valid_args):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -611,7 +611,7 @@ class Exporter:
         check_requirements(requirements)
         import onnx  # noqa
 
-        opset = self.args.opset or torch.onnx.utils._constants.ONNX_MAX_OPSET
+        opset = self.args.opset or (torch.onnx.utils._constants.ONNX_MAX_OPSET - 1)
         opset = min(max(opset, torch.onnx.utils._constants.ONNX_MIN_OPSET, torch.onnx.utils._constants.ONNX_MAX_OPSET)
         LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__} opset {opset}...")
         f = str(self.file.with_suffix(".onnx"))

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -154,10 +154,21 @@ def export_formats():
 def max_supported_onnx_opset() -> int:
     """Return max ONNX opset for this torch version, floored at 12 with ONNX fallback."""
     table = {
-        "1.12": 15, "1.11": 14, "1.10": 13, "1.9": 12, "1.8": 12,
-        "1.13": 17, "2.0": 18, "2.1": 19,
-        "2.2": 19, "2.3": 19, "2.4": 20, "2.5": 20,
-        "2.6": 20, "2.7": 20, "2.8": 23,
+        "1.8":  12,
+        "1.9":  12,
+        "1.10": 13,
+        "1.11": 14,
+        "1.12": 15,
+        "1.13": 17,
+        "2.0":  18,
+        "2.1":  19,
+        "2.2":  19,
+        "2.3":  19,
+        "2.4":  20,
+        "2.5":  20,
+        "2.6":  20,
+        "2.7":  20,
+        "2.8":  23,
     }
     m = re.match(r"(\d+\.\d+)", torch.__version__)
     key = m.group(1) if m else torch.__version__

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -534,18 +534,6 @@ def copy_attr(a, b, include=(), exclude=()):
             setattr(a, k, v)
 
 
-def get_latest_opset():
-    """
-    Return the second-most recent ONNX opset version supported by this version of PyTorch, adjusted for maturity.
-
-    Returns:
-        (int): The ONNX opset version.
-    """
-    import onnx
-
-    return onnx.defs.onnx_opset_version() - 1
-
-
 def intersect_dicts(da, db, exclude=()):
     """
     Return a dictionary of intersecting keys with matching shapes, excluding 'exclude' keys, using da values.

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -541,12 +541,9 @@ def get_latest_opset():
     Returns:
         (int): The ONNX opset version.
     """
-    if TORCH_1_13:
-        # If the PyTorch>=1.13, dynamically compute the latest opset minus one using 'symbolic_opset'
-        return max(int(k[14:]) for k in vars(torch.onnx) if "symbolic_opset" in k) - 1
-    # Otherwise for PyTorch<=1.12 return the corresponding predefined opset
-    version = torch.onnx.producer_version.rsplit(".", 1)[0]  # i.e. '2.3'
-    return {"1.12": 15, "1.11": 14, "1.10": 13, "1.9": 12, "1.8": 12}.get(version, 12)
+    import onnx
+
+    return onnx.defs.onnx_opset_version() - 1
 
 
 def intersect_dicts(da, db, exclude=()):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves ONNX export reliability by introducing smarter opset selection and enforcing ONNX IR version compatibility, while cleaning up deprecated utilities. 🚀

### 📊 Key Changes
- Added `best_onnx_opset()` in `ultralytics.engine.exporter` to choose a safe, optimal ONNX opset based on the current PyTorch and ONNX versions. 🔧
- Replaced usage of `get_latest_opset()` with `best_onnx_opset()` in the ONNX export path. ✅
- Capped ONNX IR version to 10 during export for better ONNX Runtime compatibility. 🧩
- Removed `get_latest_opset()` from `ultralytics.utils.torch_utils` and its docs entry. 🧹
- Updated docs to include `ultralytics.engine.exporter.best_onnx_opset`. 📚

### 🎯 Purpose & Impact
- More reliable ONNX exports across PyTorch versions by selecting the second-latest supported opset (or a mapped fallback), while ensuring it does not exceed the ONNX package’s supported opset. 🛡️
- Prevents incompatibilities with ONNX Runtime by limiting the IR version to 10. 🔒
- Reduces maintenance and confusion by removing the older `get_latest_opset()` API and centralizing logic where it’s used. 🧠
- Users should see fewer export failures and better out-of-the-box compatibility when exporting to ONNX, especially on newer PyTorch releases. 🎉

Tip: You can still override the opset manually when exporting if needed:
```python
from ultralytics import YOLO

model = YOLO("yolo11n.pt")
model.export(format="onnx", opset=17)  # override if you have specific runtime needs
```