### PR TITLE
Require `torch>=2.1` for OpenVINO exports

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -20,7 +20,7 @@ from ultralytics.utils import (
     WINDOWS,
     checks,
 )
-from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_13
+from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_13, TORCH_2_1
 
 
 def test_export_torchscript():
@@ -35,7 +35,7 @@ def test_export_onnx():
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
 
 
-@pytest.mark.skipif(not TORCH_1_13, reason="OpenVINO requires torch>=1.13")
+@pytest.mark.skipif(not TORCH_2_1, reason="OpenVINO requires torch>=2.1")
 def test_export_openvino():
     """Test YOLO export to OpenVINO format for model inference compatibility."""
     file = YOLO(MODEL).export(format="openvino", imgsz=32)
@@ -43,7 +43,7 @@ def test_export_openvino():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(not TORCH_1_13, reason="OpenVINO requires torch>=1.13")
+@pytest.mark.skipif(not TORCH_2_1, reason="OpenVINO requires torch>=2.1")
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, batch, nms",
     [  # generate all combinations except for exclusion cases

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -112,7 +112,7 @@ from ultralytics.utils.metrics import batch_probiou
 from ultralytics.utils.nms import TorchNMS
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.patches import arange_patch
-from ultralytics.utils.torch_utils import TORCH_1_13, select_device
+from ultralytics.utils.torch_utils import TORCH_1_13, select_device, TORCH_2_1
 
 
 def export_formats():
@@ -674,7 +674,7 @@ class Exporter:
         import openvino as ov
 
         LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")
-        assert TORCH_1_13, f"OpenVINO export requires torch>=1.13.0 but torch=={TORCH_VERSION} is installed"
+        assert TORCH_2_1, f"OpenVINO export requires torch>=2.1 but torch=={TORCH_VERSION} is installed"
         ov_model = ov.convert_model(
             NMSModel(self.model, self.args) if self.args.nms else self.model,
             input=None if self.args.dynamic else [self.im.shape],

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -112,7 +112,7 @@ from ultralytics.utils.metrics import batch_probiou
 from ultralytics.utils.nms import TorchNMS
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.patches import arange_patch
-from ultralytics.utils.torch_utils import TORCH_1_13, select_device, TORCH_2_1
+from ultralytics.utils.torch_utils import TORCH_1_13, TORCH_2_1, select_device
 
 
 def export_formats():

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -40,6 +40,7 @@ from ultralytics.utils.patches import torch_load
 TORCH_1_9 = check_version(TORCH_VERSION, "1.9.0")
 TORCH_1_13 = check_version(TORCH_VERSION, "1.13.0")
 TORCH_2_0 = check_version(TORCH_VERSION, "2.0.0")
+TORCH_2_1 = check_version(TORCH_VERSION, "2.1.0")
 TORCH_2_4 = check_version(TORCH_VERSION, "2.4.0")
 TORCHVISION_0_10 = check_version(TORCHVISION_VERSION, "0.10.0")
 TORCHVISION_0_11 = check_version(TORCHVISION_VERSION, "0.11.0")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Raises the minimum PyTorch requirement for OpenVINO exports to PyTorch 2.1+, adds a version flag, and updates tests accordingly. 🚀

### 📊 Key Changes
- OpenVINO export now requires PyTorch 2.1+ (was 1.13+).
- Added `TORCH_2_1` flag in `ultralytics.utils.torch_utils`.
- Exporter now asserts `torch>=2.1` before running OpenVINO conversion.
- Tests updated to skip OpenVINO export when `torch<2.1`.

### 🎯 Purpose & Impact
- Ensures compatibility and stability with the latest OpenVINO conversion pipeline. ✅
- Clearer errors and test gating prevent unexpected failures on unsupported PyTorch versions. 🧪
- Breaking change for users on older PyTorch: to export to OpenVINO, upgrade to PyTorch 2.1+.
  - Check your version in Python: `import torch; print(torch.__version__)`
  - Follow the official [PyTorch installation instructions](https://pytorch.org/get-started/locally/) to upgrade.

Helpful links:
- See export options in the [Ultralytics export docs](https://docs.ultralytics.com/modes/export/).
- Learn more about OpenVINO integration in the [OpenVINO export guide](https://docs.ultralytics.com/modes/export/#openvino).