### PR TITLE
Fix meshgrid with indexing bug on `torch==1.10`

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -12,8 +12,8 @@ import torch.nn.functional as F
 from torch.nn.init import constant_, xavier_uniform_
 
 from ultralytics.utils import NOT_MACOS14
-from ultralytics.utils.tal import TORCH_1_10, dist2bbox, dist2rbox, make_anchors
-from ultralytics.utils.torch_utils import fuse_conv_and_bn, smart_inference_mode
+from ultralytics.utils.tal import dist2bbox, dist2rbox, make_anchors
+from ultralytics.utils.torch_utils import fuse_conv_and_bn, smart_inference_mode, TORCH_1_11
 
 from .block import DFL, SAVPE, BNContrastiveHead, ContrastiveHead, Proto, Residual, SwiGLUFFN
 from .conv import Conv, DWConv
@@ -1052,7 +1052,7 @@ class RTDETRDecoder(nn.Module):
         for i, (h, w) in enumerate(shapes):
             sy = torch.arange(end=h, dtype=dtype, device=device)
             sx = torch.arange(end=w, dtype=dtype, device=device)
-            grid_y, grid_x = torch.meshgrid(sy, sx, indexing="ij") if TORCH_1_10 else torch.meshgrid(sy, sx)
+            grid_y, grid_x = torch.meshgrid(sy, sx, indexing="ij") if TORCH_1_11 else torch.meshgrid(sy, sx)
             grid_xy = torch.stack([grid_x, grid_y], -1)  # (h, w, 2)
 
             valid_WH = torch.tensor([w, h], dtype=dtype, device=device)

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -13,7 +13,7 @@ from torch.nn.init import constant_, xavier_uniform_
 
 from ultralytics.utils import NOT_MACOS14
 from ultralytics.utils.tal import dist2bbox, dist2rbox, make_anchors
-from ultralytics.utils.torch_utils import fuse_conv_and_bn, smart_inference_mode, TORCH_1_11
+from ultralytics.utils.torch_utils import TORCH_1_11, fuse_conv_and_bn, smart_inference_mode
 
 from .block import DFL, SAVPE, BNContrastiveHead, ContrastiveHead, Proto, Residual, SwiGLUFFN
 from .conv import Conv, DWConv

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -3,12 +3,10 @@
 import torch
 import torch.nn as nn
 
-from . import LOGGER, TORCH_VERSION
-from .checks import check_version
+from . import LOGGER
 from .metrics import bbox_iou, probiou
 from .ops import xywhr2xyxyxyxy
-
-TORCH_1_10 = check_version(TORCH_VERSION, "1.10.0")
+from .torch_utils import TORCH_1_11
 
 
 class TaskAlignedAssigner(nn.Module):
@@ -373,7 +371,7 @@ def make_anchors(feats, strides, grid_cell_offset=0.5):
         h, w = feats[i].shape[2:] if isinstance(feats, list) else (int(feats[i][0]), int(feats[i][1]))
         sx = torch.arange(end=w, device=device, dtype=dtype) + grid_cell_offset  # shift x
         sy = torch.arange(end=h, device=device, dtype=dtype) + grid_cell_offset  # shift y
-        sy, sx = torch.meshgrid(sy, sx, indexing="ij") if TORCH_1_10 else torch.meshgrid(sy, sx)
+        sy, sx = torch.meshgrid(sy, sx, indexing="ij") if TORCH_1_11 else torch.meshgrid(sy, sx)
         anchor_points.append(torch.stack((sx, sy), -1).view(-1, 2))
         stride_tensor.append(torch.full((h * w, 1), stride, dtype=dtype, device=device))
     return torch.cat(anchor_points), torch.cat(stride_tensor)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -38,6 +38,7 @@ from ultralytics.utils.patches import torch_load
 
 # Version checks (all default to version>=min_version)
 TORCH_1_9 = check_version(TORCH_VERSION, "1.9.0")
+TORCH_1_11 = check_version(TORCH_VERSION, "1.11.0")
 TORCH_1_13 = check_version(TORCH_VERSION, "1.13.0")
 TORCH_2_0 = check_version(TORCH_VERSION, "2.0.0")
 TORCH_2_1 = check_version(TORCH_VERSION, "2.1.0")


### PR DESCRIPTION
Partially resolves https://github.com/ultralytics/ultralytics/pull/22152

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Aligns PyTorch version checks and fixes `torch.meshgrid` compatibility by switching to a unified `TORCH_1_11` flag, preventing errors on older PyTorch versions. ✅

### 📊 Key Changes
- Replaced `TORCH_1_10` with `TORCH_1_11` for feature gating of `torch.meshgrid(..., indexing="ij")`.
- Centralized version flag in `ultralytics/utils/torch_utils.py` and imported it where needed:
  - `utils/torch_utils.py`: added `TORCH_1_11`.
  - `nn/modules/head.py` and `utils/tal.py`: now import and use `TORCH_1_11`.
- Updated anchor/grid generation to use `indexing="ij"` only on PyTorch ≥ 1.11:
  - `_generate_anchors` in `nn/modules/head.py`
  - `make_anchors` in `utils/tal.py`
- Removed redundant version checks and imports from `utils/tal.py`.

### 🎯 Purpose & Impact
- Prevents runtime errors on PyTorch 1.10 due to unsupported `indexing` argument in `torch.meshgrid`. 🛡️
- Improves compatibility across PyTorch versions without changing public APIs. 🔁
- Simplifies and standardizes version checks across the codebase for easier maintenance. 🧹
- No performance changes; detection and anchor generation behavior remains the same. 🚀