### PR TITLE
Require `torch>=1.13` for YOLOE models

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -34,7 +34,7 @@ from ultralytics.utils import (
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download
-from ultralytics.utils.torch_utils import TORCH_1_9
+from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_13
 
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 
@@ -636,7 +636,8 @@ def test_yolo_world():
     )
 
 
-@pytest.mark.skipif(checks.IS_PYTHON_3_12 or not TORCH_1_9, reason="YOLOE with CLIP is not supported in Python 3.12")
+@pytest.mark.skipif(not TORCH_1_13, reason="YOLOE with CLIP requires torch>=1.13")
+@pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="YOLOE with CLIP is not supported in Python 3.12")
 @pytest.mark.skipif(
     checks.IS_PYTHON_3_8 and LINUX and ARM64,
     reason="YOLOE with CLIP is not supported in Python 3.8 and aarch64 Linux",
@@ -650,16 +651,12 @@ def test_yoloe():
     model.set_classes(names, model.get_text_pe(names))
     model(SOURCE, conf=0.01)
 
-    import numpy as np
-
     from ultralytics import YOLOE
     from ultralytics.models.yolo.yoloe import YOLOEVPSegPredictor
 
     # visual-prompts
     visuals = dict(
-        bboxes=np.array(
-            [[221.52, 405.8, 344.98, 857.54], [120, 425, 160, 445]],
-        ),
+        bboxes=np.array([[221.52, 405.8, 344.98, 857.54], [120, 425, 160, 445]]),
         cls=np.array([0, 1]),
     )
     model.predict(

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -83,7 +83,6 @@ from ultralytics.utils.ops import make_divisible
 from ultralytics.utils.patches import torch_load
 from ultralytics.utils.plotting import feature_visualization
 from ultralytics.utils.torch_utils import (
-    TORCH_1_13,
     fuse_conv_and_bn,
     fuse_deconv_and_bn,
     initialize_weights,

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -90,7 +90,7 @@ from ultralytics.utils.torch_utils import (
     model_info,
     scale_img,
     smart_inference_mode,
-    time_sync, TORCH_1_13,
+    time_sync,
 )
 
 
@@ -1007,7 +1007,6 @@ class YOLOEModel(DetectionModel):
             verbose (bool): Whether to display model information.
         """
         super().__init__(cfg=cfg, ch=ch, nc=nc, verbose=verbose)
-        assert TORCH_1_13, "YOLOE with CLIP requires torch>=1.13"
 
     @smart_inference_mode()
     def get_text_pe(self, text, batch=80, cache_clip_model=False, without_reprta=False):

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -83,6 +83,7 @@ from ultralytics.utils.ops import make_divisible
 from ultralytics.utils.patches import torch_load
 from ultralytics.utils.plotting import feature_visualization
 from ultralytics.utils.torch_utils import (
+    TORCH_1_13,
     fuse_conv_and_bn,
     fuse_deconv_and_bn,
     initialize_weights,
@@ -90,7 +91,7 @@ from ultralytics.utils.torch_utils import (
     model_info,
     scale_img,
     smart_inference_mode,
-    time_sync, TORCH_1_13,
+    time_sync,
 )
 
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -90,7 +90,7 @@ from ultralytics.utils.torch_utils import (
     model_info,
     scale_img,
     smart_inference_mode,
-    time_sync,
+    time_sync, TORCH_1_13,
 )
 
 
@@ -1007,6 +1007,7 @@ class YOLOEModel(DetectionModel):
             verbose (bool): Whether to display model information.
         """
         super().__init__(cfg=cfg, ch=ch, nc=nc, verbose=verbose)
+        assert TORCH_1_13, "YOLOE with CLIP requires torch>=1.13"
 
     @smart_inference_mode()
     def get_text_pe(self, text, batch=80, cache_clip_model=False, without_reprta=False):

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from PIL import Image
 
 from ultralytics.utils import checks
-from ultralytics.utils.torch_utils import smart_inference_mode, TORCH_1_13
+from ultralytics.utils.torch_utils import TORCH_1_13, smart_inference_mode
 
 try:
     import clip

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from PIL import Image
 
 from ultralytics.utils import checks
-from ultralytics.utils.torch_utils import smart_inference_mode
+from ultralytics.utils.torch_utils import smart_inference_mode, TORCH_1_13
 
 try:
     import clip
@@ -33,6 +33,7 @@ class TextModel(nn.Module):
 
     def __init__(self):
         """Initialize the TextModel base class."""
+        assert TORCH_1_13, "Text models like CLIP require torch>=1.13"
         super().__init__()
 
     @abstractmethod


### PR DESCRIPTION
May resolve issues in https://github.com/ultralytics/ultralytics/pull/22152

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enforces a minimum PyTorch version (>=1.13) for CLIP-based text models (e.g., YOLOE with CLIP) and updates tests to reflect this requirement, improving reliability and clearer errors. ✅

### 📊 Key Changes
- Added TORCH_1_13 checks:
  - Tests now skip YOLOE with CLIP when torch<1.13.
  - TextModel now asserts torch>=1.13 on initialization for CLIP/text models.
- Kept existing skips:
  - Python 3.12 remains unsupported for YOLOE with CLIP.
  - Python 3.8 on Linux ARM64 remains skipped.
- Minor test cleanup for numpy usage and formatting.

### 🎯 Purpose & Impact
- Clearer errors and safer behavior: Users on torch<1.13 get an immediate, informative assertion instead of runtime failures. 🛡️
- More reliable CI: Tests accurately reflect supported environments, reducing false failures. 🧪
- User guidance: Signals the required environment for CLIP-based features like YOLOE with CLIP, helping users upgrade proactively. 🔧

Tip: To use YOLOE with CLIP and other text models, upgrade PyTorch:
```bash
pip install --upgrade torch torchvision
```