### PR TITLE
Require `torch>=1.11` for RTDETR models

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,12 +48,14 @@ def test_export(model: str) -> None:
     """Test exporting a YOLO model to TorchScript format."""
     run(f"yolo export model={model} format=torchscript imgsz=32")
 
+
 @pytest.mark.skipif(not TORCH_1_11, reason="RTDETR requires torch>=1.11")
 def test_rtdetr(task: str = "detect", model: Path = WEIGHTS_DIR / "rtdetr-l.pt", data: str = "coco8.yaml") -> None:
     """Test the RTDETR functionality within Ultralytics for detection tasks using specified model and data."""
     # Add comma, spaces, fraction=0.25 args to test single-image training
     run(f"yolo predict {task} model={model} source={ASSETS / 'bus.jpg'} imgsz=160 save save_crop save_txt")
     run(f"yolo train {task} model={model} data={data} --imgsz= 160 epochs =1, cache = disk fraction=0.25")
+
 
 @pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="MobileSAM with CLIP is not supported in Python 3.12")
 @pytest.mark.skipif(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,14 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import subprocess
+from pathlib import Path
 
 import pytest
 from PIL import Image
 
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODELS, TASK_MODEL_DATA
 from ultralytics.utils import ARM64, ASSETS, LINUX, WEIGHTS_DIR, checks
-from ultralytics.utils.torch_utils import TORCH_1_9
+from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_11
 
 
 def run(cmd: str) -> None:
@@ -47,17 +48,12 @@ def test_export(model: str) -> None:
     """Test exporting a YOLO model to TorchScript format."""
     run(f"yolo export model={model} format=torchscript imgsz=32")
 
-
-def test_rtdetr(task: str = "detect", model: str = "yolov8n-rtdetr.yaml", data: str = "coco8.yaml") -> None:
+@pytest.mark.skipif(not TORCH_1_11, reason="RTDETR requires torch>=1.11")
+def test_rtdetr(task: str = "detect", model: Path = WEIGHTS_DIR / "rtdetr-l.pt", data: str = "coco8.yaml") -> None:
     """Test the RTDETR functionality within Ultralytics for detection tasks using specified model and data."""
-    # Warning: must use imgsz=640 (note also add comma, spaces, fraction=0.25 args to test single-image training)
-    run(f"yolo train {task} model={model} data={data} --imgsz= 160 epochs =1, cache = disk fraction=0.25")  # spaces
+    # Add comma, spaces, fraction=0.25 args to test single-image training
     run(f"yolo predict {task} model={model} source={ASSETS / 'bus.jpg'} imgsz=160 save save_crop save_txt")
-    if TORCH_1_9:
-        weights = WEIGHTS_DIR / "rtdetr-l.pt"
-        run(f"yolo predict {task} model={weights} source={ASSETS / 'bus.jpg'} imgsz=160 save save_crop save_txt")
-        run(f"yolo train {task} model={weights} epochs=1 imgsz=160 cache=disk data=coco8.yaml")
-
+    run(f"yolo train {task} model={model} data={data} --imgsz= 160 epochs =1, cache = disk fraction=0.25")
 
 @pytest.mark.skipif(checks.IS_PYTHON_3_12, reason="MobileSAM with CLIP is not supported in Python 3.12")
 @pytest.mark.skipif(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODELS, TASK_MODEL_DATA
 from ultralytics.utils import ARM64, ASSETS, LINUX, WEIGHTS_DIR, checks
-from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_11
+from ultralytics.utils.torch_utils import TORCH_1_11
 
 
 def run(cmd: str) -> None:

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -34,7 +34,7 @@ from ultralytics.utils import (
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download
-from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_13, TORCH_1_11
+from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
 
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -34,7 +34,7 @@ from ultralytics.utils import (
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download
-from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_13
+from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_13, TORCH_1_11
 
 IS_TMP_WRITEABLE = is_dir_writeable(TMP)  # WARNING: must be run once tests start as TMP does not exist on tests/init
 
@@ -248,7 +248,7 @@ def test_all_model_yamls():
     """Test YOLO model creation for all available YAML configurations in the `cfg/models` directory."""
     for m in (ROOT / "cfg" / "models").rglob("*.yaml"):
         if "rtdetr" in m.name:
-            if TORCH_1_9:  # torch<=1.8 issue - TypeError: __init__() got an unexpected keyword argument 'batch_first'
+            if TORCH_1_11:
                 _ = RTDETR(m.name)(SOURCE, imgsz=640)  # must be 640
         else:
             YOLO(m.name)

--- a/ultralytics/models/rtdetr/model.py
+++ b/ultralytics/models/rtdetr/model.py
@@ -11,6 +11,7 @@ References:
 
 from ultralytics.engine.model import Model
 from ultralytics.nn.tasks import RTDETRDetectionModel
+from ultralytics.utils.torch_utils import TORCH_1_11
 
 from .predict import RTDETRPredictor
 from .train import RTDETRTrainer
@@ -44,6 +45,7 @@ class RTDETR(Model):
         Args:
             model (str): Path to the pre-trained model. Supports .pt, .yaml, and .yml formats.
         """
+        assert TORCH_1_11, "RTDETR requires torch>=1.11"
         super().__init__(model=model, task="detect")
 
     @property

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from PIL import Image
 
 from ultralytics.utils import checks
-from ultralytics.utils.torch_utils import TORCH_1_13, smart_inference_mode
+from ultralytics.utils.torch_utils import smart_inference_mode
 
 try:
     import clip
@@ -33,7 +33,6 @@ class TextModel(nn.Module):
 
     def __init__(self):
         """Initialize the TextModel base class."""
-        assert TORCH_1_13, "Text models like CLIP require torch>=1.13"
         super().__init__()
 
     @abstractmethod


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Aligns RTDETR with a minimum PyTorch requirement (>=1.11) and relaxes strict version checks for text models like CLIP, improving clarity and compatibility across environments. ✅

### 📊 Key Changes
- RTDETR now explicitly requires PyTorch >= 1.11:
  - Added `@pytest.mark.skipif(not TORCH_1_11, ...)` in tests.
  - Replaced legacy `TORCH_1_9` checks with `TORCH_1_11`.
  - Added runtime assertion in `RTDETR` model init: `assert TORCH_1_11, "RTDETR requires torch>=1.11"`.
- Test improvements:
  - Standardized RTDETR tests to use `WEIGHTS_DIR / "rtdetr-l.pt"` via `pathlib.Path`.
  - Simplified predict/train calls and ensured consistent single-image training args.
- Text models (e.g., CLIP) no longer enforce a strict `torch>=1.13` assertion in code, removing an unnecessary constraint.
- Minor cleanup of imports and conditions in `tests/test_python.py` for RTDETR YAML creation.

### 🎯 Purpose & Impact
- Clearer version requirements for RTDETR reduce confusion and test flakiness. 🧩
- Broader compatibility for text-based models by removing the hard `torch>=1.13` gate; more environments should work out of the box. 🚀
- Potential breaking change: users running RTDETR on PyTorch <= 1.10 will be blocked with a clear error or skipped tests; upgrade to PyTorch 1.11+ is required.
- More robust and maintainable tests, improving CI reliability.

For model specifics, see the RTDETR documentation: RTDETR model overview.