### PR TITLE
Require `torch>=1.11` for CoreML exports

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -20,7 +20,7 @@ from ultralytics.utils import (
     WINDOWS,
     checks,
 )
-from ultralytics.utils.torch_utils import TORCH_1_9, TORCH_1_13, TORCH_2_1
+from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13, TORCH_2_1
 
 
 def test_export_torchscript():
@@ -117,7 +117,7 @@ def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms):
 
 @pytest.mark.slow
 @pytest.mark.skipif(not MACOS, reason="CoreML inference only supported on macOS")
-@pytest.mark.skipif(not TORCH_1_9, reason="CoreML>=7.2 not supported with PyTorch<=1.8")
+@pytest.mark.skipif(not TORCH_1_11, reason="CoreML export requires torch>=1.11")
 @pytest.mark.skipif(checks.IS_PYTHON_3_13, reason="CoreML not supported in Python 3.13")
 @pytest.mark.parametrize(
     "task, dynamic, int8, half, nms, batch",
@@ -169,7 +169,7 @@ def test_export_tflite_matrix(task, dynamic, int8, half, batch, nms):
     Path(file).unlink()  # cleanup
 
 
-@pytest.mark.skipif(not TORCH_1_9, reason="CoreML>=7.2 not supported with PyTorch<=1.8")
+@pytest.mark.skipif(not TORCH_1_11, reason="CoreML export requires torch>=1.11")
 @pytest.mark.skipif(WINDOWS, reason="CoreML not supported on Windows")  # RuntimeError: BlobWriter not loaded
 @pytest.mark.skipif(LINUX and ARM64, reason="CoreML not supported on aarch64 Linux")
 @pytest.mark.skipif(checks.IS_PYTHON_3_13, reason="CoreML not supported in Python 3.13")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -112,7 +112,7 @@ from ultralytics.utils.metrics import batch_probiou
 from ultralytics.utils.nms import TorchNMS
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.patches import arange_patch
-from ultralytics.utils.torch_utils import TORCH_1_13, TORCH_2_1, select_device
+from ultralytics.utils.torch_utils import TORCH_1_13, TORCH_2_1, select_device, TORCH_1_11
 
 
 def export_formats():
@@ -867,6 +867,7 @@ class Exporter:
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")
         assert not WINDOWS, "CoreML export is not supported on Windows, please run on macOS or Linux."
+        assert TORCH_1_11, "CoreML export requires torch>=1.11"
         assert self.args.batch == 1, "CoreML batch sizes > 1 are not supported. Please retry at 'batch=1'."
         f = self.file.with_suffix(".mlmodel" if mlmodel else ".mlpackage")
         if f.is_dir():

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -112,7 +112,7 @@ from ultralytics.utils.metrics import batch_probiou
 from ultralytics.utils.nms import TorchNMS
 from ultralytics.utils.ops import Profile
 from ultralytics.utils.patches import arange_patch
-from ultralytics.utils.torch_utils import TORCH_1_13, TORCH_2_1, select_device, TORCH_1_11
+from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13, TORCH_2_1, select_device
 
 
 def export_formats():


### PR DESCRIPTION
May help resolve https://github.com/ultralytics/ultralytics/pull/22152

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Bumps the minimum PyTorch version required for CoreML export to 1.11 and aligns tests and runtime checks accordingly. ✅

### 📊 Key Changes
- Updated CoreML-related checks from `TORCH_1_9` to `TORCH_1_11` in tests and exporter.
- Added a clear runtime assertion in `export_coreml()` enforcing `torch>=1.11`.
- Improved skip reasons/messages in tests for clearer guidance.
- No behavior change for other export formats.

### 🎯 Purpose & Impact
- Ensures reliable CoreML exports by requiring a compatible PyTorch version.
- Prevents confusing failures with a clear, early error message if `torch<1.11`.
- Harmonizes tests and runtime logic, reducing CI flakiness and support burden.
- User impact: those using CoreML exports must upgrade to PyTorch 1.11+.

Tip: Upgrade PyTorch if needed:
- CPU/CUDA: `pip install --upgrade torch`
- Apple Silicon/macOS: follow the official [PyTorch installation guide](https://pytorch.org/get-started/locally/).