### PR TITLE
Fix transformer.py meshgrid for `torch<1.11`

### DIFF
--- a/ultralytics/nn/modules/transformer.py
+++ b/ultralytics/nn/modules/transformer.py
@@ -29,7 +29,6 @@ __all__ = (
 )
 
 
-
 class TransformerEncoderLayer(nn.Module):
     """
     A single layer of the transformer encoder.

--- a/ultralytics/nn/modules/transformer.py
+++ b/ultralytics/nn/modules/transformer.py
@@ -12,6 +12,7 @@ from torch.nn.init import constant_, xavier_uniform_
 
 from .conv import Conv
 from .utils import _get_clones, inverse_sigmoid, multi_scale_deformable_attn_pytorch
+from ultralytics.utils.torch_utils import TORCH_1_11
 
 __all__ = (
     "TransformerEncoderLayer",
@@ -25,6 +26,7 @@ __all__ = (
     "MSDeformAttn",
     "MLP",
 )
+
 
 
 class TransformerEncoderLayer(nn.Module):
@@ -236,7 +238,7 @@ class AIFI(TransformerEncoderLayer):
         assert embed_dim % 4 == 0, "Embed dimension must be divisible by 4 for 2D sin-cos position embedding"
         grid_w = torch.arange(w, dtype=torch.float32)
         grid_h = torch.arange(h, dtype=torch.float32)
-        grid_w, grid_h = torch.meshgrid(grid_w, grid_h, indexing="ij")
+        grid_w, grid_h = torch.meshgrid(grid_w, grid_h, indexing="ij") if TORCH_1_11 else torch.meshgrid(grid_w, grid_h)
         pos_dim = embed_dim // 4
         omega = torch.arange(pos_dim, dtype=torch.float32) / pos_dim
         omega = 1.0 / (temperature**omega)

--- a/ultralytics/nn/modules/transformer.py
+++ b/ultralytics/nn/modules/transformer.py
@@ -10,9 +10,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.init import constant_, xavier_uniform_
 
+from ultralytics.utils.torch_utils import TORCH_1_11
+
 from .conv import Conv
 from .utils import _get_clones, inverse_sigmoid, multi_scale_deformable_attn_pytorch
-from ultralytics.utils.torch_utils import TORCH_1_11
 
 __all__ = (
     "TransformerEncoderLayer",


### PR DESCRIPTION
May partially resolve https://github.com/ultralytics/ultralytics/pull/22152


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves PyTorch version compatibility in transformer positional embeddings by conditionally handling `torch.meshgrid` arguments. 🧭

### 📊 Key Changes
- Added import of `TORCH_1_11` from `ultralytics.utils.torch_utils`.
- Updated `build_2d_sincos_position_embedding` to use:
  - `torch.meshgrid(..., indexing="ij")` for PyTorch ≥ 1.11.
  - `torch.meshgrid(...)` without `indexing` for older versions.

### 🎯 Purpose & Impact
- Ensures compatibility across PyTorch versions, preventing errors on older releases and avoiding deprecation warnings on newer ones. ✅
- No behavioral or performance changes to model outputs—purely a stability and compatibility improvement. 🔧
- Smoother user experience when running transformer-based components without needing to upgrade/downgrade PyTorch. 🚀