### PR TITLE
Add `uv` `required-version = "==0.8.19"`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,9 @@ source = ["ultralytics/"]
 data_file = "tests/.coverage"
 omit = ["ultralytics/utils/callbacks/*"]
 
+[tool.uv]
+required-version = ">=0.8.19"
+
 [tool.isort]
 line_length = 120
 multi_line_output = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ data_file = "tests/.coverage"
 omit = ["ultralytics/utils/callbacks/*"]
 
 [tool.uv]
-required-version = ">=0.8.19"
+required-version = "==0.8.19"
 
 [tool.isort]
 line_length = 120


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Pins the project’s uv tooling version to 0.8.19 in pyproject.toml to ensure consistent, reproducible developer environments. 🔧

### 📊 Key Changes
- Added a new `[tool.uv]` section to `pyproject.toml`:
  - `required-version = "==0.8.19"`

### 🎯 Purpose & Impact
- Ensures all contributors using uv have the same version, reducing environment drift and build inconsistencies. ✅
- Improves CI stability and reproducibility by standardizing tooling across machines. 🔄
- No impact on end users installing Ultralytics via pip; this only affects development workflows. 🧑‍💻
- Developers may need to update/downgrade their uv to 0.8.19; see the uv documentation for guidance: [uv documentation](https://docs.astral.sh/uv/).