### PR TITLE
`ultralytics 8.3.203` Restore `GradScaler` on resuming training

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.202"
+__version__ = "8.3.203"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -584,6 +584,7 @@ class BaseTrainer:
                 "ema": deepcopy(unwrap_model(self.ema.ema)).half(),
                 "updates": self.ema.updates,
                 "optimizer": convert_optimizer_state_dict_to_fp16(deepcopy(self.optimizer.state_dict())),
+                "scaler": self.scaler.state_dict(),
                 "train_args": vars(self.args),  # save as dict
                 "train_metrics": {**self.metrics, **{"fitness": self.fitness}},
                 "train_results": self.read_results_csv(),
@@ -812,9 +813,11 @@ class BaseTrainer:
             return
         best_fitness = 0.0
         start_epoch = ckpt.get("epoch", -1) + 1
-        if ckpt.get("optimizer", None) is not None:
+        if ckpt.get("optimizer") is not None:
             self.optimizer.load_state_dict(ckpt["optimizer"])  # optimizer
             best_fitness = ckpt["best_fitness"]
+        if ckpt.get("scaler") is not None:
+            self.scaler.load_state_dict(ckpt["scaler"])
         if self.ema and ckpt.get("ema"):
             self.ema.ema.load_state_dict(ckpt["ema"].float().state_dict())  # EMA
             self.ema.updates = ckpt["updates"]


### PR DESCRIPTION
Fixes https://github.com/ultralytics/ultralytics/issues/21913
Fixes https://github.com/ultralytics/ultralytics/issues/17282

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds AMP scaler state saving/loading to improve reliability when resuming mixed-precision training, plus a version bump to 8.3.203. ⚙️🚀

### 📊 Key Changes
- Bumped version: `8.3.202` → `8.3.203`.
- Trainer now saves the AMP GradScaler state in checkpoints: `"scaler": self.scaler.state_dict()`.
- Trainer restores the scaler state on resume if present: `self.scaler.load_state_dict(ckpt["scaler"])`.
- Minor cleanup in checkpoint loading checks.

### 🎯 Purpose & Impact
- More reliable resume for mixed-precision (AMP) training ✅
  - Preserves loss scaling state to avoid instability or slow warm-up after resuming.
- Backward compatible with older checkpoints 🙌
  - Scaler is loaded only if available; older checkpoints continue to work.
- Smoother training continuity and potentially fewer NaNs/overflows on resume 💪