### PR TITLE
Verify passed dataset is a directory and not a file for classification training

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,8 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   Tests:
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.tests == 'true'
+    if: false
+    # if: github.event_name != 'workflow_dispatch' || github.event.inputs.tests == 'true'
     timeout-minutes: 360
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   Tests:
-    if: false
-    # if: github.event_name != 'workflow_dispatch' || github.event.inputs.tests == 'true'
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.tests == 'true'
     timeout-minutes: 360
     runs-on: ${{ matrix.os }}
     strategy:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -514,7 +514,7 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
     if not data_dir.is_dir():
         if data_dir.suffix != "":
             raise ValueError(f"Invalid argument: received a non-directory path 'data={dataset}'. "
-            "For classification training you must provide a dataset directory, not a file. "
+            "For classification task you must provide a dataset directory, not a file. "
             "Refer to https://docs.ultralytics.com/datasets/classify/")
         LOGGER.info("")
         LOGGER.warning(f"Dataset not found, missing path {data_dir}, attempting download...")

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -514,9 +514,8 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
     if not data_dir.is_dir():
         if data_dir.suffix != "":
             raise ValueError(
-                f"Invalid argument: received a non-directory path 'data={dataset}'. "
-                "For classification task you must provide a dataset directory, not a file. "
-                "Refer to https://docs.ultralytics.com/datasets/classify/"
+                f'Classification datasets must be a directory (data="path/to/dir") not a file (data="{dataset}"), '
+                "See https://docs.ultralytics.com/datasets/classify/"
             )
         LOGGER.info("")
         LOGGER.warning(f"Dataset not found, missing path {data_dir}, attempting download...")

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -513,9 +513,11 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
     data_dir = (dataset if dataset.is_dir() else (DATASETS_DIR / dataset)).resolve()
     if not data_dir.is_dir():
         if data_dir.suffix != "":
-            raise ValueError(f"Invalid argument: received a non-directory path 'data={dataset}'. "
-            "For classification task you must provide a dataset directory, not a file. "
-            "Refer to https://docs.ultralytics.com/datasets/classify/")
+            raise ValueError(
+                f"Invalid argument: received a non-directory path 'data={dataset}'. "
+                "For classification task you must provide a dataset directory, not a file. "
+                "Refer to https://docs.ultralytics.com/datasets/classify/"
+            )
         LOGGER.info("")
         LOGGER.warning(f"Dataset not found, missing path {data_dir}, attempting download...")
         t = time.time()

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -512,6 +512,10 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
     dataset = Path(dataset)
     data_dir = (dataset if dataset.is_dir() else (DATASETS_DIR / dataset)).resolve()
     if not data_dir.is_dir():
+        if data_dir.suffix != "":
+            raise ValueError(f"Invalid argument: received a non-directory path 'data={dataset}'. "
+            "For classification training you must provide a dataset directory, not a file. "
+            "Refer to https://docs.ultralytics.com/datasets/classify/")
         LOGGER.info("")
         LOGGER.warning(f"Dataset not found, missing path {data_dir}, attempting download...")
         t = time.time()


### PR DESCRIPTION
This has happened a couple of times already. Some users think that Classification training uses a YAML for dataset like other tasks, and the error message is not helpful.

https://www.reddit.com/r/computervision/comments/1nmuo7w/first_time_training_yolo_dataset_not_found/

Fixes https://github.com/ultralytics/ultralytics/issues/18261
Fixes https://github.com/ultralytics/ultralytics/issues/16729
Fixes https://github.com/ultralytics/ultralytics/issues/14732

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds a clear validation to ensure classification datasets are directories, raising a helpful error instead of attempting a download. ✅

### 📊 Key Changes
- 🔍 In `check_cls_dataset`, if the provided classification dataset path looks like a file (has a suffix), a `ValueError` is raised with guidance.
- 📎 Error message includes a link to the classification dataset docs: [Classification dataset docs](https://docs.ultralytics.com/datasets/classify/).
- 🛑 Prevents unintended auto-download attempts when a file path is mistakenly supplied.

### 🎯 Purpose & Impact
- 🧭 Improves user experience with immediate, clear feedback when the dataset path is incorrect.
- ⏱️ Saves time and bandwidth by avoiding unnecessary downloads.
- 🔧 Helps users configure classification training correctly (expects a directory with the dataset structure).
- ⚠️ Potentially a breaking change for users who passed a file path (e.g., YAML); update scripts to provide a directory path.

Example:
```python
from ultralytics import YOLO

# Correct: directory path for classification datasets
model = YOLO('yolo11n-cls.pt')
model.train(data='path/to/classify_dataset')  # e.g., contains /train and /val subfolders
```