### PR TITLE
Fix --slow CUDA tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,8 +237,7 @@ jobs:
           if [[ "${{ github.event_name }}" =~ ^(schedule|workflow_dispatch)$ ]]; then
             slow="--slow"
           fi
-          # pytest $slow --cov=ultralytics/ --cov-report xml tests/test_cuda.py -sv
-          pytest --slow --cov=ultralytics/ --cov-report=xml tests/test_cuda.py -sv
+          pytest $slow --cov=ultralytics/ --cov-report xml tests/test_cuda.py -sv
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Upload Coverage Reports to CodeCov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,8 @@ jobs:
           if [[ "${{ github.event_name }}" =~ ^(schedule|workflow_dispatch)$ ]]; then
             slow="--slow"
           fi
-          pytest $slow --cov=ultralytics/ --cov-report xml tests/test_cuda.py -sv
+          # pytest $slow --cov=ultralytics/ --cov-report xml tests/test_cuda.py -sv
+          pytest --slow --cov=ultralytics/ --cov-report=xml tests/test_cuda.py -sv
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Upload Coverage Reports to CodeCov

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -70,7 +70,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         simplify=simplify,
         nms=nms,
         device=DEVICES[0],
-        opset=19 if nms else None,  # fix ONNX Runtime errors with NMS
+        opset=20 if nms else None,  # fix ONNX Runtime errors with NMS
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
     Path(file).unlink()  # cleanup

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -70,7 +70,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         simplify=simplify,
         nms=nms,
         device=DEVICES[0],
-        opset=21 if nms else None,  # fix ONNX Runtime errors with NMS
+        # opset=20 if nms else None,  # fix ONNX Runtime errors with NMS
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
     Path(file).unlink()  # cleanup

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -70,7 +70,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         simplify=simplify,
         nms=nms,
         device=DEVICES[0],
-        opset=20 if nms else None,  # fix ONNX Runtime errors with NMS
+        opset=21 if nms else None,  # fix ONNX Runtime errors with NMS
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
     Path(file).unlink()  # cleanup

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -70,7 +70,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         simplify=simplify,
         nms=nms,
         device=DEVICES[0],
-        opset=17 if nms else None,  # fix ONNX Runtime errors with NMS
+        opset=19 if nms else None,  # fix ONNX Runtime errors with NMS
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
     Path(file).unlink()  # cleanup

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -70,6 +70,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         simplify=simplify,
         nms=nms,
         device=DEVICES[0],
+        opset=17 if nms else None,  # fix ONNX Runtime errors with NMS
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
     Path(file).unlink()  # cleanup

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -249,7 +249,7 @@ class AutoBackend(nn.Module):
                     LOGGER.warning("Failed to start ONNX Runtime with CUDA. Using CPU...")
                     device = torch.device("cpu")
                     cuda = False
-            LOGGER.info(f"Using ONNX Runtime {providers[0]}")
+            LOGGER.info(f"Using ONNX Runtime {onnxruntime.__version__} {providers[0]}")
             if onnx:
                 session = onnxruntime.InferenceSession(w, providers=providers)
             else:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves ONNX export stability on CUDA by adjusting the default opset for GPU exports and enhances ONNX Runtime logging for clearer debugging. 🚀

### 📊 Key Changes
- ONNX opset selection now considers CUDA: `best_onnx_opset()` accepts a `cuda` flag and reduces the opset by 2 on GPU to avoid NMS-related squeeze errors.
- `export_onnx()` auto-detects CUDA and uses the adjusted opset when exporting on GPU.
- ONNX Runtime logging improved to include the ONNX Runtime version alongside the active provider (e.g., CUDA or CPU).
- Minor test cleanup (commented suggestion for setting `opset=20` when NMS is enabled).

### 🎯 Purpose & Impact
- Fewer ONNX Runtime errors on CUDA, especially with NMS-enabled exports ✅
- More reliable ONNX exports out of the box for GPU users, reducing manual opset tweaking 🔧
- Better visibility during inference with clear ONNX Runtime version and provider logs 🔍
- Users can still override the opset via `opset=` if needed, maintaining flexibility.