### PR TITLE
Fix `AttributeError` error for validation with `visualize`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,7 +34,7 @@ def test_train(task: str, model: str, data: str) -> None:
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)
 def test_val(task: str, model: str, data: str) -> None:
     """Test YOLO validation process for specified task, model, and data using a shell command."""
-    run(f"yolo val {task} model={model} data={data} imgsz=32 save_txt save_json")
+    run(f"yolo val {task} model={model} data={data} imgsz=32 save_txt save_json visualize")
 
 
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -491,12 +491,12 @@ class ConfusionMatrix(DataExportMixin):
         for i, mtype in enumerate(["GT", "FP", "TP", "FN"]):
             mbatch = self.matches[mtype]
             if "conf" not in mbatch:
-                mbatch["conf"] = torch.tensor([1.0] * mbatch["bboxes"].shape[0], device=img.device)
-            mbatch["batch_idx"] = torch.ones(mbatch["bboxes"].shape[0], device=img.device) * i
+                mbatch["conf"] = torch.tensor([1.0] * len(mbatch["bboxes"]), device=img.device)
+            mbatch["batch_idx"] = torch.ones(len(mbatch["bboxes"]), device=img.device) * i
             for k in mbatch.keys():
                 labels[k] += mbatch[k]
 
-        labels = {k: torch.stack(v, 0) if len(v) else v for k, v in labels.items()}
+        labels = {k: torch.stack(v, 0) if len(v) else torch.empty(0, 0) for k, v in labels.items()}
         if self.task != "obb" and labels["bboxes"].shape[0]:
             labels["bboxes"] = xyxy2xywh(labels["bboxes"])
         (save_dir / "visualizations").mkdir(parents=True, exist_ok=True)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -496,7 +496,7 @@ class ConfusionMatrix(DataExportMixin):
             for k in mbatch.keys():
                 labels[k] += mbatch[k]
 
-        labels = {k: torch.stack(v, 0) if len(v) else torch.empty(0, 0) for k, v in labels.items()}
+        labels = {k: torch.stack(v, 0) if len(v) else torch.empty(0) for k, v in labels.items()}
         if self.task != "obb" and labels["bboxes"].shape[0]:
             labels["bboxes"] = xyxy2xywh(labels["bboxes"])
         (save_dir / "visualizations").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes ULTRALYTICS-21DQ

**MRE**
```
yolo val data=coco128.yaml visualize
```
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves validation visualization robustness and test coverage, ensuring YOLO validation plots are stable even with empty or list-based inputs. 🛠️🖼️

### 📊 Key Changes
- Tests: Added `visualize` flag to `yolo val` CLI tests to exercise visualization during validation.
- Metrics: Hardened `plot_matches()` to handle list-based or empty `bboxes` safely by:
  - Using `len(mbatch["bboxes"])` instead of `.shape[0]`
  - Creating consistent empty tensors when no labels exist (`torch.empty(0)`)
  - Ensuring default confidences are set correctly for empty cases

### 🎯 Purpose & Impact
- More robust validation visualizations with fewer edge-case errors (e.g., empty matches).
- Improved test coverage to catch visualization regressions early.
- No breaking changes; users can safely use `yolo val ... visualize` for YOLO11/YOLO12 models and expect stable output saved under visualizations. ✅