### PR TITLE
Remove the compromise of criterion initialization for `torch.compile`

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -673,7 +673,7 @@ def test_yoloe():
     model.val(data="coco128-seg.yaml", load_vp=True, imgsz=32)
 
     # Train, fine-tune
-    from ultralytics.models.yolo.yoloe import YOLOEPESegTrainer
+    from ultralytics.models.yolo.yoloe import YOLOEPESegTrainer, YOLOESegTrainerFromScratch
 
     model = YOLOE("yoloe-11s-seg.pt")
     model.train(
@@ -681,6 +681,15 @@ def test_yoloe():
         epochs=1,
         close_mosaic=1,
         trainer=YOLOEPESegTrainer,
+        imgsz=32,
+    )
+    # Train, from scratch
+    model = YOLOE("yoloe-11s-seg.yaml")
+    model.train(
+        data=dict(train=dict(yolo_data=["coco128-seg.yaml"]), val=dict(yolo_data=["coco128-seg.yaml"])),
+        epochs=1,
+        close_mosaic=1,
+        trainer=YOLOESegTrainerFromScratch,
         imgsz=32,
     )
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -260,10 +260,6 @@ class BaseTrainer:
         self.model = self.model.to(self.device)
         self.set_model_attributes()
 
-        # Initialize loss criterion before compilation for torch.compile compatibility
-        if hasattr(self.model, "init_criterion"):
-            self.model.criterion = self.model.init_criterion()
-
         # Compile model
         self.model = attempt_compile(self.model, device=self.device, mode=self.args.compile)
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds a new “train from scratch” path for YOLOE segmentation and simplifies loss initialization to improve trainer flexibility and compilation behavior. 🚀

### 📊 Key Changes
- Introduces `YOLOESegTrainerFromScratch` for YOLOE segmentation.
- Expands tests to cover YOLOE segmentation training:
  - Fine-tuning with `YOLOEPESegTrainer` (existing).
  - Training from scratch using `YOLOESegTrainerFromScratch` with a YAML model config.
- Removes early loss initialization (`init_criterion`) in `engine/trainer.py` before `torch.compile`.

### 🎯 Purpose & Impact
- Easier from-scratch training for YOLOE segmentation models (e.g., YOLO11-Seg) with a dedicated trainer. 🧪
- Cleaner trainer responsibilities: loss is now initialized where appropriate (by the specific model/trainer), reducing side effects and mismatches. 🧩
- Better compatibility with `torch.compile` by avoiding pre-compilation loss setup, potentially improving stability and performance. ⚙️

Example usage:
```python
from ultralytics import YOLOE
from ultralytics.models.yolo.yoloe import YOLOESegTrainerFromScratch

model = YOLOE("yoloe-11s-seg.yaml")
model.train(
    data=dict(train=dict(yolo_data=["coco128-seg.yaml"]), val=dict(yolo_data=["coco128-seg.yaml"])),
    epochs=1,
    imgsz=32,
    close_mosaic=1,
    trainer=YOLOESegTrainerFromScratch,
)
```