### PR TITLE
Docs: Add `rect` behavior note to `predict.md`

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -396,7 +396,8 @@ Below are code examples for using each source type:
 `model.predict()` accepts multiple arguments that can be passed at inference time to override defaults:
 
 !!! note
-Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way up to the full `imgsz`. When running inference on a batch, however, minimal padding only works if all images are of same size. Otherwise, they are uniformly padded to a square shape with both sides equal to `imgsz`.
+
+    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way up to the full `imgsz`. When running inference on a batch, however, minimal padding only works if all images are of same size. Otherwise, they are uniformly padded to a square shape with both sides equal to `imgsz`.
 
 !!! example
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -397,7 +397,7 @@ Below are code examples for using each source type:
 
 !!! note
 
-    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way up to the full `imgsz`. When running inference on a batch, however, minimal padding only works if all images are of same size. Otherwise, they are uniformly padded to a square shape with both sides equal to `imgsz`.
+    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way to the full `imgsz`. When running inference on a batch of images with different sizes, minimal padding only works if all images have the same dimensions. Otherwise, images are uniformly padded to a square shape with both sides equal to `imgsz`.
 
 !!! example
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -396,7 +396,7 @@ Below are code examples for using each source type:
 `model.predict()` accepts multiple arguments that can be passed at inference time to override defaults:
 
 !!! note
-    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model’s maximum stride, rather than padding it all the way up to the full `imgsz`. When running inference on a batch, however, minimal padding only works if all images are of same size. Otherwise, they are uniformly padded to a square shape with both sides equal to `imgsz`.
+Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model’s maximum stride, rather than padding it all the way up to the full `imgsz`. When running inference on a batch, however, minimal padding only works if all images are of same size. Otherwise, they are uniformly padded to a square shape with both sides equal to `imgsz`.
 
 !!! example
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -396,7 +396,7 @@ Below are code examples for using each source type:
 `model.predict()` accepts multiple arguments that can be passed at inference time to override defaults:
 
 !!! note
-Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model’s maximum stride, rather than padding it all the way up to the full `imgsz`. When running inference on a batch, however, minimal padding only works if all images are of same size. Otherwise, they are uniformly padded to a square shape with both sides equal to `imgsz`.
+Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way up to the full `imgsz`. When running inference on a batch, however, minimal padding only works if all images are of same size. Otherwise, they are uniformly padded to a square shape with both sides equal to `imgsz`.
 
 !!! example
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -395,6 +395,9 @@ Below are code examples for using each source type:
 
 `model.predict()` accepts multiple arguments that can be passed at inference time to override defaults:
 
+!!! note
+    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model’s maximum stride, rather than padding it all the way up to the full `imgsz`. When running inference on a batch, however, minimal padding only works if all images are of same size. Otherwise, they are uniformly padded to a square shape with both sides equal to `imgsz`.
+
 !!! example
 
     ```python

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -397,7 +397,10 @@ Below are code examples for using each source type:
 
 !!! note
 
-    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way to the full `imgsz`. When running inference on a batch of images with different sizes, minimal padding only works if all images have the same dimensions. Otherwise, images are uniformly padded to a square shape with both sides equal to `imgsz`.
+    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way to the full `imgsz`. When running inference on a batch of images, minimal padding only works if all images have the same size. Otherwise, images are uniformly padded to a square shape with both sides equal to `imgsz`.
+
+    - `batch=1`, using `rect` padding by default.
+    - `batch>1`, using `rect` padding only if all the images in one batch have the same size, otherwise using square padding.
 
 !!! example
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -397,10 +397,10 @@ Below are code examples for using each source type:
 
 !!! note
 
-    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way to the full `imgsz`. When running inference on a batch of images, minimal padding only works if all images have the same size. Otherwise, images are uniformly padded to a square shape with both sides equal to `imgsz`.
+    Ultralytics uses minimal padding during inference by default (`rect=True`). In this mode, the shorter side of each image is padded only as much as needed to make it divisible by the model's maximum stride, rather than padding it all the way to the full `imgsz`. When running inference on a batch of images, minimal padding only works if all images have identical size. Otherwise, images are uniformly padded to a square shape with both sides equal to `imgsz`.
 
     - `batch=1`, using `rect` padding by default.
-    - `batch>1`, using `rect` padding only if all the images in one batch have the same size, otherwise using square padding.
+    - `batch>1`, using `rect` padding only if all the images in one batch have identical size, otherwise using square padding to `imgsz`.
 
 !!! example
 


### PR DESCRIPTION
User request to add behavior explanation.

Closes #22259 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Docs update clarifies how YOLO inference pads images by default, especially in batch scenarios, to optimize speed and memory. 🧠⚡

### 📊 Key Changes
- Added a note explaining default minimal padding behavior during inference (`rect=True`).
- Clarified that:
  - For `batch=1`, minimal “rect” padding is used by default.
  - For `batch>1`, “rect” padding is used only if all images in the batch have identical size; otherwise, images are padded to a square with sides equal to `imgsz`.
- Explained that minimal padding pads only to the model’s max stride, not the full `imgsz`.

### 🎯 Purpose & Impact
- Helps users understand why batch inference may switch from minimal “rect” padding to square padding depending on image sizes.
- Improves predictability of performance and memory usage:
  - Consistent image sizes in a batch → faster inference and less padding.
  - Mixed sizes in a batch → automatic square padding for compatibility.
- Encourages better data batching practices for higher throughput and efficiency.
  
Example:
```python
from ultralytics import YOLO

model = YOLO("yolo11n.pt")
# Keep images the same size to retain minimal rect padding in batches
model.predict(source="images/", imgsz=640, batch=8, rect=True)
```