### PR TITLE
Add Documentation Guide for Resuming Training from Checkpoints

### DIFF
--- a/docs/en/guides/index.md
+++ b/docs/en/guides/index.md
@@ -56,6 +56,7 @@ Here's a compilation of in-depth guides to help you master different aspects of 
 - [Best Practices for Model Deployment](model-deployment-practices.md) 🚀 NEW: Walk through tips and best practices for efficiently deploying models in computer vision projects, with a focus on optimization, troubleshooting, and security.
 - [Maintaining Your Computer Vision Model](model-monitoring-and-maintenance.md) 🚀 NEW: Understand the key practices for monitoring, maintaining, and documenting computer vision models to guarantee accuracy, spot anomalies, and mitigate data drift.
 - [Vertex AI Deployment with Docker](vertex-ai-deployment-with-docker.md) 🚀 NEW: Streamlined guide to containerizing YOLO models with Docker and deploying them on Google Cloud Vertex AI—covering build, push, autoscaling, and monitoring.
+- [Resume training](resume-training.md): 🚀 NEW: Resume Training Guide for YOLO models with CLI and Python API examples, best practices, troubleshooting tips, and workflows.
 
 ## Contribute to Our Guides
 

--- a/docs/en/guides/resume-training.md
+++ b/docs/en/guides/resume-training.md
@@ -1,6 +1,6 @@
 # Resume Training from Checkpoints
 
-Training large models can take hours or even days, and interruptions (system restarts, crashes, or early stops) are common. 
+Training large models can take hours or even days, and interruptions (system restarts, crashes, or early stops) are common.
 Ultralytics provides built-in support to **resume training** from a previously saved checkpoint so you don’t have to start over.
 This guide explains how to continue training from the last saved checkpoint using both the **CLI** and **Python API**.
 
@@ -13,6 +13,7 @@ To resume training from the **last checkpoint** in your `runs/` directory:
 ```bash
 yolo detect train resume model=runs/detect/train/weights/last.pt
 ```
+
 Or for segmentation/classification tasks:
 
 ```bash
@@ -46,21 +47,21 @@ model.train(resume=True, epochs=50)
 
 ### Additional Parameters
 
-* `epochs`: Specify how many more epochs to run.
-* `device`: Control GPU/CPU placement if needed.
-* All other training arguments (`batch`, `imgsz`, `data`, etc.) can still be used.
+- `epochs`: Specify how many more epochs to run.
+- `device`: Control GPU/CPU placement if needed.
+- All other training arguments (`batch`, `imgsz`, `data`, etc.) can still be used.
 
 ---
 
 ## 3. Best Practices
 
-* **Save regularly**: Ultralytics automatically saves `last.pt` and `best.pt`.
-* **Use `resume=True`**: This restores optimizer state, learning rate, and scheduler so training continues smoothly.
-* **Monitor logs**: Training will append to the same run folder (e.g., `runs/detect/train`).
+- **Save regularly**: Ultralytics automatically saves `last.pt` and `best.pt`.
+- **Use `resume=True`**: This restores optimizer state, learning rate, and scheduler so training continues smoothly.
+- **Monitor logs**: Training will append to the same run folder (e.g., `runs/detect/train`).
 
 ---
 
-  ## 4. Troubleshooting
+## 4. Troubleshooting
 
 | Problem                                            | Solution                                                                                      |
 | -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
@@ -73,10 +74,10 @@ model.train(resume=True, epochs=50)
 
 ## 5. Related Documentation
 
-* [Checkpoints and Weights](https://github.com/ultralytics/ultralytics/blob/main/docs/en/reference/engine/results.md)
-* [Python API Reference](https://github.com/ultralytics/ultralytics/blob/main/docs/en/reference/engine/model.md)
+- [Checkpoints and Weights](https://github.com/ultralytics/ultralytics/blob/main/docs/en/reference/engine/results.md)
+- [Python API Reference](https://github.com/ultralytics/ultralytics/blob/main/docs/en/reference/engine/model.md)
 
-  ---
+    ***
 
 ## 6. Example Workflow
 

--- a/docs/en/guides/resume-training.md
+++ b/docs/en/guides/resume-training.md
@@ -1,0 +1,96 @@
+# Resume Training from Checkpoints
+
+Training large models can take hours or even days, and interruptions (system restarts, crashes, or early stops) are common. 
+Ultralytics provides built-in support to **resume training** from a previously saved checkpoint so you don’t have to start over.
+This guide explains how to continue training from the last saved checkpoint using both the **CLI** and **Python API**.
+
+---
+
+## 1. Using the CLI
+
+To resume training from the **last checkpoint** in your `runs/` directory:
+
+```bash
+yolo detect train resume model=runs/detect/train/weights/last.pt
+```
+Or for segmentation/classification tasks:
+
+```bash
+yolo segment train resume model=runs/segment/train/weights/last.pt
+yolo classify train resume model=runs/classify/train/weights/last.pt
+```
+
+> **Note:**
+> `last.pt` is automatically saved during training in the `weights/` folder of your run.
+> You can also resume from a specific checkpoint by providing its path:
+
+```bash
+yolo detect train resume model=path/to/custom_checkpoint.pt
+```
+
+---
+
+## 2. Using the Python API
+
+You can also resume training programmatically:
+
+```python
+from ultralytics import YOLO
+
+# Load last checkpoint
+model = YOLO("runs/detect/train/weights/last.pt")
+
+# Resume training for 50 more epochs
+model.train(resume=True, epochs=50)
+```
+
+### Additional Parameters
+
+* `epochs`: Specify how many more epochs to run.
+* `device`: Control GPU/CPU placement if needed.
+* All other training arguments (`batch`, `imgsz`, `data`, etc.) can still be used.
+
+---
+
+## 3. Best Practices
+
+* **Save regularly**: Ultralytics automatically saves `last.pt` and `best.pt`.
+* **Use `resume=True`**: This restores optimizer state, learning rate, and scheduler so training continues smoothly.
+* **Monitor logs**: Training will append to the same run folder (e.g., `runs/detect/train`).
+
+---
+
+  ## 4. Troubleshooting
+
+| Problem                                            | Solution                                                                                      |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Training restarts from epoch 0 instead of resuming | Ensure you pass `resume=True` and point to `last.pt`, not `best.pt`.                          |
+| Checkpoint not found                               | Verify the path: `runs/detect/train/weights/last.pt`.                                         |
+| CUDA out of memory                                 | Resume with a smaller batch size: `model.train(resume=True, batch=8)`.                        |
+| Wrong dataset used                                 | When resuming, the dataset is taken from the checkpoint. Use a new run if switching datasets. |
+
+---
+
+## 5. Related Documentation
+
+* [Checkpoints and Weights](https://github.com/ultralytics/ultralytics/blob/main/docs/en/reference/engine/results.md)
+* [Python API Reference](https://github.com/ultralytics/ultralytics/blob/main/docs/en/reference/engine/model.md)
+
+  ---
+
+## 6. Example Workflow
+
+1. Start training:
+
+```bash
+yolo detect train data=coco128.yaml model=yolov8n.pt epochs=100
+```
+
+2. Interrupt training after 20 epochs (Ctrl+C).
+3. Resume from last checkpoint:
+
+```bash
+yolo detect train resume model=runs/detect/train/weights/last.pt
+```
+
+4. Training continues from epoch 21 → 100 instead of restarting. 🎉


### PR DESCRIPTION
[📊Gap Analysis Document](https://docs.google.com/document/d/1C6hG56KrjrkzvoSMgWfb1bVKWKoGgwLnLRXcUa0uYNI/edit?usp=sharing)

## 🌟Summary

This PR adds a new guide to the documentation that explains how to **resume training from saved checkpoints** in **Ultralytics YOLO**. The guide includes both CLI and Python API examples, troubleshooting advice, and cross-references to related documentation.

## 🙌Problem

Users frequently encounter issues when trying to continue interrupted training runs. Current documentation:

* Mentions checkpoints briefly but does not explain resume workflows.

* Lacks clear CLI and Python examples for resuming training.

* Provides no troubleshooting section (common errors like restarting from epoch 0 or using the wrong checkpoint).

This gap results in recurring GitHub issues and user confusion when training gets interrupted.

## 🛠️Solution

* Added new page:  `/docs/en/guides/resume-training.md`

* Includes:

    * Step-by-step CLI usage examples

    * Python API usage with `resume=True`

    * Best practices and notes (difference between `last.pt` and `best.pt`)

    * Troubleshooting tips for common pitfalls

## ⏱️Before / After

### Before:

* No dedicated documentation for resuming training.

* Users had to guess flags or rely on GitHub discussions.

### After:

* Clear, standalone guide under `/docs/en/guides/resume-training.md.`

* Easy-to-follow CLI + Python examples.

* Troubleshooting table to prevent repeated user questions.

## 🛠️Testing

* Verified that:

    * `yolo detect train resume model=runs/detect/train/weights/last.pt` successfully resumes training.

    * Python API call `model.train(resume=True)` resumes correctly and continues from previous epoch.

    * Examples tested with `yolov8n.pt` on COCO128 dataset.

* Confirmed links to related docs resolve correctly.

## 🎯Impact

* **User benefit**: Saves users from restarting long training runs, reducing frustration and compute waste.

* **Support burden reduction**: Addresses a recurring GitHub issue by providing a clear reference guide.

* **Consistency**: Aligns CLI and Python API workflows with existing style in Ultralytics documentation.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds a new “Resume training” guide that shows how to continue YOLO model training from checkpoints via CLI and Python, with best practices and troubleshooting. 🚀

### 📊 Key Changes
- 🆕 New guide: “Resume Training from Checkpoints” with clear CLI and Python API examples.
- 📚 Indexed in Guides: Added “Resume training” to the main guides page for easy discovery.
- ✅ Best practices: Explains `resume=True`, using `last.pt` vs `best.pt`, and how runs/logs continue.
- 🛠️ Troubleshooting: Covers common issues (wrong checkpoint, epoch reset, OOM, dataset switching).
- 🔗 Helpful links: Points to relevant API references for checkpoints and models.
- 🧪 Example workflow: Start, interrupt, and resume training end-to-end.

### 🎯 Purpose & Impact
- ⏱️ Save time and compute by resuming interrupted trainings instead of restarting from scratch.
- 🧠 Reduce errors by clarifying correct checkpoint usage (`last.pt`) and state restoration (optimizer/LR/scheduler).
- 🧩 Works across tasks (detect/segment/classify) and supports both CLI and Python workflows.
- 🙌 Low risk: Documentation-only change; improves usability and reduces support friction for all users.