### PR TITLE
Fix import typo in `python.md` Docs

### DIFF
--- a/docs/en/usage/python.md
+++ b/docs/en/usage/python.md
@@ -263,7 +263,7 @@ The `YOLO` model class serves as a high-level wrapper for the Trainer classes. E
 !!! tip "Detection Trainer Example"
 
     ```python
-    from ultralytics.models.yolo import DetectionPredictor, DetectionTrainer, DetectionValidator
+    from ultralytics.models.yolo.detect import DetectionPredictor, DetectionTrainer, DetectionValidator
 
     # trainer
     trainer = DetectionTrainer(overrides={})


### PR DESCRIPTION
 I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes a documentation import path so users can correctly import YOLO detection components without errors. ✅

### 📊 Key Changes
- Updated Python usage docs to import detection classes from the correct module:
  - `from ultralytics.models.yolo.detect import DetectionPredictor, DetectionTrainer, DetectionValidator`

### 🎯 Purpose & Impact
- Prevents import errors and confusion when following the docs 🧩
- Aligns examples with the current public API structure 🔧
- Improves onboarding and developer experience with accurate code samples 📘
- No changes to library code or behavior; docs-only fix, low risk ✅

Example (corrected):
```python
from ultralytics.models.yolo.detect import DetectionPredictor, DetectionTrainer, DetectionValidator

trainer = DetectionTrainer(overrides={})
```