### PR TITLE
`ultralytics 8.3.205` Reset checkpoint arguments after training

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.204"
+__version__ = "8.3.205"
 
 import importlib
 import os

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -802,7 +802,7 @@ class Model(torch.nn.Module):
         if RANK in {-1, 0}:
             ckpt = self.trainer.best if self.trainer.best.exists() else self.trainer.last
             self.model, self.ckpt = load_checkpoint(ckpt)
-            self.overrides = self.model.args
+            self.overrides = selt._reset_ckpt_args(self.model.args)
             self.metrics = getattr(self.trainer.validator, "metrics", None)  # TODO: no metrics returned by DDP
         return self.metrics
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -802,7 +802,7 @@ class Model(torch.nn.Module):
         if RANK in {-1, 0}:
             ckpt = self.trainer.best if self.trainer.best.exists() else self.trainer.last
             self.model, self.ckpt = load_checkpoint(ckpt)
-            self.overrides = selt._reset_ckpt_args(self.model.args)
+            self.overrides = self._reset_ckpt_args(self.model.args)
             self.metrics = getattr(self.trainer.validator, "metrics", None)  # TODO: no metrics returned by DDP
         return self.metrics
 


### PR DESCRIPTION
Fixed https://community.ultralytics.com/t/model-val-results-get-saved-in-content-runs-detect-train2-folder/1528

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Version bump to 8.3.205 with a fix that safely resets checkpoint arguments after training, improving reliability when using models post-train. ✅

### 📊 Key Changes
- Bumped package version: `8.3.204` → `8.3.205` 🆙
- In `Model.train()`, replaced `self.overrides = self.model.args` with `self.overrides = self._reset_ckpt_args(self.model.args)` to sanitize/normalize args loaded from the best/last checkpoint 🧹

### 🎯 Purpose & Impact
- Ensures clean, consistent configuration after training by removing or normalizing transient/legacy checkpoint args 🔧
- Reduces edge-case bugs when immediately validating, exporting, or resuming after `train()` in the same process (locally or in Ultralytics HUB) 🔄
- Provides more reliable `model.overrides` and results behavior post-train, preventing stale or conflicting settings from the checkpoint 🛡️
- Backward-compatible; no changes to public APIs or user workflows 🎯