### PR TITLE
Fix duplicate `ignore_init_summary` in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -737,7 +737,6 @@ plugins:
             docstring_options:
               ignore_init_summary: true
             merge_init_into_class: true
-            ignore_init_summary: true
             docstring_style: google
             show_root_heading: true
             show_source: true


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Tiny docs config cleanup: removes a duplicate `ignore_init_summary` setting in `mkdocs.yml` to keep the documentation build tidy. 🧹

### 📊 Key Changes
- Removed a duplicated `ignore_init_summary: true` entry in the `mkdocstrings` configuration of `mkdocs.yml`.

### 🎯 Purpose & Impact
- Prevents potential confusion or warnings from duplicate config keys ✅
- Improves maintainability and clarity of the documentation configuration 🛠️
- No behavioral change expected in the generated docs; builds should remain the same 📚