### PR TITLE
Show `check_requirements` pip install extras example

### DIFF
--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -376,10 +376,10 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         >>> check_requirements("path/to/requirements.txt")
 
         Check a single package
-        >>> check_requirements("ultralytics>=8.0.0")
+        >>> check_requirements("ultralytics>=8.3.200", cmds="--index-url https://download.pytorch.org/whl/cpu")
 
         Check multiple packages
-        >>> check_requirements(["numpy", "ultralytics>=8.0.0"])
+        >>> check_requirements(["numpy", "ultralytics>=8.3.200"])
     """
     prefix = colorstr("red", "bold", "requirements:")
     if isinstance(requirements, Path):  # requirements.txt file


### PR DESCRIPTION
@onuralpszr here is how to use `check_requirements` with extra args :)

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refreshes `check_requirements` usage examples to point to the latest Ultralytics version and demonstrate installing with a custom PyTorch wheel index for smoother setup 🧰✨

### 📊 Key Changes
- Updated docstring examples from `ultralytics>=8.0.0` to `ultralytics>=8.3.200` 📦
- Added an example showing how to pass pip args via `cmds`, e.g. `--index-url https://download.pytorch.org/whl/cpu` for CPU-only installs 🖥️
- Synced multi-package example to the newer version constraint ✅

Example:
```python
# Check a single package with a custom pip index (e.g., CPU-only PyTorch wheels)
check_requirements("ultralytics>=8.3.200", cmds="--index-url https://download.pytorch.org/whl/cpu")

# Check multiple packages
check_requirements(["numpy", "ultralytics>=8.3.200"])
```

### 🎯 Purpose & Impact
- Promotes installing a more current Ultralytics release, reducing compatibility issues and confusion 🎯
- Guides users in constrained environments (e.g., CPU-only) to the correct PyTorch wheel source, improving installation success rates 🧭
- No behavior changes to code—documentation/examples only; safe and non-breaking ✔️