### PR TITLE
Drop deprecated dependabot fields

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       interval: weekly
       time: "04:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - glenn-jocher
     labels:
       - dependencies
 
@@ -22,7 +20,5 @@ updates:
       interval: weekly
       time: "04:00"
     open-pull-requests-limit: 5
-    reviewers:
-      - glenn-jocher
     labels:
-      - dependencies
+      - CI


### PR DESCRIPTION
Just a minor update since the `reviewer` field was deprecated

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refines Dependabot settings to streamline triage: removes default reviewer assignments and clarifies labels by category. 🛠️🧹

### 📊 Key Changes
- Removed automatic Dependabot reviewer assignment of @glenn-jocher.
- Kept `dependencies` label for Python package updates.
- Changed GitHub Actions updates label from `dependencies` to `CI`.
- No changes to schedule or PR limits (Python: weekly, max 10; GitHub Actions: weekly, max 5).

### 🎯 Purpose & Impact
- Reduces reviewer noise and manual load on @glenn-jocher. 🙅‍♂️🔔
- Improves triage by clearly separating CI-related updates from general dependencies. 🏷️
- Makes maintenance workflows cleaner without affecting users or runtime behavior. ✅
- No impact on YOLO11/YOLO26 features, performance, or Ultralytics HUB integrations—CI/config-only change. 🚫🧑‍💻