### PR TITLE
Add `_apply` method to RTDETR for better `device` consistency

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1120,7 +1120,7 @@ class RTDETRDecoder(nn.Module):
             enc_scores (torch.Tensor): Encoded scores.
         """
         bs = feats.shape[0]
-        if self.dynamic or self.shapes != shapes or self.anchors.device != feats.device:
+        if self.dynamic or self.shapes != shapes:
             self.anchors, self.valid_mask = self._generate_anchors(shapes, dtype=feats.dtype, device=feats.device)
             self.shapes = shapes
 

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1120,7 +1120,7 @@ class RTDETRDecoder(nn.Module):
             enc_scores (torch.Tensor): Encoded scores.
         """
         bs = feats.shape[0]
-        if self.dynamic or self.shapes != shapes:
+        if self.dynamic or self.shapes != shapes or self.anchors.device != feats.device:
             self.anchors, self.valid_mask = self._generate_anchors(shapes, dtype=feats.dtype, device=feats.device)
             self.shapes = shapes
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -743,6 +743,22 @@ class RTDETRDetectionModel(DetectionModel):
         """
         super().__init__(cfg=cfg, ch=ch, nc=nc, verbose=verbose)
 
+    def _apply(self, fn):
+        """
+        Apply a function to all tensors in the model that are not parameters or registered buffers.
+
+        Args:
+            fn (function): The function to apply to the model.
+
+        Returns:
+            (RTDETRDetectionModel): An updated BaseModel object.
+        """
+        self = super()._apply(fn)
+        m = self.model[-1]
+        m.anchors = fn(m.anchors)
+        m.valid_mask = fn(m.valid_mask)
+        return self
+
     def init_criterion(self):
         """Initialize the loss criterion for the RTDETRDetectionModel."""
         from ultralytics.models.utils.loss import RTDETRDetectionLoss


### PR DESCRIPTION
Closes #22338 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ensures RT-DETR models correctly move all needed tensors (like anchors and masks) across devices/dtypes when calling `.to()`, `.cuda()`, `.cpu()`, `.half()`, etc. ✅

### 📊 Key Changes
- Added a custom `_apply` method to `RTDETRDetectionModel` in `ultralytics/nn/tasks.py`. 🛠️
- Explicitly applies device/dtype transforms to non-parameter tensors:
  - `m.anchors`
  - `m.valid_mask`
- No API changes; behavior is transparent to users.

### 🎯 Purpose & Impact
- Prevents device/dtype mismatch errors during training and inference with RT-DETR. 🐛➡️✅
- Improves reliability when moving models between CPU/GPU or changing precision (FP32/FP16/BF16). 🚀
- Reduces edge-case bugs in deployments and exports involving RT-DETR heads.
- Users don’t need to change any code—just update and continue using `.to()`, `.half()`, etc. as usual.

Example:
```python
from ultralytics import RTDETR
model = RTDETR('rtdetr-l.pt').half().to('cuda')  # anchors and valid_mask now move correctly
```