### PR TITLE
`ultralytics 8.3.211` Skip non-finite gradients in `optimizer_step()`

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.209"
+__version__ = "8.3.210"
 
 import importlib
 import os

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.210"
+__version__ = "8.3.211"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -671,7 +671,6 @@ class BaseTrainer:
             self.scaler.step(self.optimizer)
         except RuntimeError as e:
             if "finite" in str(e).lower():
-                LOGGER.warning("Non-finite gradients, skipping optimizer updates")
                 self.scaler.update()
                 self.optimizer.zero_grad()
                 return

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -665,8 +665,14 @@ class BaseTrainer:
     def optimizer_step(self):
         """Perform a single step of the training optimizer with gradient clipping and EMA update."""
         self.scaler.unscale_(self.optimizer)  # unscale gradients
-        torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0)  # clip gradients
-        self.scaler.step(self.optimizer)
+        try:
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0, error_if_nonfinite=True)
+            self.scaler.step(self.optimizer)
+        except RuntimeError as e:
+            if "finite" in str(e).lower():
+                LOGGER.warning(f"Non-finite gradients detected, skipping optimizer step")
+            else:
+                raise
         self.scaler.update()
         self.optimizer.zero_grad()
         if self.ema:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -671,6 +671,7 @@ class BaseTrainer:
             self.scaler.step(self.optimizer)
         except RuntimeError as e:
             if "finite" in str(e).lower():
+                LOGGER.warning("Non-finite gradients, skipping optimizer updates")
                 self.scaler.update()
                 self.optimizer.zero_grad()
                 return

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -671,6 +671,9 @@ class BaseTrainer:
         except RuntimeError as e:
             if "finite" in str(e).lower():
                 LOGGER.warning("Non-finite gradients detected, skipping optimizer step")
+                self.scaler.update()
+                self.optimizer.zero_grad()
+                return
             else:
                 raise
         self.scaler.update()

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -44,6 +44,7 @@ from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command
 from ultralytics.utils.files import get_latest_run
 from ultralytics.utils.plotting import plot_results
 from ultralytics.utils.torch_utils import (
+    TORCH_1_9,
     TORCH_2_4,
     EarlyStopping,
     ModelEMA,
@@ -56,7 +57,7 @@ from ultralytics.utils.torch_utils import (
     strip_optimizer,
     torch_distributed_zero_first,
     unset_deterministic,
-    unwrap_model, TORCH_1_9,
+    unwrap_model,
 )
 
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -674,8 +674,7 @@ class BaseTrainer:
                 self.scaler.update()
                 self.optimizer.zero_grad()
                 return
-            else:
-                raise
+            raise
         self.scaler.update()
         self.optimizer.zero_grad()
         if self.ema:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -429,7 +429,7 @@ class BaseTrainer:
                     if ni - last_opt_step >= self.accumulate:
                         self.optimizer_step()
                         last_opt_step = ni
-    
+
                         # Timed stopping
                         if self.args.time:
                             self.stop = (time.time() - self.train_time_start) > (self.args.time * 3600)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -422,8 +422,8 @@ class BaseTrainer:
                     if RANK != -1:
                         self.loss *= self.world_size
                     if not self.loss.isfinite():
-                        LOGGER.warning(f"Non-finite forward pass with loss {self.loss}, skipping batch...")
-                        continue
+                        LOGGER.warning(f"Non-finite forward pass with loss={self.loss}")
+                        # continue
                     self.tloss = self.loss_items if self.tloss is None else (self.tloss * i + self.loss_items) / (i + 1)
 
                 # Backward

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -672,7 +672,7 @@ class BaseTrainer:
             self.scaler.step(self.optimizer)
         except RuntimeError as e:
             if "finite" in str(e).lower():
-                LOGGER.warning("Non-finite gradients detected, skipping optimizer step")
+                LOGGER.warning("Non-finite gradients, skipping optimizer updates")
                 self.scaler.update()
                 self.optimizer.zero_grad()
                 return

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -670,7 +670,7 @@ class BaseTrainer:
             self.scaler.step(self.optimizer)
         except RuntimeError as e:
             if "finite" in str(e).lower():
-                LOGGER.warning(f"Non-finite gradients detected, skipping optimizer step")
+                LOGGER.warning("Non-finite gradients detected, skipping optimizer step")
             else:
                 raise
         self.scaler.update()

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -421,28 +421,26 @@ class BaseTrainer:
                     self.loss = loss.sum()
                     if RANK != -1:
                         self.loss *= self.world_size
-                    if not self.loss.isfinite():
-                        LOGGER.warning(f"Non-finite forward pass with loss={self.loss}")
-                        # continue
                     self.tloss = self.loss_items if self.tloss is None else (self.tloss * i + self.loss_items) / (i + 1)
 
                 # Backward
-                self.scaler.scale(self.loss).backward()
-
-                # Optimize - https://pytorch.org/docs/master/notes/amp_examples.html
-                if ni - last_opt_step >= self.accumulate:
-                    self.optimizer_step()
-                    last_opt_step = ni
-
-                    # Timed stopping
-                    if self.args.time:
-                        self.stop = (time.time() - self.train_time_start) > (self.args.time * 3600)
-                        if RANK != -1:  # if DDP training
-                            broadcast_list = [self.stop if RANK == 0 else None]
-                            dist.broadcast_object_list(broadcast_list, 0)  # broadcast 'stop' to all ranks
-                            self.stop = broadcast_list[0]
-                        if self.stop:  # training time exceeded
-                            break
+                if self.loss.isfinite():
+                    self.scaler.scale(self.loss).backward()
+                    if ni - last_opt_step >= self.accumulate:
+                        self.optimizer_step()
+                        last_opt_step = ni
+    
+                        # Timed stopping
+                        if self.args.time:
+                            self.stop = (time.time() - self.train_time_start) > (self.args.time * 3600)
+                            if RANK != -1:  # if DDP training
+                                broadcast_list = [self.stop if RANK == 0 else None]
+                                dist.broadcast_object_list(broadcast_list, 0)  # broadcast 'stop' to all ranks
+                                self.stop = broadcast_list[0]
+                            if self.stop:  # training time exceeded
+                                break
+                else:
+                    LOGGER.warning(f"Non-finite forward pass (loss={self.loss}), skipping backwards pass...")
 
                 # Log
                 if RANK in {-1, 0}:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -56,7 +56,7 @@ from ultralytics.utils.torch_utils import (
     strip_optimizer,
     torch_distributed_zero_first,
     unset_deterministic,
-    unwrap_model,
+    unwrap_model, TORCH_1_9,
 )
 
 
@@ -666,7 +666,8 @@ class BaseTrainer:
         """Perform a single step of the training optimizer with gradient clipping and EMA update."""
         self.scaler.unscale_(self.optimizer)  # unscale gradients
         try:
-            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0, error_if_nonfinite=True)
+            if TORCH_1_9:
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0, error_if_nonfinite=True)
             self.scaler.step(self.optimizer)
         except RuntimeError as e:
             if "finite" in str(e).lower():


### PR DESCRIPTION
@Laughing-q @prateek-ultralytics @ultralytics/yolo may help prevent nan training losses

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves training stability and error handling by safely skipping non-finite losses/gradients and refining optimizer steps in v8.3.211. 🚀

### 📊 Key Changes
- Version bump to 8.3.211.
- Safer training loop:
  - Only runs backward/optimizer steps if loss is finite; otherwise logs a warning and skips the step.
  - Keeps timed stopping and DDP broadcast, but only after successful optimizer steps.
- More robust optimizer step:
  - Uses gradient clipping with `error_if_nonfinite=True` when supported (PyTorch ≥1.9).
  - Catches non-finite gradient errors, skips the optimizer update, advances the scaler, and clears gradients.
- Added `TORCH_1_9` guard for compatibility across PyTorch versions.

### 🎯 Purpose & Impact
- Better resilience to NaN/Inf issues during training, preventing crashes and corrupted optimizer updates. 🛡️
- Cleaner logs and behavior when numerical instability occurs—problematic batches are skipped safely. 🧹
- Works across multiple PyTorch versions, improving compatibility in diverse environments. 🔧
- No API changes; users may see occasional warnings and slightly longer epochs if many batches are skipped, but overall training should be more reliable for YOLO11/YOLO26 and other models. ✅