### PR TITLE
Optimizer `zero_grad(set_to_none=True)`

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -372,7 +372,7 @@ class BaseTrainer:
             base_idx = (self.epochs - self.args.close_mosaic) * nb
             self.plot_idx.extend([base_idx, base_idx + 1, base_idx + 2])
         epoch = self.start_epoch
-        self.optimizer.zero_grad()  # zero any resumed gradients to ensure stability on train start
+        self.optimizer.zero_grad(set_to_none=True)  # zero any resumed gradients to ensure stability on train start
         while True:
             self.epoch = epoch
             self.run_callbacks("on_train_epoch_start")
@@ -668,7 +668,7 @@ class BaseTrainer:
         torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0)  # clip gradients
         self.scaler.step(self.optimizer)
         self.scaler.update()
-        self.optimizer.zero_grad()
+        self.optimizer.zero_grad(set_to_none=True)
         if self.ema:
             self.ema.update(self.model)
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switches optimizer gradient reset to use `set_to_none=True` for faster, more memory‑efficient training. 🚀

### 📊 Key Changes
- Replaced `optimizer.zero_grad()` with `optimizer.zero_grad(set_to_none=True)`:
  - At the start of training
  - After each optimizer step

### 🎯 Purpose & Impact
- Performance boost: Avoids writing zeros to gradient buffers, reducing overhead and improving speed on large models/batches. ⚡
- Lower memory usage: Frees gradient tensors until needed, helping fit bigger batches or models. 📉
- Same training behavior: No change to loss, metrics, or results; EMA and gradient clipping are unaffected. ✅
- Compatibility note: If custom callbacks/extensions read `param.grad` immediately after `zero_grad()`, it may now be `None` (not a zero tensor). Such code should handle `None` or create grads on demand. 🧠

For more details on this PyTorch option, see the PyTorch docs on zero_grad with set_to_none.