### PR TITLE
`ultralytics 8.3.213` NaN epoch recovery

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,11 +78,12 @@ jobs:
             platforms: "linux/arm64"
             runs_on: "ubuntu-24.04-arm"
             derivatives: ""
-          - dockerfile: "Dockerfile-jetson-jetpack5"
-            tags: "latest-jetson-jetpack5"
-            platforms: "linux/arm64"
-            runs_on: "ubuntu-24.04-arm"
-            derivatives: ""
+          # Disabled due to NaN training errors in https://github.com/ultralytics/ultralytics/pull/22352
+          # - dockerfile: "Dockerfile-jetson-jetpack5"
+          #   tags: "latest-jetson-jetpack5"
+          #   platforms: "linux/arm64"
+          #   runs_on: "ubuntu-24.04-arm"
+          #   derivatives: ""
           - dockerfile: "Dockerfile-jetson-jetpack4"
             tags: "latest-jetson-jetpack4"
             platforms: "linux/arm64"
@@ -91,7 +92,7 @@ jobs:
           # - dockerfile: "Dockerfile-conda"
           #   tags: "latest-conda"
           #   platforms: "linux/amd64"
-          #   derivatives: []
+          #   derivatives: ""
 
     runs-on: ${{ matrix.runs_on }}
     outputs:

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -32,7 +32,7 @@ from ultralytics.utils import (
     YAML,
     checks,
     is_dir_writeable,
-    is_github_action_running,
+    is_github_action_running, IS_JETSON, IS_RASPBERRYPI,
 )
 from ultralytics.utils.downloads import download
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
@@ -217,6 +217,7 @@ def test_val(task: str, weight: str, data: str) -> None:
         metrics.confusion_matrix.to_json()
 
 
+@pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
 def test_train_scratch():
     """Test training the YOLO model from scratch using the provided configuration."""
     model = YOLO(CFG)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -23,6 +23,8 @@ from ultralytics.utils import (
     ASSETS_URL,
     DEFAULT_CFG,
     DEFAULT_CFG_PATH,
+    IS_JETSON,
+    IS_RASPBERRYPI,
     LINUX,
     LOGGER,
     ONLINE,
@@ -32,7 +34,7 @@ from ultralytics.utils import (
     YAML,
     checks,
     is_dir_writeable,
-    is_github_action_running, IS_JETSON, IS_RASPBERRYPI,
+    is_github_action_running,
 )
 from ultralytics.utils.downloads import download
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.212"
+__version__ = "8.3.213"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -488,7 +488,9 @@ class BaseTrainer:
                 self.nan_recovery_attempts += 1
                 if self.nan_recovery_attempts > 3:
                     raise RuntimeError(f"Training failed: corruption persisted for {self.nan_recovery_attempts} epochs")
-                LOGGER.warning(f"Corruption detected (attempt {self.nan_recovery_attempts}/3), recovering from checkpoint...")
+                LOGGER.warning(
+                    f"Corruption detected (attempt {self.nan_recovery_attempts}/3), recovering from checkpoint..."
+                )
                 if epoch == self.start_epoch or not self.last.exists():
                     raise RuntimeError(f"Cannot recover: no valid checkpoint at epoch {epoch}")
                 ckpt = load_checkpoint(self.last)[0]

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -496,6 +496,7 @@ class BaseTrainer:
                     unwrap_model(self.ema.ema).load_state_dict(ema_state)
                 unwrap_model(self.model).load_state_dict(ema_state)
                 self._load_checkpoint_state(ckpt)
+                del ckpt, ema_state  # free memory
                 self.scheduler.last_epoch = epoch - 1
                 continue
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -426,7 +426,7 @@ class BaseTrainer:
 
                     # NaN detection and recovery
                     if torch.isnan(self.tloss).any():
-                        LOGGER.warning(f"NaN loss detected, attempting recovery from last checkpoint...")
+                        LOGGER.warning("NaN loss detected, attempting recovery from last checkpoint...")
                         if not self.last.exists():
                             raise RuntimeError(f"Cannot recover from NaN: checkpoint {self.last} not found")
                         ckpt = load_checkpoint(self.last)[0]

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -761,6 +761,8 @@ class BaseTrainer:
         n = len(metrics) + 2  # number of cols
         s = "" if self.csv.exists() else (("%s," * n % tuple(["epoch", "time"] + keys)).rstrip(",") + "\n")  # header
         t = time.time() - self.train_time_start
+        if not self.csv.parent.exists():  # user may accidentally delete save_dir
+            self.csv.parent.mkdir()
         with open(self.csv, "a", encoding="utf-8") as f:
             f.write(s + ("%.6g," * n % tuple([self.epoch + 1, t] + vals)).rstrip(",") + "\n")
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -761,7 +761,7 @@ class BaseTrainer:
         n = len(metrics) + 2  # number of cols
         s = "" if self.csv.exists() else (("%s," * n % tuple(["epoch", "time"] + keys)).rstrip(",") + "\n")  # header
         t = time.time() - self.train_time_start
-        if not self.csv.parent.exists():  # user may accidentally delete save_dir
+        if not self.csv.parent.is_dir():  # user may accidentally delete save_dir
             self.csv.parent.mkdir()
         with open(self.csv, "a", encoding="utf-8") as f:
             f.write(s + ("%.6g," * n % tuple([self.epoch + 1, t] + vals)).rstrip(",") + "\n")

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -828,10 +828,9 @@ class BaseTrainer:
         """Detect and recover from NaN/Inf loss or fitness collapse by loading last checkpoint."""
         loss_nan = self.tloss is not None and not torch.isfinite(self.tloss).all()
         fitness_nan = self.fitness is not None and not np.isfinite(self.fitness)
-        fitness_collapse = (
-            self.fitness is not None and self.best_fitness and self.best_fitness > 0 and self.fitness == 0
-        )
+        fitness_collapse = self.best_fitness and self.best_fitness > 0 and self.fitness == 0
         corrupted = RANK in {-1, 0} and (loss_nan or fitness_nan or fitness_collapse)
+        reason = "Loss NaN/Inf" if loss_nan else "Fitness NaN/Inf" if fitness_nan else "Fitness collapse"
         if RANK != -1:  # DDP: broadcast to all ranks
             broadcast_list = [corrupted if RANK == 0 else None]
             dist.broadcast_object_list(broadcast_list, 0)
@@ -844,7 +843,6 @@ class BaseTrainer:
         self.nan_recovery_attempts += 1
         if self.nan_recovery_attempts > 3:
             raise RuntimeError(f"Training failed: NaN persisted for {self.nan_recovery_attempts} epochs")
-        reason = "Loss NaN/Inf" if loss_nan else "Fitness NaN/Inf" if fitness_nan else "Fitness collapse"
         LOGGER.warning(f"{reason} detected (attempt {self.nan_recovery_attempts}/3), recovering from last.pt...")
         ckpt = load_checkpoint(self.last)[0]
         ema_state = ckpt["ema"].float().state_dict()

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -838,7 +838,7 @@ class BaseTrainer:
         if not corrupted:
             return False
         if epoch == self.start_epoch or not self.last.exists():
-            LOGGER.warning("Training corrupted but can not recover from last.pt...")
+            LOGGER.warning(f"{reason} detected but can not recover from last.pt...")
             return False  # Cannot recover on first epoch, let training continue
         self.nan_recovery_attempts += 1
         if self.nan_recovery_attempts > 3:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -844,7 +844,7 @@ class BaseTrainer:
         if self.nan_recovery_attempts > 3:
             raise RuntimeError(f"Training failed: NaN persisted for {self.nan_recovery_attempts} epochs")
         LOGGER.warning(f"{reason} detected (attempt {self.nan_recovery_attempts}/3), recovering from last.pt...")
-        ckpt = load_checkpoint(self.last)[0]
+        _, ckpt = load_checkpoint(self.last)
         ema_state = ckpt["ema"].float().state_dict()
         if not all(torch.isfinite(v).all() for v in ema_state.values() if isinstance(v, torch.Tensor)):
             raise RuntimeError(f"Checkpoint {self.last} is corrupted with NaN/Inf weights")

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -473,7 +473,9 @@ class BaseTrainer:
             # NaN recovery
             loss_nan = self.tloss is not None and not torch.isfinite(self.tloss).all()
             fitness_nan = self.fitness is not None and not np.isfinite(self.fitness)
-            fitness_collapse = self.fitness is not None and self.best_fitness and self.best_fitness > 0 and self.fitness == 0
+            fitness_collapse = (
+                self.fitness is not None and self.best_fitness and self.best_fitness > 0 and self.fitness == 0
+            )
             if self._handle_nan_recovery(epoch, loss_nan, fitness_nan, fitness_collapse):
                 continue
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -839,7 +839,7 @@ class BaseTrainer:
         if not corrupted:
             return False
         if epoch == self.start_epoch or not self.last.exists():
-            LOGGER.warning(f"Training corrupted but can not recover from last.pt...")
+            LOGGER.warning("Training corrupted but can not recover from last.pt...")
             return False  # Cannot recover on first epoch, let training continue
         self.nan_recovery_attempts += 1
         if self.nan_recovery_attempts > 3:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -828,7 +828,9 @@ class BaseTrainer:
         """Detect and recover from NaN/Inf loss or fitness collapse by loading last checkpoint."""
         loss_nan = self.tloss is not None and not torch.isfinite(self.tloss).all()
         fitness_nan = self.fitness is not None and not np.isfinite(self.fitness)
-        fitness_collapse = self.fitness is not None and self.best_fitness and self.best_fitness > 0 and self.fitness == 0
+        fitness_collapse = (
+            self.fitness is not None and self.best_fitness and self.best_fitness > 0 and self.fitness == 0
+        )
         corrupted = RANK in {-1, 0} and (loss_nan or fitness_nan or fitness_collapse)
         if RANK != -1:  # DDP: broadcast to all ranks
             broadcast_list = [corrupted if RANK == 0 else None]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Automatic NaN/Inf recovery added to training, Jetson JetPack 5 Docker build temporarily disabled, tests updated, and version bumped to 8.3.213. 🚑🛡️

### 📊 Key Changes
- Trainer robustness
  - Added automatic detection and recovery for NaN/Inf loss or fitness collapse during training by restoring from the last checkpoint (EMA weights, optimizer, scaler, best fitness).
  - Limits recovery to 3 attempts per run, with clear warnings and safe fallback behavior.
  - Introduced `nan_recovery_attempts` and factored checkpoint loading into `_load_checkpoint_state`.
  - DDP-aware: recovery state is broadcast across ranks.
- Tests
  - New `test_nan_recovery` injects NaN during training to validate recovery flow.
  - Skips train-from-scratch test on Jetson and Raspberry Pi (`@pytest.mark.skipif`) to avoid edge-device training.
- CI/CD
  - Disabled Docker image build for Jetson JetPack 5 due to NaN training errors (see PR reference) while keeping JetPack 4 active.
- Version
  - Bumped to `8.3.213`.

### 🎯 Purpose & Impact
- Improved stability: Training auto-recovers from transient numerical issues without manual intervention, reducing failed runs and saving time. 🧩
- Better multi-GPU reliability: Ensures consistent recovery in DDP setups via rank broadcast. 🔗
- Safer checkpoints: Validates checkpoint tensors for NaN/Inf before restoring; fails fast with clear errors if corrupted. 🔒
- Clearer resume behavior: Centralized checkpoint state loading improves maintainability and reduces resume edge cases.
- CI reliability: Disabling JetPack 5 images avoids shipping unstable builds while the root cause is addressed (see details in the related PR). 🧪

Note: Recovery won’t trigger on the first epoch or if no `last.pt` exists; after 3 failed recovery attempts, training stops with an error.

Quick tip: Update to the latest version to benefit:
`pip install -U ultralytics`

Related reference: NaN issue context in [PR discussing Jetson JetPack 5 NaNs](https://github.com/ultralytics/ultralytics/pull/22352).