### PR TITLE
Use `ASSETS_URL` in tests

### DIFF
--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -129,26 +129,23 @@ def test_faster_coco_eval():
     from ultralytics.models.yolo.pose import PoseValidator
     from ultralytics.models.yolo.segment import SegmentationValidator
 
-    # Download annotations after each dataset downloads first
-    url = "https://github.com/ultralytics/assets/releases/download/v0.0.0/"
-
     args = {"model": "yolo11n.pt", "data": "coco8.yaml", "save_json": True, "imgsz": 64}
     validator = DetectionValidator(args=args)
     validator()
     validator.is_coco = True
-    download(f"{url}instances_val2017.json", dir=DATASETS_DIR / "coco8/annotations")
+    download(f"{ASSETS_URL}/instances_val2017.json", dir=DATASETS_DIR / "coco8/annotations")
     _ = validator.eval_json(validator.stats)
 
     args = {"model": "yolo11n-seg.pt", "data": "coco8-seg.yaml", "save_json": True, "imgsz": 64}
     validator = SegmentationValidator(args=args)
     validator()
     validator.is_coco = True
-    download(f"{url}instances_val2017.json", dir=DATASETS_DIR / "coco8-seg/annotations")
+    download(f"{ASSETS_URL}/instances_val2017.json", dir=DATASETS_DIR / "coco8-seg/annotations")
     _ = validator.eval_json(validator.stats)
 
     args = {"model": "yolo11n-pose.pt", "data": "coco8-pose.yaml", "save_json": True, "imgsz": 64}
     validator = PoseValidator(args=args)
     validator()
     validator.is_coco = True
-    download(f"{url}person_keypoints_val2017.json", dir=DATASETS_DIR / "coco8-pose/annotations")
+    download(f"{ASSETS_URL}/person_keypoints_val2017.json", dir=DATASETS_DIR / "coco8-pose/annotations")
     _ = validator.eval_json(validator.stats)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests import MODEL, SOURCE, TMP
 from ultralytics import YOLO, download
-from ultralytics.utils import DATASETS_DIR, SETTINGS
+from ultralytics.utils import ASSETS_URL, DATASETS_DIR, SETTINGS
 from ultralytics.utils.checks import check_requirements
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -126,9 +126,7 @@ def test_predict_img(model_name):
     batch = [
         str(SOURCE),  # filename
         Path(SOURCE),  # Path
-        f"{ASSETS_URL}/zidane.jpg?token=123"
-        if ONLINE
-        else SOURCE,  # URI
+        f"{ASSETS_URL}/zidane.jpg?token=123" if ONLINE else SOURCE,  # URI
         im,  # OpenCV
         Image.open(SOURCE),  # PIL
         np.zeros((320, 640, channels), dtype=np.uint8),  # numpy

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -32,6 +32,7 @@ from ultralytics.utils import (
     checks,
     is_dir_writeable,
     is_github_action_running,
+    ASSETS_URL
 )
 from ultralytics.utils.downloads import download
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
@@ -125,7 +126,7 @@ def test_predict_img(model_name):
     batch = [
         str(SOURCE),  # filename
         Path(SOURCE),  # Path
-        "https://github.com/ultralytics/assets/releases/download/v0.0.0/zidane.jpg?token=123"
+        f"{ASSETS_URL}/zidane.jpg?token=123"
         if ONLINE
         else SOURCE,  # URI
         im,  # OpenCV
@@ -190,7 +191,7 @@ def test_track_stream(model):
     """
     if model == "yolo11n-cls.pt":  # classification model not supported for tracking
         return
-    video_url = "https://github.com/ultralytics/assets/releases/download/v0.0.0/decelera_portrait_min.mov"
+    video_url = f"{ASSETS_URL}/decelera_portrait_min.mov"
     model = YOLO(model)
     model.track(video_url, imgsz=160, tracker="bytetrack.yaml")
     model.track(video_url, imgsz=160, tracker="botsort.yaml", save_frames=True)  # test frame saving also
@@ -229,9 +230,7 @@ def test_train_scratch():
 def test_train_ndjson():
     """Test training the YOLO model using NDJSON format dataset."""
     model = YOLO(WEIGHTS_DIR / "yolo11n.pt")
-    model.train(
-        data="https://github.com/ultralytics/assets/releases/download/v0.0.0/coco8-ndjson.ndjson", epochs=1, imgsz=32
-    )
+    model.train(data=f"{ASSETS_URL}/coco8-ndjson.ndjson", epochs=1, imgsz=32)
 
 
 @pytest.mark.parametrize("scls", [False, True])
@@ -290,8 +289,8 @@ def test_predict_callback_and_setup():
 @pytest.mark.parametrize("model", MODELS)
 def test_results(model: str):
     """Test YOLO model results processing and output in various formats."""
-    temp_s = "https://ultralytics.com/images/boats.jpg" if model == "yolo11n-obb.pt" else SOURCE
-    results = YOLO(WEIGHTS_DIR / model)([temp_s, temp_s], imgsz=160)
+    im = f"{ASSETS_URL}/boats.jpg" if model == "yolo11n-obb.pt" else SOURCE
+    results = YOLO(WEIGHTS_DIR / model)([im, im], imgsz=160)
     for r in results:
         assert len(r), f"'{model}' results should not be empty!"
         r = r.cpu().numpy()
@@ -358,7 +357,7 @@ def test_data_converter():
     from ultralytics.data.converter import coco80_to_coco91_class, convert_coco
 
     file = "instances_val2017.json"
-    download(f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{file}", dir=TMP)
+    download(f"{ASSETS_URL}/{file}", dir=TMP)
     convert_coco(labels_dir=TMP, save_dir=TMP / "yolo_labels", use_segments=True, use_keypoints=False, cls91to80=True)
     coco80_to_coco91_class()
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -356,8 +356,7 @@ def test_data_converter():
     """Test dataset conversion functions from COCO to YOLO format and class mappings."""
     from ultralytics.data.converter import coco80_to_coco91_class, convert_coco
 
-    file = "instances_val2017.json"
-    download(f"{ASSETS_URL}/{file}", dir=TMP)
+    download(f"{ASSETS_URL}/instances_val2017.json", dir=TMP)
     convert_coco(labels_dir=TMP, save_dir=TMP / "yolo_labels", use_segments=True, use_keypoints=False, cls91to80=True)
     coco80_to_coco91_class()
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -20,6 +20,7 @@ from ultralytics.data.utils import check_det_dataset
 from ultralytics.utils import (
     ARM64,
     ASSETS,
+    ASSETS_URL,
     DEFAULT_CFG,
     DEFAULT_CFG_PATH,
     LINUX,
@@ -32,7 +33,6 @@ from ultralytics.utils import (
     checks,
     is_dir_writeable,
     is_github_action_running,
-    ASSETS_URL
 )
 from ultralytics.utils.downloads import download
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -14,7 +14,7 @@ import cv2
 import numpy as np
 from PIL import Image
 
-from ultralytics.utils import DATASETS_DIR, LOGGER, NUM_THREADS, TQDM, YAML
+from ultralytics.utils import DATASETS_DIR, LOGGER, NUM_THREADS, TQDM, YAML, ASSETS_URL
 from ultralytics.utils.checks import check_file, check_requirements
 from ultralytics.utils.downloads import download, zip_directory
 from ultralytics.utils.files import increment_path
@@ -678,9 +678,7 @@ def create_synthetic_coco_dataset():
 
     # Download labels
     dir = DATASETS_DIR / "coco"
-    url = "https://github.com/ultralytics/assets/releases/download/v0.0.0/"
-    label_zip = "coco2017labels-segments.zip"
-    download([url + label_zip], dir=dir.parent)
+    download([f"{ASSETS_URL}/coco2017labels-segments.zip"], dir=dir.parent)
 
     # Create synthetic images
     shutil.rmtree(dir / "labels" / "test2017", ignore_errors=True)  # Remove test2017 directory as not needed

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -14,7 +14,7 @@ import cv2
 import numpy as np
 from PIL import Image
 
-from ultralytics.utils import DATASETS_DIR, LOGGER, NUM_THREADS, TQDM, YAML, ASSETS_URL
+from ultralytics.utils import ASSETS_URL, DATASETS_DIR, LOGGER, NUM_THREADS, TQDM, YAML
 from ultralytics.utils.checks import check_file, check_requirements
 from ultralytics.utils.downloads import download, zip_directory
 from ultralytics.utils.files import increment_path

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -19,6 +19,7 @@ from PIL import Image, ImageOps
 
 from ultralytics.nn.autobackend import check_class_names
 from ultralytics.utils import (
+    ASSETS_URL,
     DATASETS_DIR,
     LOGGER,
     NUM_THREADS,
@@ -30,7 +31,6 @@ from ultralytics.utils import (
     colorstr,
     emojis,
     is_dir_writeable,
-    ASSETS_URL,
 )
 from ultralytics.utils.checks import check_file, check_font, is_ascii
 from ultralytics.utils.downloads import download, safe_download, unzip_file

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -30,6 +30,7 @@ from ultralytics.utils import (
     colorstr,
     emojis,
     is_dir_writeable,
+    ASSETS_URL,
 )
 from ultralytics.utils.checks import check_file, check_font, is_ascii
 from ultralytics.utils.downloads import download, safe_download, unzip_file
@@ -523,8 +524,7 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
         if str(dataset) == "imagenet":
             subprocess.run(["bash", str(ROOT / "data/scripts/get_imagenet.sh")], check=True)
         else:
-            url = f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{dataset}.zip"
-            download(url, dir=data_dir.parent)
+            download(f"{ASSETS_URL}/{dataset}.zip", dir=data_dir.parent)
         LOGGER.info(f"Dataset download success ✅ ({time.time() - t:.1f}s), saved to {colorstr('bold', data_dir)}\n")
     train_set = data_dir / "train"
     if not train_set.is_dir():

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -421,7 +421,7 @@ class BaseTrainer:
                     if RANK != -1:
                         self.loss *= self.world_size
                     if not self.loss.isfinite():
-                        LOGGER.warning("Non-finite forward pass, skipping batch...")
+                        LOGGER.warning(f"Non-finite forward pass with loss {self.loss}, skipping batch...")
                         continue
                     self.tloss = self.loss_items if self.tloss is None else (self.tloss * i + self.loss_items) / (i + 1)
 

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -43,7 +43,7 @@ import torch.cuda
 from ultralytics import YOLO, YOLOWorld
 from ultralytics.cfg import TASK2DATA, TASK2METRIC
 from ultralytics.engine.exporter import export_formats
-from ultralytics.utils import ARM64, ASSETS, IS_JETSON, LINUX, LOGGER, MACOS, TQDM, WEIGHTS_DIR, YAML, ASSETS_URL
+from ultralytics.utils import ARM64, ASSETS, ASSETS_URL, IS_JETSON, LINUX, LOGGER, MACOS, TQDM, WEIGHTS_DIR, YAML
 from ultralytics.utils.checks import IS_PYTHON_3_13, check_imgsz, check_requirements, check_yolo, is_rockchip
 from ultralytics.utils.downloads import safe_download
 from ultralytics.utils.files import file_size

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -43,7 +43,7 @@ import torch.cuda
 from ultralytics import YOLO, YOLOWorld
 from ultralytics.cfg import TASK2DATA, TASK2METRIC
 from ultralytics.engine.exporter import export_formats
-from ultralytics.utils import ARM64, ASSETS, IS_JETSON, LINUX, LOGGER, MACOS, TQDM, WEIGHTS_DIR, YAML
+from ultralytics.utils import ARM64, ASSETS, IS_JETSON, LINUX, LOGGER, MACOS, TQDM, WEIGHTS_DIR, YAML, ASSETS_URL
 from ultralytics.utils.checks import IS_PYTHON_3_13, check_imgsz, check_requirements, check_yolo, is_rockchip
 from ultralytics.utils.downloads import safe_download
 from ultralytics.utils.files import file_size
@@ -281,7 +281,7 @@ class RF100Benchmark:
         (shutil.rmtree("rf-100"), os.mkdir("rf-100")) if os.path.exists("rf-100") else os.mkdir("rf-100")
         os.chdir("rf-100")
         os.mkdir("ultralytics-benchmarks")
-        safe_download("https://github.com/ultralytics/assets/releases/download/v0.0.0/datasets_links.txt")
+        safe_download(f"{ASSETS_URL}/datasets_links.txt")
 
         with open(ds_link_txt, encoding="utf-8") as file:
             for line in file:

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -23,6 +23,7 @@ import torch
 from ultralytics.utils import (
     ARM64,
     ASSETS,
+    ASSETS_URL,
     AUTOINSTALL,
     GIT,
     IS_COLAB,
@@ -47,7 +48,7 @@ from ultralytics.utils import (
     colorstr,
     downloads,
     is_github_action_running,
-    url2file, ASSETS_URL,
+    url2file,
 )
 
 

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -47,7 +47,7 @@ from ultralytics.utils import (
     colorstr,
     downloads,
     is_github_action_running,
-    url2file,
+    url2file, ASSETS_URL,
 )
 
 
@@ -336,7 +336,7 @@ def check_font(font="Arial.ttf"):
         return matches[0]
 
     # Download to USER_CONFIG_DIR if missing
-    url = f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{name}"
+    url = f"{ASSETS_URL}/{name}"
     if downloads.is_url(url, check=True):
         downloads.safe_download(url=url, file=file)
         return file

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -60,10 +60,11 @@ def is_url(url: str | Path, check: bool = False) -> bool:
     try:
         url = str(url)
         result = parse.urlparse(url)
-        assert all([result.scheme, result.netloc])  # check if is url
+        if not (result.scheme and result.netloc):
+            return False
         if check:
-            with request.urlopen(url) as response:
-                return response.getcode() == 200  # check if exists online
+            r = request.urlopen(request.Request(url, method='HEAD'), timeout=3)
+            return 200 <= r.getcode() < 400
         return True
     except Exception:
         return False

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -10,7 +10,7 @@ from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from urllib import parse, request
 
-from ultralytics.utils import LOGGER, TQDM, checks, clean_url, emojis, is_online, url2file, ASSETS_URL
+from ultralytics.utils import ASSETS_URL, LOGGER, TQDM, checks, clean_url, emojis, is_online, url2file
 
 # Define Ultralytics GitHub assets maintained at https://github.com/ultralytics/assets
 GITHUB_ASSETS_REPO = "ultralytics/assets"

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -10,7 +10,7 @@ from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from urllib import parse, request
 
-from ultralytics.utils import LOGGER, TQDM, checks, clean_url, emojis, is_online, url2file
+from ultralytics.utils import LOGGER, TQDM, checks, clean_url, emojis, is_online, url2file, ASSETS_URL
 
 # Define Ultralytics GitHub assets maintained at https://github.com/ultralytics/assets
 GITHUB_ASSETS_REPO = "ultralytics/assets"
@@ -323,10 +323,7 @@ def safe_download(
     if "://" not in str(url) and Path(url).is_file():  # URL exists ('://' check required in Windows Python<3.10)
         f = Path(url)  # filename
     elif not f.is_file():  # URL and file do not exist
-        uri = (url if gdrive else clean_url(url)).replace(  # cleaned and aliased url
-            "https://github.com/ultralytics/assets/releases/download/v0.0.0/",
-            "https://ultralytics.com/assets/",  # assets alias
-        )
+        uri = (url if gdrive else clean_url(url)).replace(ASSETS_URL, "https://ultralytics.com/assets")  # clean
         desc = f"Downloading {uri} to '{f}'"
         f.parent.mkdir(parents=True, exist_ok=True)  # make directory if missing
         curl_installed = shutil.which("curl")

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -63,7 +63,7 @@ def is_url(url: str | Path, check: bool = False) -> bool:
         if not (result.scheme and result.netloc):
             return False
         if check:
-            r = request.urlopen(request.Request(url, method='HEAD'), timeout=3)
+            r = request.urlopen(request.Request(url, method="HEAD"), timeout=3)
             return 200 <= r.getcode() < 400
         return True
     except Exception:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Consolidates all asset downloads to a single ASSETS_URL constant and improves network robustness and logging across the codebase. 🚀

### 📊 Key Changes
- Replaced hardcoded GitHub asset URLs with the ASSETS_URL constant across tests and utilities:
  - tests: integrations, python IO, tracking, NDJSON training, results, converters ✅
  - data: converter and classification dataset utilities
  - utils: benchmarks, checks (font download), downloads logic
- Improved downloads.is_url:
  - Returns False instead of asserting on invalid URLs
  - Uses a fast HEAD request with a short timeout for existence checks
- safe_download now cleans/aliases URLs using ASSETS_URL, simplifying host switching
- Trainer log enhancement: includes the actual loss value when skipping non-finite batches

### 🎯 Purpose & Impact
- Consistency and maintainability:
  - Centralizes asset host management for easy future updates or CDN/mirror switches 🔗
  - Reduces duplication and risk of outdated links in tests and utilities
- Reliability and performance:
  - Faster, more reliable URL existence checks with HEAD requests ⚡
  - Clearer, more informative training logs to aid debugging (non-finite loss message includes loss value) 🧠
- User-facing impact:
  - Smoother downloads across commands like training, tracking, and dataset conversion
  - Minimal behavior change; mostly internal improvements with better resiliency and diagnostics

Example (conceptual):
```python
from ultralytics.utils import ASSETS_URL
# Previously hardcoded URL -> now derived from ASSETS_URL
url = f"{ASSETS_URL}/coco8-ndjson.ndjson"
```