### PR TITLE
Revert optimizer_step() nan error changes

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -44,7 +44,6 @@ from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command
 from ultralytics.utils.files import get_latest_run
 from ultralytics.utils.plotting import plot_results
 from ultralytics.utils.torch_utils import (
-    TORCH_1_9,
     TORCH_2_4,
     EarlyStopping,
     ModelEMA,

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -665,17 +665,8 @@ class BaseTrainer:
     def optimizer_step(self):
         """Perform a single step of the training optimizer with gradient clipping and EMA update."""
         self.scaler.unscale_(self.optimizer)  # unscale gradients
-        try:
-            if TORCH_1_9:
-                torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0, error_if_nonfinite=True)
-            self.scaler.step(self.optimizer)
-        except RuntimeError as e:
-            if "finite" in str(e).lower():
-                LOGGER.warning("Non-finite gradients, skipping optimizer updates")
-                self.scaler.update()
-                self.optimizer.zero_grad()
-                return
-            raise
+        torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=10.0)
+        self.scaler.step(self.optimizer)
         self.scaler.update()
         self.optimizer.zero_grad()
         if self.ema:


### PR DESCRIPTION
@Laughing-q

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplifies the training optimizer step by removing legacy PyTorch 1.9 handling and unifying gradient clipping and scaler behavior ⚙️

### 📊 Key Changes
- Removed `TORCH_1_9` import and version-specific branches in `trainer.py`.
- Always apply gradient clipping with `torch.nn.utils.clip_grad_norm_(..., max_norm=10.0)`.
- Removed try/except around optimizer stepping; now directly calls `self.scaler.step(self.optimizer)` and `self.scaler.update()`.
- Relies on PyTorch GradScaler’s built-in handling for non-finite gradients instead of custom warnings.

### 🎯 Purpose & Impact
- Streamlines and modernizes the training loop, focusing on PyTorch 2.x (notably 2.4+) ✅
- Reduces complexity and maintenance overhead by removing legacy code 🧹
- Keeps training stability intact; GradScaler still skips optimizer steps when encountering NaNs/Infs, but without the previous custom warning ⚠️
- Produces cleaner logs and may offer minor performance benefits due to fewer conditional checks 🚀
- Note: Implicitly de-emphasizes compatibility with very old PyTorch versions (e.g., 1.9).