### PR TITLE
Reset `results.csv` if not resuming

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -170,6 +170,8 @@ class BaseTrainer:
         self.tloss = None
         self.loss_names = ["Loss"]
         self.csv = self.save_dir / "results.csv"
+        if self.csv.exists() and not self.args.resume:
+            self.csv.unlink()
         self.plot_idx = [0, 1, 2]
         self.nan_recovery_attempts = 0
 


### PR DESCRIPTION
Training keeps appending to same `results.csv` when using `exist_ok=True` because old CSV is never removed.

```
epoch,time,train/box_loss,train/cls_loss,train/dfl_loss,metrics/precision(B),metrics/recall(B),metrics/mAP50(B),metrics/mAP50-95(B),val/box_loss,val/cls_loss,val/dfl_loss,lr/pg0,lr/pg1,lr/pg2
1,24.4814,1.22343,1.56148,1.27994,0.72719,0.58196,0.68009,0.51252,1.05834,1.00741,1.10736,8.33e-06,8.33e-06,8.33e-06
2,26.508,1.18872,1.32958,1.23583,0.70084,0.60727,0.68555,0.5166,1.05199,0.98603,1.10275,1.43157e-05,1.43157e-05,1.43157e-05
3,28.4326,1.15575,1.32238,1.22283,0.70769,0.60483,0.69072,0.52163,1.0503,0.97382,1.10158,1.65315e-05,1.65315e-05,1.65315e-05
4,30.4725,1.18616,1.28988,1.21827,0.70682,0.61166,0.69807,0.52526,1.04738,0.96461,1.09685,1.49773e-05,1.49773e-05,1.49773e-05
5,32.7332,1.19492,1.30334,1.23305,0.69145,0.61752,0.69987,0.52802,1.04626,0.95739,1.09592,9.65328e-06,9.65328e-06,9.65328e-06
1,24.6425,1.04755,2.94362,1.20039,0.7043,0.59105,0.6802,0.51512,0.93879,2.39172,1.07615,8.33e-06,8.33e-06,8.33e-06
2,26.8075,1.02129,2.74427,1.17834,0.70227,0.60395,0.68008,0.51752,0.93474,2.31812,1.07553,1.43157e-05,1.43157e-05,1.43157e-05
3,28.8631,1.01279,2.54344,1.18615,0.70518,0.61041,0.68331,0.51646,0.93354,2.24649,1.07601,1.65315e-05,1.65315e-05,1.65315e-05
4,30.868,1.04328,2.41115,1.18206,0.72547,0.60665,0.68856,0.51738,0.93258,2.18527,1.07766,1.49773e-05,1.49773e-05,1.49773e-05
5,33.1013,1.03851,2.48224,1.18817,0.71644,0.60858,0.6888,0.51943,0.92876,2.13056,1.07648,9.65328e-06,9.65328e-06,9.65328e-06
1,24.3143,1.04755,2.94362,1.20039,0.7043,0.59105,0.6802,0.51512,0.93879,2.39172,1.07615,8.33e-06,8.33e-06,8.33e-06
2,26.5053,1.02129,2.74427,1.17834,0.70227,0.60395,0.68008,0.51752,0.93474,2.31812,1.07553,1.43157e-05,1.43157e-05,1.43157e-05
3,28.5591,1.01279,2.54344,1.18615,0.70518,0.61041,0.68331,0.51646,0.93354,2.24649,1.07601,1.65315e-05,1.65315e-05,1.65315e-05
4,30.5577,1.04328,2.41115,1.18206,0.72547,0.60665,0.68856,0.51738,0.93258,2.18527,1.07766,1.49773e-05,1.49773e-05,1.49773e-05
5,32.5766,1.03851,2.48224,1.18817,0.71644,0.60858,0.6888,0.51943,0.92876,2.13056,1.07648,9.65328e-06,9.65328e-06,9.65328e-06
1,24.4613,2.02946,1.42731,1.80864,0.7174,0.58202,0.67967,0.51558,nan,nan,nan,8.33e-06,8.33e-06,8.33e-06
2,26.639,1.86265,1.21601,1.62418,0.70248,0.60271,0.68799,0.52176,nan,nan,nan,1.43157e-05,1.43157e-05,1.43157e-05
3,28.693,1.86971,1.18739,1.63109,0.71402,0.60061,0.69235,0.5248,nan,nan,nan,1.65315e-05,1.65315e-05,1.65315e-05
4,30.7282,1.87981,1.14008,1.60752,0.70282,0.61336,0.69505,0.5311,nan,nan,nan,1.49773e-05,1.49773e-05,1.49773e-05
5,32.9802,1.88761,1.1633,1.62404,0.73939,0.59283,0.69632,0.52987,nan,nan,nan,9.65328e-06,9.65328e-06,9.65328e-06
1,24.4736,2.17554,1.54529,1.88531,0.72375,0.57575,0.67739,0.50978,1.74866,1.03379,1.49424,8.33e-06,8.33e-06,8.33e-06
2,26.5904,2.02356,1.31314,1.70276,0.71959,0.58987,0.6876,0.52209,1.72871,0.97749,1.47365,1.43157e-05,1.43157e-05,1.43157e-05
3,28.639,1.98834,1.26779,1.68676,0.73043,0.58898,0.68916,0.52427,1.71505,0.95146,1.45644,1.65315e-05,1.65315e-05,1.65315e-05
4,30.6687,2.0154,1.23356,1.66504,0.69616,0.61082,0.69332,0.52599,1.70452,0.92972,1.44493,1.49773e-05,1.49773e-05,1.49773e-05
5,32.8831,2.02038,1.24973,1.68769,0.77457,0.57282,0.69354,0.52501,1.6974,0.91877,1.43461,9.65328e-06,9.65328e-06,9.65328e-06
1,24.4257,1.7898,1.29029,1.66979,0.7289,0.58112,0.68021,0.51425,1.40089,0.88579,1.32429,8.33e-06,8.33e-06,8.33e-06
2,26.5662,1.62258,1.13277,1.49215,0.71631,0.60348,0.68859,0.52096,1.39222,0.87377,1.31329,1.43157e-05,1.43157e-05,1.43157e-05
3,28.5727,1.65497,1.13069,1.52278,0.69786,0.60876,0.68988,0.52238,1.37999,0.86402,1.29975,1.65315e-05,1.65315e-05,1.65315e-05
4,30.6199,1.6783,1.10647,1.51273,0.70491,0.60719,0.69413,0.52794,1.37315,0.85497,1.29345,1.49773e-05,1.49773e-05,1.49773e-05
5,32.8455,1.67364,1.12385,1.50066,0.68108,0.63452,0.69556,0.52853,1.37769,0.84961,1.29823,9.65328e-06,9.65328e-06,9.65328e-06
1,4.17203,1.92562,1.35954,1.75123,0.7254,0.58236,0.67943,0.51165,1.51299,0.91389,1.3799,8.33e-06,8.33e-06,8.33e-06
2,6.24025,1.74862,1.15808,1.56098,0.70633,0.59797,0.68846,0.52031,1.50068,0.88734,1.36787,1.43157e-05,1.43157e-05,1.43157e-05
3,8.25743,1.76806,1.13783,1.58061,0.70476,0.60245,0.69179,0.52264,1.4934,0.87366,1.35892,1.65315e-05,1.65315e-05,1.65315e-05
4,10.3392,1.76806,1.0982,1.54934,0.7125,0.60799,0.69505,0.52507,1.48476,0.8602,1.34926,1.49773e-05,1.49773e-05,1.49773e-05
5,12.3863,1.78743,1.12036,1.56481,0.68269,0.6347,0.69989,0.53054,1.47965,0.85148,1.34246,9.65328e-06,9.65328e-06,9.65328e-06
1,4.47831,1.85667,1.32883,1.71003,0.7266,0.58191,0.67889,0.51119,1.44797,0.90602,1.34705,8.33e-06,8.33e-06,8.33e-06
2,6.53415,1.67744,1.1422,1.5208,0.70907,0.59288,0.68742,0.51827,1.43899,0.88746,1.33568,1.43157e-05,1.43157e-05,1.43157e-05
3,8.55336,1.70493,1.12896,1.54848,0.71952,0.60553,0.69422,0.52225,1.42915,0.87668,1.32498,1.65315e-05,1.65315e-05,1.65315e-05
4,10.6005,1.70825,1.09483,1.52026,0.69638,0.62084,0.69517,0.52626,1.42947,0.86591,1.32676,1.49773e-05,1.49773e-05,1.49773e-05
5,12.6367,1.72573,1.11746,1.52855,0.67797,0.63362,0.70025,0.53014,1.42083,0.85917,1.316,9.65328e-06,9.65328e-06,9.65328e-06
1,4.21702,2.7043,1.72242,2.2504,0.69781,0.58942,0.67728,0.51156,2.08719,1.12178,1.69848,8.33e-06,8.33e-06,8.33e-06
2,6.25331,2.53743,1.46602,2.00489,0.71595,0.5927,0.68544,0.51869,2.06635,1.04528,1.67603,1.43157e-05,1.43157e-05,1.43157e-05
3,8.25057,2.45415,1.38835,1.95261,0.71222,0.5933,0.68602,0.51893,2.057,1.00896,1.66067,1.65315e-05,1.65315e-05,1.65315e-05
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Ensures a fresh `results.csv` is created for new training runs, preventing old metrics from persisting unless explicitly resuming. 🧹📊

### 📊 Key Changes
- Automatically deletes `results.csv` at startup if it exists and `resume` is not set.
- Keeps `results.csv` intact when `resume=True`, supporting proper continuation of training.

### 🎯 Purpose & Impact
- Prevents mixing metrics from previous runs, ensuring clean and accurate logs for plots and analysis. ✅
- Reduces confusion and plotting issues caused by leftover CSV data. 📈
- Maintains expected behavior when resuming a run, preserving continuity of metrics. 🔁

Tip: To resume training and keep the existing `results.csv`, run:
- CLI: `yolo train resume=True`
- Python:
  ```python
  from ultralytics import YOLO
  model = YOLO("yolov8n.pt")
  model.train(resume=True)
  ```