### PR TITLE
Recreate EMA to avoid `InferenceTensor` error during NaN recovery

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -146,7 +146,7 @@ Explore the Ultralytics Docs, a comprehensive resource designed to help you unde
 - [YOLOv9](models/yolov9.md) introduces innovative methods like Programmable Gradient Information (PGI) and the Generalized Efficient Layer Aggregation Network (GELAN).
 - [YOLOv10](models/yolov10.md) created by researchers from [Tsinghua University](https://www.tsinghua.edu.cn/en/) using the [Ultralytics](https://www.ultralytics.com/) [Python package](https://pypi.org/project/ultralytics/), provides real-time [object detection](tasks/detect.md) advancements by introducing an End-to-End head that eliminates Non-Maximum Suppression (NMS) requirements.
 - **[YOLO11](models/yolo11.md) 🚀**: Ultralytics' latest YOLO models, deliver state-of-the-art (SOTA) performance across multiple tasks, including [object detection](tasks/detect.md), [segmentation](tasks/segment.md), [pose estimation](tasks/pose.md), [tracking](modes/track.md), and [classification](tasks/classify.md), leveraging capabilities across diverse AI applications and domains.
-- **[YOLO26](models/yolo26.md) ⚠️ COMING SOON**: Ultralytics' next-generation YOLO model optimized for edge deployment with end-to-end NMS-free inference.
+- **[YOLO26](models/yolo26.md) ⚠️ Coming Soon**: Ultralytics' next-generation YOLO model optimized for edge deployment with end-to-end NMS-free inference.
 
 ## YOLO Licenses: How is Ultralytics YOLO licensed?
 

--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -23,10 +23,10 @@ Here are some of the key models supported:
 7. **[YOLOv9](yolov9.md)**: An experimental model trained on the Ultralytics [YOLOv5](yolov5.md) codebase implementing Programmable Gradient Information (PGI).
 8. **[YOLOv10](yolov10.md)**: By Tsinghua University, featuring NMS-free training and efficiency-accuracy driven architecture, delivering state-of-the-art performance and latency.
 9. **[YOLO11](yolo11.md) 🚀**: Ultralytics' latest YOLO models delivering state-of-the-art (SOTA) performance across multiple tasks including detection, segmentation, pose estimation, tracking, and classification.
-10. **[YOLO26](yolo26.md) ⚠️ COMING SOON**: Ultralytics' next-generation YOLO model optimized for edge deployment with end-to-end NMS-free inference.
+10. **[YOLO26](yolo26.md) ⚠️ Coming Soon**: Ultralytics' next-generation YOLO model optimized for edge deployment with end-to-end NMS-free inference.
 11. **[Segment Anything Model (SAM)](sam.md)**: Meta's original Segment Anything Model (SAM).
 12. **[Segment Anything Model 2 (SAM2)](sam-2.md)**: The next generation of Meta's Segment Anything Model for videos and images.
-13. **[Segment Anything Model 3 (SAM3)](sam-3.md) ⚠️ COMING SOON**: Meta's upcoming third generation Segment Anything Model with enhanced memory and performance.
+13. **[Segment Anything Model 3 (SAM3)](sam-3.md) ⚠️ Coming Soon**: Meta's upcoming third generation Segment Anything Model with enhanced memory and performance.
 14. **[Mobile Segment Anything Model (MobileSAM)](mobile-sam.md)**: MobileSAM for mobile applications, by Kyung Hee University.
 15. **[Fast Segment Anything Model (FastSAM)](fast-sam.md)**: FastSAM by Image & Video Analysis Group, Institute of Automation, Chinese Academy of Sciences.
 16. **[YOLO-NAS](yolo-nas.md)**: YOLO [Neural Architecture Search](https://www.ultralytics.com/glossary/neural-architecture-search-nas) (NAS) Models.

--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -4,15 +4,11 @@ description: Discover SAM 2, the next generation of Meta's Segment Anything Mode
 keywords: SAM 2, SAM 2.1, Segment Anything, video segmentation, image segmentation, promptable segmentation, zero-shot performance, SA-V dataset, Ultralytics, real-time segmentation, AI, machine learning
 ---
 
-!!! tip "SAM 2.1"
-
-    We have just added support for the more accurate SAM2.1 model. Please give it a try!
+# SAM 2: Segment Anything Model 2
 
 !!! note "SAM Evolution"
 
     SAM 2 builds upon the original [SAM](sam.md) with video segmentation capabilities. For the upcoming next-generation model with enhanced memory and 2× faster processing, see [SAM 3](sam-3.md).
-
-# SAM 2: Segment Anything Model 2
 
 <a href="https://colab.research.google.com/github/ultralytics/notebooks/blob/main/notebooks/inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Inference with Segment Anything 2 In Colab"></a>
 

--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 description: Discover SAM 3, Meta's next evolution of the Segment Anything Model, introducing Promptable Concept Segmentation with text and image exemplar prompts for detecting all instances of visual concepts across images and videos.
-keywords: SAM 3, Segment Anything, SAM3, video segmentation, image segmentation, concept segmentation, promptable AI, SA-Co dataset, Meta, Ultralytics, computer vision, AI, machine learning, open vocabulary
+keywords: SAM 3, Segment Anything 3, SAM3, SAM-3 video segmentation, image segmentation, concept segmentation, promptable AI, SA-Co dataset, Meta, Ultralytics, computer vision, AI, machine learning, open vocabulary
 ---
 
 # SAM 3: Segment Anything with Concepts

--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 description: Discover SAM 3, Meta's next evolution of the Segment Anything Model, introducing Promptable Concept Segmentation with text and image exemplar prompts for detecting all instances of visual concepts across images and videos.
-keywords: SAM 3, Segment Anything 3, SAM3, SAM-3 video segmentation, image segmentation, concept segmentation, promptable AI, SA-Co dataset, Meta, Ultralytics, computer vision, AI, machine learning, open vocabulary
+keywords: SAM 3, Segment Anything 3, SAM3, SAM-3, video segmentation, image segmentation, concept segmentation, promptable AI, SA-Co dataset, Meta, Ultralytics, computer vision, AI, machine learning, open vocabulary
 ---
 
 # SAM 3: Segment Anything with Concepts

--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -4,12 +4,12 @@ description: Discover SAM 3, Meta's next evolution of the Segment Anything Model
 keywords: SAM 3, Segment Anything, SAM3, video segmentation, image segmentation, concept segmentation, promptable AI, SA-Co dataset, Meta, Ultralytics, computer vision, AI, machine learning, open vocabulary
 ---
 
+# SAM 3: Segment Anything with Concepts
+
 !!! note "Coming Soon ⚠️"
 
     🚧 SAM 3 models have not yet been publicly released by Meta. The information below is based on the research paper submitted to ICLR 2026.
     Model downloads and final benchmarks will be available following Meta's official release.
-
-# SAM 3: Segment Anything with Concepts
 
 ![SAM 3 Overview](https://github.com/ultralytics/docs/releases/download/0/sam-3-overview.webp)
 
@@ -21,7 +21,7 @@ SAM 3 achieves a **2× performance gain** over existing systems in Promptable Co
 
 ![SAM 3 Segmentation](https://github.com/ultralytics/docs/releases/download/0/sam-3-segmentation.webp)
 
-### What Is Promptable Concept Segmentation (PCS)?
+### What is Promptable Concept Segmentation (PCS)?
 
 The PCS task takes a **concept prompt** as input and returns segmentation masks with unique identities for **all matching object instances**. Concept prompts can be:
 
@@ -489,9 +489,10 @@ While SAM 3 represents a major advancement, it has certain limitations:
         @inproceedings{sam3_2025,
           title     = {SAM 3: Segment Anything with Concepts},
           author    = {Anonymous authors},
-          booktitle = {Under review as a conference paper at ICLR 2026},
+          booktitle = {Submitted to ICLR 2026},
           year      = {2025},
-          note      = {Paper under double-blind review}
+          url       = {https://openreview.net/forum?id=r35clVtGzw},
+          note      = {Paper ID: 4183, under double-blind review}
         }
         ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -305,8 +305,8 @@ nav:
       - YOLOv9: models/yolov9.md
       - YOLOv10: models/yolov10.md
       - YOLO11: models/yolo11.md
-      - YOLO26 🚀 Coming soon: models/yolo26.md
       - YOLO12: models/yolo12.md
+      - YOLO26 🚀 Coming soon: models/yolo26.md
       - SAM (Segment Anything Model): models/sam.md
       - SAM 2 (Segment Anything Model 2): models/sam-2.md
       - SAM 3 (Segment Anything Model 3) 🚀 Coming soon: models/sam-3.md

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -53,7 +53,6 @@ from ultralytics.utils.torch_utils import (
     init_seeds,
     one_cycle,
     select_device,
-    smart_inference_mode,
     strip_optimizer,
     torch_distributed_zero_first,
     unset_deterministic,

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -53,6 +53,7 @@ from ultralytics.utils.torch_utils import (
     init_seeds,
     one_cycle,
     select_device,
+    smart_inference_mode,
     strip_optimizer,
     torch_distributed_zero_first,
     unset_deterministic,
@@ -815,6 +816,7 @@ class BaseTrainer:
                 ) from e
         self.resume = resume
 
+    @smart_inference_mode()
     def _load_checkpoint_state(self, ckpt):
         """Load optimizer, scaler, EMA, and best_fitness from checkpoint."""
         if ckpt.get("optimizer") is not None:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -816,7 +816,6 @@ class BaseTrainer:
                 ) from e
         self.resume = resume
 
-    @smart_inference_mode()
     def _load_checkpoint_state(self, ckpt):
         """Load optimizer, scaler, EMA, and best_fitness from checkpoint."""
         if ckpt.get("optimizer") is not None:
@@ -824,6 +823,7 @@ class BaseTrainer:
         if ckpt.get("scaler") is not None:
             self.scaler.load_state_dict(ckpt["scaler"])
         if self.ema and ckpt.get("ema"):
+            self.ema.ema.eval()
             self.ema.ema.load_state_dict(ckpt["ema"].float().state_dict())
             self.ema.updates = ckpt["updates"]
         self.best_fitness = ckpt.get("best_fitness", 0.0)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -832,7 +832,7 @@ class BaseTrainer:
         loss_nan = self.tloss is not None and not torch.isfinite(self.tloss).all()
         fitness_nan = self.fitness is not None and not np.isfinite(self.fitness)
         fitness_collapse = self.best_fitness and self.best_fitness > 0 and self.fitness == 0
-        corrupted = RANK in {-1, 0} and (loss_nan or fitness_nan or fitness_collapse)
+        corrupted = RANK in {-1, 0} and loss_nan and (fitness_nan or fitness_collapse)
         reason = "Loss NaN/Inf" if loss_nan else "Fitness NaN/Inf" if fitness_nan else "Fitness collapse"
         if RANK != -1:  # DDP: broadcast to all ranks
             broadcast_list = [corrupted if RANK == 0 else None]

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -822,7 +822,7 @@ class BaseTrainer:
         if ckpt.get("scaler") is not None:
             self.scaler.load_state_dict(ckpt["scaler"])
         if self.ema and ckpt.get("ema"):
-            self.ema.ema.eval()
+            self.ema = ModelEMA(self.model)  # validation with EMA creates inference tensors that can't be updated
             self.ema.ema.load_state_dict(ckpt["ema"].float().state_dict())
             self.ema.updates = ckpt["updates"]
         self.best_fitness = ckpt.get("best_fitness", 0.0)


### PR DESCRIPTION
**MRE**
```bash
yolo train model=yolo11n.pt data=coco128.yaml epochs=10 exist_ok lr0=0.05 optimizer=Adam
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Documentation polish and training stability improvements: clearer “Coming Soon” labels, refined SAM 2/3 docs, nav tweaks, and a fix for EMA state loading when resuming training—plus a more conservative NaN recovery trigger. ✨

### 📊 Key Changes
- Docs wording consistency:
  - Standardized “⚠️ Coming Soon” (was “COMING SOON”) for YOLO26 and SAM3 across docs. 📝
- SAM pages updates:
  - SAM 2: removed outdated “SAM 2.1” tip; streamlined headings. 🎯
  - SAM 3: improved keywords, heading placement, grammar (“What is…”), and updated citation (ICLR 2026 submission with OpenReview link and paper ID). 🔗
- Docs navigation:
  - Reordered models in mkdocs to place YOLO26 after YOLO12 for clearer progression. 🧭
- Trainer fixes:
  - When loading checkpoints, reinitialize EMA with `ModelEMA(self.model)` before loading EMA weights to avoid inference-tensor update errors. 🛠️
  - Tightened NaN recovery condition: now triggers only if loss is NaN/Inf and fitness is NaN/Inf or collapsed. 🧪

### 🎯 Purpose & Impact
- Better clarity and consistency in docs:
  - Users see uniform “Coming Soon” messaging and up-to-date SAM 2/3 info, including a direct reference to the SAM 3 submission status. 📚
- Smoother training resumes:
  - Fix prevents errors when resuming training with EMA checkpoints after validation, reducing interruptions for users using EMA. ✅
- Reduced false positives in recovery:
  - More conservative NaN recovery avoids unnecessary training resets, improving training stability—though it may detect purely fitness-based issues less aggressively. ⚖️