### PR TITLE
NaN handler check `self.loss` instead of `self.tloss`

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -829,7 +829,7 @@ class BaseTrainer:
 
     def _handle_nan_recovery(self, epoch):
         """Detect and recover from NaN/Inf loss and fitness collapse by loading last checkpoint."""
-        loss_nan = self.tloss is not None and not torch.isfinite(self.tloss).all()
+        loss_nan = self.loss is not None and not self.loss.isfinite()
         fitness_nan = self.fitness is not None and not np.isfinite(self.fitness)
         fitness_collapse = self.best_fitness and self.best_fitness > 0 and self.fitness == 0
         corrupted = RANK in {-1, 0} and loss_nan and (fitness_nan or fitness_collapse)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves NaN/Inf recovery during training by checking the correct loss attribute, making failure detection more reliable and aligned with current trainer state. ✅

### 📊 Key Changes
- Switched NaN/Inf check from `self.tloss` to `self.loss` in `_handle_nan_recovery`.
- Updated finite check to use the loss object’s own `isfinite()` call for clarity and consistency.

### 🎯 Purpose & Impact
- Prevents missed detections caused by referencing an outdated loss variable, leading to more robust training recovery.
- Ensures trainers auto-recover (reload last checkpoint) when loss becomes NaN/Inf or fitness collapses, reducing wasted training time.
- Benefits all training runs across YOLO models (e.g., YOLO11, YOLO26) by improving stability and reliability under edge-case failures. 🚀