### PR TITLE
Prevent `nms` export for RTDETR models

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -77,12 +77,7 @@ from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import check_class_names, default_class_names
 from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder
-from ultralytics.nn.tasks import (
-    ClassificationModel,
-    DetectionModel,
-    SegmentationModel,
-    WorldModel
-)
+from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel, WorldModel
 from ultralytics.utils import (
     ARM64,
     DEFAULT_CFG,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -77,7 +77,7 @@ from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import check_class_names, default_class_names
 from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder
-from ultralytics.nn.tasks import ClassificationModel, DetectionModel, SegmentationModel, WorldModel
+from ultralytics.nn.tasks import ClassificationModel, DetectionModel, RTDETRDetectionModel, SegmentationModel, WorldModel
 from ultralytics.utils import (
     ARM64,
     DEFAULT_CFG,
@@ -385,7 +385,7 @@ class Exporter:
             assert not tflite or not ARM64 or not LINUX, "TFLite export with NMS unsupported on ARM64 Linux"
             assert not is_tf_format or TORCH_1_13, "TensorFlow exports with NMS require torch>=1.13"
             assert not onnx or TORCH_1_13, "ONNX export with NMS requires torch>=1.13"
-            if getattr(model, "end2end", False):
+            if getattr(model, "end2end", False) or isinstance(model, RTDETRDetectionModel):
                 LOGGER.warning("'nms=True' is not available for end2end models. Forcing 'nms=False'.")
                 self.args.nms = False
             self.args.conf = self.args.conf or 0.25  # set conf default value for nms export
@@ -1039,7 +1039,7 @@ class Exporter:
             attempt_download_asset(f"{onnx2tf_file}.zip", unzip=True, delete=True)
 
         # Export to ONNX
-        if "rtdetr" in self.model.model[-1]._get_name().lower():
+        if isinstance(self.model.model[-1], RTDETRDecoder):
             self.args.opset = self.args.opset or 19
             assert 16 <= self.args.opset <= 19, "RTDETR export requires opset>=16;<=19"
         self.args.simplify = True

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -80,9 +80,8 @@ from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder
 from ultralytics.nn.tasks import (
     ClassificationModel,
     DetectionModel,
-    RTDETRDetectionModel,
     SegmentationModel,
-    WorldModel,
+    WorldModel
 )
 from ultralytics.utils import (
     ARM64,
@@ -391,7 +390,7 @@ class Exporter:
             assert not tflite or not ARM64 or not LINUX, "TFLite export with NMS unsupported on ARM64 Linux"
             assert not is_tf_format or TORCH_1_13, "TensorFlow exports with NMS require torch>=1.13"
             assert not onnx or TORCH_1_13, "ONNX export with NMS requires torch>=1.13"
-            if getattr(model, "end2end", False) or isinstance(model, RTDETRDetectionModel):
+            if getattr(model, "end2end", False) or isinstance(model.model[-1], RTDETRDecoder):
                 LOGGER.warning("'nms=True' is not available for end2end models. Forcing 'nms=False'.")
                 self.args.nms = False
             self.args.conf = self.args.conf or 0.25  # set conf default value for nms export

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -77,7 +77,13 @@ from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import check_class_names, default_class_names
 from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder
-from ultralytics.nn.tasks import ClassificationModel, DetectionModel, RTDETRDetectionModel, SegmentationModel, WorldModel
+from ultralytics.nn.tasks import (
+    ClassificationModel,
+    DetectionModel,
+    RTDETRDetectionModel,
+    SegmentationModel,
+    WorldModel,
+)
 from ultralytics.utils import (
     ARM64,
     DEFAULT_CFG,

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -900,7 +900,6 @@ class RTDETRDecoder(nn.Module):
     anchors = torch.empty(0)
     valid_mask = torch.empty(0)
     dynamic = False
-    end2end = True
 
     def __init__(
         self,

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -900,6 +900,7 @@ class RTDETRDecoder(nn.Module):
     anchors = torch.empty(0)
     valid_mask = torch.empty(0)
     dynamic = False
+    end2end = True
 
     def __init__(
         self,


### PR DESCRIPTION
Related #22384 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves RT-DETR export reliability by using explicit class checks, automatically disabling NMS for end-to-end RT-DETR models, and enforcing correct ONNX opset settings. 🚀

### 📊 Key Changes
- Uses explicit class detection (`RTDETRDecoder`) instead of string name matching to identify RT-DETR models.
- Automatically forces `nms=False` for end-to-end models and RT-DETR decoders, with a clear warning.
- Sets ONNX opset defaults for RT-DETR exports to 19 and enforces valid range 16–19.
- Keeps `simplify=True` for ONNX export in the TensorFlow SavedModel path.

### 🎯 Purpose & Impact
- Increases robustness by avoiding fragile string-based checks, reducing false detections. ✅
- Prevents export-time errors by disallowing NMS on end-to-end/RT-DETR models where it’s unsupported. 🧩
- Ensures compatible ONNX opset versions for RT-DETR, improving cross-tool export stability. 🔒
- Provides clearer behavior and fewer surprises for users exporting RT-DETR models to ONNX/TensorFlow. 😊