### PR TITLE
Set `dynamo=False` by default for ONNX exports

### DIFF
--- a/ultralytics/utils/export/__init__.py
+++ b/ultralytics/utils/export/__init__.py
@@ -37,7 +37,7 @@ def torch2onnx(
     Notes:
         Setting `do_constant_folding=True` may cause issues with DNN inference for torch>=1.12.
     """
-    kwargs = { "dynamo": False } if TORCH_2_4 else {}
+    kwargs = {"dynamo": False} if TORCH_2_4 else {}
     torch.onnx.export(
         torch_model,
         im,

--- a/ultralytics/utils/export/__init__.py
+++ b/ultralytics/utils/export/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import torch
 
 from ultralytics.utils import IS_JETSON, LOGGER
+from ultralytics.utils.torch_utils import TORCH_2_4
 
 from .imx import torch2imx  # noqa
 
@@ -36,6 +37,7 @@ def torch2onnx(
     Notes:
         Setting `do_constant_folding=True` may cause issues with DNN inference for torch>=1.12.
     """
+    kwargs = { "dynamo": False } if TORCH_2_4 else {}
     torch.onnx.export(
         torch_model,
         im,
@@ -46,6 +48,7 @@ def torch2onnx(
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic or None,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improve ONNX export reliability with PyTorch 2.4 by disabling Dynamo during export, ensuring stable, version-aware behavior. ⚙️✅

### 📊 Key Changes
- Added PyTorch 2.4 check via `TORCH_2_4` and conditionally passed `dynamo=False` to `torch.onnx.export`.
- Imported `TORCH_2_4` from `ultralytics.utils.torch_utils`.
- No change for PyTorch versions below 2.4; behavior remains the same.

### 🎯 Purpose & Impact
- Prevents ONNX export errors or instability introduced by PyTorch 2.4’s Dynamo-based export path. 🛡️
- Ensures consistent, reliable ONNX exports across environments and CI/deployment pipelines (including Ultralytics HUB). 🔁
- Transparent to users—no API changes required; existing export commands continue to work. 🧑‍💻
- Minor trade-off: potential performance differences on 2.4 exports, but improved stability is prioritized. 🚀

Example (no changes needed from users):
```python
from ultralytics import YOLO

model = YOLO('yolo11n.pt')
model.export(format='onnx')  # Works reliably across PyTorch versions
```