### PR TITLE
Pin `torch<=2.8.0` in `Dockerfile-python-export`

### DIFF
--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -18,6 +18,7 @@ RUN apt-get update && \
 RUN uv pip install --system -e ".[export]" && \
     # Need lower version of 'numpy' for Sony IMX export
     uv pip install --system numpy==1.26.4 && \
+    uv pip install --system onnxscript && \
     # Run exports to AutoInstall packages
     yolo export model=tmp/yolo11n.pt format=edgetpu imgsz=32 && \
     yolo export model=tmp/yolo11n.pt format=ncnn imgsz=32 && \

--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -15,6 +15,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install export dependencies and run exports to AutoInstall packages
+RUN sed -i -e 's/"torch>=1.8.0/"torch>=1.8.0,torch<=2.8.0/' pyproject.toml
 RUN uv pip install --system -e ".[export]" && \
     # Need lower version of 'numpy' for Sony IMX export
     uv pip install --system numpy==1.26.4 && \

--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -15,11 +15,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install export dependencies and run exports to AutoInstall packages
-RUN sed -i -e 's/"torch>=1.8.0/"torch>=1.8.0,torch<=2.8.0/' pyproject.toml
+RUN sed -i -e 's/"torch>=1.8.0/"torch>=1.8.0,<=2.8.0/' pyproject.toml
 RUN uv pip install --system -e ".[export]" && \
     # Need lower version of 'numpy' for Sony IMX export
     uv pip install --system numpy==1.26.4 && \
-    uv pip install --system onnxscript && \
     # Run exports to AutoInstall packages
     yolo export model=tmp/yolo11n.pt format=edgetpu imgsz=32 && \
     yolo export model=tmp/yolo11n.pt format=ncnn imgsz=32 && \

--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -15,6 +15,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install export dependencies and run exports to AutoInstall packages
+# Prevent torch upgrade to 2.9.0 which has issues with imx export
 RUN sed -i -e 's/"torch>=1.8.0/"torch>=1.8.0,<=2.8.0/' pyproject.toml
 RUN uv pip install --system -e ".[export]" && \
     # Need lower version of 'numpy' for Sony IMX export


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Pins PyTorch to <=2.8.0 in the export Docker image to avoid IMX export issues, ensuring more reliable model exports. 🛠️🔒

### 📊 Key Changes
- Updated `docker/Dockerfile-python-export` to cap PyTorch: `torch>=1.8.0,<=2.8.0` to prevent unintended upgrades to 2.9.0. ⛔️⬆️
- Keeps existing lower `numpy` pin (`1.26.4`) for Sony IMX export compatibility. 🧩

### 🎯 Purpose & Impact
- Prevents export failures or instability caused by PyTorch 2.9.0 with IMX targets. ✅
- Improves reproducibility and stability of Docker-based exports. 📦
- Minimal user impact: only affects the Python export Docker image; training/inference outside this image remain unaffected. 🔄
- Trade-off: delays access to PyTorch 2.9.0 features within this export environment until compatibility is ensured. ⏳