### PR TITLE
Support keypoint names metadata for pose models

### DIFF
--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -22,6 +22,27 @@ flip_idx: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
 names:
   0: person
 
+# Keypoint names per class
+kpt_names:
+  0:
+    - nose
+    - left_eye
+    - right_eye
+    - left_ear
+    - right_ear
+    - left_shoulder
+    - right_shoulder
+    - left_elbow
+    - right_elbow
+    - left_wrist
+    - right_wrist
+    - left_hip
+    - right_hip
+    - left_knee
+    - right_knee
+    - left_ankle
+    - right_ankle
+
 # Download script/URL (optional)
 download: |
   from pathlib import Path

--- a/ultralytics/cfg/datasets/coco8-pose.yaml
+++ b/ultralytics/cfg/datasets/coco8-pose.yaml
@@ -22,5 +22,26 @@ flip_idx: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
 names:
   0: person
 
+# Keypoint names per class
+kpt_names:
+  0:
+    - nose
+    - left_eye
+    - right_eye
+    - left_ear
+    - right_ear
+    - left_shoulder
+    - right_shoulder
+    - left_elbow
+    - right_elbow
+    - left_wrist
+    - right_wrist
+    - left_hip
+    - right_hip
+    - left_knee
+    - right_knee
+    - left_ankle
+    - right_ankle
+
 # Download script/URL (optional)
 download: https://github.com/ultralytics/assets/releases/download/v0.0.0/coco8-pose.zip

--- a/ultralytics/cfg/datasets/dog-pose.yaml
+++ b/ultralytics/cfg/datasets/dog-pose.yaml
@@ -41,7 +41,7 @@ kpt_names:
     - right_hind_hock
     - None
     - None
-    - withers
+    - tail_base
     - None
     - None
     - left_ear_tip

--- a/ultralytics/cfg/datasets/dog-pose.yaml
+++ b/ultralytics/cfg/datasets/dog-pose.yaml
@@ -20,5 +20,37 @@ kpt_shape: [24, 3] # number of keypoints, number of dims (2 for x,y or 3 for x,y
 names:
   0: dog
 
+# Keypoint names per class
+kpt_names:
+  0:
+    - left_front_paw
+    - None
+    - None
+    - left_front_wrist
+    - None
+    - None
+    - left_hind_hock
+    - None
+    - None
+    - right_front_paw
+    - None
+    - None
+    - right_front_wrist
+    - None
+    - None
+    - right_hind_hock
+    - None
+    - None
+    - withers
+    - None
+    - None
+    - left_ear_tip
+    - None
+    - None
+    - nose
+    - None
+    - None
+    - left_ear_base
+
 # Download script/URL (optional)
 download: https://github.com/ultralytics/assets/releases/download/v0.0.0/dog-pose.zip

--- a/ultralytics/cfg/datasets/dog-pose.yaml
+++ b/ultralytics/cfg/datasets/dog-pose.yaml
@@ -23,34 +23,30 @@ names:
 # Keypoint names per class
 kpt_names:
   0:
-    - left_front_paw
-    - None
-    - None
-    - left_front_wrist
-    - None
-    - None
-    - left_hind_hock
-    - None
-    - None
-    - right_front_paw
-    - None
-    - None
-    - right_front_wrist
-    - None
-    - None
-    - right_hind_hock
-    - None
-    - None
-    - tail_base
-    - None
-    - None
-    - left_ear_tip
-    - None
-    - None
-    - nose
-    - None
-    - None
+    - front_left_paw
+    - front_left_knee
+    - front_left_elbow
+    - rear_left_paw
+    - rear_left_knee
+    - rear_left_elbow
+    - front_right_paw
+    - front_right_knee
+    - front_right_elbow
+    - rear_right_paw
+    - rear_right_knee
+    - rear_right_elbow
+    - tail_start
+    - tail_end
     - left_ear_base
+    - right_ear_base
+    - nose
+    - chin
+    - left_ear_tip
+    - right_ear_tip
+    - left_eye
+    - right_eye
+    - withers
+    - throat
 
 # Download script/URL (optional)
 download: https://github.com/ultralytics/assets/releases/download/v0.0.0/dog-pose.zip

--- a/ultralytics/cfg/datasets/hand-keypoints.yaml
+++ b/ultralytics/cfg/datasets/hand-keypoints.yaml
@@ -22,5 +22,30 @@ flip_idx:
 names:
   0: hand
 
+# Keypoint names per class
+kpt_names:
+  0:
+    - wrist
+    - thumb_cmc
+    - thumb_mcp
+    - thumb_ip
+    - thumb_tip
+    - index_mcp
+    - index_pip
+    - index_dip
+    - index_tip
+    - middle_mcp
+    - middle_pip
+    - middle_dip
+    - middle_tip
+    - ring_mcp
+    - ring_pip
+    - ring_dip
+    - ring_tip
+    - pinky_mcp
+    - pinky_pip
+    - pinky_dip
+    - pinky_tip
+
 # Download script/URL (optional)
 download: https://github.com/ultralytics/assets/releases/download/v0.0.0/hand-keypoints.zip

--- a/ultralytics/cfg/datasets/tiger-pose.yaml
+++ b/ultralytics/cfg/datasets/tiger-pose.yaml
@@ -21,5 +21,21 @@ flip_idx: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 names:
   0: tiger
 
+# Keypoint names per class
+kpt_names:
+  0:
+    - nose
+    - head
+    - withers
+    - tail_base
+    - right_hind_hock
+    - right_hind_paw
+    - left_hind_paw
+    - left_hind_hock
+    - right_front_wrist
+    - right_front_paw
+    - left_front_wrist
+    - left_front_paw
+
 # Download script/URL (optional)
 download: https://github.com/ultralytics/assets/releases/download/v0.0.0/tiger-pose.zip

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -502,6 +502,8 @@ class Exporter:
             self.metadata["dla"] = dla  # make sure `AutoBackend` uses correct dla device if it has one
         if model.task == "pose":
             self.metadata["kpt_shape"] = model.model[-1].kpt_shape
+            if hasattr(model, "kpt_names"):
+                self.metadata["kpt_names"] = model.kpt_names
 
         LOGGER.info(
             f"\n{colorstr('PyTorch:')} starting from '{file}' with input shape {tuple(im.shape)} BCHW and "

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -94,7 +94,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
         kpt_names = self.data.get("kpt_names")
         if not kpt_names:
             names = list(map(str, range(self.model.kpt_shape[0])))
-            kpt_names = {i:names for i in range(self.model.nc)}
+            kpt_names = {i: names for i in range(self.model.nc)}
         self.model.kpt_names = kpt_names
 
     def get_validator(self):

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -91,6 +91,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
         """Set keypoints shape attribute of PoseModel."""
         super().set_model_attributes()
         self.model.kpt_shape = self.data["kpt_shape"]
+        self.model.kpt_names = self.data["kpt_names"]
 
     def get_validator(self):
         """Return an instance of the PoseValidator class for validation."""

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -91,7 +91,11 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
         """Set keypoints shape attribute of PoseModel."""
         super().set_model_attributes()
         self.model.kpt_shape = self.data["kpt_shape"]
-        self.model.kpt_names = self.data.get("kpt_names", {})
+        kpt_names = self.data.get("kpt_names")
+        if not kpt_names:
+            names = list(map(str, range(self.model.kpt_shape[0])))
+            kpt_names = {i:names for i in range(self.model.nc)}
+        self.model.kpt_names = kpt_names
 
     def get_validator(self):
         """Return an instance of the PoseValidator class for validation."""

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -91,7 +91,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
         """Set keypoints shape attribute of PoseModel."""
         super().set_model_attributes()
         self.model.kpt_shape = self.data["kpt_shape"]
-        self.model.kpt_names = self.data["kpt_names"]
+        self.model.kpt_names = self.data.get("kpt_names", {})
 
     def get_validator(self):
         """Return an instance of the PoseValidator class for validation."""

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -585,7 +585,7 @@ class AutoBackend(nn.Module):
             for k, v in metadata.items():
                 if k in {"stride", "batch", "channels"}:
                     metadata[k] = int(v)
-                elif k in {"imgsz", "names", "kpt_shape", "args"} and isinstance(v, str):
+                elif k in {"imgsz", "names", "kpt_shape", "kpt_names", "args"} and isinstance(v, str):
                     metadata[k] = eval(v)
             stride = metadata["stride"]
             task = metadata["task"]

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -593,6 +593,7 @@ class AutoBackend(nn.Module):
             imgsz = metadata["imgsz"]
             names = metadata["names"]
             kpt_shape = metadata.get("kpt_shape")
+            kpt_names = metadata.get("kpt_names")
             end2end = metadata.get("args", {}).get("nms", False)
             dynamic = metadata.get("args", {}).get("dynamic", dynamic)
             ch = metadata.get("channels", 3)


### PR DESCRIPTION
```python
from ultralytics import YOLO
model = YOLO("yolo11n-pose.pt")
results = model.train(data="coco8-pose.yaml", epochs=1, exist_ok=True)
model = YOLO("runs/pose/train/weights/best.pt")
print(model.kpt_names)
results = model()
for i, result in enumerate(results):
    classes = result.boxes.cls.tolist()
    kpts = result.keypoints.xy.tolist()
    for cls, kpt in zip(classes, kpts):
        print(dict(zip(model.kpt_names[cls], kpt)))
```

```python
{'nose': [652.0538940429688, 358.3094482421875], 'left_eye': [659.1234130859375, 331.9946594238281], 'right_eye': [627.3772583007812, 326.6024169921875], 'left_ear': [617.7488403320312, 332.4612731933594], 'right_ear': [528.3828735351562, 317.5885009765625], 'left_shoulder': [631.0384521484375, 426.4150390625], 'right_shoulder': [349.49560546875, 419.6319580078125], 'left_elbow': [826.8046875, 508.06060791015625], 'right_elbow': [211.17703247070312, 594.3692016601562], 'left_wrist': [969.5433349609375, 545.4529418945312], 'right_wrist': [307.29205322265625, 714.197021484375], 'left_hip': [497.0877380371094, 711.0231323242188], 'right_hip': [317.22705078125, 717.8145751953125], 'left_knee': [506.6791076660156, 596.5565795898438], 'right_knee': [265.020263671875, 610.9822998046875], 'left_ankle': [509.8736267089844, 711.9202880859375], 'right_ankle': [296.5079650878906, 720.0]}
{'nose': [999.6265258789062, 202.27635192871094], 'left_eye': [1026.495849609375, 172.95150756835938], 'right_eye': [964.1179809570312, 168.3924102783203], 'left_ear': [1052.182861328125, 186.03170776367188], 'right_ear': [905.0728759765625, 177.27322387695312], 'left_shoulder': [1048.4482421875, 337.449462890625], 'right_shoulder': [853.6993408203125, 327.23736572265625], 'left_elbow': [1064.6339111328125, 519.8368530273438], 'right_elbow': [784.0687255859375, 523.6309814453125], 'left_wrist': [1090.9337158203125, 486.72943115234375], 'right_wrist': [960.6470336914062, 459.84271240234375], 'left_hip': [1034.6888427734375, 720.0], 'right_hip': [900.2042846679688, 720.0], 'left_knee': [1074.7962646484375, 720.0], 'right_knee': [919.947509765625, 720.0], 'left_ankle': [1072.2864990234375, 720.0], 'right_ankle': [894.8368530273438, 720.0]
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds human-readable keypoint names to pose datasets and propagates them through training, export, and inference for clearer, more informative pose outputs. 🧍‍♂️🐶✋

### 📊 Key Changes
- Dataset updates: Added `kpt_names` to pose YAMLs:
  - `coco-pose.yaml`, `coco8-pose.yaml`, `dog-pose.yaml`, `hand-keypoints.yaml`, `tiger-pose.yaml` now include per-class keypoint name lists.
- Training: `PoseModel` now sets `model.kpt_names` from dataset config, with an automatic fallback to numeric labels if none provided.
- Export: Pose model exports now include `kpt_names` in model metadata for downstream consumers.
- Inference backend: `AutoBackend` now reads `kpt_names` from exported metadata, ensuring keypoint names are available across formats/backends.

### 🎯 Purpose & Impact
- Improved clarity: Users can see meaningful keypoint names (e.g., “left_wrist”, “nose”) instead of indices, aiding interpretation and debugging. 🔎
- Better visualization and reporting: Plots, logs, and UIs can show named keypoints for more readable outputs.
- Seamless deployment: Named keypoints are preserved through export and inference, improving interoperability across runtimes. 🚀
- Backward compatible: If `kpt_names` aren’t provided, defaults to numeric labels, so existing workflows remain unaffected.
- Multi-class readiness: Supports per-class keypoint naming, enabling more complex pose datasets.