### PR TITLE
Change torch.load to include `weights_only` parameter

### DIFF
--- a/ultralytics/models/sam/build.py
+++ b/ultralytics/models/sam/build.py
@@ -10,6 +10,7 @@ from functools import partial
 
 import torch
 
+from ultralytics.utils.torch_utils import TORCH_1_13
 from ultralytics.utils.downloads import attempt_download_asset
 
 from .modules.decoders import MaskDecoder
@@ -207,7 +208,7 @@ def _build_sam(
     if checkpoint is not None:
         checkpoint = attempt_download_asset(checkpoint)
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f, weights_only=False)
+            state_dict = torch.load(f, weights_only=False) if TORCH_1_13 else torch.load(f)
         sam.load_state_dict(state_dict)
     sam.eval()
     return sam
@@ -302,7 +303,7 @@ def _build_sam2(
     if checkpoint is not None:
         checkpoint = attempt_download_asset(checkpoint)
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f, weights_only=False)["model"]
+            state_dict = (torch.load(f, weights_only=False) if TORCH_1_13 else torch.load(f))["model"]
         sam2.load_state_dict(state_dict)
     sam2.eval()
     return sam2

--- a/ultralytics/models/sam/build.py
+++ b/ultralytics/models/sam/build.py
@@ -207,7 +207,7 @@ def _build_sam(
     if checkpoint is not None:
         checkpoint = attempt_download_asset(checkpoint)
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)
+            state_dict = torch.load(f, weights_only=False)
         sam.load_state_dict(state_dict)
     sam.eval()
     return sam
@@ -302,7 +302,7 @@ def _build_sam2(
     if checkpoint is not None:
         checkpoint = attempt_download_asset(checkpoint)
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)["model"]
+            state_dict = torch.load(f, weights_only=False)["model"]
         sam2.load_state_dict(state_dict)
     sam2.eval()
     return sam2

--- a/ultralytics/models/sam/build.py
+++ b/ultralytics/models/sam/build.py
@@ -10,8 +10,8 @@ from functools import partial
 
 import torch
 
-from ultralytics.utils.torch_utils import TORCH_1_13
 from ultralytics.utils.downloads import attempt_download_asset
+from ultralytics.utils.torch_utils import TORCH_1_13
 
 from .modules.decoders import MaskDecoder
 from .modules.encoders import FpnNeck, Hiera, ImageEncoder, ImageEncoderViT, MemoryEncoder, PromptEncoder


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improve SAM/SAM 2 checkpoint loading to be compatible across PyTorch versions, reducing errors and warnings during model load. 🔧✅

### 📊 Key Changes
- Updated SAM (`_build_sam`) and SAM 2 (`_build_sam2`) loaders to use `torch.load(..., weights_only=False)` when supported.
- Added conditional import/use of `TORCH_1_13` to decide whether to pass the `weights_only` argument.
- Maintains fallback to standard `torch.load` on older PyTorch versions.

### 🎯 Purpose & Impact
- Ensures robust checkpoint loading across different PyTorch versions, preventing "unexpected keyword" errors on older versions and avoiding warnings on newer ones. 🔄
- Improves reliability when loading downloaded checkpoints for SAM/SAM 2 models. 🧩
- No user-facing API changes; behavior remains the same aside from fewer load-time issues and warnings. 🚀