### PR TITLE
Add NMS warmup for clearer post-processing latency

### DIFF
--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -181,7 +181,15 @@ def build_grounding(
     )
 
 
-def build_dataloader(dataset, batch: int, workers: int, shuffle: bool = True, rank: int = -1, drop_last: bool = False, pin_memory: bool = True):
+def build_dataloader(
+    dataset,
+    batch: int,
+    workers: int,
+    shuffle: bool = True,
+    rank: int = -1,
+    drop_last: bool = False,
+    pin_memory: bool = True,
+):
     """
     Create and return an InfiniteDataLoader or DataLoader for training or validation.
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -181,7 +181,7 @@ def build_grounding(
     )
 
 
-def build_dataloader(dataset, batch: int, workers: int, shuffle: bool = True, rank: int = -1, drop_last: bool = False):
+def build_dataloader(dataset, batch: int, workers: int, shuffle: bool = True, rank: int = -1, drop_last: bool = False, pin_memory: bool = True):
     """
     Create and return an InfiniteDataLoader or DataLoader for training or validation.
 
@@ -192,6 +192,7 @@ def build_dataloader(dataset, batch: int, workers: int, shuffle: bool = True, ra
         shuffle (bool, optional): Whether to shuffle the dataset.
         rank (int, optional): Process rank in distributed training. -1 for single-GPU training.
         drop_last (bool, optional): Whether to drop the last incomplete batch.
+        pin_memory (bool, optional): Whether to use pinned memory for dataloader.
 
     Returns:
         (InfiniteDataLoader): A dataloader that can be used for training or validation.
@@ -214,7 +215,7 @@ def build_dataloader(dataset, batch: int, workers: int, shuffle: bool = True, ra
         num_workers=nw,
         sampler=sampler,
         prefetch_factor=4 if nw > 0 else None,  # increase over default 2
-        pin_memory=nd > 0,
+        pin_memory=nd > 0 and pin_memory,
         collate_fn=getattr(dataset, "collate_fn", None),
         worker_init_fn=seed_worker,
         generator=generator,

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -300,7 +300,13 @@ class DetectionValidator(BaseValidator):
         """
         dataset = self.build_dataset(dataset_path, batch=batch_size, mode="val")
         return build_dataloader(
-            dataset, batch_size, self.args.workers, shuffle=False, rank=-1, drop_last=self.args.compile
+            dataset,
+            batch_size,
+            self.args.workers,
+            shuffle=False,
+            rank=-1,
+            drop_last=self.args.compile,
+            pin_memory=self.training,
         )
 
     def plot_val_samples(self, batch: dict[str, Any], ni: int) -> None:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -19,6 +19,7 @@ from PIL import Image
 from ultralytics.utils import ARM64, IS_JETSON, LINUX, LOGGER, PYTHON_VERSION, ROOT, YAML, is_jetson
 from ultralytics.utils.checks import check_requirements, check_suffix, check_version, check_yaml, is_rockchip
 from ultralytics.utils.downloads import attempt_download_asset, is_url
+from ultralytics.utils.nms import non_max_suppression
 
 
 def check_class_names(names: list | dict) -> dict[int, str]:
@@ -854,7 +855,10 @@ class AutoBackend(nn.Module):
         if any(warmup_types) and (self.device.type != "cpu" or self.triton):
             im = torch.empty(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
             for _ in range(2 if self.jit else 1):
-                self.forward(im)  # warmup
+                self.forward(im)  # warmup model
+                warmup_boxes = torch.rand(1, 84, 100, device=self.device)
+                warmup_boxes[:, :4] *= imgsz[-1]
+                non_max_suppression(warmup_boxes)  # warmup NMS
 
     @staticmethod
     def _model_type(p: str = "path/to/model.pt") -> list[bool]:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -856,9 +856,10 @@ class AutoBackend(nn.Module):
             im = torch.empty(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
             for _ in range(2 if self.jit else 1):
                 self.forward(im)  # warmup model
-                warmup_boxes = torch.rand(1, 84, 100, device=self.device)
-                warmup_boxes[:, :4] *= imgsz[-1]
-                non_max_suppression(warmup_boxes)  # warmup NMS
+                for i in (16, 20):
+                    warmup_boxes = torch.rand(1, 84, i, device=self.device)
+                    warmup_boxes[:, :4] *= imgsz[-1]
+                    non_max_suppression(warmup_boxes)  # warmup NMS
 
     @staticmethod
     def _model_type(p: str = "path/to/model.pt") -> list[bool]:

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -856,10 +856,9 @@ class AutoBackend(nn.Module):
             im = torch.empty(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
             for _ in range(2 if self.jit else 1):
                 self.forward(im)  # warmup model
-                for i in (16, 20):
-                    warmup_boxes = torch.rand(1, 84, i, device=self.device)
-                    warmup_boxes[:, :4] *= imgsz[-1]
-                    non_max_suppression(warmup_boxes)  # warmup NMS
+                warmup_boxes = torch.rand(1, 84, 16, device=self.device)  # 16 boxes works best empirically
+                warmup_boxes[:, :4] *= imgsz[-1]
+                non_max_suppression(warmup_boxes)  # warmup NMS
 
     @staticmethod
     def _model_type(p: str = "path/to/model.pt") -> list[bool]:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds configurable pin_memory to dataloaders and warms up NMS during backend warmup to smooth first-iteration latency and give users better memory control. ⚡🧠

### 📊 Key Changes
- build_dataloader now accepts a new parameter: `pin_memory: bool = True`.
  - Internally uses `pin_memory = (num_device_gpus > 0) and pin_memory`.
- Validation dataloader sets `pin_memory=self.training`, disabling pinning during eval by default.
- Autobackend warmup now also warms up Non-Max Suppression (NMS) by running a small synthetic NMS pass after the first forward.
- Updated docstrings to reflect the new `pin_memory` option.

### 🎯 Purpose & Impact
- Faster, smoother first-batch performance by pre-warming NMS kernels on supported devices. 🚀
- More robust memory behavior:
  - Keeps pin_memory on by default where beneficial (GPU training).
  - Disables it during validation to reduce host memory pressure and potential stalls. 🧩
- Backward compatible API: existing code continues to work; advanced users can fine-tune memory behavior.

Example: manually disable pin memory if needed
```python
from ultralytics.data.build import build_dataloader

loader = build_dataloader(dataset, batch=16, workers=8, shuffle=True, pin_memory=False)
```