### PR TITLE
`ultralytics 8.3.217` Segment masks now 4× lighter with `.byte()` optimization

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.216"
+__version__ = "8.3.217"
 
 import importlib
 import os

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -527,7 +527,7 @@ class Results(SimpleClass, DataExportMixin):
         """
         assert color_mode in {"instance", "class"}, f"Expected color_mode='instance' or 'class', not {color_mode}."
         if img is None and isinstance(self.orig_img, torch.Tensor):
-            img = (self.orig_img[0].detach().permute(1, 2, 0).contiguous() * 255).to(torch.uint8).cpu().numpy()
+            img = (self.orig_img[0].detach().permute(1, 2, 0).contiguous() * 255).byte().cpu().numpy()
 
         names = self.names
         is_obb = self.obb is not None

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -173,7 +173,7 @@ class SegmentationValidator(DetectionValidator):
         if gt_cls.shape[0] == 0 or preds["cls"].shape[0] == 0:
             tp_m = np.zeros((preds["cls"].shape[0], self.niou), dtype=bool)
         else:
-            iou = mask_iou(batch["masks"].flatten(1), preds["masks"].flatten(1))
+            iou = mask_iou(batch["masks"].flatten(1), preds["masks"].flatten(1).float())  # float, uint8
             tp_m = self.match_predictions(preds["cls"], gt_cls, iou).cpu().numpy()
         tp.update({"tp_m": tp_m})  # update tp with mask IoU
         return tp

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -557,7 +557,7 @@ def process_mask(protos, masks_in, bboxes, shape, upsample: bool = False):
     masks = crop_mask(masks, boxes=bboxes * ratios)  # CHW
     if upsample:
         masks = F.interpolate(masks[None], shape, mode="bilinear")[0]  # CHW
-    return masks.gt_(0.0)
+    return masks.gt_(0.0).byte()
 
 
 def process_mask_native(protos, masks_in, bboxes, shape):
@@ -577,7 +577,7 @@ def process_mask_native(protos, masks_in, bboxes, shape):
     masks = (masks_in @ protos.float().view(c, -1)).view(-1, mh, mw)
     masks = scale_masks(masks[None], shape)[0]  # CHW
     masks = crop_mask(masks, bboxes)  # CHW
-    return masks.gt_(0.0)
+    return masks.gt_(0.0).byte()
 
 
 def scale_masks(masks, shape, padding: bool = True):
@@ -674,7 +674,7 @@ def masks2segments(masks, strategy: str = "all"):
     from ultralytics.data.converter import merge_multi_segment
 
     segments = []
-    for x in masks.int().cpu().numpy().astype("uint8"):
+    for x in masks.cpu().numpy():
         c = cv2.findContours(x, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
         if c:
             if strategy == "all":  # merge and concatenate all segments

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -674,7 +674,7 @@ def masks2segments(masks, strategy: str = "all"):
     from ultralytics.data.converter import merge_multi_segment
 
     segments = []
-    for x in masks.cpu().numpy():
+    for x in masks.byte().cpu().numpy():
         c = cv2.findContours(x, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
         if c:
             if strategy == "all":  # merge and concatenate all segments

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -701,7 +701,7 @@ def convert_torch2numpy_batch(batch: torch.Tensor) -> np.ndarray:
     Returns:
         (np.ndarray): Output NumPy array batch with shape (Batch, Height, Width, Channels) and dtype uint8.
     """
-    return (batch.permute(0, 2, 3, 1).contiguous() * 255).clamp(0, 255).to(torch.uint8).cpu().numpy()
+    return (batch.permute(0, 2, 3, 1).contiguous() * 255).clamp(0, 255).byte().cpu().numpy()
 
 
 def clean_str(s):


### PR DESCRIPTION
@Laughing-q @Y-T-G

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Standardizes mask and image dtype handling across the codebase and fixes a segmentation IoU evaluation edge case, improving reliability and compatibility in segmentation workflows. 🧹🧠

### 📊 Key Changes
- Bumped version to 8.3.217.
- Results plotting: use `.byte()` when converting tensors to uint8 for images.
- Segmentation eval: cast predicted masks to `float()` before IoU calculation to avoid dtype issues.
- Mask processing:
  - `process_mask` and `process_mask_native` now return `byte` (uint8) tensors instead of bool.
  - `masks2segments` processes masks as `byte` tensors directly (no extra cast).
- Batch conversion: `convert_torch2numpy_batch` uses `.byte()` to ensure uint8 NumPy output.

### 🎯 Purpose & Impact
- Improves dtype consistency (bool vs uint8) in masks and images, reducing unexpected behavior and dtype-related errors. ✅
- Fixes potential inaccuracies in segmentation IoU evaluation by ensuring correct arithmetic types. 🎯
- Streamlines conversions and avoids unnecessary casts, potentially improving performance and reducing warnings. ⚡
- Minor internal API nuance: some mask-returning functions now yield uint8 instead of bool; users relying on bool masks may need to adjust. 🔧