### PR TITLE
Enhance CI configuration with concurrency settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request: {}
   schedule:
     - cron: "0 8 * * *" # runs at 08:00 UTC every day
   workflow_dispatch:
@@ -47,9 +47,19 @@ on:
         default: true
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
+
 jobs:
   HUB:
-    if: github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.hub == 'true'))
+    if: >
+      github.repository == 'ultralytics/ultralytics' &&
+      (
+        github.event_name == 'schedule' ||
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.hub == 'true')
+      )
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improve CI reliability and efficiency by adding concurrency control and clarifying triggers, with no functional change to HUB job logic. ⚙️🚀

### 📊 Key Changes
- Added GitHub Actions concurrency:
  - Grouped by workflow, ref, and head_ref.
  - Automatically cancels in-progress runs on non-main/non-release branches to avoid duplicate CI runs.
  - Preserves full runs on `main` and `release/*` branches.
- Explicitly set `pull_request: {}` (equivalent behavior, made explicit).
- Reformatted the HUB job `if:` condition for readability without changing its logic.

### 🎯 Purpose & Impact
- Faster feedback on PRs by canceling outdated CI runs on feature branches ⏩
- Reduced CI load and runner usage, improving efficiency and reducing costs 💸
- Maintains stability for critical branches (`main` and `release/*`) by never canceling their runs 🛡️
- Clearer workflow configuration, making CI behavior easier to understand and maintain 🧽