### PR TITLE
Adds "headless" install option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,24 @@ typing = [
     "types-shapely",
 ]
 
+# Dependency groups (PEP 735) for alternative installations ----------------------------------------------------------
+[dependency-groups]
+headless = [
+    "numpy>=1.23.0",
+    "matplotlib>=3.3.0",
+    "opencv-python-headless>=4.6.0",
+    "pillow>=7.1.2",
+    "pyyaml>=5.3.1",
+    "requests>=2.23.0",
+    "scipy>=1.4.1",
+    "torch>=1.8.0",
+    "torch>=1.8.0,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
+    "torchvision>=0.9.0",
+    "psutil", # system utilization
+    "polars",
+    "ultralytics-thop>=2.0.0", # FLOPs computation https://github.com/ultralytics/thop
+]  # uv pip install -e . --no-deps --group headless
+
 [project.urls]
 "Homepage" = "https://ultralytics.com"
 "Source" = "https://github.com/ultralytics/ultralytics"

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -732,7 +732,6 @@ def collect_system_info():
             current = metadata.version(r.name)
             is_met = "✅ " if check_version(current, str(r.specifier), name=r.name, hard=True) else "❌ "
         except metadata.PackageNotFoundError:
-
             current = "(not installed)"
             is_met = "❌ "
         package_info[r.name] = f"{is_met}{current}{r.specifier}"

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -642,6 +642,7 @@ def check_imshow(warn=False):
         if LINUX:
             assert not IS_COLAB and not IS_KAGGLE
             assert "DISPLAY" in os.environ, "The DISPLAY environment variable isn't set."
+        assert not check_requirements("opencv-python-headless", install=False)
         cv2.imshow("test", np.zeros((8, 8, 3), dtype=np.uint8))  # show a small 8-pixel image
         cv2.waitKey(1)
         cv2.destroyAllWindows()
@@ -726,9 +727,12 @@ def collect_system_info():
     package_info = {}
     for r in parse_requirements(package="ultralytics"):
         try:
+            if "opencv" in r.name and check_requirements("opencv-python-headless", install=False):
+                r.name = "opencv-python-headless"
             current = metadata.version(r.name)
             is_met = "✅ " if check_version(current, str(r.specifier), name=r.name, hard=True) else "❌ "
         except metadata.PackageNotFoundError:
+
             current = "(not installed)"
             is_met = "❌ "
         package_info[r.name] = f"{is_met}{current}{r.specifier}"


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

Still a WIP, but added a dependency group for "headless" installs (frequent user request). Would like to try to make a Dockerfile to go with this as well. Lots of tests will need to be explored to see about how to handle this change, but I figured I would put this up in case anyone wanted to run with it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Add a PEP 735 headless install group and update runtime checks to gracefully handle opencv-python-headless environments 🖥️🧰

### 📊 Key Changes
- Introduces [dependency-groups] `headless` in `pyproject.toml` for lightweight, GUI-free installs (uses `opencv-python-headless`, pins Torch appropriately on Windows)
- Enhances `check_imshow()` to fail fast if `opencv-python-headless` is detected, preventing GUI calls in headless environments
- Improves `collect_system_info()` to report `opencv-python-headless` when present
- Minor housekeeping: ensures consistent codespell config (newline at EOF)

### 🎯 Purpose & Impact
- Simplifies server/CI/container deployments without GUI dependencies
- Prevents runtime display errors by detecting headless OpenCV and adjusting behavior
- Produces clearer system diagnostics by accurately reflecting installed OpenCV variant
- Adds Windows-specific Torch constraint to avoid known CPU issues with 2.4.0
