### PR TITLE
Fix `VisualAI` clip feature extraction numpy() grad error

### DIFF
--- a/ultralytics/solutions/similarity_search.py
+++ b/ultralytics/solutions/similarity_search.py
@@ -78,11 +78,11 @@ class VisualAISearch:
 
     def extract_image_feature(self, path: Path) -> np.ndarray:
         """Extract CLIP image embedding from the given image path."""
-        return self.model.encode_image(Image.open(path)).cpu().numpy()
+        return self.model.encode_image(Image.open(path)).detach().cpu().numpy()
 
     def extract_text_feature(self, text: str) -> np.ndarray:
         """Extract CLIP text embedding from the given text query."""
-        return self.model.encode_text(self.model.tokenize([text])).cpu().numpy()
+        return self.model.encode_text(self.model.tokenize([text])).detach().cpu().numpy()
 
     def load_or_build_index(self) -> None:
         """


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Safely detaches CLIP embeddings before converting to NumPy in the similarity search solution to prevent gradient-related issues and reduce memory overhead. 🔧

### 📊 Key Changes
- Added `.detach()` before `.cpu().numpy()` in:
  - `extract_image_feature`: `encode_image(...).detach().cpu().numpy()`
  - `extract_text_feature`: `encode_text(...).detach().cpu().numpy()`

### 🎯 Purpose & Impact
- Prevents PyTorch errors when converting tensors that require gradients to NumPy (common in non-training/inference flows). ✅
- Reduces unnecessary gradient tracking and memory usage during embedding extraction. 🧠💾
- Improves stability and compatibility across environments where autograd may be enabled. 🌐
- Non-breaking change; behavior remains the same for users, with fewer warnings/errors. 👍