### PR TITLE
Update Banner Text

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,7 +8,7 @@
   target="_blank"
 >
   <div class="banner-content-wrapper">
-    <p>Register now for</p>
+    <p>Join now</p>
     <img
       src="https://cdn.prod.website-files.com/680a070c3b99253410dd3dcf/6895ca9b3ece7244d9981ab9_yv25-logo.avif"
       loading="lazy"


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates docs site banner copy from “Register now for” to a shorter, friendlier “Join now.” ✅

### 📊 Key Changes
- Replaces banner text in `docs/overrides/main.html` from “Register now for” to “Join now” ✍️
- No changes to code, models, or APIs—docs UI copy only 🧩

### 🎯 Purpose & Impact
- Improves clarity and tone with a concise, welcoming call-to-action 🗣️
- May increase engagement and click-through on the docs banner 📈
- Zero impact on package behavior; safe for all users to adopt ✅