### PR TITLE
Improve accuracy of NMS export with quantization

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1488,7 +1488,7 @@ class NMSModel(torch.nn.Module):
         preds = self.model(x)
         pred = preds[0] if isinstance(preds, tuple) else preds
         if self.obb:
-            pred.float()  # OBB requires FP32 NMS for accuracy
+            pred = pred.float()  # OBB requires FP32 NMS for accuracy
         kwargs = dict(device=pred.device, dtype=pred.dtype)
         bs = pred.shape[0]
         pred = pred.transpose(-1, -2)  # shape(1,84,6300) to shape(1,6300,84)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1519,7 +1519,7 @@ class NMSModel(torch.nn.Module):
             if not self.args.agnostic_nms:  # class-wise NMS
                 end = 2 if self.obb else 4
                 # fully explicit expansion otherwise reshape error
-                cls_offset = cls.reshape(cls.shape[0], 1).expand(cls.shape[0], end)
+                cls_offset = cls.view(cls.shape[0], 1).expand(cls.shape[0], end)
                 offbox = nmsbox[:, :end] + cls_offset * multiplier
                 nmsbox = torch.cat((offbox, nmsbox[:, end:]), dim=-1)
             nms_fn = (

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1508,7 +1508,7 @@ class NMSModel(torch.nn.Module):
                 # Explicit length otherwise reshape error, hardcoded to `self.args.max_det * 5`
                 mask = score.topk(min(self.args.max_det * 5, score.shape[0])).indices
             box, score, cls, extra = box[mask], score[mask], cls[mask], extra[mask]
-            nmsbox = box.clone()  # force FP32 for better accuracy
+            nmsbox = box.clone()
             # `8` is the minimum value experimented to get correct NMS results for obb
             multiplier = (8 if self.obb else 1) / len(self.model.names)
             # Normalize boxes for NMS since large values for class offset causes issue with int8 quantization

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1509,7 +1509,7 @@ class NMSModel(torch.nn.Module):
                 mask = score.topk(min(self.args.max_det * 5, score.shape[0])).indices
             box, score, cls, extra = box[mask], score[mask], cls[mask], extra[mask]
             nmsbox = box.clone()
-            # `8` is the minimum value experimented to get correct NMS results for obb
+            multiplier = (8 if self.obb else 1) / max(len(self.model.names), 1)
             multiplier = (8 if self.obb else 1) / len(self.model.names)
             # Normalize boxes for NMS since large values for class offset causes issue with int8 quantization
             if self.args.format == "tflite":  # TFLite is already normalized

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1509,8 +1509,8 @@ class NMSModel(torch.nn.Module):
                 mask = score.topk(min(self.args.max_det * 5, score.shape[0])).indices
             box, score, cls, extra = box[mask], score[mask], cls[mask], extra[mask]
             nmsbox = box.clone()
+            # `8` is the minimum value experimented to get correct NMS results for obb
             multiplier = (8 if self.obb else 1) / max(len(self.model.names), 1)
-            multiplier = (8 if self.obb else 1) / len(self.model.names)
             # Normalize boxes for NMS since large values for class offset causes issue with int8 quantization
             if self.args.format == "tflite":  # TFLite is already normalized
                 nmsbox *= multiplier

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1487,8 +1487,7 @@ class NMSModel(torch.nn.Module):
 
         preds = self.model(x)
         pred = preds[0] if isinstance(preds, tuple) else preds
-        if self.obb:
-            pred = pred.float()  # OBB requires FP32 NMS for accuracy
+        pred = pred.float()  # force FP32 for NMS accuracy
         kwargs = dict(device=pred.device, dtype=pred.dtype)
         bs = pred.shape[0]
         pred = pred.transpose(-1, -2)  # shape(1,84,6300) to shape(1,6300,84)
@@ -1510,7 +1509,7 @@ class NMSModel(torch.nn.Module):
                 # Explicit length otherwise reshape error, hardcoded to `self.args.max_det * 5`
                 mask = score.topk(min(self.args.max_det * 5, score.shape[0])).indices
             box, score, cls, extra = box[mask], score[mask], cls[mask], extra[mask]
-            nmsbox = box.clone()
+            nmsbox = box.clone()  # force FP32 for better accuracy
             # `8` is the minimum value experimented to get correct NMS results for obb
             multiplier = (8 if self.obb else 1) / len(self.model.names)
             # Normalize boxes for NMS since large values for class offset causes issue with int8 quantization

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1470,7 +1470,7 @@ class NMSModel(torch.nn.Module):
         self.obb = model.task == "obb"
         self.is_tf = self.args.format in frozenset({"saved_model", "tflite", "tfjs"})
 
-    def forward(self, x, *args, **kwargs):
+    def forward(self, x):
         """
         Perform inference with NMS post-processing. Supports Detect, Segment, OBB and Pose.
 
@@ -1517,7 +1517,7 @@ class NMSModel(torch.nn.Module):
                 nmsbox *= multiplier
             else:
                 nmsbox = multiplier * (nmsbox / torch.tensor(x.shape[2:], **kwargs).max())
-            if not self.args.agnostic_nms:
+            if not self.args.agnostic_nms:  # class-wise NMS
                 end = 2 if self.obb else 4
                 # fully explicit expansion otherwise reshape error
                 cls_offset = cls.reshape(cls.shape[0], 1).expand(cls.shape[0], end)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1487,7 +1487,6 @@ class NMSModel(torch.nn.Module):
 
         preds = self.model(x)
         pred = preds[0] if isinstance(preds, tuple) else preds
-        pred = pred.float()  # force FP32 for NMS accuracy
         kwargs = dict(device=pred.device, dtype=pred.dtype)
         bs = pred.shape[0]
         pred = pred.transpose(-1, -2)  # shape(1,84,6300) to shape(1,6300,84)


### PR DESCRIPTION
**PyTorch reference**
```
yolo val model=yolo11n.pt data=coco.yaml rect=False exist_ok half

 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.387
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.542
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.421
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.196
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.425
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.561
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.311
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.509
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.561
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.334
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.624
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.734
 Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.768
 Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.612
```

**main**
```
yolo export model=yolo11n.pt format=onnx half device=0 nms conf=0.001
yolo val model=yolo11n.onnx data=coco.yaml rect=False exist_ok half

 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.374
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.520
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.407
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.177
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.411
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.559
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.311
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.504
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.558
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.329
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.622
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.734
 Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.762
 Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.604
```

**PR**
```
yolo export model=yolo11n.pt format=onnx half device=0 nms conf=0.001
yolo val model=yolo11n.onnx data=coco.yaml rect=False exist_ok half

 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.387
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.542
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.421
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.195
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.425
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.561
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.312
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.510
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.561
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.334
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.625
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.735
 Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.769
 Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.611
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refines NMS box normalization and class-offset scaling in the exporter to improve stability, especially for quantized and OBB models. 🚀

### 📊 Key Changes
- Scales NMS multiplier by the number of classes: `(8 if OBB else 1) / max(len(model.names), 1)` to avoid large class offsets.
- Keeps TFLite path normalized as-is but applies new multiplier consistently.
- Clarifies class-wise NMS logic and improves tensor shaping using `view(...).expand(...)` for safer expansion.
- Minor comment/wording cleanup (e.g., “class-wise NMS”).

### 🎯 Purpose & Impact
- Reduces quantization issues (e.g., int8 overflow/precision loss) by shrinking class-dependent offsets, improving NMS reliability. ✅
- Enhances stability for datasets with many classes and for OBB use cases. 🧭
- Lowers risk of shape-related errors during export by aligning expansions with class tensor shapes. 🧩
- Leads to more consistent postprocessing in exported models, especially TFLite, improving downstream accuracy. 📈