### PR TITLE
Clarify hyperparameter tuning limitations in guide

### DIFF
--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -106,7 +106,11 @@ The following table lists the default search space parameters for hyperparameter
 
 ## Custom Search Space Example
 
-Here's how to define a search space and use the `model.tune()` method to utilize the `Tuner` class for hyperparameter tuning of YOLO11n on COCO8 for 30 epochs with an AdamW optimizer and skipping plotting, checkpointing and validation other than on final epoch for faster Tuning. Please note that hyperparameters obtained from quick tuning with a small number of epochs are likely not optimal for full training. The tuning process may, for instance, increase certain loss weights to make the network converge faster within fewer epochs, or reduce the intensity of some image augmentations to improve validation performance under such limited training conditions.
+Here's how to define a search space and use the `model.tune()` method to utilize the `Tuner` class for hyperparameter tuning of YOLO11n on COCO8 for 30 epochs with an AdamW optimizer and skipping plotting, checkpointing and validation other than on final epoch for faster Tuning. 
+
+!!! warning
+
+    Note that hyperparameters obtained from quick tuning with a small number of epochs are likely not optimal for full training. The tuning process may, for instance, increase certain loss weights to make the network converge faster within fewer epochs, or reduce the intensity of some image augmentations to improve validation performance under such limited training conditions.
 
 !!! example
 

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -106,7 +106,7 @@ The following table lists the default search space parameters for hyperparameter
 
 ## Custom Search Space Example
 
-Here's how to define a search space and use the `model.tune()` method to utilize the `Tuner` class for hyperparameter tuning of YOLO11n on COCO8 for 30 epochs with an AdamW optimizer and skipping plotting, checkpointing and validation other than on final epoch for faster Tuning.
+Here's how to define a search space and use the `model.tune()` method to utilize the `Tuner` class for hyperparameter tuning of YOLO11n on COCO8 for 30 epochs with an AdamW optimizer and skipping plotting, checkpointing and validation other than on final epoch for faster Tuning. Please note that hyperparameters obtained from quick tuning with a small number of epochs are likely not optimal for full training. The tuning process may, for instance, increase certain loss weights to make the network converge faster within fewer epochs, or reduce the intensity of some image augmentations to improve validation performance under such limited training conditions.
 
 !!! example
 


### PR DESCRIPTION
Added a note about the potential non-optimality of hyperparameters obtained from quick tuning with fewer epochs.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies limitations of quick hyperparameter tuning in the YOLO11 guide, explaining that results from few-epoch runs may not generalize to full training. 📝

### 📊 Key Changes
- Adds a cautionary note to the hyperparameter tuning guide
- Explains why few-epoch tuning may bias loss weights and augmentation settings
- No code changes; documentation-only update

### 🎯 Purpose & Impact
- Helps users set realistic expectations for tuning results
- Reduces misconfiguration by highlighting differences between quick and full training
- Improves documentation clarity without affecting functionality 🚀