### PR TITLE
Remove British class names

### DIFF
--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -110,7 +110,7 @@ Here's how to define a search space and use the `model.tune()` method to utilize
 
 !!! warning
 
-    Code is for **example purposes only**. Hyperparameters obtained from quick tuning with a small number of epochs are likely not optimal for full training. The tuning process may, for instance, increase certain loss weights to make the network converge faster within fewer epochs, or reduce the intensity of some image augmentations to improve validation performance under such limited training conditions.
+    This example is for **demonstration** only. Hyperparameters derived from short or small-scale tuning runs are rarely optimal for real-world training. In practice, tuning should be performed under settings similar to full training — including comparable datasets, epochs, and augmentations — to ensure reliable and transferable results. Quick tuning may bias parameters toward faster convergence or short-term validation gains that do not generalize.
 
 !!! example
 

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -106,7 +106,7 @@ The following table lists the default search space parameters for hyperparameter
 
 ## Custom Search Space Example
 
-Here's how to define a search space and use the `model.tune()` method to utilize the `Tuner` class for hyperparameter tuning of YOLO11n on COCO8 for 30 epochs with an AdamW optimizer and skipping plotting, checkpointing and validation other than on final epoch for faster Tuning. 
+Here's how to define a search space and use the `model.tune()` method to utilize the `Tuner` class for hyperparameter tuning of YOLO11n on COCO8 for 30 epochs with an AdamW optimizer and skipping plotting, checkpointing and validation other than on final epoch for faster Tuning.
 
 !!! warning
 

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -110,7 +110,7 @@ Here's how to define a search space and use the `model.tune()` method to utilize
 
 !!! warning
 
-    Note that hyperparameters obtained from quick tuning with a small number of epochs are likely not optimal for full training. The tuning process may, for instance, increase certain loss weights to make the network converge faster within fewer epochs, or reduce the intensity of some image augmentations to improve validation performance under such limited training conditions.
+    Code is for **example purposes only**. Hyperparameters obtained from quick tuning with a small number of epochs are likely not optimal for full training. The tuning process may, for instance, increase certain loss weights to make the network converge faster within fewer epochs, or reduce the intensity of some image augmentations to improve validation performance under such limited training conditions.
 
 !!! example
 

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -40,6 +40,9 @@
 146309319+leonnil@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/146309319?v=4
   username: leonnil
+1490435889@qq.com:
+  avatar: null
+  username: null
 1579093407@qq.com:
   avatar: https://avatars.githubusercontent.com/u/160490334?v=4
   username: YOLOv5-Magic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,4 +190,4 @@ in-place = true
 
 [tool.codespell]
 ignore-words-list = "grey,writeable,finalY,RepResNet,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,iTerm,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin"
-skip = "lvis.yaml,open-images-v7.yaml,ImageNet.yaml,*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml"
+skip = "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml"

--- a/ultralytics/cfg/datasets/ImageNet.yaml
+++ b/ultralytics/cfg/datasets/ImageNet.yaml
@@ -342,7 +342,7 @@ names:
   322: ringlet
   323: monarch butterfly
   324: small white
-  325: sulphur butterfly
+  325: sulfur butterfly
   326: gossamer-winged butterfly
   327: starfish
   328: sea urchin

--- a/ultralytics/cfg/datasets/lvis.yaml
+++ b/ultralytics/cfg/datasets/lvis.yaml
@@ -35,7 +35,7 @@ names:
   17: armband
   18: armchair
   19: armoire
-  20: armor/armour
+  20: armor
   21: artichoke
   22: trash can/garbage can/wastebin/dustbin/trash barrel/trash bin
   23: ashtray
@@ -245,7 +245,7 @@ names:
   227: CD player
   228: celery
   229: cellular telephone/cellular phone/cellphone/mobile phone/smart phone
-  230: chain mail/ring mail/chain armor/chain armour/ring armor/ring armour
+  230: chain mail/ring mail/chain armor/ring armor
   231: chair
   232: chaise longue/chaise/daybed
   233: chalice
@@ -305,7 +305,7 @@ names:
   287: coin
   288: colander/cullender
   289: coleslaw/slaw
-  290: coloring material/colouring material
+  290: coloring material
   291: combination lock
   292: pacifier/teething ring
   293: comic book
@@ -401,7 +401,7 @@ names:
   383: domestic ass/donkey
   384: doorknob/doorhandle
   385: doormat/welcome mat
-  386: doughnut/donut
+  386: donut
   387: dove
   388: dragonfly
   389: drawer
@@ -1072,7 +1072,7 @@ names:
   1054: tag
   1055: taillight/rear light
   1056: tambourine
-  1057: army tank/armored combat vehicle/armoured combat vehicle
+  1057: army tank/armored combat vehicle
   1058: tank/tank storage vessel/storage tank
   1059: tank top/tank top clothing
   1060: tape/tape sticky cloth or paper

--- a/ultralytics/cfg/datasets/open-images-v7.yaml
+++ b/ultralytics/cfg/datasets/open-images-v7.yaml
@@ -182,7 +182,7 @@ names:
   163: Dolphin
   164: Door
   165: Door handle
-  166: Doughnut
+  166: Donut
   167: Dragonfly
   168: Drawer
   169: Dress


### PR DESCRIPTION
The class names are only used for display/output - LVIS training uses the numerical indices (0-1202). The dataset annotations reference class IDs, not text strings.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Standardizes dataset class names to American English, clarifies hyperparameter tuning docs, and tightens spelling checks across the repo. 🇺🇸🛠️

### 📊 Key Changes
- Docs: Strengthened warning in the hyperparameter tuning guide to stress demo-only settings and real-world tuning best practices.
- Datasets:
  - ImageNet: “sulphur butterfly” → “sulfur butterfly”.
  - LVIS: Simplified/standardized names (e.g., “armor/armour” → “armor”, “doughnut” → “donut”, removed British variants like “colouring”).
  - Open Images V7: “Doughnut” → “Donut”.
- Tooling: Updated codespell config to stop excluding specific dataset YAMLs, allowing spelling checks on them.
- Docs metadata: Added a new author entry to docs configuration.

### 🎯 Purpose & Impact
- Clearer guidance ✅: Users get more reliable expectations for hyperparameter tuning; encourages tuning under full-training-like conditions.
- Consistent labels 🧭: Cleaner, more consistent class names (American English) improve readability and reduce confusion across datasets.
- Fewer typos 🔍: Including dataset YAMLs in codespell checks helps catch and prevent spelling inconsistencies going forward.
- Low risk, minor compatibility notes ⚠️:
  - Indexes/IDs are unchanged, so training and evaluation are unaffected.
  - If your code relies on exact class-name strings (e.g., “doughnut”), update to the new names (“donut”) to avoid mismatches or UI label differences.