### PR TITLE
Update `ultralytics-thop>=2.0.18`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "torchvision>=0.9.0",
     "psutil", # system utilization
     "polars",
-    "ultralytics-thop>=2.0.0", # FLOPs computation https://github.com/ultralytics/thop
+    "ultralytics-thop>=2.0.18", # FLOPs computation https://github.com/ultralytics/thop
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps the minimum version of the ultralytics-thop dependency to ensure more accurate and reliable FLOPs computation ⚙️📈

### 📊 Key Changes
- Update dependency: `ultralytics-thop` from `>=2.0.0` to `>=2.0.18`
- Applies to FLOPs calculation used across models (via the FLOPs utility)

Reference: See the FLOPs tool in [ultralytics-thop](https://github.com/ultralytics/thop).

### 🎯 Purpose & Impact
- Improved FLOPs accuracy and stability through bug fixes and enhancements in newer `ultralytics-thop` versions ✅
- Better compatibility with recent PyTorch and model layers, reducing errors during FLOPs computation 🔧
- More consistent benchmarking and reporting for users comparing models (e.g., YOLO11/YOLO26), potentially with minor changes to reported FLOPs 📊
- Fewer install/runtime issues by avoiding older, less maintained versions 🚀

Example:
- After upgrading, `pip install ultralytics` will pull a newer FLOPs backend, so `model.info(verbose=True)` and training logs show more reliable FLOPs values.