### PR TITLE
Commit Weights & Biases logs after each epoch to force dashboard update

### DIFF
--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -145,7 +145,7 @@ def on_fit_epoch_end(trainer):
     _log_plots(trainer.validator.plots, step=trainer.epoch + 1)
     if trainer.epoch == 0:
         wb.run.log(model_info_for_loggers(trainer), step=trainer.epoch + 1)
-    wb.run.log({}, commit=True)  # manual commit
+    wb.run.log({}, commit=True)  # force sync
 
 
 def on_train_epoch_end(trainer):

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -140,12 +140,11 @@ def on_pretrain_routine_start(trainer):
 
 def on_fit_epoch_end(trainer):
     """Log training metrics and model information at the end of an epoch."""
-    wb.run.log(trainer.metrics, step=trainer.epoch + 1)
     _log_plots(trainer.plots, step=trainer.epoch + 1)
     _log_plots(trainer.validator.plots, step=trainer.epoch + 1)
     if trainer.epoch == 0:
         wb.run.log(model_info_for_loggers(trainer), step=trainer.epoch + 1)
-    wb.run.log({}, commit=True)  # force sync
+    wb.run.log(trainer.metrics, step=trainer.epoch + 1, commit=True)  # commit forces sync
 
 
 def on_train_epoch_end(trainer):

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -145,6 +145,7 @@ def on_fit_epoch_end(trainer):
     _log_plots(trainer.validator.plots, step=trainer.epoch + 1)
     if trainer.epoch == 0:
         wb.run.log(model_info_for_loggers(trainer), step=trainer.epoch + 1)
+    wb.run.log({}, commit=True)  # manual commit
 
 
 def on_train_epoch_end(trainer):


### PR DESCRIPTION
Without manual commit, it doesn't update the dashboard until the next epoch completes.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improve Weights & Biases (W&B) logging reliability by committing epoch metrics explicitly and aligning log order for cleaner, real-time dashboards. ✅

### 📊 Key Changes
- Move W&B metrics logging to after plot logging within `on_fit_epoch_end`.
- Add `commit=True` to `wb.run.log(trainer.metrics, ...)` to force per-epoch sync. 🔄
- Keep first-epoch model info logging intact (`model_info_for_loggers`) at step `epoch + 1`.

### 🎯 Purpose & Impact
- Ensure metrics are committed and visible immediately each epoch in W&B, reducing delays or missing data. 📈
- Align plots and metrics at the same step for consistent, easier-to-read dashboards. 🧭
- Improve reliability of training monitoring without breaking changes; minimal overhead added. 🚀
- Better real-time feedback for users tracking YOLO11/YOLO26 training runs via Ultralytics HUB or local setups.