### PR TITLE
Fix 429 forum links in Dockerfile-jetson-jetpack4

### DIFF
--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -41,11 +41,6 @@ RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
     sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
-# Download onnxruntime-gpu 1.8.0 and tensorrt 8.2.0.6
-# Other versions can be seen in https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
-ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl .
-ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl .
-
 # Replace pyproject.toml TF.js version with 'tensorflowjs>=3.9.0' for JetPack4 compatibility
 RUN sed -i 's/^\( *"tensorflowjs\)>=.*\(".*\)/\1>=3.9.0\2/' pyproject.toml
 
@@ -53,9 +48,10 @@ RUN sed -i 's/^\( *"tensorflowjs\)>=.*\(".*\)/\1>=3.9.0\2/' pyproject.toml
 RUN python3 -m pip install --upgrade pip && \
     python3 -m pip install uv
 # Install pip packages and remove extra build files
+# Onnxruntime and TensorRT from https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
 RUN uv pip install --system \
-    onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl \
-    tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-1.11.0a0+gitbc2c6ed-cp38-cp38-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.12.0a0+9b5a3fe-cp38-cp38-linux_aarch64.whl && \
     uv pip install --system -e ".[export]" && \

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -43,8 +43,8 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
 # Download onnxruntime-gpu 1.8.0 and tensorrt 8.2.0.6
 # Other versions can be seen in https://elinux.org/Jetson_Zoo and https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048
-ADD https://nvidia.box.com/shared/static/gjqofg7rkg97z3gc8jeyup6t8n9j8xjw.whl onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl
-ADD https://forums.developer.nvidia.com/uploads/short-url/hASzFOm9YsJx6VVFrDW1g44CMmv.whl tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl
+ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.8.0-cp38-cp38-linux_aarch64.whl .
+ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/tensorrt-8.2.0.6-cp38-none-linux_aarch64.whl .
 
 # Replace pyproject.toml TF.js version with 'tensorflowjs>=3.9.0' for JetPack4 compatibility
 RUN sed -i 's/^\( *"tensorflowjs\)>=.*\(".*\)/\1>=3.9.0\2/' pyproject.toml


### PR DESCRIPTION
@lakshanthad links in this Dockerfile are unreliable, we should not link to forums or box.com links in Dockerfiles for important downloads.
https://github.com/ultralytics/ultralytics/actions/runs/19043760302/job/54386856287

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Switches Jetson JetPack 4 Docker build to fetch ONNX Runtime and TensorRT wheels from Ultralytics Assets instead of external/ephemeral sources for more reliable, reproducible builds. 🚀

### 📊 Key Changes
- Removed direct ADD of ONNX Runtime (1.8.0) and TensorRT (8.2.0.6) wheels from third-party links (nvidia.box.com and NVIDIA forums).
- Updated installation to pull the same wheels directly from the Ultralytics-hosted assets:
  - ONNX Runtime GPU: [Ultralytics Assets (v0.0.0)](https://github.com/ultralytics/assets/releases/tag/v0.0.0)
  - TensorRT: [Ultralytics Assets (v0.0.0)](https://github.com/ultralytics/assets/releases/tag/v0.0.0)
- Kept JetPack 4 compatibility tweaks (e.g., TensorFlow.js version pin and OpenCV headless).
- Added clarifying comment with reference sources (Jetson Zoo and NVIDIA PyTorch for Jetson thread):
  - [Jetson Zoo reference](https://elinux.org/Jetson_Zoo)
  - [NVIDIA PyTorch for Jetson thread](https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048)

### 🎯 Purpose & Impact
- Improves reliability: avoids broken or expiring third‑party links by using stable Ultralytics-hosted artifacts. ✅
- Enhances reproducibility: consistent, versioned wheels ensure deterministic Docker builds across environments. 🧱
- Simplifies Docker layers: eliminates intermediate wheel files, reducing layer clutter and potential cache issues. 📦
- Maintains device compatibility: preserves tested versions for Jetson JetPack 4, ensuring ONNX/TensorRT and YOLO11 workflows continue to work as expected. 🤖