### PR TITLE
add support for multi-gpu acceleration in offline validation

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -42,7 +42,7 @@ from ultralytics.utils import (
 )
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, check_model_file_from_stem, print_args
-from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command
+from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command, decide_world_size
 from ultralytics.utils.files import get_latest_run
 from ultralytics.utils.plotting import plot_results
 from ultralytics.utils.torch_utils import (
@@ -178,17 +178,7 @@ class BaseTrainer:
         # Callbacks
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
 
-        if isinstance(self.args.device, str) and len(self.args.device):  # i.e. device='0' or device='0,1,2,3'
-            world_size = len(self.args.device.split(","))
-        elif isinstance(self.args.device, (tuple, list)):  # i.e. device=[0, 1, 2, 3] (multi-GPU from CLI is list)
-            world_size = len(self.args.device)
-        elif self.args.device in {"cpu", "mps"}:  # i.e. device='cpu' or 'mps'
-            world_size = 0
-        elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number
-            world_size = 1  # default to device 0
-        else:  # i.e. device=None or device=''
-            world_size = 0
-
+        world_size = decide_world_size(self.args.device)
         self.ddp = world_size > 1 and "LOCAL_RANK" not in os.environ
         self.world_size = world_size
         # Run subprocess if DDP training, else train normally

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -42,7 +42,7 @@ from ultralytics.utils import (
 )
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, check_model_file_from_stem, print_args
-from ultralytics.utils.dist import ddp_cleanup, generate_ddp_command, decide_world_size
+from ultralytics.utils.dist import ddp_cleanup, decide_world_size, generate_ddp_command
 from ultralytics.utils.files import get_latest_run
 from ultralytics.utils.plotting import plot_results
 from ultralytics.utils.torch_utils import (

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -22,7 +22,9 @@ Usage - formats:
                           yolo11n_imx_model          # Sony IMX
                           yolo11n_rknn_model         # Rockchip RKNN
 """
-
+import os
+import subprocess
+from datetime import timedelta
 import json
 import time
 from pathlib import Path
@@ -30,14 +32,17 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.distributed as dist
+from typing import Optional, Callable
 
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import LOGGER, RANK, TQDM, callbacks, colorstr, emojis
+from ultralytics.utils import LOGGER, RANK, LOCAL_RANK, TQDM, callbacks, colorstr, emojis
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
-from ultralytics.utils.torch_utils import attempt_compile, select_device, smart_inference_mode, unwrap_model
+from ultralytics.utils.dist import decide_world_size, ddp_cleanup, generate_distributed_validation_command
+from ultralytics.utils.torch_utils import attempt_compile, select_device, smart_inference_mode, unwrap_model, torch_distributed_zero_first
+
 
 
 class BaseValidator:
@@ -106,7 +111,14 @@ class BaseValidator:
         self.dataloader = dataloader
         self.stride = None
         self.data = None
-        self.device = None
+        self.device = select_device(self.args.device)
+
+        # Update "-1" devices so post-training val does not repeat search
+        self.args.device = os.getenv("CUDA_VISIBLE_DEVICES") if "cuda" in str(self.device) else str(self.device)
+        world_size = decide_world_size(self.args.device)
+        self.ddp = world_size > 1 and "LOCAL_RANK" not in os.environ
+        self.world_size = world_size
+
         self.batch_i = None
         self.training = True
         self.names = None
@@ -119,13 +131,124 @@ class BaseValidator:
         self.speed = {"preprocess": 0.0, "inference": 0.0, "loss": 0.0, "postprocess": 0.0}
 
         self.save_dir = save_dir or get_save_dir(self.args)
-        (self.save_dir / "labels" if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
+        if RANK in {-1, 0}:
+            (self.save_dir / "labels" if self.args.save_txt else self.save_dir).mkdir(parents=True, exist_ok=True)
         if self.args.conf is None:
             self.args.conf = 0.01 if self.args.task == "obb" else 0.001  # reduce OBB val memory usage
         self.args.imgsz = check_imgsz(self.args.imgsz, max_dim=1)
 
         self.plots = {}
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
+
+    def _setup_distributed(self):
+        """Initialize the distributed process group for multi-process validation.
+
+        This was originally copied from the trainer's DDP setup. For validation we don't
+        wrap the model in DistributedDataParallel (no gradient sync), but we may still
+        need a process group when running multi-process validation so that collective
+        operations (e.g. dist.reduce in loss aggregation or other gather/reduce ops in
+        `gather_stats`) work correctly on spawned child processes.
+
+        This method must be called in each spawned process (where `LOCAL_RANK` is set)
+        to configure the device and initialize the torch.distributed process group.
+        """
+        # bind the current process to the correct CUDA device index
+        torch.cuda.set_device(RANK)
+        self.device = torch.device("cuda", RANK)
+        # make NCCL blocking waits deterministic for timeouts
+        os.environ["TORCH_NCCL_BLOCKING_WAIT"] = "1"
+        dist.init_process_group(
+            backend="nccl" if dist.is_nccl_available() else "gloo",
+            timeout=timedelta(seconds=10800 * 3),  # 3 hours
+            rank=RANK,
+            world_size=self.world_size,
+        )
+
+    def _setup_model(self, model_nn: Optional[torch.nn.Module]) -> AutoBackend:
+        """Load, create, or download model for any task.
+
+        Returns:
+            torch.nn.Module
+        """
+        if str(self.args.model).endswith(".yaml") and model_nn is None:
+            LOGGER.warning("Validating an untrained model YAML will result in 0 mAP.")
+
+        model = AutoBackend(
+            model=model_nn or self.args.model,
+            device=self.device,
+            dnn=self.args.dnn,
+            data=self.args.data,
+            fp16=self.args.half,
+        )
+        
+        if self.args.compile:
+            model = attempt_compile(model, device=self.device)
+
+        model.eval()
+        return model
+
+    def _setup_dataset_once(self) -> dict:
+        """Setup dataset once to avoid auto-downloading multiple times."""
+        with torch_distributed_zero_first(LOCAL_RANK):  # avoid auto-downloading dataset multiple times
+            if str(self.args.data).rsplit(".", 1)[-1] in {"yaml", "yml"}:
+                data = check_det_dataset(self.args.data)
+            elif self.args.task == "classify":
+                data = check_cls_dataset(self.args.data, split=self.args.split)
+            else:
+                raise FileNotFoundError(emojis(f"Dataset '{self.args.data}' for task={self.args.task} not found ❌"))
+
+        return data
+
+    def _setup_validation(self, model_nn: Optional[torch.nn.Module] = None):
+        """Build dataloaders and optimizer on correct rank process."""
+        self.model = self._setup_model(model_nn)
+        self.stride = self.model.stride  # used in get_dataloader() for padding
+
+        self.args.half = self.model.fp16  # update half
+        stride, pt, jit = self.model.stride, self.model.pt, self.model.jit
+        imgsz = check_imgsz(self.args.imgsz, stride=stride)
+
+        if not (pt or jit or getattr(self.model, "dynamic", False)):
+            self.args.batch = self.model.metadata.get("batch", 1)  # export.py models default to batch-size 1
+            LOGGER.info(f"Setting batch={self.args.batch} input of shape ({self.args.batch}, 3, {imgsz}, {imgsz})")
+
+        self.data = self._setup_dataset_once()
+
+        local_batch_size = self.args.batch // max(self.world_size, 1)
+        # Subclasses will use LOCAL_RANK to construct loader
+        self.dataloader = self.get_dataloader(self.data.get(self.args.split), local_batch_size)
+
+        self.model.warmup(imgsz=(1 if self.model.pt else self.args.batch, self.data["channels"], imgsz, imgsz))  # warmup
+
+    def do_offline_validation(self):
+        """Allow device='', device=None on Multi-GPU systems to default to device=0."""
+        # Run subprocess if DDP training, else train normally
+        if self.ddp:
+            # Argument checks
+            if self.args.batch < 1.0:
+                raise ValueError(
+                    "Autobatch with batch<1 not supported for Multi-GPU training, "
+                    "please specify a valid batch size multiple of GPU count (self.world_size), i.e. batch=(self.world_size * 8)."
+                )
+            
+            # Command: spawn multiple processes for distributed (multi-process) validation
+            cmd, file = generate_distributed_validation_command(self)
+            try:
+                LOGGER.info(f"{colorstr('DISTRIBUTED:')} debug command {' '.join(cmd)}")
+                subprocess.run(cmd, check=True)
+            except Exception:
+                raise
+            finally:
+                # cleanup temporary file created for distributed validation
+                ddp_cleanup(self, file)
+        else:
+            self.training = False
+            if self.world_size > 1:
+                # initialize distributed process group in spawned child processes
+                self._setup_distributed()
+            self._setup_validation()
+            # Run single-worker validation path: no label_loss_items and no augmentation
+            return self._do_val_single_worker(self.model, None, False)
 
     @smart_inference_mode()
     def __call__(self, trainer=None, model=None):
@@ -152,44 +275,15 @@ class BaseValidator:
             self.loss = torch.zeros_like(trainer.loss_items, device=trainer.device)
             self.args.plots &= trainer.stopper.possible_stop or (trainer.epoch == trainer.epochs - 1)
             model.eval()
+            return self._do_val_single_worker(model, trainer.label_loss_items, augment)
         else:
-            if str(self.args.model).endswith(".yaml") and model is None:
-                LOGGER.warning("validating an untrained model YAML will result in 0 mAP.")
-            callbacks.add_integration_callbacks(self)
-            model = AutoBackend(
-                model=model or self.args.model,
-                device=select_device(self.args.device) if RANK == -1 else torch.device("cuda", RANK),
-                dnn=self.args.dnn,
-                data=self.args.data,
-                fp16=self.args.half,
-            )
-            self.device = model.device  # update device
-            self.args.half = model.fp16  # update half
-            stride, pt, jit = model.stride, model.pt, model.jit
-            imgsz = check_imgsz(self.args.imgsz, stride=stride)
-            if not (pt or jit or getattr(model, "dynamic", False)):
-                self.args.batch = model.metadata.get("batch", 1)  # export.py models default to batch-size 1
-                LOGGER.info(f"Setting batch={self.args.batch} input of shape ({self.args.batch}, 3, {imgsz}, {imgsz})")
-
-            if str(self.args.data).rsplit(".", 1)[-1] in {"yaml", "yml"}:
-                self.data = check_det_dataset(self.args.data)
-            elif self.args.task == "classify":
-                self.data = check_cls_dataset(self.args.data, split=self.args.split)
+            if self.world_size <= 1:
+                self._setup_validation(model_nn=model)
+                return self._do_val_single_worker(self.model, None, augment)
             else:
-                raise FileNotFoundError(emojis(f"Dataset '{self.args.data}' for task={self.args.task} not found ❌"))
+                return self.do_offline_validation()
 
-            if self.device.type in {"cpu", "mps"}:
-                self.args.workers = 0  # faster CPU val as time dominated by inference, not dataloading
-            if not (pt or (getattr(model, "dynamic", False) and not model.imx)):
-                self.args.rect = False
-            self.stride = model.stride  # used in get_dataloader() for padding
-            self.dataloader = self.dataloader or self.get_dataloader(self.data.get(self.args.split), self.args.batch)
-
-            model.eval()
-            if self.args.compile:
-                model = attempt_compile(model, device=self.device)
-            model.warmup(imgsz=(1 if pt else self.args.batch, self.data["channels"], imgsz, imgsz))  # warmup
-
+    def _do_val_single_worker(self, model: torch.nn.Module, label_loss_items: Optional[Callable], augment: bool = False):
         self.run_callbacks("on_val_start")
         dt = (
             Profile(device=self.device),
@@ -240,11 +334,11 @@ class BaseValidator:
             model.float()
             # Reduce loss across all GPUs
             loss = self.loss.clone().detach()
-            if trainer.world_size > 1:
+            if self.world_size > 1:
                 dist.reduce(loss, dst=0, op=dist.ReduceOp.AVG)
             if RANK > 0:
                 return
-            results = {**stats, **trainer.label_loss_items(loss.cpu() / len(self.dataloader), prefix="val")}
+            results = {**stats, **label_loss_items(loss.cpu() / len(self.dataloader), prefix="val")}
             return {k: round(float(v), 5) for k, v in results.items()}  # return results as 5 decimal place floats
         else:
             if RANK > 0:

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -12,7 +12,7 @@ import torch.distributed as dist
 
 from ultralytics.data import build_dataloader, build_yolo_dataset, converter
 from ultralytics.engine.validator import BaseValidator
-from ultralytics.utils import LOGGER, RANK, LOCAL_RANK, nms, ops
+from ultralytics.utils import LOCAL_RANK, LOGGER, RANK, nms, ops
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.metrics import ConfusionMatrix, DetMetrics, box_iou
 from ultralytics.utils.plotting import plot_images

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -12,7 +12,7 @@ import torch.distributed as dist
 
 from ultralytics.data import build_dataloader, build_yolo_dataset, converter
 from ultralytics.engine.validator import BaseValidator
-from ultralytics.utils import LOGGER, RANK, nms, ops
+from ultralytics.utils import LOGGER, RANK, LOCAL_RANK, nms, ops
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.metrics import ConfusionMatrix, DetMetrics, box_iou
 from ultralytics.utils.plotting import plot_images
@@ -316,7 +316,7 @@ class DetectionValidator(BaseValidator):
             batch_size,
             self.args.workers,
             shuffle=False,
-            rank=-1,
+            rank=LOCAL_RANK,
             drop_last=self.args.compile,
             pin_memory=self.training,
         )

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -1,4 +1,5 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+from __future__ import annotations
 
 import os
 import shutil
@@ -107,11 +108,10 @@ def generate_ddp_command(trainer):
 def generate_distributed_validation_file(validator):
     """Generate a temporary helper file to run distributed (multi-process) validation.
 
-    This creates a small Python script under ``USER_CONFIG_DIR/DDP`` which imports the validator
-    class, instantiates it with the validator's `args` (passed as ``overrides``), and runs the
-    offline validation entrypoint. This is intended to be executed with ``torch.distributed.run``
-    (or the legacy ``torch.distributed.launch``) to spawn one process per GPU for parallel
-    validation/inference. Note: this is for inference/validation only — it does not perform
+    This creates a small Python script under ``USER_CONFIG_DIR/DDP`` which imports the validator class, instantiates it
+    with the validator's `args` (passed as ``overrides``), and runs the offline validation entrypoint. This is intended
+    to be executed with ``torch.distributed.run`` (or the legacy ``torch.distributed.launch``) to spawn one process per
+    GPU for parallel validation/inference. Note: this is for inference/validation only — it does not perform
     DistributedDataParallel (DDP) model wrapping or gradient synchronization.
 
     Args:
@@ -120,7 +120,6 @@ def generate_distributed_validation_file(validator):
     Returns:
         str: Path to the generated temporary Python file.
     """
-
     # Derive import path for the validator class
     module, name = f"{validator.__class__.__module__}.{validator.__class__.__name__}".rsplit(".", 1)
 
@@ -149,7 +148,6 @@ if __name__ == "__main__":
     return file.name
 
 
-
 def generate_distributed_validation_command(validator):
     """Generate the command list to run distributed (multi-process) validation.
 
@@ -159,7 +157,6 @@ def generate_distributed_validation_command(validator):
     Returns:
         tuple[list[str], str]: (command args list, path to the generated temp file)
     """
-
     # Calculate world size
     world_size = validator.world_size
     if world_size <= 1:
@@ -202,6 +199,7 @@ def ddp_cleanup(trainer, file):
 
 def decide_world_size(device: str | tuple) -> int:
     import torch
+
     if isinstance(device, str) and len(device):  # i.e. device='0' or device='0,1,2,3'
         world_size = len(device.split(","))
     elif isinstance(device, (tuple, list)):  # i.e. device=[0, 1, 2, 3] (multi-GPU from CLI is list)
@@ -212,5 +210,5 @@ def decide_world_size(device: str | tuple) -> int:
         world_size = 1  # default to device 0
     else:  # i.e. device=None or device=''
         world_size = 0
-    
+
     return world_size

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -104,6 +104,83 @@ def generate_ddp_command(trainer):
     return cmd, file
 
 
+def generate_distributed_validation_file(validator):
+    """Generate a temporary helper file to run distributed (multi-process) validation.
+
+    This creates a small Python script under ``USER_CONFIG_DIR/DDP`` which imports the validator
+    class, instantiates it with the validator's `args` (passed as ``overrides``), and runs the
+    offline validation entrypoint. This is intended to be executed with ``torch.distributed.run``
+    (or the legacy ``torch.distributed.launch``) to spawn one process per GPU for parallel
+    validation/inference. Note: this is for inference/validation only — it does not perform
+    DistributedDataParallel (DDP) model wrapping or gradient synchronization.
+
+    Args:
+        validator: An instance of the project's validator (must have an ``args`` attribute).
+
+    Returns:
+        str: Path to the generated temporary Python file.
+    """
+
+    # Derive import path for the validator class
+    module, name = f"{validator.__class__.__module__}.{validator.__class__.__name__}".rsplit(".", 1)
+
+    content = f"""
+# Ultralytics Multi-GPU validation temp file (auto-generated)
+overrides = {vars(validator.args)}
+
+if __name__ == "__main__":
+    from {module} import {name}
+
+    validator = {name}(args=overrides)
+    # run the validator's offline validation routine
+    validator.do_offline_validation()
+"""
+
+    (USER_CONFIG_DIR / "DDP").mkdir(exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        prefix="_temp_",
+        suffix=f"{id(validator)}.py",
+        mode="w+",
+        encoding="utf-8",
+        dir=USER_CONFIG_DIR / "DDP",
+        delete=False,
+    ) as file:
+        file.write(content)
+    return file.name
+
+
+
+def generate_distributed_validation_command(validator):
+    """Generate the command list to run distributed (multi-process) validation.
+
+    Args:
+        validator: An instance which exposes a ``world_size`` attribute (number of processes/GPU).
+
+    Returns:
+        tuple[list[str], str]: (command args list, path to the generated temp file)
+    """
+
+    # Calculate world size
+    world_size = validator.world_size
+    if world_size <= 1:
+        raise ValueError("Distributed validation requires world_size > 1")
+
+    file = generate_distributed_validation_file(validator)
+    dist_cmd = "torch.distributed.run" if TORCH_1_9 else "torch.distributed.launch"
+    port = find_free_network_port()
+    cmd = [
+        sys.executable,
+        "-m",
+        dist_cmd,
+        "--nproc_per_node",
+        f"{world_size}",
+        "--master_port",
+        f"{port}",
+        file,
+    ]
+    return cmd, file
+
+
 def ddp_cleanup(trainer, file):
     """Delete temporary file if created during distributed data parallel (DDP) training.
 
@@ -121,3 +198,19 @@ def ddp_cleanup(trainer, file):
     """
     if f"{id(trainer)}.py" in file:  # if temp_file suffix in file
         os.remove(file)
+
+
+def decide_world_size(device: str | tuple) -> int:
+    import torch
+    if isinstance(device, str) and len(device):  # i.e. device='0' or device='0,1,2,3'
+        world_size = len(device.split(","))
+    elif isinstance(device, (tuple, list)):  # i.e. device=[0, 1, 2, 3] (multi-GPU from CLI is list)
+        world_size = len(device)
+    elif device in {"cpu", "mps"}:  # i.e. device='cpu' or 'mps'
+        world_size = 0
+    elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number
+        world_size = 1  # default to device 0
+    else:  # i.e. device=None or device=''
+        world_size = 0
+    
+    return world_size


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Add multi-GPU (distributed) acceleration for offline validation by introducing world size detection, distributed spawning, and per-rank-safe behaviors across validator, trainer, and utilities. 🚀

### 📊 Key Changes
- Introduce decide_world_size() and integrate it into Trainer and Validator for consistent device/world-size handling
- Add distributed validation utilities: generate_distributed_validation_file() and generate_distributed_validation_command()
- Implement BaseValidator multi-process flow: setup methods for distributed init, model/dataset, and a single-worker validation path
- Use LOCAL_RANK in dataloader construction to ensure correct sharding without gradient sync
- Avoid redundant filesystem ops by guarding save_dir creation to rank {-1, 0}; update args.device from CUDA_VISIBLE_DEVICES post-selection

### 🎯 Purpose & Impact
- Enable faster offline validation on multi-GPU systems via parallel, spawn-based execution
- Improve reliability and consistency of device selection and world-size computation across code paths
- Reduce redundant dataset downloads and directory writes in multi-process scenarios
- Provide a clearer, modular validation flow that’s easier to maintain and extend