### PR TITLE
Remove redundant `Executorch` test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODELS, TASK_MODEL_DATA
 from ultralytics.utils import ARM64, ASSETS, LINUX, WEIGHTS_DIR, checks
-from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_2_9, WINDOWS
+from ultralytics.utils.torch_utils import TORCH_1_11
 
 
 def run(cmd: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,10 +129,3 @@ def test_train_gpu(task: str, model: str, data: str) -> None:
 def test_solutions(solution: str) -> None:
     """Test yolo solutions command-line modes."""
     run(f"yolo solutions {solution} verbose=False")
-
-
-@pytest.mark.skipif(not checks.IS_PYTHON_MINIMUM_3_10 or not TORCH_2_9, reason="Requires Python>=3.10 and Torch>=2.9.0")
-@pytest.mark.skipif(WINDOWS, reason="Skipping test on Windows")
-def test_export_executorch() -> None:
-    """Test exporting a YOLO model to ExecuTorch format via CLI."""
-    run("yolo export model=yolo11n.pt format=executorch imgsz=32")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Remove the ExecuTorch export CLI test and clean up unused imports to stabilize CI and simplify test suite 🧹

### 📊 Key Changes
- Deleted the `test_export_executorch` test in `tests/test_cli.py` that attempted `yolo export model=yolo11n.pt format=executorch`.
- Removed unused imports (`TORCH_2_9`, `WINDOWS`) tied to that test; kept only `TORCH_1_11`.

### 🎯 Purpose & Impact
- Improves CI stability by removing an environment-sensitive test (Python/Torch/OS-dependent), reducing flakiness ✅
- Speeds up test runs and simplifies maintenance of the CLI test suite 🏃
- No user-facing changes to the export feature itself; only test coverage for ExecuTorch export is reduced 🔧