### PR TITLE
Add `KITTI` notebook in docs

### DIFF
--- a/docs/en/datasets/detect/kitti.md
+++ b/docs/en/datasets/detect/kitti.md
@@ -6,6 +6,8 @@ keywords: kitti, Ultralytics, dataset, object detection, 3D vision, YOLO11, trai
 
 # KITTI Dataset
 
+<a href="https://colab.research.google.com/github/ultralytics/notebooks/blob/main/notebooks/how-to-train-ultralytics-yolo-on-kitti-detection-dataset.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open KITTI Dataset In Colab"></a>
+
 The kitti dataset is one of the most influential benchmark datasets for autonomous driving and computer vision. Released by the Karlsruhe Institute of Technology and Toyota Technological Institute at Chicago, it contains stereo camera, LiDAR, and GPS/IMU data collected from real-world driving scenarios.
 
 It is widely used for evaluating algorithms in object detection, depth estimation, optical flow, and visual odometry. The dataset is fully compatible with Ultralytics YOLO11 for 2D object detection tasks and can be easily integrated into the Ultralytics platform for training and evaluation.


### PR DESCRIPTION
CC: @glenn-jocher @Laughing-q @Bovey0809

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a Google Colab badge to the KITTI dataset docs, linking directly to a ready-to-run training notebook for YOLO11. 🚀

### 📊 Key Changes
- Introduced a Colab badge on the KITTI dataset page that opens the [How to Train Ultralytics YOLO on KITTI (Colab notebook)](https://colab.research.google.com/github/ultralytics/notebooks/blob/main/notebooks/how-to-train-ultralytics-yolo-on-kitti-detection-dataset.ipynb). 🔗
- Documentation-only update; no code or API changes. 📚

### 🎯 Purpose & Impact
- Simplifies onboarding with a one-click, runnable environment for training on KITTI. ⚡
- Reduces setup friction and improves reproducibility for new users and educators. 🧪
- Enhances the usability of the KITTI docs and highlights YOLO11 training workflows. 🧭
- No breaking changes; safe for all users and versions. ✅