### PR TITLE
adaptation

### DIFF
--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -178,7 +178,7 @@ class BaseValidator:
             else:
                 raise FileNotFoundError(emojis(f"Dataset '{self.args.data}' for task={self.args.task} not found ❌"))
 
-            if self.device.type in {"cpu", "mps"}:
+            if self.device.type in {"cpu", "mps", "npu"}:
                 self.args.workers = 0  # faster CPU val as time dominated by inference, not dataloading
             if not (pt or (getattr(model, "dynamic", False) and not model.imx)):
                 self.args.rect = False

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -1111,6 +1111,7 @@ class SAM2VideoPredictor(SAM2Predictor):
 
             if prev_out is not None and prev_out.get("pred_masks") is not None:
                 prev_sam_mask_logits = prev_out["pred_masks"].to(
+                    # TODO: enable non_blocking for ascend as well, search for all non_blocking
                     device=self.device, non_blocking=self.device.type == "cuda"
                 )
                 # Clamp the scale of prev_sam_mask_logits to avoid rare numerical issues.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -1112,7 +1112,8 @@ class SAM2VideoPredictor(SAM2Predictor):
             if prev_out is not None and prev_out.get("pred_masks") is not None:
                 prev_sam_mask_logits = prev_out["pred_masks"].to(
                     # TODO: enable non_blocking for ascend as well, search for all non_blocking
-                    device=self.device, non_blocking=self.device.type == "cuda"
+                    device=self.device,
+                    non_blocking=self.device.type == "cuda",
                 )
                 # Clamp the scale of prev_sam_mask_logits to avoid rare numerical issues.
                 prev_sam_mask_logits.clamp_(-32.0, 32.0)

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -753,7 +753,7 @@ def check_amp(model):
 
     device = next(model.parameters()).device  # get model device
     prefix = colorstr("AMP: ")
-    if device.type in {"cpu", "mps"}:
+    if device.type in {"cpu", "mps", "npu"}:
         return False  # AMP only used on CUDA devices
     else:
         # GPUs that have issues with AMP

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -156,8 +156,12 @@ def select_device(device="", newline=False, verbose=True):
     Notes:
         Sets the 'CUDA_VISIBLE_DEVICES' environment variable for specifying which GPUs to use.
     """
-    if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel")):
+    if isinstance(device, torch.device):
         return device
+    if device.startswith(("tpu", "intel")):
+        return device
+    if device == "npu":
+        return torch.device("npu")
 
     s = f"Ultralytics {__version__} 🚀 Python-{PYTHON_VERSION} torch-{TORCH_VERSION} "
     device = str(device).lower()
@@ -205,7 +209,9 @@ def select_device(device="", newline=False, verbose=True):
                 f"{install}"
             )
 
-    if not cpu and not mps and torch.cuda.is_available():  # prefer GPU if available
+    if device == "npu":
+        arg = "npu"
+    elif not cpu and not mps and torch.cuda.is_available():  # prefer GPU if available
         devices = device.split(",") if device else "0"  # i.e. "0,1" -> ["0", "1"]
         space = " " * len(s)
         for i, d in enumerate(devices):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Initial Ascend NPU adaptation: adds basic NPU device handling, memory reporting, and conservative runtime defaults, with TODOs for DDP/HCCL and AMP.

### 📊 Key Changes
- Device selection: recognize `npu` in `select_device` and return `torch.device("npu")`; bypass CUDA-preference path when `device=="npu"`.
- Memory reporting: `_get_memory` now supports NPU via `torch.npu.memory.memory_allocated()`.
- Validation workers: set `workers=0` on NPU to match CPU/MPS behavior where dataloading isn’t the bottleneck.
- AMP behavior: `check_amp` disables AMP on NPU (aligned with CPU/MPS), keeping current CUDA-only scaler; TODO for Ascend support.
- SAM predict non_blocking: retains non_blocking only for CUDA with a TODO to enable for Ascend where appropriate.
- DDP setup: adds TODOs for Ascend (HCCL) integration; current init remains NCCL/Gloo.

### 🎯 Purpose & Impact
- Enables early, single-device execution on Ascend NPUs with safer defaults.
- Reduces runtime friction for NPU environments by correctly selecting devices and reporting memory.
- Maintains backward compatibility for CUDA/CPU/MPS users.
- Surfaces clear TODOs for future work: DDP/HCCL backend, AMP/scaler for NPU, and broader non_blocking support.