### PR TITLE
Change retry delay from 900 to 1800 seconds on links.yml

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ultralytics/actions/retry@main
         with:
           timeout_minutes: 60
-          retry_delay_seconds: 900
+          retry_delay_seconds: 1800
           retries: 2
           run: |
             lychee \

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -68,7 +68,7 @@ jobs:
         uses: ultralytics/actions/retry@main
         with:
           timeout_minutes: 60
-          retry_delay_seconds: 900
+          retry_delay_seconds: 1800
           retries: 2
           run: |
             lychee \


### PR DESCRIPTION
Increased the retry delay for link testing.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Increase retry delay for the link-checking workflow to reduce flaky failures and improve CI reliability ⏱️🔗

### 📊 Key Changes
- Doubled `retry_delay_seconds` from 900 to 1800 (15 → 30 minutes) in `.github/workflows/links.yml`
- Applies to both lychee link-check jobs using `ultralytics/actions/retry@main`
- Keeps existing `timeout_minutes: 60` and `retries: 2` unchanged

### 🎯 Purpose & Impact
- Reduces false failures from transient network issues and rate limits ✅
- Improves stability of link checks, resulting in cleaner CI signals and fewer reruns 🔁
- Slightly increases total CI time for link-check jobs, but enhances overall reliability ⏳
- No changes to library behavior; impact is limited to CI workflow only 🔧