### PR TITLE
Fix undefined `final_epoch` for DDP training when `val=False`

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -118,9 +118,7 @@ def test_train():
         results = YOLO(MODEL).train(
             data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15
         )  # requires imgsz>=64
-        results = YOLO(MODEL).train(
-            data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False
-        )
+        results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
         visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
         assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
         assert (

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -118,6 +118,9 @@ def test_train():
         results = YOLO(MODEL).train(
             data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15
         )  # requires imgsz>=64
+        results = YOLO(MODEL).train(
+            data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False
+        )
         visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
         assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
         assert (

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -469,10 +469,10 @@ class BaseTrainer:
 
             self.run_callbacks("on_train_epoch_end")
             if RANK in {-1, 0}:
-                final_epoch = epoch + 1 >= self.epochs
                 self.ema.update_attr(self.model, include=["yaml", "nc", "args", "names", "stride", "class_weights"])
 
             # Validation
+            final_epoch = epoch + 1 >= self.epochs
             if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
                 self._clear_memory(threshold=0.5)  # prevent VRAM spike
                 self.metrics, self.fitness = self.validate()


### PR DESCRIPTION
Closes #22598 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a potential multi-GPU training crash by correctly scoping final_epoch and adds a test to ensure training works when validation is disabled. ✅

### 📊 Key Changes
- Moves final_epoch calculation outside the rank-restricted block so it’s always defined before validation runs.
- Keeps EMA attribute updates unchanged but ensures they don’t interfere with validation logic.
- Adds a new CUDA test that runs `YOLO(...).train(..., val=False)` to verify training without validation and checks GPU visibility.

### 🎯 Purpose & Impact
- Prevents crashes in multi-GPU/DDP runs where non-main ranks could encounter an undefined final_epoch.
- Improves training robustness and consistency across ranks, especially in distributed setups.
- Validates the no-validation path (`val=False`), enabling faster training iterations when validation isn’t needed.
- Backward compatible; users don’t need to change their scripts. 🚀