### PR TITLE
Fix `check_requirements()` missing output when using `uv` package manager

### DIFF
--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -412,17 +412,19 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
                 f"--index-strategy=unsafe-best-match --break-system-packages --prerelease=allow"
             )
             try:
-                return subprocess.check_output(base, shell=True, stderr=subprocess.PIPE, text=True)
+                return subprocess.check_output(base, shell=True, stderr=subprocess.STDOUT, text=True)
             except subprocess.CalledProcessError as e:
-                if e.stderr and "No virtual environment found" in e.stderr:
+                if e.output and "No virtual environment found" in e.output:
                     return subprocess.check_output(
                         base.replace("uv pip install", "uv pip install --system"),
                         shell=True,
-                        stderr=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
                         text=True,
                     )
                 raise
-        return subprocess.check_output(f"pip install --no-cache-dir {packages} {commands}", shell=True, text=True)
+        return subprocess.check_output(
+            f"pip install --no-cache-dir {packages} {commands}", shell=True, stderr=subprocess.STDOUT, text=True
+        )
 
     s = " ".join(f'"{x}"' for x in pkgs)  # console string
     if s:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Consolidates installer logging and error handling in `attempt_install()` to improve reliability and visibility of package installation outputs. 🛠️📦

### 📊 Key Changes
- Routes installer stderr to stdout (`stderr=subprocess.STDOUT`) for all `subprocess.check_output` calls.
- Switches error checks from `e.stderr` to `e.output` to match the unified stream.
- Ensures proper handling of uv’s “No virtual environment found” case by checking the combined output and retrying with `--system`.
- Applies the same stdout-only logging to the non-uv `pip install` path.

### 🎯 Purpose & Impact
- More complete and readable install logs, making debugging easier in notebooks, CI, and containers. 📋
- Fixes missed detection of uv’s no-venv message, improving fallback behavior and reducing install failures. ✅
- Consistent output stream across installers simplifies log capture and user support. 🧩
- Minimal risk; potential change is that tools expecting errors on stderr may now find them in stdout. ℹ️