### PR TITLE
`ultralytics 8.3.227` Pin `onnx<=1.19.1` for Conda compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,7 +464,7 @@ jobs:
       - name: Install Ultralytics package from conda-forge
         run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino
       - name: Install pip packages
-        run: uv pip install pytest "onnx>=1.12.0,<=1.19.1"
+        run: uv pip install pytest
       - name: Check environment
         run: conda list
       - name: Test CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,7 +464,7 @@ jobs:
       - name: Install Ultralytics package from conda-forge
         run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino
       - name: Install pip packages
-        run: uv pip install pytest
+        run: uv pip install pytest "onnx>=1.12.0,<1.19.0"
       - name: Check environment
         run: conda list
       - name: Test CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,7 +464,7 @@ jobs:
       - name: Install Ultralytics package from conda-forge
         run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino
       - name: Install pip packages
-        run: uv pip install pytest "onnx>=1.12.0,<=1.19.0"
+        run: uv pip install pytest "onnx>=1.12.0,<=1.19.1"
       - name: Check environment
         run: conda list
       - name: Test CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,7 +464,7 @@ jobs:
       - name: Install Ultralytics package from conda-forge
         run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino
       - name: Install pip packages
-        run: uv pip install pytest "onnx>=1.12.0,<1.19.0"
+        run: uv pip install pytest "onnx>=1.12.0,<=1.19.0"
       - name: Check environment
         run: conda list
       - name: Test CLI

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.226"
+__version__ = "8.3.227"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -627,7 +627,7 @@ class Exporter:
     @try_export
     def export_onnx(self, prefix=colorstr("ONNX:")):
         """Export YOLO model to ONNX format."""
-        requirements = ["onnx>=1.12.0,<=1.19.1"]
+        requirements = ["onnx>=1.12.0"]
         if self.args.simplify:
             requirements += ["onnxslim>=0.1.71", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
@@ -995,7 +995,7 @@ class Exporter:
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "ai-edge-litert>=1.2.0" + (",<1.4.0" if MACOS else ""),  # required by 'onnx2tf' package
-                "onnx>=1.12.0,<=1.19.1",
+                "onnx>=1.12.0",
                 "onnx2tf>=1.26.3",
                 "onnxslim>=0.1.71",
                 "onnxruntime-gpu" if cuda else "onnxruntime",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -627,7 +627,7 @@ class Exporter:
     @try_export
     def export_onnx(self, prefix=colorstr("ONNX:")):
         """Export YOLO model to ONNX format."""
-        requirements = ["onnx>=1.12.0"]
+        requirements = ["onnx>=1.12.0,<=1.19.1"]
         if self.args.simplify:
             requirements += ["onnxslim>=0.1.71", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
@@ -995,7 +995,7 @@ class Exporter:
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "ai-edge-litert>=1.2.0" + (",<1.4.0" if MACOS else ""),  # required by 'onnx2tf' package
-                "onnx>=1.12.0",
+                "onnx>=1.12.0,<=1.19.1",
                 "onnx2tf>=1.26.3",
                 "onnxslim>=0.1.71",
                 "onnxruntime-gpu" if cuda else "onnxruntime",


### PR DESCRIPTION
May resolve: https://github.com/ultralytics/ultralytics/actions/runs/19190271178/job/54865985950

@glenn-jocher FYI.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Pins ONNX to <=1.19.1 for exports and bumps package version to 8.3.227 to ensure stable ONNX and TensorFlow SavedModel exports 🚀

### 📊 Key Changes
- Bumped version: `8.3.226` → `8.3.227` 🏷️
- Added upper-bound ONNX constraint in exporters:
  - ONNX export now requires `onnx>=1.12.0,<=1.19.1`
  - TensorFlow SavedModel export pipeline also uses `onnx>=1.12.0,<=1.19.1`
- Retains existing conditional dependencies (e.g., `onnxruntime[-gpu]`, `ai-edge-litert` pin on macOS)

### 🎯 Purpose & Impact
- Prevents export failures caused by breaking changes in newer ONNX releases 🙅‍♂️
- Improves reliability of ONNX and TensorFlow SavedModel exports across CPU/GPU setups ✅
- Users with newer ONNX versions will be guided to compatible versions automatically via `check_requirements`
- If needed, users can manually align with:
  - `pip install "onnx<=1.19.1"`
- Overall, more predictable, stable export behavior for production pipelines 📦