### PR TITLE
fix: 🐞 Update `scipy-stubs` dependency to require version `>=1.14.1.4` for Python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ extra = [
     "faster-coco-eval>=1.6.7", # COCO mAP
 ]
 typing = [
-    "scipy-stubs",
+    "scipy-stubs>=1.14.1.4; python_version >= '3.10'",
     "types-pillow",
     "types-psutil",
     "types-pyyaml",


### PR DESCRIPTION

Previously "uv lock" error output, this PR fix this. Also scipy-stubs project started minimum python version 3.10. It can't be lower than this. 

```
uv lock
  × No solution found when resolving dependencies for split (markers: python_full_version == '3.9.*'
  │ and platform_machine == 'aarch64' and sys_platform == 'win32'):
  ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.10 and
      scipy-stubs<=1.14.1.3 depends on Python>=3.10.1,<4.0.0, we can conclude that
      scipy-stubs<=1.14.1.3 cannot be used.
      And because only the following versions of scipy-stubs are available:
          scipy-stubs==1.14.1.0
          scipy-stubs==1.14.1.1
          scipy-stubs==1.14.1.2
          scipy-stubs==1.14.1.3
          scipy-stubs==1.14.1.4
          scipy-stubs==1.14.1.5
          scipy-stubs==1.14.1.6
          scipy-stubs==1.15.0.0
          scipy-stubs==1.15.1.0
          scipy-stubs==1.15.2.0
          scipy-stubs==1.15.2.1
          scipy-stubs==1.15.2.2
          scipy-stubs==1.15.3.0
          scipy-stubs==1.16.0.0
          scipy-stubs==1.16.0.1
          scipy-stubs==1.16.0.2
          scipy-stubs==1.16.1.0
          scipy-stubs==1.16.1.1
          scipy-stubs==1.16.2.0
          scipy-stubs==1.16.2.1
          scipy-stubs==1.16.2.2
          scipy-stubs==1.16.2.3
          scipy-stubs==1.16.2.4
          scipy-stubs==1.16.3.0
      we can conclude that scipy-stubs<1.14.1.4 cannot be used. (1)

      Because the requested Python version (>=3.8) does not satisfy Python>=3.10 and
      scipy-stubs==1.14.1.4 depends on Python>=3.10,<4.0, we can conclude that scipy-stubs==1.14.1.4
      cannot be used.
      And because we know from (1) that scipy-stubs<1.14.1.4 cannot be used, we can conclude that
      scipy-stubs<1.14.1.5 cannot be used. (2)

      Because the requested Python version (>=3.8) does not satisfy Python>=3.10 and
      scipy-stubs>=1.14.1.5,<=1.15.3.0 depends on Python>=3.10, we can conclude that
      scipy-stubs>=1.14.1.5,<=1.15.3.0 cannot be used.
      And because we know from (2) that scipy-stubs<1.14.1.5 cannot be used, we can conclude that
      scipy-stubs<1.16.0.0 cannot be used. (3)

      Because the requested Python version (>=3.8) does not satisfy Python>=3.10 and all of:
          scipy-stubs>=1.16.0.0,<=1.16.2.0
          scipy-stubs>=1.16.2.3
      depend on Python>=3.11, we can conclude that all of:
          scipy-stubs>=1.16.0.0,<=1.16.2.0
          scipy-stubs>=1.16.2.3
       cannot be used.
      And because we know from (3) that scipy-stubs<1.16.0.0 cannot be used, we can conclude that
      all of:
          scipy-stubs<1.16.2.1
          scipy-stubs>1.16.2.2
       cannot be used.
      And because scipy-stubs==1.16.2.2 was yanked (reason: incorrect upper bound on the optype
      version (again)) and scipy-stubs==1.16.2.1 was yanked (reason: missing upper bound on the
      optype version), we can conclude that all versions of scipy-stubs cannot be used.
      And because ultralytics[typing] depends on scipy-stubs and your project requires
      ultralytics[typing], we can conclude that your project's requirements are unsatisfiable.

      hint: Pre-releases are available for `scipy-stubs` in the requested range (e.g., 1.4.1a3), but
      pre-releases weren't enabled (try: `--prerelease=allow`)

      hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by
      your dependencies (e.g., scipy-stubs<=1.14.1.3 only supports >=3.10.1, <4.0.0). Consider using
      a more restrictive `requires-python` value (like >=3.10.1, <4.0.0).

      hint: While the active Python version is 3.12, the resolution failed for other Python versions
      supported by your project. Consider limiting your project's supported Python versions using
      `requires-python`.
  help: If you want to add the package regardless of the failed resolution, provide the `--frozen`
        flag to skip locking and syncing.

```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Pins and scopes `scipy-stubs` to Python 3.10+ in the `typing` extra, improving compatibility and type-checking reliability. ✅

### 📊 Key Changes
- Updates `typing` extra dependency from `scipy-stubs` to `scipy-stubs>=1.14.1.4; python_version >= '3.10'`.
- Adds a Python version marker so `scipy-stubs` is only installed on Python 3.10+.

### 🎯 Purpose & Impact
- Improves compatibility on older Python versions by avoiding unnecessary or failing stub installs. 🧩
- Ensures consistent, up-to-date SciPy type hints for better IDE support and static analysis (e.g., mypy) on Python 3.10+. 🧠
- Reduces dependency resolution issues and makes installs more predictable when using `pip install ultralytics[typing]`. 📦
- No runtime impact for standard users; this only affects the optional `typing` extra. 🚀