### PR TITLE
Fix typo in the augmentation guide

### DIFF
--- a/docs/en/guides/yolo-data-augmentation.md
+++ b/docs/en/guides/yolo-data-augmentation.md
@@ -142,7 +142,7 @@ Then launch the training with the Python API:
 
 - **Range**: `0.0` - `1.0`
 - **Default**: `{{ hsv_s }}`
-- **Usage**: Modifies the intensity of colors in the image. The `hsv_h` hyperparameter defines the shift magnitude, with the final adjustment randomly chosen between `-hsv_s` and `hsv_s`. For example, with `hsv_s=0.7`, the intensity is randomly selected within`-0.7` to `0.7`.
+- **Usage**: Modifies the intensity of colors in the image. The `hsv_s` hyperparameter defines the shift magnitude, with the final adjustment randomly chosen between `-hsv_s` and `hsv_s`. For example, with `hsv_s=0.7`, the intensity is randomly selected within`-0.7` to `0.7`.
 - **Purpose**: Helps models handle varying weather conditions and camera settings. For example, a red traffic sign might appear highly vivid on a sunny day but look dull and faded in foggy conditions.
 - **Ultralytics' implementation**: [RandomHSV](https://docs.ultralytics.com/reference/data/augment/#ultralytics.data.augment.RandomHSV)
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a documentation typo in the data augmentation guide, correctly identifying `hsv_s` (not `hsv_h`) as the saturation shift parameter. ✅

### 📊 Key Changes
- Corrected the parameter name in the "HSV Saturation" section from `hsv_h` to `hsv_s`.
- Clarified that the final saturation adjustment is randomly selected between `-hsv_s` and `hsv_s`.
- No code, API, or behavior changes—documentation only.

### 🎯 Purpose & Impact
- Prevents confusion when configuring HSV saturation augmentation, reducing setup errors. 🎯
- Aligns docs with actual implementation of RandomHSV for accurate guidance. 📚
- No action required from users; models and training flows remain unchanged. 🚀