### PR TITLE
`ultralytics 8.3.228` Fix CLIP token truncation

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.227"
+__version__ = "8.3.228"
 
 import importlib
 import os

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -103,7 +103,7 @@ class CLIP(TextModel):
             >>> tokens = model.tokenize("a photo of a cat")
             >>> print(tokens.shape)  # torch.Size([1, 77])
         """
-        return clip.tokenize(texts).to(self.device)
+        return clip.tokenize(texts, truncate=True).to(self.device)
 
     @smart_inference_mode()
     def encode_text(self, texts: torch.Tensor, dtype: torch.dtype = torch.float32) -> torch.Tensor:

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -89,11 +89,13 @@ class CLIP(TextModel):
         self.device = device
         self.eval()
 
-    def tokenize(self, texts: str | list[str]) -> torch.Tensor:
+    def tokenize(self, texts: str | list[str], truncate: bool = True) -> torch.Tensor:
         """Convert input texts to CLIP tokens.
 
         Args:
             texts (str | list[str]): Input text or list of texts to tokenize.
+            truncate (bool, optional): Whether to trim texts that exceed CLIP's context length. Defaults to True to
+                avoid RuntimeError from overly long inputs while still allowing explicit opt-out.
 
         Returns:
             (torch.Tensor): Tokenized text tensor with shape (batch_size, context_length) ready for model processing.
@@ -102,8 +104,10 @@ class CLIP(TextModel):
             >>> model = CLIP("ViT-B/32", device="cpu")
             >>> tokens = model.tokenize("a photo of a cat")
             >>> print(tokens.shape)  # torch.Size([1, 77])
+            >>> strict_tokens = model.tokenize("a photo of a cat", truncate=False)  # Enforce strict length checks
+            >>> print(strict_tokens.shape)  # Same shape/content as tokens since prompt less than 77 tokens
         """
-        return clip.tokenize(texts, truncate=True).to(self.device)
+        return clip.tokenize(texts, truncate=truncate).to(self.device)
 
     @smart_inference_mode()
     def encode_text(self, texts: torch.Tensor, dtype: torch.dtype = torch.float32) -> torch.Tensor:
@@ -308,11 +312,13 @@ class MobileCLIPTS(TextModel):
         self.tokenizer = clip.clip.tokenize
         self.device = device
 
-    def tokenize(self, texts: list[str]) -> torch.Tensor:
+    def tokenize(self, texts: list[str], truncate: bool = True) -> torch.Tensor:
         """Convert input texts to MobileCLIP tokens.
 
         Args:
             texts (list[str]): List of text strings to tokenize.
+            truncate (bool, optional): Whether to trim texts that exceed the tokenizer context length. Defaults to True,
+                matching CLIP's behavior to prevent runtime failures on long captions.
 
         Returns:
             (torch.Tensor): Tokenized text inputs with shape (batch_size, sequence_length).
@@ -320,8 +326,9 @@ class MobileCLIPTS(TextModel):
         Examples:
             >>> model = MobileCLIPTS("cpu")
             >>> tokens = model.tokenize(["a photo of a cat", "a photo of a dog"])
+            >>> strict_tokens = model.tokenize(["a very long caption"], truncate=False)  # RuntimeError if exceeds 77-token
         """
-        return self.tokenizer(texts).to(self.device)
+        return self.tokenizer(texts, truncate=truncate).to(self.device)
 
     @smart_inference_mode()
     def encode_text(self, texts: torch.Tensor, dtype: torch.dtype = torch.float32) -> torch.Tensor:

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -326,7 +326,9 @@ class MobileCLIPTS(TextModel):
         Examples:
             >>> model = MobileCLIPTS("cpu")
             >>> tokens = model.tokenize(["a photo of a cat", "a photo of a dog"])
-            >>> strict_tokens = model.tokenize(["a very long caption"], truncate=False)  # RuntimeError if exceeds 77-token
+            >>> strict_tokens = model.tokenize(
+            ...     ["a very long caption"], truncate=False
+            ... )  # RuntimeError if exceeds 77-token
         """
         return self.tokenizer(texts, truncate=truncate).to(self.device)
 


### PR DESCRIPTION
resolve #22647 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Add a truncate option to CLIP/MobileCLIP tokenizers to safely handle overlength text inputs and prevent runtime errors.

### 📊 Key Changes
- Introduced `truncate: bool = True` parameter to `CLIP.tokenize` and `MobileCLIPTS.tokenize`
- Forwarded `truncate` into underlying `clip.tokenize(..., truncate=truncate)` calls
- Updated docstrings and examples to document new behavior and strict mode (`truncate=False`)
- Preserved existing behavior by default (safe truncation to avoid errors)

### 🎯 Purpose & Impact
- Prevents RuntimeError when tokenizing overly long prompts by default ✅
- Offers explicit strict mode (`truncate=False`) for debugging or exact-length validation 🔧
- Small, backward-compatible API enhancement improving robustness and user experience 📈