### PR TITLE
Clean up self-hosted GitHub runners before initial run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,8 @@ jobs:
     timeout-minutes: 120
     runs-on: raspberry-pi
     steps:
+      - name: Clean up runner
+        uses: eviden-actions/clean-self-hosted-runner@v1
       - uses: actions/checkout@v5
       - name: Activate Virtual Environment for Tests
         run: |
@@ -419,6 +421,8 @@ jobs:
             torchvision_whl: "https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl"
             onnxruntime_whl: "https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.16.3-cp38-cp38-linux_aarch64.whl"
     steps:
+      - name: Clean up runner
+        uses: eviden-actions/clean-self-hosted-runner@v1
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
       - name: Activate virtual environment


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a cleanup step to self-hosted Raspberry Pi CI jobs to ensure a clean environment and more reliable ARM builds 🧹🚀

### 📊 Key Changes
- Introduces a pre-step in two Raspberry Pi CI jobs to clean the self-hosted runner using `eviden-actions/clean-self-hosted-runner@v1`.
- Places the cleanup before `actions/checkout@v5` to start jobs from a fresh state.
- Applies to both Python venv–based and uv-based ARM/aarch64 test workflows.

### 🎯 Purpose & Impact
- Improves CI reliability by preventing leftover files, caches, and processes from previous runs.
- Reduces flaky failures and environmental inconsistencies on self-hosted Raspberry Pi runners.
- Helps maintain disk space and system hygiene, potentially speeding up builds and tests.
- No user-facing changes; benefits are internal CI stability for ARM workflows. ✅