### PR TITLE
Improve tqdm rate format readability for slow iterations

### DIFF
--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -159,9 +159,17 @@ class TQDM:
             self._display()
 
     def _format_rate(self, rate: float) -> str:
-        """Format rate with units."""
+        """Format rate with units, switching between it/s and s/it for readability."""
         if rate <= 0:
             return ""
+
+        inv_rate = 1 / rate if rate else None
+
+        # Use s/it format when inv_rate > 1 (i.e., rate < 1 it/s) for better readability
+        if inv_rate and inv_rate > 1:
+            return f"{inv_rate:.1f}s/B" if self.is_bytes else f"{inv_rate:.1f}s/{self.unit}"
+
+        # Use it/s format for fast iterations
         fallback = f"{rate:.1f}B/s" if self.is_bytes else f"{rate:.1f}{self.unit}/s"
         return next((f"{rate / t:.1f}{u}" for t, u in self.scales if rate >= t), fallback)
 


### PR DESCRIPTION
Switch tqdm rate display from "0.0it/s" to readable "s/it" format for slow iterations

- Aligns with original tqdm behavior in [tqdm/std.py:L450](https://github.com/tqdm/tqdm/blob/fc69d5dcf578f7c7986fa76841a6b793f813df35/tqdm/std.py#L450) ([related issue](https://github.com/tqdm/tqdm/issues/1259))

Example output improvement:
- Before: `6%|▌ | 6/100 [00:09<02:21, 0.0it/s]` (confusing)
- After: `6%|▌ | 6/100 [00:09<02:21, 1.5s/it]` (readable)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves tqdm rate formatting to automatically switch between it/s and s/it for clearer, more readable progress bars 🚀

### 📊 Key Changes
- Updates `_format_rate` to:
  - Show seconds per iteration (s/it) when the rate is slower than 1 iteration/sec.
  - Maintain iterations per second (it/s) for faster rates.
  - Apply the same behavior for byte rates (s/B vs B/s).
- Keeps existing behavior for non-positive rates (still returns an empty string).

### 🎯 Purpose & Impact
- Enhances readability of progress bars, especially during slow operations or I/O-bound tasks 🧭
- Helps users better understand performance by showing s/it when it’s more intuitive than it/s ⏱️
- No breaking changes; purely a display improvement with negligible overhead ✅