### PR TITLE
feat: add `save_after` option to delay periodic checkpoint saving (Closes #22658)

### DIFF
--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -59,7 +59,8 @@ document.addEventListener("DOMContentLoaded", () => {
   ultralyticsChat = new UltralyticsChat({
     welcome: {
       title: "Hello 👋",
-      message: "Ask about YOLO, tutorials, training, export, deployment, or troubleshooting.",
+      message:
+        "Ask about YOLO, tutorials, training, export, deployment, or troubleshooting.",
       examples: [
         "What's new in SAM 3?",
         "How can I get started with YOLO?",

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -201,6 +201,7 @@ CFG_INT_KEYS = frozenset(
         "line_width",
         "nbs",
         "save_period",
+        "save_after",
     }
 )
 CFG_BOOL_KEYS = frozenset(

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -16,6 +16,7 @@ batch: 16 # (int) batch size; use -1 for AutoBatch
 imgsz: 640 # (int | list) train/val use int (square); predict/export may use [h,w]
 save: True # (bool) save train checkpoints and predict results
 save_period: -1 # (int) save checkpoint every N epochs; disabled if < 1
+save_after: 0 # (int) start periodic saving only after this epoch (1-based); 0 means no threshold
 cache: False # (bool | str) cache images in RAM (True/'ram') or on 'disk' to speed dataloading; False disables
 device: # (int | str | list) device: 0 or [0,1,2,3] for CUDA, 'cpu'/'mps', or -1/[-1,-1] to auto-select idle GPUs
 workers: 8 # (int) dataloader workers (per RANK if DDP)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -589,10 +589,10 @@ class BaseTrainer:
         Adds `save_after` so that periodic checkpoints (epochXX.pt) are only saved
         after a specified starting epoch. This reduces early, often-useless checkpoints.
         `last.pt` and `best.pt` behaviors remain unchanged.
-    
+
         Args:
             None
-    
+
         Returns:
             None
         """
@@ -632,7 +632,7 @@ class BaseTrainer:
         self.last.write_bytes(serialized_ckpt)  # save last.pt
         if self.best_fitness == self.fitness:
             self.best.write_bytes(serialized_ckpt)  # save best.pt
-            
+
         e = self.epoch + 1
         try:
             save_after = max(0, int(getattr(self, "save_after", getattr(self.args, "save_after", 0)) or 0))
@@ -641,7 +641,7 @@ class BaseTrainer:
 
         # Only save every `save_period` epochs AFTER epoch >= `save_after` (1-based check). Backward-compatible.
         if int(getattr(self, "save_period", 0) or 0) > 0 and e >= save_after and e % int(self.save_period) == 0:
-            (self.wdir / f"epoch{e}.pt").write_bytes(serialized_ckpt) 
+            (self.wdir / f"epoch{e}.pt").write_bytes(serialized_ckpt)
 
     def get_dataset(self):
         """Get train and validation datasets from data dictionary.

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -78,6 +78,7 @@ class BaseTrainer:
         last (Path): Path to the last checkpoint.
         best (Path): Path to the best checkpoint.
         save_period (int): Save checkpoint every x epochs (disabled if < 1).
+        save_after (int): Delay periodic checkpoint saving until this 1-based epoch (default 0 = no delay).
         batch_size (int): Batch size for training.
         epochs (int): Number of epochs to train for.
         start_epoch (int): Starting epoch for training.
@@ -146,7 +147,7 @@ class BaseTrainer:
             YAML.save(self.save_dir / "args.yaml", args_dict)  # save run args
         self.last, self.best = self.wdir / "last.pt", self.wdir / "best.pt"  # checkpoint paths
         self.save_period = self.args.save_period
-        self.save_after = getattr(self.args, "save_after", 0) 
+        self.save_after = int(getattr(self.args, "save_after", 0))
 
         self.batch_size = self.args.batch
         self.epochs = self.args.epochs or 100  # in case users accidentally pass epochs=None with timed training
@@ -583,7 +584,18 @@ class BaseTrainer:
                 m.eval()
 
     def save_model(self):
-        """Save model training checkpoints with additional metadata."""
+        """Save training checkpoints with metadata.
+
+        Adds `save_after` so that periodic checkpoints (epochXX.pt) are only saved
+        after a specified starting epoch. This reduces early, often-useless checkpoints.
+        `last.pt` and `best.pt` behaviors remain unchanged.
+    
+        Args:
+            None
+    
+        Returns:
+            None
+        """
         import io
 
         # Serialize ckpt to a byte buffer once (faster than repeated torch.save() calls)
@@ -628,9 +640,8 @@ class BaseTrainer:
             save_after = 0
 
         # Only save every `save_period` epochs AFTER epoch >= `save_after` (1-based check). Backward-compatible.
-        if (self.save_period > 0) and (e >= save_after) and (e % self.save_period == 0):
-            (self.wdir / f"epoch{self.epoch}.pt").write_bytes(serialized_ckpt)
-        
+        if int(getattr(self, "save_period", 0) or 0) > 0 and e >= save_after and e % int(self.save_period) == 0:
+            (self.wdir / f"epoch{e}.pt").write_bytes(serialized_ckpt) 
 
     def get_dataset(self):
         """Get train and validation datasets from data dictionary.

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -146,6 +146,7 @@ class BaseTrainer:
             YAML.save(self.save_dir / "args.yaml", args_dict)  # save run args
         self.last, self.best = self.wdir / "last.pt", self.wdir / "best.pt"  # checkpoint paths
         self.save_period = self.args.save_period
+        self.save_after = getattr(self.args, "save_after", 0) 
 
         self.batch_size = self.args.batch
         self.epochs = self.args.epochs or 100  # in case users accidentally pass epochs=None with timed training
@@ -619,8 +620,17 @@ class BaseTrainer:
         self.last.write_bytes(serialized_ckpt)  # save last.pt
         if self.best_fitness == self.fitness:
             self.best.write_bytes(serialized_ckpt)  # save best.pt
-        if (self.save_period > 0) and (self.epoch % self.save_period == 0):
-            (self.wdir / f"epoch{self.epoch}.pt").write_bytes(serialized_ckpt)  # save epoch, i.e. 'epoch3.pt'
+            
+        e = self.epoch + 1
+        try:
+            save_after = max(0, int(getattr(self, "save_after", getattr(self.args, "save_after", 0)) or 0))
+        except Exception:
+            save_after = 0
+
+        # Only save every `save_period` epochs AFTER epoch >= `save_after` (1-based check). Backward-compatible.
+        if (self.save_period > 0) and (e >= save_after) and (e % self.save_period == 0):
+            (self.wdir / f"epoch{self.epoch}.pt").write_bytes(serialized_ckpt)
+        
 
     def get_dataset(self):
         """Get train and validation datasets from data dictionary.

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -640,7 +640,11 @@ class BaseTrainer:
             save_after = 0
 
         # Only save every `save_period` epochs AFTER epoch >= `save_after` (1-based check). Backward-compatible.
-        if int(getattr(self, "save_period", 0) or 0) > 0 and e >= save_after and self.epoch % int(self.save_period) == 0:
+        if (
+            int(getattr(self, "save_period", 0) or 0) > 0
+            and e >= save_after
+            and self.epoch % int(self.save_period) == 0
+        ):
             (self.wdir / f"epoch{e}.pt").write_bytes(serialized_ckpt)
 
     def get_dataset(self):

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -640,7 +640,7 @@ class BaseTrainer:
             save_after = 0
 
         # Only save every `save_period` epochs AFTER epoch >= `save_after` (1-based check). Backward-compatible.
-        if int(getattr(self, "save_period", 0) or 0) > 0 and e >= save_after and e % int(self.save_period) == 0:
+        if int(getattr(self, "save_period", 0) or 0) > 0 and e >= save_after and self.epoch % int(self.save_period) == 0:
             (self.wdir / f"epoch{e}.pt").write_bytes(serialized_ckpt)
 
     def get_dataset(self):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


### Summary
This PR implements a new `save_after` parameter to delay periodic checkpoint saving until a specified epoch.
It enhances training flexibility and efficiency for long runs, Closes #22658.

### Motivation
Currently, `save_period` saves checkpoints every *N* epochs from the beginning, producing many unnecessary early checkpoints.
This PR introduces `save_after`, enabling users to start periodic saving *after* a threshold epoch, e.g., after 150 epochs, save every 10 epochs.

### What's Changed
- **ultralytics/engine/trainer.py**
  - Added `save_after` arg parsing and logic to control checkpoint scheduling.
  - Updated `save_model` docstring to Google-style with clear explanations.
- **ultralytics/cfg/__init__.py**
  - Registered `"save_after"` as a valid configuration key.
- **ultralytics/cfg/default.yaml**
  - Added new default parameter `save_after: 0` (no delay by default, fully backward-compatible).

### Example Usage
**YAML**
```yaml
save_period: 10
save_after: 150  # start periodic saving after epoch 150 (1-based)
```

**Python**

```python
from ultralytics import YOLO
model = YOLO("yolo11n.pt")
model.train(data="coco8.yaml", epochs=300, save_period=10, save_after=150)
```

**CLI**

```bash
yolo train model=yolo11n.pt data=coco8.yaml epochs=25 save_period=5 save_after=12 imgsz=320 device="0" workers=0 deterministic=True
```

This demonstrates that checkpoint saving will begin **after epoch 12** and continue every **5 epochs** thereafter.
`best.pt` and `last.pt` remain unaffected, ensuring compatibility with existing workflows.


### Backward Compatibility

- Default behavior unchanged (`save_after=0`).
- `last.pt` and `best.pt` unaffected.

### Tests

- All local tests and formatting (ruff + pytest) passed.
- Confirmed functional behavior across both YAML \ Python \ CLI usage.

<img width="1160" height="461" alt="屏幕截图 2025-11-13 010559" src="https://github.com/user-attachments/assets/7a39e877-79a2-4e0c-853e-57a5ddea9833" />

### Checklist
- [x] Code formatted (`ruff format .`)
- [x] Tests passed (`pytest -q`)
- [x] Signed commits (`-s`)
- [x] Closes #22658
- [x] Added docstring and inline comments


------

I have read the CLA Document and I sign the CLA.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Introduce a new `save_after` option to delay periodic checkpoint saving until a specified epoch, reducing early-run checkpoint clutter while keeping `last.pt` and `best.pt` unchanged.

### 📊 Key Changes
- Add `save_after` to allowed config keys in `ultralytics/cfg/__init__.py`.
- Define `save_after` in `ultralytics/cfg/default.yaml` with default `0` and clear description.
- Store `save_after` in `BaseTrainer` and update `save_model()` to start periodic saves only after epoch >= `save_after` (1-based), keeping `last.pt` and `best.pt` behavior intact.
- Adjust periodic filename to use 1-based epoch index when saving: `epoch{e}.pt`.

### 🎯 Purpose & Impact
- Reduce disk usage and file noise from frequent early checkpoints on long trainings.
- Provide finer control over checkpoint cadence without affecting `last.pt`/`best.pt`.
- Backward-compatible default (0 = no delay); users can opt-in by setting `save_after` alongside `save_period`.