### PR TITLE
Binary attributes

### DIFF
--- a/training_utils/export.py
+++ b/training_utils/export.py
@@ -1,0 +1,37 @@
+from training_utils import (
+    GiveModel
+)
+import os
+import argparse
+
+
+def Export(checkpoint_file_path):
+    if os.path.exists(checkpoint_file_path):
+        model = GiveModel(checkpoint_file_path)
+    else:
+        print(f"[ERROR] : Model {checkpoint_file_path} does not exists")
+        exit(1)
+
+    prefix = os.path.splitext(os.path.basename(checkpoint_file_path))[0]
+
+    base_path, _ = os.path.split(checkpoint_file_path)
+    path = model.export(format="onnx", imgsz=[2144, 768], opset=12)
+    os.system(f"mv {path} {base_path}/{prefix}_full_height.onnx")
+
+    path = model.export(format="onnx", imgsz=[2144, 4096], opset=12)
+    os.system(f"mv {path} {base_path}/{prefix}_full_frame.onnx")
+
+    path = model.export(format="onnx", imgsz=[768, 768], opset=12)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Export the model")
+    parser.add_argument(
+        "-m",
+        "--checkpoint_path",
+        type=str,
+        required=True,
+        help="Path to the model weight checkpoint; This model will be exported")
+
+    args = parser.parse_args()
+    Export(args.checkpoint_path)

--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -1,0 +1,68 @@
+from ultralytics import YOLO
+from training_utils import (
+    PrepareDataset,
+    GetModelYaml,
+    GetLatestWeightsDir,
+)
+from training_utils import (
+    dataset_yaml_path,
+    coco_classes_file,
+    training_task,
+    experiment_name,
+)
+import os
+import argparse
+from export import Export
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train the model")
+    parser.add_argument("-l", "--load", type=str, default=None, help="Path to the model weights to load. Load the pretrained model")
+    parser.add_argument("-r", "--learning-rate", type=float, default=0.01, help="Learning rate for training")
+    parser.add_argument("-e", "--epochs", type=int, default=200, help="Number of epochs for training")
+    parser.add_argument("-p", "--patience", type=int, default=50, help="Number of epochs triggering early stopping when no improvement")
+    parser.add_argument("-s", "--batch-size", type=int, default=128, help="Batch size for training")
+    parser.add_argument("-b", "--disable-wandb", action="store_true", help="Disable wandb logging")
+
+    args = parser.parse_args()
+
+    print(f"Model weights initialized from: {args.load if args.load else 'scratch'}")
+    print(f"Learning rate: {args.learning_rate}, Epochs: {args.epochs}, Patience: {args.patience}, Batch size: {args.batch_size}")
+
+    PrepareDataset(coco_classes_file, dataset_yaml_path, training_task)
+
+    if args.load is not None:
+        if os.path.exists(args.load):
+            model = YOLO(args.load)
+        else:
+            print(f"[ERROR] : Model {args.load} does not exists")
+            exit(1)
+    else:
+        model = YOLO(GetModelYaml(training_task))  # Initialize model
+
+    if args.disable_wandb:
+        os.environ['WANDB_MODE'] = 'disabled'
+
+    model.train(
+        task=training_task,
+        data="verdant.yaml",
+        optimizer='SGD',
+        lr0=args.learning_rate,
+        lrf=0.01,
+        epochs=args.epochs,
+        flipud=0.5,
+        fliplr=0.5,
+        scale=0.2,
+        mosaic=0.0, # Please set this to 0.0 TODO: Fix the issue with mosaic and keypoint detection
+        imgsz=768,
+        seed=1,
+        batch=args.batch_size,
+        name=experiment_name,
+        device=[0, 1, 2, 3, 4, 5, 6, 7],
+        patience=args.patience,
+    )
+
+    print("Training completed. Exporting the model by converting checkpoints to ONNX format...")
+    latest_weights_dir = GetLatestWeightsDir()
+    Export(f"{latest_weights_dir}/best.pt")
+    Export(f"{latest_weights_dir}/last.pt")

--- a/training_utils/training_utils.py
+++ b/training_utils/training_utils.py
@@ -5,6 +5,7 @@ from ultralytics import YOLO
 dataset_yaml_path = os.environ.get("DATASET_YAML", 
                                    "/training/ultralytics/ultralytics/cfg/datasets/verdant.yaml")
 coco_classes_file = os.environ.get("COCO_LABELS", "/dataset/classes.txt")
+coco_attributes_file = os.environ.get("COCO_ATTRIBUTES", "/dataset/attributes.txt")
 runs_directory = os.environ.get("RUNS_DIR", "/training/runs")
 training_task = os.environ.get("TASK", "detect")   # 'detect' for bbox | 'pose' for hybrid model
 experiment_name = os.environ.get("EXP_NAME", None)  # Results will be saved with this name  under runs/<task>/<exp_name>
@@ -12,11 +13,15 @@ experiment_name = os.environ.get("EXP_NAME", None)  # Results will be saved with
 
 def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
     classes = []
+    attributes = []
     with open(coco_classes_file, "r") as f:
-        for l in f.readlines():
-            l = l.strip("\n")
-            l = l.strip(" ")
-            classes.append(l)
+        for line in f.readlines():
+            classes.append(line.strip("\n").strip(" "))
+
+    if os.path.exists(coco_attributes_file):
+        with open(coco_attributes_file, "r") as f:
+            for line in f.readlines():
+                attributes.append(line.strip("\n").strip(" "))
 
     with open(dataset_yaml, "w") as f:
         f.write("path: /dataset\n")
@@ -26,6 +31,10 @@ def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
         f.write("names:\n")
         for i in range(len(classes)):
             f.write(f"  {i}: {classes[i]}\n")
+        if len(attributes) > 0:
+            f.write("\nattributes:\n")
+            for i in range(len(attributes)):
+                f.write(f"  {i}: {attributes[i]}\n")
         if training_task == "pose":
             f.write("\nkpt_shape: [1, 3]\n")  # enforce keypoint shape to [1, 3] for pose models
             f.write("flip_idx: [0]\n")  # enforce left-right flipping of keypoints

--- a/training_utils/training_utils.py
+++ b/training_utils/training_utils.py
@@ -1,0 +1,71 @@
+import os
+from ultralytics import YOLO
+
+
+dataset_yaml_path = os.environ.get("DATASET_YAML", 
+                                   "/training/ultralytics/ultralytics/cfg/datasets/verdant.yaml")
+coco_classes_file = os.environ.get("COCO_LABELS", "/dataset/classes.txt")
+runs_directory = os.environ.get("RUNS_DIR", "/training/runs")
+training_task = os.environ.get("TASK", "detect")   # 'detect' for bbox | 'pose' for hybrid model
+experiment_name = os.environ.get("EXP_NAME", None)  # Results will be saved with this name  under runs/<task>/<exp_name>
+
+
+def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
+    classes = []
+    with open(coco_classes_file, "r") as f:
+        for l in f.readlines():
+            l = l.strip("\n")
+            l = l.strip(" ")
+            classes.append(l)
+
+    with open(dataset_yaml, "w") as f:
+        f.write("path: /dataset\n")
+        f.write("train: images/train\n")
+        f.write("val: images/val\n")
+        f.write("test: images/test\n\n")
+        f.write("names:\n")
+        for i in range(len(classes)):
+            f.write(f"  {i}: {classes[i]}\n")
+        if training_task == "pose":
+            f.write("\nkpt_shape: [1, 3]\n")  # enforce keypoint shape to [1, 3] for pose models
+            f.write("flip_idx: [0]\n")  # enforce left-right flipping of keypoints
+    return
+
+
+def GetModelYaml(task):
+    if task == "detect":
+        return "yolo11n.yaml"
+    elif task == "pose":
+        return "yolo11n-pose.yaml"
+    print(f"Unknown task {task}")
+    return None
+
+
+def GiveModel(ckpt_path):
+    if os.path.exists(ckpt_path):
+        return YOLO(ckpt_path)
+    print(f"[ERROR] : Model {ckpt_path} does not exists")
+    return None
+
+
+def GetLatestWeightsDir():
+    base_dir = f"{runs_directory}/{training_task}"
+
+    # Get all entries in the directory given by path
+    entries = os.listdir(base_dir)
+    # Filter entries to only include directories
+    directories = [entry for entry in entries if os.path.isdir(os.path.join(base_dir, entry))]
+    # Sort directories by creation time
+    sorted_directories = sorted(
+        directories,
+        key=lambda x: os.path.getctime(os.path.join(base_dir, x)))
+
+    if len(sorted_directories) == 0:
+        print(f"[ERROR] : No weights directory found in {base_dir}")
+        return None
+    return f"{base_dir}/{sorted_directories[-1]}/weights"
+
+
+def LoadBestModel():
+    best_ckpt = f"{GetLatestWeightsDir()}/best.pt"
+    return GiveModel(best_ckpt)

--- a/ultralytics/cfg/datasets/verdant.yaml
+++ b/ultralytics/cfg/datasets/verdant.yaml
@@ -4,7 +4,7 @@ val: images/val
 test: images/test
 
 names:
-  0: crop
+  0: grass_blue
   1: weed
 
 kpt_shape: [1, 3]

--- a/ultralytics/cfg/datasets/verdant.yaml
+++ b/ultralytics/cfg/datasets/verdant.yaml
@@ -1,0 +1,11 @@
+path: /dataset
+train: images/train
+val: images/val
+test: images/test
+
+names:
+  0: crop
+  1: weed
+
+kpt_shape: [1, 3]
+flip_idx: [0]

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -103,6 +103,7 @@ cls: 0.5 # (float) classification loss gain
 dfl: 1.5 # (float) distribution focal loss gain
 pose: 12.0 # (float) pose loss gain (pose tasks)
 kobj: 1.0 # (float) keypoint objectness loss gain (pose tasks)
+attr: 0.5 # (float) attribute loss gain (binary classification tasks conditioned on class)
 nbs: 64 # (int) nominal batch size used for loss normalization
 hsv_h: 0.015 # (float) HSV hue augmentation fraction
 hsv_s: 0.7 # (float) HSV saturation augmentation fraction

--- a/ultralytics/cfg/models/11/yolo11-pose.yaml
+++ b/ultralytics/cfg/models/11/yolo11-pose.yaml
@@ -6,6 +6,7 @@
 
 # Parameters
 nc: 80 # number of classes
+na: 0  # Number of binary attributes
 kpt_shape: [17, 3] # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
 scales: # model compound scaling constants, i.e. 'model=yolo11n-pose.yaml' will call yolo11.yaml with scale 'n'
   # [depth, width, max_channels]
@@ -48,4 +49,4 @@ head:
   - [[-1, 10], 1, Concat, [1]] # cat head P5
   - [-1, 2, C3k2, [1024, True]] # 22 (P5/32-large)
 
-  - [[16, 19, 22], 1, Pose, [nc, kpt_shape]] # Detect(P3, P4, P5)
+  - [[16, 19, 22], 1, Pose, [nc, na, kpt_shape]] # Detect(P3, P4, P5)

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -192,11 +192,13 @@ class BaseDataset(Dataset):
         for i in range(len(self.labels)):
             if include_class is not None:
                 cls = self.labels[i]["cls"]
+                attributes = self.labels[i]["attributes"]
                 bboxes = self.labels[i]["bboxes"]
                 segments = self.labels[i]["segments"]
                 keypoints = self.labels[i]["keypoints"]
                 j = (cls == include_class_array).any(1)
                 self.labels[i]["cls"] = cls[j]
+                self.labels[i]["attributes"] = attributes[j]
                 self.labels[i]["bboxes"] = bboxes[j]
                 if segments:
                     self.labels[i]["segments"] = [segments[si] for si, idx in enumerate(j) if idx]

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -121,7 +121,7 @@ class YOLODataset(BaseDataset):
                 ),
             )
             pbar = TQDM(results, desc=desc, total=total)
-            for im_file, lb, shape, segments, keypoint, nm_f, nf_f, ne_f, nc_f, msg in pbar:
+            for im_file, lb, shape, segments, keypoint, ignore_kpt, nm_f, nf_f, ne_f, nc_f, msg in pbar:
                 nm += nm_f
                 nf += nf_f
                 ne += ne_f
@@ -135,6 +135,7 @@ class YOLODataset(BaseDataset):
                             "bboxes": lb[:, 1:],  # n, 4
                             "segments": segments,
                             "keypoints": keypoint,
+                            "ignore_kpt": ignore_kpt,
                             "normalized": True,
                             "bbox_format": "xywh",
                         }

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -402,6 +402,7 @@ class BaseTrainer:
                 pbar = TQDM(enumerate(self.train_loader), total=nb)
             self.tloss = None
             for i, batch in pbar:
+                assert "ignore_kpt" in batch
                 self.run_callbacks("on_train_batch_start")
                 # Warmup
                 ni = i + nb * epoch

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -141,6 +141,7 @@ class DetectionTrainer(BaseTrainer):
         # self.args.cls *= (self.args.imgsz / 640) ** 2 * 3 / nl  # scale to image size and layers
         self.model.nc = self.data["nc"]  # attach number of classes to model
         self.model.names = self.data["names"]  # attach class names to model
+        # TODO: Should we add attributes as well?
         self.model.args = self.args  # attach hyperparameters to model
         # TODO: self.model.class_weights = labels_to_class_weights(dataset.labels, nc).to(device) * nc
 
@@ -162,7 +163,7 @@ class DetectionTrainer(BaseTrainer):
 
     def get_validator(self):
         """Return a DetectionValidator for YOLO model validation."""
-        self.loss_names = "box_loss", "cls_loss", "dfl_loss"
+        self.loss_names = "box_loss", "cls_loss", "dfl_loss", "attr_loss"
         return yolo.detect.DetectionValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -96,7 +96,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Return an instance of the PoseValidator class for validation."""
-        self.loss_names = "box_loss", "pose_loss", "kobj_loss", "cls_loss", "dfl_loss"
+        self.loss_names = "box_loss", "pose_loss", "kobj_loss", "cls_loss", "dfl_loss", "attr_loss"
         return yolo.pose.PoseValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1499,7 +1499,7 @@ def parse_model(d, ch, verbose=True):
     # Args
     legacy = True  # backward compatibility for v3/v5/v8/v9 models
     max_channels = float("inf")
-    nc, act, scales = (d.get(x) for x in ("nc", "activation", "scales"))
+    nc, na, act, scales = (d.get(x) for x in ("nc", "na", "activation", "scales"))
     depth, width, kpt_shape = (d.get(x, 1.0) for x in ("depth_multiple", "width_multiple", "kpt_shape"))
     scale = d.get("scale")
     if scales:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1288,7 +1288,7 @@ class SettingsManager(JSONDict):
             "neptune": True,  # Neptune integration
             "raytune": True,  # Ray Tune integration
             "tensorboard": False,  # TensorBoard logging
-            "wandb": False,  # Weights & Biases logging
+            "wandb": True,  # Weights & Biases logging
             "vscode_msg": True,  # VSCode message
             "openvino_msg": True,  # OpenVINO export on Intel CPU message
         }

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -127,13 +127,7 @@ def _log_plots(plots, step):
 
 def on_pretrain_routine_start(trainer):
     """Initialize and start wandb project if module is present."""
-    if not wb.run:
-        wb.init(
-            project=str(trainer.args.project).replace("/", "-") if trainer.args.project else "Ultralytics",
-            name=str(trainer.args.name).replace("/", "-"),
-            config=vars(trainer.args),
-        )
-
+    wb.run or wb.init(project=trainer.args.project or 'YOLO11', name=trainer.args.name, config=vars(trainer.args))
 
 def on_fit_epoch_end(trainer):
     """Log training metrics and model information at the end of an epoch."""

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -496,15 +496,19 @@ class v8PoseLoss(v8DetectionLoss):
         sigmas = torch.from_numpy(OKS_SIGMA).to(self.device) if is_pose else torch.ones(nkpt, device=self.device) / nkpt
         self.keypoint_loss = KeypointLoss(sigmas=sigmas)
 
-    def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
-        """Calculate the total loss and detach it for pose estimation."""
+    def __call__(self, preds, batch):
+        """Calculate the total loss and detach it."""
         loss = torch.zeros(5, device=self.device)  # box, cls, dfl, kpt_location, kpt_visibility
         feats, pred_kpts = preds if isinstance(preds[0], list) else preds[1]
-        pred_distri, pred_scores = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
-            (self.reg_max * 4, self.nc), 1
-        )
+        batch_size = feats[0].shape[0]
+        pred_distri, pred_scores = torch.cat([xi.view(batch_size, self.no, -1) for xi in feats], 2).split(
+            (self.reg_max * 4, self.nc), 1)
 
-        # B, grids, ..
+        loss = self.calculate_bbox_kpt_loss(loss, batch, feats, pred_distri, pred_scores, pred_kpts)
+
+        return loss.sum() * batch_size, loss.detach()  # loss(box, cls, dfl)
+
+    def calculate_bbox_kpt_loss(self, loss, batch, feats, pred_distri, pred_scores, pred_kpts):
         pred_scores = pred_scores.permute(0, 2, 1).contiguous()
         pred_distri = pred_distri.permute(0, 2, 1).contiguous()
         pred_kpts = pred_kpts.permute(0, 2, 1).contiguous()
@@ -513,54 +517,39 @@ class v8PoseLoss(v8DetectionLoss):
         imgsz = torch.tensor(feats[0].shape[2:], device=self.device, dtype=dtype) * self.stride[0]  # image size (h,w)
         anchor_points, stride_tensor = make_anchors(feats, self.stride, 0.5)
 
-        # Targets
         batch_size = pred_scores.shape[0]
-        batch_idx = batch["batch_idx"].view(-1, 1)
-        targets = torch.cat((batch_idx, batch["cls"].view(-1, 1), batch["bboxes"]), 1)
-        targets = self.preprocess(targets, batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
-        gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls, xyxy
-        mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0.0)
+        batch_idx = batch['batch_idx'].view(-1, 1)
+        targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes']), 1)
+        targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
+        gt_labels, gt_bboxes = targets.split((1, 4), 2)  # (B, T, 1), (B, T, 4)
+        mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)
 
-        # Pboxes
-        pred_bboxes = self.bbox_decode(anchor_points, pred_distri)  # xyxy, (b, h*w, 4)
-        pred_kpts = self.kpts_decode(anchor_points, pred_kpts.view(batch_size, -1, *self.kpt_shape))  # (b, h*w, 17, 3)
-
+        pred_bboxes = self.bbox_decode(anchor_points, pred_distri)  # (B, h x w, 4(xyxy))
+        pred_kpts = self.kpts_decode(anchor_points, pred_kpts.view(batch_size, -1, *self.kpt_shape))
         _, target_bboxes, target_scores, fg_mask, target_gt_idx = self.assigner(
-            pred_scores.detach().sigmoid(),
-            (pred_bboxes.detach() * stride_tensor).type(gt_bboxes.dtype),
-            anchor_points * stride_tensor,
-            gt_labels,
-            gt_bboxes,
-            mask_gt,
-        )
-
+            pred_scores.detach().sigmoid(), (pred_bboxes.detach() * stride_tensor).type(gt_bboxes.dtype),
+            anchor_points * stride_tensor, gt_labels, gt_bboxes, mask_gt)
         target_scores_sum = max(target_scores.sum(), 1)
 
-        # Cls loss
-        # loss[1] = self.varifocal_loss(pred_scores, target_scores, target_labels) / target_scores_sum  # VFL way
-        loss[3] = self.bce(pred_scores, target_scores.to(dtype)).sum() / target_scores_sum  # BCE
+        loss[3] = self.bce(pred_scores, target_scores.to(dtype)).sum() / target_scores_sum
 
-        # Bbox loss
         if fg_mask.sum():
             target_bboxes /= stride_tensor
-            loss[0], loss[4] = self.bbox_loss(
-                pred_distri, pred_bboxes, anchor_points, target_bboxes, target_scores, target_scores_sum, fg_mask
-            )
-            keypoints = batch["keypoints"].to(self.device).float().clone()
+            loss[0], loss[4] = self.bbox_loss(pred_distri, pred_bboxes, anchor_points, target_bboxes, target_scores,
+                                              target_scores_sum, fg_mask)
+            keypoints = batch['keypoints'].to(self.device).float().clone()
             keypoints[..., 0] *= imgsz[1]
             keypoints[..., 1] *= imgsz[0]
 
-            loss[1], loss[2] = self.calculate_keypoints_loss(
-                fg_mask, target_gt_idx, keypoints, batch_idx, stride_tensor, target_bboxes, pred_kpts
-            )
+            loss[1], loss[2] = self.calculate_keypoints_loss(fg_mask, target_gt_idx, keypoints, batch_idx,
+                                                             stride_tensor, target_bboxes, pred_kpts, batch['ignore_kpt'])
 
         loss[0] *= self.hyp.box  # box gain
         loss[1] *= self.hyp.pose  # pose gain
         loss[2] *= self.hyp.kobj  # kobj gain
         loss[3] *= self.hyp.cls  # cls gain
         loss[4] *= self.hyp.dfl  # dfl gain
-
-        return loss * batch_size, loss.detach()  # loss(box, cls, dfl)
+        return loss
 
     @staticmethod
     def kpts_decode(anchor_points: torch.Tensor, pred_kpts: torch.Tensor) -> torch.Tensor:
@@ -580,6 +569,7 @@ class v8PoseLoss(v8DetectionLoss):
         stride_tensor: torch.Tensor,
         target_bboxes: torch.Tensor,
         pred_kpts: torch.Tensor,
+        ignore_kpt: bool,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Calculate the keypoints loss for the model.
 
@@ -630,6 +620,12 @@ class v8PoseLoss(v8DetectionLoss):
 
         kpts_loss = 0
         kpts_obj_loss = 0
+
+        for i in range(batch_size):
+            if ignore_kpt[i]:
+                # We should ignore the keypoints for this image
+                # We replace gt keypoints with pred keypoints so distance is 0. kpts_loss will be 0
+                selected_keypoints[i] = pred_kpts[i]
 
         if masks.any():
             gt_kpt = selected_keypoints[masks]

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -108,7 +108,8 @@ class TaskAlignedAssigner(nn.Module):
 
         target_gt_idx, fg_mask, mask_pos = self.select_highest_overlaps(mask_pos, overlaps, self.n_max_boxes)
 
-        # Assigned target
+        # Assigned target.
+        # target_scores: (b, h*w, num_classes) for one-hot encoding (or 0 if the anchor is negative)
         target_labels, target_bboxes, target_scores = self.get_targets(gt_labels, gt_bboxes, target_gt_idx, fg_mask)
 
         # Normalize


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds end-to-end support for binary per-box attributes in YOLO11/pose workflows, along with custom training/export utilities and minor logging tweaks.

### 📊 Key Changes
- ➕ Introduces `training_utils` helpers (`training_utils.py`, `simple_training.py`, `export.py`) to prepare Verdant-style datasets (classes + optional attributes), run YOLO-based training, and export ONNX checkpoints at multiple image sizes.
- 🧩 Extends dataset config and parsing to handle `attributes`/`na` in data YAML, propagating attribute tensors alongside `cls`, `bboxes`, and `keypoints` (including `ignore_kpt` flags for flexible keypoint supervision).
- 🧠 Updates YOLO11 detect and pose heads to support an additional `na` attribute dimension, adjusting channel counts, parsing in `parse_model`, and ensuring postprocessing works with combined class+attribute outputs.
- 📦 Enhances loss functions: detection loss now consumes attribute targets and reports an `attr_loss`, and pose loss is refactored to compute attribute loss plus conditional keypoint loss using the new `ignore_kpt` signal.
- 🧪 Integrates attributes into training/validation: validators now track `attr_loss`, datasets carry `attributes` through label caching and filtering, and the core trainer asserts the presence of `ignore_kpt` in batches.
- ⚙️ Adds an `attr` hyperparameter to `default.yaml` to weight attribute loss, and augments `yolo11-pose.yaml` with an `na` field used by the Pose head.
- 📈 Adjusts W&B callbacks and settings to default-enable wandb logging with a simplified `wb.init` call.

### 🎯 Purpose & Impact
- 🎯 Enables binary attribute prediction per detection (conditioned on class), which is useful for tasks that require richer labels than pure class IDs, such as presence/absence of properties or states.
- 🔗 Keeps attributes tightly integrated into the existing training pipeline (data loading, TAL assignment, losses, validators), reducing friction for users who want to extend YOLO11/pose to multi-task setups.
- 🧪 Improves robustness of pose training with flexible keypoint supervision via `ignore_kpt`, allowing images without keypoint annotations to coexist with fully annotated ones.
- 🚀 Provides ready-to-use scripts and configs for Verdant-like datasets, making it easier to bootstrap custom experiments and export trained models to ONNX for deployment.
- 📊 Exposes attribute loss as a first-class metric, giving users better visibility into multi-task performance during training and validation.