### PR TITLE
Remove `pip install uv` from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,8 +41,7 @@ RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
 # Install pip packages
-RUN pip install uv && \
-    uv pip install --system -e "." albumentations faster-coco-eval wandb && \
+RUN uv pip install --system -e "." albumentations faster-coco-eval wandb && \
     # Remove extra build files \
     rm -rf tmp /root/.config/Ultralytics/persistent_cache.json
 


### PR DESCRIPTION
Included in base image

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Simplifies the Docker image build by relying on `uv` already being available, removing a redundant installation step ⚙️

### 📊 Key Changes
- 🧹 Removed the explicit `pip install uv` command from the Dockerfile.
- 🚀 Now directly uses `uv pip install --system -e "." albumentations faster-coco-eval wandb` for Python dependencies.
- 📦 Keeps the existing cleanup step to remove temporary build files and cache.

### 🎯 Purpose & Impact
- ⚡ Speeds up Docker image builds by avoiding an unnecessary `uv` reinstallation.
- 🔁 Reduces duplication and potential version conflicts if `uv` is already provided in the base image.
- 🧩 Keeps the dependency installation behavior unchanged for users, so runtime behavior should remain the same.