### PR TITLE
New RTX6000 Pro `gpu-latest` runners in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,9 +305,7 @@ jobs:
         run: uv cache prune --ci
 
   GPU:
-    # Disabled temporarily due to GPU availability issues
-    # if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
-    if: false
+    if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
     timeout-minutes: 60
     runs-on: gpu-latest
     steps:

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -116,9 +116,9 @@ def test_train():
     # NVIDIA Jetson only has one GPU and therefore skipping checks
     if not IS_JETSON:
         results = YOLO(MODEL).train(
-            data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15
+            data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15
         )  # requires imgsz>=64
-        results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
+        results = YOLO(MODEL).train(data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
         visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
         assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
         assert (

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -1,11 +1,11 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import os
 from itertools import product
 from pathlib import Path
 
 import pytest
 import torch
-import os
 
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODEL, SOURCE
 from ultralytics import YOLO

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import torch
+import os
 
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODEL, SOURCE
 from ultralytics import YOLO
@@ -110,20 +111,15 @@ def test_export_engine_matrix(task, dynamic, int8, half, batch):
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 def test_train():
     """Test model training on a minimal dataset using available CUDA devices."""
-    import os
-
     device = tuple(DEVICES) if len(DEVICES) > 1 else DEVICES[0]
     # NVIDIA Jetson only has one GPU and therefore skipping checks
     if not IS_JETSON:
-        results = YOLO(MODEL).train(
-            data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15
-        )  # requires imgsz>=64
+        results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15)
         results = YOLO(MODEL).train(data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
         visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
         assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
-        assert (
-            (results is None) if len(DEVICES) > 1 else (results is not None)
-        )  # DDP returns None, single-GPU returns metrics
+        # Note DDP training returns None, single-GPU returns metrics
+        assert (results is None) if len(DEVICES) > 1 else (results is not None)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Re-enables GPU CI tests and updates CUDA training tests to better validate multi-GPU behavior using a larger dataset. 🚀

---

### 📊 Key Changes
- ✅ **GPU CI job re-enabled**  
  - The `GPU` job in `.github/workflows/ci.yml` is no longer forced off (`if: false` removed).  
  - It now runs for `ultralytics/ultralytics` when appropriate, including optional triggering via `workflow_dispatch` with a `gpu` input.

- 🔁 **CUDA training test updated** (`tests/test_cuda.py`)  
  - Moves the `os` import to the top-level for cleaner test structure.  
  - Changes the second training run to use `coco128.yaml` instead of `coco8.yaml` for a more realistic training scenario.  
  - Keeps and clarifies the assertion that checks `CUDA_VISIBLE_DEVICES` matches the devices passed to YOLO.  
  - Clarifies behavior where multi-GPU (DDP) training returns `None` and single-GPU training returns metrics, and asserts accordingly.

---

### 🎯 Purpose & Impact
- 🧪 **Stronger GPU test coverage**  
  - Re-enabling GPU CI ensures GPU-related regressions are caught early, improving reliability for users training YOLO models on CUDA devices.

- 🎯 **More realistic training validation**  
  - Using `coco128.yaml` in tests better represents real-world training workloads while still remaining lightweight, leading to more meaningful coverage.

- 🔍 **Clearer multi-GPU behavior checks**  
  - The explicit assertion and comment about DDP vs single-GPU return values help maintainers and contributors understand expected training behavior and catch issues in distributed setups.