### PR TITLE
Handle multi-GPU validation when`batch_size` is greater than the total dataset size

### DIFF
--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -161,11 +161,12 @@ class ContiguousDistributedSampler(torch.utils.data.Sampler):
             batch_size = getattr(dataset, "batch_size", 1)
 
         self.num_replicas = num_replicas
-        self.batch_size = batch_size
         self.rank = rank
         self.epoch = 0
         self.shuffle = shuffle
         self.total_size = len(dataset)
+        # ensure all ranks have a sample if batch size >= total size; degenerates to round-robin sampler
+        self.batch_size = 1 if batch_size >= self.total_size else batch_size 
         self.num_batches = math.ceil(self.total_size / self.batch_size)
 
     def _get_rank_indices(self) -> tuple[int, int]:

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -166,7 +166,7 @@ class ContiguousDistributedSampler(torch.utils.data.Sampler):
         self.shuffle = shuffle
         self.total_size = len(dataset)
         # ensure all ranks have a sample if batch size >= total size; degenerates to round-robin sampler
-        self.batch_size = 1 if batch_size >= self.total_size else batch_size 
+        self.batch_size = 1 if batch_size >= self.total_size else batch_size
         self.num_batches = math.ceil(self.total_size / self.batch_size)
 
     def _get_rank_indices(self) -> tuple[int, int]:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Tweaks the data sampler so that when the batch size is larger than the dataset, it safely falls back to a round-robin, single-sample batching strategy. 🧠

---

### 📊 Key Changes
- Adjusts `DistributedSampler` initialization in `ultralytics/data/build.py`:
  - If `batch_size >= total_size` of the dataset, it now forces `self.batch_size = 1`.
  - This effectively turns sampling into a round-robin style when the requested batch size is too large.
- Keeps calculation of `num_batches` consistent by using the adjusted `batch_size`.

---

### 🎯 Purpose & Impact
- Prevents edge-case issues when users set a batch size larger than the dataset size (common in small or toy datasets). 🧪
- Ensures all ranks still receive samples in distributed training, avoiding empty batches or failures. ⚙️
- Improves robustness and predictability of training behavior, especially in multi-GPU setups with unusual batch size configurations. 🚀