### PR TITLE
Print warning when fewer GPUs are selected

### DIFF
--- a/ultralytics/utils/autodevice.py
+++ b/ultralytics/utils/autodevice.py
@@ -152,9 +152,10 @@ class GPUInfo:
         """
         assert min_memory_fraction <= 1.0, f"min_memory_fraction must be <= 1.0, got {min_memory_fraction}"
         assert min_util_fraction <= 1.0, f"min_util_fraction must be <= 1.0, got {min_util_fraction}"
-        LOGGER.info(
-            f"Searching for {count} idle GPUs with free memory >= {min_memory_fraction * 100:.1f}% and free utilization >= {min_util_fraction * 100:.1f}%..."
+        criteria = (
+            f"free memory >= {min_memory_fraction * 100:.1f}% and free utilization >= {min_util_fraction * 100:.1f}%"
         )
+        LOGGER.info(f"Searching for {count} idle GPUs with {criteria}...")
 
         if count <= 0:
             return []
@@ -177,11 +178,11 @@ class GPUInfo:
         selected = [gpu["index"] for gpu in eligible_gpus[:count]]
 
         if selected:
+            if len(selected) < count:
+                LOGGER.warning(f"Requested {count} GPUs but only {len(selected)} met the idle criteria.")
             LOGGER.info(f"Selected idle CUDA devices {selected}")
         else:
-            LOGGER.warning(
-                f"No GPUs met criteria (Free Mem >= {min_memory_fraction * 100:.1f}% and Free Util >= {min_util_fraction * 100:.1f}%)."
-            )
+            LOGGER.warning(f"No GPUs met criteria ({criteria}).")
 
         return selected
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves GPU auto-selection logging to be clearer and more informative when searching for idle GPUs. 🚀

### 📊 Key Changes
- Refactors the GPU selection log message to use a shared `criteria` string for consistent, clearer output. 🧩
- Adds a specific warning when fewer GPUs than requested meet the idle criteria (instead of silently returning fewer). ⚠️
- Simplifies and unifies the warning message when no GPUs meet the selection criteria. 🔍

### 🎯 Purpose & Impact
- Makes logs easier to read and understand, especially when debugging GPU allocation issues. 📖
- Helps users quickly see when their requested number of GPUs is not fully available under the given constraints. 🎯
- Reduces confusion around GPU selection behavior, improving transparency in multi-GPU training setups. 💡