### PR TITLE
feature: imx segmentation export 

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1181,9 +1181,9 @@ class Exporter:
         if getattr(self.model, "end2end", False):
             raise ValueError("IMX export is not supported for end2end models.")
         check_requirements(
-            ("model-compression-toolkit>=2.4.1", "sony-custom-layers>=0.3.0", "edge-mdt-tpc>=1.1.0", "pydantic<=2.11.7")
+            ("model-compression-toolkit>=2.4.1", "edge-mdt-cl[torch]>=1.0.0", "edge-mdt-tpc>=1.1.0", "pydantic<=2.11.7")
         )
-        check_requirements("imx500-converter[pt]>=3.16.1")  # Separate requirements for imx500-converter
+        check_requirements("imx500-converter[pt]>=3.17.3")  # Separate requirements for imx500-converter
         check_requirements("mct-quantizers>=1.6.0")  # Separate for compatibility with model-compression-toolkit
 
         # Install Java>=17

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -364,7 +364,7 @@ class Exporter:
             if not self.args.nms and model.task in {"detect", "pose"}:
                 LOGGER.warning("IMX export requires nms=True, setting nms=True.")
                 self.args.nms = True
-            if model.task not in {"detect", "pose", "classify"}:
+            if model.task not in {"detect", "pose", "classify", "segment"}:
                 raise ValueError("IMX export only supported for detection, pose estimation, and classification models.")
         if not hasattr(model, "names"):
             model.names = default_class_names()

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -28,6 +28,7 @@ MCT_CONFIG = {
             "n_layers": 257,
         },
         "classify": {"layer_names": [], "weights_memory": np.inf, "n_layers": 112},
+        "segment": {"layer_names": ["sub", "mul_2", "add_14", "cat_22"], "weights_memory": 2466604.8, "n_layers": 265},
     },
     "YOLOv8": {
         "detect": {"layer_names": ["sub", "mul", "add_6", "cat_17"], "weights_memory": 2550540.8, "n_layers": 168},
@@ -37,6 +38,7 @@ MCT_CONFIG = {
             "n_layers": 187,
         },
         "classify": {"layer_names": [], "weights_memory": np.inf, "n_layers": 73},
+        "segment": {"layer_names": ["sub", "mul", "add_6", "cat_18"], "weights_memory": 2580060.0, "n_layers": 195},
     },
 }
 
@@ -143,7 +145,7 @@ class NMSWrapper(torch.nn.Module):
 
     def forward(self, images):
         """Forward pass with model inference and NMS post-processing."""
-        from sony_custom_layers.pytorch import multiclass_nms_with_indices
+        from edgemdt_cl.pytorch import MulticlassNMSWithIndices
 
         # model inference
         outputs = self.model(images)
@@ -218,7 +220,7 @@ def torch2imx(
             img = img / 255.0
             yield [img]
 
-    tpc = get_target_platform_capabilities(tpc_version="4.0", device_type="imx500")
+    tpc = get_target_platform_capabilities(tpc_version="5.0", device_type="imx500")
 
     bit_cfg = mct.core.BitWidthConfig()
     mct_config = MCT_CONFIG["YOLO11" if "C2PSA" in model.__str__() else "YOLOv8"][model.task]

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -145,8 +145,6 @@ class NMSWrapper(torch.nn.Module):
 
     def forward(self, images):
         """Forward pass with model inference and NMS post-processing."""
-        from edgemdt_cl.pytorch import MulticlassNMSWithIndices
-
         # model inference
         outputs = self.model(images)
         boxes, scores = outputs[0], outputs[1]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds IMX500 export support for segmentation models and updates the IMX toolchain/dependencies for better compatibility and future-proofing. 🚀

---

### 📊 Key Changes
- ✅ **IMX export now supports segmentation (`segment`) models** in addition to detect, pose, and classify.
- 🧩 **IMX model config extended** with segmentation profiles for YOLO11 and YOLOv8 (layer names, memory, and layer count).
- 🔧 **Dependencies updated**:
  - Replaces `sony-custom-layers` with `edge-mdt-cl[torch]>=1.0.0`.
  - Bumps `imx500-converter[pt]` minimum version from `3.16.1` to `3.17.3`.
- 🧱 **Target platform capabilities (TPC) version updated** from `4.0` to `5.0` for IMX500.
- 🧹 **Removes direct import** of `multiclass_nms_with_indices` from `sony_custom_layers` in the IMX export wrapper, simplifying the forward logic.

---

### 🎯 Purpose & Impact
- 🎨 **Segmentation support on IMX500**: Users can now export YOLO11/YOLOv8 segmentation models to IMX500, enabling on-device segmentation use cases (e.g., instance/semantic segmentation at the edge).
- 🔄 **Improved compatibility & maintenance**: Updated dependencies and TPC version align with the latest IMX500 toolchain, reducing integration issues and keeping the exporter up to date.
- 🧰 **Cleaner, more flexible export pipeline**: Removing tight coupling to `sony_custom_layers` and using the new `edge-mdt-cl` stack makes future updates and bug fixes easier.
- 📈 **More reliable exports**: The refined configuration for segmentation models helps ensure accurate resource estimation and smoother deployment on constrained IMX hardware.