### PR TITLE
Revert "fix(pyproject.toml): 🐞 Update dependency versions in pyproject.toml to enforce upper limits"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "torch>=1.8.0,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
     "torchvision>=0.9.0",
     "psutil>=5.8.0", # system utilization
-    "polars",
+    "polars>=0.20.0",
     "ultralytics-thop>=2.0.18", # FLOPs computation https://github.com/ultralytics/thop
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,19 +61,19 @@ classifiers = [
 
 # Required dependencies ------------------------------------------------------------------------------------------------
 dependencies = [
-    "numpy>=1.23.0,<=2.3.4",
-    "matplotlib>=3.3.0,<=3.10.7",
-    "opencv-python>=4.6.0,<=4.12.0.88",
-    "pillow>=7.1.2,<=12.0.0",
-    "pyyaml>=5.3.1,<=6.0.3",
-    "requests>=2.23.0,<=2.32.5",
-    "scipy>=1.4.1,<=1.16.3",
-    "torch>=1.8.0,<=2.9.1; sys_platform != 'win32'",
-    "torch>=1.8.0,!=2.4.0,<=2.9.1; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
-    "torchvision>=0.9.0,<=0.24.1",
-    "psutil>=5.8.0,<=7.1.3",  # system utilization
-    "polars>=0.20.0,<=1.35.2",
-    "ultralytics-thop<=2.0.18", # FLOPs computation https://github.com/ultralytics/thop
+    "numpy>=1.23.0",
+    "matplotlib>=3.3.0",
+    "opencv-python>=4.6.0",
+    "pillow>=7.1.2",
+    "pyyaml>=5.3.1",
+    "requests>=2.23.0",
+    "scipy>=1.4.1",
+    "torch>=1.8.0",
+    "torch>=1.8.0,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
+    "torchvision>=0.9.0",
+    "psutil", # system utilization
+    "polars",
+    "ultralytics-thop>=2.0.18", # FLOPs computation https://github.com/ultralytics/thop
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "torch>=1.8.0",
     "torch>=1.8.0,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
     "torchvision>=0.9.0",
-    "psutil", # system utilization
+    "psutil>=5.8.0", # system utilization
     "polars",
     "ultralytics-thop>=2.0.18", # FLOPs computation https://github.com/ultralytics/thop
 ]


### PR DESCRIPTION
Reverts ultralytics/ultralytics#22701

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Loosens dependency version limits to better support newer libraries while keeping a specific safety constraint for Windows PyTorch. 🚀

### 📊 Key Changes
- 🔓 Removed upper version bounds for core dependencies like `numpy`, `matplotlib`, `opencv-python`, `pillow`, `pyyaml`, `requests`, `scipy`, `torchvision`, `psutil`, and `polars`.
- 🧠 Simplified PyTorch requirements:
  - General: `torch>=1.8.0` (no upper bound).
  - Windows: `torch>=1.8.0,!=2.4.0` to avoid known CPU errors on Windows.
- 📈 Updated `ultralytics-thop` requirement from `<=2.0.18` to `>=2.0.18`, allowing newer versions while enforcing a minimum.

### 🎯 Purpose & Impact
- ✅ Improves compatibility with newer versions of popular Python libraries (e.g., latest `numpy`, `torch`, `torchvision`), reducing install conflicts.
- 🔄 Makes it easier to integrate YOLO models into modern environments and updated dependency stacks.
- 🛡️ Retains a targeted safeguard for Windows users to avoid known PyTorch 2.4.0 CPU issues.
- ⚠️ Slightly increases the chance of future breaking changes from upstream libraries, but offers more flexibility and easier upgrades overall.