### PR TITLE
`ultralytics 8.3.230` Fix color conversion for Tensor inputs and PIL plots

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.229"
+__version__ = "8.3.230"
 
 import importlib
 import os

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -589,7 +589,7 @@ class Results(SimpleClass, DataExportMixin):
         if save:
             annotator.save(filename or f"results_{Path(self.path).name}")
 
-        return annotator.im if pil else annotator.result()
+        return annotator.result(pil)
 
     def show(self, *args, **kwargs):
         """Display the image with annotated inference results.

--- a/ultralytics/models/rtdetr/predict.py
+++ b/ultralytics/models/rtdetr/predict.py
@@ -55,7 +55,7 @@ class RTDETRPredictor(BasePredictor):
         bboxes, scores = preds[0].split((4, nd - 4), dim=-1)
 
         if not isinstance(orig_imgs, list):  # input images are a torch.Tensor, not a list
-            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
+            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)[..., ::-1]
 
         results = []
         for bbox, score, orig_img, img_path in zip(bboxes, scores, orig_imgs, self.batch[0]):  # (300, 4)

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -502,7 +502,7 @@ class Predictor(BasePredictor):
         names = dict(enumerate(str(i) for i in range(pred_masks.shape[0])))
 
         if not isinstance(orig_imgs, list):  # input images are a torch.Tensor, not a list
-            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
+            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)[..., ::-1]
 
         results = []
         for masks, orig_img, img_path in zip([pred_masks], orig_imgs, self.batch[0]):

--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -81,7 +81,7 @@ class ClassificationPredictor(BasePredictor):
             (list[Results]): List of Results objects containing classification results for each image.
         """
         if not isinstance(orig_imgs, list):  # Input images are a torch.Tensor, not a list
-            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
+            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)[..., ::-1]
 
         preds = preds[0] if isinstance(preds, (list, tuple)) else preds
         return [

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -65,7 +65,7 @@ class DetectionPredictor(BasePredictor):
         )
 
         if not isinstance(orig_imgs, list):  # input images are a torch.Tensor, not a list
-            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
+            orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)[..., ::-1]
 
         if save_feats:
             obj_feats = self.get_obj_feats(self._feats, preds[1])

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -207,7 +207,7 @@ class Annotator:
             elif im.shape[2] > 3:  # multispectral
                 im = np.ascontiguousarray(im[..., :3])
         if self.pil:  # use PIL
-            self.im = im if input_is_pil else Image.fromarray(im[..., ::-1])
+            self.im = im if input_is_pil else Image.fromarray(im)  # stay in BGR since color palette is in BGR
             if self.im.mode not in {"RGB", "RGBA"}:  # multispectral
                 self.im = self.im.convert("RGB")
             self.draw = ImageDraw.Draw(self.im, "RGBA")
@@ -515,9 +515,10 @@ class Annotator:
         self.im = im if isinstance(im, Image.Image) else Image.fromarray(im)
         self.draw = ImageDraw.Draw(self.im)
 
-    def result(self):
-        """Return annotated image as array."""
-        return np.asarray(self.im)
+    def result(self, pil=False):
+        """Return annotated image as array or PIL image."""
+        im = np.asarray(self.im)  # self.im is in BGR
+        return Image.fromarray(im[..., ::-1]) if pil else im
 
     def show(self, title: str | None = None):
         """Show the annotated image."""

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -207,7 +207,7 @@ class Annotator:
             elif im.shape[2] > 3:  # multispectral
                 im = np.ascontiguousarray(im[..., :3])
         if self.pil:  # use PIL
-            self.im = im if input_is_pil else Image.fromarray(im)
+            self.im = im if input_is_pil else Image.fromarray(im[..., ::-1])
             if self.im.mode not in {"RGB", "RGBA"}:  # multispectral
                 self.im = self.im.convert("RGB")
             self.draw = ImageDraw.Draw(self.im, "RGBA")


### PR DESCRIPTION
1. Tensor input needs to be converted from RGB to BGR.
2. Plotting with `pil=True` needs to convert from BGR to RGB


Fixes #22732 
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
3. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
4. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
5. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes image color handling and plotting outputs across multiple models, ensuring consistent, correct-color visualizations and a cleaner `Results.plot()` API. 🎨✅

---

### 📊 Key Changes
- 🔼 Bumped package version from `8.3.229` to `8.3.230`.
- 🖼️ Updated `Results.plot()` to always use `annotator.result(pil)` so the `pil` flag properly controls whether a NumPy array or PIL image is returned.
- 🎨 Adjusted `Annotator`:
  - Keeps internal images in BGR when using PIL (to match the existing color palette).
  - Changed `result()` to `result(pil=False)`:
    - Returns a BGR NumPy array by default.
    - Returns an RGB PIL image when `pil=True`.
- 🌈 Fixed original-image color ordering in postprocessing for:
  - RT-DETR (`rtdetr/predict.py`)
  - SAM (`sam/predict.py`)
  - YOLO classification (`yolo/classify/predict.py`)
  - YOLO detection (`yolo/detect/predict.py`)
  - When `orig_imgs` is a tensor, it’s converted then channel-flipped (`[..., ::-1]`) to correct BGR/RGB order.

---

### 🎯 Purpose & Impact
- ✅ **Correct colors in visualizations**: Fixes BGR/RGB mismatches so plotted outputs (detections, masks, classifications) look natural and match the original image colors.
- 🧩 **Consistent API behavior**: `Results.plot(pil=True/False)` now reliably returns the type users expect (PIL image vs NumPy array), reducing confusion and bugs in downstream code.
- 📸 **Better compatibility for tensor inputs**: When users pass tensors directly, postprocessing now uses correctly ordered images, improving overlays and saved results across RT-DETR, SAM, and YOLO models.
- 🧪 **More predictable plotting pipeline**: Internal BGR handling is explicit, making future debugging and extension of plotting logic more robust.