### PR TITLE
Set `CUDA_VISIBLE_DEVICES` to empty string instead of -1 to avoid Windows crash

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -179,7 +179,7 @@ def select_device(device="", newline=False, verbose=True):
     cpu = device == "cpu"
     mps = device in {"mps", "mps:0"}  # Apple Metal Performance Shaders (MPS)
     if cpu or mps:
-        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # force torch.cuda.is_available() = False
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
         if device == "cuda":
             device = "0"


### PR DESCRIPTION
Fixes https://github.com/ultralytics/hub/issues/1225

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates device selection so choosing CPU or MPS now clears `CUDA_VISIBLE_DEVICES` instead of setting it to `-1`, improving compatibility and avoiding CUDA-related side effects. ⚙️

### 📊 Key Changes
- 🧠 When `select_device` is called with `cpu` or `mps`, it now sets `os.environ["CUDA_VISIBLE_DEVICES"] = ""` instead of `"-1"`.
- 🔒 This still forces `torch.cuda.is_available()` to behave as if no GPU is visible, but in a cleaner, more standard way.

### 🎯 Purpose & Impact
- ✅ Improves compatibility with external libraries and tools that interpret `CUDA_VISIBLE_DEVICES`, reducing the risk of warnings or unexpected behavior from using `-1`.
- 💻 Ensures CPU- or MPS-only runs more reliably “hide” GPUs without confusing downstream CUDA logic.
- 🔁 Provides a more standard environment setting that aligns with common CUDA practices, making behavior more predictable for users and integrators.