### PR TITLE
Remove MPS warnings for pose models

### DIFF
--- a/ultralytics/models/yolo/pose/predict.py
+++ b/ultralytics/models/yolo/pose/predict.py
@@ -45,11 +45,6 @@ class PosePredictor(DetectionPredictor):
         """
         super().__init__(cfg, overrides, _callbacks)
         self.args.task = "pose"
-        if isinstance(self.args.device, str) and self.args.device.lower() == "mps":
-            LOGGER.warning(
-                "Apple MPS known Pose bug. Recommend 'device=cpu' for Pose models. "
-                "See https://github.com/ultralytics/ultralytics/issues/4031."
-            )
 
     def construct_result(self, pred, img, orig_img, img_path):
         """Construct the result object from the prediction, including keypoints.

--- a/ultralytics/models/yolo/pose/predict.py
+++ b/ultralytics/models/yolo/pose/predict.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from ultralytics.models.yolo.detect.predict import DetectionPredictor
-from ultralytics.utils import DEFAULT_CFG, LOGGER, ops
+from ultralytics.utils import DEFAULT_CFG, ops
 
 
 class PosePredictor(DetectionPredictor):

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import PoseModel
-from ultralytics.utils import DEFAULT_CFG, LOGGER
+from ultralytics.utils import DEFAULT_CFG
 
 
 class PoseTrainer(yolo.detect.DetectionTrainer):

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -54,12 +54,6 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
         overrides["task"] = "pose"
         super().__init__(cfg, overrides, _callbacks)
 
-        if isinstance(self.args.device, str) and self.args.device.lower() == "mps":
-            LOGGER.warning(
-                "Apple MPS known Pose bug. Recommend 'device=cpu' for Pose models. "
-                "See https://github.com/ultralytics/ultralytics/issues/4031."
-            )
-
     def get_model(
         self,
         cfg: str | Path | dict[str, Any] | None = None,

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 
 from ultralytics.models.yolo.detect import DetectionValidator
-from ultralytics.utils import LOGGER, ops
+from ultralytics.utils import ops
 from ultralytics.utils.metrics import OKS_SIGMA, PoseMetrics, kpt_iou
 
 

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -75,11 +75,6 @@ class PoseValidator(DetectionValidator):
         self.kpt_shape = None
         self.args.task = "pose"
         self.metrics = PoseMetrics()
-        if isinstance(self.args.device, str) and self.args.device.lower() == "mps":
-            LOGGER.warning(
-                "Apple MPS known Pose bug. Recommend 'device=cpu' for Pose models. "
-                "See https://github.com/ultralytics/ultralytics/issues/4031."
-            )
 
     def preprocess(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Preprocess batch by converting keypoints data to float and moving it to the device."""

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -15,7 +15,10 @@ import torch
 from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, plt_settings
 
 OKS_SIGMA = (
-    np.array([0.26, 0.25, 0.25, 0.35, 0.35, 0.79, 0.79, 0.72, 0.72, 0.62, 0.62, 1.07, 1.07, 0.87, 0.87, 0.89, 0.89])
+    np.array(
+        [0.26, 0.25, 0.25, 0.35, 0.35, 0.79, 0.79, 0.72, 0.72, 0.62, 0.62, 1.07, 1.07, 0.87, 0.87, 0.89, 0.89],
+        dtype=np.float32,
+    )
     / 10.0
 )
 


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/4031

Bug doesn't seem to be present anymore

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes outdated Apple MPS pose warnings and standardizes pose metric precision to float32 for more consistent behavior. ✅

### 📊 Key Changes
- 🧹 **Apple MPS warnings removed** from:
  - `PosePredictor` (`pose/predict.py`)
  - `PoseTrainer` (`pose/train.py`)
  - `PoseValidator` (`pose/val.py`)
- 🧾 **Unused `LOGGER` imports** cleaned up where no longer needed.
- 🎯 **`OKS_SIGMA` now explicitly uses `float32`** in `metrics.py`:
  - `np.array(..., dtype=np.float32)` for the pose OKS sigma values.

### 🎯 Purpose & Impact
- 💻 **Better Apple Silicon experience**: Users on MPS devices (Apple GPUs) no longer see an always-on warning about a historic pose bug, reducing confusion and noise in logs.
- 📈 **More consistent metrics behavior**: Using `float32` for `OKS_SIGMA` aligns with typical model tensor dtypes, helping avoid subtle type mismatches and improving numerical consistency in pose evaluation.
- 🧼 **Cleaner codebase**: Removing unused imports and obsolete warnings simplifies maintenance and keeps logs and code easier to understand.