### PR TITLE
Document Windows RuntimeError workaround

### DIFF
--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -51,7 +51,7 @@ Train YOLO11n on the COCO8 dataset for 100 [epochs](https://www.ultralytics.com/
 
 !!! warning "Windows Multi-Processing Error"
 
-    On Windows, you may receive a `RuntimeError` when launching the training as a script. Add a `if __name__ == "__main__":` block before your training code to resolve it.
+    On Windows, you may receive a `RuntimeError` when launching the training as a script. Add an `if __name__ == "__main__":` block before your training code to resolve it.
 
 !!! example "Single-GPU and CPU Training Example"
 

--- a/docs/en/modes/val.md
+++ b/docs/en/modes/val.md
@@ -51,7 +51,7 @@ Validate trained YOLO11n model [accuracy](https://www.ultralytics.com/glossary/a
 
 !!! warning "Windows Multi-Processing Error"
 
-    On Windows, you may receive a `RuntimeError` when launching the validation as a script. Add a `if __name__ == "__main__":` block before your validation code to resolve it.
+    On Windows, you may receive a `RuntimeError` when launching the validation as a script. Add an `if __name__ == "__main__":` block before your validation code to resolve it.
 
 !!! example
 

--- a/docs/en/modes/val.md
+++ b/docs/en/modes/val.md
@@ -49,6 +49,10 @@ These are the notable functionalities offered by YOLO11's Val mode:
 
 Validate trained YOLO11n model [accuracy](https://www.ultralytics.com/glossary/accuracy) on the COCO8 dataset. No arguments are needed as the `model` retains its training `data` and arguments as model attributes. See Arguments section below for a full list of validation arguments.
 
+!!! warning "Windows Multi-Processing Error"
+
+    On Windows, you may receive a `RuntimeError` when launching the validation as a script. Add a `if __name__ == "__main__":` block before your validation code to resolve it.
+
 !!! example
 
     === "Python"


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/19524

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documentation updates clarify Windows multi-processing behavior for training and validation, helping users avoid common runtime errors on YOLO11 workflows. 💡

### 📊 Key Changes
- ✅ Clarified wording in the Windows multi-processing warning for training docs (`train.md`) to improve readability.
- ⚠️ Added a new "Windows Multi-Processing Error" warning section to validation docs (`val.md`) explaining how to avoid `RuntimeError` when running validation as a script.
- 🧩 Provided explicit guidance to wrap validation code in an `if __name__ == "__main__":` block on Windows.

### 🎯 Purpose & Impact
- 💻 Reduces confusing `RuntimeError` issues for Windows users running training or validation as Python scripts.
- 🧠 Makes the docs more beginner-friendly by surfacing a common platform-specific pitfall and its fix.
- 🚀 Improves overall developer experience and reliability of running YOLO11 workflows on Windows environments.