### PR TITLE
Clarify TIFF/TIF images must be `uint8`

### DIFF
--- a/docs/en/datasets/detect/coco8-multispectral.md
+++ b/docs/en/datasets/detect/coco8-multispectral.md
@@ -49,7 +49,7 @@ The COCO8-Multispectral dataset is configured using a YAML file, which defines d
 
 !!! note
 
-    Prepare your TIFF images in `(channel, height, width)` order and saved with `.tiff` or `.tif` extension for use with Ultralytics:
+    Prepare your TIFF images in `(channel, height, width)` order and saved with `.tiff` or `.tif` extension for use with Ultralytics. The TIFF images must be `uint8`:
 
     ```python
     import cv2

--- a/docs/en/datasets/detect/coco8-multispectral.md
+++ b/docs/en/datasets/detect/coco8-multispectral.md
@@ -49,7 +49,7 @@ The COCO8-Multispectral dataset is configured using a YAML file, which defines d
 
 !!! note
 
-    Prepare your TIFF images in `(channel, height, width)` order and saved with `.tiff` or `.tif` extension for use with Ultralytics. The TIFF images must be `uint8`:
+    Prepare your TIFF images in `(channel, height, width)` order, saved with `.tiff` or `.tif` extension, and ensure they are `uint8` for use with Ultralytics:
 
     ```python
     import cv2


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/22743

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies that multispectral TIFF images must be `uint8` in addition to having the correct shape and extension for use with Ultralytics. 🛰️

### 📊 Key Changes
- 📝 Updated the COCO8-Multispectral dataset documentation to:
  - Keep the required image layout: `(channel, height, width)`.
  - Keep supported file extensions: `.tiff` or `.tif`.
  - **Add** a new requirement that TIFF images must be stored as `uint8`.

### 🎯 Purpose & Impact
- ✅ Reduces confusion for users preparing multispectral datasets by clearly stating the expected data type.
- 🧪 Helps prevent runtime errors or unexpected behavior caused by incompatible image formats or types.
- 🚀 Makes it easier for users to correctly format and load multispectral data with Ultralytics models.