### PR TITLE
Remove Class __init__ examples

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1542,10 +1542,10 @@ class LetterBox:
         interpolation: int = cv2.INTER_LINEAR,
     ):
         """Initialize LetterBox object for resizing and padding images.
-
+        
         This class is designed to resize and pad images for object detection, instance segmentation, and pose estimation
         tasks. It supports various resizing modes including auto-sizing, scale-fill, and letterboxing.
-
+        
         Args:
             new_shape (tuple[int, int]): Target size (height, width) for the resized image.
             auto (bool): If True, use minimum rectangle to resize. If False, use new_shape directly.
@@ -1555,15 +1555,6 @@ class LetterBox:
             stride (int): Stride of the model (e.g., 32 for YOLOv5).
             padding_value (int): Value for padding the image. Default is 114.
             interpolation (int): Interpolation method for resizing. Default is cv2.INTER_LINEAR.
-
-        Attributes:
-            new_shape (tuple[int, int]): Target size for the resized image.
-            auto (bool): Flag for using minimum rectangle resizing.
-            scale_fill (bool): Flag for stretching image without padding.
-            scaleup (bool): Flag for allowing upscaling.
-            stride (int): Stride value for ensuring image size is divisible by stride.
-            padding_value (int): Value used for padding the image.
-            interpolation (int): Interpolation method used for resizing.
         """
         self.new_shape = new_shape
         self.auto = auto
@@ -1801,35 +1792,25 @@ class Albumentations:
         >>> augmented_labels = transform(labels)
 
     Notes:
-        - The Albumentations package must be installed to use this class.
-        - If the package is not installed or an error occurs during initialization, the transform will be set to None.
-        - Spatial transforms are handled differently and require special processing for bounding boxes.
+        - Requires Albumentations version 1.0.3 or higher.
+        - Spatial transforms are handled differently to ensure bbox compatibility.
+        - Some transforms are applied with very low probability (0.01) by default.
     """
 
     def __init__(self, p: float = 1.0, transforms: list | None = None) -> None:
         """Initialize the Albumentations transform object for YOLO bbox formatted parameters.
-
+        
         This class applies various image augmentations using the Albumentations library, including Blur, Median Blur,
         conversion to grayscale, Contrast Limited Adaptive Histogram Equalization, random changes of brightness and
         contrast, RandomGamma, and image quality reduction through compression.
-
+        
         Args:
             p (float): Probability of applying the augmentations. Must be between 0 and 1.
             transforms (list, optional): List of custom Albumentations transforms. If None, uses default transforms.
-
-        Attributes:
-            p (float): Probability of applying the augmentations.
-            transform (albumentations.Compose): Composed Albumentations transforms.
-            contains_spatial (bool): Indicates if the transforms include spatial transformations.
-
+        
         Raises:
             ImportError: If the Albumentations package is not installed.
             Exception: For any other errors during initialization.
-
-        Notes:
-            - Requires Albumentations version 1.0.3 or higher.
-            - Spatial transforms are handled differently to ensure bbox compatibility.
-            - Some transforms are applied with very low probability (0.01) by default.
         """
         self.p = p
         self.transform = None
@@ -2016,10 +1997,10 @@ class Format:
         bgr: float = 0.0,
     ):
         """Initialize the Format class with given parameters for image and instance annotation formatting.
-
+        
         This class standardizes image and instance annotations for object detection, instance segmentation, and pose
         estimation tasks, preparing them for use in PyTorch DataLoader's `collate_fn`.
-
+        
         Args:
             bbox_format (str): Format for bounding boxes. Options are 'xywh', 'xyxy', etc.
             normalize (bool): Whether to normalize bounding boxes to [0,1].
@@ -2030,17 +2011,6 @@ class Format:
             mask_overlap (bool): If True, allows mask overlap.
             batch_idx (bool): If True, keeps batch indexes.
             bgr (float): Probability of returning BGR images instead of RGB.
-
-        Attributes:
-            bbox_format (str): Format for bounding boxes.
-            normalize (bool): Whether bounding boxes are normalized.
-            return_mask (bool): Whether to return instance masks.
-            return_keypoint (bool): Whether to return keypoints.
-            return_obb (bool): Whether to return oriented bounding boxes.
-            mask_ratio (int): Downsample ratio for masks.
-            mask_overlap (bool): Whether masks can overlap.
-            batch_idx (bool): Whether to keep batch indexes.
-            bgr (float): The probability to return BGR images.
         """
         self.bbox_format = bbox_format
         self.normalize = normalize
@@ -2312,10 +2282,10 @@ class RandomLoadText:
         padding_value: list[str] = [""],
     ) -> None:
         """Initialize the RandomLoadText class for randomly sampling positive and negative texts.
-
+        
         This class is designed to randomly sample positive texts and negative texts, and update the class indices
         accordingly to the number of samples. It can be used for text-based object detection tasks.
-
+        
         Args:
             prompt_format (str): Format string for the prompt. The format string should contain a single pair of curly
                 braces {} where the text will be inserted.
@@ -2325,13 +2295,6 @@ class RandomLoadText:
             padding (bool): Whether to pad texts to max_samples. If True, the number of texts will always be equal to
                 max_samples.
             padding_value (str): The padding text to use when padding is True.
-
-        Attributes:
-            prompt_format (str): The format string for the prompt.
-            neg_samples (tuple[int, int]): The range for sampling negative texts.
-            max_samples (int): The maximum number of text samples.
-            padding (bool): Whether padding is enabled.
-            padding_value (str): The value used for padding.
         """
         self.prompt_format = prompt_format
         self.neg_samples = neg_samples
@@ -2658,21 +2621,15 @@ class ClassifyLetterBox:
 
     def __init__(self, size: int | tuple[int, int] = (640, 640), auto: bool = False, stride: int = 32):
         """Initialize the ClassifyLetterBox object for image preprocessing.
-
+        
         This class is designed to be part of a transformation pipeline for image classification tasks. It resizes and
         pads images to a specified size while maintaining the original aspect ratio.
-
+        
         Args:
             size (int | tuple[int, int]): Target size for the letterboxed image. If an int, a square image of (size,
                 size) is created. If a tuple, it should be (height, width).
             auto (bool): If True, automatically calculates the short side based on stride.
             stride (int): The stride value, used when 'auto' is True.
-
-        Attributes:
-            h (int): Target height of the letterboxed image.
-            w (int): Target width of the letterboxed image.
-            auto (bool): Flag indicating whether to automatically calculate short side.
-            stride (int): Stride value for automatic short side calculation.
         """
         super().__init__()
         self.h, self.w = (size, size) if isinstance(size, int) else size

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -45,12 +45,9 @@ class BaseTransform:
 
     def __init__(self) -> None:
         """Initialize the BaseTransform object.
-
+        
         This constructor sets up the base transformation object, which can be extended for specific image processing
         tasks. It is designed to be compatible with both classification and semantic segmentation.
-
-        Examples:
-            >>> transform = BaseTransform()
         """
         pass
 
@@ -163,14 +160,9 @@ class Compose:
 
     def __init__(self, transforms):
         """Initialize the Compose object with a list of transforms.
-
+        
         Args:
             transforms (list[Callable]): A list of callable transform objects to be applied sequentially.
-
-        Examples:
-            >>> from ultralytics.data.augment import Compose, RandomHSV, RandomFlip
-            >>> transforms = [RandomHSV(), RandomFlip()]
-            >>> compose = Compose(transforms)
         """
         self.transforms = transforms if isinstance(transforms, list) else [transforms]
 
@@ -334,18 +326,13 @@ class BaseMixTransform:
 
     def __init__(self, dataset, pre_transform=None, p=0.0) -> None:
         """Initialize the BaseMixTransform object for mix transformations like CutMix, MixUp and Mosaic.
-
+        
         This class serves as a base for implementing mix transformations in image processing pipelines.
-
+        
         Args:
             dataset (Any): The dataset object containing images and labels for mixing.
             pre_transform (Callable | None): Optional transform to apply before mixing.
             p (float): Probability of applying the mix transformation. Should be in the range [0.0, 1.0].
-
-        Examples:
-            >>> dataset = YOLODataset("path/to/data")
-            >>> pre_transform = Compose([RandomFlip(), RandomPerspective()])
-            >>> mix_transform = BaseMixTransform(dataset, pre_transform, p=0.5)
         """
         self.dataset = dataset
         self.pre_transform = pre_transform
@@ -499,20 +486,15 @@ class Mosaic(BaseMixTransform):
 
     def __init__(self, dataset, imgsz: int = 640, p: float = 1.0, n: int = 4):
         """Initialize the Mosaic augmentation object.
-
+        
         This class performs mosaic augmentation by combining multiple (4 or 9) images into a single mosaic image. The
         augmentation is applied to a dataset with a given probability.
-
+        
         Args:
             dataset (Any): The dataset on which the mosaic augmentation is applied.
             imgsz (int): Image size (height and width) after mosaic pipeline of a single image.
             p (float): Probability of applying the mosaic augmentation. Must be in the range 0-1.
             n (int): The grid size, either 4 (for 2x2) or 9 (for 3x3).
-
-        Examples:
-            >>> from ultralytics.data.augment import Mosaic
-            >>> dataset = YourDataset(...)
-            >>> mosaic_aug = Mosaic(dataset, imgsz=640, p=0.5, n=4)
         """
         assert 0 <= p <= 1.0, f"The probability should be in range [0, 1], but got {p}."
         assert n in {4, 9}, "grid must be equal to 4 or 9."
@@ -858,19 +840,14 @@ class MixUp(BaseMixTransform):
 
     def __init__(self, dataset, pre_transform=None, p: float = 0.0) -> None:
         """Initialize the MixUp augmentation object.
-
+        
         MixUp is an image augmentation technique that combines two images by taking a weighted sum of their pixel values
         and labels. This implementation is designed for use with the Ultralytics YOLO framework.
-
+        
         Args:
             dataset (Any): The dataset to which MixUp augmentation will be applied.
             pre_transform (Callable | None): Optional transform to apply to images before MixUp.
             p (float): Probability of applying MixUp augmentation to an image. Must be in the range [0, 1].
-
-        Examples:
-            >>> from ultralytics.data.dataset import YOLODataset
-            >>> dataset = YOLODataset("path/to/data.yaml")
-            >>> mixup = MixUp(dataset, pre_transform=None, p=0.5)
         """
         super().__init__(dataset=dataset, pre_transform=pre_transform, p=p)
 
@@ -1056,10 +1033,10 @@ class RandomPerspective:
         pre_transform=None,
     ):
         """Initialize RandomPerspective object with transformation parameters.
-
+        
         This class implements random perspective and affine transformations on images and corresponding bounding boxes,
         segments, and keypoints. Transformations include rotation, translation, scaling, and shearing.
-
+        
         Args:
             degrees (float): Degree range for random rotations.
             translate (float): Fraction of total width and height for random translation.
@@ -1069,10 +1046,6 @@ class RandomPerspective:
             border (tuple[int, int]): Tuple specifying mosaic border (top/bottom, left/right).
             pre_transform (Callable | None): Function/transform to apply to the image before starting the random
                 transformation.
-
-        Examples:
-            >>> transform = RandomPerspective(degrees=10.0, translate=0.1, scale=0.5, shear=5.0)
-            >>> result = transform(labels)  # Apply random perspective to labels
         """
         self.degrees = degrees
         self.translate = translate
@@ -1395,17 +1368,13 @@ class RandomHSV:
 
     def __init__(self, hgain: float = 0.5, sgain: float = 0.5, vgain: float = 0.5) -> None:
         """Initialize the RandomHSV object for random HSV (Hue, Saturation, Value) augmentation.
-
+        
         This class applies random adjustments to the HSV channels of an image within specified limits.
-
+        
         Args:
             hgain (float): Maximum variation for hue. Should be in the range [0, 1].
             sgain (float): Maximum variation for saturation. Should be in the range [0, 1].
             vgain (float): Maximum variation for value. Should be in the range [0, 1].
-
-        Examples:
-            >>> hsv_aug = RandomHSV(hgain=0.5, sgain=0.5, vgain=0.5)
-            >>> hsv_aug(image)
         """
         self.hgain = hgain
         self.sgain = sgain
@@ -1473,21 +1442,17 @@ class RandomFlip:
 
     def __init__(self, p: float = 0.5, direction: str = "horizontal", flip_idx: list[int] | None = None) -> None:
         """Initialize the RandomFlip class with probability and direction.
-
+        
         This class applies a random horizontal or vertical flip to an image with a given probability. It also updates
         any instances (bounding boxes, keypoints, etc.) accordingly.
-
+        
         Args:
             p (float): The probability of applying the flip. Must be between 0 and 1.
             direction (str): The direction to apply the flip. Must be 'horizontal' or 'vertical'.
             flip_idx (list[int] | None): Index mapping for flipping keypoints, if any.
-
+        
         Raises:
             AssertionError: If direction is not 'horizontal' or 'vertical', or if p is not between 0 and 1.
-
-        Examples:
-            >>> flip = RandomFlip(p=0.5, direction="horizontal")
-            >>> flip_with_idx = RandomFlip(p=0.7, direction="vertical", flip_idx=[1, 0, 3, 2, 5, 4])
         """
         assert direction in {"horizontal", "vertical"}, f"Support direction `horizontal` or `vertical`, got {direction}"
         assert 0 <= p <= 1.0, f"The probability should be in range [0, 1], but got {p}."
@@ -1577,10 +1542,10 @@ class LetterBox:
         interpolation: int = cv2.INTER_LINEAR,
     ):
         """Initialize LetterBox object for resizing and padding images.
-
+        
         This class is designed to resize and pad images for object detection, instance segmentation, and pose estimation
         tasks. It supports various resizing modes including auto-sizing, scale-fill, and letterboxing.
-
+        
         Args:
             new_shape (tuple[int, int]): Target size (height, width) for the resized image.
             auto (bool): If True, use minimum rectangle to resize. If False, use new_shape directly.
@@ -1590,7 +1555,7 @@ class LetterBox:
             stride (int): Stride of the model (e.g., 32 for YOLOv5).
             padding_value (int): Value for padding the image. Default is 114.
             interpolation (int): Interpolation method for resizing. Default is cv2.INTER_LINEAR.
-
+        
         Attributes:
             new_shape (tuple[int, int]): Target size for the resized image.
             auto (bool): Flag for using minimum rectangle resizing.
@@ -1599,10 +1564,6 @@ class LetterBox:
             stride (int): Stride value for ensuring image size is divisible by stride.
             padding_value (int): Value used for padding the image.
             interpolation (int): Interpolation method used for resizing.
-
-        Examples:
-            >>> letterbox = LetterBox(new_shape=(640, 640), auto=False, scale_fill=False, scaleup=True, stride=32)
-            >>> resized_img = letterbox(original_img)
         """
         self.new_shape = new_shape
         self.auto = auto
@@ -1847,35 +1808,24 @@ class Albumentations:
 
     def __init__(self, p: float = 1.0, transforms: list | None = None) -> None:
         """Initialize the Albumentations transform object for YOLO bbox formatted parameters.
-
+        
         This class applies various image augmentations using the Albumentations library, including Blur, Median Blur,
         conversion to grayscale, Contrast Limited Adaptive Histogram Equalization, random changes of brightness and
         contrast, RandomGamma, and image quality reduction through compression.
-
+        
         Args:
             p (float): Probability of applying the augmentations. Must be between 0 and 1.
             transforms (list, optional): List of custom Albumentations transforms. If None, uses default transforms.
-
+        
         Attributes:
             p (float): Probability of applying the augmentations.
             transform (albumentations.Compose): Composed Albumentations transforms.
             contains_spatial (bool): Indicates if the transforms include spatial transformations.
-
+        
         Raises:
             ImportError: If the Albumentations package is not installed.
             Exception: For any other errors during initialization.
-
-        Examples:
-            >>> transform = Albumentations(p=0.5)
-            >>> augmented = transform(image=image, bboxes=bboxes, class_labels=classes)
-            >>> augmented_image = augmented["image"]
-            >>> augmented_bboxes = augmented["bboxes"]
-
-            >>> # Custom transforms example
-            >>> import albumentations as A
-            >>> custom_transforms = [A.Blur(p=0.01), A.CLAHE(p=0.01)]
-            >>> transform = Albumentations(p=1.0, transforms=custom_transforms)
-
+        
         Notes:
             - Requires Albumentations version 1.0.3 or higher.
             - Spatial transforms are handled differently to ensure bbox compatibility.
@@ -2066,10 +2016,10 @@ class Format:
         bgr: float = 0.0,
     ):
         """Initialize the Format class with given parameters for image and instance annotation formatting.
-
+        
         This class standardizes image and instance annotations for object detection, instance segmentation, and pose
         estimation tasks, preparing them for use in PyTorch DataLoader's `collate_fn`.
-
+        
         Args:
             bbox_format (str): Format for bounding boxes. Options are 'xywh', 'xyxy', etc.
             normalize (bool): Whether to normalize bounding boxes to [0,1].
@@ -2080,7 +2030,7 @@ class Format:
             mask_overlap (bool): If True, allows mask overlap.
             batch_idx (bool): If True, keeps batch indexes.
             bgr (float): Probability of returning BGR images instead of RGB.
-
+        
         Attributes:
             bbox_format (str): Format for bounding boxes.
             normalize (bool): Whether bounding boxes are normalized.
@@ -2091,11 +2041,6 @@ class Format:
             mask_overlap (bool): Whether masks can overlap.
             batch_idx (bool): Whether to keep batch indexes.
             bgr (float): The probability to return BGR images.
-
-        Examples:
-            >>> format = Format(bbox_format="xyxy", return_mask=True, return_keypoint=False)
-            >>> print(format.bbox_format)
-            xyxy
         """
         self.bbox_format = bbox_format
         self.normalize = normalize
@@ -2367,10 +2312,10 @@ class RandomLoadText:
         padding_value: list[str] = [""],
     ) -> None:
         """Initialize the RandomLoadText class for randomly sampling positive and negative texts.
-
+        
         This class is designed to randomly sample positive texts and negative texts, and update the class indices
         accordingly to the number of samples. It can be used for text-based object detection tasks.
-
+        
         Args:
             prompt_format (str): Format string for the prompt. The format string should contain a single pair of curly
                 braces {} where the text will be inserted.
@@ -2380,22 +2325,13 @@ class RandomLoadText:
             padding (bool): Whether to pad texts to max_samples. If True, the number of texts will always be equal to
                 max_samples.
             padding_value (str): The padding text to use when padding is True.
-
+        
         Attributes:
             prompt_format (str): The format string for the prompt.
             neg_samples (tuple[int, int]): The range for sampling negative texts.
             max_samples (int): The maximum number of text samples.
             padding (bool): Whether padding is enabled.
             padding_value (str): The value used for padding.
-
-        Examples:
-            >>> random_load_text = RandomLoadText(prompt_format="Object: {}", neg_samples=(50, 100), max_samples=120)
-            >>> random_load_text.prompt_format
-            'Object: {}'
-            >>> random_load_text.neg_samples
-            (50, 100)
-            >>> random_load_text.max_samples
-            120
         """
         self.prompt_format = prompt_format
         self.neg_samples = neg_samples
@@ -2722,28 +2658,21 @@ class ClassifyLetterBox:
 
     def __init__(self, size: int | tuple[int, int] = (640, 640), auto: bool = False, stride: int = 32):
         """Initialize the ClassifyLetterBox object for image preprocessing.
-
+        
         This class is designed to be part of a transformation pipeline for image classification tasks. It resizes and
         pads images to a specified size while maintaining the original aspect ratio.
-
+        
         Args:
             size (int | tuple[int, int]): Target size for the letterboxed image. If an int, a square image of (size,
                 size) is created. If a tuple, it should be (height, width).
             auto (bool): If True, automatically calculates the short side based on stride.
             stride (int): The stride value, used when 'auto' is True.
-
+        
         Attributes:
             h (int): Target height of the letterboxed image.
             w (int): Target width of the letterboxed image.
             auto (bool): Flag indicating whether to automatically calculate short side.
             stride (int): Stride value for automatic short side calculation.
-
-        Examples:
-            >>> transform = ClassifyLetterBox(size=224)
-            >>> img = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
-            >>> result = transform(img)
-            >>> print(result.shape)
-            (224, 224, 3)
         """
         super().__init__()
         self.h, self.w = (size, size) if isinstance(size, int) else size
@@ -2808,23 +2737,16 @@ class CenterCrop:
 
     def __init__(self, size: int | tuple[int, int] = (640, 640)):
         """Initialize the CenterCrop object for image preprocessing.
-
+        
         This class is designed to be part of a transformation pipeline, e.g., T.Compose([CenterCrop(size), ToTensor()]).
         It performs a center crop on input images to a specified size.
-
+        
         Args:
             size (int | tuple[int, int]): The desired output size of the crop. If size is an int, a square crop (size,
                 size) is made. If size is a sequence like (h, w), it is used as the output size.
-
+        
         Returns:
             (None): This method initializes the object and does not return anything.
-
-        Examples:
-            >>> transform = CenterCrop(224)
-            >>> img = np.random.rand(300, 300, 3)
-            >>> cropped_img = transform(img)
-            >>> print(cropped_img.shape)
-            (224, 224, 3)
         """
         super().__init__()
         self.h, self.w = (size, size) if isinstance(size, int) else size
@@ -2882,20 +2804,13 @@ class ToTensor:
 
     def __init__(self, half: bool = False):
         """Initialize the ToTensor object for converting images to PyTorch tensors.
-
+        
         This class is designed to be used as part of a transformation pipeline for image preprocessing in the
         Ultralytics YOLO framework. It converts numpy arrays or PIL Images to PyTorch tensors, with an option for
         half-precision (float16) conversion.
-
+        
         Args:
             half (bool): If True, converts the tensor to half precision (float16).
-
-        Examples:
-            >>> transform = ToTensor(half=True)
-            >>> img = np.random.rand(640, 640, 3)
-            >>> tensor_img = transform(img)
-            >>> print(tensor_img.dtype)
-            torch.float16
         """
         super().__init__()
         self.half = half

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1542,10 +1542,10 @@ class LetterBox:
         interpolation: int = cv2.INTER_LINEAR,
     ):
         """Initialize LetterBox object for resizing and padding images.
-        
+
         This class is designed to resize and pad images for object detection, instance segmentation, and pose estimation
         tasks. It supports various resizing modes including auto-sizing, scale-fill, and letterboxing.
-        
+
         Args:
             new_shape (tuple[int, int]): Target size (height, width) for the resized image.
             auto (bool): If True, use minimum rectangle to resize. If False, use new_shape directly.
@@ -1799,15 +1799,15 @@ class Albumentations:
 
     def __init__(self, p: float = 1.0, transforms: list | None = None) -> None:
         """Initialize the Albumentations transform object for YOLO bbox formatted parameters.
-        
+
         This class applies various image augmentations using the Albumentations library, including Blur, Median Blur,
         conversion to grayscale, Contrast Limited Adaptive Histogram Equalization, random changes of brightness and
         contrast, RandomGamma, and image quality reduction through compression.
-        
+
         Args:
             p (float): Probability of applying the augmentations. Must be between 0 and 1.
             transforms (list, optional): List of custom Albumentations transforms. If None, uses default transforms.
-        
+
         Raises:
             ImportError: If the Albumentations package is not installed.
             Exception: For any other errors during initialization.
@@ -1997,10 +1997,10 @@ class Format:
         bgr: float = 0.0,
     ):
         """Initialize the Format class with given parameters for image and instance annotation formatting.
-        
+
         This class standardizes image and instance annotations for object detection, instance segmentation, and pose
         estimation tasks, preparing them for use in PyTorch DataLoader's `collate_fn`.
-        
+
         Args:
             bbox_format (str): Format for bounding boxes. Options are 'xywh', 'xyxy', etc.
             normalize (bool): Whether to normalize bounding boxes to [0,1].
@@ -2282,10 +2282,10 @@ class RandomLoadText:
         padding_value: list[str] = [""],
     ) -> None:
         """Initialize the RandomLoadText class for randomly sampling positive and negative texts.
-        
+
         This class is designed to randomly sample positive texts and negative texts, and update the class indices
         accordingly to the number of samples. It can be used for text-based object detection tasks.
-        
+
         Args:
             prompt_format (str): Format string for the prompt. The format string should contain a single pair of curly
                 braces {} where the text will be inserted.
@@ -2621,10 +2621,10 @@ class ClassifyLetterBox:
 
     def __init__(self, size: int | tuple[int, int] = (640, 640), auto: bool = False, stride: int = 32):
         """Initialize the ClassifyLetterBox object for image preprocessing.
-        
+
         This class is designed to be part of a transformation pipeline for image classification tasks. It resizes and
         pads images to a specified size while maintaining the original aspect ratio.
-        
+
         Args:
             size (int | tuple[int, int]): Target size for the letterboxed image. If an int, a square image of (size,
                 size) is created. If a tuple, it should be (height, width).

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -45,7 +45,7 @@ class BaseTransform:
 
     def __init__(self) -> None:
         """Initialize the BaseTransform object.
-        
+
         This constructor sets up the base transformation object, which can be extended for specific image processing
         tasks. It is designed to be compatible with both classification and semantic segmentation.
         """
@@ -160,7 +160,7 @@ class Compose:
 
     def __init__(self, transforms):
         """Initialize the Compose object with a list of transforms.
-        
+
         Args:
             transforms (list[Callable]): A list of callable transform objects to be applied sequentially.
         """
@@ -326,9 +326,9 @@ class BaseMixTransform:
 
     def __init__(self, dataset, pre_transform=None, p=0.0) -> None:
         """Initialize the BaseMixTransform object for mix transformations like CutMix, MixUp and Mosaic.
-        
+
         This class serves as a base for implementing mix transformations in image processing pipelines.
-        
+
         Args:
             dataset (Any): The dataset object containing images and labels for mixing.
             pre_transform (Callable | None): Optional transform to apply before mixing.
@@ -486,10 +486,10 @@ class Mosaic(BaseMixTransform):
 
     def __init__(self, dataset, imgsz: int = 640, p: float = 1.0, n: int = 4):
         """Initialize the Mosaic augmentation object.
-        
+
         This class performs mosaic augmentation by combining multiple (4 or 9) images into a single mosaic image. The
         augmentation is applied to a dataset with a given probability.
-        
+
         Args:
             dataset (Any): The dataset on which the mosaic augmentation is applied.
             imgsz (int): Image size (height and width) after mosaic pipeline of a single image.
@@ -840,10 +840,10 @@ class MixUp(BaseMixTransform):
 
     def __init__(self, dataset, pre_transform=None, p: float = 0.0) -> None:
         """Initialize the MixUp augmentation object.
-        
+
         MixUp is an image augmentation technique that combines two images by taking a weighted sum of their pixel values
         and labels. This implementation is designed for use with the Ultralytics YOLO framework.
-        
+
         Args:
             dataset (Any): The dataset to which MixUp augmentation will be applied.
             pre_transform (Callable | None): Optional transform to apply to images before MixUp.
@@ -1033,10 +1033,10 @@ class RandomPerspective:
         pre_transform=None,
     ):
         """Initialize RandomPerspective object with transformation parameters.
-        
+
         This class implements random perspective and affine transformations on images and corresponding bounding boxes,
         segments, and keypoints. Transformations include rotation, translation, scaling, and shearing.
-        
+
         Args:
             degrees (float): Degree range for random rotations.
             translate (float): Fraction of total width and height for random translation.
@@ -1368,9 +1368,9 @@ class RandomHSV:
 
     def __init__(self, hgain: float = 0.5, sgain: float = 0.5, vgain: float = 0.5) -> None:
         """Initialize the RandomHSV object for random HSV (Hue, Saturation, Value) augmentation.
-        
+
         This class applies random adjustments to the HSV channels of an image within specified limits.
-        
+
         Args:
             hgain (float): Maximum variation for hue. Should be in the range [0, 1].
             sgain (float): Maximum variation for saturation. Should be in the range [0, 1].
@@ -1442,15 +1442,15 @@ class RandomFlip:
 
     def __init__(self, p: float = 0.5, direction: str = "horizontal", flip_idx: list[int] | None = None) -> None:
         """Initialize the RandomFlip class with probability and direction.
-        
+
         This class applies a random horizontal or vertical flip to an image with a given probability. It also updates
         any instances (bounding boxes, keypoints, etc.) accordingly.
-        
+
         Args:
             p (float): The probability of applying the flip. Must be between 0 and 1.
             direction (str): The direction to apply the flip. Must be 'horizontal' or 'vertical'.
             flip_idx (list[int] | None): Index mapping for flipping keypoints, if any.
-        
+
         Raises:
             AssertionError: If direction is not 'horizontal' or 'vertical', or if p is not between 0 and 1.
         """
@@ -1542,10 +1542,10 @@ class LetterBox:
         interpolation: int = cv2.INTER_LINEAR,
     ):
         """Initialize LetterBox object for resizing and padding images.
-        
+
         This class is designed to resize and pad images for object detection, instance segmentation, and pose estimation
         tasks. It supports various resizing modes including auto-sizing, scale-fill, and letterboxing.
-        
+
         Args:
             new_shape (tuple[int, int]): Target size (height, width) for the resized image.
             auto (bool): If True, use minimum rectangle to resize. If False, use new_shape directly.
@@ -1555,7 +1555,7 @@ class LetterBox:
             stride (int): Stride of the model (e.g., 32 for YOLOv5).
             padding_value (int): Value for padding the image. Default is 114.
             interpolation (int): Interpolation method for resizing. Default is cv2.INTER_LINEAR.
-        
+
         Attributes:
             new_shape (tuple[int, int]): Target size for the resized image.
             auto (bool): Flag for using minimum rectangle resizing.
@@ -1808,24 +1808,24 @@ class Albumentations:
 
     def __init__(self, p: float = 1.0, transforms: list | None = None) -> None:
         """Initialize the Albumentations transform object for YOLO bbox formatted parameters.
-        
+
         This class applies various image augmentations using the Albumentations library, including Blur, Median Blur,
         conversion to grayscale, Contrast Limited Adaptive Histogram Equalization, random changes of brightness and
         contrast, RandomGamma, and image quality reduction through compression.
-        
+
         Args:
             p (float): Probability of applying the augmentations. Must be between 0 and 1.
             transforms (list, optional): List of custom Albumentations transforms. If None, uses default transforms.
-        
+
         Attributes:
             p (float): Probability of applying the augmentations.
             transform (albumentations.Compose): Composed Albumentations transforms.
             contains_spatial (bool): Indicates if the transforms include spatial transformations.
-        
+
         Raises:
             ImportError: If the Albumentations package is not installed.
             Exception: For any other errors during initialization.
-        
+
         Notes:
             - Requires Albumentations version 1.0.3 or higher.
             - Spatial transforms are handled differently to ensure bbox compatibility.
@@ -2016,10 +2016,10 @@ class Format:
         bgr: float = 0.0,
     ):
         """Initialize the Format class with given parameters for image and instance annotation formatting.
-        
+
         This class standardizes image and instance annotations for object detection, instance segmentation, and pose
         estimation tasks, preparing them for use in PyTorch DataLoader's `collate_fn`.
-        
+
         Args:
             bbox_format (str): Format for bounding boxes. Options are 'xywh', 'xyxy', etc.
             normalize (bool): Whether to normalize bounding boxes to [0,1].
@@ -2030,7 +2030,7 @@ class Format:
             mask_overlap (bool): If True, allows mask overlap.
             batch_idx (bool): If True, keeps batch indexes.
             bgr (float): Probability of returning BGR images instead of RGB.
-        
+
         Attributes:
             bbox_format (str): Format for bounding boxes.
             normalize (bool): Whether bounding boxes are normalized.
@@ -2312,10 +2312,10 @@ class RandomLoadText:
         padding_value: list[str] = [""],
     ) -> None:
         """Initialize the RandomLoadText class for randomly sampling positive and negative texts.
-        
+
         This class is designed to randomly sample positive texts and negative texts, and update the class indices
         accordingly to the number of samples. It can be used for text-based object detection tasks.
-        
+
         Args:
             prompt_format (str): Format string for the prompt. The format string should contain a single pair of curly
                 braces {} where the text will be inserted.
@@ -2325,7 +2325,7 @@ class RandomLoadText:
             padding (bool): Whether to pad texts to max_samples. If True, the number of texts will always be equal to
                 max_samples.
             padding_value (str): The padding text to use when padding is True.
-        
+
         Attributes:
             prompt_format (str): The format string for the prompt.
             neg_samples (tuple[int, int]): The range for sampling negative texts.
@@ -2658,16 +2658,16 @@ class ClassifyLetterBox:
 
     def __init__(self, size: int | tuple[int, int] = (640, 640), auto: bool = False, stride: int = 32):
         """Initialize the ClassifyLetterBox object for image preprocessing.
-        
+
         This class is designed to be part of a transformation pipeline for image classification tasks. It resizes and
         pads images to a specified size while maintaining the original aspect ratio.
-        
+
         Args:
             size (int | tuple[int, int]): Target size for the letterboxed image. If an int, a square image of (size,
                 size) is created. If a tuple, it should be (height, width).
             auto (bool): If True, automatically calculates the short side based on stride.
             stride (int): The stride value, used when 'auto' is True.
-        
+
         Attributes:
             h (int): Target height of the letterboxed image.
             w (int): Target width of the letterboxed image.
@@ -2737,14 +2737,14 @@ class CenterCrop:
 
     def __init__(self, size: int | tuple[int, int] = (640, 640)):
         """Initialize the CenterCrop object for image preprocessing.
-        
+
         This class is designed to be part of a transformation pipeline, e.g., T.Compose([CenterCrop(size), ToTensor()]).
         It performs a center crop on input images to a specified size.
-        
+
         Args:
             size (int | tuple[int, int]): The desired output size of the crop. If size is an int, a square crop (size,
                 size) is made. If size is a sequence like (h, w), it is used as the output size.
-        
+
         Returns:
             (None): This method initializes the object and does not return anything.
         """
@@ -2804,11 +2804,11 @@ class ToTensor:
 
     def __init__(self, half: bool = False):
         """Initialize the ToTensor object for converting images to PyTorch tensors.
-        
+
         This class is designed to be used as part of a transformation pipeline for image preprocessing in the
         Ultralytics YOLO framework. It converts numpy arrays or PIL Images to PyTorch tensors, with an option for
         half-precision (float16) conversion.
-        
+
         Args:
             half (bool): If True, converts the tensor to half precision (float16).
         """

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -85,17 +85,17 @@ class Model(torch.nn.Module):
         verbose: bool = False,
     ) -> None:
         """Initialize a new instance of the YOLO model class.
-        
+
         This constructor sets up the model based on the provided model path or name. It handles various types of model
         sources, including local files, Ultralytics HUB models, and Triton Server models. The method initializes several
         important attributes of the model and prepares it for operations like training, prediction, or export.
-        
+
         Args:
             model (str | Path | Model): Path or name of the model to load or create. Can be a local file path, a model
                 name from Ultralytics HUB, a Triton Server model, or an already initialized Model instance.
             task (str, optional): The specific task for the model. If None, it will be inferred from the config.
             verbose (bool): If True, enables verbose output during the model's initialization and subsequent operations.
-        
+
         Raises:
             FileNotFoundError: If the specified model file does not exist or is inaccessible.
             ValueError: If the model file or configuration is invalid or unsupported.

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -85,26 +85,21 @@ class Model(torch.nn.Module):
         verbose: bool = False,
     ) -> None:
         """Initialize a new instance of the YOLO model class.
-
+        
         This constructor sets up the model based on the provided model path or name. It handles various types of model
         sources, including local files, Ultralytics HUB models, and Triton Server models. The method initializes several
         important attributes of the model and prepares it for operations like training, prediction, or export.
-
+        
         Args:
             model (str | Path | Model): Path or name of the model to load or create. Can be a local file path, a model
                 name from Ultralytics HUB, a Triton Server model, or an already initialized Model instance.
             task (str, optional): The specific task for the model. If None, it will be inferred from the config.
             verbose (bool): If True, enables verbose output during the model's initialization and subsequent operations.
-
+        
         Raises:
             FileNotFoundError: If the specified model file does not exist or is inaccessible.
             ValueError: If the model file or configuration is invalid or unsupported.
             ImportError: If required dependencies for specific model types (like HUB SDK) are not installed.
-
-        Examples:
-            >>> model = Model("yolo11n.pt")
-            >>> model = Model("path/to/model.yaml", task="detect")
-            >>> model = Model("hub_model", verbose=True)
         """
         if isinstance(model, Model):
             self.__dict__ = model.__dict__  # accepts an already initialized Model

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -234,7 +234,7 @@ class Results(SimpleClass, DataExportMixin):
         speed: dict[str, float] | None = None,
     ) -> None:
         """Initialize the Results class for storing and manipulating inference results.
-
+        
         Args:
             orig_img (np.ndarray): The original image as a numpy array.
             path (str): The path to the image file.
@@ -851,20 +851,15 @@ class Boxes(BaseTensor):
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize the Boxes class with detection box data and the original image shape.
-
+        
         This class manages detection boxes, providing easy access and manipulation of box coordinates, confidence
         scores, class identifiers, and optional tracking IDs. It supports multiple formats for box coordinates,
         including both absolute and normalized forms.
-
+        
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array with detection boxes of shape (num_boxes, 6) or
                 (num_boxes, 7). Columns should contain [x1, y1, x2, y2, (optional) track_id, confidence, class].
             orig_shape (tuple[int, int]): The original image shape as (height, width). Used for normalization.
-
-        Attributes:
-            data (torch.Tensor): The raw tensor containing detection boxes and their associated data.
-            orig_shape (tuple[int, int]): The original image size, used for normalization.
-            is_track (bool): Indicates whether tracking IDs are included in the box data.
         """
         if boxes.ndim == 1:
             boxes = boxes[None, :]
@@ -1243,21 +1238,14 @@ class Probs(BaseTensor):
 
     def __init__(self, probs: torch.Tensor | np.ndarray, orig_shape: tuple[int, int] | None = None) -> None:
         """Initialize the Probs class with classification probabilities.
-
+        
         This class stores and manages classification probabilities, providing easy access to top predictions and their
         confidences.
-
+        
         Args:
             probs (torch.Tensor | np.ndarray): A 1D tensor or array of classification probabilities.
             orig_shape (tuple | None): The original image shape as (height, width). Not used in this class but kept for
                 consistency with other result classes.
-
-        Attributes:
-            data (torch.Tensor | np.ndarray): The raw tensor or array containing classification probabilities.
-            top1 (int): Index of the top 1 class.
-            top5 (list[int]): Indices of the top 5 classes.
-            top1conf (torch.Tensor | np.ndarray): Confidence of the top 1 class.
-            top5conf (torch.Tensor | np.ndarray): Confidences of the top 5 classes.
         """
         super().__init__(probs, orig_shape)
 
@@ -1366,21 +1354,16 @@ class OBB(BaseTensor):
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize an OBB (Oriented Bounding Box) instance with oriented bounding box data and original image shape.
-
+        
         This class stores and manipulates Oriented Bounding Boxes (OBB) for object detection tasks. It provides various
         properties and methods to access and transform the OBB data.
-
+        
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array containing the detection boxes, with shape
                 (num_boxes, 7) or (num_boxes, 8). The last two columns contain confidence and class values. If present,
                 the third last column contains track IDs, and the fifth column contains rotation.
             orig_shape (tuple[int, int]): Original image size, in the format (height, width).
-
-        Attributes:
-            data (torch.Tensor | np.ndarray): The raw OBB tensor.
-            orig_shape (tuple[int, int]): The original image shape.
-            is_track (bool): Whether the boxes include tracking IDs.
-
+        
         Raises:
             AssertionError: If the number of values per box is not 7 or 8.
         """

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -234,7 +234,7 @@ class Results(SimpleClass, DataExportMixin):
         speed: dict[str, float] | None = None,
     ) -> None:
         """Initialize the Results class for storing and manipulating inference results.
-        
+
         Args:
             orig_img (np.ndarray): The original image as a numpy array.
             path (str): The path to the image file.
@@ -851,11 +851,11 @@ class Boxes(BaseTensor):
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize the Boxes class with detection box data and the original image shape.
-        
+
         This class manages detection boxes, providing easy access and manipulation of box coordinates, confidence
         scores, class identifiers, and optional tracking IDs. It supports multiple formats for box coordinates,
         including both absolute and normalized forms.
-        
+
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array with detection boxes of shape (num_boxes, 6) or
                 (num_boxes, 7). Columns should contain [x1, y1, x2, y2, (optional) track_id, confidence, class].
@@ -1238,10 +1238,10 @@ class Probs(BaseTensor):
 
     def __init__(self, probs: torch.Tensor | np.ndarray, orig_shape: tuple[int, int] | None = None) -> None:
         """Initialize the Probs class with classification probabilities.
-        
+
         This class stores and manages classification probabilities, providing easy access to top predictions and their
         confidences.
-        
+
         Args:
             probs (torch.Tensor | np.ndarray): A 1D tensor or array of classification probabilities.
             orig_shape (tuple | None): The original image shape as (height, width). Not used in this class but kept for
@@ -1354,16 +1354,16 @@ class OBB(BaseTensor):
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize an OBB (Oriented Bounding Box) instance with oriented bounding box data and original image shape.
-        
+
         This class stores and manipulates Oriented Bounding Boxes (OBB) for object detection tasks. It provides various
         properties and methods to access and transform the OBB data.
-        
+
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array containing the detection boxes, with shape
                 (num_boxes, 7) or (num_boxes, 8). The last two columns contain confidence and class values. If present,
                 the third last column contains track IDs, and the fifth column contains rotation.
             orig_shape (tuple[int, int]): Original image size, in the format (height, width).
-        
+
         Raises:
             AssertionError: If the number of values per box is not 7 or 8.
         """

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -49,16 +49,10 @@ class BaseTensor(SimpleClass):
 
     def __init__(self, data: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize BaseTensor with prediction data and the original shape of the image.
-
+        
         Args:
             data (torch.Tensor | np.ndarray): Prediction data such as bounding boxes, masks, or keypoints.
             orig_shape (tuple[int, int]): Original shape of the image in (height, width) format.
-
-        Examples:
-            >>> import torch
-            >>> data = torch.tensor([[1, 2, 3], [4, 5, 6]])
-            >>> orig_shape = (720, 1280)
-            >>> base_tensor = BaseTensor(data, orig_shape)
         """
         assert isinstance(data, (torch.Tensor, np.ndarray)), "data must be torch.Tensor or np.ndarray"
         self.data = data
@@ -240,7 +234,7 @@ class Results(SimpleClass, DataExportMixin):
         speed: dict[str, float] | None = None,
     ) -> None:
         """Initialize the Results class for storing and manipulating inference results.
-
+        
         Args:
             orig_img (np.ndarray): The original image as a numpy array.
             path (str): The path to the image file.
@@ -251,13 +245,7 @@ class Results(SimpleClass, DataExportMixin):
             keypoints (torch.Tensor | None): A 2D tensor of keypoint coordinates for each detection.
             obb (torch.Tensor | None): A 2D tensor of oriented bounding box coordinates for each detection.
             speed (dict | None): A dictionary containing preprocess, inference, and postprocess speeds (ms/image).
-
-        Examples:
-            >>> results = model("path/to/image.jpg")
-            >>> result = results[0]  # Get the first result
-            >>> boxes = result.boxes  # Get the boxes for the first result
-            >>> masks = result.masks  # Get the masks for the first result
-
+        
         Notes:
             For the default pose model, keypoint indices for human body pose estimation are:
             0: Nose, 1: Left Eye, 2: Right Eye, 3: Left Ear, 4: Right Ear
@@ -863,28 +851,20 @@ class Boxes(BaseTensor):
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize the Boxes class with detection box data and the original image shape.
-
+        
         This class manages detection boxes, providing easy access and manipulation of box coordinates, confidence
         scores, class identifiers, and optional tracking IDs. It supports multiple formats for box coordinates,
         including both absolute and normalized forms.
-
+        
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array with detection boxes of shape (num_boxes, 6) or
                 (num_boxes, 7). Columns should contain [x1, y1, x2, y2, (optional) track_id, confidence, class].
             orig_shape (tuple[int, int]): The original image shape as (height, width). Used for normalization.
-
+        
         Attributes:
             data (torch.Tensor): The raw tensor containing detection boxes and their associated data.
             orig_shape (tuple[int, int]): The original image size, used for normalization.
             is_track (bool): Indicates whether tracking IDs are included in the box data.
-
-        Examples:
-            >>> import torch
-            >>> boxes = torch.tensor([[100, 50, 150, 100, 0.9, 0]])
-            >>> orig_shape = (480, 640)
-            >>> detection_boxes = Boxes(boxes, orig_shape)
-            >>> print(detection_boxes.xyxy)
-            tensor([[100.,  50., 150., 100.]])
         """
         if boxes.ndim == 1:
             boxes = boxes[None, :]
@@ -1061,17 +1041,10 @@ class Masks(BaseTensor):
 
     def __init__(self, masks: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize the Masks class with detection mask data and the original image shape.
-
+        
         Args:
             masks (torch.Tensor | np.ndarray): Detection masks with shape (num_masks, height, width).
             orig_shape (tuple): The original image shape as (height, width). Used for normalization.
-
-        Examples:
-            >>> import torch
-            >>> from ultralytics.engine.results import Masks
-            >>> masks = torch.rand(10, 160, 160)  # 10 masks of 160x160 resolution
-            >>> orig_shape = (720, 1280)  # Original image shape
-            >>> mask_obj = Masks(masks, orig_shape)
         """
         if masks.ndim == 2:
             masks = masks[None, :]
@@ -1159,20 +1132,15 @@ class Keypoints(BaseTensor):
 
     def __init__(self, keypoints: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize the Keypoints object with detection keypoints and original image dimensions.
-
+        
         This method processes the input keypoints tensor, handling both 2D and 3D formats. For 3D tensors (x, y,
         confidence), it masks out low-confidence keypoints by setting their coordinates to zero.
-
+        
         Args:
             keypoints (torch.Tensor): A tensor containing keypoint data. Shape can be either:
                 - (num_objects, num_keypoints, 2) for x, y coordinates only
                 - (num_objects, num_keypoints, 3) for x, y coordinates and confidence scores
             orig_shape (tuple[int, int]): The original image dimensions (height, width).
-
-        Examples:
-            >>> kpts = torch.rand(1, 17, 3)  # 1 object, 17 keypoints (COCO format), x,y,conf
-            >>> orig_shape = (720, 1280)  # Original image height, width
-            >>> keypoints = Keypoints(kpts, orig_shape)
         """
         if keypoints.ndim == 2:
             keypoints = keypoints[None, :]
@@ -1275,32 +1243,21 @@ class Probs(BaseTensor):
 
     def __init__(self, probs: torch.Tensor | np.ndarray, orig_shape: tuple[int, int] | None = None) -> None:
         """Initialize the Probs class with classification probabilities.
-
+        
         This class stores and manages classification probabilities, providing easy access to top predictions and their
         confidences.
-
+        
         Args:
             probs (torch.Tensor | np.ndarray): A 1D tensor or array of classification probabilities.
             orig_shape (tuple | None): The original image shape as (height, width). Not used in this class but kept for
                 consistency with other result classes.
-
+        
         Attributes:
             data (torch.Tensor | np.ndarray): The raw tensor or array containing classification probabilities.
             top1 (int): Index of the top 1 class.
             top5 (list[int]): Indices of the top 5 classes.
             top1conf (torch.Tensor | np.ndarray): Confidence of the top 1 class.
             top5conf (torch.Tensor | np.ndarray): Confidences of the top 5 classes.
-
-        Examples:
-            >>> import torch
-            >>> probs = torch.tensor([0.1, 0.3, 0.2, 0.4])
-            >>> p = Probs(probs)
-            >>> print(p.top1)
-            3
-            >>> print(p.top1conf)
-            tensor(0.4000)
-            >>> print(p.top5)
-            [3, 1, 2, 0]
         """
         super().__init__(probs, orig_shape)
 
@@ -1409,30 +1366,23 @@ class OBB(BaseTensor):
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize an OBB (Oriented Bounding Box) instance with oriented bounding box data and original image shape.
-
+        
         This class stores and manipulates Oriented Bounding Boxes (OBB) for object detection tasks. It provides various
         properties and methods to access and transform the OBB data.
-
+        
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array containing the detection boxes, with shape
                 (num_boxes, 7) or (num_boxes, 8). The last two columns contain confidence and class values. If present,
                 the third last column contains track IDs, and the fifth column contains rotation.
             orig_shape (tuple[int, int]): Original image size, in the format (height, width).
-
+        
         Attributes:
             data (torch.Tensor | np.ndarray): The raw OBB tensor.
             orig_shape (tuple[int, int]): The original image shape.
             is_track (bool): Whether the boxes include tracking IDs.
-
+        
         Raises:
             AssertionError: If the number of values per box is not 7 or 8.
-
-        Examples:
-            >>> import torch
-            >>> boxes = torch.rand(3, 7)  # 3 boxes with 7 values each
-            >>> orig_shape = (640, 480)
-            >>> obb = OBB(boxes, orig_shape)
-            >>> print(obb.xywhr)  # Access the boxes in xywhr format
         """
         if boxes.ndim == 1:
             boxes = boxes[None, :]

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -49,7 +49,7 @@ class BaseTensor(SimpleClass):
 
     def __init__(self, data: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize BaseTensor with prediction data and the original shape of the image.
-        
+
         Args:
             data (torch.Tensor | np.ndarray): Prediction data such as bounding boxes, masks, or keypoints.
             orig_shape (tuple[int, int]): Original shape of the image in (height, width) format.
@@ -234,7 +234,7 @@ class Results(SimpleClass, DataExportMixin):
         speed: dict[str, float] | None = None,
     ) -> None:
         """Initialize the Results class for storing and manipulating inference results.
-        
+
         Args:
             orig_img (np.ndarray): The original image as a numpy array.
             path (str): The path to the image file.
@@ -245,7 +245,7 @@ class Results(SimpleClass, DataExportMixin):
             keypoints (torch.Tensor | None): A 2D tensor of keypoint coordinates for each detection.
             obb (torch.Tensor | None): A 2D tensor of oriented bounding box coordinates for each detection.
             speed (dict | None): A dictionary containing preprocess, inference, and postprocess speeds (ms/image).
-        
+
         Notes:
             For the default pose model, keypoint indices for human body pose estimation are:
             0: Nose, 1: Left Eye, 2: Right Eye, 3: Left Ear, 4: Right Ear
@@ -851,16 +851,16 @@ class Boxes(BaseTensor):
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize the Boxes class with detection box data and the original image shape.
-        
+
         This class manages detection boxes, providing easy access and manipulation of box coordinates, confidence
         scores, class identifiers, and optional tracking IDs. It supports multiple formats for box coordinates,
         including both absolute and normalized forms.
-        
+
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array with detection boxes of shape (num_boxes, 6) or
                 (num_boxes, 7). Columns should contain [x1, y1, x2, y2, (optional) track_id, confidence, class].
             orig_shape (tuple[int, int]): The original image shape as (height, width). Used for normalization.
-        
+
         Attributes:
             data (torch.Tensor): The raw tensor containing detection boxes and their associated data.
             orig_shape (tuple[int, int]): The original image size, used for normalization.
@@ -1041,7 +1041,7 @@ class Masks(BaseTensor):
 
     def __init__(self, masks: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize the Masks class with detection mask data and the original image shape.
-        
+
         Args:
             masks (torch.Tensor | np.ndarray): Detection masks with shape (num_masks, height, width).
             orig_shape (tuple): The original image shape as (height, width). Used for normalization.
@@ -1132,10 +1132,10 @@ class Keypoints(BaseTensor):
 
     def __init__(self, keypoints: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize the Keypoints object with detection keypoints and original image dimensions.
-        
+
         This method processes the input keypoints tensor, handling both 2D and 3D formats. For 3D tensors (x, y,
         confidence), it masks out low-confidence keypoints by setting their coordinates to zero.
-        
+
         Args:
             keypoints (torch.Tensor): A tensor containing keypoint data. Shape can be either:
                 - (num_objects, num_keypoints, 2) for x, y coordinates only
@@ -1243,15 +1243,15 @@ class Probs(BaseTensor):
 
     def __init__(self, probs: torch.Tensor | np.ndarray, orig_shape: tuple[int, int] | None = None) -> None:
         """Initialize the Probs class with classification probabilities.
-        
+
         This class stores and manages classification probabilities, providing easy access to top predictions and their
         confidences.
-        
+
         Args:
             probs (torch.Tensor | np.ndarray): A 1D tensor or array of classification probabilities.
             orig_shape (tuple | None): The original image shape as (height, width). Not used in this class but kept for
                 consistency with other result classes.
-        
+
         Attributes:
             data (torch.Tensor | np.ndarray): The raw tensor or array containing classification probabilities.
             top1 (int): Index of the top 1 class.
@@ -1366,21 +1366,21 @@ class OBB(BaseTensor):
 
     def __init__(self, boxes: torch.Tensor | np.ndarray, orig_shape: tuple[int, int]) -> None:
         """Initialize an OBB (Oriented Bounding Box) instance with oriented bounding box data and original image shape.
-        
+
         This class stores and manipulates Oriented Bounding Boxes (OBB) for object detection tasks. It provides various
         properties and methods to access and transform the OBB data.
-        
+
         Args:
             boxes (torch.Tensor | np.ndarray): A tensor or numpy array containing the detection boxes, with shape
                 (num_boxes, 7) or (num_boxes, 8). The last two columns contain confidence and class values. If present,
                 the third last column contains track IDs, and the fifth column contains rotation.
             orig_shape (tuple[int, int]): Original image size, in the format (height, width).
-        
+
         Attributes:
             data (torch.Tensor | np.ndarray): The raw OBB tensor.
             orig_shape (tuple[int, int]): The original image shape.
             is_track (bool): Whether the boxes include tracking IDs.
-        
+
         Raises:
             AssertionError: If the number of values per box is not 7 or 8.
         """

--- a/ultralytics/models/fastsam/val.py
+++ b/ultralytics/models/fastsam/val.py
@@ -23,7 +23,7 @@ class FastSAMValidator(SegmentationValidator):
 
     def __init__(self, dataloader=None, save_dir=None, args=None, _callbacks=None):
         """Initialize the FastSAMValidator class, setting the task to 'segment' and metrics to SegmentMetrics.
-
+        
         Args:
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to be used for validation.
             save_dir (Path, optional): Directory to save results.

--- a/ultralytics/models/fastsam/val.py
+++ b/ultralytics/models/fastsam/val.py
@@ -23,7 +23,7 @@ class FastSAMValidator(SegmentationValidator):
 
     def __init__(self, dataloader=None, save_dir=None, args=None, _callbacks=None):
         """Initialize the FastSAMValidator class, setting the task to 'segment' and metrics to SegmentMetrics.
-        
+
         Args:
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to be used for validation.
             save_dir (Path, optional): Directory to save results.

--- a/ultralytics/models/sam/model.py
+++ b/ultralytics/models/sam/model.py
@@ -49,16 +49,12 @@ class SAM(Model):
 
     def __init__(self, model: str = "sam_b.pt") -> None:
         """Initialize the SAM (Segment Anything Model) instance.
-
+        
         Args:
             model (str): Path to the pre-trained SAM model file. File should have a .pt or .pth extension.
-
+        
         Raises:
             NotImplementedError: If the model file extension is not .pt or .pth.
-
-        Examples:
-            >>> sam = SAM("sam_b.pt")
-            >>> print(sam.is_sam2)
         """
         if model and Path(model).suffix not in {".pt", ".pth"}:
             raise NotImplementedError("SAM prediction requires pre-trained *.pt or *.pth model.")

--- a/ultralytics/models/sam/model.py
+++ b/ultralytics/models/sam/model.py
@@ -49,10 +49,10 @@ class SAM(Model):
 
     def __init__(self, model: str = "sam_b.pt") -> None:
         """Initialize the SAM (Segment Anything Model) instance.
-        
+
         Args:
             model (str): Path to the pre-trained SAM model file. File should have a .pt or .pth extension.
-        
+
         Raises:
             NotImplementedError: If the model file extension is not .pt or .pth.
         """

--- a/ultralytics/models/sam/modules/blocks.py
+++ b/ultralytics/models/sam/modules/blocks.py
@@ -145,10 +145,10 @@ class CXBlock(nn.Module):
         use_dwconv: bool = True,
     ):
         """Initialize a ConvNeXt Block for efficient feature extraction in convolutional neural networks.
-        
+
         This block implements a modified version of the ConvNeXt architecture, offering improved performance and
         flexibility in feature extraction.
-        
+
         Args:
             dim (int): Number of input channels.
             kernel_size (int): Size of the convolutional kernel.
@@ -216,9 +216,9 @@ class Fuser(nn.Module):
 
     def __init__(self, layer: nn.Module, num_layers: int, dim: int | None = None, input_projection: bool = False):
         """Initialize the Fuser module for feature fusion through multiple layers.
-        
+
         This module creates a sequence of identical layers and optionally applies an input projection.
-        
+
         Args:
             layer (nn.Module): The layer to be replicated in the fuser.
             num_layers (int): The number of times to replicate the layer.
@@ -279,11 +279,11 @@ class SAM2TwoWayAttentionBlock(TwoWayAttentionBlock):
         skip_first_layer_pe: bool = False,
     ) -> None:
         """Initialize a SAM2TwoWayAttentionBlock for performing self-attention and cross-attention in two directions.
-        
+
         This block extends the TwoWayAttentionBlock and consists of four main components: self-attention on sparse
         inputs, cross-attention from sparse to dense inputs, an MLP block on sparse inputs, and cross-attention from
         dense to sparse inputs.
-        
+
         Args:
             embedding_dim (int): The channel dimension of the embeddings.
             num_heads (int): The number of heads in the attention layers.
@@ -334,10 +334,10 @@ class SAM2TwoWayTransformer(TwoWayTransformer):
         attention_downsample_rate: int = 2,
     ) -> None:
         """Initialize a SAM2TwoWayTransformer instance.
-        
+
         This transformer decoder attends to an input image using queries with supplied positional embeddings. It is
         designed for tasks like object detection, image segmentation, and point cloud processing.
-        
+
         Args:
             depth (int): Number of layers in the transformer.
             embedding_dim (int): Channel dimension for the input embeddings.
@@ -871,11 +871,11 @@ class Block(nn.Module):
         input_size: tuple[int, int] | None = None,
     ) -> None:
         """Initialize a transformer block with optional window attention and relative positional embeddings.
-        
+
         This constructor sets up a transformer block that can use either global or windowed self-attention, followed by
         a feed-forward network. It supports relative positional embeddings and is designed for use in vision transformer
         architectures.
-        
+
         Args:
             dim (int): Number of input channels.
             num_heads (int): Number of attention heads in the self-attention layer.
@@ -959,10 +959,10 @@ class REAttention(nn.Module):
         input_size: tuple[int, int] | None = None,
     ) -> None:
         """Initialize a Relative Position Attention module for transformer-based architectures.
-        
+
         This module implements multi-head attention with optional relative positional encodings, designed specifically
         for vision tasks in transformer models.
-        
+
         Args:
             dim (int): Number of input channels.
             num_heads (int): Number of attention heads.
@@ -1035,10 +1035,10 @@ class PatchEmbed(nn.Module):
         embed_dim: int = 768,
     ) -> None:
         """Initialize the PatchEmbed module for converting image patches to embeddings.
-        
+
         This module is typically used as the first layer in vision transformer architectures to transform image data
         into a suitable format for subsequent transformer blocks.
-        
+
         Args:
             kernel_size (tuple[int, int]): Size of the convolutional kernel for patch extraction.
             stride (tuple[int, int]): Stride of the convolutional operation.

--- a/ultralytics/models/sam/modules/blocks.py
+++ b/ultralytics/models/sam/modules/blocks.py
@@ -145,10 +145,10 @@ class CXBlock(nn.Module):
         use_dwconv: bool = True,
     ):
         """Initialize a ConvNeXt Block for efficient feature extraction in convolutional neural networks.
-
+        
         This block implements a modified version of the ConvNeXt architecture, offering improved performance and
         flexibility in feature extraction.
-
+        
         Args:
             dim (int): Number of input channels.
             kernel_size (int): Size of the convolutional kernel.
@@ -156,13 +156,6 @@ class CXBlock(nn.Module):
             drop_path (float): Stochastic depth rate.
             layer_scale_init_value (float): Initial value for Layer Scale.
             use_dwconv (bool): Whether to use depthwise convolution.
-
-        Examples:
-            >>> block = CXBlock(dim=64, kernel_size=7, padding=3)
-            >>> x = torch.randn(1, 64, 32, 32)
-            >>> output = block(x)
-            >>> print(output.shape)
-            torch.Size([1, 64, 32, 32])
         """
         super().__init__()
         self.dwconv = nn.Conv2d(
@@ -223,20 +216,14 @@ class Fuser(nn.Module):
 
     def __init__(self, layer: nn.Module, num_layers: int, dim: int | None = None, input_projection: bool = False):
         """Initialize the Fuser module for feature fusion through multiple layers.
-
+        
         This module creates a sequence of identical layers and optionally applies an input projection.
-
+        
         Args:
             layer (nn.Module): The layer to be replicated in the fuser.
             num_layers (int): The number of times to replicate the layer.
             dim (int | None): The dimension for input projection, if used.
             input_projection (bool): Whether to use input projection.
-
-        Examples:
-            >>> layer = nn.Linear(64, 64)
-            >>> fuser = Fuser(layer, num_layers=3, dim=64, input_projection=True)
-            >>> input_tensor = torch.randn(1, 64)
-            >>> output = fuser(input_tensor)
         """
         super().__init__()
         self.proj = nn.Identity()
@@ -292,11 +279,11 @@ class SAM2TwoWayAttentionBlock(TwoWayAttentionBlock):
         skip_first_layer_pe: bool = False,
     ) -> None:
         """Initialize a SAM2TwoWayAttentionBlock for performing self-attention and cross-attention in two directions.
-
+        
         This block extends the TwoWayAttentionBlock and consists of four main components: self-attention on sparse
         inputs, cross-attention from sparse to dense inputs, an MLP block on sparse inputs, and cross-attention from
         dense to sparse inputs.
-
+        
         Args:
             embedding_dim (int): The channel dimension of the embeddings.
             num_heads (int): The number of heads in the attention layers.
@@ -304,12 +291,6 @@ class SAM2TwoWayAttentionBlock(TwoWayAttentionBlock):
             activation (Type[nn.Module]): The activation function of the MLP block.
             attention_downsample_rate (int): The downsample rate for attention computations.
             skip_first_layer_pe (bool): Whether to skip the positional encoding in the first layer.
-
-        Examples:
-            >>> block = SAM2TwoWayAttentionBlock(embedding_dim=256, num_heads=8, mlp_dim=2048)
-            >>> sparse_inputs = torch.randn(1, 100, 256)
-            >>> dense_inputs = torch.randn(1, 256, 32, 32)
-            >>> sparse_outputs, dense_outputs = block(sparse_inputs, dense_inputs)
         """
         super().__init__(embedding_dim, num_heads, mlp_dim, activation, attention_downsample_rate, skip_first_layer_pe)
         self.mlp = MLP(embedding_dim, mlp_dim, embedding_dim, num_layers=2, act=activation)
@@ -353,10 +334,10 @@ class SAM2TwoWayTransformer(TwoWayTransformer):
         attention_downsample_rate: int = 2,
     ) -> None:
         """Initialize a SAM2TwoWayTransformer instance.
-
+        
         This transformer decoder attends to an input image using queries with supplied positional embeddings. It is
         designed for tasks like object detection, image segmentation, and point cloud processing.
-
+        
         Args:
             depth (int): Number of layers in the transformer.
             embedding_dim (int): Channel dimension for the input embeddings.
@@ -364,17 +345,6 @@ class SAM2TwoWayTransformer(TwoWayTransformer):
             mlp_dim (int): Channel dimension internal to the MLP block.
             activation (Type[nn.Module]): Activation function to use in the MLP block.
             attention_downsample_rate (int): Downsampling rate for attention computations.
-
-        Examples:
-            >>> transformer = SAM2TwoWayTransformer(depth=5, embedding_dim=256, num_heads=8, mlp_dim=2048)
-            >>> transformer
-            SAM2TwoWayTransformer(
-              (layers): ModuleList(
-                (0-4): 5 x SAM2TwoWayAttentionBlock(...)
-              )
-              (final_attn_token_to_image): Attention(...)
-              (norm_final_attn): LayerNorm(...)
-            )
         """
         super().__init__(depth, embedding_dim, num_heads, mlp_dim, activation, attention_downsample_rate)
         self.layers = nn.ModuleList()
@@ -901,11 +871,11 @@ class Block(nn.Module):
         input_size: tuple[int, int] | None = None,
     ) -> None:
         """Initialize a transformer block with optional window attention and relative positional embeddings.
-
+        
         This constructor sets up a transformer block that can use either global or windowed self-attention, followed by
         a feed-forward network. It supports relative positional embeddings and is designed for use in vision transformer
         architectures.
-
+        
         Args:
             dim (int): Number of input channels.
             num_heads (int): Number of attention heads in the self-attention layer.
@@ -917,13 +887,6 @@ class Block(nn.Module):
             rel_pos_zero_init (bool): If True, initializes relative positional parameters to zero.
             window_size (int): Size of attention window. If 0, uses global attention.
             input_size (tuple[int, int] | None): Input resolution for calculating relative positional parameter size.
-
-        Examples:
-            >>> block = Block(dim=256, num_heads=8, window_size=7)
-            >>> x = torch.randn(1, 56, 56, 256)
-            >>> output = block(x)
-            >>> print(output.shape)
-            torch.Size([1, 56, 56, 256])
         """
         super().__init__()
         self.norm1 = norm_layer(dim)
@@ -996,10 +959,10 @@ class REAttention(nn.Module):
         input_size: tuple[int, int] | None = None,
     ) -> None:
         """Initialize a Relative Position Attention module for transformer-based architectures.
-
+        
         This module implements multi-head attention with optional relative positional encodings, designed specifically
         for vision tasks in transformer models.
-
+        
         Args:
             dim (int): Number of input channels.
             num_heads (int): Number of attention heads.
@@ -1008,13 +971,6 @@ class REAttention(nn.Module):
             rel_pos_zero_init (bool): If True, initializes relative positional parameters to zero.
             input_size (tuple[int, int] | None): Input resolution for calculating relative positional parameter size.
                 Required if use_rel_pos is True.
-
-        Examples:
-            >>> attention = REAttention(dim=256, num_heads=8, input_size=(32, 32))
-            >>> x = torch.randn(1, 32, 32, 256)
-            >>> output = attention(x)
-            >>> print(output.shape)
-            torch.Size([1, 32, 32, 256])
         """
         super().__init__()
         self.num_heads = num_heads
@@ -1079,23 +1035,16 @@ class PatchEmbed(nn.Module):
         embed_dim: int = 768,
     ) -> None:
         """Initialize the PatchEmbed module for converting image patches to embeddings.
-
+        
         This module is typically used as the first layer in vision transformer architectures to transform image data
         into a suitable format for subsequent transformer blocks.
-
+        
         Args:
             kernel_size (tuple[int, int]): Size of the convolutional kernel for patch extraction.
             stride (tuple[int, int]): Stride of the convolutional operation.
             padding (tuple[int, int]): Padding applied to the input before convolution.
             in_chans (int): Number of input image channels.
             embed_dim (int): Dimensionality of the output patch embeddings.
-
-        Examples:
-            >>> patch_embed = PatchEmbed(kernel_size=(16, 16), stride=(16, 16), in_chans=3, embed_dim=768)
-            >>> x = torch.randn(1, 3, 224, 224)
-            >>> output = patch_embed(x)
-            >>> print(output.shape)
-            torch.Size([1, 768, 14, 14])
         """
         super().__init__()
 

--- a/ultralytics/models/sam/modules/decoders.py
+++ b/ultralytics/models/sam/modules/decoders.py
@@ -47,7 +47,7 @@ class MaskDecoder(nn.Module):
         iou_head_hidden_dim: int = 256,
     ) -> None:
         """Initialize the MaskDecoder module for generating masks and their associated quality scores.
-
+        
         Args:
             transformer_dim (int): Channel dimension for the transformer module.
             transformer (nn.Module): Transformer module used for mask prediction.
@@ -55,11 +55,6 @@ class MaskDecoder(nn.Module):
             activation (Type[nn.Module]): Type of activation to use when upscaling masks.
             iou_head_depth (int): Depth of the MLP used to predict mask quality.
             iou_head_hidden_dim (int): Hidden dimension of the MLP used to predict mask quality.
-
-        Examples:
-            >>> transformer = nn.TransformerEncoder(nn.TransformerEncoderLayer(d_model=256, nhead=8), num_layers=6)
-            >>> decoder = MaskDecoder(transformer_dim=256, transformer=transformer)
-            >>> print(decoder)
         """
         super().__init__()
         self.transformer_dim = transformer_dim
@@ -230,10 +225,10 @@ class SAM2MaskDecoder(nn.Module):
         use_multimask_token_for_obj_ptr: bool = False,
     ) -> None:
         """Initialize the SAM2MaskDecoder module for predicting instance segmentation masks.
-
+        
         This decoder extends the functionality of MaskDecoder, incorporating additional features such as high-resolution
         feature processing, dynamic multimask output, and object score prediction.
-
+        
         Args:
             transformer_dim (int): Channel dimension of the transformer.
             transformer (nn.Module): Transformer used to predict masks.
@@ -249,11 +244,6 @@ class SAM2MaskDecoder(nn.Module):
             pred_obj_scores (bool): Whether to predict object scores.
             pred_obj_scores_mlp (bool): Whether to use MLP for object score prediction.
             use_multimask_token_for_obj_ptr (bool): Whether to use multimask token for object pointer.
-
-        Examples:
-            >>> transformer = nn.TransformerEncoder(nn.TransformerEncoderLayer(d_model=256, nhead=8), num_layers=6)
-            >>> decoder = SAM2MaskDecoder(transformer_dim=256, transformer=transformer)
-            >>> print(decoder)
         """
         super().__init__()
         self.transformer_dim = transformer_dim

--- a/ultralytics/models/sam/modules/decoders.py
+++ b/ultralytics/models/sam/modules/decoders.py
@@ -47,7 +47,7 @@ class MaskDecoder(nn.Module):
         iou_head_hidden_dim: int = 256,
     ) -> None:
         """Initialize the MaskDecoder module for generating masks and their associated quality scores.
-        
+
         Args:
             transformer_dim (int): Channel dimension for the transformer module.
             transformer (nn.Module): Transformer module used for mask prediction.
@@ -225,10 +225,10 @@ class SAM2MaskDecoder(nn.Module):
         use_multimask_token_for_obj_ptr: bool = False,
     ) -> None:
         """Initialize the SAM2MaskDecoder module for predicting instance segmentation masks.
-        
+
         This decoder extends the functionality of MaskDecoder, incorporating additional features such as high-resolution
         feature processing, dynamic multimask output, and object score prediction.
-        
+
         Args:
             transformer_dim (int): Channel dimension of the transformer.
             transformer (nn.Module): Transformer used to predict masks.

--- a/ultralytics/models/sam/modules/encoders.py
+++ b/ultralytics/models/sam/modules/encoders.py
@@ -64,7 +64,7 @@ class ImageEncoderViT(nn.Module):
         global_attn_indexes: tuple[int, ...] = (),
     ) -> None:
         """Initialize an ImageEncoderViT instance for encoding images using Vision Transformer architecture.
-
+        
         Args:
             img_size (int): Input image size, assumed to be square.
             patch_size (int): Size of image patches.
@@ -82,12 +82,6 @@ class ImageEncoderViT(nn.Module):
             rel_pos_zero_init (bool): If True, initializes relative positional parameters to zero.
             window_size (int): Size of attention window for windowed attention blocks.
             global_attn_indexes (tuple[int, ...]): Indices of blocks that use global attention.
-
-        Examples:
-            >>> encoder = ImageEncoderViT(img_size=224, patch_size=16, embed_dim=768, depth=12, num_heads=12)
-            >>> input_image = torch.randn(1, 3, 224, 224)
-            >>> output = encoder(input_image)
-            >>> print(output.shape)
         """
         super().__init__()
         self.img_size = img_size
@@ -191,22 +185,13 @@ class PromptEncoder(nn.Module):
         activation: type[nn.Module] = nn.GELU,
     ) -> None:
         """Initialize the PromptEncoder module for encoding various types of prompts.
-
+        
         Args:
             embed_dim (int): The dimension of the embeddings.
             image_embedding_size (tuple[int, int]): The spatial size of the image embedding as (H, W).
             input_image_size (tuple[int, int]): The padded size of the input image as (H, W).
             mask_in_chans (int): The number of hidden channels used for encoding input masks.
             activation (Type[nn.Module]): The activation function to use when encoding input masks.
-
-        Examples:
-            >>> prompt_encoder = PromptEncoder(256, (64, 64), (1024, 1024), 16)
-            >>> points = (torch.rand(1, 5, 2), torch.randint(0, 4, (1, 5)))
-            >>> boxes = torch.rand(1, 2, 2)
-            >>> masks = torch.rand(1, 1, 256, 256)
-            >>> sparse_embeddings, dense_embeddings = prompt_encoder(points, boxes, masks)
-            >>> print(sparse_embeddings.shape, dense_embeddings.shape)
-            torch.Size([1, 7, 256]) torch.Size([1, 256, 64, 64])
         """
         super().__init__()
         self.embed_dim = embed_dim
@@ -378,21 +363,13 @@ class MemoryEncoder(nn.Module):
         in_dim=256,  # in_dim of pix_feats
     ):
         """Initialize the MemoryEncoder for encoding pixel features and masks into memory representations.
-
+        
         This encoder processes pixel-level features and masks, fusing them to generate encoded memory representations
         suitable for downstream tasks in image segmentation models like SAM (Segment Anything Model).
-
+        
         Args:
             out_dim (int): Output dimension of the encoded features.
             in_dim (int): Input dimension of the pixel features.
-
-        Examples:
-            >>> encoder = MemoryEncoder(out_dim=256, in_dim=256)
-            >>> pix_feat = torch.randn(1, 256, 64, 64)
-            >>> masks = torch.randn(1, 1, 64, 64)
-            >>> encoded_feat, pos = encoder(pix_feat, masks)
-            >>> print(encoded_feat.shape, pos.shape)
-            torch.Size([1, 256, 64, 64]) torch.Size([1, 128, 64, 64])
         """
         super().__init__()
 
@@ -460,23 +437,14 @@ class ImageEncoder(nn.Module):
         scalp: int = 0,
     ):
         """Initialize the ImageEncoder with trunk and neck networks for feature extraction and refinement.
-
+        
         This encoder combines a trunk network for feature extraction with a neck network for feature refinement and
         positional encoding generation. It can optionally discard the lowest resolution features.
-
+        
         Args:
             trunk (nn.Module): The trunk network for initial feature extraction.
             neck (nn.Module): The neck network for feature refinement and positional encoding generation.
             scalp (int): Number of lowest resolution feature levels to discard.
-
-        Examples:
-            >>> trunk = SomeTrunkNetwork()
-            >>> neck = SomeNeckNetwork()
-            >>> encoder = ImageEncoder(trunk, neck, scalp=1)
-            >>> image = torch.randn(1, 3, 224, 224)
-            >>> output = encoder(image)
-            >>> print(output.keys())
-            dict_keys(['vision_features', 'vision_pos_enc', 'backbone_fpn'])
         """
         super().__init__()
         self.trunk = trunk
@@ -539,10 +507,10 @@ class FpnNeck(nn.Module):
         fpn_top_down_levels: list[int] | None = None,
     ):
         """Initialize a modified Feature Pyramid Network (FPN) neck.
-
+        
         This FPN variant removes the output convolution and uses bicubic interpolation for feature resizing, similar to
         ViT positional embedding interpolation.
-
+        
         Args:
             d_model (int): Dimension of the model.
             backbone_channel_list (list[int]): List of channel dimensions from the backbone.
@@ -552,11 +520,6 @@ class FpnNeck(nn.Module):
             fpn_interp_model (str): Interpolation mode for FPN feature resizing.
             fuse_type (str): Type of feature fusion, either 'sum' or 'avg'.
             fpn_top_down_levels (Optional[list[int]]): Levels to have top-down features in outputs.
-
-        Examples:
-            >>> backbone_channels = [64, 128, 256, 512]
-            >>> fpn_neck = FpnNeck(256, backbone_channels)
-            >>> print(fpn_neck)
         """
         super().__init__()
         self.position_encoding = PositionEmbeddingSine(num_pos_feats=256)
@@ -701,11 +664,11 @@ class Hiera(nn.Module):
         return_interm_layers=True,  # return feats from every stage
     ):
         """Initialize a Hiera model, a hierarchical vision transformer for efficient multiscale feature extraction.
-
+        
         Hiera is a hierarchical vision transformer architecture designed for efficient multiscale feature extraction in
         image processing tasks. It uses a series of transformer blocks organized into stages, with optional pooling and
         global attention mechanisms.
-
+        
         Args:
             embed_dim (int): Initial embedding dimension for the model.
             num_heads (int): Initial number of attention heads.
@@ -720,13 +683,6 @@ class Hiera(nn.Module):
             window_spec (tuple[int, ...]): Window sizes for each stage when not using global attention.
             global_att_blocks (tuple[int, ...]): Indices of blocks that use global attention.
             return_interm_layers (bool): Whether to return intermediate layer outputs.
-
-        Examples:
-            >>> model = Hiera(embed_dim=96, num_heads=1, stages=(2, 3, 16, 3))
-            >>> input_tensor = torch.randn(1, 3, 224, 224)
-            >>> output_features = model(input_tensor)
-            >>> for feat in output_features:
-            ...     print(feat.shape)
         """
         super().__init__()
 

--- a/ultralytics/models/sam/modules/encoders.py
+++ b/ultralytics/models/sam/modules/encoders.py
@@ -64,7 +64,7 @@ class ImageEncoderViT(nn.Module):
         global_attn_indexes: tuple[int, ...] = (),
     ) -> None:
         """Initialize an ImageEncoderViT instance for encoding images using Vision Transformer architecture.
-        
+
         Args:
             img_size (int): Input image size, assumed to be square.
             patch_size (int): Size of image patches.
@@ -185,7 +185,7 @@ class PromptEncoder(nn.Module):
         activation: type[nn.Module] = nn.GELU,
     ) -> None:
         """Initialize the PromptEncoder module for encoding various types of prompts.
-        
+
         Args:
             embed_dim (int): The dimension of the embeddings.
             image_embedding_size (tuple[int, int]): The spatial size of the image embedding as (H, W).
@@ -363,10 +363,10 @@ class MemoryEncoder(nn.Module):
         in_dim=256,  # in_dim of pix_feats
     ):
         """Initialize the MemoryEncoder for encoding pixel features and masks into memory representations.
-        
+
         This encoder processes pixel-level features and masks, fusing them to generate encoded memory representations
         suitable for downstream tasks in image segmentation models like SAM (Segment Anything Model).
-        
+
         Args:
             out_dim (int): Output dimension of the encoded features.
             in_dim (int): Input dimension of the pixel features.
@@ -437,10 +437,10 @@ class ImageEncoder(nn.Module):
         scalp: int = 0,
     ):
         """Initialize the ImageEncoder with trunk and neck networks for feature extraction and refinement.
-        
+
         This encoder combines a trunk network for feature extraction with a neck network for feature refinement and
         positional encoding generation. It can optionally discard the lowest resolution features.
-        
+
         Args:
             trunk (nn.Module): The trunk network for initial feature extraction.
             neck (nn.Module): The neck network for feature refinement and positional encoding generation.
@@ -507,10 +507,10 @@ class FpnNeck(nn.Module):
         fpn_top_down_levels: list[int] | None = None,
     ):
         """Initialize a modified Feature Pyramid Network (FPN) neck.
-        
+
         This FPN variant removes the output convolution and uses bicubic interpolation for feature resizing, similar to
         ViT positional embedding interpolation.
-        
+
         Args:
             d_model (int): Dimension of the model.
             backbone_channel_list (list[int]): List of channel dimensions from the backbone.
@@ -664,11 +664,11 @@ class Hiera(nn.Module):
         return_interm_layers=True,  # return feats from every stage
     ):
         """Initialize a Hiera model, a hierarchical vision transformer for efficient multiscale feature extraction.
-        
+
         Hiera is a hierarchical vision transformer architecture designed for efficient multiscale feature extraction in
         image processing tasks. It uses a series of transformer blocks organized into stages, with optional pooling and
         global attention mechanisms.
-        
+
         Args:
             embed_dim (int): Initial embedding dimension for the model.
             num_heads (int): Initial number of attention heads.

--- a/ultralytics/models/sam/modules/memory_attention.py
+++ b/ultralytics/models/sam/modules/memory_attention.py
@@ -203,10 +203,10 @@ class MemoryAttention(nn.Module):
         batch_first: bool = True,  # Do layers expect batch first input?
     ):
         """Initialize MemoryAttention with specified layers and normalization for sequential data processing.
-        
+
         This class implements a multi-layer attention mechanism that combines self-attention and cross-attention for
         processing sequential data, particularly useful in transformer-like architectures.
-        
+
         Args:
             d_model (int): The dimension of the model's hidden state.
             pos_enc_at_input (bool): Whether to apply positional encoding at the input.

--- a/ultralytics/models/sam/modules/memory_attention.py
+++ b/ultralytics/models/sam/modules/memory_attention.py
@@ -203,28 +203,16 @@ class MemoryAttention(nn.Module):
         batch_first: bool = True,  # Do layers expect batch first input?
     ):
         """Initialize MemoryAttention with specified layers and normalization for sequential data processing.
-
+        
         This class implements a multi-layer attention mechanism that combines self-attention and cross-attention for
         processing sequential data, particularly useful in transformer-like architectures.
-
+        
         Args:
             d_model (int): The dimension of the model's hidden state.
             pos_enc_at_input (bool): Whether to apply positional encoding at the input.
             layer (nn.Module): The attention layer to be used in the module.
             num_layers (int): The number of attention layers.
             batch_first (bool): Whether the input tensors are in batch-first format.
-
-        Examples:
-            >>> d_model = 256
-            >>> layer = MemoryAttentionLayer(d_model)
-            >>> attention = MemoryAttention(d_model, pos_enc_at_input=True, layer=layer, num_layers=3)
-            >>> curr = torch.randn(10, 32, d_model)  # (seq_len, batch_size, d_model)
-            >>> memory = torch.randn(20, 32, d_model)  # (mem_len, batch_size, d_model)
-            >>> curr_pos = torch.randn(10, 32, d_model)
-            >>> memory_pos = torch.randn(20, 32, d_model)
-            >>> output = attention(curr, memory, curr_pos, memory_pos)
-            >>> print(output.shape)
-            torch.Size([10, 32, 256])
         """
         super().__init__()
         self.d_model = d_model

--- a/ultralytics/models/sam/modules/sam.py
+++ b/ultralytics/models/sam/modules/sam.py
@@ -61,7 +61,7 @@ class SAMModel(nn.Module):
         pixel_std: list[float] = (58.395, 57.12, 57.375),
     ) -> None:
         """Initialize the SAMModel class to predict object masks from an image and input prompts.
-        
+
         Args:
             image_encoder (ImageEncoderViT): The backbone used to encode the image into image embeddings.
             prompt_encoder (PromptEncoder): Encodes various types of input prompts.

--- a/ultralytics/models/sam/modules/sam.py
+++ b/ultralytics/models/sam/modules/sam.py
@@ -61,7 +61,7 @@ class SAMModel(nn.Module):
         pixel_std: list[float] = (58.395, 57.12, 57.375),
     ) -> None:
         """Initialize the SAMModel class to predict object masks from an image and input prompts.
-
+        
         Args:
             image_encoder (ImageEncoderViT): The backbone used to encode the image into image embeddings.
             prompt_encoder (PromptEncoder): Encodes various types of input prompts.

--- a/ultralytics/models/sam/modules/sam.py
+++ b/ultralytics/models/sam/modules/sam.py
@@ -61,21 +61,14 @@ class SAMModel(nn.Module):
         pixel_std: list[float] = (58.395, 57.12, 57.375),
     ) -> None:
         """Initialize the SAMModel class to predict object masks from an image and input prompts.
-
+        
         Args:
             image_encoder (ImageEncoderViT): The backbone used to encode the image into image embeddings.
             prompt_encoder (PromptEncoder): Encodes various types of input prompts.
             mask_decoder (MaskDecoder): Predicts masks from the image embeddings and encoded prompts.
             pixel_mean (list[float]): Mean values for normalizing pixels in the input image.
             pixel_std (list[float]): Standard deviation values for normalizing pixels in the input image.
-
-        Examples:
-            >>> image_encoder = ImageEncoderViT(...)
-            >>> prompt_encoder = PromptEncoder(...)
-            >>> mask_decoder = MaskDecoder(...)
-            >>> sam_model = SAMModel(image_encoder, prompt_encoder, mask_decoder)
-            >>> # Further usage depends on SAMPredictor class
-
+        
         Notes:
             All forward() operations moved to SAMPredictor.
         """
@@ -206,7 +199,7 @@ class SAM2Model(torch.nn.Module):
         compile_image_encoder: bool = False,
     ):
         """Initialize the SAM2Model for video object segmentation with memory-based tracking.
-
+        
         Args:
             image_encoder (nn.Module): Visual encoder for extracting image features.
             memory_attention (nn.Module): Module for attending to memory features.
@@ -253,15 +246,6 @@ class SAM2Model(torch.nn.Module):
             no_obj_embed_spatial (bool): Whether add no obj embedding to spatial frames.
             sam_mask_decoder_extra_args (dict | None): Extra arguments for constructing the SAM mask decoder.
             compile_image_encoder (bool): Whether to compile the image encoder for faster inference.
-
-        Examples:
-            >>> image_encoder = ImageEncoderViT(...)
-            >>> memory_attention = SAM2TwoWayTransformer(...)
-            >>> memory_encoder = nn.Sequential(...)
-            >>> model = SAM2Model(image_encoder, memory_attention, memory_encoder)
-            >>> image_batch = torch.rand(1, 3, 512, 512)
-            >>> features = model.forward_image(image_batch)
-            >>> track_results = model.track_step(0, True, features, None, None, None, {})
         """
         super().__init__()
 

--- a/ultralytics/models/sam/modules/sam.py
+++ b/ultralytics/models/sam/modules/sam.py
@@ -61,14 +61,14 @@ class SAMModel(nn.Module):
         pixel_std: list[float] = (58.395, 57.12, 57.375),
     ) -> None:
         """Initialize the SAMModel class to predict object masks from an image and input prompts.
-        
+
         Args:
             image_encoder (ImageEncoderViT): The backbone used to encode the image into image embeddings.
             prompt_encoder (PromptEncoder): Encodes various types of input prompts.
             mask_decoder (MaskDecoder): Predicts masks from the image embeddings and encoded prompts.
             pixel_mean (list[float]): Mean values for normalizing pixels in the input image.
             pixel_std (list[float]): Standard deviation values for normalizing pixels in the input image.
-        
+
         Notes:
             All forward() operations moved to SAMPredictor.
         """
@@ -199,7 +199,7 @@ class SAM2Model(torch.nn.Module):
         compile_image_encoder: bool = False,
     ):
         """Initialize the SAM2Model for video object segmentation with memory-based tracking.
-        
+
         Args:
             image_encoder (nn.Module): Visual encoder for extracting image features.
             memory_attention (nn.Module): Module for attending to memory features.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -81,11 +81,11 @@ class Predictor(BasePredictor):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize the Predictor with configuration, overrides, and callbacks.
-        
+
         Sets up the Predictor object for SAM (Segment Anything Model) and applies any configuration overrides or
         callbacks provided. Initializes task-specific settings for SAM, such as retina_masks being set to True for
         optimal results.
-        
+
         Args:
             cfg (dict): Configuration dictionary containing default settings.
             overrides (dict | None): Dictionary of values to override default configuration.
@@ -905,10 +905,10 @@ class SAM2VideoPredictor(SAM2Predictor):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize the predictor with configuration and optional overrides.
-        
+
         This constructor initializes the SAM2VideoPredictor with a given configuration, applies any specified overrides,
         and sets up the inference state along with certain flags that control the behavior of the predictor.
-        
+
         Args:
             cfg (dict): Configuration dictionary containing default settings.
             overrides (dict | None): Dictionary of values to override default configuration.
@@ -1690,10 +1690,10 @@ class SAM2DynamicInteractivePredictor(SAM2Predictor):
         _callbacks: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the predictor with configuration and optional overrides.
-        
+
         This constructor initializes the SAM2DynamicInteractivePredictor with a given configuration, applies any
         specified overrides
-        
+
         Args:
             cfg (dict[str, Any]): Configuration dictionary containing default settings.
             overrides (dict[str, Any] | None): Dictionary of values to override default configuration.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -81,20 +81,15 @@ class Predictor(BasePredictor):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize the Predictor with configuration, overrides, and callbacks.
-
+        
         Sets up the Predictor object for SAM (Segment Anything Model) and applies any configuration overrides or
         callbacks provided. Initializes task-specific settings for SAM, such as retina_masks being set to True for
         optimal results.
-
+        
         Args:
             cfg (dict): Configuration dictionary containing default settings.
             overrides (dict | None): Dictionary of values to override default configuration.
             _callbacks (dict | None): Dictionary of callback functions to customize behavior.
-
-        Examples:
-            >>> predictor_example = Predictor(cfg=DEFAULT_CFG)
-            >>> predictor_example_with_imgsz = Predictor(overrides={"imgsz": 640})
-            >>> predictor_example_with_callback = Predictor(_callbacks={"on_predict_start": custom_callback})
         """
         if overrides is None:
             overrides = {}
@@ -910,19 +905,14 @@ class SAM2VideoPredictor(SAM2Predictor):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize the predictor with configuration and optional overrides.
-
+        
         This constructor initializes the SAM2VideoPredictor with a given configuration, applies any specified overrides,
         and sets up the inference state along with certain flags that control the behavior of the predictor.
-
+        
         Args:
             cfg (dict): Configuration dictionary containing default settings.
             overrides (dict | None): Dictionary of values to override default configuration.
             _callbacks (dict | None): Dictionary of callback functions to customize behavior.
-
-        Examples:
-            >>> predictor = SAM2VideoPredictor(cfg=DEFAULT_CFG)
-            >>> predictor_example_with_imgsz = SAM2VideoPredictor(overrides={"imgsz": 640})
-            >>> predictor_example_with_callback = SAM2VideoPredictor(_callbacks={"on_predict_start": custom_callback})
         """
         super().__init__(cfg, overrides, _callbacks)
         self.inference_state = {}
@@ -1700,23 +1690,16 @@ class SAM2DynamicInteractivePredictor(SAM2Predictor):
         _callbacks: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the predictor with configuration and optional overrides.
-
+        
         This constructor initializes the SAM2DynamicInteractivePredictor with a given configuration, applies any
         specified overrides
-
+        
         Args:
             cfg (dict[str, Any]): Configuration dictionary containing default settings.
             overrides (dict[str, Any] | None): Dictionary of values to override default configuration.
             max_obj_num (int): Maximum number of objects to track. Default is 3. this is set to keep fix feature size
                 for the model.
             _callbacks (dict[str, Any] | None): Dictionary of callback functions to customize behavior.
-
-        Examples:
-            >>> predictor = SAM2DynamicInteractivePredictor(cfg=DEFAULT_CFG)
-            >>> predictor_example_with_imgsz = SAM2DynamicInteractivePredictor(overrides={"imgsz": 640})
-            >>> predictor_example_with_callback = SAM2DynamicInteractivePredictor(
-            ...     _callbacks={"on_predict_start": custom_callback}
-            ... )
         """
         super().__init__(cfg, overrides, _callbacks)
         self.non_overlap_masks = True

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -55,18 +55,12 @@ class ClassificationValidator(BaseValidator):
 
     def __init__(self, dataloader=None, save_dir=None, args=None, _callbacks=None) -> None:
         """Initialize ClassificationValidator with dataloader, save directory, and other parameters.
-
+        
         Args:
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to use for validation.
             save_dir (str | Path, optional): Directory to save results.
             args (dict, optional): Arguments containing model and validation configuration.
             _callbacks (list, optional): List of callback functions to be called during validation.
-
-        Examples:
-            >>> from ultralytics.models.yolo.classify import ClassificationValidator
-            >>> args = dict(model="yolo11n-cls.pt", data="imagenet10")
-            >>> validator = ClassificationValidator(args=args)
-            >>> validator()
         """
         super().__init__(dataloader, save_dir, args, _callbacks)
         self.targets = None

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -55,7 +55,7 @@ class ClassificationValidator(BaseValidator):
 
     def __init__(self, dataloader=None, save_dir=None, args=None, _callbacks=None) -> None:
         """Initialize ClassificationValidator with dataloader, save directory, and other parameters.
-        
+
         Args:
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to use for validation.
             save_dir (str | Path, optional): Directory to save results.

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -52,20 +52,15 @@ class YOLO(Model):
 
     def __init__(self, model: str | Path = "yolo11n.pt", task: str | None = None, verbose: bool = False):
         """Initialize a YOLO model.
-
+        
         This constructor initializes a YOLO model, automatically switching to specialized model types (YOLOWorld or
         YOLOE) based on the model filename.
-
+        
         Args:
             model (str | Path): Model name or path to model file, i.e. 'yolo11n.pt', 'yolo11n.yaml'.
             task (str, optional): YOLO task specification, i.e. 'detect', 'segment', 'classify', 'pose', 'obb'. Defaults
                 to auto-detection based on model.
             verbose (bool): Display model info on load.
-
-        Examples:
-            >>> from ultralytics import YOLO
-            >>> model = YOLO("yolo11n.pt")  # load a pretrained YOLO11n detection model
-            >>> model = YOLO("yolo11n-seg.pt")  # load a pretrained YOLO11n segmentation model
         """
         path = Path(model if isinstance(model, (str, Path)) else "")
         if "-world" in path.stem and path.suffix in {".pt", ".yaml", ".yml"}:  # if YOLOWorld PyTorch model

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -52,10 +52,10 @@ class YOLO(Model):
 
     def __init__(self, model: str | Path = "yolo11n.pt", task: str | None = None, verbose: bool = False):
         """Initialize a YOLO model.
-        
+
         This constructor initializes a YOLO model, automatically switching to specialized model types (YOLOWorld or
         YOLOE) based on the model filename.
-        
+
         Args:
             model (str | Path): Model name or path to model file, i.e. 'yolo11n.pt', 'yolo11n.yaml'.
             task (str, optional): YOLO task specification, i.e. 'detect', 'segment', 'classify', 'pose', 'obb'. Defaults

--- a/ultralytics/models/yolo/obb/predict.py
+++ b/ultralytics/models/yolo/obb/predict.py
@@ -27,7 +27,7 @@ class OBBPredictor(DetectionPredictor):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize OBBPredictor with optional model and data configuration overrides.
-        
+
         Args:
             cfg (dict, optional): Default configuration for the predictor.
             overrides (dict, optional): Configuration overrides that take precedence over the default config.

--- a/ultralytics/models/yolo/obb/predict.py
+++ b/ultralytics/models/yolo/obb/predict.py
@@ -27,17 +27,11 @@ class OBBPredictor(DetectionPredictor):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize OBBPredictor with optional model and data configuration overrides.
-
+        
         Args:
             cfg (dict, optional): Default configuration for the predictor.
             overrides (dict, optional): Configuration overrides that take precedence over the default config.
             _callbacks (list, optional): List of callback functions to be invoked during prediction.
-
-        Examples:
-            >>> from ultralytics.utils import ASSETS
-            >>> from ultralytics.models.yolo.obb import OBBPredictor
-            >>> args = dict(model="yolo11n-obb.pt", source=ASSETS)
-            >>> predictor = OBBPredictor(overrides=args)
         """
         super().__init__(cfg, overrides, _callbacks)
         self.args.task = "obb"

--- a/ultralytics/models/yolo/pose/predict.py
+++ b/ultralytics/models/yolo/pose/predict.py
@@ -27,10 +27,10 @@ class PosePredictor(DetectionPredictor):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize PosePredictor for pose estimation tasks.
-        
+
         Sets up a PosePredictor instance, configuring it for pose detection tasks and handling device-specific warnings
         for Apple MPS.
-        
+
         Args:
             cfg (Any): Configuration for the predictor.
             overrides (dict, optional): Configuration overrides that take precedence over cfg.

--- a/ultralytics/models/yolo/pose/predict.py
+++ b/ultralytics/models/yolo/pose/predict.py
@@ -27,21 +27,14 @@ class PosePredictor(DetectionPredictor):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize PosePredictor for pose estimation tasks.
-
+        
         Sets up a PosePredictor instance, configuring it for pose detection tasks and handling device-specific warnings
         for Apple MPS.
-
+        
         Args:
             cfg (Any): Configuration for the predictor.
             overrides (dict, optional): Configuration overrides that take precedence over cfg.
             _callbacks (list, optional): List of callback functions to be invoked during prediction.
-
-        Examples:
-            >>> from ultralytics.utils import ASSETS
-            >>> from ultralytics.models.yolo.pose import PosePredictor
-            >>> args = dict(model="yolo11n-pose.pt", source=ASSETS)
-            >>> predictor = PosePredictor(overrides=args)
-            >>> predictor.predict_cli()
         """
         super().__init__(cfg, overrides, _callbacks)
         self.args.task = "pose"

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -39,7 +39,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides: dict[str, Any] | None = None, _callbacks=None):
         """Initialize a PoseTrainer object for training YOLO pose estimation models.
-        
+
         Args:
             cfg (dict, optional): Default configuration dictionary containing training parameters.
             overrides (dict, optional): Dictionary of parameter overrides for the default configuration.

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -39,7 +39,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides: dict[str, Any] | None = None, _callbacks=None):
         """Initialize a PoseTrainer object for training YOLO pose estimation models.
-
+        
         Args:
             cfg (dict, optional): Default configuration dictionary containing training parameters.
             overrides (dict, optional): Dictionary of parameter overrides for the default configuration.

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -49,16 +49,16 @@ class PoseValidator(DetectionValidator):
 
     def __init__(self, dataloader=None, save_dir=None, args=None, _callbacks=None) -> None:
         """Initialize a PoseValidator object for pose estimation validation.
-        
+
         This validator is specifically designed for pose estimation tasks, handling keypoints and implementing
         specialized metrics for pose evaluation.
-        
+
         Args:
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to be used for validation.
             save_dir (Path | str, optional): Directory to save results.
             args (dict, optional): Arguments for the validator including task set to "pose".
             _callbacks (list, optional): List of callback functions to be executed during validation.
-        
+
         Notes:
             This class extends DetectionValidator with pose-specific functionality. It initializes with sigma values
             for OKS calculation and sets up PoseMetrics for evaluation. A warning is displayed when using Apple MPS

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -45,24 +45,24 @@ class PoseValidator(DetectionValidator):
         >>> args = dict(model="yolo11n-pose.pt", data="coco8-pose.yaml")
         >>> validator = PoseValidator(args=args)
         >>> validator()
+
+    Notes:
+        This class extends DetectionValidator with pose-specific functionality. It initializes with sigma values
+        for OKS calculation and sets up PoseMetrics for evaluation. A warning is displayed when using Apple MPS
+        due to a known bug with pose models.
     """
 
     def __init__(self, dataloader=None, save_dir=None, args=None, _callbacks=None) -> None:
         """Initialize a PoseValidator object for pose estimation validation.
-
+        
         This validator is specifically designed for pose estimation tasks, handling keypoints and implementing
         specialized metrics for pose evaluation.
-
+        
         Args:
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to be used for validation.
             save_dir (Path | str, optional): Directory to save results.
             args (dict, optional): Arguments for the validator including task set to "pose".
             _callbacks (list, optional): List of callback functions to be executed during validation.
-
-        Notes:
-            This class extends DetectionValidator with pose-specific functionality. It initializes with sigma values
-            for OKS calculation and sets up PoseMetrics for evaluation. A warning is displayed when using Apple MPS
-            due to a known bug with pose models.
         """
         super().__init__(dataloader, save_dir, args, _callbacks)
         self.sigma = None

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -49,22 +49,16 @@ class PoseValidator(DetectionValidator):
 
     def __init__(self, dataloader=None, save_dir=None, args=None, _callbacks=None) -> None:
         """Initialize a PoseValidator object for pose estimation validation.
-
+        
         This validator is specifically designed for pose estimation tasks, handling keypoints and implementing
         specialized metrics for pose evaluation.
-
+        
         Args:
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to be used for validation.
             save_dir (Path | str, optional): Directory to save results.
             args (dict, optional): Arguments for the validator including task set to "pose".
             _callbacks (list, optional): List of callback functions to be executed during validation.
-
-        Examples:
-            >>> from ultralytics.models.yolo.pose import PoseValidator
-            >>> args = dict(model="yolo11n-pose.pt", data="coco8-pose.yaml")
-            >>> validator = PoseValidator(args=args)
-            >>> validator()
-
+        
         Notes:
             This class extends DetectionValidator with pose-specific functionality. It initializes with sigma values
             for OKS calculation and sets up PoseMetrics for evaluation. A warning is displayed when using Apple MPS

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -54,10 +54,10 @@ class PoseValidator(DetectionValidator):
 
     def __init__(self, dataloader=None, save_dir=None, args=None, _callbacks=None) -> None:
         """Initialize a PoseValidator object for pose estimation validation.
-        
+
         This validator is specifically designed for pose estimation tasks, handling keypoints and implementing
         specialized metrics for pose evaluation.
-        
+
         Args:
             dataloader (torch.utils.data.DataLoader, optional): Dataloader to be used for validation.
             save_dir (Path | str, optional): Directory to save results.

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -53,32 +53,14 @@ class WorldTrainerFromScratch(WorldTrainer):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize a WorldTrainerFromScratch object.
-
+        
         This initializes a trainer for YOLO-World models from scratch, supporting mixed datasets including both object
         detection and grounding datasets for vision-language capabilities.
-
+        
         Args:
             cfg (dict): Configuration dictionary with default parameters for model training.
             overrides (dict, optional): Dictionary of parameter overrides to customize the configuration.
             _callbacks (list, optional): List of callback functions to be executed during different stages of training.
-
-        Examples:
-            >>> from ultralytics.models.yolo.world.train_world import WorldTrainerFromScratch
-            >>> from ultralytics import YOLOWorld
-            >>> data = dict(
-            ...     train=dict(
-            ...         yolo_data=["Objects365.yaml"],
-            ...         grounding_data=[
-            ...             dict(
-            ...                 img_path="flickr30k/images",
-            ...                 json_file="flickr30k/final_flickr_separateGT_train.json",
-            ...             ),
-            ...         ],
-            ...     ),
-            ...     val=dict(yolo_data=["lvis.yaml"]),
-            ... )
-            >>> model = YOLOWorld("yolov8s-worldv2.yaml")
-            >>> model.train(data=data, trainer=WorldTrainerFromScratch)
         """
         if overrides is None:
             overrides = {}

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -53,10 +53,10 @@ class WorldTrainerFromScratch(WorldTrainer):
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
         """Initialize a WorldTrainerFromScratch object.
-        
+
         This initializes a trainer for YOLO-World models from scratch, supporting mixed datasets including both object
         detection and grounding datasets for vision-language capabilities.
-        
+
         Args:
             cfg (dict): Configuration dictionary with default parameters for model training.
             overrides (dict, optional): Dictionary of parameter overrides to customize the configuration.

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -70,10 +70,10 @@ class CLIP(TextModel):
 
     def __init__(self, size: str, device: torch.device) -> None:
         """Initialize the CLIP text encoder.
-        
+
         This class implements the TextModel interface using OpenAI's CLIP model for text encoding. It loads a
         pre-trained CLIP model of the specified size and prepares it for text encoding tasks.
-        
+
         Args:
             size (str): Model size identifier (e.g., 'ViT-B/32').
             device (torch.device): Device to load the model on.
@@ -188,9 +188,9 @@ class MobileCLIP(TextModel):
 
     def __init__(self, size: str, device: torch.device) -> None:
         """Initialize the MobileCLIP text encoder.
-        
+
         This class implements the TextModel interface using Apple's MobileCLIP model for efficient text encoding.
-        
+
         Args:
             size (str): Model size identifier (e.g., 's0', 's1', 's2', 'b', 'blt').
             device (torch.device): Device to load the model on.
@@ -282,10 +282,10 @@ class MobileCLIPTS(TextModel):
 
     def __init__(self, device: torch.device):
         """Initialize the MobileCLIP TorchScript text encoder.
-        
+
         This class implements the TextModel interface using Apple's MobileCLIP model in TorchScript format for efficient
         text encoding with optimized inference performance.
-        
+
         Args:
             device (torch.device): Device to load the model on.
         """

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -70,18 +70,13 @@ class CLIP(TextModel):
 
     def __init__(self, size: str, device: torch.device) -> None:
         """Initialize the CLIP text encoder.
-
+        
         This class implements the TextModel interface using OpenAI's CLIP model for text encoding. It loads a
         pre-trained CLIP model of the specified size and prepares it for text encoding tasks.
-
+        
         Args:
             size (str): Model size identifier (e.g., 'ViT-B/32').
             device (torch.device): Device to load the model on.
-
-        Examples:
-            >>> import torch
-            >>> clip_model = CLIP("ViT-B/32", device=torch.device("cuda:0"))
-            >>> text_features = clip_model.encode_text(["a photo of a cat", "a photo of a dog"])
         """
         super().__init__()
         self.model, self.image_preprocess = clip.load(size, device=device)
@@ -193,18 +188,12 @@ class MobileCLIP(TextModel):
 
     def __init__(self, size: str, device: torch.device) -> None:
         """Initialize the MobileCLIP text encoder.
-
+        
         This class implements the TextModel interface using Apple's MobileCLIP model for efficient text encoding.
-
+        
         Args:
             size (str): Model size identifier (e.g., 's0', 's1', 's2', 'b', 'blt').
             device (torch.device): Device to load the model on.
-
-        Examples:
-            >>> import torch
-            >>> model = MobileCLIP("s0", device=torch.device("cpu"))
-            >>> tokens = model.tokenize(["a photo of a cat", "a photo of a dog"])
-            >>> features = model.encode_text(tokens)
         """
         try:
             import warnings
@@ -293,17 +282,12 @@ class MobileCLIPTS(TextModel):
 
     def __init__(self, device: torch.device):
         """Initialize the MobileCLIP TorchScript text encoder.
-
+        
         This class implements the TextModel interface using Apple's MobileCLIP model in TorchScript format for efficient
         text encoding with optimized inference performance.
-
+        
         Args:
             device (torch.device): Device to load the model on.
-
-        Examples:
-            >>> model = MobileCLIPTS(device=torch.device("cpu"))
-            >>> tokens = model.tokenize(["a photo of a cat", "a photo of a dog"])
-            >>> features = model.encode_text(tokens)
         """
         super().__init__()
         from ultralytics.utils.downloads import attempt_download_asset

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -57,21 +57,13 @@ class BOTrack(STrack):
         self, xywh: np.ndarray, score: float, cls: int, feat: np.ndarray | None = None, feat_history: int = 50
     ):
         """Initialize a BOTrack object with temporal parameters, such as feature history, alpha, and current features.
-
+        
         Args:
             xywh (np.ndarray): Bounding box coordinates in xywh format (center x, center y, width, height).
             score (float): Confidence score of the detection.
             cls (int): Class ID of the detected object.
             feat (np.ndarray, optional): Feature vector associated with the detection.
             feat_history (int): Maximum length of the feature history deque.
-
-        Examples:
-            Initialize a BOTrack object with bounding box, score, class ID, and feature vector
-            >>> xywh = np.array([100, 150, 60, 50])
-            >>> score = 0.9
-            >>> cls = 1
-            >>> feat = np.random.rand(128)
-            >>> bo_track = BOTrack(xywh, score, cls, feat)
         """
         super().__init__(xywh, score, cls)
 
@@ -180,15 +172,10 @@ class BOTSORT(BYTETracker):
 
     def __init__(self, args: Any, frame_rate: int = 30):
         """Initialize BOTSORT object with ReID module and GMC algorithm.
-
+        
         Args:
             args (Any): Parsed command-line arguments containing tracking parameters.
             frame_rate (int): Frame rate of the video being processed.
-
-        Examples:
-            Initialize BOTSORT with command-line arguments and a specified frame rate:
-            >>> args = parse_args()
-            >>> bot_sort = BOTSORT(args, frame_rate=30)
         """
         super().__init__(args, frame_rate)
         self.gmc = GMC(method=args.gmc_method)

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -57,7 +57,7 @@ class BOTrack(STrack):
         self, xywh: np.ndarray, score: float, cls: int, feat: np.ndarray | None = None, feat_history: int = 50
     ):
         """Initialize a BOTrack object with temporal parameters, such as feature history, alpha, and current features.
-        
+
         Args:
             xywh (np.ndarray): Bounding box coordinates in xywh format (center x, center y, width, height).
             score (float): Confidence score of the detection.
@@ -172,7 +172,7 @@ class BOTSORT(BYTETracker):
 
     def __init__(self, args: Any, frame_rate: int = 30):
         """Initialize BOTSORT object with ReID module and GMC algorithm.
-        
+
         Args:
             args (Any): Parsed command-line arguments containing tracking parameters.
             frame_rate (int): Frame rate of the video being processed.

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -54,18 +54,12 @@ class STrack(BaseTrack):
 
     def __init__(self, xywh: list[float], score: float, cls: Any):
         """Initialize a new STrack instance.
-
+        
         Args:
             xywh (list[float]): Bounding box coordinates and dimensions in the format (x, y, w, h, [a], idx), where (x,
                 y) is the center, (w, h) are width and height, [a] is optional aspect ratio, and idx is the id.
             score (float): Confidence score of the detection.
             cls (Any): Class label for the detected object.
-
-        Examples:
-            >>> xywh = [100.0, 150.0, 50.0, 75.0, 1]
-            >>> score = 0.9
-            >>> cls = "person"
-            >>> track = STrack(xywh, score, cls)
         """
         super().__init__()
         # xywh+idx or xywha+idx
@@ -271,15 +265,10 @@ class BYTETracker:
 
     def __init__(self, args, frame_rate: int = 30):
         """Initialize a BYTETracker instance for object tracking.
-
+        
         Args:
             args (Namespace): Command-line arguments containing tracking parameters.
             frame_rate (int): Frame rate of the video sequence.
-
-        Examples:
-            Initialize BYTETracker with command-line arguments and a frame rate of 30
-            >>> args = Namespace(track_buffer=30)
-            >>> tracker = BYTETracker(args, frame_rate=30)
         """
         self.tracked_stracks = []  # type: list[STrack]
         self.lost_stracks = []  # type: list[STrack]

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -54,7 +54,7 @@ class STrack(BaseTrack):
 
     def __init__(self, xywh: list[float], score: float, cls: Any):
         """Initialize a new STrack instance.
-        
+
         Args:
             xywh (list[float]): Bounding box coordinates and dimensions in the format (x, y, w, h, [a], idx), where (x,
                 y) is the center, (w, h) are width and height, [a] is optional aspect ratio, and idx is the id.
@@ -265,7 +265,7 @@ class BYTETracker:
 
     def __init__(self, args, frame_rate: int = 30):
         """Initialize a BYTETracker instance for object tracking.
-        
+
         Args:
             args (Namespace): Command-line arguments containing tracking parameters.
             frame_rate (int): Frame rate of the video sequence.

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -43,14 +43,10 @@ class GMC:
 
     def __init__(self, method: str = "sparseOptFlow", downscale: int = 2) -> None:
         """Initialize a Generalized Motion Compensation (GMC) object with tracking method and downscale factor.
-
+        
         Args:
             method (str): The tracking method to use. Options include 'orb', 'sift', 'ecc', 'sparseOptFlow', 'none'.
             downscale (int): Downscale factor for processing frames.
-
-        Examples:
-            Initialize a GMC object with the 'sparseOptFlow' method and a downscale factor of 2
-            >>> gmc = GMC(method="sparseOptFlow", downscale=2)
         """
         super().__init__()
 

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -43,7 +43,7 @@ class GMC:
 
     def __init__(self, method: str = "sparseOptFlow", downscale: int = 2) -> None:
         """Initialize a Generalized Motion Compensation (GMC) object with tracking method and downscale factor.
-        
+
         Args:
             method (str): The tracking method to use. Options include 'orb', 'sift', 'ecc', 'sparseOptFlow', 'none'.
             downscale (int): Downscale factor for processing frames.

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -37,15 +37,11 @@ class KalmanFilterXYAH:
 
     def __init__(self):
         """Initialize Kalman filter model matrices with motion and observation uncertainty weights.
-
+        
         The Kalman filter is initialized with an 8-dimensional state space (x, y, a, h, vx, vy, va, vh), where (x, y)
         represents the bounding box center position, 'a' is the aspect ratio, 'h' is the height, and their respective
         velocities are (vx, vy, va, vh). The filter uses a constant velocity model for object motion and a linear
         observation model for bounding box location.
-
-        Examples:
-            Initialize a Kalman filter for tracking:
-            >>> kf = KalmanFilterXYAH()
         """
         ndim, dt = 4, 1.0
 

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -37,7 +37,7 @@ class KalmanFilterXYAH:
 
     def __init__(self):
         """Initialize Kalman filter model matrices with motion and observation uncertainty weights.
-        
+
         The Kalman filter is initialized with an 8-dimensional state space (x, y, a, h, vx, vy, va, vh), where (x, y)
         represents the bounding box center position, 'a' is the aspect ratio, 'h' is the height, and their respective
         velocities are (vx, vy, va, vh). The filter uses a constant velocity model for object motion and a linear

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -412,7 +412,7 @@ class ProfileModels:
         device: torch.device | str | None = None,
     ):
         """Initialize the ProfileModels class for profiling models.
-        
+
         Args:
             paths (list[str]): List of paths of the models to be profiled.
             num_timed_runs (int): Number of timed runs for the profiling.
@@ -422,7 +422,7 @@ class ProfileModels:
             half (bool): Flag to indicate whether to use FP16 half-precision for TensorRT profiling.
             trt (bool): Flag to indicate whether to profile using TensorRT.
             device (torch.device | str | None): Device used for profiling. If None, it is determined automatically.
-        
+
         Notes:
             FP16 'half' argument option removed for ONNX as slower on CPU than FP32.
         """

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -412,7 +412,7 @@ class ProfileModels:
         device: torch.device | str | None = None,
     ):
         """Initialize the ProfileModels class for profiling models.
-
+        
         Args:
             paths (list[str]): List of paths of the models to be profiled.
             num_timed_runs (int): Number of timed runs for the profiling.
@@ -422,13 +422,7 @@ class ProfileModels:
             half (bool): Flag to indicate whether to use FP16 half-precision for TensorRT profiling.
             trt (bool): Flag to indicate whether to profile using TensorRT.
             device (torch.device | str | None): Device used for profiling. If None, it is determined automatically.
-
-        Examples:
-            Initialize and profile models
-            >>> from ultralytics.utils.benchmarks import ProfileModels
-            >>> profiler = ProfileModels(["yolo11n.yaml", "yolov8s.yaml"], imgsz=640)
-            >>> profiler.run()
-
+        
         Notes:
             FP16 'half' argument option removed for ONNX as slower on CPU than FP32.
         """

--- a/ultralytics/utils/errors.py
+++ b/ultralytics/utils/errors.py
@@ -25,17 +25,11 @@ class HUBModelError(Exception):
 
     def __init__(self, message: str = "Model not found. Please check model URL and try again."):
         """Initialize a HUBModelError exception.
-
+        
         This exception is raised when a requested model is not found or cannot be retrieved from Ultralytics HUB. The
         message is processed to include emojis for better user experience.
-
+        
         Args:
             message (str, optional): The error message to display when the exception is raised.
-
-        Examples:
-            >>> try:
-            ...     raise HUBModelError("Custom model error message")
-            ... except HUBModelError as e:
-            ...     print(e)
         """
         super().__init__(emojis(message))

--- a/ultralytics/utils/errors.py
+++ b/ultralytics/utils/errors.py
@@ -25,10 +25,10 @@ class HUBModelError(Exception):
 
     def __init__(self, message: str = "Model not found. Please check model URL and try again."):
         """Initialize a HUBModelError exception.
-        
+
         This exception is raised when a requested model is not found or cannot be retrieved from Ultralytics HUB. The
         message is processed to include emojis for better user experience.
-        
+
         Args:
             message (str, optional): The error message to display when the exception is raised.
         """

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -94,7 +94,7 @@ class TQDM:
         **kwargs,
     ) -> None:
         """Initialize the TQDM progress bar with specified configuration options.
-
+        
         Args:
             iterable (object, optional): Iterable to wrap with progress bar.
             desc (str, optional): Prefix description for the progress bar.
@@ -109,11 +109,6 @@ class TQDM:
             bar_format (str, optional): Custom bar format string.
             initial (int, optional): Initial counter value.
             **kwargs (Any): Additional keyword arguments for compatibility (ignored).
-
-        Examples:
-            >>> pbar = TQDM(range(100), desc="Processing")
-            >>> with TQDM(total=1000, unit="B", unit_scale=True) as pbar:
-            ...     pbar.update(1024)  # Updates by 1KB
         """
         # Disable if not verbose
         if disable is None:

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -94,7 +94,7 @@ class TQDM:
         **kwargs,
     ) -> None:
         """Initialize the TQDM progress bar with specified configuration options.
-        
+
         Args:
             iterable (object, optional): Iterable to wrap with progress bar.
             desc (str, optional): Prefix description for the progress bar.

--- a/ultralytics/utils/triton.py
+++ b/ultralytics/utils/triton.py
@@ -39,10 +39,10 @@ class TritonRemoteModel:
 
     def __init__(self, url: str, endpoint: str = "", scheme: str = ""):
         """Initialize the TritonRemoteModel for interacting with a remote Triton Inference Server.
-        
+
         Arguments may be provided individually or parsed from a collective 'url' argument of the form
         <scheme>://<netloc>/<endpoint>/<task_name>
-        
+
         Args:
             url (str): The URL of the Triton server.
             endpoint (str, optional): The name of the model on the Triton server.

--- a/ultralytics/utils/triton.py
+++ b/ultralytics/utils/triton.py
@@ -39,18 +39,14 @@ class TritonRemoteModel:
 
     def __init__(self, url: str, endpoint: str = "", scheme: str = ""):
         """Initialize the TritonRemoteModel for interacting with a remote Triton Inference Server.
-
+        
         Arguments may be provided individually or parsed from a collective 'url' argument of the form
         <scheme>://<netloc>/<endpoint>/<task_name>
-
+        
         Args:
             url (str): The URL of the Triton server.
             endpoint (str, optional): The name of the model on the Triton server.
             scheme (str, optional): The communication scheme ('http' or 'grpc').
-
-        Examples:
-            >>> model = TritonRemoteModel(url="localhost:8000", endpoint="yolov8", scheme="http")
-            >>> model = TritonRemoteModel(url="http://localhost:8000/yolov8")
         """
         if not endpoint and not scheme:  # Parse all args from URL string
             splits = urlsplit(url)


### PR DESCRIPTION
Examples, Notes, Attributes etc. all belong in Class docstring, not `__init__` (these are mostly duplicates)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR cleans up and streamlines docstrings across the codebase by removing inlined example/attribute blocks and tightening notes, without changing any runtime behavior. ✨

---

### 📊 Key Changes
- 🧹 Removed `Examples:` sections from many class and method docstrings (augmentations, models, predictors, validators, trackers, utilities, etc.).
- 🧾 Removed verbose `Attributes:` descriptions from several docstrings to reduce redundancy.
- 🔁 Consolidated and updated `Notes:` in the `Albumentations` transform to highlight:
  - Minimum required version (≥ 1.0.3),
  - Special handling for spatial transforms and bounding boxes,
  - Very low default probabilities for some transforms.
- 🧩 Reorganized the `PoseValidator` docstring so its pose-specific behavior is now documented in the class-level `Notes:` instead of the `__init__` docstring.

---

### 🎯 Purpose & Impact
- 📚 **Lean, maintainable docs**: Reducing in-code examples and attribute blocks lowers maintenance overhead and avoids duplication with external documentation (e.g., README, website).
- 🧠 **Clearer core comments**: Docstrings now focus more on what arguments do and how classes behave, rather than including long usage snippets.
- 🛡️ **No API or behavior changes**: All public interfaces and logic remain the same—existing code, models, and workflows (YOLO11, SAM/SAM2, trackers, etc.) continue to work as before.
- 🚀 **Slightly lighter imports**: Less docstring content marginally reduces source size and can make introspection and some tooling a bit snappier, especially in constrained environments.