### PR TITLE
yolo_prediction_resolved

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -427,7 +427,6 @@ class BasePredictor:
 
         # FIX: generate collision-free txt path
         from pathlib import Path
-        import hashlib
 
         p = Path(p).resolve()
         is_image_mode = self.dataset.mode == "image"
@@ -440,7 +439,7 @@ class BasePredictor:
 
             # Build final txt filename
             txt_name = rel.stem + frame_suffix + ".txt"
-            self.txt_path = (self.save_dir / "labels" / rel.parent / txt_name)
+            self.txt_path = self.save_dir / "labels" / rel.parent / txt_name
 
         except Exception:
             # Hash fallback
@@ -449,7 +448,6 @@ class BasePredictor:
 
         # Ensure directory exists
         self.txt_path.parent.mkdir(parents=True, exist_ok=True)
-
 
         string += "{:g}x{:g} ".format(*im.shape[2:])
         result = self.results[i]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Collision-resistant label file path handling is added to the predictor to avoid overwriting results when saving YOLO predictions.

### 📊 Key Changes
- Introduced robust TXT label path generation in `Predictor.write_results`, using source-relative paths where possible.
- Added a SHA1-based fallback suffix for label filenames when relative paths cannot be resolved, preventing name collisions.
- Ensured parent label directories are created as needed and switched `save_txt` to use `Path.with_suffix(".txt")` for safer extension handling.

### 🎯 Purpose & Impact
- Prevents label files from being overwritten when multiple inputs share the same basename but come from different directories or frames.
- Produces a more organized `labels` directory structure that mirrors the input source hierarchy when available.
- Improves reliability of batch inference and downstream workflows that depend on stable, non-colliding label paths.