### PR TITLE
fix: 🐞 update Dockerfile to use Ubuntu 24.04 LTS and streamline package installation commands

### DIFF
--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -4,8 +4,9 @@
 # Image is aarch64-compatible for Apple M1, M2, M3, Raspberry Pi and other ARM architectures
 
 # Start FROM Ubuntu image https://hub.docker.com/_/ubuntu with "FROM arm64v8/ubuntu:22.04" (deprecated)
-# Start FROM Debian image for arm64v8 https://hub.docker.com/r/arm64v8/debian (new)
-FROM arm64v8/debian:bookworm-slim
+# Start FROM Debian image for arm64v8 https://hub.docker.com/r/arm64v8/debian (deprecated)
+# Start FROM official arm64v8 Ubuntu 24.04 image https://hub.docker.com/layers/arm64v8/ubuntu/24.04/
+FROM arm64v8/ubuntu:24.04
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
@@ -21,10 +22,11 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
 # Install linux packages
 # pkg-config and libhdf5-dev (not included) are needed to build 'h5py==3.11.0' aarch64 wheel required by 'tensorflow'
 # gnupg required for Edge TPU install
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y --no-install-recommends \
     python3-pip git zip unzip wget curl htop gcc libgl1 libglib2.0-0 gnupg && \
-    apt-get clean && \
+    apt clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Create working directory


### PR DESCRIPTION
This update switches debian bookworm to ubuntu 24.04 LTS docker image with lower initial image size and also fixing our JDK installation as well. I also include "apt upgrade" that make sure docker fully upgraded packages. 

Failing problem in our slow CI 

<img width="999" height="494" alt="image" src="https://github.com/user-attachments/assets/71a71f78-bc74-441f-9336-fb3100f9265c" />


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Switches the ARM64 Docker image from Debian to Ubuntu 24.04 and updates package installation for better compatibility, security, and consistency. 🚀

---

### 📊 Key Changes
- 🐧 **Base image updated**: Changes `FROM arm64v8/debian:bookworm-slim` to `FROM arm64v8/ubuntu:24.04`.
- 🔁 **Apt commands modernized**: Uses `apt` instead of `apt-get` for update, install, clean steps.
- 🔒 **System upgrade added**: Adds `apt upgrade -y` to pull in the latest security and system updates during build.
- 📦 **Package install step updated**: Keeps the same core tools (e.g., `python3-pip`, `git`, `wget`, `curl`, `gnupg`) while aligning with the new Ubuntu base.

---

### 🎯 Purpose & Impact
- ✅ **Better compatibility on ARM64**: Ubuntu 24.04 base improves alignment with many ARM64 environments (Apple Silicon, Raspberry Pi, etc.), reducing dependency issues.
- 🔐 **Improved security & stability**: Running `apt upgrade -y` ensures the image includes the latest patches at build time.
- 🔁 **Consistency with other images**: Moving back to an official Ubuntu base may align more closely with other Ultralytics images and common user setups.
- 🧰 **Smoother installs for ML tooling**: Updated base and packages help ensure smoother builds for dependencies like TensorFlow and other Python libraries on ARM64.