### PR TITLE
save problem solved

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -349,6 +349,7 @@ class LoadImagesAndVideos:
             vid_stride (int): Video frame-rate stride.
             channels (int): Number of image channels (1 for grayscale, 3 for RGB).
         """
+        self.root = Path(path).resolve()
         parent = None
         if isinstance(path, str) and Path(path).suffix in {".txt", ".csv"}:  # txt/csv file with source paths
             parent, content = Path(path).parent, Path(path).read_text()
@@ -515,6 +516,7 @@ class LoadPilAndNumpy:
             im0 (PIL.Image.Image | np.ndarray | list): Single image or list of images in PIL or numpy format.
             channels (int): Number of image channels (1 for grayscale, 3 for RGB).
         """
+        self.root = None
         if not isinstance(im0, list):
             im0 = [im0]
         # use `image{i}.jpg` when Image.filename returns an empty path.

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -424,7 +424,11 @@ class BasePredictor:
             match = re.search(r"frame (\d+)/", s[i])
             frame = int(match[1]) if match else None  # 0 if frame undetermined
 
-        rel = p.relative_to(self.dataset.root)
+        if getattr(self.dataset, "root", None):
+            rel = p.relative_to(self.dataset.root)
+        else:
+            rel = p.name  # or p, but p.name is better for non-filesystem inputs
+
         self.txt_path = (self.save_dir / "labels" / rel).with_suffix(
             ".txt" if self.dataset.mode == "image" else f"_{frame}.txt"
         )

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -43,7 +43,6 @@ from typing import Any
 
 import cv2
 import numpy as np
-from sympy import root
 import torch
 
 from ultralytics.cfg import get_cfg, get_save_dir
@@ -433,8 +432,8 @@ class BasePredictor:
             else:
                 rel = p.name
         except ValueError:
-            rel = p.name  
-              
+            rel = p.name
+
         rel = Path(rel)
 
         if frame is None:

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -425,7 +425,9 @@ class BasePredictor:
             frame = int(match[1]) if match else None  # 0 if frame undetermined
 
         rel = p.relative_to(self.dataset.root)
-        self.txt_path = (self.save_dir / "labels" / rel).with_suffix(".txt" if self.dataset.mode == "image" else f"_{frame}.txt")
+        self.txt_path = (self.save_dir / "labels" / rel).with_suffix(
+            ".txt" if self.dataset.mode == "image" else f"_{frame}.txt"
+        )
         string += "{:g}x{:g} ".format(*im.shape[2:])
         result = self.results[i]
         result.save_dir = self.save_dir.__str__()  # used in other locations

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -424,7 +424,8 @@ class BasePredictor:
             match = re.search(r"frame (\d+)/", s[i])
             frame = int(match[1]) if match else None  # 0 if frame undetermined
 
-        self.txt_path = self.save_dir / "labels" / (p.stem + ("" if self.dataset.mode == "image" else f"_{frame}"))
+        rel = p.relative_to(self.dataset.root)
+        self.txt_path = (self.save_dir / "labels" / rel).with_suffix(".txt" if self.dataset.mode == "image" else f"_{frame}.txt")
         string += "{:g}x{:g} ".format(*im.shape[2:])
         result = self.results[i]
         result.save_dir = self.save_dir.__str__()  # used in other locations
@@ -442,7 +443,7 @@ class BasePredictor:
 
         # Save results
         if self.args.save_txt:
-            result.save_txt(f"{self.txt_path}.txt", save_conf=self.args.save_conf)
+            result.save_txt(self.txt_path, save_conf=self.args.save_conf)
         if self.args.save_crop:
             result.save_crop(save_dir=self.save_dir / "crops", file_name=self.txt_path.stem)
         if self.args.show:


### PR DESCRIPTION
## Summary of changes
- Fixes save_txt collisions by preserving full relative image paths instead of using only p.stem.

- Ensures unique label files for images with identical filenames.

- Prevents merged/overwritten .txt outputs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes label saving paths in the predictor so `.txt` outputs mirror dataset-relative structure and avoid duplicate extensions.

### 📊 Key Changes
- Updates `write_results` to build `txt_path` using `p.relative_to(self.dataset.root)` so label files are stored in a directory structure matching the dataset layout.
- Uses `Path.with_suffix` to correctly assign `.txt` (or `_{frame}.txt` for non-image modes), preventing `.txt.txt` style issues.
- Passes the `Path` object directly to `result.save_txt`, aligning file naming between text saving and crops (`save_crop`).

### 🎯 Purpose & Impact
- Resolves incorrect or unexpected label file save paths when running predictions, especially for nested datasets.
- Prevents double file extensions and improves consistency of saved label and crop filenames.
- Makes it easier for users and downstream tools to locate and manage prediction label files based on the original dataset structure.