### PR TITLE
chore: 🧹 update .gitignore to include uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,12 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+uv.lock
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 


### PR DESCRIPTION
Currently we don't include uv.lock so let's ignore for safety. We can re-enable if needed to do it. I copied description from here (https://github.com/github/gitignore/blob/main/Python.gitignore#L97C1-L101C10) 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds `uv.lock` to `.gitignore` to prevent committing UV dependency lock files. 🧹

### 📊 Key Changes
- Updates `.gitignore` to ignore `uv.lock`, the lock file generated by the UV package/dependency manager.
- Includes comments explaining why `uv.lock` is typically ignored (especially for libraries).

### 🎯 Purpose & Impact
- 🧱 Keeps the repository clean by avoiding accidental commits of environment-specific lock files.
- 🔁 Reduces noise in PRs and diffs related to local dependency management.
- 📦 Aligns with common practice for libraries, where lock files are often managed per-project rather than in the shared repo.