### PR TITLE
`ultralytics 8.3.232` Fix OBB NMS export lower box count

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -55,6 +55,9 @@
 17316848+maianumerosky@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/17316848?v=4
   username: maianumerosky
+177153165+akdanz@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/177153165?v=4
+  username: akdanz
 25704330+JairajJangle@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/25704330?v=4
   username: JairajJangle

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.231"
+__version__ = "8.3.232"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1408,7 +1408,7 @@ class NMSModel(torch.nn.Module):
             box, score, cls, extra = box[mask], score[mask], cls[mask], extra[mask]
             nmsbox = box.clone()
             # `8` is the minimum value experimented to get correct NMS results for obb
-            multiplier = (8 if self.obb else 1) / max(len(self.model.names), 1)
+            multiplier = 8 if self.obb else 1 / max(len(self.model.names), 1)
             # Normalize boxes for NMS since large values for class offset causes issue with int8 quantization
             if self.args.format == "tflite":  # TFLite is already normalized
                 nmsbox *= multiplier


### PR DESCRIPTION
Closes #22781 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Small release bump that tweaks NMS box normalization logic for exported models and adds a new docs author entry. 🚀

---

### 📊 Key Changes
- 🔢 **Version bump**: Updated package version from `8.3.231` to `8.3.232`.
- 👤 **Docs authors update**: Added GitHub user `@akdanz` (avatar and username) to `mkdocs_github_authors.yaml` for documentation attribution.
- 📦 **Exporter NMS tweak**: Adjusted the `multiplier` used in the exporter’s NMS box normalization:
  - For OBB (`self.obb == True`): `multiplier` is now fixed at `8`.
  - For non-OBB (`self.obb == False`): `multiplier` is now `1 / max(len(self.model.names), 1)`.

---

### 🎯 Purpose & Impact
- 📐 **More controlled NMS behavior**:  
  - Keeps a strong offset (`8`) for oriented bounding boxes, which can help preserve correct NMS behavior in OBB scenarios.
  - Scales boxes more conservatively for non-OBB models by factoring in the number of classes.
- 🤖 **Better export robustness**:  
  - The normalization change is specifically relevant for formats like TFLite, where large class offsets and int8 quantization can cause issues. This tweak aims to improve stability and correctness of exported models.
- 🙌 **Improved contributor recognition**:  
  - Ensures `@akdanz` is properly credited in the docs, supporting clearer authorship and community contributions.