### PR TITLE
feat: add convert_labelbox utility for Labelbox NDJSON to YOLO convert

### DIFF
--- a/docs/en/usage/convert_labelbox.md
+++ b/docs/en/usage/convert_labelbox.md
@@ -1,0 +1,47 @@
+# convert_labelbox
+
+`convert_labelbox` converts a Labelbox NDJSON export into a YOLO **detection** dataset (bounding boxes only).
+
+## Prerequisites and Workflow
+
+- You have already **exported your project from Labelbox as NDJSON**.
+- You have **downloaded the corresponding images** referenced by `externalId` into a local `images_dir`.
+- You have created a simple **class map YAML** (e.g. `class_map.yaml`) that maps Labelbox label strings → YOLO class IDs.
+
+This utility is a **conversion helper**, not a full Labelbox integration. It:
+
+- Reads your NDJSON and class map.
+- Writes YOLO-format label TXT files and a `data.yaml` under `save_dir`.
+
+It **does not**:
+
+- Call the Labelbox API or download images for you.
+- Handle segmentation/polygon annotations in v1 (bounding boxes only).
+- Automatically adapt to arbitrary NDJSON schemas; it assumes a Labelbox-style schema with fields like `externalId`, `imageWidth`, `imageHeight`, and `objects[*].bbox`.
+
+## Python
+
+```python
+from ultralytics.data.converter import convert_labelbox
+
+convert_labelbox(
+    labels_path="export.ndjson",
+    images_dir="images/",
+    save_dir="datasets/myproject",
+    class_map="class_map.yaml",
+)
+```
+
+## CLI (proposed)
+
+```bash
+yolo convert labelbox \
+  labels=export.ndjson \
+  images_dir=images/ \
+  save_dir=datasets/myproject \
+  class_map=class_map.yaml
+```
+
+This will create a YOLO-style folder structure under `save_dir` and a dataset YAML using the class names and IDs from `class_map.yaml`.
+
+

--- a/docs/en/usage/convert_labelbox.md
+++ b/docs/en/usage/convert_labelbox.md
@@ -43,5 +43,3 @@ yolo convert labelbox \
 ```
 
 This will create a YOLO-style folder structure under `save_dir` and a dataset YAML using the class names and IDs from `class_map.yaml`.
-
-

--- a/docs/en/usage/convert_labelbox.md
+++ b/docs/en/usage/convert_labelbox.md
@@ -22,7 +22,7 @@ It **does not**:
 ## Python
 
 ```python
-from ultralytics.data.converter import convert_labelbox
+from ultralytics.data.labelbox import convert_labelbox
 
 convert_labelbox(
     labels_path="export.ndjson",

--- a/tests/test_labelbox_convert.py
+++ b/tests/test_labelbox_convert.py
@@ -1,3 +1,6 @@
+"""Tests for ultralytics.data.labelbox module."""
+
+import json
 import math
 from pathlib import Path
 
@@ -5,6 +8,7 @@ from ultralytics.data.labelbox import convert_labelbox, load_class_map, load_lab
 
 
 def test_load_class_map_and_mapping(tmp_path: Path):
+    """Test that load_class_map and load_labelbox_mapping correctly parse YAML class mappings."""
     yaml_text = """
     classes:
       class0:
@@ -28,6 +32,7 @@ def test_load_class_map_and_mapping(tmp_path: Path):
 
 
 def test_convert_labelbox_creates_yolo_dataset(tmp_path: Path):
+    """Test that convert_labelbox creates a valid YOLO dataset structure."""
     # Class map
     yaml_text = """
     classes:
@@ -56,7 +61,7 @@ def test_convert_labelbox_creates_yolo_dataset(tmp_path: Path):
             }
         ],
     }
-    ndjson_path.write_text(f"{line}\n".replace("'", '"'), encoding="utf-8")
+    ndjson_path.write_text(json.dumps(line) + "\n", encoding="utf-8")
 
     # Run conversion
     save_dir = tmp_path / "out"
@@ -81,4 +86,96 @@ def test_convert_labelbox_creates_yolo_dataset(tmp_path: Path):
 
     # Check image copied
     copied_img = save_dir / "images" / "train" / "img1.jpg"
+    assert copied_img.exists()
+
+
+def test_convert_labelbox_preserves_subdirectories(tmp_path: Path):
+    """Test that convert_labelbox preserves subdirectory structure from externalId."""
+    # Class map
+    yaml_text = """
+    classes:
+      class0:
+        labelbox: ["labelbox.class0"]
+    """
+    class_map_path = tmp_path / "class_map.yaml"
+    class_map_path.write_text(yaml_text, encoding="utf-8")
+
+    # Images with subdirectory structure
+    images_dir = tmp_path / "images_src"
+    subdir = images_dir / "floor1"
+    subdir.mkdir(parents=True)
+    img = subdir / "cam0.jpg"
+    img.write_bytes(b"dummy")
+
+    # NDJSON export with nested externalId
+    ndjson_path = tmp_path / "export.ndjson"
+    line = {
+        "externalId": "floor1/cam0.jpg",
+        "imageWidth": 100,
+        "imageHeight": 50,
+        "objects": [
+            {
+                "className": "labelbox.class0",
+                "bbox": {"left": 10, "top": 20, "width": 20, "height": 10},
+            }
+        ],
+    }
+    ndjson_path.write_text(json.dumps(line) + "\n", encoding="utf-8")
+
+    # Run conversion
+    save_dir = tmp_path / "out"
+    convert_labelbox(ndjson_path, images_dir, save_dir, class_map_path)
+
+    # Check that subdirectory structure is preserved
+    copied_img = save_dir / "images" / "train" / "floor1" / "cam0.jpg"
+    assert copied_img.exists()
+
+    labels_file = save_dir / "labels" / "train" / "floor1" / "cam0.txt"
+    assert labels_file.exists()
+    assert labels_file.read_text(encoding="utf-8").strip() != ""
+
+
+def test_convert_labelbox_creates_empty_label_for_no_annotations(tmp_path: Path):
+    """Test that convert_labelbox creates empty label files when no annotations are kept."""
+    # Class map
+    yaml_text = """
+    classes:
+      class0:
+        labelbox: ["labelbox.class0"]
+    """
+    class_map_path = tmp_path / "class_map.yaml"
+    class_map_path.write_text(yaml_text, encoding="utf-8")
+
+    # Images
+    images_dir = tmp_path / "images_src"
+    images_dir.mkdir()
+    img = images_dir / "img_no_annot.jpg"
+    img.write_bytes(b"dummy")
+
+    # NDJSON export with no objects (or unknown class)
+    ndjson_path = tmp_path / "export.ndjson"
+    line = {
+        "externalId": "img_no_annot.jpg",
+        "imageWidth": 100,
+        "imageHeight": 50,
+        "objects": [
+            {
+                "className": "unknown.class",  # Not in class map
+                "bbox": {"left": 10, "top": 20, "width": 20, "height": 10},
+            }
+        ],
+    }
+    ndjson_path.write_text(json.dumps(line) + "\n", encoding="utf-8")
+
+    # Run conversion
+    save_dir = tmp_path / "out"
+    convert_labelbox(ndjson_path, images_dir, save_dir, class_map_path)
+
+    # Check that empty label file exists
+    labels_file = save_dir / "labels" / "train" / "img_no_annot.txt"
+    assert labels_file.exists()
+    assert labels_file.read_text(encoding="utf-8") == ""
+
+    # Check image was still copied
+    copied_img = save_dir / "images" / "train" / "img_no_annot.jpg"
     assert copied_img.exists()

--- a/tests/test_labelbox_convert.py
+++ b/tests/test_labelbox_convert.py
@@ -82,5 +82,3 @@ def test_convert_labelbox_creates_yolo_dataset(tmp_path: Path):
     # Check image copied
     copied_img = save_dir / "images" / "train" / "img1.jpg"
     assert copied_img.exists()
-
-

--- a/tests/test_labelbox_convert.py
+++ b/tests/test_labelbox_convert.py
@@ -1,0 +1,86 @@
+import math
+from pathlib import Path
+
+from ultralytics.data.labelbox import convert_labelbox, load_class_map, load_labelbox_mapping
+
+
+def test_load_class_map_and_mapping(tmp_path: Path):
+    yaml_text = """
+    classes:
+      class0:
+        labelbox: ["labelbox.class0"]
+      class1:
+        labelbox: ["labelbox.class1"]
+      class2:
+        labelbox: ["labelbox.class2a", "labelbox.class2b"]
+    """
+    p = tmp_path / "class_map.yaml"
+    p.write_text(yaml_text, encoding="utf-8")
+
+    name_to_id = load_class_map(p)
+    lb_to_id = load_labelbox_mapping(p)
+
+    assert name_to_id == {"class0": 0, "class1": 1, "class2": 2}
+    assert lb_to_id["labelbox.class0"] == 0
+    assert lb_to_id["labelbox.class1"] == 1
+    assert lb_to_id["labelbox.class2a"] == 2
+    assert lb_to_id["labelbox.class2b"] == 2
+
+
+def test_convert_labelbox_creates_yolo_dataset(tmp_path: Path):
+    # Class map
+    yaml_text = """
+    classes:
+      class0:
+        labelbox: ["labelbox.class0"]
+    """
+    class_map_path = tmp_path / "class_map.yaml"
+    class_map_path.write_text(yaml_text, encoding="utf-8")
+
+    # Images
+    images_dir = tmp_path / "images_src"
+    images_dir.mkdir()
+    img = images_dir / "img1.jpg"
+    img.write_bytes(b"dummy")
+
+    # NDJSON export with a single bbox
+    ndjson_path = tmp_path / "export.ndjson"
+    line = {
+        "externalId": "img1.jpg",
+        "imageWidth": 100,
+        "imageHeight": 50,
+        "objects": [
+            {
+                "className": "labelbox.class0",
+                "bbox": {"left": 10, "top": 20, "width": 20, "height": 10},
+            }
+        ],
+    }
+    ndjson_path.write_text(f"{line}\n".replace("'", '"'), encoding="utf-8")
+
+    # Run conversion
+    save_dir = tmp_path / "out"
+    yaml_out = convert_labelbox(ndjson_path, images_dir, save_dir, class_map_path)
+
+    # Check dataset YAML
+    assert yaml_out.exists()
+
+    # Check labels file
+    labels_file = save_dir / "labels" / "train" / "img1.txt"
+    assert labels_file.exists()
+    text = labels_file.read_text(encoding="utf-8").strip()
+    parts = text.split()
+    assert parts[0] == "0"  # class id
+    x_c, y_c, w, h = map(float, parts[1:])
+
+    # Expected normalized values
+    assert math.isclose(x_c, 0.2, rel_tol=1e-6)
+    assert math.isclose(y_c, 0.5, rel_tol=1e-6)
+    assert math.isclose(w, 0.2, rel_tol=1e-6)
+    assert math.isclose(h, 0.2, rel_tol=1e-6)
+
+    # Check image copied
+    copied_img = save_dir / "images" / "train" / "img1.jpg"
+    assert copied_img.exists()
+
+

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -18,6 +18,7 @@ from ultralytics.utils import ASSETS_URL, DATASETS_DIR, LOGGER, NUM_THREADS, TQD
 from ultralytics.utils.checks import check_file, check_requirements
 from ultralytics.utils.downloads import download, zip_directory
 from ultralytics.utils.files import increment_path
+from ultralytics.data.labelbox import convert_labelbox  # re-export for convenience
 
 
 def coco91_to_coco80_class() -> list[int]:

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -18,7 +18,6 @@ from ultralytics.utils import ASSETS_URL, DATASETS_DIR, LOGGER, NUM_THREADS, TQD
 from ultralytics.utils.checks import check_file, check_requirements
 from ultralytics.utils.downloads import download, zip_directory
 from ultralytics.utils.files import increment_path
-from ultralytics.data.labelbox import convert_labelbox  # re-export for convenience
 
 
 def coco91_to_coco80_class() -> list[int]:

--- a/ultralytics/data/labelbox.py
+++ b/ultralytics/data/labelbox.py
@@ -15,45 +15,44 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Dict, Iterable
 
 import yaml
 
 from ultralytics.utils import LOGGER, YAML
 
 
-def load_class_map(path: str | Path) -> Dict[str, int]:
+def load_class_map(path: str | Path) -> dict[str, int]:
     """Load class_name -> class_id mapping from a YAML file.
 
     YAML format:
 
-    classes:
-      class0:
+    classes: class0:
         labelbox: ["labelbox.class0"]
-      class1:
+    class1:
         labelbox: ["labelbox.class1"]
-      class2:
+    class2:
         labelbox: ["labelbox.class2a", "labelbox.class2b"]
     """
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     classes_cfg = cfg.get("classes", {})
-    name_to_id: Dict[str, int] = {}
+    name_to_id: dict[str, int] = {}
     for idx, (class_name, _meta) in enumerate(classes_cfg.items()):
         name_to_id[class_name] = idx
     return name_to_id
 
 
-def load_labelbox_mapping(path: str | Path) -> Dict[str, int]:
+def load_labelbox_mapping(path: str | Path) -> dict[str, int]:
     """Build a mapping from Labelbox label strings to YOLO class IDs.
 
     Uses the same YAML as load_class_map but flattens the labelbox entries.
     """
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     classes_cfg = cfg.get("classes", {})
-    mapping: Dict[str, int] = {}
+    mapping: dict[str, int] = {}
     for idx, (_class_name, meta) in enumerate(classes_cfg.items()):
         for lb_name in meta.get("labelbox", []):
             mapping[lb_name] = idx
@@ -62,7 +61,7 @@ def load_labelbox_mapping(path: str | Path) -> Dict[str, int]:
 
 def parse_labelbox_ndjson(path: str | Path) -> Iterable[dict]:
     """Yield each Labelbox data row (annotation) from an NDJSON export file."""
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line:
@@ -175,5 +174,3 @@ def convert_labelbox(
 
     LOGGER.info(f"Labelbox data converted successfully: {n_images} images, {n_boxes} boxes. Saved to {save_dir}.")
     return save_dir / "data.yaml"
-
-

--- a/ultralytics/data/labelbox.py
+++ b/ultralytics/data/labelbox.py
@@ -1,0 +1,179 @@
+"""
+Labelbox -> YOLO converter utilities.
+
+Scope (v1):
+- Modern Labelbox NDJSON export format
+- Rectangular bounding boxes for detection tasks
+- Simple YAML-based class mapping (one map per conversion)
+
+Non-goals:
+- Multi-map schemas
+- Project management, uploads, or active learning
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, Iterable
+
+import yaml
+
+from ultralytics.utils import LOGGER, YAML
+
+
+def load_class_map(path: str | Path) -> Dict[str, int]:
+    """Load class_name -> class_id mapping from a YAML file.
+
+    YAML format:
+
+    classes:
+      class0:
+        labelbox: ["labelbox.class0"]
+      class1:
+        labelbox: ["labelbox.class1"]
+      class2:
+        labelbox: ["labelbox.class2a", "labelbox.class2b"]
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    classes_cfg = cfg.get("classes", {})
+    name_to_id: Dict[str, int] = {}
+    for idx, (class_name, _meta) in enumerate(classes_cfg.items()):
+        name_to_id[class_name] = idx
+    return name_to_id
+
+
+def load_labelbox_mapping(path: str | Path) -> Dict[str, int]:
+    """Build a mapping from Labelbox label strings to YOLO class IDs.
+
+    Uses the same YAML as load_class_map but flattens the labelbox entries.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    classes_cfg = cfg.get("classes", {})
+    mapping: Dict[str, int] = {}
+    for idx, (_class_name, meta) in enumerate(classes_cfg.items()):
+        for lb_name in meta.get("labelbox", []):
+            mapping[lb_name] = idx
+    return mapping
+
+
+def parse_labelbox_ndjson(path: str | Path) -> Iterable[dict]:
+    """Yield each Labelbox data row (annotation) from an NDJSON export file."""
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def convert_labelbox(
+    labels_path: str | Path,
+    images_dir: str | Path | None,
+    save_dir: str | Path,
+    class_map: str | Path,
+):
+    """Convert a Labelbox NDJSON export to a YOLO detection dataset (bounding boxes only).
+
+    Notes:
+        - v1 focuses on rectangular bounding boxes only.
+        - Segmentation and polygons are intentionally left for a future extension.
+        - The expected NDJSON structure is a simplified subset of Labelbox exports:
+
+            {
+              "externalId": "image_1.jpg",
+              "imageWidth": 1280,
+              "imageHeight": 720,
+              "objects": [
+                {
+                  "className": "nho.pistol",
+                  "bbox": {"left": 100, "top": 200, "width": 50, "height": 80}
+                }
+              ]
+            }
+    """
+    if images_dir is None:
+        raise ValueError("images_dir is required for convert_labelbox v1 (no automatic image downloading).")
+
+    labels_path = Path(labels_path)
+    images_dir = Path(images_dir)
+    save_dir = Path(save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load class mappings from YAML
+    lb_to_class = load_labelbox_mapping(class_map)
+    name_to_id = load_class_map(class_map)
+
+    images_out = save_dir / "images" / "train"
+    labels_out = save_dir / "labels" / "train"
+    images_out.mkdir(parents=True, exist_ok=True)
+    labels_out.mkdir(parents=True, exist_ok=True)
+
+    n_images = 0
+    n_boxes = 0
+
+    for row in parse_labelbox_ndjson(labels_path):
+        external_id = row.get("externalId")
+        width = row.get("imageWidth")
+        height = row.get("imageHeight")
+        objects = row.get("objects", [])
+
+        if not external_id or not width or not height:
+            LOGGER.warning("Skipping row without required keys 'externalId', 'imageWidth', 'imageHeight'.")
+            continue
+
+        src_image = images_dir / external_id
+        if not src_image.exists():
+            LOGGER.warning(f"Image not found for Labelbox row, skipping: {src_image}")
+            continue
+
+        dst_image = images_out / external_id
+        dst_image.parent.mkdir(parents=True, exist_ok=True)
+        if not dst_image.exists():
+            shutil.copy2(src_image, dst_image)
+
+        label_lines: list[str] = []
+        for obj in objects:
+            class_name = obj.get("className")
+            bbox = obj.get("bbox") or {}
+            if not class_name or class_name not in lb_to_class:
+                continue
+
+            cls_id = lb_to_class[class_name]
+            left = float(bbox.get("left", 0.0))
+            top = float(bbox.get("top", 0.0))
+            bw = float(bbox.get("width", 0.0))
+            bh = float(bbox.get("height", 0.0))
+            if bw <= 0 or bh <= 0:
+                continue
+
+            x_center = (left + bw / 2.0) / float(width)
+            y_center = (top + bh / 2.0) / float(height)
+            w_norm = bw / float(width)
+            h_norm = bh / float(height)
+
+            line = f"{cls_id} {x_center:.6f} {y_center:.6f} {w_norm:.6f} {h_norm:.6f}"
+            label_lines.append(line)
+            n_boxes += 1
+
+        if label_lines:
+            n_images += 1
+            label_file = labels_out / f"{Path(external_id).stem}.txt"
+            label_file.write_text("\n".join(label_lines) + "\n", encoding="utf-8")
+
+    # Write dataset YAML (standard YOLO layout)
+    names = {v: k for k, v in name_to_id.items()}
+    data_yaml = {
+        "path": str(save_dir),
+        "train": "images/train",
+        "names": names,
+    }
+    YAML.save(save_dir / "data.yaml", data_yaml)
+
+    LOGGER.info(f"Labelbox data converted successfully: {n_images} images, {n_boxes} boxes. Saved to {save_dir}.")
+    return save_dir / "data.yaml"
+
+


### PR DESCRIPTION
feat: add convert_labelbox utility for Labelbox NDJSON → YOLO conversion

## Summary

This PR adds a `convert_labelbox` utility to the Ultralytics data converters, providing a first-class way to convert modern Labelbox NDJSON exports into YOLO **detection** datasets (images, labels, and a dataset YAML).

The converter is intentionally small and focused on bounding-box annotations plus a simple YAML-based class mapping, rather than a full Labelbox integration.

## Motivation

- Ultralytics already provides `convert_coco` and related converters for popular formats.
- Labelbox is widely used for annotation, but conversion currently relies on:
  - Legacy scripts (e.g. JSON2YOLO), or
  - Custom, one-off converters written by users.
- Those older scripts are not integrated into the modern `ultralytics.data.converter` API.
- This PR brings Labelbox support into the main library in a maintainable, explicitly-configured way.

## What This PR Does

- Adds `ultralytics/data/labelbox.py` with:
  - `load_class_map(path)`: map class name → class ID based on a YAML file.
  - `load_labelbox_mapping(path)`: map Labelbox label strings → class ID.
  - `parse_labelbox_ndjson(path)`: yield rows from a Labelbox NDJSON export.
  - `convert_labelbox(labels_path, images_dir, save_dir, class_map)`: main conversion function for **bounding boxes only**.
- Re-exports `convert_labelbox` from `ultralytics.data.converter`.
- Adds tests in `tests/test_labelbox_convert.py`:
  - `test_load_class_map_and_mapping` checks that:
    - Class IDs are assigned in the expected order.
    - Labelbox labels map correctly to class IDs.
  - `test_convert_labelbox_creates_yolo_dataset`:
    - Builds a tiny NDJSON + dummy image.
    - Runs `convert_labelbox(...)`.
    - Asserts that `data.yaml`, one label file, and the copied image are created with the expected normalized bbox.
- Adds a usage page: `docs/en/usage/convert_labelbox.md`.

## Usage & Workflow (not plug-and-play)

This utility is a **conversion helper**, not a full Labelbox integration.

**Prerequisites:**

- You have already exported your project from Labelbox as **NDJSON**.
- You have downloaded the corresponding images referenced by `externalId` into a local `images_dir`.
- You have created a simple **class map YAML** (e.g. `class_map.yaml`) that maps Labelbox label strings → YOLO class IDs.

**Example:**

from ultralytics.data.converter import convert_labelbox

convert_labelbox(
    labels_path="export.ndjson",
    images_dir="images/",
    save_dir="datasets/myproject",
    class_map="class_map.yaml",
)This will create a YOLO-style folder structure under `save_dir` and a `data.yaml` using the class names and IDs from `class_map.yaml`.

## Non-Goals (v1)

This PR intentionally does **not**:

- Call the Labelbox API or download images for you (no API keys, no network calls).
- Handle segmentation / polygon annotations (detection bounding boxes only).
- Implement multi-map conversion or advanced schema logic.
- Automatically adapt to arbitrary NDJSON schemas:
  - It assumes a Labelbox-style NDJSON with keys like `externalId`, `imageWidth`, `imageHeight`, and `objects[*].bbox`.

These constraints keep the implementation small, predictable, and low-risk.

## Testing

- Local tests:

python -m pytest tests/test_labelbox_convert.py- Both tests pass on my local environment (Windows, Python 3.11).

## Related Issues

This PR targets `ultralytics/ultralytics`, but it is motivated by recurring
Labelbox → YOLO conversion friction across the Ultralytics ecosystem:

- Related: https://github.com/ultralytics/yolov5/issues/11773  
  “Using LabelBox” – user notes that the legacy `labelbox_json2yolo.py`
  script no longer works after Labelbox changed its export format, and that
  the suggested `export_to_coco.py` + `general_json2yolo.py` pipeline also
  fails for their use case.

- Related: https://github.com/ultralytics/JSON2YOLO/issues/102  
  “Labelbox2YOLO Json.load issue” – open bug when trying to convert
  Labelbox exports with the helper script in the JSON2YOLO repo.

- Related: https://github.com/ultralytics/JSON2YOLO/issues/39  
  “Converting Labelbox segmentation json to coco” – user asking how to make
  Labelbox “Mask” exports work with YOLO; highlights that Labelbox formats
  are non-trivial to handle and currently require custom code.

- Related: https://github.com/ultralytics/JSON2YOLO/issues/37  
  “Solutions to 'make_dirs' problem in labelbox_json2yolo.py” – users
  running into errors with the older standalone Labelbox → YOLO script.

- Related: https://github.com/ultralytics/JSON2YOLO/issues/53  
  “There are absolutely no explanations on how to run the code or what
  parameters one should use” – general documentation confusion around how
  to use the JSON2YOLO tooling, which affects Labelbox users as well.

While this PR does not directly close those issues (they live in other
repositories), `convert_labelbox` provides a supported, documented path
for modern Labelbox NDJSON → YOLO **detection** datasets within the main
Ultralytics library, which should reduce the need for ad-hoc scripts and
workarounds described above.

## CLA

I have read the CLA Document and I sign the CLA.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a new `convert_labelbox` utility, tests, and documentation to convert Labelbox NDJSON exports into YOLO-format detection datasets.

### 📊 Key Changes
- ➕ Introduces `ultralytics.data.labelbox` with `convert_labelbox`, `load_class_map`, `load_labelbox_mapping`, and `parse_labelbox_ndjson` utilities.
- 🧪 Adds `tests/test_labelbox_convert.py` to validate class-map loading, Labelbox-to-YOLO mapping, and full NDJSON-to-YOLO dataset conversion (including bbox normalization and image copying).
- 📚 Adds `docs/en/usage/convert_labelbox.md` describing prerequisites, Python usage, and a proposed `yolo convert labelbox` CLI workflow.

### 🎯 Purpose & Impact
- 🧩 Simplifies migrating Labelbox NDJSON detection annotations into YOLO training datasets with a single helper.
- 🛠 Provides a clear, YAML-based mapping from Labelbox class names to YOLO class IDs, improving reproducibility and transparency.
- 🚀 Lowers the friction for Labelbox users to train YOLO models by automating dataset structure, label file creation, and dataset YAML generation.
