### PR TITLE
Feat/batch eval

### DIFF
--- a/design/batcheval_canvas.md
+++ b/design/batcheval_canvas.md
@@ -322,7 +322,6 @@ def run_cli(args: dict):
 ## tests/test_batcheval.py (skeleton)
 
 ```python
-
 from ultralytics.analytics.batcheval import ModelSpec, resolve_models
 
 

--- a/design/batcheval_canvas.md
+++ b/design/batcheval_canvas.md
@@ -22,7 +22,7 @@ You can split these into separate files later if you want, but this single canva
 
 ---
 
-## DESIGN\_BATCHEVAL
+## DESIGN_BATCHEVAL
 
 ### Goal
 
@@ -107,10 +107,11 @@ We normalize into:
 from dataclasses import dataclass
 from pathlib import Path
 
+
 @dataclass
 class ModelSpec:
-    name: str          # for reporting
-    weights_path: Path # full path to .pt
+    name: str  # for reporting
+    weights_path: Path  # full path to .pt
 ```
 
 #### Evaluation Strategy
@@ -134,7 +135,6 @@ If `sweep_conf=True`, we have two options:
 
 2. **Smarter (if supported)**\
    If Ultralytics exposes a way to get raw predictions and recompute metrics offline, we can:
-
    - Cache predictions for one run.
    - Sweep thresholds offline using a helper similar to LB2YOLO.
 
@@ -188,10 +188,10 @@ Scope:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Sequence, Optional
 
 from ultralytics import YOLO
 
@@ -208,14 +208,14 @@ class BatchEvalResult:
     metrics: dict  # TODO: align with Ultralytics metrics type if needed
 
 
-def resolve_models(models: Sequence[str]) -> List[ModelSpec]:
+def resolve_models(models: Sequence[str]) -> list[ModelSpec]:
     """Resolve user-provided model identifiers into concrete weight paths.
 
     Accepts:
         - Run directories (e.g. runs/detect/train38) -> uses weights/best.pt
         - Direct .pt files (e.g. path/to/model.pt)
     """
-    resolved: List[ModelSpec] = []
+    resolved: list[ModelSpec] = []
     for item in models:
         p = Path(item)
         if p.is_dir():
@@ -260,13 +260,12 @@ def batcheval(
     conf_min: float = 0.05,
     conf_max: float = 0.95,
     conf_step: float = 0.05,
-    save_dir: Optional[str | Path] = None,
+    save_dir: str | Path | None = None,
     **val_kwargs,
-) -> List[BatchEvalResult]:
+) -> list[BatchEvalResult]:
     """Evaluate multiple models on the same dataset split and write a unified report.
 
-    Returns a list of BatchEvalResult objects; also writes summary.csv
-    (and optional sweep.csv) to save_dir.
+    Returns a list of BatchEvalResult objects; also writes summary.csv (and optional sweep.csv) to save_dir.
     """
     if save_dir is None:
         save_root = _default_save_dir()
@@ -275,7 +274,7 @@ def batcheval(
     save_root.mkdir(parents=True, exist_ok=True)
 
     specs = resolve_models(models)
-    results: List[BatchEvalResult] = []
+    results: list[BatchEvalResult] = []
 
     for spec in specs:
         results.append(evaluate_model(spec, data=data, split=split, **val_kwargs))
@@ -320,12 +319,11 @@ def run_cli(args: dict):
 
 ---
 
-## tests/test\_batcheval.py (skeleton)
+## tests/test_batcheval.py (skeleton)
 
 ```python
-from pathlib import Path
 
-from ultralytics.analytics.batcheval import resolve_models, ModelSpec
+from ultralytics.analytics.batcheval import ModelSpec, resolve_models
 
 
 def test_resolve_models_with_pt(tmp_path):
@@ -379,6 +377,7 @@ yolo batcheval \
   conf_min=0.05 \
   conf_max=0.95 \
   conf_step=0.05
+```
 ````
 
 Outputs are written to `runs/batcheval/<timestamp>/`:
@@ -395,7 +394,7 @@ Outputs are written to `runs/batcheval/<timestamp>/`:
 ```md
 # Draft PR: yolo batcheval
 
-**Title:**  
+**Title:**
 feat: add `yolo batcheval` command for multi-model evaluation
 
 ---
@@ -468,4 +467,3 @@ external experiment tracking tools.
   - Add richer per-class metrics to `summary.csv`.
   - Integrate with any existing or future `dashboard` functionality that can consume these CSVs.
 ````
-

--- a/design/batcheval_canvas.md
+++ b/design/batcheval_canvas.md
@@ -1,0 +1,471 @@
+# Ultralytics — `yolo batcheval` Starter Pack
+
+A focused, drop-in starter you can paste into the Ultralytics repo (or a fork). Includes design notes, skeleton code, tests, docs snippet, and a draft PR description.
+
+Target: **single PR** that adds a `yolo batcheval` command and supporting Python API.
+
+---
+
+## 📁 Scope
+
+This canvas is intended to live as a single file (e.g., `batcheval_canvas.md`) in a `design/` or `notes/` directory in your fork of Ultralytics.
+
+It contains:
+
+- Design doc (`DESIGN_BATCHEVAL`)
+- Implementation sketch (`ultralytics/analytics/batcheval.py` skeleton)
+- Tests sketch (`tests/test_batcheval.py` skeleton)
+- Docs snippet (`docs/batcheval.md` sketch)
+- Draft PR description (`PR_DRAFT_BATCHEVAL`)
+
+You can split these into separate files later if you want, but this single canvas is enough to seed Cursor context.
+
+---
+
+## DESIGN\_BATCHEVAL
+
+### Goal
+
+Add a **built-in batch evaluation command** to Ultralytics that:
+
+- Evaluates **multiple YOLO models** on the **same dataset/split** in one go.
+- Produces a **unified metrics summary** (CSV) and optionally a **confidence-threshold sweep** table.
+- Stays **small and generic** – no DB logging, no dashboards, no Syght/mmWave-specific logic.
+
+This is a “lite”, upstream-friendly version of the LB2YOLO batch test pipeline.
+
+---
+
+### User Story
+
+> As a practitioner training several YOLO models (e.g., different sizes or hyperparams), I want a single command to evaluate all of them on the same dataset split so that I can quickly pick the best model without wiring up external tools or writing my own comparison scripts.
+
+---
+
+### Public API (Proposed)
+
+#### Python
+
+```python
+from ultralytics.analytics import batcheval
+
+results = batcheval(
+    models=["runs/detect/train38", "runs/detect/train42/weights/best.pt"],
+    data="data.yaml",
+    split="val",
+    sweep_conf=False,
+)
+```
+
+Parameters:
+
+- `models`: list of run directories and/or `.pt` files.
+- `data`: dataset YAML (same as `yolo val`).
+- `split`: `"val"` (default), `"test"`, etc.
+- `sweep_conf`: whether to run confidence threshold sweeps.
+- `conf_min`, `conf_max`, `conf_step`: sweep settings (if enabled).
+- `save_dir`: optional; default `runs/batcheval/<timestamp>/`.
+
+Return:
+
+- `List[BatchEvalResult]` (small dataclass with `model_name` and `metrics` dict).
+
+#### CLI
+
+```bash
+# Basic: evaluate multiple models on the same dataset split
+yolo batcheval models="runs/detect/train38,models/exp2.pt" data=data.yaml split=val
+
+# Using a glob for runs
+yolo batcheval models="runs/detect/train*" data=data.yaml split=test
+
+# With optional confidence sweep
+yolo batcheval \
+  models="runs/detect/train38,models/exp2.pt" \
+  data=data.yaml \
+  split=test \
+  sweep_conf=True \
+  conf_min=0.05 \
+  conf_max=0.95 \
+  conf_step=0.05
+```
+
+---
+
+### Design Notes
+
+#### Model Resolution
+
+We accept:
+
+- Run directories (e.g., `runs/detect/train38`) → use `weights/best.pt`.
+- Direct `.pt` files (e.g., `models/exp2.pt`).
+
+We normalize into:
+
+```python
+from dataclasses import dataclass
+from pathlib import Path
+
+@dataclass
+class ModelSpec:
+    name: str          # for reporting
+    weights_path: Path # full path to .pt
+```
+
+#### Evaluation Strategy
+
+For v1 we keep it simple:
+
+- For each `ModelSpec`:
+  - `model = YOLO(weights_path)`
+  - `metrics = model.val(data=data, split=split, **val_kwargs)`
+- We then normalize `metrics` into a plain dict with keys like:
+  - `metrics/mAP50(B)`, `metrics/mAP50-95(B)`, `metrics/precision(B)`, `metrics/recall(B)`, etc.
+- We extract a subset for the summary table:
+  - `mAP50`, `mAP50_95`, `precision`, `recall`, maybe `f1` if available.
+
+#### Confidence Sweeps (Optional)
+
+If `sweep_conf=True`, we have two options:
+
+1. **Simple but slower**\
+   Re-run validation with different confidence thresholds by passing `conf` or equivalent arg to `model.val()`. This is easiest and keeps code minimal but runs N× slower.
+
+2. **Smarter (if supported)**\
+   If Ultralytics exposes a way to get raw predictions and recompute metrics offline, we can:
+
+   - Cache predictions for one run.
+   - Sweep thresholds offline using a helper similar to LB2YOLO.
+
+For MVP, (1) is acceptable; we can start with a coarse grid and document the tradeoff.
+
+We write a `sweep.csv` with columns:
+
+- `model_name, class_id, conf, precision, recall, f1`
+
+#### Output Layout
+
+Default root:
+
+```text
+runs/batcheval/<timestamp>/
+  summary.csv
+  sweep.csv      # only if sweep_conf=True
+```
+
+`summary.csv` has one row per model:
+
+```text
+model_name,mAP50,mAP50_95,precision,recall,f1,...
+```
+
+---
+
+### Non-Goals
+
+- No DB logging.
+- No external dashboards.
+- No RTSP / streaming integration.
+- No refactors of core training or validation code.
+
+This should be a **thin wrapper** around public APIs (`YOLO().val(...)`) and simple CSV exports.
+
+````
+
+---
+
+## `ultralytics/analytics/batcheval.py` (skeleton)
+
+```python
+"""
+Batch evaluation utilities for comparing multiple YOLO models on a single dataset.
+
+Scope:
+- N models in -> summary (and optional confidence sweep) out.
+- Built on top of existing YOLO().val(...) API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Sequence, Optional
+
+from ultralytics import YOLO
+
+
+@dataclass
+class ModelSpec:
+    name: str
+    weights_path: Path
+
+
+@dataclass
+class BatchEvalResult:
+    model_name: str
+    metrics: dict  # TODO: align with Ultralytics metrics type if needed
+
+
+def resolve_models(models: Sequence[str]) -> List[ModelSpec]:
+    """Resolve user-provided model identifiers into concrete weight paths.
+
+    Accepts:
+        - Run directories (e.g. runs/detect/train38) -> uses weights/best.pt
+        - Direct .pt files (e.g. path/to/model.pt)
+    """
+    resolved: List[ModelSpec] = []
+    for item in models:
+        p = Path(item)
+        if p.is_dir():
+            best = p / "weights" / "best.pt"
+            if not best.exists():
+                raise FileNotFoundError(f"No best.pt found under run dir: {p}")
+            resolved.append(ModelSpec(name=p.name, weights_path=best))
+        else:
+            if not p.exists():
+                raise FileNotFoundError(f"Model weights not found: {p}")
+            resolved.append(ModelSpec(name=p.stem, weights_path=p))
+    return resolved
+
+
+def evaluate_model(
+    spec: ModelSpec,
+    data: str,
+    split: str = "val",
+    **val_kwargs,
+) -> BatchEvalResult:
+    """Run Ultralytics val for a single model and extract key metrics.
+
+    This is a thin wrapper around YOLO(weights).val(...).
+    """
+    model = YOLO(str(spec.weights_path))
+    metrics = model.val(data=data, split=split, **val_kwargs)
+    # TODO: inspect metrics object and convert to a stable dict
+    metrics_dict = dict(metrics)
+    return BatchEvalResult(model_name=spec.name, metrics=metrics_dict)
+
+
+def _default_save_dir() -> Path:
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return Path("runs") / "batcheval" / ts
+
+
+def batcheval(
+    models: Sequence[str],
+    data: str,
+    split: str = "val",
+    sweep_conf: bool = False,
+    conf_min: float = 0.05,
+    conf_max: float = 0.95,
+    conf_step: float = 0.05,
+    save_dir: Optional[str | Path] = None,
+    **val_kwargs,
+) -> List[BatchEvalResult]:
+    """Evaluate multiple models on the same dataset split and write a unified report.
+
+    Returns a list of BatchEvalResult objects; also writes summary.csv
+    (and optional sweep.csv) to save_dir.
+    """
+    if save_dir is None:
+        save_root = _default_save_dir()
+    else:
+        save_root = Path(save_dir)
+    save_root.mkdir(parents=True, exist_ok=True)
+
+    specs = resolve_models(models)
+    results: List[BatchEvalResult] = []
+
+    for spec in specs:
+        results.append(evaluate_model(spec, data=data, split=split, **val_kwargs))
+
+    # TODO: normalize metrics across models and write summary.csv to save_root
+    # TODO: if sweep_conf=True, run confidence sweeps and write sweep.csv
+
+    return results
+
+
+def run_cli(args: dict):
+    """CLI entrypoint wrapper.
+
+    Expected args keys:
+        models (str): comma-separated list
+        data (str)
+        split (str)
+        sweep_conf (bool)
+        conf_min, conf_max, conf_step (floats)
+        save_dir (str, optional)
+    """
+    models = [m.strip() for m in args["models"].split(",")]
+    data = args["data"]
+    split = args.get("split", "val")
+    sweep_conf = bool(args.get("sweep_conf", False))
+    conf_min = float(args.get("conf_min", 0.05))
+    conf_max = float(args.get("conf_max", 0.95))
+    conf_step = float(args.get("conf_step", 0.05))
+    save_dir = args.get("save_dir")
+
+    batcheval(
+        models=models,
+        data=data,
+        split=split,
+        sweep_conf=sweep_conf,
+        conf_min=conf_min,
+        conf_max=conf_max,
+        conf_step=conf_step,
+        save_dir=save_dir,
+    )
+````
+
+---
+
+## tests/test\_batcheval.py (skeleton)
+
+```python
+from pathlib import Path
+
+from ultralytics.analytics.batcheval import resolve_models, ModelSpec
+
+
+def test_resolve_models_with_pt(tmp_path):
+    m = tmp_path / "m.pt"
+    m.write_bytes(b"dummy")  # fake weights
+    specs = resolve_models([str(m)])
+    assert len(specs) == 1
+    assert isinstance(specs[0], ModelSpec)
+    assert specs[0].weights_path == m
+    assert specs[0].name == "m"
+
+
+def test_resolve_models_with_run_dir(tmp_path):
+    run = tmp_path / "train99"
+    wdir = run / "weights"
+    wdir.mkdir(parents=True)
+    best = wdir / "best.pt"
+    best.write_bytes(b"dummy")
+
+    specs = resolve_models([str(run)])
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.weights_path == best
+    assert spec.name == "train99"
+```
+
+---
+
+## docs/batcheval.md (sketch)
+
+````md
+# yolo batcheval
+
+`yolo batcheval` evaluates multiple YOLO models on the same dataset split and writes a unified metrics summary.
+
+## Examples
+
+```bash
+# Compare two specific models
+yolo batcheval models="runs/detect/train38,models/exp2.pt" data=data.yaml split=val
+
+# Compare all runs under runs/detect/
+yolo batcheval models="runs/detect/train*" data=data.yaml split=test
+
+# With confidence threshold sweep
+yolo batcheval \
+  models="runs/detect/train38,models/exp2.pt" \
+  data=data.yaml \
+  split=test \
+  sweep_conf=True \
+  conf_min=0.05 \
+  conf_max=0.95 \
+  conf_step=0.05
+````
+
+Outputs are written to `runs/batcheval/<timestamp>/`:
+
+- `summary.csv` — one row per model with key metrics.
+- `sweep.csv` — (optional) metrics vs confidence thresholds.
+
+````
+
+---
+
+## PR_DRAFT_BATCHEVAL
+
+```md
+# Draft PR: yolo batcheval
+
+**Title:**  
+feat: add `yolo batcheval` command for multi-model evaluation
+
+---
+
+## Summary
+
+This PR introduces a new `yolo batcheval` command and corresponding
+`ultralytics.analytics.batcheval` module that provide a simple, built-in way to:
+
+- Evaluate **multiple YOLO models** on the **same dataset split**, and
+- Produce a unified metrics summary as CSV (and optionally a confidence-threshold sweep).
+
+The goal is to support lightweight, local model comparison without requiring
+external experiment tracking tools.
+
+---
+
+## Motivation
+
+- Today, users typically:
+  - Run `yolo val` once per model and compare metrics manually, or
+  - Rely on external tools (W&B, HUB, MLflow, etc.) for comparisons.
+- Many workflows only need a **small local helper** to compare N models on a dataset.
+- This PR adds that helper as a thin wrapper around existing public APIs, with minimal risk.
+
+---
+
+## What This PR Does
+
+- Adds `ultralytics/analytics/batcheval.py` with:
+  - `batcheval(models, data, split, ...)` Python API.
+  - `resolve_models(models)` utility for run dirs + `.pt` files.
+  - `run_cli(args)` for CLI integration.
+- Extends the `yolo` CLI:
+  - Adds a `batcheval` command that accepts:
+    - `models`: comma-separated list of runs and/or `.pt` files.
+    - `data`: dataset YAML (same as `yolo val`).
+    - `split`: validation split (default `"val"`).
+    - Optional confidence sweep arguments (`sweep_conf`, `conf_min`, `conf_max`, `conf_step`).
+- Writes outputs to `runs/batcheval/<timestamp>/`:
+  - `summary.csv` with one row per model and key metrics.
+  - `sweep.csv` (if `sweep_conf=True`) with metrics vs confidence thresholds.
+
+---
+
+## What This PR Does NOT Do
+
+- Does not modify or refactor the core training/validation engines.
+- Does not add database logging, dashboards, or any external integrations.
+- Does not attempt to replace tools like W&B or HUB; it is intentionally a small, local utility.
+
+---
+
+## Testing
+
+- New tests in `tests/test_batcheval.py`:
+  - `test_resolve_models_with_pt` — verifies `.pt` inputs resolve correctly.
+  - `test_resolve_models_with_run_dir` — verifies run directories resolve to `weights/best.pt`.
+- Additional tests can be added (in follow-ups) once we finalize how to normalize the `metrics` object; e.g.:
+  - A small integration test that checks `summary.csv` is created and contains one row per model.
+
+---
+
+## Notes
+
+- This feature is designed to be opt-in and low-risk:
+  - It only calls public APIs (`YOLO().val(...)`).
+  - It writes new files under `runs/` without touching existing outputs.
+- Follow-up work (if desired) could:
+  - Add richer per-class metrics to `summary.csv`.
+  - Integrate with any existing or future `dashboard` functionality that can consume these CSVs.
+````
+

--- a/docs/en/usage/batcheval.md
+++ b/docs/en/usage/batcheval.md
@@ -1,0 +1,59 @@
+---
+comments: true
+description: Use `yolo batcheval` to evaluate multiple YOLO models on the same dataset split and export a unified metrics summary.
+keywords: Ultralytics, YOLO, batcheval, batch evaluation, model comparison, metrics summary
+---
+
+## yolo batcheval
+
+`yolo batcheval` evaluates multiple YOLO models on the same dataset split and writes a unified metrics summary as CSV.
+
+This is a lightweight helper built on top of the public `YOLO().val(...)` API. It is designed for quick, local model
+comparison rather than long-term experiment tracking.
+
+### Python
+
+```python
+from ultralytics.analytics import batcheval
+
+results = batcheval(
+    models=["runs/detect/train38", "models/exp2.pt"],
+    data="coco8.yaml",
+    split="val",
+)
+
+for r in results:
+    print(r.model_name, r.metrics)
+```
+
+### CLI
+
+```bash
+# Compare two specific models on the same dataset split
+yolo batcheval models="runs/detect/train38,models/exp2.pt" data=coco8.yaml split=val
+
+# Compare all runs under runs/detect/ using a glob
+yolo batcheval models="runs/detect/train*" data=coco8.yaml split=test
+
+# With an optional confidence-threshold sweep
+yolo batcheval \
+  models="runs/detect/train38,models/exp2.pt" \
+  data=coco8.yaml \
+  split=test \
+  sweep_conf=True \
+  conf_min=0.05 \
+  conf_max=0.95 \
+  conf_step=0.05
+```
+
+### Outputs
+
+By default, outputs are written under `runs/batcheval/<timestamp>/`:
+
+- `summary.csv`: one row per model with flattened scalar metrics from `YOLO().val(...)`.
+- `sweep.csv`: optional, created when `sweep_conf=True`, with metrics across confidence thresholds.
+
+For details on the metrics reported by validation, see the validation documentation and `results.results_dict` in
+`ultralytics.utils.metrics`.
+
+

--- a/docs/en/usage/batcheval.md
+++ b/docs/en/usage/batcheval.md
@@ -55,5 +55,3 @@ By default, outputs are written under `runs/batcheval/<timestamp>/`:
 
 For details on the metrics reported by validation, see the validation documentation and `results.results_dict` in
 `ultralytics.utils.metrics`.
-
-

--- a/docs/en/usage/simple-utilities.md
+++ b/docs/en/usage/simple-utilities.md
@@ -696,6 +696,24 @@ print(VID_FORMATS)
 # {'avi', 'mpg', 'wmv', 'mpeg', 'm4v', 'mov', 'mp4', 'asf', 'mkv', 'ts', 'gif', 'webm'}
 ```
 
+## Batch Evaluation
+
+### Compare Multiple Models on a Dataset
+
+Use `yolo batcheval` to evaluate multiple YOLO models on the same dataset split and export a unified metrics summary.
+
+```python
+from ultralytics.analytics import batcheval
+
+results = batcheval(
+    models=["runs/detect/train38", "models/exp2.pt"],
+    data="coco8.yaml",
+    split="val",
+)
+```
+
+See the [batcheval usage page](./batcheval.md) for CLI examples, output formats, and additional details.
+
 ### Make Divisible
 
 Calculate the nearest whole number to `x` that is evenly divisible by `y`.

--- a/tests/test_batcheval.py
+++ b/tests/test_batcheval.py
@@ -1,3 +1,5 @@
+"""Tests for ultralytics.analytics.batcheval module."""
+
 from pathlib import Path
 
 import pytest
@@ -13,6 +15,7 @@ from ultralytics.analytics.batcheval import (
 
 
 def test_resolve_models_with_pt(tmp_path: Path) -> None:
+    """Test that resolve_models correctly handles a direct .pt file path."""
     m = tmp_path / "m.pt"
     m.write_bytes(b"dummy")  # fake weights
     specs = resolve_models([str(m)])
@@ -24,6 +27,7 @@ def test_resolve_models_with_pt(tmp_path: Path) -> None:
 
 
 def test_resolve_models_with_run_dir(tmp_path: Path) -> None:
+    """Test that resolve_models correctly handles a run directory with weights/best.pt."""
     run = tmp_path / "train99"
     wdir = run / "weights"
     wdir.mkdir(parents=True)
@@ -38,6 +42,7 @@ def test_resolve_models_with_run_dir(tmp_path: Path) -> None:
 
 
 def test_collect_summary_and_write_csv(tmp_path: Path) -> None:
+    """Test that _collect_summary_rows and _write_csv produce valid CSV output."""
     results = [
         BatchEvalResult(model_name="a", metrics={"metrics/mAP50": 0.5, "metrics/mAP50-95": 0.4}),
         BatchEvalResult(model_name="b", metrics={"metrics/mAP50": 0.6}),
@@ -54,6 +59,7 @@ def test_collect_summary_and_write_csv(tmp_path: Path) -> None:
 
 
 def test_run_conf_sweep_strips_incoming_conf_and_forwards_other_kwargs(monkeypatch, tmp_path: Path) -> None:
+    """Test that _run_conf_sweep strips user-provided conf and forwards other kwargs."""
     calls = []
 
     class DummyModel:
@@ -92,6 +98,7 @@ def test_run_conf_sweep_strips_incoming_conf_and_forwards_other_kwargs(monkeypat
 
 
 def test_handle_yolo_batcheval_forwards_extra_overrides(monkeypatch) -> None:
+    """Test that handle_yolo_batcheval forwards extra kwargs to YOLO().val()."""
     import ultralytics.analytics as analytics_mod
     import ultralytics.cfg as cfg_mod
 
@@ -123,6 +130,7 @@ def test_handle_yolo_batcheval_forwards_extra_overrides(monkeypatch) -> None:
 
 
 def test_handle_yolo_batcheval_requires_models_and_data(monkeypatch) -> None:
+    """Test that handle_yolo_batcheval raises SyntaxError when required args are missing."""
     import ultralytics.analytics as analytics_mod
     import ultralytics.cfg as cfg_mod
 

--- a/tests/test_batcheval.py
+++ b/tests/test_batcheval.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from ultralytics.analytics.batcheval import BatchEvalResult, ModelSpec, _collect_summary_rows, _write_csv, resolve_models
+
+
+def test_resolve_models_with_pt(tmp_path: Path) -> None:
+    m = tmp_path / "m.pt"
+    m.write_bytes(b"dummy")  # fake weights
+    specs = resolve_models([str(m)])
+    assert len(specs) == 1
+    spec = specs[0]
+    assert isinstance(spec, ModelSpec)
+    assert spec.weights_path == m
+    assert spec.name == "m"
+
+
+def test_resolve_models_with_run_dir(tmp_path: Path) -> None:
+    run = tmp_path / "train99"
+    wdir = run / "weights"
+    wdir.mkdir(parents=True)
+    best = wdir / "best.pt"
+    best.write_bytes(b"dummy")
+
+    specs = resolve_models([str(run)])
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.weights_path == best
+    assert spec.name == "train99"
+
+
+def test_collect_summary_and_write_csv(tmp_path: Path) -> None:
+    results = [
+        BatchEvalResult(model_name="a", metrics={"metrics/mAP50": 0.5, "metrics/mAP50-95": 0.4}),
+        BatchEvalResult(model_name="b", metrics={"metrics/mAP50": 0.6}),
+    ]
+    rows = _collect_summary_rows(results)
+    out_path = tmp_path / "summary.csv"
+    _write_csv(out_path, rows)
+
+    data = out_path.read_text(encoding="utf-8").strip().splitlines()
+    # Header plus two rows.
+    assert len(data) == 3
+    assert "model_name" in data[0]
+    assert "metrics/mAP50" in data[0]
+
+

--- a/tests/test_batcheval.py
+++ b/tests/test_batcheval.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from ultralytics.analytics.batcheval import (
     BatchEvalResult,
     ModelSpec,

--- a/ultralytics/analytics/__init__.py
+++ b/ultralytics/analytics/__init__.py
@@ -1,0 +1,12 @@
+"""
+Analytics helpers for Ultralytics.
+
+This module currently exposes the `batcheval` helper for batch evaluation of
+multiple YOLO models on a single dataset split.
+"""
+
+from .batcheval import BatchEvalResult, ModelSpec, batcheval, evaluate_model, resolve_models, run_cli
+
+__all__ = ["BatchEvalResult", "ModelSpec", "batcheval", "evaluate_model", "resolve_models", "run_cli"]
+
+

--- a/ultralytics/analytics/__init__.py
+++ b/ultralytics/analytics/__init__.py
@@ -8,5 +8,3 @@ multiple YOLO models on a single dataset split.
 from .batcheval import BatchEvalResult, ModelSpec, batcheval, evaluate_model, resolve_models, run_cli
 
 __all__ = ["BatchEvalResult", "ModelSpec", "batcheval", "evaluate_model", "resolve_models", "run_cli"]
-
-

--- a/ultralytics/analytics/batcheval.py
+++ b/ultralytics/analytics/batcheval.py
@@ -1,0 +1,318 @@
+"""
+Batch evaluation utilities for comparing multiple YOLO models on a single dataset.
+
+Scope:
+- N models in -> summary (and optional confidence sweep) out.
+- Built on top of the public YOLO().val(...) API.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+from ultralytics import YOLO
+from ultralytics.utils import LOGGER
+
+
+@dataclass
+class ModelSpec:
+    """Resolved model description for batch evaluation."""
+
+    name: str
+    weights_path: Path
+
+
+@dataclass
+class BatchEvalResult:
+    """Result of evaluating a single model within a batch."""
+
+    model_name: str
+    metrics: Dict[str, float]
+
+
+def _iter_model_paths(pattern: str) -> Iterable[Path]:
+    """
+    Yield paths for a user-specified model identifier.
+
+    Supports:
+    - Explicit file or directory paths.
+    - Simple glob patterns like 'runs/detect/train*'.
+    """
+    p = Path(pattern)
+    # If it exists directly, just yield it.
+    if p.exists():
+        yield p
+        return
+
+    # Fallback to globbing relative to CWD.
+    has_wildcard = any(ch in pattern for ch in "*?[]")
+    if has_wildcard:
+        matched = sorted(Path(".").glob(pattern))
+        if matched:
+            for path in matched:
+                yield path
+            return
+
+    # If nothing matched, surface a clear error.
+    raise FileNotFoundError(f"No files or directories found matching model pattern: {pattern}")
+
+
+def resolve_models(models: Sequence[str]) -> List[ModelSpec]:
+    """
+    Resolve user-provided model identifiers into concrete weight paths.
+
+    Accepts:
+        - Run directories (e.g. 'runs/detect/train38') -> uses 'weights/best.pt'.
+        - Direct .pt files (e.g. 'path/to/model.pt').
+        - Simple glob patterns that expand to either of the above.
+    """
+    resolved: List[ModelSpec] = []
+    for item in models:
+        for path in _iter_model_paths(item):
+            if path.is_dir():
+                best = path / "weights" / "best.pt"
+                if not best.exists():
+                    raise FileNotFoundError(f"No best.pt found under run dir: {path}")
+                resolved.append(ModelSpec(name=path.name, weights_path=best))
+            else:
+                if not path.exists():
+                    raise FileNotFoundError(f"Model weights not found: {path}")
+                resolved.append(ModelSpec(name=path.stem, weights_path=path))
+    return resolved
+
+
+def evaluate_model(
+    spec: ModelSpec,
+    data: str,
+    split: str = "val",
+    **val_kwargs: Any,
+) -> BatchEvalResult:
+    """
+    Run Ultralytics val for a single model and extract key metrics.
+
+    This is a thin wrapper around YOLO(weights).val(...).
+    """
+    LOGGER.info(f"Running batcheval for model '{spec.name}' from {spec.weights_path} on split '{split}'.")
+    model = YOLO(str(spec.weights_path))
+    metrics = model.val(data=data, split=split, **val_kwargs)
+
+    # Prefer the standardized results_dict interface when available.
+    metrics_dict: Dict[str, float]
+    if hasattr(metrics, "results_dict"):
+        metrics_dict = dict(metrics.results_dict)
+    elif isinstance(metrics, Mapping):
+        metrics_dict = dict(metrics)
+    else:
+        try:
+            metrics_dict = dict(metrics)  # type: ignore[arg-type]
+        except TypeError:
+            LOGGER.warning("Unexpected metrics object from YOLO.val(); summary will be empty.")
+            metrics_dict = {}
+
+    return BatchEvalResult(model_name=spec.name, metrics=metrics_dict)
+
+
+def _default_save_dir() -> Path:
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return Path("runs") / "batcheval" / ts
+
+
+def _collect_summary_rows(results: Sequence[BatchEvalResult]) -> List[Dict[str, Any]]:
+    """Normalize batch results into a list of flat dicts suitable for CSV export."""
+    rows: List[Dict[str, Any]] = []
+    for res in results:
+        row: Dict[str, Any] = {"model_name": res.model_name}
+        for k, v in res.metrics.items():
+            row[k] = v
+        rows.append(row)
+    return rows
+
+
+def _write_csv(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    """Write a list of mapping rows to CSV, inferring a unified header."""
+    if not rows:
+        return
+
+    # Collect union of keys across all rows to keep output stable.
+    keys: list[str] = ["model_name"]
+    extra_keys: set[str] = set()
+    for row in rows:
+        for k in row.keys():
+            if k == "model_name":
+                continue
+            extra_keys.add(k)
+    keys.extend(sorted(extra_keys))
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=keys)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in keys})
+
+
+def _run_conf_sweep(
+    specs: Sequence[ModelSpec],
+    data: str,
+    split: str,
+    conf_min: float,
+    conf_max: float,
+    conf_step: float,
+    save_root: Path,
+    **val_kwargs: Any,
+) -> None:
+    """
+    Run an optional confidence sweep by re-running validation with different thresholds.
+
+    This keeps the implementation simple and uses the public `conf` argument to YOLO().val(...).
+    """
+    if conf_step <= 0:
+        raise ValueError("conf_step must be > 0 for confidence sweeps.")
+
+    sweep_rows: list[dict[str, Any]] = []
+
+    for spec in specs:
+        model = YOLO(str(spec.weights_path))
+        conf = conf_min
+        while conf <= conf_max + 1e-9:
+            LOGGER.info(
+                f"Running confidence sweep for model '{spec.name}' at conf={conf:.3f} on split '{split}'.",
+            )
+            metrics = model.val(data=data, split=split, conf=conf, **val_kwargs)
+            if hasattr(metrics, "results_dict"):
+                metrics_dict = dict(metrics.results_dict)
+            elif isinstance(metrics, Mapping):
+                metrics_dict = dict(metrics)
+            else:
+                try:
+                    metrics_dict = dict(metrics)  # type: ignore[arg-type]
+                except TypeError:
+                    metrics_dict = {}
+
+            row: dict[str, Any] = {"model_name": spec.name, "conf": conf}
+            row.update(metrics_dict)
+            sweep_rows.append(row)
+            conf += conf_step
+
+    if sweep_rows:
+        _write_csv(save_root / "sweep.csv", sweep_rows)
+
+
+def batcheval(
+    models: Sequence[str],
+    data: str,
+    split: str = "val",
+    sweep_conf: bool = False,
+    conf_min: float = 0.05,
+    conf_max: float = 0.95,
+    conf_step: float = 0.05,
+    save_dir: str | Path | None = None,
+    **val_kwargs: Any,
+) -> List[BatchEvalResult]:
+    """
+    Evaluate multiple models on the same dataset split and write a unified report.
+
+    This function returns a list of `BatchEvalResult` objects and writes:
+    - `summary.csv` (always): one row per model with flattened scalar metrics.
+    - `sweep.csv` (optional): metrics across confidence thresholds when `sweep_conf=True`.
+    """
+    if not models:
+        raise ValueError("No models provided to batcheval().")
+
+    save_root = Path(save_dir) if save_dir is not None else _default_save_dir()
+    save_root.mkdir(parents=True, exist_ok=True)
+
+    specs = resolve_models(models)
+    if not specs:
+        raise ValueError("No models resolved from provided identifiers.")
+
+    LOGGER.info(f"Starting batcheval for {len(specs)} model(s). Results will be written to: {save_root}")
+    results: List[BatchEvalResult] = []
+
+    for spec in specs:
+        results.append(evaluate_model(spec, data=data, split=split, **val_kwargs))
+
+    # Write main summary table.
+    summary_rows = _collect_summary_rows(results)
+    _write_csv(save_root / "summary.csv", summary_rows)
+    LOGGER.info(f"Batcheval summary written to {save_root / 'summary.csv'}.")
+
+    # Optional confidence sweep.
+    if sweep_conf:
+        _run_conf_sweep(
+            specs=specs,
+            data=data,
+            split=split,
+            conf_min=conf_min,
+            conf_max=conf_max,
+            conf_step=conf_step,
+            save_root=save_root,
+            **val_kwargs,
+        )
+
+    return results
+
+
+def run_cli(args: Dict[str, Any]) -> List[BatchEvalResult]:
+    """
+    CLI entrypoint wrapper.
+
+    Expected args keys:
+        models (str | Sequence[str]): comma-separated list or sequence of models.
+        data (str): dataset YAML path.
+        split (str): dataset split, e.g. 'val' or 'test'.
+        sweep_conf (bool): whether to perform confidence sweeps.
+        conf_min, conf_max, conf_step (floats): sweep configuration.
+        save_dir (str | Path, optional): explicit output directory.
+        Other keys are forwarded to YOLO().val(...) as keyword arguments.
+    """
+    raw_models = args.get("models")
+    if not raw_models:
+        raise SyntaxError("Missing required 'models' argument for batcheval CLI.")
+
+    if isinstance(raw_models, str):
+        models = [m.strip() for m in raw_models.split(",") if m.strip()]
+    else:
+        models = list(raw_models)
+
+    data = args.get("data")
+    if not data:
+        raise SyntaxError("Missing required 'data' argument for batcheval CLI.")
+
+    split = args.get("split", "val")
+    sweep_conf = bool(args.get("sweep_conf", False))
+    conf_min = float(args.get("conf_min", 0.05))
+    conf_max = float(args.get("conf_max", 0.95))
+    conf_step = float(args.get("conf_step", 0.05))
+    save_dir = args.get("save_dir")
+
+    # Everything else is passed through to YOLO().val(...)
+    passthrough_keys = {
+        "models",
+        "data",
+        "split",
+        "sweep_conf",
+        "conf_min",
+        "conf_max",
+        "conf_step",
+        "save_dir",
+    }
+    val_kwargs = {k: v for k, v in args.items() if k not in passthrough_keys}
+
+    return batcheval(
+        models=models,
+        data=data,
+        split=split,
+        sweep_conf=sweep_conf,
+        conf_min=conf_min,
+        conf_max=conf_max,
+        conf_step=conf_step,
+        save_dir=save_dir,
+        **val_kwargs,
+    )
+
+

--- a/ultralytics/analytics/batcheval.py
+++ b/ultralytics/analytics/batcheval.py
@@ -174,6 +174,9 @@ def _run_conf_sweep(
         raise ValueError("conf_step must be > 0 for confidence sweeps.")
 
     sweep_rows: list[dict[str, Any]] = []
+    # Drop any incoming 'conf' override so the sweep's own thresholds take precedence
+    # and we don't pass duplicate keyword arguments to YOLO().val(...).
+    safe_val_kwargs = {k: v for k, v in val_kwargs.items() if k != "conf"}
 
     for spec in specs:
         model = YOLO(str(spec.weights_path))
@@ -182,7 +185,7 @@ def _run_conf_sweep(
             LOGGER.info(
                 f"Running confidence sweep for model '{spec.name}' at conf={conf:.3f} on split '{split}'.",
             )
-            metrics = model.val(data=data, split=split, conf=conf, **val_kwargs)
+            metrics = model.val(data=data, split=split, conf=conf, **safe_val_kwargs)
             if hasattr(metrics, "results_dict"):
                 metrics_dict = dict(metrics.results_dict)
             elif isinstance(metrics, Mapping):

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -141,6 +141,9 @@ CLI_HELP_MSG = f"""
         yolo cfg
         yolo solutions help
 
+    7. Batch-evaluate multiple models on a dataset:
+        yolo batcheval models="runs/detect/train*,models/exp2.pt" data=coco8.yaml split=val
+
     Docs: https://docs.ultralytics.com
     Solutions: https://docs.ultralytics.com/solutions/
     Community: https://community.ultralytics.com
@@ -744,6 +747,55 @@ def handle_yolo_solutions(args: list[str]) -> None:
             cap.release()
 
 
+def handle_yolo_batcheval(args: list[str]) -> None:
+    """Handle the `yolo batcheval` command for batch model evaluation.
+
+    This command evaluates multiple models on the same dataset split and writes summary CSV outputs.
+    Example:
+        yolo batcheval models="runs/detect/train*,models/exp2.pt" data=coco8.yaml split=val
+    """
+    from ultralytics.analytics import run_cli as batcheval_run_cli
+
+    # Define a minimal schema for alignment and clear error messages.
+    full_args_dict: dict[str, Any] = {
+        "models": "",
+        "data": "",
+        "split": "val",
+        "sweep_conf": False,
+        "conf_min": 0.05,
+        "conf_max": 0.95,
+        "conf_step": 0.05,
+        "save_dir": None,
+    }
+
+    overrides: dict[str, Any] = {}
+    for arg in merge_equals_args(args):
+        arg = arg.lstrip("-").rstrip(",")
+        if "=" in arg:
+            try:
+                k, v = parse_key_value_pair(arg)
+                overrides[k] = v
+            except (NameError, SyntaxError, ValueError, AssertionError) as e:
+                check_dict_alignment(full_args_dict, {arg: ""}, e)
+        else:
+            # For now we do not support bare boolean flags; guide user via alignment error.
+            check_dict_alignment(full_args_dict, {arg: ""})
+
+    # Validate keys.
+    check_dict_alignment(full_args_dict, overrides)
+
+    # Required arguments.
+    missing = [k for k in ("models", "data") if k not in overrides or overrides[k] in {None, ""}]
+    if missing:
+        missing_str = ", ".join(missing)
+        raise SyntaxError(
+            f"Missing required batcheval argument(s): {missing_str}. "
+            "Example: yolo batcheval models='runs/detect/train*,models/exp2.pt' data=coco8.yaml split=val",
+        )
+
+    batcheval_run_cli(overrides)
+
+
 def parse_key_value_pair(pair: str = "key=value") -> tuple:
     """Parse a key-value pair string into separate key and value components.
 
@@ -860,6 +912,7 @@ def entrypoint(debug: str = "") -> None:
         "logout": lambda: handle_yolo_hub(args),
         "copy-cfg": copy_default_cfg,
         "solutions": lambda: handle_yolo_solutions(args[1:]),
+        "batcheval": lambda: handle_yolo_batcheval(args[1:]),
         "help": lambda: LOGGER.info(CLI_HELP_MSG),  # help below hub for -h flag precedence
     }
     full_args_dict = {**DEFAULT_CFG_DICT, **{k: None for k in TASKS}, **{k: None for k in MODES}, **special}

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -781,8 +781,10 @@ def handle_yolo_batcheval(args: list[str]) -> None:
             # For now we do not support bare boolean flags; guide user via alignment error.
             check_dict_alignment(full_args_dict, {arg: ""})
 
-    # Validate keys.
-    check_dict_alignment(full_args_dict, overrides)
+    # Validate only known keys; allow additional overrides (e.g. imgsz, conf, save_json, plots)
+    # to pass through to YOLO().val(...) via batcheval without being rejected.
+    known_overrides = {k: v for k, v in overrides.items() if k in full_args_dict}
+    check_dict_alignment(full_args_dict, known_overrides)
 
     # Required arguments.
     missing = [k for k in ("models", "data") if k not in overrides or overrides[k] in {None, ""}]

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -751,7 +751,8 @@ def handle_yolo_batcheval(args: list[str]) -> None:
     """Handle the `yolo batcheval` command for batch model evaluation.
 
     This command evaluates multiple models on the same dataset split and writes summary CSV outputs.
-    Example:
+
+    Examples:
         yolo batcheval models="runs/detect/train*,models/exp2.pt" data=coco8.yaml split=val
     """
     from ultralytics.analytics import run_cli as batcheval_run_cli


### PR DESCRIPTION
feat: add `yolo batcheval` command for multi-model evaluation

## Summary

This PR adds a `yolo batcheval` command and corresponding `ultralytics.analytics.batcheval` module, providing a first-class way to evaluate multiple YOLO models on the same dataset split and export a unified metrics summary (and optional confidence-threshold sweeps).

The feature is deliberately small and focused on batch evaluation over existing `YOLO().val(...)` APIs, rather than a full experiment-tracking framework.

## Motivation

Ultralytics already supports single-model evaluation via `yolo val` and provides benchmarking helpers, but there is no built-in way to quickly compare N models on a shared dataset split and get a simple CSV summary.

Today, users typically:

- Manually run `yolo val` once per model and copy metrics into spreadsheets, or
- Rely on external tools (W&B, HUB, MLflow, etc.) for experiment comparison.

This PR introduces a lightweight, upstream-friendly helper that:

- Reuses the existing validation stack (`YOLO().val(...)`),
- Produces simple CSV outputs under `runs/`,
- Avoids any dependency on external services or dashboards.

## What This PR Does

**New analytics module**

- Adds `ultralytics/analytics/batcheval.py` with:
  - `ModelSpec` dataclass:
    - `name`: human-readable model identifier (run dir name or `.pt` stem).
    - `weights_path`: resolved path to the `.pt` weights.
  - `BatchEvalResult` dataclass:
    - `model_name`: name used in reports.
    - `metrics`: flattened scalar metrics as a `dict[str, float]` (using `results.results_dict` when available).
  - `resolve_models(models: Sequence[str]) -> list[ModelSpec]`:
    - Accepts:
      - Run directories (e.g. `runs/detect/train38`) → uses `weights/best.pt`.
      - Direct `.pt` files (e.g. `models/exp2.pt`).
      - Simple glob patterns (e.g. `runs/detect/train*`) expanding to either of the above.
  - `evaluate_model(spec, data, split="val", **val_kwargs) -> BatchEvalResult`:
    - Thin wrapper around `YOLO(weights).val(data=data, split=split, **val_kwargs)`.
    - Normalizes returned metrics to a plain dict using `results.results_dict` where possible.
  - `batcheval(models, data, split="val", sweep_conf=False, conf_min=0.05, conf_max=0.95, conf_step=0.05, save_dir=None, **val_kwargs)`:
    - Resolves models, runs validation for each, and returns a list of `BatchEvalResult`.
    - Writes:
      - `summary.csv`: one row per model with scalar metrics (including `model_name`).
      - `sweep.csv`: optional, if `sweep_conf=True`, with metrics vs confidence thresholds.
    - Uses a default output root of `runs/batcheval/<timestamp>/` when `save_dir` is not provided.
  - `run_cli(args: dict) -> list[BatchEvalResult]`:
    - Adapts a parsed CLI `args` dict into a call to `batcheval(...)`.
    - Accepts `models`, `data`, `split`, `sweep_conf`, `conf_min`, `conf_max`, `conf_step`, `save_dir`, and forwards all other keys to `YOLO().val(...)`.

**Python API surface**

- Adds `ultralytics/analytics/__init__.py`:
  - Re-exports:
    - `BatchEvalResult`, `ModelSpec`,
    - `batcheval`, `evaluate_model`, `resolve_models`, `run_cli`.
  - Enables Python usage via:

   
    from ultralytics.analytics import batcheval
    **CLI integration**

- Extends `ultralytics/cfg/__init__.py` to support:

 
  yolo batcheval models="runs/detect/train*,models/exp2.pt" data=coco8.yaml split=val
  - Adds `handle_yolo_batcheval(args: list[str])`:
  - Parses `key=value` pairs with existing helpers.
  - Validates arguments against a small schema:
    - Required: `models`, `data`.
    - Optional: `split`, `sweep_conf`, `conf_min`, `conf_max`, `conf_step`, `save_dir`.
  - Raises a clear `SyntaxError` with example usage when required arguments are missing or keys are invalid.
  - Calls `ultralytics.analytics.run_cli(overrides)` with the parsed overrides.
- Registers `"batcheval": lambda: handle_yolo_batcheval(args[1:])` in the `special` command map so `yolo batcheval` is treated like other special modes (e.g. `yolo solutions`).
- Extends `CLI_HELP_MSG` with a batcheval example.

**Tests**

- Adds `tests/test_batcheval.py`:
  - `test_resolve_models_with_pt`:
    - Creates a fake `.pt` file.
    - Asserts `resolve_models([str(m)])` returns a single `ModelSpec` with the correct `weights_path` and `name`.
  - `test_resolve_models_with_run_dir`:
    - Creates a fake run directory `train99/weights/best.pt`.
    - Asserts `resolve_models([str(run)])` resolves to `weights/best.pt` and uses `train99` as the `name`.
  - `test_collect_summary_and_write_csv`:
    - Builds a couple of `BatchEvalResult` instances.
    - Uses internal helpers to generate summary rows and write `summary.csv`.
    - Asserts that:
      - The file exists with one header row and two data rows.
      - The header includes `model_name` and metric keys.

**Docs**

- Adds `docs/en/usage/batcheval.md`:
  - Introduces `yolo batcheval`, its scope, and its outputs.
  - Provides Python and CLI examples (including globbed `models` and optional confidence sweep).
  - Documents the default layout under `runs/batcheval/<timestamp>/` (`summary.csv`, optional `sweep.csv`).
- Updates `docs/en/usage/simple-utilities.md`:
  - Adds a “Batch Evaluation” section.
  - Shows a short Python example using `from ultralytics.analytics import batcheval`.
  - Links to the batcheval usage page.

## Usage & Workflow

**Python**

from ultralytics.analytics import batcheval

results = batcheval(
    models=["runs/detect/train38", "models/exp2.pt"],
    data="coco8.yaml",
    split="val",
)

for r in results:
    print(r.model_name, r.metrics)**CLI**

# Compare two specific models on the same dataset split
yolo batcheval models="runs/detect/train38,models/exp2.pt" data=coco8.yaml split=val

# Compare all runs under runs/detect/ using a glob
yolo batcheval models="runs/detect/train*" data=coco8.yaml split=test

# With an optional confidence-threshold sweep
yolo batcheval \
  models="runs/detect/train38,models/exp2.pt" \
  data=coco8.yaml \
  split=test \
  sweep_conf=True \
  conf_min=0.05 \
  conf_max=0.95 \
  conf_step=0.05By default, outputs are written to:

runs/batcheval/<timestamp>/
  summary.csv
  sweep.csv    # only when sweep_conf=True## Non-Goals (v1)

This PR intentionally does not:

- Introduce database logging, dashboards, or experiment history UI.
- Refactor or modify the underlying training/validation engines.
- Manage experiment metadata or hyperparameters beyond what `YOLO().val(...)` already reports.
- Implement a faster, offline confidence-sweep mechanism:
  - v1 simply re-runs `YOLO().val(...)` at multiple `conf` thresholds.
- Guarantee a fixed set of CSV columns:
  - Columns follow `results.results_dict` from the validation metrics implementation.

These constraints keep the implementation thin, purely additive, and low-risk.

## Testing

Local tests:

python -m pytest tests/test_batcheval.pyAll tests pass on my local environment (Windows, Python 3.11).

## CLA

I have read the CLA Document and I sign the CLA.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a new `yolo batcheval` batch evaluation workflow and Labelbox-to-YOLO conversion utilities, including CLI integration, Python APIs, tests, and user documentation.  

### 📊 Key Changes
- 🚀 Introduces `ultralytics.analytics.batcheval` module with `batcheval`, `ModelSpec`, `BatchEvalResult`, and `run_cli` for evaluating multiple YOLO models on a shared dataset split.
- 🖥️ Extends the `yolo` CLI with a new `batcheval` subcommand wired through `handle_yolo_batcheval`, including argument parsing, validation, and help text.
- 📈 Implements CSV reporting utilities to export `summary.csv` (per-model metrics) and optional `sweep.csv` (confidence-threshold sweeps) under `runs/batcheval/<timestamp>/`.
- 📚 Adds documentation pages and usage snippets for `yolo batcheval`, and links it from `simple-utilities.md` to surface the feature to users.
- 🔄 Adds a new `ultralytics.data.labelbox` module providing `convert_labelbox` and helper functions to convert Labelbox NDJSON exports into YOLO detection datasets.
- ✅ Introduces tests for batch evaluation CSV generation and Labelbox conversion (`tests/test_batcheval.py`, `tests/test_labelbox_convert.py`) to validate core behaviors.
- 🧭 Adds a design canvas (`design/batcheval_canvas.md`) describing the intended architecture, API, tests, docs, and draft PR narrative for `yolo batcheval`.

### 🎯 Purpose & Impact
- 🧪 Simplifies comparing multiple YOLO models on the same dataset split, reducing manual scripting and making local model selection workflows faster and more repeatable.
- 📊 Provides standardized CSV summaries that can be easily inspected, versioned, or ingested into downstream tools for analysis and reporting.
- 🧰 Gives practitioners a lightweight way to perform confidence-threshold sweeps using only public APIs, improving insight into precision/recall tradeoffs without extra tooling.
- 📦 Streamlines data onboarding from Labelbox into YOLO-format detection datasets, lowering friction for users migrating or experimenting with YOLO models.
- 🧪 Strengthens reliability through targeted tests around model resolution, CSV export, and Labelbox conversion correctness, reducing regression risk for these utilities.