### PR TITLE
Update style.css for language switcher

### DIFF
--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -330,3 +330,11 @@ div.highlight {
 .md-typeset a {
   text-decoration: none !important;
 }
+
+/* Remove language switcher */
+.weglot-container,
+.weglot_switcher,
+[id^="weglot-switcher"],
+.weglot-container[id^="weglot-switcher"] {
+  display: none !important;
+}


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Hides the Weglot language switcher from the Ultralytics documentation site. 🌐🚫

### 📊 Key Changes
- Added new CSS rules in `docs/overrides/stylesheets/style.css`.
- Specifically target Weglot language switcher elements (`.weglot-container`, `.weglot_switcher`, and IDs starting with `weglot-switcher`).
- Force these elements to be hidden using `display: none !important;`.

### 🎯 Purpose & Impact
- Removes the language switcher UI from the docs, likely to standardize or simplify the user experience. 🧭
- Prevents users from switching languages, which can avoid confusion if translations are incomplete or not maintained. ❌🌍
- Ensures a cleaner, more consistent documentation interface across all pages. 🧹📚