### PR TITLE
Update axelera.md

### DIFF
--- a/docs/en/integrations/axelera.md
+++ b/docs/en/integrations/axelera.md
@@ -6,6 +6,10 @@ keywords: Axelera AI, Metis AIPU, Europa, Voyager SDK, Edge AI, YOLOv8, YOLO11, 
 
 # Axelera AI Acceleration
 
+!!! note "Coming soon — Q1 2026 availability"
+
+    Axelera export/runtime support in `ultralytics` is **in progress** and slated for **Q1 2026**. The examples on this page describe the expected workflow and will work once the Axelera runtime package is published.
+
 !!! note "Partner Integration"
 
     Ultralytics partners with **Axelera AI** to streamline high-performance, energy-efficient inference on [Edge AI](https://docs.ultralytics.com/glossary/edge-ai) devices. This integration allows users to export and deploy **Ultralytics YOLO models** directly to the **Metis® AIPU** and **Europa®** platforms using the **Voyager SDK**.
@@ -79,6 +83,10 @@ Key features for Ultralytics users:
 
 To use Axelera acceleration, you need the `ultralytics` package installed. Note that the Voyager SDK is a separate system-level installation required to interface with the hardware.
 
+!!! note "Axelera runtime pending release"
+
+    Axelera-specific wheels are not yet published to PyPI or the Axelera portal. Installation commands below represent the **future** workflow once the runtime becomes available (ETA Q1 2026).
+
 ```bash
 # Install Ultralytics
 pip install ultralytics
@@ -89,7 +97,7 @@ pip install ultralytics
 
 ## Exporting YOLO Models to Axelera
 
-You can export your trained YOLO models to the Axelera format using the standard Ultralytics export command. This process generates the artifacts required by the Voyager compiler.
+When the Axelera runtime package ships (target Q1 2026), you will export your trained YOLO models to the Axelera format using the standard Ultralytics export command. This process generates the artifacts required by the Voyager compiler.
 
 !!! warning "Voyager SDK Required"
 
@@ -125,26 +133,26 @@ For available arguments, refer to the [Export Mode documentation](https://docs.u
 
 ## Running Inference
 
-Once exported, inference is typically managed via the Voyager SDK's runtime bindings. Below is a conceptual example of running a compiled YOLO model.
+Once exported, you will be able to load the Axelera-compiled model directly with the `ultralytics` API (similar to loading [ONNX](https://docs.ultralytics.com/integrations/onnx/) models). The example below shows the expected usage pattern for running inference and saving results after the runtime package ships.
 
 ```python
-# Pseudo-code for running inference with Axelera runtime
-import cv2
-from axelera.runtime import InferenceSession  # Hypothetical import
+from ultralytics import YOLO
 
-# Initialize the Axelera Inference Session with your compiled model
-session = InferenceSession("yolo11n_metis.axmodel")
+# Load the Axelera-compiled model (example path; same flow as ONNX)
+model = YOLO("yolo11n_axelera.axmodel")  # will work once Axelera runtime is released
 
-# Load and preprocess image
-image = cv2.imread("path/to/image.jpg")
-input_data = preprocess(image)  # Resize and normalize as per model requirements
+# Run inference; you can pass a file, folder, glob, or list of sources
+results = model("path/to/images", imgsz=640, save=True)
 
-# Run inference on the AIPU
-results = session.run(input_data)
+# Iterate over result objects to inspect or render detections
+for r in results:
+    boxes = r.boxes  # bounding boxes tensor + metadata
+    print(f"Detected {len(boxes)} objects")
 
-# Process results (NMS, coordinate scaling)
-detections = postprocess(results)
-print(f"Detected {len(detections)} objects")
+    # Save visuals per result (files saved alongside inputs)
+    r.save()  # saves annotated image(s) to disk
+    # Or display interactively (desktop environments)
+    # r.show()
 ```
 
 ## Inference Performance

--- a/docs/en/integrations/axelera.md
+++ b/docs/en/integrations/axelera.md
@@ -6,13 +6,11 @@ keywords: Axelera AI, Metis AIPU, Europa, Voyager SDK, Edge AI, YOLOv8, YOLO11, 
 
 # Axelera AI Acceleration
 
-!!! note "Coming soon — Q1 2026 availability"
+!!! note "Coming soon — Q1 2026"
 
-    Axelera export/runtime support in `ultralytics` is **in progress** and slated for **Q1 2026**. The examples on this page describe the expected workflow and will work once the Axelera runtime package is published.
+    Axelera support in `ultralytics` is **in progress**. The examples here show the planned UI/UX and will become runnable once the Axelera runtime package is released.
 
-!!! note "Partner Integration"
-
-    Ultralytics partners with **Axelera AI** to streamline high-performance, energy-efficient inference on [Edge AI](https://docs.ultralytics.com/glossary/edge-ai) devices. This integration allows users to export and deploy **Ultralytics YOLO models** directly to the **Metis® AIPU** and **Europa®** platforms using the **Voyager SDK**.
+Ultralytics partners with **Axelera AI** to streamline high-performance, energy-efficient inference on [Edge AI](https://docs.ultralytics.com/glossary/edge-ai) devices. This integration allows users to export and deploy **Ultralytics YOLO models** directly to the **Metis® AIPU** and **Europa®** platforms using the **Voyager SDK**.
 
 ![Axelera AI Ecosystem](https://github.com/user-attachments/assets/c97a0297-390d-47df-bb13-ff1aa499f34a)
 
@@ -81,11 +79,7 @@ Key features for Ultralytics users:
 
 ## Installation & Setup
 
-To use Axelera acceleration, you need the `ultralytics` package installed. Note that the Voyager SDK is a separate system-level installation required to interface with the hardware.
-
-!!! note "Axelera runtime pending release"
-
-    Axelera-specific wheels are not yet published to PyPI or the Axelera portal. Installation commands below represent the **future** workflow once the runtime becomes available (ETA Q1 2026).
+To use Axelera acceleration, you need the `ultralytics` package installed. Note that the Voyager SDK is a separate system-level installation required to interface with the hardware. Runtime wheels are expected in **Q1 2026**; the commands below reflect the intended setup flow.
 
 ```bash
 # Install Ultralytics
@@ -108,6 +102,10 @@ When the Axelera runtime package ships (target Q1 2026), you will export your tr
 Convert a YOLO11 model for Metis deployment.
 
 !!! example "Export to Axelera Format"
+
+    !!! note "Future example — will work when runtime is released"
+    
+        This code block demonstrates the planned flow. It will require the upcoming Axelera runtime package (ETA Q1 2026) to execute successfully.
 
     === "Python"
 
@@ -135,25 +133,33 @@ For available arguments, refer to the [Export Mode documentation](https://docs.u
 
 Once exported, you will be able to load the Axelera-compiled model directly with the `ultralytics` API (similar to loading [ONNX](https://docs.ultralytics.com/integrations/onnx/) models). The example below shows the expected usage pattern for running inference and saving results after the runtime package ships.
 
-```python
-from ultralytics import YOLO
+!!! example "Inference with Axelera Format"
 
-# Load the Axelera-compiled model (example path; same flow as ONNX)
-model = YOLO("yolo11n_axelera.axmodel")  # will work once Axelera runtime is released
+    !!! note "Future example — will work when runtime is released"
 
-# Run inference; you can pass a file, folder, glob, or list of sources
-results = model("path/to/images", imgsz=640, save=True)
+        This code block demonstrates the planned flow. It will require the upcoming Axelera runtime package (ETA Q1 2026) to execute successfully.
 
-# Iterate over result objects to inspect or render detections
-for r in results:
-    boxes = r.boxes  # bounding boxes tensor + metadata
-    print(f"Detected {len(boxes)} objects")
+    === "Python"
 
-    # Save visuals per result (files saved alongside inputs)
-    r.save()  # saves annotated image(s) to disk
-    # Or display interactively (desktop environments)
-    # r.show()
-```
+        ```python
+        from ultralytics import YOLO
+
+        # Load the Axelera-compiled model (example path; same flow as ONNX)
+        model = YOLO("yolo11n_axelera.axmodel")  # will work once Axelera runtime is released
+
+        # Run inference; you can pass a file, folder, glob, or list of sources
+        results = model("path/to/images", imgsz=640, save=True)
+
+        # Iterate over result objects to inspect or render detections
+        for r in results:
+            boxes = r.boxes  # bounding boxes tensor + metadata
+            print(f"Detected {len(boxes)} objects")
+
+            # Save visuals per result (files saved alongside inputs)
+            r.save()  # saves annotated image(s) to disk
+            # Or display interactively (desktop environments)
+            # r.show()
+        ```
 
 ## Inference Performance
 

--- a/docs/en/integrations/axelera.md
+++ b/docs/en/integrations/axelera.md
@@ -104,7 +104,7 @@ Convert a YOLO11 model for Metis deployment.
 !!! example "Export to Axelera Format"
 
     !!! note "Future example — will work when runtime is released"
-    
+
         This code block demonstrates the planned flow. It will require the upcoming Axelera runtime package (ETA Q1 2026) to execute successfully.
 
     === "Python"


### PR DESCRIPTION
@ambitious-octopus @lakshanthad please update with any fixes required to our new Axelera coming soon docs page.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies that Axelera AI support is planned for Q1 2026, marking all examples as future workflow and showing how Axelera models will be used with the standard `ultralytics` API. 🚀

### 📊 Key Changes
- Updated Axelera integration banner to: **“Coming soon — Q1 2026”**, clearly stating support is not yet available.
- Added a note that Axelera support in `ultralytics` is **in progress** and that current examples are **non-runnable** until the runtime package is released.
- Clarified that **Voyager SDK runtime wheels are expected in Q1 2026**, and that installation commands reflect the **intended** future setup flow.
- Reworded export section to describe how users **will** export YOLO models to Axelera format **once** the runtime is available.
- Tagged code blocks with explicit **“Future example — will work when runtime is released”** notes, including ETA.
- Replaced low-level pseudo Axelera runtime example with a future **high-level `ultralytics.YOLO` API pattern** for loading `.axmodel` files and running inference.

### 🎯 Purpose & Impact
- 🧭 **Manages expectations:** Prevents confusion by making it clear that Axelera integration is not yet functional and is planned for Q1 2026.
- 🧪 **Avoids broken workflows:** Reduces user frustration by labeling all Axelera examples as future, so users do not treat them as currently executable.
- 🔌 **Shows future UX:** Demonstrates that Axelera-compiled models will be usable via the familiar `YOLO("model.axmodel")` flow, similar to ONNX, easing future adoption.
- 📅 **Communicates roadmap:** Gives users and partners a clear timeline (Q1 2026) for planning deployments on Axelera hardware.
- 📚 **Improves documentation clarity:** Aligns the docs with the actual development state, keeping technical content accurate and trustworthy.