### PR TITLE
Quiet git clones in Docs build

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -70,7 +70,7 @@ def prepare_docs_markdown(clone_repos: bool = True):
         repo = "https://github.com/ultralytics/hub-sdk"
         local_dir = DOCS / "repos" / Path(repo).name
         subprocess.run(
-            ["git", "clone", repo, str(local_dir), "--depth", "1", "--single-branch", "--branch", "main"], check=True
+            ["git", "clone", "-q", "--depth=1", "--single-branch", "-b", "main", repo, str(local_dir)], check=True
         )
         shutil.rmtree(DOCS / "en/hub/sdk", ignore_errors=True)  # delete if exists
         shutil.copytree(local_dir / "docs", DOCS / "en/hub/sdk")  # for docs
@@ -80,7 +80,7 @@ def prepare_docs_markdown(clone_repos: bool = True):
         repo = "https://github.com/ultralytics/docs"
         local_dir = DOCS / "repos" / Path(repo).name
         subprocess.run(
-            ["git", "clone", repo, str(local_dir), "--depth", "1", "--single-branch", "--branch", "main"], check=True
+            ["git", "clone", "-q", "--depth=1", "--single-branch", "-b", "main", repo, str(local_dir)], check=True
         )
         shutil.rmtree(DOCS / "en/compare", ignore_errors=True)  # delete if exists
         shutil.copytree(local_dir / "docs/en/compare", DOCS / "en/compare")  # for docs


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Streamlines the documentation build process by making Git clones quieter and slightly more efficient 🧹📚

### 📊 Key Changes
- Updated `git clone` commands in `docs/build_docs.py` for:
  - The `hub-sdk` repo
  - The `docs` repo
- Switched to a more conventional argument order and style:
  - Added quiet flag `-q` to suppress clone output
  - Used `--depth=1` instead of `--depth", "1"`
  - Replaced `--branch main` with `-b main`
  - Reordered arguments to `git clone -q ... repo local_dir`

### 🎯 Purpose & Impact
- 🚀 Faster, cleaner docs builds with less noisy console/CI logs
- ✅ More standard and readable `git clone` usage for maintainers
- 🧩 Reduces distraction and potential log clutter when generating or debugging documentation builds