### PR TITLE
Fix: add css rules via js to prevent chatbot screen to be appear on page load in docs pages

### DIFF
--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -159,3 +159,41 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 200);
   }
 })();
+
+//Fix chatbot window appearing glitch on page switching
+(function () {
+  const CLASS = "ult-chat-modal";   // <-- change this
+  const STYLE_ID = "temp-hide-popup-style";
+  const DURATION = 1000;             // 5 seconds
+
+  function hideTemporarily() {
+    // Remove any previous style (from previous page)
+    const old = document.getElementById(STYLE_ID);
+    if (old) old.remove();
+
+    // Create new style rule
+    const styleEl = document.createElement("style");
+    styleEl.id = STYLE_ID;
+    styleEl.textContent = `
+      .${CLASS} {
+        display: none !important;
+        visibility: hidden !important;
+      }
+    `;
+    document.documentElement.appendChild(styleEl);
+
+    
+    setTimeout(() => {
+      styleEl.remove();
+    }, DURATION);
+  }
+
+  // Initial page load
+  document.addEventListener("DOMContentLoaded", hideTemporarily);
+
+  // MkDocs Material internal navigation hook
+  if (window.document$) {
+    window.document$.subscribe(hideTemporarily);
+  }
+})();
+

--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -162,9 +162,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
 //Fix chatbot window appearing glitch on page switching
 (function () {
-  const CLASS = "ult-chat-modal";   // <-- change this
+  const CLASS = "ult-chat-modal"; // <-- change this
   const STYLE_ID = "temp-hide-popup-style";
-  const DURATION = 1000;             // 5 seconds
+  const DURATION = 1000; // 5 seconds
 
   function hideTemporarily() {
     // Remove any previous style (from previous page)
@@ -182,7 +182,6 @@ document.addEventListener("DOMContentLoaded", () => {
     `;
     document.documentElement.appendChild(styleEl);
 
-    
     setTimeout(() => {
       styleEl.remove();
     }, DURATION);
@@ -196,4 +195,3 @@ document.addEventListener("DOMContentLoaded", () => {
     window.document$.subscribe(hideTemporarily);
   }
 })();
-


### PR DESCRIPTION
Fix: add css rules via js to prevent chatbot screen to be appear on page load in docs pages

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improve docs chatbot UX by temporarily hiding the chat modal via injected CSS to prevent it flashing on page load and internal page switches.

### 📊 Key Changes
- Add an IIFE that defines a temporary CSS rule targeting the `ult-chat-modal` class.
- Dynamically inject a `<style>` element on `DOMContentLoaded` to hide the chatbot popup briefly.
- Remove any previous style element before adding a new one to avoid duplicates across page navigations.
- Hook into MkDocs Material’s `window.document$` navigation events so the same behavior applies on internal page switches.

### 🎯 Purpose & Impact
- Prevent the chatbot window from visibly flashing or glitching when docs pages load or change.
- Provide a smoother, less distracting user experience when browsing documentation.
- Keep the change scoped to CSS/JS for docs only, minimizing impact on the core Python package and models like YOLO11.
