### PR TITLE
Change `onnxruntime-gpu` download from Ultralytics assets

### DIFF
--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -221,7 +221,7 @@ You can find all available `onnxruntime-gpu` packages—organized by JetPack ver
 For **JetPack 6** with `Python 3.10` support, you can install `onnxruntime-gpu 1.23.0`:
 
 ```bash
-pip install https://pypi.jetson-ai-lab.io/jp6/cu129/+f/e1e/9e3dc2f4d5551/onnxruntime_gpu-1.23.0-cp310-cp310-linux_aarch64.whl#sha256=e1e9e3dc2f4d5551c5f0b5554cf490d141cd0d339a5a7f4826ac0e04f20a35fc
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.23.0-cp310-cp310-linux_aarch64.whl
 ```
 
 Alternatively, for `onnxruntime-gpu 1.20.0`:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the NVIDIA Jetson setup guide to use an Ultralytics-hosted download link for the JetPack 6 `onnxruntime-gpu` wheel, simplifying installation and improving reliability. 🚀

### 📊 Key Changes
- 🔗 Replaces the long, custom `pypi.jetson-ai-lab.io` URL for `onnxruntime-gpu 1.23.0` (JetPack 6, Python 3.10) with a cleaner Ultralytics GitHub asset link.
- 📄 Keeps all other Jetson installation steps and options (including the 1.20.0 option) unchanged.

### 🎯 Purpose & Impact
- ✅ Makes the installation command easier to read, copy, and use for Jetson users.
- 🛡️ Improves reliability by hosting the wheel on an official Ultralytics GitHub release asset.
- 🌍 Reduces dependency on a third-party index, lowering the chance of broken links or unavailable packages during setup.