### PR TITLE
Feature xpu

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,16 @@
+import pytest
+import torch
+from ultralytics import YOLO
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(torch, "xpu") or not torch.xpu.is_available(),
+    reason="XPU not available",
+)
+
+def test_yolo_xpu_forward():
+    model = YOLO("/root/ultralytics/yolov8n.pt")
+    model.to("xpu")
+    x = torch.rand(1, 3, 64, 64, device="xpu")
+    y = model.model(x)
+    assert y is not None
+    print("\n[XPU Test] YOLO XPU forward passed successfully ✔")

--- a/tests/xpu_test.py
+++ b/tests/xpu_test.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 def test_yolo_xpu_forward():
-    model = YOLO("/root/ultralytics/yolov8n.pt")
+    model = YOLO("/root/ultralytics/yolov11n.pt")
     model.to("xpu")
     x = torch.rand(1, 3, 64, 64, device="xpu")
     y = model.model(x)

--- a/tests/xpu_test.py
+++ b/tests/xpu_test.py
@@ -1,11 +1,13 @@
 import pytest
 import torch
+
 from ultralytics import YOLO
 
 pytestmark = pytest.mark.skipif(
     not hasattr(torch, "xpu") or not torch.xpu.is_available(),
     reason="XPU not available",
 )
+
 
 def test_yolo_xpu_forward():
     model = YOLO("/root/ultralytics/yolov11n.pt")

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -544,6 +544,10 @@ class BaseTrainer:
             memory = torch.mps.driver_allocated_memory()
             if fraction:
                 return __import__("psutil").virtual_memory().percent / 100
+        elif self.device.type != "cpu" and hasattr(torch, "xpu") and torch.xpu.is_available():
+            memory = torch.xpu.memory_allocated(self.device)
+            total = torch.xpu.get_device_properties(self.device).total_memory
+            return ((memory / total) if total > 0 else 0) if fraction else (memory / 2**30)
         elif self.device.type != "cpu":
             memory = torch.cuda.memory_reserved()
             if fraction:

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -756,6 +756,9 @@ def check_amp(model):
 
     device = next(model.parameters()).device  # get model device
     prefix = colorstr("AMP: ")
+    if hasattr(torch, "xpu") and torch.xpu.is_available() and device.type == "xpu":
+        LOGGER.warning(f"{prefix}Intel XPU detected. AMP is disabled (not supported on XPU).")
+        return False
     if device.type in {"cpu", "mps"}:
         return False  # AMP only used on CUDA devices
     else:

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -192,8 +192,8 @@ def select_device(device="", newline=False, verbose=True):
             index = None
         if index is not None:
             if verbose:
-                info = get_gpu_info(index)  
-                s += f"XPU:{index} ({info})\n"  
+                info = get_gpu_info(index)
+                s += f"XPU:{index} ({info})\n"
                 LOGGER.info(s if newline else s.rstrip())
             return torch.device("xpu", index)
     elif device:  # non-cpu device requested


### PR DESCRIPTION
 - I have read the CLA Document and I sign the CLA

 - This PR adds initial Intel XPU single-device training support to Ultralytics.
 - It is a minimal, safe, backward-compatible implementation that activates the XPU path only when the installed PyTorch build supports XPU.

# 🚀 Motivation

 - PyTorch ≥ 2.8.0 now provides official Intel XPU support.
 - Many users on Intel Arc / B60 / Flex want to train YOLO models without CUDA GPUs.

# Basic Configuration
 - Operating System：ubuntu25.04
 - Kernel：6.14.0-1006-intel
 - GPU：Blue Ocean or MaxSun B60 Pro.，
 In fact, the hardware vendor does not matter, because PyTorch is not tightly bound to the GPU model. The only real complexity is the driver installation. As long as your driver installation succeeds, everything should work normally.
 - Driver + Installation Guide：https://github.com/intel/llm-scaler/blob/main/vllm/README.md/#1-getting-started-and-usagexit
 - Driver Version：multi-arc-bmg-offline-installer-25.38.4.1

# Environment Installation
 - Install the customized PyTorch build：https://pytorch-extension.intel.com/installation
 - Install the same PyTorch version as mine:

```bash
cd ultralytics
pip install -e .
pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/xpu
# The following two are optional because multi-XPU training is not supported yet:
# pip install intel-extension-for-pytorch==2.8.10+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
# pip install oneccl_bind_pt==2.8.0+xpu --index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
````

 - Verify successful installation:

```bash
(B60) root@b60:~/ultralytics# python
Python 3.10.19 (main, Oct 21 2025, 16:43:05) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> print(torch.version.xpu)
20250101
>>> print(torch.xpu.is_available())
True
>>> print(torch.xpu.get_device_name(0))
Intel(R) Graphics [0xe211]
````
# Avoid runtime errors on environments where XPU is not supported.
 - to ensure that all XPU-specific logic is only executed when the installed PyTorch build actually supports Intel XPU.
 - If the user installs a PyTorch version without XPU support, the code will safely skip the XPU branch and fall back to existing CUDA/CPU logic without raising errors.
 - This improves compatibility across environments and prevents runtime failures on systems where torch.xpu is not compiled.
 
```python
if hasattr(torch, "xpu") and torch.xpu.is_available():
````
---

- ultralytics/ultralytics/utils/torch_utils.py/ get_gpu_info()
- Purpose: Add XPU information parsing.

```pyhton
@functools.lru_cache
def get_gpu_info(index):
    """Return a string with system GPU information, i.e. 'Tesla T4, 15102MiB'."""
    if hasattr(torch, "xpu") and torch.xpu.is_available():
        properties = torch.xpu.get_device_properties(index)
        return f"{properties.name}, {properties.total_memory / (1 << 20):.0f}MiB"
    properties = torch.cuda.get_device_properties(index)
    return f"{properties.name}, {properties.total_memory / (1 << 20):.0f}MiB"
````
 - Test Case: Same as training code
 - Result: After modification, training outputs XPU device information:
 
```bash
Ultralytics 8.3.231 🚀 Python-3.10.19 torch-2.8.0+xpu XPU:0 (Intel(R) Graphics [0xe211]
````

---

- ultralytics/ultralytics/utils/torch_utils.py/  time_sync()
- Purpose: XPU synchronization
```pyhton
def time_sync():
    """Return PyTorch-accurate time."""
    if hasattr(torch, "xpu") and torch.xpu.is_available():
            torch.xpu.synchronize()
    if torch.cuda.is_available():
        torch.cuda.synchronize()
    return time.time()
````

---

- ultralytics/ultralytics/utils/torch_utils.py/ select_device()
- XPU single-card selection support
```pyhton
    if hasattr(torch, "xpu") and torch.xpu.is_available():
        if device.startswith("xpu"):
            index = int(device.split(":")[1]) if ":" in device else 0
        elif device in {"", "0"}:
            index = 0
        else:
            index = None
        if index is not None:
            if verbose:
                info = get_gpu_info(index)  
                s += f"XPU:{index} ({info})\n"  
                LOGGER.info(s if newline else s.rstrip())
            return torch.device("xpu", index)
````

```pyhton
from ultralytics import YOLO
model = YOLO("yolo11n.yaml")
model.train(
        data="coco128.yaml",
        epochs=50,
        imgsz=256,
        #device="xpu:0"
        #device="xpu:1"
        device="xpu")
````

---

- ultralytics/ultralytics/utils/checks.py/ check_amp()
- disable AMP on XPU
```pyhton
    if hasattr(torch, "xpu") and torch.xpu.is_available() and device.type == "xpu":
        LOGGER.warning(f"{prefix}Intel XPU detected. AMP is disabled (not supported on XPU).")
        return False
````

 - Result:
```bash
WARNING ⚠️ AMP: Intel XPU detected. AMP is disabled (not supported on XPU).
````

---
     
 - ultralytics/engine/trainer.py _get_memory()
 - Purpose: Use correct memory query on XPU

```python 
    def _get_memory(self, fraction=False):
        """Get accelerator memory utilization in GB or as a fraction of total memory."""
        memory, total = 0, 0
        if self.device.type == "mps":
            memory = torch.mps.driver_allocated_memory()
            if fraction:
                return __import__("psutil").virtual_memory().percent / 100
        elif self.device.type != "cpu" and hasattr(torch, "xpu") and torch.xpu.is_available():
            memory = torch.xpu.memory_allocated(self.device)
            total = torch.xpu.get_device_properties(self.device).total_memory
            return ((memory / total) if total > 0 else 0) if fraction else (memory / 2**30)
        elif self.device.type != "cpu":
            memory = torch.cuda.memory_reserved()
            if fraction:
                total = torch.cuda.get_device_properties(self.device).total_memory
        return ((memory / total) if total > 0 else 0) if fraction else (memory / 2**30)
````


```bash
(B60) root@b60:~/ultralytics# python
Python 3.10.19 (main, Oct 21 2025, 16:43:05) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
Ctrl click to launch VS Code Native REPL
>>> import torch
>>> torch.xpu.get_device_properties(0).total_memory
24385683456
>>> x = torch.randn((1024, 1024, 256), device="xpu")
>>> torch.xpu.memory_allocated(0)
1073741824
````
> [!WARNING]
> This is a warning message — please pay attention to the explanation here.
 - However, during actual execution, when I run yolov8x with an input size of 640, the memory usage is extremely low. But I believe there is no problem with my code.
 - So I suspect the issue may not come from my implementation but from the upstream logic or the runtime environment.

```bash
Epoch    GPU_mem   box_loss   cls_loss   dfl_loss  Instances       Size
1/50      1.18G      3.651       5.77        4.3        162        640: 100% ━━━━━━━━━━━━ 8/8 3.4s/it 27.1s
Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 75% ━━━━━━━━━─── 3/4 4.0s/it 6.4s<4.0s
````

---

 - ultralytics/engine/trainer.py _clear_memory()
 - Purpose: support clear memory query on XPU

```python 
    def _clear_memory(self, threshold: float | None = None):
        """Clear accelerator memory by calling garbage collector and emptying cache."""
        if threshold:
            assert 0 <= threshold <= 1, "Threshold must be between 0 and 1."
            if self._get_memory(fraction=True) <= threshold:
                return
        gc.collect()
        if self.device.type == "mps":
            torch.mps.empty_cache()
        elif self.device.type == "cpu":
            return
        elif hasattr(torch, "xpu") and torch.xpu.is_available():
            torch.xpu.empty_cache()
        else:
            torch.cuda.empty_cache()
````

```bash
(B60) root@b60:~/ultralytics# python
Python 3.10.19 (main, Oct 21 2025, 16:43:05) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
Ctrl click to launch VS Code Native REPL
>>> import torch
>>> torch.xpu.empty_cache()
>>> 
````

---

# Test case

```bash
/root/anaconda3/envs/B60/bin/python -m pytest -s -q test.py
````

```python
import pytest
import torch
from ultralytics import YOLO

pytestmark = pytest.mark.skipif(
    not hasattr(torch, "xpu") or not torch.xpu.is_available(),
    reason="XPU not available",
)

def test_yolo_xpu_forward():
    model = YOLO("yolo11n.pt") # 填入本地的模型
    model.to("xpu")
    x = torch.rand(1, 3, 64, 64, device="xpu")
    y = model.model(x)
    assert y is not None
    print("\n[XPU Test] YOLO XPU forward passed successfully ✔")
````

 - Test case results

```bash
(B60) root@b60:~/ultralytics# /root/anaconda3/envs/B60/bin/python -m pytest -s -q test.py

[XPU Test] YOLO XPU forward passed successfully ✔
.
=============================================================== slowest 30 durations ================================================================
1.20s call     test.py::test_yolo_xpu_forward

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
1 passed in 28.89s
````    

---

 - XPU support testing
 - Create a training file in the current directory and modify the device parameter to:
   - xpu
   - xpu:0
   - xpu:1
```python
from ultralytics import YOLO
model = YOLO("yolo10n.yaml")
model.train(
        data="coco128.yaml",
        epochs=50,
        imgsz=256,
        device="xpu:0")
````

 - For long-duration stability and stress testing, I increased the training schedule to 50 epochs.

 - Unfortunately, when training entirely from scratch using the YAML configuration, the model performance is not ideal.

 - That said, I believe the ecosystem should not remain limited to a single NVIDIA GPU. Therefore, our priority should be to complete the framework-level adaptation first.
 
 - Operator-level optimization can come afterward — and at that stage, we will need stronger support and collaboration from the Intel team.

- When training using pretrained weights only, the results are noticeably better.
 
 # The following results are obtained using partially pretrained weights.
| epoch | time | train/box_loss | precision(B) | mAP50(B) | val/box_loss |
|-------|-------|----------------|---------------|-----------|---------------|
| 1  | 16.677  | 1.57275 | 0.61519 | 0.44667 | 1.1658 |
| 2  | 19.09   | 1.55932 | 0.58063 | 0.44085 | 1.17004 |
| 3  | 21.5743 | 1.58362 | 0.57267 | 0.44635 | 1.17207 |
| 4  | 23.9711 | 1.59142 | 0.55874 | 0.44612 | 1.17544 |
| 5  | 26.2329 | 1.5043  | 0.60292 | 0.44695 | 1.1745 |
| 6  | 28.9009 | 1.46778 | 0.59566 | 0.45138 | 1.17976 |
| 7  | 31.3829 | 1.48921 | 0.6531  | 0.45758 | 1.18727 |
| 8  | 33.6152 | 1.45977 | 0.65791 | 0.47068 | 1.17514 |
| 9  | 36.1311 | 1.49054 | 0.63523 | 0.47322 | 1.17033 |
| 10 | 38.761  | 1.36505 | 0.69117 | 0.47324 | 1.1707 |
| 11 | 41.2902 | 1.35502 | 0.71326 | 0.48303 | 1.16648 |
| 12 | 43.8088 | 1.3514  | 0.66831 | 0.48799 | 1.16152 |
| 13 | 46.4099 | 1.332   | 0.68353 | 0.49374 | 1.14584 |
| 14 | 48.9732 | 1.37742 | 0.71426 | 0.49713 | 1.13077 |
| 15 | 51.5884 | 1.38346 | 0.7076  | 0.49745 | 1.13032 |
| ... | ...    | ...     | ...     | ...     | ...     |
| 41 | 119.006 | 1.12213 | 0.71739 | 0.60639 | 0.99312 |
| 42 | 121.317 | 1.15439 | 0.72032 | 0.60901 | 0.99179 |
| 43 | 123.502 | 1.09189 | 0.72232 | 0.61391 | 0.98833 |
| 44 | 126.063 | 1.11224 | 0.81704 | 0.61871 | 0.98884 |
| 45 | 128.791 | 1.18574 | 0.81506 | 0.61953 | 0.99165 |
| 46 | 131.331 | 1.07524 | 0.80147 | 0.62052 | 0.99334 |
| 47 | 133.926 | 1.0565  | 0.79649 | 0.62348 | 0.99335 |
| 48 | 136.49  | 1.09021 | 0.79817 | 0.6232  | 0.99135 |
| 49 | 138.96  | 1.09611 | 0.78176 | 0.6221  | 0.99239 |
| 50 | 141.386 | 1.08103 | 0.79039 | 0.61891 | 0.99291 |
---
## ⚠️ Why this PR supports single-XPU only

- This limitation is intentional.
  - Ultralytics’ training pipeline currently assumes CUDA semantics:
  - device list comes from CUDA_VISIBLE_DEVICES
  - DDP initialization infers world_size from CUDA-style strings (“0,1,2”)
  - backend init tightly couples CUDA → NCCL
  - Multi-XPU requires:
  - backend abstraction
  - device parser refactor
  - optional oneccl initialization
  - distributed launch redesign

- To keep this PR minimal, safe and upstream-ready, only single-XPU support is implemented.

 - Multi-XPU can be added later after structural refactoring.

⸻

## ✅ Summary

# This PR provides:
 - Full single-device Intel XPU support
  - Zero regression for CUDA, CPU, and MPS
 - Correct device selection, info, sync, and memory reporting
 - Clean, minimal, backwards-compatible patch
 - Verified by both forward and long-duration training tests

# It significantly broadens Ultralytics’ ecosystem beyond CUDA-only hardware.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds initial Intel XPU device support across core utilities and testing, enabling YOLO11 models to run and be profiled on XPU hardware. 🎉

### 📊 Key Changes
- ➕ Introduces `tests/xpu_test.py` to validate a YOLO11n forward pass on XPU, conditionally skipped when XPU is unavailable.
- 🧠 Extends `Trainer._get_memory` to report memory usage and fractions for XPU devices using `torch.xpu` APIs.
- ⚠️ Updates `check_amp` to detect XPU devices and explicitly disable AMP with a clear warning, since AMP is not supported on XPU.
- 🖥️ Enhances `get_gpu_info` and `select_device` to recognize `xpu` devices, log XPU device details, and return `torch.device('xpu', index)` when requested.
- ⏱️ Updates `time_sync` to call `torch.xpu.synchronize()` when XPU is available for accurate timing on XPU devices.

### 🎯 Purpose & Impact
- 🚀 Enables running YOLO11 models on Intel XPU hardware with native device selection (`device='xpu'` / `xpu:0`) and memory reporting.
- 🧪 Adds coverage to ensure XPU inference paths remain functional as the codebase evolves.
- 🔒 Improves robustness by safely handling unsupported AMP on XPU and synchronizing XPU timelines for profiling and benchmarking.
- 💻 Broadens hardware compatibility, making Ultralytics models more accessible on Intel accelerator ecosystems.
