### PR TITLE
`ultralytics 8.3.234` Security fix: ast.literal_eval for safer evaluation of metadata strings

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.233"
+__version__ = "8.3.234"
 
 import importlib
 import os

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -606,7 +606,7 @@ class AutoBackend(nn.Module):
                 if k in {"stride", "batch", "channels"}:
                     metadata[k] = int(v)
                 elif k in {"imgsz", "names", "kpt_shape", "kpt_names", "args"} and isinstance(v, str):
-                    metadata[k] = eval(v)
+                    metadata[k] = ast.literal_eval(v)
             stride = metadata["stride"]
             task = metadata["task"]
             batch = metadata["batch"]

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1730,10 +1730,10 @@ def guess_model_task(model):
     if isinstance(model, torch.nn.Module):  # PyTorch model
         for x in "model.args", "model.model.args", "model.model.model.args":
             with contextlib.suppress(Exception):
-                return eval(x)["task"]
+                return eval(x)["task"]  # nosec B307: safe eval of known attribute paths
         for x in "model.yaml", "model.model.yaml", "model.model.model.yaml":
             with contextlib.suppress(Exception):
-                return cfg2task(eval(x))
+                return cfg2task(eval(x))  # nosec B307: safe eval of known attribute paths
         for m in model.modules():
             if isinstance(m, (Segment, YOLOESegment)):
                 return "segment"


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Small security-focused update that hardens metadata parsing and clarifies safe `eval` usage, released as version `8.3.234` 🚀

### 📊 Key Changes
- 🔐 Replaced `eval` with `ast.literal_eval` when parsing string metadata (like `imgsz`, `names`, `kpt_shape`, etc.) in `torch_to_mnn` for safer deserialization.
- ✅ Added `# nosec B307` comments to specific `eval` calls in `cfg2task` to document that they are safe uses on known attribute paths and silence security linters.
- 🔄 Bumped the library version from `8.3.233` to `8.3.234`.

### 🎯 Purpose & Impact
- 🛡️ Improves security by avoiding generic `eval` on untrusted strings in the autobackend, reducing risk of code execution via crafted metadata.
- 📏 Keeps code scanning tools (like Bandit) happy by explicitly marking vetted `eval` usages as safe and intentional.
- 📦 Provides a clean, minor version update with no expected breaking changes, so users can upgrade smoothly.