### PR TITLE
Update `Dockerfile-jetson-jetpack6` to pin `onnx<1.20.0`

### DIFF
--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -35,6 +35,7 @@ RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
 # Pip install numpy, onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files
+# Prevent onnx upgrade to 1.20.0 which has issues with tflite export on Jetson-jetpack6 environment
 RUN sed -i -e 's/"onnx>=1.12.0/"onnx>=1.12.0,<1.20.0/' pyproject.toml
 RUN python3 -m pip install --upgrade pip uv && \
     uv pip install --system \

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -35,6 +35,7 @@ RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
 # Pip install numpy, onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files
+RUN sed -i -e 's/"onnx>=1.12.0/"onnx>=1.12.0,<1.20.0/' pyproject.toml
 RUN python3 -m pip install --upgrade pip uv && \
     uv pip install --system \
     numpy==1.26.4 \


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Pins the `onnx` version below 1.20.0 in the Jetson JetPack 6 Docker image to avoid TensorFlow Lite export issues 🚀

### 📊 Key Changes
- 🧩 Updates `docker/Dockerfile-jetson-jetpack6` to modify `pyproject.toml` before installation.
- 🔒 Adds a version upper bound for `onnx` (`<1.20.0`) specifically in the Jetson JetPack 6 environment.
- 🛠 Keeps the rest of the image build process (installing `numpy`, `onnxruntime-gpu`, `torch`, `torchvision`, `ultralytics`) unchanged.

### 🎯 Purpose & Impact
- ✅ Prevents known issues with TFLite export when using `onnx` 1.20.0 on Jetson JetPack 6.
- 📦 Improves stability and reliability of model export workflows on NVIDIA Jetson devices.
- 🤝 Ensures a more consistent, reproducible environment for users deploying YOLO models on Jetson hardware.