### PR TITLE
Fix #22818: clamp DOTA OBB labels to [0,1] 

### DIFF
--- a/tests/test_split_dota.py
+++ b/tests/test_split_dota.py
@@ -1,0 +1,39 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+import cv2
+import numpy as np
+
+from ultralytics.data.split_dota import crop_and_save
+
+
+def test_crop_and_save_clips_labels(tmp_path):
+    """Ensure crop_and_save clamps normalized OBB coords into [0, 1]."""
+    # Create a dummy image
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    img_path = tmp_path / "img.jpg"
+    cv2.imwrite(str(img_path), img)
+
+    # Fake anno: one polygon that extends outside the window
+    # class_id, x1, y1, x2, y2, x3, y3, x4, y4 (absolute pixels)
+    label = np.array([[0, -10.0, 50.0, 50.0, 50.0, 120.0, 60.0, -10.0, 60.0]], dtype=np.float32)
+
+    anno = {"filepath": str(img_path), "label": label.copy(), "ori_size": (100, 100)}
+
+    # Single full-image window
+    windows = np.array([[0, 0, 100, 100]], dtype=np.int64)
+    window_objs = [label.copy()]
+
+    im_dir = tmp_path / "images"
+    lb_dir = tmp_path / "labels"
+    im_dir.mkdir()
+    lb_dir.mkdir()
+
+    crop_and_save(anno, windows, window_objs, str(im_dir), str(lb_dir))
+
+    txt_files = list(lb_dir.glob("*.txt"))
+    assert txt_files, "Expected a label file to be written"
+
+    coords = np.loadtxt(txt_files[0], ndmin=2)[:, 1:]  # drop class id
+    eps = 1e-8
+    assert coords.min() >= 0.0 - eps
+    assert coords.max() <= 1.0 + eps

--- a/ultralytics/data/split_dota.py
+++ b/ultralytics/data/split_dota.py
@@ -212,7 +212,7 @@ def crop_and_save(
             label[:, 1::2] /= pw
             label[:, 2::2] /= ph
 
-            # Clamp normalized coordinates into [0, 1] 
+            # Clamp normalized coordinates into [0, 1]
             label[:, 1::2] = np.clip(label[:, 1::2], 0.0, 1.0)
             label[:, 2::2] = np.clip(label[:, 2::2], 0.0, 1.0)
 

--- a/ultralytics/data/split_dota.py
+++ b/ultralytics/data/split_dota.py
@@ -204,10 +204,17 @@ def crop_and_save(
         if len(label) or allow_background_images:
             cv2.imwrite(str(Path(im_dir) / f"{new_name}.jpg"), patch_im)
         if len(label):
+            # Shift into the window coordinate system
             label[:, 1::2] -= x_start
             label[:, 2::2] -= y_start
+
+            # Normalize by patch size
             label[:, 1::2] /= pw
             label[:, 2::2] /= ph
+
+            # Clamp normalized coordinates into [0, 1] 
+            label[:, 1::2] = np.clip(label[:, 1::2], 0.0, 1.0)
+            label[:, 2::2] = np.clip(label[:, 2::2], 0.0, 1.0)
 
             with open(Path(lb_dir) / f"{new_name}.txt", "w", encoding="utf-8") as f:
                 for lb in label:


### PR DESCRIPTION
### Summary

This PR fixes out-of-bounds OBB label coordinates produced by the DOTA splitting pipeline when objects cross tile boundaries. These labels later trigger `non-normalized or out of bounds coordinates` warnings during training and get discarded.

* Clamps normalized OBB coordinates into the valid `[0, 1]` range in `split_dota.crop_and_save`.
* Adds a regression test to ensure labels produced by `crop_and_save` always remain within `[0, 1]`.

Fixes #22818

---

### Motivation

When following the official DOTA → YOLO OBB pipeline:

1. `convert_dota_to_yolo_obb(...)`
2. `split_trainval(...)` with multi-scale windows
3. `yolo obb train ...` / `YOLO(...).train(...)`

some polygons that cross a window boundary end up with coordinates `< 0` or `> 1` after tiling and normalization. The standard Ultralytics label checks then emit warnings like:

> ignoring corrupt image/label: non-normalized or out of bounds coordinates [...]

and those samples are dropped.

This makes the labels generated by the official DOTA helper incompatible with the model’s own validation logic and causes training to silently lose data.

---

### Changes

**1. Clamp normalized coordinates in `crop_and_save`**

In `ultralytics/data/split_dota.py`:

- After shifting into the window coordinate system and normalizing by patch width/height, the code now clamps all polygon coordinates into `[0.0, 1.0]`:

```python
# Shift into the window coordinate system
label[:, 1::2] -= x_start
label[:, 2::2] -= y_start

# Normalize by patch size
label[:, 1::2] /= pw
label[:, 2::2] /= ph

# Clamp normalized coordinates into [0, 1]
label[:, 1::2] = np.clip(label[:, 1::2], 0.0, 1.0)
label[:, 2::2] = np.clip(label[:, 2::2], 0.0, 1.0)
```

This keeps the current behavior (background tiles, label format, etc.) while ensuring all labels satisfy the YOLO `[0, 1]` range checks.

**2. Add regression test**

New test: `tests/test_split_dota.py`

* Creates a small synthetic image and an OBB polygon that partially lies outside the window.
* Calls `crop_and_save`.
* Loads the resulting label file and asserts that all normalized coordinates are within `[0, 1]` (with a small numerical tolerance).

This guards against future regressions where tiling or coordinate math might reintroduce out-of-range labels.

---

### Testing

* Ran `pytest tests/` locally.
* New `test_crop_and_save_clips_labels` passes and existing tests pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes DOTA OBB label normalization by clamping coordinates to the valid range and adds a regression test to prevent future issues.

### 📊 Key Changes
- Add `tests/test_split_dota.py` to validate that `crop_and_save` clamps normalized OBB coordinates to within `[0, 1]` for DOTA labels.
- Update `ultralytics/data/split_dota.py` `crop_and_save` to explicitly clamp normalized polygon coordinates using `np.clip` after shifting and normalization.
- Ensure written label files for OBB crops remain numerically stable even when polygons extend outside the crop window.

### 🎯 Purpose & Impact
- Prevents OBB labels from containing out-of-range normalized coordinates, which can cause training or augmentation issues.
- Improves robustness of DOTA dataset splitting and label export, especially for polygons crossing image boundaries.
- Adds a targeted regression test to guard against future regressions in DOTA OBB label handling.
