### PR TITLE
fix: 🐞 update coreml exports and executorch update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ export = [
     "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
-    "coremltools>=8.0,<10.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
+    "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ export = [
     "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
-    "coremltools>=8.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
+    "coremltools<9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ export = [
     "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
-    "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
+    "coremltools>=8.0,<10.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ export = [
     "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS
-    "coremltools<9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
+    "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools<=9.0")
+        check_requirements("coremltools>=9.0",cmds="--upgrade")
         check_requirements("numpy<2.4.0rc1")  # latest numpy 2.4.0rc1 breaks coremltools exports
 
         import coremltools as ct

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools>=8.0,<10.0",cmds="--upgrade")
+        check_requirements("coremltools>=8.0,<10.0", cmds="--upgrade")
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements(["coremltools>=9.0", "numpy<=2.3.5"])  # latest numpy 2.4.0rc1 breaks coremltools exports
+        check_requirements(["coremltools>=9.0", "numpy>=1.14.5,<=2.3.5"])  # latest numpy 2.4.0rc1 breaks coremltools exports
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,9 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements(["coremltools>=9.0", "numpy>=1.14.5,<=2.3.5"])  # latest numpy 2.4.0rc1 breaks coremltools exports
+        check_requirements(
+            ["coremltools>=9.0", "numpy>=1.14.5,<=2.3.5"]
+        )  # latest numpy 2.4.0rc1 breaks coremltools exports
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -882,16 +882,15 @@ class Exporter:
         classifier_config = None
         if self.model.task == "classify":
             classifier_config = ct.ClassifierConfig(list(self.model.names.values()))
-            source_model = torch.jit.trace(self.model.eval(), self.im, strict=False)
+            model = self.model
         elif self.model.task == "detect":
             model = IOSDetectModel(self.model, self.im, mlprogram=not mlmodel) if self.args.nms else self.model
-            source_model = torch.jit.trace(model.eval(), self.im, strict=False)
         else:
             if self.args.nms:
                 LOGGER.warning(f"{prefix} 'nms=True' is only available for Detect models like 'yolo11n.pt'.")
                 # TODO CoreML Segment and Pose model pipelining
             model = self.model
-            source_model = torch.jit.trace(model.eval(), self.im, strict=False)
+        ts = torch.jit.trace(model.eval(), self.im, strict=False)  # TorchScript model
 
         if self.args.dynamic:
             input_shape = ct.Shape(
@@ -911,12 +910,11 @@ class Exporter:
         # Setting minimum_depoloyment_target >= iOS16 will require setting compute_precision=ct.precision.FLOAT32.
         # iOS16 adds in better support for FP16, but none of the CoreML NMS specifications handle FP16 as input.
         ct_model = ct.convert(
-            source_model,
+            ts,
             inputs=inputs,
             classifier_config=classifier_config,
             convert_to="neuralnetwork" if mlmodel else "mlprogram",
         )
-
         bits, mode = (8, "kmeans") if self.args.int8 else (16, "linear") if self.args.half else (32, None)
         if bits < 32:
             if "kmeans" in mode:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -861,7 +861,7 @@ class Exporter:
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
         check_requirements("coremltools>=9.0", cmds="--upgrade")
-        check_requirements("numpy<2.4.0rc1")  # latest numpy 2.4.0rc1 breaks coremltools exports
+        check_requirements("numpy<=2.3.5")  # latest numpy 2.4.0rc1 breaks coremltools exports
 
         import coremltools as ct
 
@@ -911,7 +911,6 @@ class Exporter:
         # Internally based on the model conversion and output type.
         # Setting minimum_depoloyment_target >= iOS16 will require setting compute_precision=ct.precision.FLOAT32.
         # iOS16 adds in better support for FP16, but none of the CoreML NMS specifications handle FP16 as input.
-
         ct_model = ct.convert(
             ts,
             inputs=inputs,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        # check_requirements("coremltools>=8.0,<10.0")
+        # check_requirements("coremltools>=8.0,<10.0")
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,9 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools>=9.0", cmds="--upgrade")
-        check_requirements("numpy<=2.3.5")  # latest numpy 2.4.0rc1 breaks coremltools exports
-
+        check_requirements(["coremltools>=9.0", "numpy<=2.3.5"])  # latest numpy 2.4.0rc1 breaks coremltools exports
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        # check_requirements("coremltools>=8.0,<10.0")
+        check_requirements("coremltools>=8.0,<10.0",cmds="--upgrade")
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1091,7 +1091,7 @@ class Exporter:
         # TorchAO release compatibility table bug https://github.com/pytorch/ao/issues/2919
         # Setuptools bug: https://github.com/pypa/setuptools/issues/4483
         check_requirements("setuptools<71.0.0")  # Setuptools bug: https://github.com/pypa/setuptools/issues/4483
-        check_requirements(("executorch==1.0.0", "flatbuffers"))
+        check_requirements(("executorch==1.0.1", "flatbuffers"))
 
         import torch
         from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -861,7 +861,7 @@ class Exporter:
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
         check_requirements("coremltools<=9.0")
-        check_requirements("numpy<2.4.0rc1") # latest numpy 2.4.0rc1 breaks coremltools exports
+        check_requirements("numpy<2.4.0rc1")  # latest numpy 2.4.0rc1 breaks coremltools exports
 
         import coremltools as ct
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools>=8.0")
+        check_requirements("coremltools>=9.0")
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools>=8.0,<10.0", cmds="--upgrade")
+        check_requirements("coremltools==9.0", cmds="--upgrade")
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,9 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools==9.0", cmds="--upgrade")
+        check_requirements("coremltools<=9.0")
+        check_requirements("numpy<2.4.0rc1") # latest numpy 2.4.0rc1 breaks coremltools exports
+
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")
@@ -909,6 +911,7 @@ class Exporter:
         # Internally based on the model conversion and output type.
         # Setting minimum_depoloyment_target >= iOS16 will require setting compute_precision=ct.precision.FLOAT32.
         # iOS16 adds in better support for FP16, but none of the CoreML NMS specifications handle FP16 as input.
+
         ct_model = ct.convert(
             ts,
             inputs=inputs,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools>=9.0",cmds="--upgrade")
+        check_requirements("coremltools>=9.0", cmds="--upgrade")
         check_requirements("numpy<2.4.0rc1")  # latest numpy 2.4.0rc1 breaks coremltools exports
 
         import coremltools as ct

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools>=8.0,<10.0")
+        # check_requirements("coremltools>=8.0,<10.0")
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,7 @@ class Exporter:
     def export_coreml(self, prefix=colorstr("CoreML:")):
         """Export YOLO model to CoreML format."""
         mlmodel = self.args.format.lower() == "mlmodel"  # legacy *.mlmodel export format requested
-        check_requirements("coremltools>=9.0")
+        check_requirements("coremltools>=8.0,<10.0")
         import coremltools as ct
 
         LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -400,7 +400,7 @@ class AutoBackend(nn.Module):
 
         # CoreML
         elif coreml:
-            check_requirements("coremltools>=9.0")
+            check_requirements(["coremltools>=9.0", "numpy>=1.14.5,<=2.3.5"]) # latest numpy 2.4.0rc1 breaks coremltools exports
             LOGGER.info(f"Loading {w} for CoreML inference...")
             import coremltools as ct
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -573,7 +573,7 @@ class AutoBackend(nn.Module):
             LOGGER.info(f"Loading {w} for ExecuTorch inference...")
             # TorchAO release compatibility table bug https://github.com/pytorch/ao/issues/2919
             check_requirements("setuptools<71.0.0")  # Setuptools bug: https://github.com/pypa/setuptools/issues/4483
-            check_requirements(("executorch==1.0.0", "flatbuffers"))
+            check_requirements(("executorch==1.0.1", "flatbuffers"))
             from executorch.runtime import Runtime
 
             w = Path(w)

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -400,7 +400,9 @@ class AutoBackend(nn.Module):
 
         # CoreML
         elif coreml:
-            check_requirements(["coremltools>=9.0", "numpy>=1.14.5,<=2.3.5"]) # latest numpy 2.4.0rc1 breaks coremltools exports
+            check_requirements(
+                ["coremltools>=9.0", "numpy>=1.14.5,<=2.3.5"]
+            )  # latest numpy 2.4.0rc1 breaks coremltools exports
             LOGGER.info(f"Loading {w} for CoreML inference...")
             import coremltools as ct
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -400,7 +400,7 @@ class AutoBackend(nn.Module):
 
         # CoreML
         elif coreml:
-            check_requirements("coremltools>=9.0",cmds="--upgrade")
+            check_requirements("coremltools>=9.0", cmds="--upgrade")
             LOGGER.info(f"Loading {w} for CoreML inference...")
             import coremltools as ct
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -400,7 +400,7 @@ class AutoBackend(nn.Module):
 
         # CoreML
         elif coreml:
-            check_requirements("coremltools>=9.0")
+            check_requirements("coremltools>=8.0,<10.0")
             LOGGER.info(f"Loading {w} for CoreML inference...")
             import coremltools as ct
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -400,7 +400,7 @@ class AutoBackend(nn.Module):
 
         # CoreML
         elif coreml:
-            check_requirements("coremltools>=9.0", cmds="--upgrade")
+            check_requirements("coremltools>=9.0")
             LOGGER.info(f"Loading {w} for CoreML inference...")
             import coremltools as ct
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -400,7 +400,7 @@ class AutoBackend(nn.Module):
 
         # CoreML
         elif coreml:
-            check_requirements("coremltools>=8.0")
+            check_requirements("coremltools<9.0")
             LOGGER.info(f"Loading {w} for CoreML inference...")
             import coremltools as ct
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -400,7 +400,7 @@ class AutoBackend(nn.Module):
 
         # CoreML
         elif coreml:
-            check_requirements("coremltools>=8.0,<10.0")
+            check_requirements("coremltools>=9.0",cmds="--upgrade")
             LOGGER.info(f"Loading {w} for CoreML inference...")
             import coremltools as ct
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -400,7 +400,7 @@ class AutoBackend(nn.Module):
 
         # CoreML
         elif coreml:
-            check_requirements("coremltools<9.0")
+            check_requirements("coremltools>=9.0")
             LOGGER.info(f"Loading {w} for CoreML inference...")
             import coremltools as ct
 

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -410,7 +410,7 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         if use_uv:
             base = (
                 f"uv pip install --no-cache-dir {packages} {commands} "
-                f"--index-strategy=unsafe-best-match --break-system-packages --prerelease=allow"
+                f"--index-strategy=unsafe-best-match --break-system-packages"
             )
             try:
                 return subprocess.check_output(base, shell=True, stderr=subprocess.STDOUT, text=True)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates CoreML and ExecuTorch dependencies and tightens install behavior to improve export/inference stability and avoid breaking changes. 🚀

---

### 📊 Key Changes
- 🔁 **CoreML dependency bump**
  - Raised `coremltools` minimum version from `>=8.0` to `>=9.0` in:
    - `pyproject.toml` export extras
    - CoreML export (`export_coreml`)
    - CoreML autobackend loading (`autobackend.py`)
  - Added a **numpy version constraint** for CoreML paths: `numpy>=1.14.5,<=2.3.5` to avoid issues with `numpy 2.4.0rc1`.

- ⚙️ **ExecuTorch version upgrade**
  - Updated ExecuTorch requirement from `executorch==1.0.0` to `executorch==1.0.1` for:
    - ExecuTorch export
    - ExecuTorch inference backend

- 🔒 **uv install behavior tightened**
  - Removed `--prerelease=allow` from `uv pip install` in `attempt_install`, so prerelease packages are no longer installed automatically.

---

### 🎯 Purpose & Impact
- ✅ **More reliable CoreML exports & inference**
  - Aligns with newer `coremltools` while explicitly avoiding a known-breaking numpy prerelease.
  - Reduces unexpected export/inference failures for CoreML users on macOS and Linux.

- 🧩 **Improved ExecuTorch compatibility**
  - Ensures users get a newer, pinned ExecuTorch version (`1.0.1`), which is expected to contain fixes and compatibility improvements for ExecuTorch exports and runtime.

- 🛡️ **Safer dependency installation**
  - Prevents accidental installation of unstable prerelease packages when using `uv`, leading to more predictable and stable environments for users running YOLO models.