### PR TITLE
`ultralytics 8.3.235` Remove `torch 2.8.0` pin for Sony IMX export

### DIFF
--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -15,8 +15,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install export dependencies and run exports to AutoInstall packages
-# Prevent torch upgrade to 2.9.0 which has issues with imx export
-RUN sed -i -e 's/"torch>=1.8.0/"torch>=1.8.0,<=2.8.0/' pyproject.toml
 RUN uv pip install --system -e ".[export]" && \
     # Need lower version of 'numpy' for Sony IMX export
     uv pip install --system numpy==1.26.4 && \

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.234"
+__version__ = "8.3.235"
 
 import importlib
 import os


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Python export Docker image to allow newer PyTorch versions and bumps the Ultralytics package version. 🚀

### 📊 Key Changes
- 🐍 **Docker export image**: Removed the manual edit that pinned `torch` to `<=2.8.0` in `pyproject.toml`, so export builds now respect the standard PyTorch version constraints.
- 📦 **Dependencies**: Kept explicit `numpy==1.26.4` install for Sony IMX export compatibility.
- 🔖 **Version bump**: Updated `__version__` from `8.3.234` to `8.3.235`.

### 🎯 Purpose & Impact
- ✅ **Better compatibility with newer PyTorch**: Allows using newer `torch` releases (including 2.9.0+) in export images, which can bring performance improvements and bug fixes.
- 🧩 **Maintains IMX stability**: Retains the known-good `numpy` version for Sony IMX exports, reducing risk of breaking existing workflows.
- 📦 **Clear release tracking**: Version bump signals the change in Docker/export behavior for users and downstream integrations.