### PR TITLE
Fix bbox & clipping for contours

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -252,9 +252,9 @@ class Compose:
         """
         assert isinstance(index, (int, list)), f"The indices should be either list or int type but got {type(index)}"
         if isinstance(index, list):
-            assert isinstance(
-                value, list
-            ), f"The indices should be the same type as values, but got {type(index)} and {type(value)}"
+            assert isinstance(value, list), (
+                f"The indices should be the same type as values, but got {type(index)} and {type(value)}"
+            )
         if isinstance(index, int):
             index, value = [index], [value]
         for i, v in zip(index, value):

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -252,9 +252,9 @@ class Compose:
         """
         assert isinstance(index, (int, list)), f"The indices should be either list or int type but got {type(index)}"
         if isinstance(index, list):
-            assert isinstance(value, list), (
-                f"The indices should be the same type as values, but got {type(index)} and {type(value)}"
-            )
+            assert isinstance(
+                value, list
+            ), f"The indices should be the same type as values, but got {type(index)} and {type(value)}"
         if isinstance(index, int):
             index, value = [index], [value]
         for i, v in zip(index, value):
@@ -1182,8 +1182,6 @@ class RandomPerspective:
         xy = xy[:, :2] / xy[:, 2:3]
         segments = xy.reshape(n, -1, 2)
         bboxes = np.stack([segment2box(xy, self.size[0], self.size[1]) for xy in segments], 0)
-        segments[..., 0] = segments[..., 0].clip(bboxes[:, 0:1], bboxes[:, 2:3])
-        segments[..., 1] = segments[..., 1].clip(bboxes[:, 1:2], bboxes[:, 3:4])
         return bboxes, segments
 
     def apply_keypoints(self, keypoints: np.ndarray, M: np.ndarray) -> np.ndarray:

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -386,8 +386,6 @@ class Instances:
         self.bboxes[:, [1, 3]] = self.bboxes[:, [1, 3]].clip(0, h)
         if ori_format != "xyxy":
             self.convert_bbox(format=ori_format)
-        self.segments[..., 0] = self.segments[..., 0].clip(0, w)
-        self.segments[..., 1] = self.segments[..., 1].clip(0, h)
         if self.keypoints is not None:
             # Set out of bounds visibility to zero
             self.keypoints[..., 2][

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -85,13 +85,6 @@ def segment2box(segment, width: int = 640, height: int = 640):
         (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
     """
     x, y = segment.T  # segment xy
-    # Clip coordinates if 3 out of 4 sides are outside the image
-    if np.array([x.min() < 0, y.min() < 0, x.max() > width, y.max() > height]).sum() >= 3:
-        x = x.clip(0, width)
-        y = y.clip(0, height)
-    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
-    x = x[inside]
-    y = y[inside]
     return (
         np.array([x.min(), y.min(), x.max(), y.max()], dtype=segment.dtype)
         if any(x)


### PR DESCRIPTION
Application of `RandomPerspective` was breaking the segmentation in a few examples.

Because:
1. The old implementation **only** clipped points of the contour *if at least 3 sides fall outside image bounds*, which was added in https://github.com/ultralytics/ultralytics/pull/18294	
2. The points of the contour are clipped, when in fact this changes the shape of the mask 

Fix:
1. Use all contour points in `segment2box`, preventing some from being ignored in bounding-box computation
2. Remove polygon clipping to the bounding box - this way, `cv2.fillPoly` will handle out-of-bounds points by itself

With the new changes it works

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refines how segmentation contours are converted to bounding boxes by removing aggressive clipping logic, ensuring more accurate boxes and segment coordinates.

### 📊 Key Changes
- Removed post-processing clipping of segment coordinates to their corresponding bounding boxes in `apply_segments`.
- Removed contour point clipping and inside-image filtering logic from `segment2box`, now computing boxes directly from the original segment coordinates.
- Simplified the bounding box computation path for segments, reducing hidden coordinate alterations during augmentation.

### 🎯 Purpose & Impact
- Improves consistency between stored segment coordinates and their derived bounding boxes.
- Prevents unexpected contour distortion from over-aggressive clipping, especially for segments partially or mostly outside the image.
- Leads to more predictable augmentation behavior for segmentation tasks, which can improve training stability and debugging clarity.
