### PR TITLE
Refactor language switcher link handling

### DIFF
--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -80,10 +80,8 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 // Ultralytics Chat Widget ---------------------------------------------------------------------------------------------
-let ultralyticsChat = null;
-
 document.addEventListener("DOMContentLoaded", () => {
-  ultralyticsChat = new UltralyticsChat({
+  new UltralyticsChat({
     welcome: {
       title: "Hello 👋",
       message: "Ask about YOLO, tutorials, training, export, deployment, or troubleshooting.",
@@ -136,40 +134,28 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 });
 
-// Fix language switcher links
+// Fix language switcher links to preserve current page path, query string, and hash
 (() => {
   function fixLanguageLinks() {
     const path = location.pathname;
-    const links = document.querySelectorAll(".md-select__link");
-    if (!links.length) {
-      return;
-    }
+    const links = document.querySelectorAll(".md-select__link[hreflang]");
+    if (!links.length) return;
 
-    const langs = [];
-    let defaultLink = null;
+    // Derive language codes from the actual links (config-driven)
+    const langCodes = Array.from(links)
+      .map((link) => link.getAttribute("hreflang"))
+      .filter(Boolean);
+    const defaultLang =
+      Array.from(links)
+        .find((link) => link.getAttribute("href") === "/")
+        ?.getAttribute("hreflang") || "en";
 
-    // Extract language codes
-    links.forEach((link) => {
-      const href = link.getAttribute("href");
-      if (!href) {
-        return;
-      }
-
-      const url = new URL(href, location.origin);
-      const match = url.pathname.match(/^\/([a-z]{2})\/?$/);
-
-      if (match) {
-        langs.push({ code: match[1], link });
-      } else if (url.pathname === "/" || url.pathname === "") {
-        defaultLink = link;
-      }
-    });
-
-    // Find current language and extract base path (without leading slash)
+    // Extract base path (without leading slash and language prefix)
     let basePath = path.startsWith("/") ? path.slice(1) : path;
-    for (const lang of langs) {
-      const prefix = `${lang.code}/`;
-      if (basePath === lang.code || basePath === prefix) {
+    for (const code of langCodes) {
+      if (code === defaultLang) continue;
+      const prefix = `${code}/`;
+      if (basePath === code || basePath === prefix) {
         basePath = "";
         break;
       }
@@ -179,28 +165,23 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     }
 
-    // Update links
-    langs.forEach((lang) => {
-      lang.link.href = `${location.origin}/${lang.code}/${basePath}`;
+    // Preserve query string and hash
+    const suffix = location.search + location.hash;
+
+    // Update all language links
+    links.forEach((link) => {
+      const lang = link.getAttribute("hreflang");
+      link.href =
+        lang === defaultLang
+          ? `${location.origin}/${basePath}${suffix}`
+          : `${location.origin}/${lang}/${basePath}${suffix}`;
     });
-    if (defaultLink) {
-      defaultLink.href = `${location.origin}/${basePath}`;
-    }
   }
 
-  // Run immediately
+  // Run on load and navigation
   fixLanguageLinks();
 
-  // Handle SPA navigation
   if (typeof document$ !== "undefined") {
     document$.subscribe(() => setTimeout(fixLanguageLinks, 50));
-  } else {
-    let lastPath = location.pathname;
-    setInterval(() => {
-      if (location.pathname !== lastPath) {
-        lastPath = location.pathname;
-        setTimeout(fixLanguageLinks, 50);
-      }
-    }, 200);
   }
 })();


### PR DESCRIPTION
Refactor language switcher links to preserve current page path, query string, and hash. Simplify language extraction and update logic.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the docs site language switcher so it keeps your current page (including query and hash) when changing languages, and simplifies the chat widget initialization. 🌐💬

---

### 📊 Key Changes
- 💬 **Chat widget initialization simplified**
  - Removed the global `ultralyticsChat` variable.
  - Now directly instantiates `new UltralyticsChat({...})` on `DOMContentLoaded`.

- 🌍 **Language switcher logic rewritten**
  - Targets only language links using the `hreflang` attribute.
  - Automatically derives available language codes from the actual links.
  - Determines the default language from the link whose `href` is `/`, falling back to `"en"` if needed.
  - Correctly strips language prefixes from the current path to get a shared base path.
  - Preserves **current path, query string, and hash** when switching languages.
  - Simplifies SPA navigation handling by relying on `document$` (MkDocs) and removing the manual `setInterval` path watcher.

---

### 🎯 Purpose & Impact
- ✅ **More reliable language switching**
  - Users stay on the *same* page (including filters, tabs, or anchors in the URL) when changing language, improving UX for multilingual docs.

- 🔗 **Better URL consistency**
  - Query parameters and hash fragments are preserved, avoiding loss of state (for example, section anchors or search parameters).

- 🧹 **Cleaner, more maintainable code**
  - Logic is now configuration-driven (using `hreflang`), easier to align with docs config, and avoids unnecessary global variables and polling timers.

- ⚙️ **Fewer edge-case bugs**
  - More robust handling of default vs. non-default languages reduces chances of broken or incorrect language links across the docs site.