### PR TITLE
Update IMX and Edge TPU exports with `check_apt_requirements` function

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1222,7 +1222,7 @@ class Exporter:
                 f'echo "deb [signed-by=/etc/apt/keyrings/google.gpg] https://packages.cloud.google.com/apt coral-edgetpu-stable main" | {sudo}tee /etc/apt/sources.list.d/coral-edgetpu.list',
             ):
                 subprocess.run(c, shell=True, check=True)
-            check_apt_requirements("edgetpu-compiler")
+            check_apt_requirements(["edgetpu-compiler"])
 
         ver = subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().rsplit(maxsplit=1)[-1]
         LOGGER.info(f"\n{prefix} starting export with Edge TPU compiler {ver}...")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1220,6 +1220,7 @@ class Exporter:
                 f"{sudo}mkdir -p /etc/apt/keyrings",
                 f"curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | {sudo}gpg --dearmor -o /etc/apt/keyrings/google.gpg",
                 f'echo "deb [signed-by=/etc/apt/keyrings/google.gpg] https://packages.cloud.google.com/apt coral-edgetpu-stable main" | {sudo}tee /etc/apt/sources.list.d/coral-edgetpu.list',
+                f"{sudo}apt-get update",
             ):
                 subprocess.run(c, shell=True, check=True)
             check_apt_requirements(["edgetpu-compiler"])

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1220,7 +1220,6 @@ class Exporter:
                 f"{sudo}mkdir -p /etc/apt/keyrings",
                 f"curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | {sudo}gpg --dearmor -o /etc/apt/keyrings/google.gpg",
                 f'echo "deb [signed-by=/etc/apt/keyrings/google.gpg] https://packages.cloud.google.com/apt coral-edgetpu-stable main" | {sudo}tee /etc/apt/sources.list.d/coral-edgetpu.list',
-                f"{sudo}apt-get update",
             ):
                 subprocess.run(c, shell=True, check=True)
             check_apt_requirements(["edgetpu-compiler"])

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1299,17 +1299,13 @@ class Exporter:
             version_match = re.search(r"(?:openjdk|java) (\d+)", java_output)
             java_version = int(version_match.group(1)) if version_match else 0
             assert java_version >= 17, "Java version too old"
-        except (FileNotFoundError, subprocess.CalledProcessError, AssertionError):           
+        except (FileNotFoundError, subprocess.CalledProcessError, AssertionError):
             if IS_UBUNTU or IS_DEBIAN_TRIXIE:
                 LOGGER.info(f"\n{prefix} installing Java 21 for Ubuntu...")
-                check_apt_requirements(
-                ["openjdk-21-jre"]
-                )
+                check_apt_requirements(["openjdk-21-jre"])
             elif IS_RASPBERRYPI or IS_DEBIAN_BOOKWORM:
                 LOGGER.info(f"\n{prefix} installing Java 17 for Raspberry Pi or Debian ...")
-                check_apt_requirements(
-                ["openjdk-17-jre"]
-                )
+                check_apt_requirements(["openjdk-17-jre"])
 
         return torch2imx(
             self.model,

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -379,8 +379,8 @@ def check_apt_requirements(requirements):
             f"{prefix} Ultralytics requirement{'s' * (len(missing_packages) > 1)} {missing_packages} not found, attempting AutoUpdate..."
         )
         # Optionally update package list first
-        if is_sudo_available():
-            subprocess.run(["sudo", "apt", "update"], check=False)
+        cmd = (["sudo"] if is_sudo_available() else []) + ["apt", "update"]
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
 
         # Build and run the install command
         cmd = (["sudo"] if is_sudo_available() else []) + ["apt", "install", "-y"] + missing_packages


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Linux dependency auto-install for Edge TPU and IMX exports by standardizing on `check_apt_requirements()` and making `apt update` stricter ✅🐧

### 📊 Key Changes
- 🔧 **Edge TPU export (`export_edgetpu`)**: removed hardcoded `apt-get update/install` shell commands and now uses `check_apt_requirements(["edgetpu-compiler"])` for installation.
- ☕ **IMX export (`export_imx`)**: replaced manual Java install logic (`subprocess.run(["apt-get", "install", ...])`) with `check_apt_requirements()` for:
  - `openjdk-21-jre` on Ubuntu / Debian Trixie
  - `openjdk-17-jre` on Raspberry Pi / Debian Bookworm
- 🧰 **`check_apt_requirements()` behavior**: changes `apt update` to run with `check=True` and captures output, making update failures explicit rather than silently ignored.

### 🎯 Purpose & Impact
- ✅ **More consistent installs**: all apt-based dependencies now go through one shared helper, reducing duplicated logic and edge-case differences.
- 🚀 **More reliable exports** (Edge TPU + IMX): users are less likely to hit missing-compiler/Java issues during export because installs follow a unified path.
- 🧯 **Faster failure when apt is broken**: if `apt update` fails (network/proxy/repos), exports will error sooner and more clearly instead of proceeding in a half-updated state.