### PR TITLE
Auto-install SAM3 tokenizer dependencies

### DIFF
--- a/ultralytics/models/sam/sam3/tokenizer_ve.py
+++ b/ultralytics/models/sam/sam3/tokenizer_ve.py
@@ -18,10 +18,19 @@ import os
 import string
 from functools import lru_cache
 
-import ftfy
-import regex as re
 import torch
-from iopath.common.file_io import g_pathmgr
+
+from ultralytics.utils import checks
+
+try:
+    import ftfy
+    import regex as re
+    from iopath.common.file_io import g_pathmgr
+except ImportError:
+    checks.check_requirements(["ftfy", "regex", "iopath"])
+    import ftfy
+    import regex as re
+    from iopath.common.file_io import g_pathmgr
 
 
 @lru_cache


### PR DESCRIPTION
Add auto-installation for SAM3 tokenizer dependencies (`ftfy`, `regex`, `iopath`) when not available.

- Wrap imports in try/except block with `checks.check_requirements()` fallback in [tokenizer_ve.py:21-32](ultralytics/models/sam/sam3/tokenizer_ve.py#L21-L32)

Fixes `ModuleNotFoundError` when using SAM3:

```python
from ultralytics.models.sam.predict import SAM3SemanticPredictor
predictor = SAM3SemanticPredictor(overrides=dict(model='sam3.pt'), bpe_path='bpe_simple_vocab_16e6.txt.gz')
# Previously raised: ModuleNotFoundError: No module named 'ftfy'
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves SAM3 tokenizer imports by auto-checking and prompting installation of missing optional dependencies 🧩✅

### 📊 Key Changes
- Wrapped `ftfy`, `regex`, and `iopath` imports in a `try/except ImportError` block.
- Added `ultralytics.utils.checks` usage to call `checks.check_requirements(["ftfy", "regex", "iopath"])` when dependencies are missing.
- Ensures `g_pathmgr` is imported only after requirements are verified.

### 🎯 Purpose & Impact
- Reduces “module not found” crashes when using SAM3 by providing a clearer, guided dependency setup 🛠️
- Makes the SAM3 tokenizer more robust in minimal/custom environments (e.g., fresh installs, slim containers) 📦
- Improves user experience with consistent Ultralytics-style dependency checks and actionable install prompts 🚀