### PR TITLE
Update import path for `SAM3VideoSemanticPredictor`

### DIFF
--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -281,7 +281,7 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
     === "Python"
 
         ```python
-        from ultralytics.models.sam.sam3_video_model import SAM3VideoSemanticPredictor
+        from ultralytics.models.sam import SAM3VideoSemanticPredictor
 
         # Initialize semantic video predictor
         overrides = dict(conf=0.25, task="segment", mode="predict", imgsz=640, model="sam3.pt", half=True)


### PR DESCRIPTION
@glenn-jocher @Laughing-q FYI. Thank you.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the SAM 3 docs to use the new, simplified import path for the semantic video predictor 📦✨

### 📊 Key Changes
- Updated Python example import in `docs/en/models/sam-3.md`:
  - From `from ultralytics.models.sam.sam3_video_model import SAM3VideoSemanticPredictor`
  - To `from ultralytics.models.sam import SAM3VideoSemanticPredictor` ✅

### 🎯 Purpose & Impact
- Makes documentation match the public/official API surface, reducing confusion for users following the guide 🧭
- Improves usability by encouraging a cleaner, more stable import path (less likely to break if internal module layout changes) 🛠️
- Helps users avoid import errors when `SAM3VideoSemanticPredictor` is re-exported through `ultralytics.models.sam` 🔧