### PR TITLE
Fix SAM3SemanticPredictor feature cache mutation when batching prompts

### DIFF
--- a/ultralytics/models/sam/sam3/sam3_image.py
+++ b/ultralytics/models/sam/sam3/sam3_image.py
@@ -96,11 +96,12 @@ class SAM3SemanticModel(torch.nn.Module):
     def _prepare_backbone_features(self, backbone_out, num_prompts=1):
         """Prepare and flatten visual features from the image backbone output for further processing."""
         if num_prompts > 1:  # expand features if there's more than one prompt
-            for i, feat in enumerate(backbone_out["backbone_fpn"]):
-                backbone_out["backbone_fpn"][i] = feat.expand(num_prompts, -1, -1, -1)
-            for i, pos in enumerate(backbone_out["vision_pos_enc"]):
-                pos = pos.expand(num_prompts, -1, -1, -1)
-                backbone_out["vision_pos_enc"][i] = pos
+            # Create a shallow copy to avoid modifying the original cached features
+            backbone_out = {
+                **backbone_out,
+                "backbone_fpn": [feat.expand(num_prompts, -1, -1, -1) for feat in backbone_out["backbone_fpn"]],
+                "vision_pos_enc": [pos.expand(num_prompts, -1, -1, -1) for pos in backbone_out["vision_pos_enc"]],
+            }
         assert len(backbone_out["backbone_fpn"]) == len(backbone_out["vision_pos_enc"])
         assert len(backbone_out["backbone_fpn"]) >= self.num_feature_levels
 


### PR DESCRIPTION
## Summary
This PR fixes a cache pollution issue in `SAM3SemanticPredictor` where running inference multiple times on the same encoded image with different numbers of text prompts could crash with a batch/shape mismatch.

The root cause was an in-place `expand()` on cached backbone outputs inside `_prepare_backbone_features`, which mutated the cached feature dict (typically `self.features`) based on the previous prompt count.

## Related Issues / PRs
- Fixes: N/A (no existing issue found)
- Related: N/A
- Note: I searched existing PRs/issues for `SAM3SemanticPredictor`, `_prepare_backbone_features`, and cache/in-place expand related keywords, but did not find a prior report.

## Motivation
SAM is designed for "encode once, query multiple times". However, with the current behavior, users must call `reset_image()` + `set_image()` whenever the number of prompts changes, otherwise inference may fail. This breaks the intended workflow and significantly impacts efficiency.

## Reproduction
```python
from ultralytics.models.sam.predict import SAM3SemanticPredictor

# Initialize predictor with configuration
overrides = dict(
    conf=0.25,
    task="segment",
    mode="predict",
    model="sam3.pt",
    half=True,  # Use FP16 for faster inference
)
predictor = SAM3SemanticPredictor(
    overrides=overrides,
    bpe_path="path/to/bpe_simple_vocab_16e6.txt.gz",  # Required for text encoding
)

# Set image once for multiple queries
predictor.set_image("path/to/image.jpg")

# Query with multiple text prompts
results = predictor(text=["person", "bus", "glasses"], save=True) # OK (3 prompts)

# Works with descriptive phrases
results = predictor(text=["person with red cloth", "person with blue cloth"], save=True) # ERROR before this PR (2 prompts)

# Query with a single concept
results = predictor(text=["a person"], save=True)
```
## Root Cause

When `num_prompts > 1`, `_prepare_backbone_features` expanded tensors along the batch dimension by overwriting elements of:

* `backbone_out["backbone_fpn"]`
* `backbone_out["vision_pos_enc"]`

If `backbone_out` references the cached features dict (e.g., `self.features`), this in-place expansion mutates the cache. Subsequent calls with a different `num_prompts` then hit a batch/shape mismatch because the cached tensors no longer have the original single-image batch shape.

## Fix

When `num_prompts > 1`, this PR avoids mutating the input dict by constructing a new mapping and replacing:

* `backbone_fpn` with a new list of expanded tensor *views*
* `vision_pos_enc` with a new list of expanded tensor *views*

This keeps the original cached features intact while still supporting batched prompt inference. No tensor cloning is introduced; `expand()` is still used (views), but without in-place cache mutation.

## Scope of Change

* File: `ultralytics/models/sam/sam3/sam3_image.py`
* Function: `_prepare_backbone_features`
* No API changes
* Behavior unchanged for `num_prompts=1`; only avoids in-place cache mutation when `num_prompts > 1`

## Testing

Environment:

* OS: Ubuntu 22.04
* Python: 3.12
* PyTorch: 2.8.0
* CUDA: 12.8

Test plan:

* Called `set_image()` once and ran consecutive inferences with different numbers of text prompts.
* Before this change: the second call fails with a batch/shape mismatch when the prompt count differs.
* After this change: the same sequence succeeds without needing `reset_image()` / `set_image()`.

Repro snippet:

```python
predictor.set_image(img)
predictor(text=["boy", "girl", "window"])  # OK

predictor(text=["person", "car"])          # used to error; now OK
```

## Checklist

* [√] I confirmed the repro case above fails on `main` and passes with this patch.
* [√] I verified there are no functional changes for the single-prompt path (`num_prompts=1`).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a bug in SAM3SemanticPredictor where expanding backbone features for batched prompts accidentally mutated cached features. 🐛➡️✅

### 📊 Key Changes
- Refactors `_prepare_backbone_features()` to avoid in-place edits of `backbone_out` when `num_prompts > 1`
- Creates a shallow copy of `backbone_out` and rebuilds expanded `backbone_fpn` and `vision_pos_enc` lists via comprehensions
- Preserves original cached backbone outputs while still supporting prompt batching

### 🎯 Purpose & Impact
- Prevents subtle cache corruption when the same image features are reused across multiple prompt batches
- Improves correctness and reproducibility for SAM3 semantic prediction workflows that rely on feature caching
- Reduces risk of hard-to-debug downstream issues caused by unintended shared-state mutation