### PR TITLE
Use FP32 ONNX model for TFLite export

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1074,7 +1074,7 @@ class Exporter:
             self.args.opset = self.args.opset or 19
             assert 16 <= self.args.opset <= 19, "RTDETR export requires opset>=16;<=19"
         self.args.simplify = True
-        self.args.half = False
+        self.args.half = self.args.format == "tflite"
         f_onnx = self.export_onnx()  # ensure ONNX is available
         keras_model = onnx2saved_model(
             f_onnx,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -719,7 +719,7 @@ class Exporter:
             model_onnx.ir_version = 10
 
         # FP16 conversion for CPU export (GPU exports are already FP16 from model.half() during tracing)
-        if self.args.half and seld.args.format == "onnx" and self.device.type == "cpu":
+        if self.args.half and self.args.format == "onnx" and self.device.type == "cpu":
             try:
                 from onnxruntime.transformers import float16
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1074,6 +1074,7 @@ class Exporter:
             self.args.opset = self.args.opset or 19
             assert 16 <= self.args.opset <= 19, "RTDETR export requires opset>=16;<=19"
         self.args.simplify = True
+        self.args.half = False
         f_onnx = self.export_onnx()  # ensure ONNX is available
         keras_model = onnx2saved_model(
             f_onnx,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -719,7 +719,7 @@ class Exporter:
             model_onnx.ir_version = 10
 
         # FP16 conversion for CPU export (GPU exports are already FP16 from model.half() during tracing)
-        if self.args.half and self.device.type == "cpu":
+        if self.args.half and seld.args.format == "onnx" and self.device.type == "cpu":
             try:
                 from onnxruntime.transformers import float16
 
@@ -1074,7 +1074,6 @@ class Exporter:
             self.args.opset = self.args.opset or 19
             assert 16 <= self.args.opset <= 19, "RTDETR export requires opset>=16;<=19"
         self.args.simplify = True
-        self.args.half = self.args.format != "tflite"
         f_onnx = self.export_onnx()  # ensure ONNX is available
         keras_model = onnx2saved_model(
             f_onnx,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1074,7 +1074,7 @@ class Exporter:
             self.args.opset = self.args.opset or 19
             assert 16 <= self.args.opset <= 19, "RTDETR export requires opset>=16;<=19"
         self.args.simplify = True
-        self.args.half = self.args.format == "tflite"
+        self.args.half = self.args.format != "tflite"
         f_onnx = self.export_onnx()  # ensure ONNX is available
         keras_model = onnx2saved_model(
             f_onnx,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a float16 conversion path so it only runs for **CPU ONNX exports**, avoiding unintended behavior in other export formats 🛠️✅

### 📊 Key Changes
- Restricts the **FP16 conversion step** (`onnxruntime.transformers.float16`) to run **only when**:
  - `--half` is enabled
  - export `--format` is explicitly `onnx`
  - the export device is `cpu`
- Previously, the conversion could trigger on **CPU exports even when the format wasn’t ONNX**, which could cause unnecessary imports or errors ⚠️

### 🎯 Purpose & Impact
- Prevents **unexpected failures** (e.g., missing `onnxruntime.transformers`) when exporting non-ONNX formats on CPU with `--half` 🧯
- Keeps the exporter behavior **more predictable and format-correct**, reducing confusion for users exporting to TorchScript/CoreML/etc. 🎯
- Improves overall **export reliability** by ensuring ONNX-specific logic only runs in the ONNX export path 🚀