### PR TITLE
Refactor SAM backbone output and remove duplication

### DIFF
--- a/ultralytics/models/sam/modules/sam.py
+++ b/ultralytics/models/sam/modules/sam.py
@@ -607,8 +607,14 @@ class SAM2Model(torch.nn.Module):
             backbone_out["backbone_fpn"][1] = self.sam_mask_decoder.conv_s1(backbone_out["backbone_fpn"][1])
         return backbone_out
 
-    def _prepare_backbone_features(self, backbone_out):
+    def _prepare_backbone_features(self, backbone_out, batch=1):
         """Prepare and flatten visual features from the image backbone output for further processing."""
+        if batch > 1:  # expand features if there's more than one prompt
+            backbone_out = {
+                **backbone_out,
+                "backbone_fpn": [feat.expand(batch, -1, -1, -1) for feat in backbone_out["backbone_fpn"]],
+                "vision_pos_enc": [pos.expand(batch, -1, -1, -1) for pos in backbone_out["vision_pos_enc"]],
+            }
         assert len(backbone_out["backbone_fpn"]) == len(backbone_out["vision_pos_enc"])
         assert len(backbone_out["backbone_fpn"]) >= self.num_feature_levels
 
@@ -619,7 +625,6 @@ class SAM2Model(torch.nn.Module):
         # flatten NxCxHxW to HWxNxC
         vision_feats = [x.flatten(2).permute(2, 0, 1) for x in feature_maps]
         vision_pos_embeds = [x.flatten(2).permute(2, 0, 1) for x in vision_pos_embeds]
-
         return backbone_out, vision_feats, vision_pos_embeds, feat_sizes
 
     def _prepare_memory_conditioned_features(

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -1247,7 +1247,9 @@ class SAM2VideoPredictor(SAM2Predictor):
             - The method leverages the model's `_prepare_backbone_features` method to prepare the backbone features.
         """
         # check if there's cached backbone output
-        backbone_out = getattr(self, "backbone_out", self.model.forward_image(im))
+        backbone_out = getattr(self, "backbone_out", None)
+        if backbone_out is None:
+            backbone_out = self.model.forward_image(im)
         if batch > 1:  # expand features if there's more than one prompt
             backbone_out = {
                 **backbone_out,

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -1246,17 +1246,8 @@ class SAM2VideoPredictor(SAM2Predictor):
             - If `batch` is greater than 1, the features are expanded to fit the batch size.
             - The method leverages the model's `_prepare_backbone_features` method to prepare the backbone features.
         """
-        # check if there's cached backbone output
-        backbone_out = getattr(self, "backbone_out", None)
-        if backbone_out is None:
-            backbone_out = self.model.forward_image(im)
-        if batch > 1:  # expand features if there's more than one prompt
-            backbone_out = {
-                **backbone_out,
-                "backbone_fpn": [feat.expand(batch, -1, -1, -1) for feat in backbone_out["backbone_fpn"]],
-                "vision_pos_enc": [pos.expand(batch, -1, -1, -1) for pos in backbone_out["vision_pos_enc"]],
-            }
-        _, vis_feats, vis_pos_embed, feat_sizes = self.model._prepare_backbone_features(backbone_out)
+        backbone_out = self.model.forward_image(im)
+        _, vis_feats, vis_pos_embed, feat_sizes = self.model._prepare_backbone_features(backbone_out, batch=batch)
         return vis_feats, vis_pos_embed, feat_sizes
 
     def _obj_id_to_idx(self, obj_id, inference_state: dict[str, Any] | None = None):

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -1246,7 +1246,10 @@ class SAM2VideoPredictor(SAM2Predictor):
             - If `batch` is greater than 1, the features are expanded to fit the batch size.
             - The method leverages the model's `_prepare_backbone_features` method to prepare the backbone features.
         """
-        backbone_out = self.model.forward_image(im)
+        # check if there's precomputed backbone output
+        backbone_out = getattr(self, "backbone_out", None)
+        if backbone_out is None:
+            backbone_out = self.model.forward_image(im)
         _, vis_feats, vis_pos_embed, feat_sizes = self.model._prepare_backbone_features(backbone_out, batch=batch)
         return vis_feats, vis_pos_embed, feat_sizes
 

--- a/ultralytics/models/sam/sam3/sam3_image.py
+++ b/ultralytics/models/sam/sam3/sam3_image.py
@@ -10,8 +10,8 @@ import torch
 
 from ultralytics.nn.modules.utils import inverse_sigmoid
 from ultralytics.utils.ops import xywh2xyxy
-from ..modules.sam import SAM2Model
 
+from ..modules.sam import SAM2Model
 from .geometry_encoders import Prompt
 from .vl_combiner import SAM3VLBackbone
 

--- a/ultralytics/models/sam/sam3/sam3_image.py
+++ b/ultralytics/models/sam/sam3/sam3_image.py
@@ -10,6 +10,7 @@ import torch
 
 from ultralytics.nn.modules.utils import inverse_sigmoid
 from ultralytics.utils.ops import xywh2xyxy
+from ..modules.sam import SAM2Model
 
 from .geometry_encoders import Prompt
 from .vl_combiner import SAM3VLBackbone
@@ -92,26 +93,6 @@ class SAM3SemanticModel(torch.nn.Module):
 
         self.text_embeddings = {}
         self.names = []
-
-    def _prepare_backbone_features(self, backbone_out, num_prompts=1):
-        """Prepare and flatten visual features from the image backbone output for further processing."""
-        if num_prompts > 1:  # expand features if there's more than one prompt
-            # Create a shallow copy to avoid modifying the original cached features
-            backbone_out = {
-                **backbone_out,
-                "backbone_fpn": [feat.expand(num_prompts, -1, -1, -1) for feat in backbone_out["backbone_fpn"]],
-                "vision_pos_enc": [pos.expand(num_prompts, -1, -1, -1) for pos in backbone_out["vision_pos_enc"]],
-            }
-        assert len(backbone_out["backbone_fpn"]) == len(backbone_out["vision_pos_enc"])
-        assert len(backbone_out["backbone_fpn"]) >= self.num_feature_levels
-
-        feature_maps = backbone_out["backbone_fpn"][-self.num_feature_levels :]
-        vision_pos_embeds = backbone_out["vision_pos_enc"][-self.num_feature_levels :]
-        feat_sizes = [(x.shape[-2], x.shape[-1]) for x in vision_pos_embeds]
-        # flatten NxCxHxW to HWxNxC
-        vision_feats = [x.flatten(2).permute(2, 0, 1) for x in feature_maps]
-        vision_pos_embeds = [x.flatten(2).permute(2, 0, 1) for x in vision_pos_embeds]
-        return backbone_out, vision_feats, vision_pos_embeds, feat_sizes
 
     def _encode_prompt(
         self,
@@ -305,8 +286,8 @@ class SAM3SemanticModel(torch.nn.Module):
         self, backbone_out: dict[str, torch.Tensor], text_ids: torch.Tensor, geometric_prompt: Prompt = None
     ):
         """Forward pass for grounding (detection + segmentation) given input images and text."""
-        backbone_out, img_feats, img_pos_embeds, vis_feat_sizes = self._prepare_backbone_features(
-            backbone_out, num_prompts=len(text_ids)
+        backbone_out, img_feats, img_pos_embeds, vis_feat_sizes = SAM2Model._prepare_backbone_features(
+            self, backbone_out, batch=len(text_ids)
         )
         backbone_out.update({k: v for k, v in self.text_embeddings.items()})
         with torch.profiler.record_function("SAM3Image._encode_prompt"):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refactored SAM/SAM3 image feature preparation to centralize multi-prompt batching and reuse cached backbone outputs for cleaner, more consistent inference 🚀

### 📊 Key Changes
- 🧠 **Centralized feature expansion logic**: `SAM2Model._prepare_backbone_features()` now accepts a `batch` arg and expands `backbone_fpn` + `vision_pos_enc` when multiple prompts are used.
- 🧹 **Removed duplicated code paths**:
  - Deleted an extra `get_im_features()` override in `ultralytics/models/sam/predict.py` that duplicated cached-backbone handling.
  - Removed `SAM3Image._prepare_backbone_features()` and switched SAM3 to reuse `SAM2Model._prepare_backbone_features()`.
- ⚡ **Improved cached backbone reuse**: `get_im_features()` now checks `self.backbone_out` (precomputed features) before running `forward_image()`, reducing redundant backbone computation when available.

### 🎯 Purpose & Impact
- ✅ **More consistent behavior across SAM2/SAM3**: Multi-prompt (batch > 1) handling is implemented once, reducing the chance of subtle mismatches or bugs 🧩
- 🚄 **Potential speedups in workflows with cached features**: If `self.backbone_out` is set, inference can skip recomputing backbone outputs, improving performance in repeated-prompt scenarios 🏎️
- 🛠️ **Easier maintenance and extension**: Less copy-pasted logic means simpler future changes and fewer places for regressions to hide 🔧