### PR TITLE
Fix SAM3 inference with MPS

### DIFF
--- a/ultralytics/models/sam/sam3/geometry_encoders.py
+++ b/ultralytics/models/sam/sam3/geometry_encoders.py
@@ -42,8 +42,8 @@ def concat_padded_sequences(seq1, mask1, seq2, mask2, return_index: bool = False
     assert seq1_length == mask1.size(1)
     assert seq2_length == mask2.size(1)
 
-    torch._assert_async(is_right_padded(mask1))
-    torch._assert_async(is_right_padded(mask2))
+    torch._assert(is_right_padded(mask1), "Mask is not right padded")
+    torch._assert(is_right_padded(mask2), "Mask is not right padded")
 
     actual_seq1_lengths = (~mask1).sum(dim=-1)
     actual_seq2_lengths = (~mask2).sum(dim=-1)

--- a/ultralytics/models/sam/sam3/geometry_encoders.py
+++ b/ultralytics/models/sam/sam3/geometry_encoders.py
@@ -288,7 +288,7 @@ class SequenceGeometryEncoder(nn.Module):
             # Convert boxes to xyxy format and denormalize
             boxes_xyxy = xywh2xyxy(boxes.to(img_feats.dtype))
             scale = torch.tensor([W, H, W, H], dtype=boxes_xyxy.dtype)
-            scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            scale = scale.to(device=boxes_xyxy.device, non_blocking=True)
             scale = scale.view(1, 1, 4)
             boxes_xyxy = boxes_xyxy * scale
 


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/22954

> However, contrary to a somewhat common belief, calling pin_memory() on a pageable tensor before casting it to GPU should not bring any significant speed-up, on the contrary this call is usually slower than just executing the transfer. 

https://docs.pytorch.org/tutorials/intermediate/pinmem_nonblock.html

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves SAM3 encoder stability and efficiency by enforcing contiguous tensors, simplifying dtype conversions, and making padding checks stricter ✅⚡

### 📊 Key Changes
- Ensured normalized target tensors are contiguous before attention (`self.norm1(tgt).contiguous()`), helping avoid non-contiguous memory issues 🧠
- Converted `memory` once to the target dtype and made it contiguous before cross-attention, then reused it for both `key` and `value` (instead of repeated `memory.to(...)`) 🚀
- Replaced `torch._assert_async(...)` with explicit `torch._assert(..., "Mask is not right padded")` for clearer, deterministic validation and error messages 🛡️
- Removed `pin_memory()` from a small CPU tensor (`scale`) before moving it to the device, simplifying the transfer path and reducing unnecessary pinned-memory usage 🧹

### 🎯 Purpose & Impact
- More robust attention execution (fewer edge-case failures/perf hits due to non-contiguous tensors) 🔧
- Slight runtime and memory efficiency improvements by avoiding repeated dtype casts and redundant operations during cross-attention ⚡
- Easier debugging when sequence masks are incorrectly padded thanks to clearer assertion messages 🧩
- Cleaner device transfer behavior and less pinned-memory overhead, which can help especially in CPU→GPU preprocessing paths 🖥️➡️🎛️