### PR TITLE
Centralize warning suppression

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -66,7 +66,6 @@ import re
 import shutil
 import subprocess
 import time
-import warnings
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
@@ -517,11 +516,6 @@ class Exporter:
             y = NMSModel(model, self.args)(im) if self.args.nms and not coreml and not imx else model(im)
         if self.args.half and (onnx or jit) and self.device.type != "cpu":
             im, model = im.half(), model.half()  # to FP16
-
-        # Filter warnings
-        warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)  # suppress TracerWarning
-        warnings.filterwarnings("ignore", category=UserWarning)  # suppress shape prim::Constant missing ONNX warning
-        warnings.filterwarnings("ignore", category=DeprecationWarning)  # suppress CoreML np.bool deprecation warning
 
         # Assign
         self.im = im

--- a/ultralytics/nn/text_model.py
+++ b/ultralytics/nn/text_model.py
@@ -196,12 +196,7 @@ class MobileCLIP(TextModel):
             device (torch.device): Device to load the model on.
         """
         try:
-            import warnings
-
-            # Suppress 'timm.models.layers is deprecated, please import via timm.layers' warning from mobileclip usage
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=FutureWarning)
-                import mobileclip
+            import mobileclip
         except ImportError:
             # Ultralytics fork preferred since Apple MobileCLIP repo has incorrect version of torchvision
             checks.check_requirements("git+https://github.com/ultralytics/mobileclip.git")

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from threading import Lock
 from types import SimpleNamespace
 from urllib.parse import unquote
+import warnings
 
 import cv2
 import numpy as np
@@ -131,6 +132,13 @@ os.environ["NUMEXPR_MAX_THREADS"] = str(NUM_THREADS)  # NumExpr max threads
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress verbose TF compiler warnings in Colab
 os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not initialize NNPACK" warnings
 os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output when computing FLOPs
+
+# Centralized warning suppression
+warnings.filterwarnings("ignore", message="torch.distributed.reduce_op is deprecated")  # PyTorch deprecation
+warnings.filterwarnings("ignore", message="The figure layout has changed to tight")  # matplotlib>=3.7.2
+warnings.filterwarnings("ignore", message=".*is deprecated and slated for removal.*")  # mobileclip and others
+warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)  # ONNX/TorchScript export tracer warnings
+warnings.filterwarnings("ignore", category=UserWarning, module="torch.jit")  # JIT trace warnings
 
 # Precompiled type tuples for faster isinstance() checks
 FLOAT_OR_INT = (float, int)

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -136,9 +136,10 @@ os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output
 # Centralized warning suppression
 warnings.filterwarnings("ignore", message="torch.distributed.reduce_op is deprecated")  # PyTorch deprecation
 warnings.filterwarnings("ignore", message="The figure layout has changed to tight")  # matplotlib>=3.7.2
-warnings.filterwarnings("ignore", message=".*is deprecated and slated for removal.*")  # mobileclip and others
+warnings.filterwarnings("ignore", category=FutureWarning, module="timm")  # mobileclip timm.layers deprecation
 warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)  # ONNX/TorchScript export tracer warnings
-warnings.filterwarnings("ignore", category=UserWarning, module="torch.jit")  # JIT trace warnings
+warnings.filterwarnings("ignore", category=UserWarning, message=".*prim::Constant.*")  # ONNX shape warning
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="coremltools")  # CoreML np.bool deprecation
 
 # Precompiled type tuples for faster isinstance() checks
 FLOAT_OR_INT = (float, int)

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -14,12 +14,12 @@ import socket
 import sys
 import threading
 import time
+import warnings
 from functools import lru_cache
 from pathlib import Path
 from threading import Lock
 from types import SimpleNamespace
 from urllib.parse import unquote
-import warnings
 
 import cv2
 import numpy as np

--- a/ultralytics/utils/callbacks/tensorboard.py
+++ b/ultralytics/utils/callbacks/tensorboard.py
@@ -66,7 +66,7 @@ def _log_tensorboard_graph(trainer) -> None:
         WRITER.add_graph(torch.jit.trace(torch_utils.unwrap_model(trainer.model), im, strict=False), [])
         LOGGER.info(f"{PREFIX}model graph visualization added ✅")
         return
-    except Exception:
+    except Exception as e1:
         # Fallback to TorchScript export steps (RTDETR)
         try:
             model = deepcopy(torch_utils.unwrap_model(trainer.model))
@@ -79,8 +79,8 @@ def _log_tensorboard_graph(trainer) -> None:
             model(im)  # dry run
             WRITER.add_graph(torch.jit.trace(model, im, strict=False), [])
             LOGGER.info(f"{PREFIX}model graph visualization added ✅")
-        except Exception as e:
-            LOGGER.warning(f"{PREFIX}TensorBoard graph visualization failure {e}")
+        except Exception as e2:
+            LOGGER.warning(f"{PREFIX}TensorBoard graph visualization failure: {e1} -> {e2}")
 
 
 def on_pretrain_routine_start(trainer) -> None:

--- a/ultralytics/utils/callbacks/tensorboard.py
+++ b/ultralytics/utils/callbacks/tensorboard.py
@@ -9,7 +9,6 @@ try:
     PREFIX = colorstr("TensorBoard: ")
 
     # Imports below only required if TensorBoard enabled
-    import warnings
     from copy import deepcopy
 
     import torch
@@ -61,32 +60,27 @@ def _log_tensorboard_graph(trainer) -> None:
     p = next(trainer.model.parameters())  # for device, type
     im = torch.zeros((1, 3, *imgsz), device=p.device, dtype=p.dtype)  # input image (must be zeros, not empty)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=UserWarning)  # suppress jit trace warning
-        warnings.simplefilter("ignore", category=torch.jit.TracerWarning)  # suppress jit trace warning
-
-        # Try simple method first (YOLO)
+    # Try simple method first (YOLO)
+    try:
+        trainer.model.eval()  # place in .eval() mode to avoid BatchNorm statistics changes
+        WRITER.add_graph(torch.jit.trace(torch_utils.unwrap_model(trainer.model), im, strict=False), [])
+        LOGGER.info(f"{PREFIX}model graph visualization added ✅")
+        return
+    except Exception:
+        # Fallback to TorchScript export steps (RTDETR)
         try:
-            trainer.model.eval()  # place in .eval() mode to avoid BatchNorm statistics changes
-            WRITER.add_graph(torch.jit.trace(torch_utils.unwrap_model(trainer.model), im, strict=False), [])
+            model = deepcopy(torch_utils.unwrap_model(trainer.model))
+            model.eval()
+            model = model.fuse(verbose=False)
+            for m in model.modules():
+                if hasattr(m, "export"):  # Detect, RTDETRDecoder (Segment and Pose use Detect base class)
+                    m.export = True
+                    m.format = "torchscript"
+            model(im)  # dry run
+            WRITER.add_graph(torch.jit.trace(model, im, strict=False), [])
             LOGGER.info(f"{PREFIX}model graph visualization added ✅")
-            return
-
-        except Exception:
-            # Fallback to TorchScript export steps (RTDETR)
-            try:
-                model = deepcopy(torch_utils.unwrap_model(trainer.model))
-                model.eval()
-                model = model.fuse(verbose=False)
-                for m in model.modules():
-                    if hasattr(m, "export"):  # Detect, RTDETRDecoder (Segment and Pose use Detect base class)
-                        m.export = True
-                        m.format = "torchscript"
-                model(im)  # dry run
-                WRITER.add_graph(torch.jit.trace(model, im, strict=False), [])
-                LOGGER.info(f"{PREFIX}model graph visualization added ✅")
-            except Exception as e:
-                LOGGER.warning(f"{PREFIX}TensorBoard graph visualization failure {e}")
+        except Exception as e:
+            LOGGER.warning(f"{PREFIX}TensorBoard graph visualization failure {e}")
 
 
 def on_pretrain_routine_start(trainer) -> None:

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-import warnings
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -574,10 +573,6 @@ def plot_labels(boxes, cls, names=(), save_dir=Path(""), on_plot=None):
     import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
     import polars
     from matplotlib.colors import LinearSegmentedColormap
-
-    # Filter matplotlib>=3.7.2 warning
-    warnings.filterwarnings("ignore", category=UserWarning, message="The figure layout has changed to tight")
-    warnings.filterwarnings("ignore", category=FutureWarning)
 
     # Plot dataset labels
     LOGGER.info(f"Plotting labels to {save_dir / 'labels.jpg'}... ")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Centralizes warning suppression across Ultralytics to reduce noisy logs and simplify exporter, plotting, MobileCLIP, and TensorBoard code 🧹🔕.

### 📊 Key Changes
- Moved scattered `warnings.filterwarnings(...)` calls into a single, global suppression block in `ultralytics/utils/__init__.py` 🔧
- Removed local warning suppression from:
  - Export pipeline (`ultralytics/engine/exporter.py`) 🧠➡️📦
  - MobileCLIP text model import (`ultralytics/nn/text_model.py`) 📝
  - Label plotting (`ultralytics/utils/plotting.py`) 📈
  - TensorBoard callback module imports (`ultralytics/utils/callbacks/tensorboard.py`) 📊
- Improved TensorBoard graph logging flow:
  - Uses a clearer two-stage attempt (simple trace first, then RT-DETR-style export fallback)
  - Logs a more informative failure message showing both errors if both attempts fail 🧾✅⚠️

### 🎯 Purpose & Impact
- Cleaner, more maintainable code by avoiding repeated per-file warning filters 🧼
- More consistent user experience: common third-party warnings (PyTorch tracer, ONNX shape warnings, timm FutureWarnings, CoreML deprecations, matplotlib layout messages) are suppressed uniformly 🔇
- Better TensorBoard debugging: when graph logging fails, users get clearer context about what went wrong 📌
- Potential tradeoff: centralized suppression applies globally, which may hide warnings some advanced users relied on for debugging 🕵️‍♂️