### PR TITLE
SystemLogger rate mode

### DIFF
--- a/ultralytics/models/sam/modules/sam.py
+++ b/ultralytics/models/sam/modules/sam.py
@@ -1155,6 +1155,6 @@ class SAM3Model(SAM2Model):
         # Apply pixel-wise non-overlapping constraint based on mask scores
         pixel_level_non_overlapping_masks = self._apply_non_overlapping_constraints(pred_masks)
         # Fully suppress masks with high shrinkage (probably noisy) based on the pixel wise non-overlapping constraints
-        # NOTE: The output of this function can be a no op if none of the masks shrinked by a large factor.
+        # NOTE: The output of this function can be a no op if none of the masks shrink by a large factor.
         pred_masks = self._suppress_shrinked_masks(pred_masks, pixel_level_non_overlapping_masks)
         return pred_masks

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -290,11 +290,10 @@ class SystemLogger:
         statistics, and GPU metrics (if available).
 
         Args:
-            rates (bool): If True, return MB/s rates for disk and network I/O instead of cumulative MB.
-                When False (default), returns cumulative MB since initialization.
-                When True, returns MB/s rates calculated from delta since last call.
-
-        Example output (rates=False, default):
+            rates (bool): If True, return MB/s rates for disk and network I/O instead of cumulative MB. When False
+                (default), returns cumulative MB since initialization. When True, returns MB/s rates calculated from
+                delta since last call.
+            Example output (rates=False, default):
 
         ```python
         {
@@ -303,13 +302,10 @@ class SystemLogger:
             "disk": {"read_mb": 156.7, "write_mb": 89.3, "used_gb": 256.8},
             "network": {"recv_mb": 157.2, "sent_mb": 89.1},
             "gpus": {
-                "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
-                "1": {"usage": 94.1, "memory": 82.7, "temp": 70, "power": 278},
-            },
-        }
+            "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
+            "1": {"usage": 94.1, "memory": 82.7, "temp": 70, "power": 278}, }, }
         ```
-
-        Example output (rates=True):
+            Example output (rates=True):
 
         ```python
         {
@@ -318,9 +314,7 @@ class SystemLogger:
             "disk": {"read_mbs": 12.5, "write_mbs": 8.3, "used_gb": 256.8},
             "network": {"recv_mbs": 5.2, "sent_mbs": 1.1},
             "gpus": {
-                "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
-            },
-        }
+            "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285}, }, }
         ```
 
         Returns:

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -267,6 +267,11 @@ class SystemLogger:
         self.net_start = psutil.net_io_counters()
         self.disk_start = psutil.disk_io_counters()
 
+        # For rate calculation
+        self._prev_net = self.net_start
+        self._prev_disk = self.disk_start
+        self._prev_time = time.time()
+
     def _init_nvidia(self):
         """Initialize NVIDIA GPU monitoring with pynvml."""
         try:
@@ -278,11 +283,18 @@ class SystemLogger:
         except Exception:
             return False
 
-    def get_metrics(self):
+    def get_metrics(self, rates=False):
         """Get current system metrics.
 
         Collects comprehensive system metrics including CPU usage, RAM usage, disk I/O statistics, network I/O
-        statistics, and GPU metrics (if available). Example output:
+        statistics, and GPU metrics (if available).
+
+        Args:
+            rates (bool): If True, return MB/s rates for disk and network I/O instead of cumulative MB.
+                When False (default), returns cumulative MB since initialization.
+                When True, returns MB/s rates calculated from delta since last call.
+
+        Example output (rates=False, default):
 
         ```python
         metrics = {
@@ -291,26 +303,23 @@ class SystemLogger:
             "disk": {"read_mb": 156.7, "write_mb": 89.3, "used_gb": 256.8},
             "network": {"recv_mb": 157.2, "sent_mb": 89.1},
             "gpus": {
-                0: {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
-                1: {"usage": 94.1, "memory": 82.7, "temp": 70, "power": 278},
+                "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
+                "1": {"usage": 94.1, "memory": 82.7, "temp": 70, "power": 278},
             },
         }
         ```
 
-        - cpu (float): CPU usage percentage (0-100%)
-        - ram (float): RAM usage percentage (0-100%)
-        - disk (dict):
-            - read_mb (float): Cumulative disk read in MB since initialization
-            - write_mb (float): Cumulative disk write in MB since initialization
-            - used_gb (float): Total disk space used in GB
-        - network (dict):
-            - recv_mb (float): Cumulative network received in MB since initialization
-            - sent_mb (float): Cumulative network sent in MB since initialization
-        - gpus (dict): GPU metrics by device index (e.g., 0, 1) containing:
-            - usage (int): GPU utilization percentage (0-100%)
-            - memory (float): CUDA memory usage percentage (0-100%)
-            - temp (int): GPU temperature in degrees Celsius
-            - power (int): GPU power consumption in watts
+        Example output (rates=True):
+
+        ```python
+        metrics = {
+            "cpu": 45.2,
+            "ram": 78.9,
+            "disk": {"read_mbs": 12.5, "write_mbs": 8.3, "used_gb": 256.8},
+            "network": {"recv_mbs": 5.2, "sent_mbs": 1.1},
+            "gpus": {...},
+        }
+        ```
 
         Returns:
             metrics (dict): System metrics containing 'cpu', 'ram', 'disk', 'network', 'gpus' with usage data.
@@ -321,21 +330,41 @@ class SystemLogger:
         disk = psutil.disk_io_counters()
         memory = psutil.virtual_memory()
         disk_usage = shutil.disk_usage("/")
+        now = time.time()
 
         metrics = {
             "cpu": round(psutil.cpu_percent(), 3),
             "ram": round(memory.percent, 3),
-            "disk": {
+            "gpus": {},
+        }
+
+        if rates:
+            # Calculate MB/s rates from delta since last call
+            elapsed = max(0.1, now - self._prev_time)  # Avoid division by zero
+            metrics["disk"] = {
+                "read_mbs": round(max(0, (disk.read_bytes - self._prev_disk.read_bytes) / (1 << 20) / elapsed), 3),
+                "write_mbs": round(max(0, (disk.write_bytes - self._prev_disk.write_bytes) / (1 << 20) / elapsed), 3),
+                "used_gb": round(disk_usage.used / (1 << 30), 3),
+            }
+            metrics["network"] = {
+                "recv_mbs": round(max(0, (net.bytes_recv - self._prev_net.bytes_recv) / (1 << 20) / elapsed), 3),
+                "sent_mbs": round(max(0, (net.bytes_sent - self._prev_net.bytes_sent) / (1 << 20) / elapsed), 3),
+            }
+            # Update previous values for next rate calculation
+            self._prev_net = net
+            self._prev_disk = disk
+            self._prev_time = now
+        else:
+            # Cumulative MB since initialization (original behavior)
+            metrics["disk"] = {
                 "read_mb": round((disk.read_bytes - self.disk_start.read_bytes) / (1 << 20), 3),
                 "write_mb": round((disk.write_bytes - self.disk_start.write_bytes) / (1 << 20), 3),
                 "used_gb": round(disk_usage.used / (1 << 30), 3),
-            },
-            "network": {
+            }
+            metrics["network"] = {
                 "recv_mb": round((net.bytes_recv - self.net_start.bytes_recv) / (1 << 20), 3),
                 "sent_mb": round((net.bytes_sent - self.net_start.bytes_sent) / (1 << 20), 3),
-            },
-            "gpus": {},
-        }
+            }
 
         # Add GPU metrics (NVIDIA only)
         if self.nvidia_initialized:

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -284,18 +284,12 @@ class SystemLogger:
             return False
 
     def get_metrics(self, rates=False):
-        """Get current system metrics.
+        """Get current system metrics including CPU, RAM, disk, network, and GPU usage.
 
         Collects comprehensive system metrics including CPU usage, RAM usage, disk I/O statistics, network I/O
         statistics, and GPU metrics (if available).
 
-        Args:
-            rates (bool): If True, return MB/s rates for disk and network I/O instead of cumulative MB.
-                When False (default), returns cumulative MB since initialization.
-                When True, returns MB/s rates calculated from delta since last call.
-
         Example output (rates=False, default):
-
         ```python
         {
             "cpu": 45.2,
@@ -310,7 +304,6 @@ class SystemLogger:
         ```
 
         Example output (rates=True):
-
         ```python
         {
             "cpu": 45.2,
@@ -323,8 +316,17 @@ class SystemLogger:
         }
         ```
 
+
+        Args:
+            rates (bool): If True, return disk/network as MB/s rates instead of cumulative MB.
+
         Returns:
-            (dict): System metrics containing 'cpu', 'ram', 'disk', 'network', 'gpus' with usage data.
+            (dict): Metrics dictionary. Example
+
+        Examples:
+            >>> logger = SystemLogger()
+            >>> logger.get_metrics()["cpu"]  # CPU percentage
+            >>> logger.get_metrics(rates=True)["network"]["recv_mbs"]  # MB/s download rate
         """
         import psutil  # scoped as slow import
 

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -320,7 +320,7 @@ class SystemLogger:
             rates (bool): If True, return disk/network as MB/s rates instead of cumulative MB.
 
         Returns:
-            (dict): Metrics dictionary. Example
+            (dict): Metrics dictionary with cpu, ram, disk, network, and gpus keys.
 
         Examples:
             >>> logger = SystemLogger()

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -316,7 +316,6 @@ class SystemLogger:
         }
         ```
 
-
         Args:
             rates (bool): If True, return disk/network as MB/s rates instead of cumulative MB.
 

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -290,11 +290,10 @@ class SystemLogger:
         statistics, and GPU metrics (if available).
 
         Args:
-            rates (bool): If True, return MB/s rates for disk and network I/O instead of cumulative MB.
-                When False (default), returns cumulative MB since initialization.
-                When True, returns MB/s rates calculated from delta since last call.
-
-        Example output (rates=False, default):
+            rates (bool): If True, return MB/s rates for disk and network I/O instead of cumulative MB. When False
+                (default), returns cumulative MB since initialization. When True, returns MB/s rates calculated from
+                delta since last call.
+            Example output (rates=False, default):
 
         ```python
         metrics = {
@@ -303,13 +302,10 @@ class SystemLogger:
             "disk": {"read_mb": 156.7, "write_mb": 89.3, "used_gb": 256.8},
             "network": {"recv_mb": 157.2, "sent_mb": 89.1},
             "gpus": {
-                "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
-                "1": {"usage": 94.1, "memory": 82.7, "temp": 70, "power": 278},
-            },
-        }
+            "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
+            "1": {"usage": 94.1, "memory": 82.7, "temp": 70, "power": 278}, }, }
         ```
-
-        Example output (rates=True):
+            Example output (rates=True):
 
         ```python
         metrics = {
@@ -317,8 +313,7 @@ class SystemLogger:
             "ram": 78.9,
             "disk": {"read_mbs": 12.5, "write_mbs": 8.3, "used_gb": 256.8},
             "network": {"recv_mbs": 5.2, "sent_mbs": 1.1},
-            "gpus": {...},
-        }
+            "gpus": {...}, }
         ```
 
         Returns:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds optional real-time disk/network throughput reporting to `SystemLogger.get_metrics()` and fixes a small SAM comment typo 🛠️✨

### 📊 Key Changes
- ✅ **Enhanced `SystemLogger.get_metrics()`** in `ultralytics/utils/logger.py`:
  - New parameter: `get_metrics(rates=False)`
  - When `rates=True`, disk and network stats return **MB/s rates** (`read_mbs`, `write_mbs`, `recv_mbs`, `sent_mbs`) computed from deltas since the previous call.
  - Default behavior remains the same: **cumulative MB since initialization** (`read_mb`, `write_mb`, `recv_mb`, `sent_mb`).
  - Adds internal state tracking (`_prev_net`, `_prev_disk`, `_prev_time`) to support rate calculations safely (with a minimum elapsed time to avoid divide-by-zero).
  - Documentation/examples updated; GPU keys in examples shown as strings (e.g., `"0"`, `"1"`).
- 📝 **Minor typo fix** in `ultralytics/models/sam/modules/sam.py`: “shrinked” → “shrink” in a comment.

### 🎯 Purpose & Impact
- 📈 **More actionable monitoring**: users can now see *instantaneous* disk and network throughput (MB/s), which is often more useful than cumulative totals for debugging bottlenecks.
- 🔄 **Backwards compatible by default**: existing code relying on cumulative `*_mb` fields won’t break unless `rates=True` is explicitly used.
- 🧪 **Improved observability for long-running jobs**: makes it easier to correlate performance drops with I/O or network saturation during training/inference runs.
- 🧹 **Small polish**: the SAM change is documentation-only, with no functional impact.