### PR TITLE
`ultralytics 8.3.240` SAM3 Apple MPS tensor `repeat()` fixes

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.239"
+__version__ = "8.3.240"
 
 import importlib
 import os

--- a/ultralytics/models/sam/modules/utils.py
+++ b/ultralytics/models/sam/modules/utils.py
@@ -222,6 +222,7 @@ def apply_rotary_enc(
     xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
     return xq_out.type_as(xq).to(xq.device), xk_out.type_as(xk).to(xk.device)
 
+
 def window_partition(x: torch.Tensor, window_size: int):
     """Partition input tensor into non-overlapping windows with padding if needed.
 

--- a/ultralytics/models/sam/modules/utils.py
+++ b/ultralytics/models/sam/modules/utils.py
@@ -210,9 +210,17 @@ def apply_rotary_enc(
         # No keys to rotate, due to dropout
         return xq_out.type_as(xq).to(xq.device), xk
     # Repeat freqs along seq_len dim to match k seq_len
-    if repeat_freqs_k:
+     if repeat_freqs_k:
         r = xk_.shape[-2] // xq_.shape[-2]
-        freqs_cis = freqs_cis.repeat(*([1] * (freqs_cis.ndim - 2)), r, 1)
+        # MPS doesn't support repeat on complex tensors, decompose to real representation
+        if freqs_cis.device.type == "mps":
+            freqs_real = torch.view_as_real(freqs_cis)
+            freqs_real = freqs_real.repeat(*([1] * (freqs_real.ndim - 3)), r, 1, 1)
+            freqs_cis = torch.view_as_complex(freqs_real.contiguous())
+        else:
+            freqs_cis = freqs_cis.repeat(*([1] * (freqs_cis.ndim - 2)), r, 1)
+    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+    return xq_out.type_as(xq).to(xq.device), xk_out.type_as(xk).to(xk.device)
     xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
     return xq_out.type_as(xq).to(xq.device), xk_out.type_as(xk).to(xk.device)
 

--- a/ultralytics/models/sam/modules/utils.py
+++ b/ultralytics/models/sam/modules/utils.py
@@ -210,13 +210,12 @@ def apply_rotary_enc(
         # No keys to rotate, due to dropout
         return xq_out.type_as(xq).to(xq.device), xk
     # Repeat freqs along seq_len dim to match k seq_len
-    if repeat_freqs_k:
-        r = xk_.shape[-2] // xq_.shape[-2]
+    if repeat_freqs_k and (r := xk_.shape[-2] // xq_.shape[-2]) > 1:
         # MPS doesn't support repeat on complex tensors, decompose to real representation
         if freqs_cis.device.type == "mps":
-            freqs_real = torch.view_as_real(freqs_cis)
-            freqs_real = freqs_real.repeat(*([1] * (freqs_real.ndim - 3)), r, 1, 1)
-            freqs_cis = torch.view_as_complex(freqs_real.contiguous())
+            freqs_cis = torch.view_as_real(freqs_cis)
+            freqs_cis = freqs_cis.repeat(*([1] * (freqs_cis.ndim - 3)), r, 1, 1)
+            freqs_cis = torch.view_as_complex(freqs_cis.contiguous())
         else:
             freqs_cis = freqs_cis.repeat(*([1] * (freqs_cis.ndim - 2)), r, 1)
     xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)

--- a/ultralytics/models/sam/modules/utils.py
+++ b/ultralytics/models/sam/modules/utils.py
@@ -210,7 +210,7 @@ def apply_rotary_enc(
         # No keys to rotate, due to dropout
         return xq_out.type_as(xq).to(xq.device), xk
     # Repeat freqs along seq_len dim to match k seq_len
-     if repeat_freqs_k:
+    if repeat_freqs_k:
         r = xk_.shape[-2] // xq_.shape[-2]
         # MPS doesn't support repeat on complex tensors, decompose to real representation
         if freqs_cis.device.type == "mps":
@@ -221,9 +221,6 @@ def apply_rotary_enc(
             freqs_cis = freqs_cis.repeat(*([1] * (freqs_cis.ndim - 2)), r, 1)
     xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
     return xq_out.type_as(xq).to(xq.device), xk_out.type_as(xk).to(xk.device)
-    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
-    return xq_out.type_as(xq).to(xq.device), xk_out.type_as(xk).to(xk.device)
-
 
 def window_partition(x: torch.Tensor, window_size: int):
     """Partition input tensor into non-overlapping windows with padding if needed.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves SAM rotary-embedding logic to work reliably on Apple Silicon (MPS) and bumps Ultralytics version to `8.3.240` 🍎⚙️

### 📊 Key Changes
- 🔖 Version bump: `ultralytics` updated from `8.3.239` → `8.3.240`.
- 🧠 Fixed `apply_rotary_enc()` in `ultralytics/models/sam/modules/utils.py` to avoid unsupported complex-tensor `repeat()` on MPS.
- 🛠️ When repeating key frequencies (`repeat_freqs_k`), the code now:
  - ✅ Only repeats if the computed repeat factor `r` is greater than 1.
  - 🍏 On MPS: converts complex tensors to real (`view_as_real`), repeats safely, then converts back to complex (`view_as_complex`).
  - 🖥️ On other devices: keeps the original complex `repeat()` path.

### 🎯 Purpose & Impact
- 🍎 **Better Apple Silicon compatibility:** prevents runtime errors on MPS backends when SAM uses rotary embeddings.
- ✅ **More robust behavior:** avoids unnecessary repeat operations when no repetition is needed (`r <= 1`).
- 🚀 **Smoother SAM usage on Mac:** improves reliability for users running SAM models on M1/M2/M3 devices via PyTorch MPS.