### PR TITLE
Prune SAM3 tracker memory to prevent VRAM leak

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -3328,6 +3328,7 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         # Step 2: remove from SAM2 inference states those objects removed by heuristics
         if len(obj_ids_newly_removed) > 0:
             self._tracker_remove_objects(tracker_states_local, obj_ids_newly_removed)
+
         return tracker_states_local
 
     def build_outputs(

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -953,8 +953,7 @@ class SAM2VideoPredictor(SAM2Predictor):
                 run_mem_encoder=True,
             )
             output_dict[storage_key][frame] = current_out
-            if storage_key == "non_cond_frame_outputs":
-                self._prune_non_cond_memory(frame)
+            self._prune_non_cond_memory(frame)
 
         # Create slices of per-object outputs for subsequent interaction with each
         # individual object after tracking.

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -1840,18 +1840,17 @@ class SAM2VideoPredictor(SAM2Predictor):
         inference_state = inference_state or self.inference_state
 
         # Determine window size
-        window = self.model.num_maskmem * self.model.memory_temporal_stride_for_eval
-        min_frame = frame_idx - window
+        min_frame = frame_idx - self.model.num_maskmem * self.model.memory_temporal_stride_for_eval
         output_dict = inference_state["output_dict"]
 
         # Prune global non_cond_frame_outputs
         for f in [k for k in output_dict["non_cond_frame_outputs"] if k < min_frame]:
-            del output_dict["non_cond_frame_outputs"][f]
+            output_dict["non_cond_frame_outputs"].pop(f, None)
 
         # Prune per-object non_cond_frame_outputs
         for obj_output_dict in inference_state.get("output_dict_per_obj", {}).values():
             for f in [k for k in obj_output_dict["non_cond_frame_outputs"] if k < min_frame]:
-                del obj_output_dict["non_cond_frame_outputs"][f]
+                obj_output_dict["non_cond_frame_outputs"].pop(f, None)
 
 
 class SAM2DynamicInteractivePredictor(SAM2Predictor):

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2530,7 +2530,7 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         num_obj_for_compile = 16
         self.max_num_objects = max_num_objects
         self.num_obj_for_compile = num_obj_for_compile
-        self.memory_bank_max_frames = 32  # Only keep last N frames of memory
+        self.memory_bank_max_frames = 16  # Only keep last N frames of memory
         self.recondition_every_nth_frame = recondition_every_nth_frame
         self.masklet_confirmation_enable = masklet_confirmation_enable
         self.masklet_confirmation_consecutive_det_thresh = masklet_confirmation_consecutive_det_thresh
@@ -3953,14 +3953,14 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
                     for f in frames_to_remove:
                         del obj_output[storage_key][f]
 
-    def _consolidate_tracker_states(self, tracker_states_local, max_states=4):
+    def _consolidate_tracker_states(self, tracker_states_local):
         """Prevent unbounded growth of tracker_states_local list."""
         # Remove empty states
         tracker_states_local[:] = [s for s in tracker_states_local if len(s.get("obj_ids", [])) > 0]
         return tracker_states_local
 
-    def _prune_frame_scores(self, metadata, frame_idx, window=32):
+    def _prune_frame_scores(self, metadata, frame_idx):
         """Prune old entries from frame-wise score dict."""
         scores = metadata.get("obj_id_to_tracker_score_frame_wise", {})
-        for f in [k for k in scores if isinstance(k, int) and k < frame_idx - window]:
+        for f in [k for k in scores if isinstance(k, int) and k < frame_idx - self.memory_bank_max_frames]:
             del scores[f]

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -954,7 +954,6 @@ class SAM2VideoPredictor(SAM2Predictor):
             )
             output_dict[storage_key][frame] = current_out
             self._prune_non_cond_memory(frame)
-
         # Create slices of per-object outputs for subsequent interaction with each
         # individual object after tracking.
         self._add_output_per_object(frame, current_out, storage_key)
@@ -2445,6 +2444,7 @@ class SAM3VideoPredictor(SAM2VideoPredictor, SAM3Predictor):
                 inference_state=inference_state,
             )
             output_dict[storage_key][frame] = current_out
+            self._prune_non_cond_memory(frame, inference_state=inference_state)
         # Create slices of per-object outputs for subsequent interaction with each
         # individual object after tracking.
         self._add_output_per_object(frame, current_out, storage_key, inference_state=inference_state)
@@ -3328,9 +3328,6 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         # Step 2: remove from SAM2 inference states those objects removed by heuristics
         if len(obj_ids_newly_removed) > 0:
             self._tracker_remove_objects(tracker_states_local, obj_ids_newly_removed)
-        # Step 3: prune existing tracker state to prevent memory leak
-        for state in tracker_states_local:
-            self.tracker._prune_non_cond_memory(frame_idx, inference_state=state)
         return tracker_states_local
 
     def build_outputs(


### PR DESCRIPTION
Closes #22950 

**MRE**

```python
from ultralytics.models.sam import SAM3VideoSemanticPredictor

# Initialize semantic video predictor
overrides = dict(
    conf=0.25, 
    task="segment", 
    mode="predict", 
    imgsz=640, 
    model="sam3.pt", 
    half=True, 
    device=0
)
predictor = SAM3VideoSemanticPredictor(overrides=overrides)

# Track concepts using text prompts
results = predictor(source="video1.mp4", text=["person"], stream=True, save=False)

# Process results
import torch

for i, r in enumerate(results):
    if torch.cuda.is_available():
        print(i, "MB alloc=", torch.cuda.memory_allocated() / 1024**2,
                 "MB max=", torch.cuda.max_memory_allocated() / 1024**2)
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds automatic pruning of SAM2 “non-conditioning” frame memory to keep video inference memory usage bounded 🧠🧹

### 📊 Key Changes
- Enables a new default flag `self.clear_non_cond_mem = True` to periodically clear old non-conditioning memory ✅
- Calls a new helper `_prune_non_cond_memory(...)` after each frame’s output is stored during:
  - Standard `inference(...)`
  - Video `propagate_in_video(...)` 🎥
- Implements `_prune_non_cond_memory` to delete outdated entries from:
  - Global `output_dict["non_cond_frame_outputs"]`
  - Per-object `output_dict_per_obj[*]["non_cond_frame_outputs"]` 🗂️
- Uses the model’s temporal memory parameters (`num_maskmem` and `memory_temporal_stride_for_eval`) to decide how far back to retain frames ⏱️

### 🎯 Purpose & Impact
- Reduces RAM/VRAM growth over long videos by preventing unbounded accumulation of cached frame outputs 📉
- Improves stability for extended tracking/segmentation runs (fewer slowdowns and memory-related crashes) 🛡️
- Keeps recent context needed for quality while discarding older, less useful non-conditioning history ⚖️
- Minimal user-facing changes: behavior improves by default without requiring new configuration 🙌