### PR TITLE
Fix Docs header tooltips in CSS

### DIFF
--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -62,6 +62,11 @@ div.highlight {
   max-height: 75vh;
 }
 
+/* Fix tooltips appearing under the sticky header */
+.md-tooltip {
+  z-index: 100 !important;
+}
+
 /* Ultralytics Search Bar ------------------------------------------------------------------------------------------- */
 :root {
   --ult-search-bg: #f5f6f8;


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves docs UI by ensuring tooltips display above the sticky header 🧩✨

### 📊 Key Changes
- Added a CSS override for `.md-tooltip` to set a higher `z-index` (`100 !important`) 🛠️
- Included an explicit comment explaining the issue and intent (“Fix tooltips appearing under the sticky header”) 📝

### 🎯 Purpose & Impact
- Prevents tooltips from being hidden behind the sticky header in the documentation site ✅
- Enhances readability and usability of hover-help elements (e.g., link/tooltips) for all users 🧭
- Low-risk visual fix confined to docs styling; no effect on training/inference code paths 🔒