### PR TITLE
Docs: clarify save argument usage for SAM3SemanticPredictor

### DIFF
--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -116,7 +116,7 @@ pip install -U ultralytics
 
 !!! warning "SAM 3 Model Weights Required"
 
-    Unlike other Ultralytics models, SAM 3 weights (`sam3.pt`) are **not automatically downloaded**. You must manually download the model weights from the [official SAM 3 repository](https://github.com/facebookresearch/sam3) before using SAM 3. Place the downloaded `sam3.pt` file in your working directory or specify the full path when loading the model.
+    Unlike other Ultralytics models, SAM 3 weights (`sam3.pt`) are **not automatically downloaded**. You must first request access for the model weights on the [SAM 3 model page on Hugging Face](https://huggingface.co/facebook/sam3) and then, once approved, download the [`sam3.pt` file](https://huggingface.co/facebook/sam3/resolve/main/sam3.pt?download=true). Place the downloaded `sam3.pt` file in your working directory or specify the full path when loading the model.
 
 ## How to Use SAM 3: Versatility in Concept Segmentation
 

--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -150,7 +150,7 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
             mode="predict",
             model="sam3.pt",
             half=True,  # Use FP16 for faster inference
-			save=True
+        True
         )
         predictor = SAM3SemanticPredictor(overrides=overrides)
 

--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -116,7 +116,7 @@ pip install -U ultralytics
 
 !!! warning "SAM 3 Model Weights Required"
 
-    Unlike other Ultralytics models, SAM 3 weights (`sam3.pt`) are **not automatically downloaded**. You must first request access for the model weights on the [SAM 3 model page on Hugging Face](https://huggingface.co/facebook/sam3) and then, once approved, download the [`sam3.pt` file](https://huggingface.co/facebook/sam3/resolve/main/sam3.pt?download=true). Place the downloaded `sam3.pt` file in your working directory or specify the full path when loading the model.
+    Unlike other Ultralytics models, SAM 3 weights (`sam3.pt`) are **not automatically downloaded**. You must manually download the model weights from the [official SAM 3 repository](https://github.com/facebookresearch/sam3) before using SAM 3. Place the downloaded `sam3.pt` file in your working directory or specify the full path when loading the model.
 
 ## How to Use SAM 3: Versatility in Concept Segmentation
 
@@ -150,7 +150,7 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
             mode="predict",
             model="sam3.pt",
             half=True,  # Use FP16 for faster inference
-        True
+            save=True,
         )
         predictor = SAM3SemanticPredictor(overrides=overrides)
 

--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -150,6 +150,7 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
             mode="predict",
             model="sam3.pt",
             half=True,  # Use FP16 for faster inference
+			save=True
         )
         predictor = SAM3SemanticPredictor(overrides=overrides)
 
@@ -157,13 +158,13 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
         predictor.set_image("path/to/image.jpg")
 
         # Query with multiple text prompts
-        results = predictor(text=["person", "bus", "glasses"], save=True)
+        results = predictor(text=["person", "bus", "glasses"])
 
         # Works with descriptive phrases
-        results = predictor(text=["person with red cloth", "person with blue cloth"], save=True)
+        results = predictor(text=["person with red cloth", "person with blue cloth"])
 
         # Query with a single concept
-        results = predictor(text=["a person"], save=True)
+        results = predictor(text=["a person"])
         ```
 
 #### Segment with Image Exemplars
@@ -178,17 +179,17 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
         from ultralytics.models.sam import SAM3SemanticPredictor
 
         # Initialize predictor
-        overrides = dict(conf=0.25, task="segment", mode="predict", model="sam3.pt", half=True)
+        overrides = dict(conf=0.25, task="segment", mode="predict", model="sam3.pt", half=True, save=True)
         predictor = SAM3SemanticPredictor(overrides=overrides)
 
         # Set image
         predictor.set_image("path/to/image.jpg")
 
         # Provide bounding box examples to segment similar objects
-        results = predictor(bboxes=[[480.0, 290.0, 590.0, 650.0]], save=True)
+        results = predictor(bboxes=[[480.0, 290.0, 590.0, 650.0]])
 
         # Multiple bounding boxes for different concepts
-        results = predictor(bboxes=[[539, 599, 589, 639], [343, 267, 499, 662]], save=True)
+        results = predictor(bboxes=[[539, 599, 589, 639], [343, 267, 499, 662]])
         ```
 
 #### Feature-based Inference for Efficiency
@@ -272,11 +273,11 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
         from ultralytics.models.sam import SAM3VideoSemanticPredictor
 
         # Initialize semantic video predictor
-        overrides = dict(conf=0.25, task="segment", mode="predict", imgsz=640, model="sam3.pt", half=True)
+        overrides = dict(conf=0.25, task="segment", mode="predict", imgsz=640, model="sam3.pt", half=True, save=True)
         predictor = SAM3VideoSemanticPredictor(overrides=overrides)
 
         # Track concepts using text prompts
-        results = predictor(source="path/to/video.mp4", text=["person", "bicycle"], stream=True, save=True)
+        results = predictor(source="path/to/video.mp4", text=["person", "bicycle"], stream=True)
 
         # Process results
         for r in results:
@@ -288,7 +289,6 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
             bboxes=[[864, 383, 975, 620], [705, 229, 782, 402]],
             labels=[1, 1],  # Positive labels
             stream=True,
-            save=True,
         )
         ```
 


### PR DESCRIPTION
Fixes #22977

This PR fixes a misleading example in the SAM3 documentation:
- Passing `save=True` directly to `predictor()` is ignored
- The correct usage is to pass `save=True` in `overrides` when initializing the predictor

No code behavior is changed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies how to use the `save` option with `SAM3SemanticPredictor` in the SAM 3 docs 📝

### 📊 Key Changes
- Removes per-call `save=True` usage from `predictor(...)` examples and shifts `save=True` into the `overrides` dict for predictor initialization
- Updates both image and video semantic predictor examples to reflect the recommended `save` configuration behavior
- Introduces an extra standalone `True` line in the first code snippet (likely unintended) ⚠️

### 🎯 Purpose & Impact
- Helps users configure output saving consistently via predictor overrides, reducing confusion around where `save` should be set ✅
- Makes examples more aligned across text-prompt, bbox-exemplar, and video workflows for SAM 3 📚
- Potential doc build/render issue due to the stray `True` line in a code block, which may confuse readers or break formatting 🧩