### PR TITLE
Add support for rv1126b Rockchip processor

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -65,6 +65,7 @@ RKNN_CHIPS = frozenset(
         "rv1103b",
         "rv1106b",
         "rk2118",
+        "rv1126b",
     }
 )  # Rockchip processors available for export
 HELP_MSG = """


### PR DESCRIPTION
The latest official code version 2.3.2 already supports the RV1126B, but the RKNN_CHIPS parameter does not include it here, which causes the failure of exporting the RKNN model with the name set to rv1126b.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds `rv1126b` to the recognized Rockchip processor list for Ultralytics export workflows. 🧩

### 📊 Key Changes
- Added `"rv1126b"` to the Rockchip processors set in `ultralytics/utils/__init__.py` ✅

### 🎯 Purpose & Impact
- Improves export compatibility/recognition for deployments targeting the Rockchip RV1126B SoC on edge/embedded devices 📦
- Helps users avoid manual patches when exporting for supported Rockchip targets 🔧