### PR TITLE
Add support for handling 2-channel images in Annotator class

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -203,6 +203,8 @@ class Annotator:
         if not input_is_pil:
             if im.shape[2] == 1:  # handle grayscale
                 im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)
+            elif im.shape[2] == 2:  # handle 2-channel images
+                im = np.ascontiguousarray(np.dstack((im, np.zeros_like(im[..., :1]))))
             elif im.shape[2] > 3:  # multispectral
                 im = np.ascontiguousarray(im[..., :3])
         if self.pil:  # use PIL


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

I have read the CLA Document and I sign the CLA.

When training a model on 2-channel spectral images and running prediction, the `Annotator` class fails to save the annotated images because it only handles:
  - Grayscale (1-channel)
  - RGB (3-channel)
  - Multispectral (>3 channels)

2-channel images are not handled, causing image save operations to fail.

The solution is to convert 2-channel images to 3-channel by appending a constant channel (zeros), consistent with how other channel formats are handled in the existing code.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds support for 2-channel (2C) numpy images in the `Annotator` image preprocessing path so they can be visualized/annotated reliably. 🖼️✅

### 📊 Key Changes
- Adds a new `elif im.shape[2] == 2` branch in `ultralytics/utils/plotting.py` to handle 2-channel images.
- Converts 2-channel input to a 3-channel contiguous array by stacking a zero-filled third channel.

### 🎯 Purpose & Impact
- Prevents errors/misrendering when users pass 2-channel images (e.g., paired modalities) into `Annotator`.
- Improves robustness of plotting/annotation utilities across more image formats without impacting existing RGB/grayscale/multispectral handling. 🛠️