### PR TITLE
Fix executorch bug

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1204,9 +1204,9 @@ class Exporter:
         # TorchAO release compatibility table bug https://github.com/pytorch/ao/issues/2919
         # Setuptools bug: https://github.com/pypa/setuptools/issues/4483
         check_requirements("setuptools<71.0.0")  # Setuptools bug: https://github.com/pypa/setuptools/issues/4483
-        check_requirements(("executorch==1.0.1", "flatbuffers"))
+        # Pin numpy to avoid coremltools errors with numpy>=2.4.0
+        check_requirements(("executorch==1.0.1", "flatbuffers", "numpy<=2.3.5"))
 
-        import torch
         from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
         from executorch.exir import to_edge_transform_and_lower
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1204,8 +1204,9 @@ class Exporter:
         # TorchAO release compatibility table bug https://github.com/pytorch/ao/issues/2919
         # Setuptools bug: https://github.com/pypa/setuptools/issues/4483
         check_requirements("setuptools<71.0.0")  # Setuptools bug: https://github.com/pypa/setuptools/issues/4483
-        # Pin numpy to avoid coremltools errors with numpy>=2.4.0
-        check_requirements(("executorch==1.0.1", "flatbuffers", "numpy<=2.3.5"))
+        check_requirements(("executorch==1.0.1", "flatbuffers"))
+        # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
+        check_requirements("numpy<=2.3.5")
 
         from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
         from executorch.exir import to_edge_transform_and_lower


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a NumPy version pin during ExecuTorch export to prevent Core ML tooling failures 🧩✅

### 📊 Key Changes
- 📌 In `ultralytics/engine/exporter.py`, updates `export_executorch()` to explicitly require `numpy<=2.3.5`
- 🛡️ Notes this is to avoid `coremltools` errors when using `numpy>=2.4.0`
- 🔧 Keeps the dependency check separate from other requirements to ensure it’s applied reliably

### 🎯 Purpose & Impact
- 🚀 Improves reliability of the ExecuTorch export path by preventing known dependency breakages
- 🧯 Reduces “random” export failures caused by newer NumPy versions, especially for users targeting Core ML workflows
- 📦 May prompt some environments to downgrade/hold NumPy, which can affect users who depend on NumPy 2.4+ features elsewhere (but makes exports more stable)