### PR TITLE
fix:  🐞 remove redundant import of torch from exporter.py

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1206,7 +1206,6 @@ class Exporter:
         check_requirements("setuptools<71.0.0")  # Setuptools bug: https://github.com/pypa/setuptools/issues/4483
         check_requirements(("executorch==1.0.1", "flatbuffers"))
 
-        import torch
         from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
         from executorch.exir import to_edge_transform_and_lower
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes an unused `torch` import from the ExecuTorch export path to keep the exporter cleaner 🧹

### 📊 Key Changes
- Deleted `import torch` inside `export_executorch()` in `ultralytics/engine/exporter.py` 🗑️
- No changes to ExecuTorch dependency checks or the actual export/lowering flow (still uses ExecuTorch + XNNPACK tooling) ✅

### 🎯 Purpose & Impact
- Reduces clutter and avoids unnecessary imports during ExecuTorch export 🔧
- Slightly improves maintainability and may marginally reduce import overhead/startup noise when exporting 📦
- No expected behavior change for users exporting models to ExecuTorch 🚀