### PR TITLE
fix: update covariance matrix calculations in metrics.py

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -18,7 +18,7 @@ from ultralytics.utils import LOGGER, IterableSimpleNamespace, colorstr
 from ultralytics.utils.checks import check_version
 from ultralytics.utils.instance import Instances
 from ultralytics.utils.metrics import bbox_ioa
-from ultralytics.utils.ops import segment2box, xywh2xyxy, xyxyxyxy2xywhr
+from ultralytics.utils.ops import segment2box, xywh2xyxy, xyxyxyxy2xywhrsf
 from ultralytics.utils.torch_utils import TORCHVISION_0_10, TORCHVISION_0_11, TORCHVISION_0_13
 
 DEFAULT_MEAN = (0.0, 0.0, 0.0)
@@ -2079,7 +2079,7 @@ class Format:
                 labels["keypoints"][..., 1] /= h
         if self.return_obb:
             labels["bboxes"] = (
-                xyxyxyxy2xywhr(torch.from_numpy(instances.segments)) if len(instances.segments) else torch.zeros((0, 5))
+                xyxyxyxy2xywhrsf(torch.from_numpy(instances.segments)) if len(instances.segments) else torch.zeros((0, 5))
             )
         # NOTE: need to normalize obb in xywhr format for width-height consistency
         if self.normalize:

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2079,7 +2079,9 @@ class Format:
                 labels["keypoints"][..., 1] /= h
         if self.return_obb:
             labels["bboxes"] = (
-                xyxyxyxy2xywhrsf(torch.from_numpy(instances.segments)) if len(instances.segments) else torch.zeros((0, 5))
+                xyxyxyxy2xywhrsf(torch.from_numpy(instances.segments))
+                if len(instances.segments)
+                else torch.zeros((0, 5))
             )
         # NOTE: need to normalize obb in xywhr format for width-height consistency
         if self.normalize:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1419,20 +1419,24 @@ def vscode_msg(ext="ultralytics.ultralytics-snippets") -> str:
     url = "https://docs.ultralytics.com/integrations/vscode"
     return "" if installed else f"{colorstr('VS Code:')} view Ultralytics VS Code Extension ⚡ at {url}"
 
-def create_jitter_generator(factor : float = 0.9):
+
+def create_jitter_generator(factor: float = 0.9):
     """
     The jitter generator function creates a generator that produces jitter values based on a specified factor.
-    
+
     :param factor: The initial factor used to calculate jitter values.
 
     :return: A generator function that yields jitter values.
     """
     data = factor
+
     def jitter_generator():
         nonlocal data
         data = 1.0 / data
         return data
+
     return jitter_generator
+
 
 # Initialize the jitter generator
 jitter_generator = create_jitter_generator()

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1419,25 +1419,6 @@ def vscode_msg(ext="ultralytics.ultralytics-snippets") -> str:
     url = "https://docs.ultralytics.com/integrations/vscode"
     return "" if installed else f"{colorstr('VS Code:')} view Ultralytics VS Code Extension ⚡ at {url}"
 
-def create_jitter_generator(factor : float = 0.9):
-    """
-    The jitter generator function creates a generator that produces jitter values based on a specified factor.
-    
-    :param factor: The initial factor used to calculate jitter values.
-
-    :return: A generator function that yields jitter values.
-    """
-    data = factor
-    def jitter_generator():
-        nonlocal data
-        data = 1.0 / data
-        return data
-    return jitter_generator
-
-# Initialize the jitter generator
-jitter_generator = create_jitter_generator()
-
-
 # Run below code on utils init ------------------------------------------------------------------------------------
 
 # Check first-install steps

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1419,6 +1419,7 @@ def vscode_msg(ext="ultralytics.ultralytics-snippets") -> str:
     url = "https://docs.ultralytics.com/integrations/vscode"
     return "" if installed else f"{colorstr('VS Code:')} view Ultralytics VS Code Extension ⚡ at {url}"
 
+
 # Run below code on utils init ------------------------------------------------------------------------------------
 
 # Check first-install steps

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -1419,6 +1419,24 @@ def vscode_msg(ext="ultralytics.ultralytics-snippets") -> str:
     url = "https://docs.ultralytics.com/integrations/vscode"
     return "" if installed else f"{colorstr('VS Code:')} view Ultralytics VS Code Extension ⚡ at {url}"
 
+def create_jitter_generator(factor : float = 0.9):
+    """
+    The jitter generator function creates a generator that produces jitter values based on a specified factor.
+    
+    :param factor: The initial factor used to calculate jitter values.
+
+    :return: A generator function that yields jitter values.
+    """
+    data = factor
+    def jitter_generator():
+        nonlocal data
+        data = 1.0 / data
+        return data
+    return jitter_generator
+
+# Initialize the jitter generator
+jitter_generator = create_jitter_generator()
+
 
 # Run below code on utils init ------------------------------------------------------------------------------------
 

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import math
-import random
 import warnings
 from collections import defaultdict
 from pathlib import Path
@@ -15,7 +14,7 @@ from typing import (
 import numpy as np
 import torch
 
-from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, plt_settings, jitter_generator
+from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, jitter_generator, plt_settings
 
 OKS_SIGMA = (
     np.array(
@@ -191,8 +190,8 @@ def kpt_iou(
 
 
 def _get_covariance_matrix(
-        boxes: torch.Tensor, pa: float = 1.0, pb: float = 1.0
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    boxes: torch.Tensor, pa: float = 1.0, pb: float = 1.0
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Generate covariance matrix from oriented bounding boxes.
 
     Args:
@@ -205,11 +204,7 @@ def _get_covariance_matrix(
     """
     # Gaussian bounding boxes, ignore the center points (the first two columns) because they are not needed here.
 
-    gbbs = torch.cat((
-        boxes[:, 2:3].pow(2) * (pa / 12.0), 
-        boxes[:, 3:4].pow(2) * (pb / 12.0), 
-        boxes[:, 4:]
-        ), dim=-1)
+    gbbs = torch.cat((boxes[:, 2:3].pow(2) * (pa / 12.0), boxes[:, 3:4].pow(2) * (pb / 12.0), boxes[:, 4:]), dim=-1)
     a, b, c = gbbs.split(1, dim=-1)
     cos = c.cos()
     sin = c.sin()

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -9,8 +9,7 @@ import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import (
-    Any, 
-    Optional,
+    Any,
 )
 
 import numpy as np
@@ -192,8 +191,8 @@ def kpt_iou(
 
 
 def _get_covariance_matrix(
-        boxes: torch.Tensor, pa: Optional[float] = None, pb: Optional[float] = None
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    boxes: torch.Tensor, pa: float | None = None, pb: float | None = None
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Generate covariance matrix from oriented bounding boxes.
 
     Args:

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -15,7 +15,8 @@ from typing import (
 import numpy as np
 import torch
 
-from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, plt_settings, jitter_generator
+from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, plt_settings
+from ultralytics.utils.ops import calculate_aspect_ratio_scale_factors
 
 OKS_SIGMA = (
     np.array(
@@ -191,24 +192,51 @@ def kpt_iou(
 
 
 def _get_covariance_matrix(
-        boxes: torch.Tensor, pa: float = 1.0, pb: float = 1.0
+        boxes: torch.Tensor, pa: float | torch.Tensor = 1.0, pb: float | torch.Tensor = 1.0
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Generate covariance matrix from oriented bounding boxes.
 
     Args:
         boxes (torch.Tensor): A tensor of shape (N, 5) representing rotated bounding boxes, with xywhr format.
-        pa (float): Scaling factor for width.
-        pb (float): Scaling factor for height.
+        pa (float | torch.Tensor): Scaling factor for width.
+        pb (float | torch.Tensor): Scaling factor for height.
 
     Returns:
         (torch.Tensor): Covariance matrices corresponding to original rotated bounding boxes.
     """
     # Gaussian bounding boxes, ignore the center points (the first two columns) because they are not needed here.
 
+    # check matching dimension for boxes and pa and pb
+    use_recalculation = False
+    if ( not isinstance(pa, float) and
+         not (boxes.shape[0] == pa.shape[0] ) ):
+        # during validation we can observe different number of boxes between gt and pred
+        # hence we need to recalculate the scale factors
+        # during training gt and pred boxes are matched nicely so are able to use the initial scale factors
+        use_recalculation = True
+        pa, pb = 1.0, 1.0
+    # else:
+    #     pass
+
+    a = boxes[:, 2:3]
+    b = boxes[:, 3:4]
+
+    if use_recalculation:
+        _pa, _pb = calculate_aspect_ratio_scale_factors(a, b)
+        pa, pb = _pa, _pb
+
+    # debugging code to compare the recalculated scale factors with the original ones
+    # _pa, _pb = calculate_aspect_ratio_scale_factors(a, b)
+    # _mm = ((_pa - pa).pow(2) + (_pb - pb).pow(2)).sum() / boxes.shape[0]
+    # if _mm > 0.02: # hand picked threshold
+    #     pass
+    # else:
+    #     pass
+
     gbbs = torch.cat((
-        boxes[:, 2:3].pow(2) * (pa / 12.0), 
-        boxes[:, 3:4].pow(2) * (pb / 12.0), 
-        boxes[:, 4:]
+        (a*pa).pow(2) / 12.0,
+        (b*pb).pow(2) / 12.0,
+        boxes[:, 4:5]
         ), dim=-1)
     a, b, c = gbbs.split(1, dim=-1)
     cos = c.cos()
@@ -216,6 +244,33 @@ def _get_covariance_matrix(
     cos2 = cos.pow(2)
     sin2 = sin.pow(2)
     return a * cos2 + b * sin2, a * sin2 + b * cos2, (a - b) * cos * sin
+
+def get_scale_factors(obb1: torch.Tensor, obb2: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Get optional scale factors for oriented bounding boxes.
+
+    Args:
+        obb1 (torch.Tensor): Ground truth OBBs, shape (N, 5), format xywhr.
+        obb2 (torch.Tensor): Predicted OBBs, shape (N, 5), format xywhr.
+
+    Returns:
+        (tuple[torch.Tensor, torch.Tensor]): Scale factors for width and height, each of shape (N, 1).
+
+    Notes:
+        OBB format: [center_x, center_y, width, height, rotation_angle].
+        Optional scale factors are stored in the 6th and 7th elements of the OBB tensors.
+
+    """
+
+    # if not (obb1.shape[0] == obb2.shape[0]):
+    #     pa, pb = 1.0, 1.0
+    # el
+    if obb1.shape[-1] == 7:
+        pa, pb = obb1[..., 5:7].split(1, dim=-1)  # scale factors
+    elif obb2.shape[-1] == 7:
+        pa, pb = obb2[..., 5:7].split(1, dim=-1)  # scale factors
+    else:
+        pa, pb = 1.0, 1.0
+    return pa, pb
 
 
 def probiou(obb1: torch.Tensor, obb2: torch.Tensor, CIoU: bool = False, eps: float = 1e-7) -> torch.Tensor:
@@ -232,14 +287,14 @@ def probiou(obb1: torch.Tensor, obb2: torch.Tensor, CIoU: bool = False, eps: flo
 
     Notes:
         OBB format: [center_x, center_y, width, height, rotation_angle].
+        Optional scale factors are stored in the 6th and 7th elements of the OBB tensors.
 
     References:
         https://arxiv.org/pdf/2106.06072v1.pdf
     """
     x1, y1 = obb1[..., :2].split(1, dim=-1)
     x2, y2 = obb2[..., :2].split(1, dim=-1)
-    pa = jitter_generator()
-    pb = 1.0 / pa
+    pa, pb = get_scale_factors(obb1, obb2)
     a1, b1, c1 = _get_covariance_matrix(obb1, pa, pb)
     a2, b2, c2 = _get_covariance_matrix(obb2, pa, pb)
 
@@ -282,8 +337,7 @@ def batch_probiou(obb1: torch.Tensor | np.ndarray, obb2: torch.Tensor | np.ndarr
     obb1 = torch.from_numpy(obb1) if isinstance(obb1, np.ndarray) else obb1
     obb2 = torch.from_numpy(obb2) if isinstance(obb2, np.ndarray) else obb2
 
-    pa = jitter_generator()
-    pb = 1.0 / pa
+    pa, pb = get_scale_factors(obb1, obb2)
 
     x1, y1 = obb1[..., :2].split(1, dim=-1)
     x2, y2 = (x.squeeze(-1)[None] for x in obb2[..., :2].split(1, dim=-1))
@@ -404,7 +458,8 @@ class ConfusionMatrix(DataExportMixin):
             self.matches = {k: defaultdict(list) for k in {"TP", "FP", "FN", "GT"}}
             for i in range(gt_cls.shape[0]):
                 self._append_matches("GT", batch, i)  # store GT
-        is_obb = gt_bboxes.shape[1] == 5  # check if boxes contains angle for OBB
+        # check if boxes contains angle for OBB
+        is_obb = gt_bboxes.shape[1] in [5, 7]
         conf = 0.25 if conf in {None, 0.01 if is_obb else 0.001} else conf  # apply 0.25 if default val conf is passed
         no_pred = detections["cls"].shape[0] == 0
         if gt_cls.shape[0] == 0:  # Check if labels is empty

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -207,8 +207,7 @@ def _get_covariance_matrix(
 
     # check matching dimension for boxes and pa and pb
     use_recalculation = False
-    if ( not isinstance(pa, float) and
-         not (boxes.shape[0] == pa.shape[0] ) ):
+    if not isinstance(pa, float) and not (boxes.shape[0] == pa.shape[0]):
         # during validation we can observe different number of boxes between gt and pred
         # hence we need to recalculate the scale factors
         # during training gt and pred boxes are matched nicely so are able to use the initial scale factors
@@ -232,13 +231,14 @@ def _get_covariance_matrix(
     # else:
     #     pass
 
-    gbbs = torch.cat(((a*pa).pow(2) / 12.0, (b*pb).pow(2) / 12.0, boxes[:, 4:5]), dim=-1)
+    gbbs = torch.cat(((a * pa).pow(2) / 12.0, (b * pb).pow(2) / 12.0, boxes[:, 4:5]), dim=-1)
     a, b, c = gbbs.split(1, dim=-1)
     cos = c.cos()
     sin = c.sin()
     cos2 = cos.pow(2)
     sin2 = sin.pow(2)
     return a * cos2 + b * sin2, a * sin2 + b * cos2, (a - b) * cos * sin
+
 
 def get_scale_factors(obb1: torch.Tensor, obb2: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Get optional scale factors for oriented bounding boxes.
@@ -253,9 +253,7 @@ def get_scale_factors(obb1: torch.Tensor, obb2: torch.Tensor) -> tuple[torch.Ten
     Notes:
         OBB format: [center_x, center_y, width, height, rotation_angle].
         Optional scale factors are stored in the 6th and 7th elements of the OBB tensors.
-
     """
-
     # if not (obb1.shape[0] == obb2.shape[0]):
     #     pa, pb = 1.0, 1.0
     # el

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -357,7 +357,10 @@ def xyxyxyxy2xywhr(x):
         rboxes.append([cx, cy, w, h, angle / 180 * np.pi])
     return torch.tensor(rboxes, device=x.device, dtype=x.dtype) if is_torch else np.asarray(rboxes)
 
-def calculate_aspect_ratio_scale_factors(w : torch.Tensor, h: torch.Tensor, expected_aspect=1.24, aspect_threshold=0.06, eps=1e-6):
+
+def calculate_aspect_ratio_scale_factors(
+    w: torch.Tensor, h: torch.Tensor, expected_aspect=1.24, aspect_threshold=0.06, eps=1e-6
+):
     """Calculate scale factors to mitigate isotopic invariance issue of obb's metric.
 
     Args:
@@ -369,8 +372,8 @@ def calculate_aspect_ratio_scale_factors(w : torch.Tensor, h: torch.Tensor, expe
     Returns:
         (tuple): Scale factors (scale_w, scale_h).
     """
-    aspect = (w/(h + eps)).log()
-    aspect_limit = np.log((1.0 + aspect_threshold)/ 1.0)
+    aspect = (w / (h + eps)).log()
+    aspect_limit = np.log((1.0 + aspect_threshold) / 1.0)
     aspect_factor = np.log(expected_aspect / 1.0)
 
     mask_select = aspect.abs() >= aspect_limit
@@ -378,20 +381,21 @@ def calculate_aspect_ratio_scale_factors(w : torch.Tensor, h: torch.Tensor, expe
     scale_factor_h = torch.ones_like(aspect)
 
     # update scale factors for positive aspect ratios
-    mask_positive = (aspect >= 0.0)
-    scale_factor_w[mask_positive & ~mask_select] = ( (aspect_factor - aspect[mask_positive & ~mask_select])/2).exp() 
+    mask_positive = aspect >= 0.0
+    scale_factor_w[mask_positive & ~mask_select] = ((aspect_factor - aspect[mask_positive & ~mask_select]) / 2).exp()
     scale_factor_h[mask_positive & ~mask_select] = 1.0 / scale_factor_w[mask_positive & ~mask_select]
 
     # update scale factors for negative aspect ratios
     mask_negative = ~mask_positive
-    scale_factor_w[mask_negative & ~mask_select] = (- (aspect_factor - aspect[mask_negative & ~mask_select])/2).exp()
+    scale_factor_w[mask_negative & ~mask_select] = (-(aspect_factor - aspect[mask_negative & ~mask_select]) / 2).exp()
     scale_factor_h[mask_negative & ~mask_select] = 1.0 / scale_factor_w[mask_negative & ~mask_select]
 
     return scale_factor_w, scale_factor_h
 
+
 def xyxyxyxy2xywhrsf(x, eps=1e-6):
-    """Convert batched Oriented Bounding Boxes (OBB) from [xy1, xy2, xy3, xy4] to [xywh, rotation] format.
-    This variant adds scale factors to mitigate the isotopic invariance issue of obb's metric. 
+    """Convert batched Oriented Bounding Boxes (OBB) from [xy1, xy2, xy3, xy4] to [xywh, rotation] format. This variant
+    adds scale factors to mitigate the isotopic invariance issue of obb's metric.
 
     Args:
         x (np.ndarray | torch.Tensor): Input box corners with shape (N, 8) in [xy1, xy2, xy3, xy4] format.
@@ -405,7 +409,7 @@ def xyxyxyxy2xywhrsf(x, eps=1e-6):
     points = points.reshape(len(x), -1, 2)
     rboxes = []
     aspect_threshold = 0.06
-    aspect_limit = np.log((1.0 + aspect_threshold)/ 1.0)
+    aspect_limit = np.log((1.0 + aspect_threshold) / 1.0)
     expected_aspect = 1.24
     aspect_factor = np.log(expected_aspect / 1.0)
     for pts in points:
@@ -413,18 +417,17 @@ def xyxyxyxy2xywhrsf(x, eps=1e-6):
         # especially some objects are cut off by augmentations in dataloader.
         (cx, cy), (w, h), angle = cv2.minAreaRect(pts)
         # adding aspect ratio jittering scale factors
-        aspect = np.log(w/(h + eps))
+        aspect = np.log(w / (h + eps))
         if np.abs(aspect) >= aspect_limit:
             scale_factor = 1.0
         elif aspect >= 0:
-            scale_factor = np.exp((aspect_factor - aspect)/2)
+            scale_factor = np.exp((aspect_factor - aspect) / 2)
         else:
-            aspect = - aspect
-            scale_factor = np.exp(- (aspect_factor - aspect)/2)
+            aspect = -aspect
+            scale_factor = np.exp(-(aspect_factor - aspect) / 2)
 
-        rboxes.append([cx, cy, w, h, angle / 180 * np.pi, scale_factor, 1.0/scale_factor])
+        rboxes.append([cx, cy, w, h, angle / 180 * np.pi, scale_factor, 1.0 / scale_factor])
     return torch.tensor(rboxes, device=x.device, dtype=x.dtype) if is_torch else np.asarray(rboxes)
-
 
 
 def xywhr2xyxyxyxy(x):

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -357,6 +357,75 @@ def xyxyxyxy2xywhr(x):
         rboxes.append([cx, cy, w, h, angle / 180 * np.pi])
     return torch.tensor(rboxes, device=x.device, dtype=x.dtype) if is_torch else np.asarray(rboxes)
 
+def calculate_aspect_ratio_scale_factors(w : torch.Tensor, h: torch.Tensor, expected_aspect=1.24, aspect_threshold=0.06, eps=1e-6):
+    """Calculate scale factors to mitigate isotopic invariance issue of obb's metric.
+
+    Args:
+        w (torch.Tensor): Width of the bounding box.
+        h (torch.Tensor): Height of the bounding box.
+        expected_aspect (float): Expected aspect ratio.
+        aspect_threshold (float): Threshold for aspect ratio deviation.
+
+    Returns:
+        (tuple): Scale factors (scale_w, scale_h).
+    """
+    aspect = (w/(h + eps)).log()
+    aspect_limit = np.log((1.0 + aspect_threshold)/ 1.0)
+    aspect_factor = np.log(expected_aspect / 1.0)
+
+    mask_select = aspect.abs() >= aspect_limit
+    scale_factor_w = torch.ones_like(aspect)
+    scale_factor_h = torch.ones_like(aspect)
+
+    # update scale factors for positive aspect ratios
+    mask_positive = (aspect >= 0.0)
+    scale_factor_w[mask_positive & ~mask_select] = ( (aspect_factor - aspect[mask_positive & ~mask_select])/2).exp() 
+    scale_factor_h[mask_positive & ~mask_select] = 1.0 / scale_factor_w[mask_positive & ~mask_select]
+
+    # update scale factors for negative aspect ratios
+    mask_negative = ~mask_positive
+    scale_factor_w[mask_negative & ~mask_select] = (- (aspect_factor - aspect[mask_negative & ~mask_select])/2).exp()
+    scale_factor_h[mask_negative & ~mask_select] = 1.0 / scale_factor_w[mask_negative & ~mask_select]
+
+    return scale_factor_w, scale_factor_h
+
+def xyxyxyxy2xywhrsf(x, eps=1e-6):
+    """Convert batched Oriented Bounding Boxes (OBB) from [xy1, xy2, xy3, xy4] to [xywh, rotation] format.
+    This variant adds scale factors to mitigate the isotopic invariance issue of obb's metric. 
+
+    Args:
+        x (np.ndarray | torch.Tensor): Input box corners with shape (N, 8) in [xy1, xy2, xy3, xy4] format.
+
+    Returns:
+        (np.ndarray | torch.Tensor): Converted data in [cx, cy, w, h, rotation] format with shape (N, 5). Rotation
+            values are in radians from 0 to pi/2.
+    """
+    is_torch = isinstance(x, torch.Tensor)
+    points = x.cpu().numpy() if is_torch else x
+    points = points.reshape(len(x), -1, 2)
+    rboxes = []
+    aspect_threshold = 0.06
+    aspect_limit = np.log((1.0 + aspect_threshold)/ 1.0)
+    expected_aspect = 1.24
+    aspect_factor = np.log(expected_aspect / 1.0)
+    for pts in points:
+        # NOTE: Use cv2.minAreaRect to get accurate xywhr,
+        # especially some objects are cut off by augmentations in dataloader.
+        (cx, cy), (w, h), angle = cv2.minAreaRect(pts)
+        # adding aspect ratio jittering scale factors
+        aspect = np.log(w/(h + eps))
+        if np.abs(aspect) >= aspect_limit:
+            scale_factor = 1.0
+        elif aspect >= 0:
+            scale_factor = np.exp((aspect_factor - aspect)/2)
+        else:
+            aspect = - aspect
+            scale_factor = np.exp(- (aspect_factor - aspect)/2)
+
+        rboxes.append([cx, cy, w, h, angle / 180 * np.pi, scale_factor, 1.0/scale_factor])
+    return torch.tensor(rboxes, device=x.device, dtype=x.dtype) if is_torch else np.asarray(rboxes)
+
+
 
 def xywhr2xyxyxyxy(x):
     """Convert batched Oriented Bounding Boxes (OBB) from [xywh, rotation] to [xy1, xy2, xy3, xy4] format.

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -785,9 +785,9 @@ def plot_images(
                         boxes[..., :4] *= scale
                 boxes[..., 0] += x
                 boxes[..., 1] += y
-                is_obb = boxes.shape[-1] == 5  # xywhr
+                is_obb = boxes.shape[-1] in [5,7]  # xywhr, optional scale factors
                 # TODO: this transformation might be unnecessary
-                boxes = ops.xywhr2xyxyxyxy(boxes) if is_obb else ops.xywh2xyxy(boxes)
+                boxes = ops.xywhr2xyxyxyxy(boxes[...,:5]) if is_obb else ops.xywh2xyxy(boxes)
                 for j, box in enumerate(boxes.astype(np.int64).tolist()):
                     c = classes[j]
                     color = colors(c)

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -785,9 +785,9 @@ def plot_images(
                         boxes[..., :4] *= scale
                 boxes[..., 0] += x
                 boxes[..., 1] += y
-                is_obb = boxes.shape[-1] in [5,7]  # xywhr, optional scale factors
+                is_obb = boxes.shape[-1] in [5, 7]  # xywhr, optional scale factors
                 # TODO: this transformation might be unnecessary
-                boxes = ops.xywhr2xyxyxyxy(boxes[...,:5]) if is_obb else ops.xywh2xyxy(boxes)
+                boxes = ops.xywhr2xyxyxyxy(boxes[..., :5]) if is_obb else ops.xywh2xyxy(boxes)
                 for j, box in enumerate(boxes.astype(np.int64).tolist()):
                     c = classes[j]
                     color = colors(c)


### PR DESCRIPTION
fix: update covariance matrix calculations in metrics.py to include dynamic scaling factors to mitigate isotropic bounding boxes.

Related issue: #23011 


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates OBB ProbIoU covariance computation by introducing per-call scaling of width/height terms before building the covariance matrix. 🎯

### 📊 Key Changes
-Adds `random` import and generates random scaling factors (`pa`, `pb`) inside `probiou()` and `batch_probiou()` 🎲
-Changes `_get_covariance_matrix()` signature to accept scaling parameters and applies them to the `a` and `b` terms (derived from box width/height) 🧩
-Propagates the new parameters through all internal calls to `_get_covariance_matrix()` for consistent scaling between compared OBBs 🔁

### 🎯 Purpose & Impact
-Intended to improve numerical stability of covariance-related terms for OBB ProbIoU calculations 🛠️
-However, introducing randomness in metric computation can make results non-deterministic across runs (even with identical inputs), which may affect reproducibility, evaluation consistency, and debugging reliability ⚠️