### PR TITLE
Fix CIB docstrings in block.py (#18585)

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1168,7 +1168,7 @@ class RepVGGDW(torch.nn.Module):
 
 
 class CIB(nn.Module):
-    """Conditional Identity Block (CIB) module.
+    """Compact Inverted Block (CIB) module.
 
     Args:
         c1 (int): Number of input channels.
@@ -1220,7 +1220,7 @@ class C2fCIB(C2f):
         c2 (int): Number of output channels.
         n (int, optional): Number of CIB modules to stack. Defaults to 1.
         shortcut (bool, optional): Whether to use shortcut connection. Defaults to False.
-        lk (bool, optional): Whether to use local key connection. Defaults to False.
+        lk (bool, optional): Whether to use large kernel. Defaults to False.
         g (int, optional): Number of groups for grouped convolution. Defaults to 1.
         e (float, optional): Expansion ratio for CIB modules. Defaults to 0.5.
     """
@@ -1235,7 +1235,7 @@ class C2fCIB(C2f):
             c2 (int): Output channels.
             n (int): Number of CIB modules.
             shortcut (bool): Whether to use shortcut connection.
-            lk (bool): Whether to use local key connection.
+            lk (bool): Whether to use large kernel.
             g (int): Groups for convolutions.
             e (float): Expansion ratio.
         """


### PR DESCRIPTION
## Description

  This PR fixes incorrect docstrings in `ultralytics/nn/modules/block.py` as reported in #18585.

  ## Changes

  - Correct CIB class description: 'Conditional Identity Block' → 'Compact Inverted Block'
  - Fix lk parameter description in C2fCIB: 'local key connection' → 'large kernel'
  - Update C2fCIB.__init__ docstring for lk parameter consistency

  These corrections align docstrings with YOLOv10 architecture where:
  - CIB is a Compact Inverted Block used for efficient feature extraction
  - lk parameter controls large kernel (7x7) vs standard kernel (3x3) in RepVGGDW

  ## Testing

  - ✅ Module imports successfully
  - ✅ CIB and C2fCIB instantiation works correctly
  - ✅ Forward pass validated with test tensors
  - ✅ No code logic changes, documentation only

  ## Related Issues

  Fixes #18585

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Corrects misleading docstrings for CIB-related blocks in `block.py` to match the actual module behavior.

### 📊 Key Changes
- Updated `CIB` docstring name from “Conditional Identity Block” to “Compact Inverted Block”
- Clarified `lk` argument description in `C2fCIB` from “local key connection” to “large kernel” (both class and `__init__` docstrings)

### 🎯 Purpose & Impact
- Improves code readability and reduces confusion when using or extending CIB/C2fCIB modules 📚
- Aligns inline documentation with intended semantics, helping prevent incorrect assumptions during model development 🔍