### PR TITLE
Remove redundant assert statements in loss.py

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -803,7 +803,6 @@ class TVPDetectLoss:
     def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Calculate the loss for text-visual prompt detection."""
         feats = preds[1] if isinstance(preds, tuple) else preds
-        assert self.ori_reg_max == self.vp_criterion.reg_max  # TODO: remove it
 
         if self.ori_reg_max * 4 + self.ori_nc == feats[0].shape[1]:
             loss = torch.zeros(3, device=self.vp_criterion.device, requires_grad=True)
@@ -839,7 +838,6 @@ class TVPSegmentLoss(TVPDetectLoss):
     def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Calculate the loss for text-visual prompt segmentation."""
         feats, pred_masks, proto = preds if len(preds) == 3 else preds[1]
-        assert self.ori_reg_max == self.vp_criterion.reg_max  # TODO: remove it
 
         if self.ori_reg_max * 4 + self.ori_nc == feats[0].shape[1]:
             loss = torch.zeros(4, device=self.vp_criterion.device, requires_grad=True)


### PR DESCRIPTION
 Removes redundant assert statements that were marked with TODO comments in ultralytics/utils/loss.py.

The assertions checked that `self.ori_reg_max == self.vp_criterion.reg_max`, but `reg_max` is never modified after initialization. Only `nc` and `no` are changed in `_get_vp_features()`, so these asserts are always true and serve no purpose.

Changes:
- Removed assert from TVPDetectLoss.__call__() (line 806)
- Removed assert from TVPSegmentLoss.__call__() (line 842)

No functional changes, just cleanup.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes redundant runtime assertions in `loss.py` for text-visual prompt loss paths to simplify execution 🧹

### 📊 Key Changes
- Removed two `assert self.ori_reg_max == self.vp_criterion.reg_max` statements (previously marked `TODO: remove it`).
- No functional logic changes to loss computation branches for prompt detection/segmentation.

### 🎯 Purpose & Impact
- Reduces unnecessary checks in hot-path loss calls for slightly cleaner and potentially faster training loops ⚡
- Avoids hard assertion failures in cases where the invariant is already guaranteed elsewhere (or should be validated at configuration time) 🛡️
- Maintains existing behavior for users; change is a safe refactor focused on code hygiene ✅