### PR TITLE
Clarify Docker output directory in Quickstart Guide (fixes #22938)

### DIFF
--- a/docs/en/guides/docker-quickstart.md
+++ b/docs/en/guides/docker-quickstart.md
@@ -209,13 +209,13 @@ Replace `/path/on/host` with the directory path on your local machine and `/path
 
 ### Persisting Training Outputs
 
-Training outputs save to `/ultralytics/runs/<task>/<name>/` inside the container by default. Outputs are lost when the container stops unless you mount a host directory.
+Training outputs save to `/ultralytics/runs/<task>/<name>/` inside the container by default. Without mounting a host directory, outputs are lost when the container is removed.
 
 To persist training outputs:
 
 ```bash
 # Recommended: mount workspace and specify project path
-sudo docker run --rm -it -v "$(pwd)":/w -w /w $t \
+sudo docker run --rm -it -v "$(pwd)":/w -w /w ultralytics/ultralytics:latest \
   yolo train model=yolo11n.pt data=coco8.yaml project=/w/runs
 ```
 

--- a/docs/en/guides/docker-quickstart.md
+++ b/docs/en/guides/docker-quickstart.md
@@ -207,6 +207,20 @@ sudo docker run -it --ipc=host --runtime=nvidia --gpus all -v /path/on/host:/pat
 
 Replace `/path/on/host` with the directory path on your local machine and `/path/in/container` with the desired path inside the Docker container.
 
+### Persisting Training Outputs
+
+Training outputs save to `/ultralytics/runs/<task>/<name>/` inside the container by default. Outputs are lost when the container stops unless you mount a host directory.
+
+To persist training outputs:
+
+```bash
+# Recommended: mount workspace and specify project path
+sudo docker run --rm -it -v "$(pwd)":/w -w /w $t \
+  yolo train model=yolo11n.pt data=coco8.yaml project=/w/runs
+```
+
+This saves all training outputs to `./runs` on your host machine.
+
 ## Run graphical user interface (GUI) applications in a Docker Container
 
 !!! danger "Highly Experimental - User Assumes All Risk"


### PR DESCRIPTION
Fixes #22938 by adding docs about Docker training output persistence.

Added section explaining default output location and how to persist results using mounted workspace with project parameter.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies how to persist Docker training outputs in the Docker Quickstart Guide by documenting the default runs path and showing a recommended volume-mount workflow 🐳📁

### 📊 Key Changes
- Added a new “Persisting Training Outputs” section to `docs/en/guides/docker-quickstart.md`
- Documented the default in-container output location: `/ultralytics/runs/<task>/<name>/`
- Provided an example `docker run` command that mounts the current directory and sets `project=/w/runs` to save outputs on the host

### 🎯 Purpose & Impact
- Reduces confusion about where training artifacts are written when using Docker 🧭
- Prevents accidental loss of results when containers stop by encouraging host volume mounts 💾
- Improves quickstart usability for new users by giving a copy-pasteable, recommended pattern ✅