### PR TITLE
Remove `numpy` pin for Sony IMX export and JetPack 6 systems

### DIFF
--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -34,10 +34,9 @@ RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
     sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
-# Pip install numpy, onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files
+# Pip install onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files
 RUN python3 -m pip install --upgrade pip uv && \
     uv pip install --system \
-    numpy==1.26.4 \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.20.0-cp310-cp310-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.5.0a0+872d972e41.nv24.08-cp310-cp310-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.20.0a0+afc54f7-cp310-cp310-linux_aarch64.whl && \

--- a/docker/Dockerfile-python-export
+++ b/docker/Dockerfile-python-export
@@ -16,8 +16,6 @@ RUN apt-get update && \
 
 # Install export dependencies and run exports to AutoInstall packages
 RUN uv pip install --system -e ".[export]" && \
-    # Need lower version of 'numpy' for Sony IMX export
-    uv pip install --system numpy==1.26.4 && \
     # Run exports to AutoInstall packages
     yolo export model=tmp/yolo11n.pt format=edgetpu imgsz=32 && \
     yolo export model=tmp/yolo11n.pt format=ncnn imgsz=32 && \

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -230,12 +230,6 @@ Alternatively, for `onnxruntime-gpu 1.20.0`:
 pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.20.0-cp310-cp310-linux_aarch64.whl
 ```
 
-!!! note
-
-    `onnxruntime-gpu` will automatically revert back the numpy version to latest. So we need to reinstall numpy to `1.23.5` to fix an issue by executing:
-
-    `pip install numpy==1.23.5`
-
 ### Run on JetPack 5.1.2
 
 #### Install Ultralytics Package


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes explicit NumPy pinning from Jetson/Export Docker builds and cleans up outdated Jetson docs for a smoother setup 🧹🚀

### 📊 Key Changes
- 🔧 **Jetson JetPack 6 Dockerfile:** removed the hard-pinned `numpy==1.26.4` install step, leaving the rest of the GPU stack installs intact (`onnxruntime-gpu`, `torch`, `torchvision`, `ultralytics`).
- 🐳 **Python export Dockerfile:** removed the extra step that forced `numpy==1.26.4` (previously noted as needed for Sony IMX export).
- 📚 **Jetson guide update:** deleted the note instructing users to reinstall NumPy (e.g., `numpy==1.23.5`) after installing `onnxruntime-gpu`, implying this workaround is no longer needed.

### 🎯 Purpose & Impact
- ✅ **Simpler installs & fewer conflicts:** reduces dependency churn and avoids forcing a specific NumPy version that could clash with other packages.
- 🛠️ **More reliable Docker builds:** fewer pinned constraints can mean smoother image builds and less breakage when upstream dependencies change.
- 📖 **Cleaner user guidance:** removes an outdated/manual “reinstall NumPy” step, making Jetson setup instructions easier to follow for everyone.