### PR TITLE
Remove `numpy` pin for JetPack 6 systems

### DIFF
--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -34,10 +34,9 @@ RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
     sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
 ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
-# Pip install numpy, onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files
+# Pip install onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files
 RUN python3 -m pip install --upgrade pip uv && \
     uv pip install --system \
-    numpy==1.26.4 \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.20.0-cp310-cp310-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.5.0a0+872d972e41.nv24.08-cp310-cp310-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.20.0a0+afc54f7-cp310-cp310-linux_aarch64.whl && \

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -230,12 +230,6 @@ Alternatively, for `onnxruntime-gpu 1.20.0`:
 pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.20.0-cp310-cp310-linux_aarch64.whl
 ```
 
-!!! note
-
-    `onnxruntime-gpu` will automatically revert back the numpy version to latest. So we need to reinstall numpy to `1.23.5` to fix an issue by executing:
-
-    `pip install numpy==1.23.5`
-
 ### Run on JetPack 5.1.2
 
 #### Install Ultralytics Package


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Simplifies Jetson/JetPack setup by removing manual NumPy pinning/reinstall steps for ONNX Runtime GPU installs 🚀

### 📊 Key Changes
- 🐳 **JetPack 6 Dockerfile:** Removed explicit `numpy==1.26.4` installation from `docker/Dockerfile-jetson-jetpack6`, leaving installation of `onnxruntime-gpu`, `torch`, `torchvision`, and `ultralytics`.
- 📚 **Jetson guide update:** Removed a note in `docs/en/guides/nvidia-jetson.md` that advised reinstalling NumPy after installing `onnxruntime-gpu` (previously suggested `numpy==1.23.5`).

### 🎯 Purpose & Impact
- ✅ **Less fragile installs:** Avoids hard-pinning or “reinstall NumPy” workarounds that can cause dependency conflicts on Jetson.
- 🧩 **Cleaner documentation:** Reduces confusion by removing guidance that may no longer be necessary or accurate for current builds.
- 🛠️ **Easier maintenance:** Fewer version constraints in the Docker image means fewer breakages as dependencies evolve, improving long-term reliability for Jetson users.