### PR TITLE
Capitalize markdown

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -455,7 +455,7 @@ def minify_files(html: bool = True, css: bool = True, js: bool = True):
 
 
 def render_jinja_macros() -> None:
-    """Render MiniJinja macros in markdown files before building with MkDocs."""
+    """Render MiniJinja macros in Markdown files before building with MkDocs."""
     mkdocs_yml = DOCS.parent / "mkdocs.yml"
     default_yaml = DOCS.parent / "ultralytics" / "cfg" / "default.yaml"
 

--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -409,12 +409,12 @@ SECTION_ALIASES = {
 
 
 def _normalize_text(text: str) -> str:
-    """Normalize text while preserving markdown structures like tables, admonitions, and code blocks."""
+    """Normalize text while preserving Markdown structures like tables, admonitions, and code blocks."""
     if not text:
         return ""
-    # Check if text contains markdown structures that need line preservation
+    # Check if text contains Markdown structures that need line preservation
     if any(marker in text for marker in ("|", "!!!", "```", "\n#", "\n- ", "\n* ", "\n1. ", "\n    ")):
-        # Preserve markdown formatting - just strip trailing whitespace from lines
+        # Preserve Markdown formatting - just strip trailing whitespace from lines
         return "\n".join(line.rstrip() for line in text.splitlines()).strip()
     # Simple text - collapse single newlines within paragraphs
     paragraphs: list[str] = []

--- a/docs/en/models/yolov7.md
+++ b/docs/en/models/yolov7.md
@@ -97,14 +97,14 @@ As of the time of writing, Ultralytics only supports ONNX and TensorRT inference
 
 To use YOLOv7 ONNX model with Ultralytics:
 
-0. (Optional) Install Ultralytics and export an ONNX model to have the required dependencies automatically installed:
+1. (Optional) Install Ultralytics and export an ONNX model to have the required dependencies automatically installed:
 
     ```bash
     pip install ultralytics
     yolo export model=yolo11n.pt format=onnx
     ```
 
-1. Export the desired YOLOv7 model by using the exporter in the [YOLOv7 repo](https://github.com/WongKinYiu/yolov7):
+2. Export the desired YOLOv7 model by using the exporter in the [YOLOv7 repo](https://github.com/WongKinYiu/yolov7):
 
     ```bash
     git clone https://github.com/WongKinYiu/yolov7
@@ -112,7 +112,7 @@ To use YOLOv7 ONNX model with Ultralytics:
     python export.py --weights yolov7-tiny.pt --grid --end2end --simplify --topk-all 100 --iou-thres 0.65 --conf-thres 0.35 --img-size 640 640 --max-wh 640
     ```
 
-2. Modify the ONNX model graph to be compatible with Ultralytics using the following script:
+3. Modify the ONNX model graph to be compatible with Ultralytics using the following script:
 
     ```python
     import numpy as np
@@ -309,7 +309,7 @@ To use YOLOv7 ONNX model with Ultralytics:
     onnx.save(model, "yolov7-ultralytics.onnx")
     ```
 
-3. You can then load the modified ONNX model and run inference with it in Ultralytics normally:
+4. You can then load the modified ONNX model and run inference with it in Ultralytics normally:
 
     ```python
     from ultralytics import ASSETS, YOLO

--- a/docs/overrides/javascript/giscus.js
+++ b/docs/overrides/javascript/giscus.js
@@ -34,7 +34,7 @@ function loadGiscus() {
   }
 
   // Register event handlers for theme changes
-  var ref = document.querySelector("[data-md-component=palette]");
+  const ref = document.querySelector("[data-md-component=palette]");
   if (ref) {
     ref.addEventListener("change", () => {
       const palette = __md_get("__palette");

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -184,7 +184,7 @@ div.highlight {
   flex-direction: column;
 }
 .banner-wrapper {
-  padding: 40px 0px;
+  padding: 40px 0;
 }
 .banner-wrapper > .banner-content-wrapper {
   gap: 0.75rem;

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -715,7 +715,7 @@ def handle_yolo_solutions(args: list[str]) -> None:
 
         from ultralytics import solutions
 
-        solution = getattr(solutions, SOLUTION_MAP[solution_name])(is_cli=True, **overrides)  # class i.e ObjectCounter
+        solution = getattr(solutions, SOLUTION_MAP[solution_name])(is_cli=True, **overrides)  # class i.e. ObjectCounter
 
         cap = cv2.VideoCapture(solution.CFG["source"])  # read the video file
         if solution_name != "crop":

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2164,7 +2164,8 @@ class LoadVisualPrompt:
         """
         self.scale_factor = scale_factor
 
-    def make_mask(self, boxes: torch.Tensor, h: int, w: int) -> torch.Tensor:
+    @staticmethod
+    def make_mask(boxes: torch.Tensor, h: int, w: int) -> torch.Tensor:
         """Create binary masks from bounding boxes.
 
         Args:

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -261,7 +261,8 @@ class Tuner:
         except Exception as e:
             LOGGER.warning(f"{self.prefix}MongoDB to CSV sync failed: {e}")
 
-    def _crossover(self, x: np.ndarray, alpha: float = 0.2, k: int = 9) -> np.ndarray:
+    @staticmethod
+    def _crossover(x: np.ndarray, alpha: float = 0.2, k: int = 9) -> np.ndarray:
         """BLX-α crossover from up to top-k parents (x[:,0]=fitness, rest=genes)."""
         k = min(k, len(x))
         # fitness weights (shifted to >0); fallback to uniform if degenerate

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -1812,7 +1812,8 @@ class SAM2VideoPredictor(SAM2Predictor):
         inference_state["output_dict_per_obj"].clear()
         inference_state["temp_output_dict_per_obj"].clear()
 
-    def _reset_tracking_results(self, inference_state):
+    @staticmethod
+    def _reset_tracking_results(inference_state):
         """Reset all tracking inputs and results across the videos."""
         for v in inference_state["point_inputs_per_obj"].values():
             v.clear()
@@ -2594,13 +2595,8 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         assert predictor.dataset is not None
         assert predictor.dataset.mode == "video"
         num_frames = predictor.dataset.frames
-        inference_state = {
-            "num_frames": num_frames,
-            "tracker_inference_states": [],
-            "tracker_metadata": {},
-        }
-        inference_state["text_prompt"] = None
-        inference_state["per_frame_geometric_prompt"] = [None] * num_frames
+        inference_state = {"num_frames": num_frames, "tracker_inference_states": [], "tracker_metadata": {},
+                           "text_prompt": None, "per_frame_geometric_prompt": [None] * num_frames}
         predictor.inference_state = inference_state
 
     def inference(self, im, bboxes=None, labels=None, text: list[str] | None = None, *args, **kwargs):
@@ -2880,7 +2876,8 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
             tracker_obj_scores_global,  # a dict: obj_id --> tracker frame-level scores
         )
 
-    def _suppress_detections_close_to_boundary(self, boxes, margin=0.025):
+    @staticmethod
+    def _suppress_detections_close_to_boundary(boxes, margin=0.025):
         """Suppress detections too close to image edges (for normalized boxes).
 
         boxes: (N, 4) in xyxy format, normalized [0,1]
@@ -3327,8 +3324,8 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
 
         return tracker_states_local
 
+    @staticmethod
     def build_outputs(
-        self,
         det_out: dict[str, torch.Tensor],
         tracker_low_res_masks_global: torch.Tensor,
         tracker_metadata_prev: dict[str, np.ndarray],
@@ -3921,7 +3918,8 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
     def _encode_prompt(self, **kwargs):
         return self.model._encode_prompt(**kwargs)
 
-    def _drop_new_det_with_obj_limit(self, new_det_fa_inds, det_scores_np, num_to_keep):
+    @staticmethod
+    def _drop_new_det_with_obj_limit(new_det_fa_inds, det_scores_np, num_to_keep):
         """Drop a few new detections based on the maximum number of objects. We drop new objects based on their
         detection scores, keeping the high-scoring ones and dropping the low-scoring ones.
         """

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2595,8 +2595,13 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         assert predictor.dataset is not None
         assert predictor.dataset.mode == "video"
         num_frames = predictor.dataset.frames
-        inference_state = {"num_frames": num_frames, "tracker_inference_states": [], "tracker_metadata": {},
-                           "text_prompt": None, "per_frame_geometric_prompt": [None] * num_frames}
+        inference_state = {
+            "num_frames": num_frames,
+            "tracker_inference_states": [],
+            "tracker_metadata": {},
+            "text_prompt": None,
+            "per_frame_geometric_prompt": [None] * num_frames,
+        }
         predictor.inference_state = inference_state
 
     def inference(self, im, bboxes=None, labels=None, text: list[str] | None = None, *args, **kwargs):

--- a/ultralytics/models/sam/sam3/encoder.py
+++ b/ultralytics/models/sam/sam3/encoder.py
@@ -144,7 +144,6 @@ class TransformerEncoderLayer(nn.Module):
         memory_key_padding_mask: torch.Tensor = None,
         pos: torch.Tensor = None,
         query_pos: torch.Tensor = None,
-        # **kwargs,
     ) -> torch.Tensor:
         """Forward pass for pre-norm architecture.
 
@@ -160,8 +159,6 @@ class TransformerEncoderLayer(nn.Module):
             memory_key_padding_mask: Key padding mask for cross-attention
             pos: Positional encoding for memory
             query_pos: Positional encoding for query
-            attn_bias: Optional attention bias tensor
-            **kwargs: Additional keyword arguments
 
         Returns:
             Processed tensor
@@ -204,7 +201,6 @@ class TransformerEncoderLayer(nn.Module):
         memory_key_padding_mask: torch.Tensor = None,
         pos: torch.Tensor = None,
         query_pos: torch.Tensor = None,
-        # **kwds: Any,
     ) -> torch.Tensor:
         """Forward pass for the transformer encoder layer.
 
@@ -218,8 +214,6 @@ class TransformerEncoderLayer(nn.Module):
             memory_key_padding_mask: Key padding mask for cross-attention
             pos: Positional encoding for memory
             query_pos: Positional encoding for query
-            attn_bias: Optional attention bias tensor
-            **kwds: Additional keyword arguments
 
         Returns:
             Processed tensor after self-attention, cross-attention, and feedforward network

--- a/ultralytics/models/sam/sam3/model_misc.py
+++ b/ultralytics/models/sam/sam3/model_misc.py
@@ -36,7 +36,8 @@ class DotProductScoring(torch.nn.Module):
         if self.clamp_logits:
             self.clamp_max_val = clamp_max_val
 
-    def mean_pool_text(self, prompt, prompt_mask):
+    @staticmethod
+    def mean_pool_text(prompt, prompt_mask):
         """Mean-pool the prompt embeddings over the valid tokens only."""
         # is_valid has shape (seq, bs, 1), where 1 is valid and 0 is padding
         is_valid = (~prompt_mask).to(prompt.dtype).permute(1, 0)[..., None]

--- a/ultralytics/models/sam/sam3/vitdet.py
+++ b/ultralytics/models/sam/sam3/vitdet.py
@@ -482,7 +482,8 @@ class ViT(nn.Module):
             if self.use_act_checkpoint and self.training:
                 torch._dynamo.config.optimize_ddp = False
 
-    def _init_weights(self, m: nn.Module) -> None:
+    @staticmethod
+    def _init_weights(m: nn.Module) -> None:
         """Initialize the weights."""
         if isinstance(m, nn.Linear):
             nn.init.trunc_normal_(m.weight, std=0.02)

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -79,7 +79,8 @@ class DetectionPredictor(BasePredictor):
 
         return results
 
-    def get_obj_feats(self, feat_maps, idxs):
+    @staticmethod
+    def get_obj_feats(feat_maps, idxs):
         """Extract object features from the feature maps."""
         import torch
 

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -798,7 +798,8 @@ class BNContrastiveHead(nn.Module):
         del self.logit_scale
         self.forward = self.forward_fuse
 
-    def forward_fuse(self, x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+    @staticmethod
+    def forward_fuse(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
         """Passes input out unchanged."""
         return x
 
@@ -1736,7 +1737,8 @@ class ABlock(nn.Module):
 
         self.apply(self._init_weights)
 
-    def _init_weights(self, m: nn.Module):
+    @staticmethod
+    def _init_weights(m: nn.Module):
         """Initialize weights using a truncated normal distribution.
 
         Args:

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -532,7 +532,8 @@ class LRPCHead(nn.Module):
         self.loc = loc
         self.enabled = enabled
 
-    def conv2linear(self, conv: nn.Conv2d) -> nn.Linear:
+    @staticmethod
+    def conv2linear(conv: nn.Conv2d) -> nn.Linear:
         """Convert a 1x1 convolutional layer to a linear layer."""
         assert isinstance(conv, nn.Conv2d) and conv.kernel_size == (1, 1)
         linear = nn.Linear(conv.in_channels, conv.out_channels)
@@ -981,8 +982,8 @@ class RTDETRDecoder(nn.Module):
         y = torch.cat((dec_bboxes.squeeze(0), dec_scores.squeeze(0).sigmoid()), -1)
         return y if self.export else (y, x)
 
+    @staticmethod
     def _generate_anchors(
-        self,
         shapes: list[list[int]],
         grid_size: float = 0.05,
         dtype: torch.dtype = torch.float32,

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -116,7 +116,7 @@ def pose_forward(self, x: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tenso
     kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nk, -1) for i in range(self.nl)], -1)  # (bs, 17*3, h*w)
     x = Detect.forward(self, x)
     pred_kpt = self.kpts_decode(bs, kpt)
-    return (*x, pred_kpt.permute(0, 2, 1))
+    return *x, pred_kpt.permute(0, 2, 1)
 
 
 def segment_forward(self, x: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -125,7 +125,7 @@ def segment_forward(self, x: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Te
     bs = p.shape[0]  # batch size
     mc = torch.cat([self.cv4[i](x[i]).view(bs, self.nm, -1) for i in range(self.nl)], 2)  # mask coefficients
     x = Detect.forward(self, x)
-    return (*x, mc.transpose(1, 2), p)
+    return *x, mc.transpose(1, 2), p
 
 
 class NMSWrapper(torch.nn.Module):

--- a/ultralytics/utils/git.py
+++ b/ultralytics/utils/git.py
@@ -63,7 +63,8 @@ class GitRepo:
                 return (root / t.split(":", 1)[1].strip()).resolve()
         return None
 
-    def _read(self, p: Path | None) -> str | None:
+    @staticmethod
+    def _read(p: Path | None) -> str | None:
         """Read and strip file if exists."""
         return p.read_text(errors="ignore").strip() if p and p.exists() else None
 

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -179,7 +179,8 @@ class TQDM:
             num /= self.unit_divisor
         return f"{num:.1f}PB"
 
-    def _format_time(self, seconds: float) -> str:
+    @staticmethod
+    def _format_time(seconds: float) -> str:
         """Format time duration."""
         if seconds < 60:
             return f"{seconds:.1f}s"


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Minor refactor and documentation polish: convert several helper methods to `@staticmethod`, tidy docs formatting, and apply small JS/CSS cleanups 🧹✨

### 📊 Key Changes
- Converted multiple internal helper methods across the codebase to `@staticmethod` (e.g., in augmentation, tuner, SAM predictors, YOLO detect predictor, NN blocks/heads, git utils, tqdm utils) 🔧
- Small SAM predictor state init cleanup: initializes `text_prompt` and `per_frame_geometric_prompt` directly in the state dict for clarity 🧠
- Docs improvements:
  - Fixed step numbering in the YOLOv7 ONNX usage guide (0→1, 1→2, etc.) 📚✅
  - Standardized “Markdown” capitalization in docstrings/comments 📝
- Frontend tweaks for docs site:
  - JS: replaced `var` with `const` in `giscus.js` for modern style and safer scoping 🌐
  - CSS: simplified `padding: 40px 0px;` → `padding: 40px 0;` 🎨
- Export utility cleanup: simplified tuple returns in IMX export helpers (`return *x, ...` instead of `return (*x, ...)`) 📦

### 🎯 Purpose & Impact
- Improves code clarity and maintainability by marking methods that don’t use instance state as static, reducing confusion and easing future refactors 🛠️
- Slightly cleaner and more consistent docs (especially the YOLOv7 ONNX instructions), reducing user friction when following setup steps 📖🚀
- Minor docs-site code/style modernizations that reduce linting/style issues and improve consistency, with effectively no behavior change for end users ⚙️✅
- Overall: a low-risk polish PR—mostly internal cleanup and documentation correctness, with minimal likelihood of breaking changes 🧩👍