### PR TITLE
Add documentation for output tensor format

### DIFF
--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -188,10 +188,10 @@ For deployment on specific hardware platforms, consider using specialized export
 
 When you export a YOLO model to formats like ONNX or TensorRT, the output tensor structure depends on the model task. Understanding these outputs is important for custom inference implementations.
 
-For **detection models** (e.g., `yolo11n.pt`), the output is a single tensor with shape `(batch_size, 84, 8400)` where 84 represents 4 bounding box coordinates plus 80 class scores (for COCO), and 8400 is the number of detection anchors.
+For **detection models** (e.g., `yolo11n.pt`), the output is typically a single tensor shaped like `(batch_size, 4 + num_classes, num_predictions)` where the channels represent box coordinates plus per-class scores, and `num_predictions` depends on the export input resolution (and can be dynamic).
 
-For **segmentation models** (e.g., `yolo11n-seg.pt`), you'll get two outputs: the first tensor `(batch_size, 116, 8400)` contains bounding boxes, class scores, and 32 mask coefficients, while the second tensor `(batch_size, 32, 160, 160)` contains the mask prototypes that combine with the coefficients to generate instance masks.
+For **segmentation models** (e.g., `yolo11n-seg.pt`), you'll typically get two outputs: the first tensor shaped like `(batch_size, 4 + num_classes + mask_dim, num_predictions)` (boxes, class scores, and mask coefficients), and the second tensor shaped like `(batch_size, mask_dim, proto_h, proto_w)` containing mask prototypes used with the coefficients to generate instance masks. Sizes depend on the export input resolution (and can be dynamic).
 
-For **pose models** (e.g., `yolo11n-pose.pt`), the output tensor has shape `(batch_size, 56, 8400)` where 56 includes bounding boxes, class scores, and keypoint coordinates for body pose estimation.
+For **pose models** (e.g., `yolo11n-pose.pt`), the output tensor is typically shaped like `(batch_size, 4 + num_classes + keypoint_dims, num_predictions)`, where `keypoint_dims` depends on the pose specification (e.g., number of keypoints and whether confidence is included), and `num_predictions` depends on the export input resolution (and can be dynamic).
 
-The examples in the [ONNX inference directory](https://github.com/ultralytics/ultralytics/tree/main/examples) demonstrate how to process these outputs for each model type.
+The examples in the [ONNX inference examples](https://github.com/ultralytics/ultralytics/tree/main/examples) demonstrate how to process these outputs for each model type.

--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -183,3 +183,15 @@ Understanding and configuring export arguments is crucial for optimizing model p
 - **`int8:`** Enables INT8 quantization, highly beneficial for [edge AI](https://www.ultralytics.com/blog/deploying-computer-vision-applications-on-edge-ai-devices) deployments.
 
 For deployment on specific hardware platforms, consider using specialized export formats like [TensorRT](../integrations/tensorrt.md) for NVIDIA GPUs, [CoreML](../integrations/coreml.md) for Apple devices, or [Edge TPU](../integrations/edge-tpu.md) for Google Coral devices.
+
+### What do the output tensors represent in exported YOLO models?
+
+When you export a YOLO model to formats like ONNX or TensorRT, the output tensor structure depends on the model task. Understanding these outputs is important for custom inference implementations.
+
+For **detection models** (e.g., `yolo11n.pt`), the output is a single tensor with shape `(batch_size, 84, 8400)` where 84 represents 4 bounding box coordinates plus 80 class scores (for COCO), and 8400 is the number of detection anchors.
+
+For **segmentation models** (e.g., `yolo11n-seg.pt`), you'll get two outputs: the first tensor `(batch_size, 116, 8400)` contains bounding boxes, class scores, and 32 mask coefficients, while the second tensor `(batch_size, 32, 160, 160)` contains the mask prototypes that combine with the coefficients to generate instance masks.
+
+For **pose models** (e.g., `yolo11n-pose.pt`), the output tensor has shape `(batch_size, 56, 8400)` where 56 includes bounding boxes, class scores, and keypoint coordinates for body pose estimation.
+
+The examples in the [ONNX inference directory](https://github.com/ultralytics/ultralytics/tree/main/examples) demonstrate how to process these outputs for each model type.


### PR DESCRIPTION
Fixes #16944 

Documents output tensor shapes and their meaning for YOLO models exported to ONNX/TensorRT formats.

Added FAQ entry explaining:
- Detection model outputs (batch_size, 84, 8400)
- Segmentation model outputs (batch_size, 116, 8400) + (batch_size, 32, 160, 160)
- Pose model outputs (batch_size, 56, 8400)

Links to ONNX examples for processing these outputs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a new documentation section explaining exported YOLO model output tensor formats for common tasks 📦

### 📊 Key Changes
- Adds a dedicated FAQ-style section to `docs/en/modes/export.md` describing exported output tensor structures 🧾
- Documents output shapes for detection, segmentation (including prototype masks), and pose models 🎯
- Points readers to the ONNX inference examples directory for practical post-processing guidance 🔎

### 🎯 Purpose & Impact
- Helps users implementing custom ONNX/TensorRT inference correctly interpret model outputs ✅
- Reduces confusion around tensor dimensions across tasks (detect/segment/pose) and speeds up deployment 🚀
- Improves export documentation clarity for users integrating Ultralytics models into external runtimes 🛠️