### PR TITLE
Add note about background class for YOLO-World models

### DIFF
--- a/docs/en/models/yolo-world.md
+++ b/docs/en/models/yolo-world.md
@@ -238,13 +238,13 @@ For instance, if your application only requires detecting 'person' and 'bus' obj
 
 !!! note "Background Class"
 
-    Some users have found that adding an empty string `""` as a background class can improve detection performance in certain scenarios. While the exact mechanism isn't fully understood, this may help with prediction scoring during non-maximum suppression:
+    Some users have found that appending an empty string `""` as a background class can improve detection performance in certain scenarios. This behavior appears to be scenario-dependent and the exact mechanism is not fully understood:
 
     ```python
     model.set_classes(["person", "bus", ""])
     ```
 
-You can also save a model after setting custom classes. By doing this you create a version of the YOLO-World model that is specialized for your specific use case. This process embeds your custom class definitions directly into the model file, making the model ready to use with your specified classes without further adjustments. Follow these steps to save and load your custom YOLOv8 model:
+You can also save a model after setting custom classes. By doing this you create a version of the YOLO-World model that is specialized for your specific use case. This process embeds your custom class definitions directly into the model file, making the model ready to use with your specified classes without further adjustments. Follow these steps to save and load your custom YOLO-World model:
 
 !!! example
 

--- a/docs/en/models/yolo-world.md
+++ b/docs/en/models/yolo-world.md
@@ -236,6 +236,14 @@ For instance, if your application only requires detecting 'person' and 'bus' obj
         results[0].show()
         ```
 
+!!! note "Background Class"
+
+    Some users have found that adding an empty string `""` as a background class can improve detection performance in certain scenarios. While the exact mechanism isn't fully understood, this may help with prediction scoring during non-maximum suppression:
+
+    ```python
+    model.set_classes(["person", "bus", ""])
+    ```
+
 You can also save a model after setting custom classes. By doing this you create a version of the YOLO-World model that is specialized for your specific use case. This process embeds your custom class definitions directly into the model file, making the model ready to use with your specified classes without further adjustments. Follow these steps to save and load your custom YOLOv8 model:
 
 !!! example

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -32,7 +32,7 @@ def _send(event, data, project, name):
     """Send event to Platform endpoint."""
     try:
         requests.post(
-            "https://alpha.ultralytics.com/api/training/webhook",
+            "https://alpha.ultralytics.com/api/webhooks/training/metrics",
             json={"event": event, "project": project, "name": name, "data": data},
             headers={"Authorization": f"Bearer {_api_key}"},
             timeout=10,
@@ -55,7 +55,7 @@ def _upload_model(model_path, project, name):
 
         # Get signed upload URL
         response = requests.post(
-            "https://alpha.ultralytics.com/api/training/upload-url",
+            "https://alpha.ultralytics.com/api/webhooks/models/upload",
             json={"project": project, "name": name, "filename": model_path.name},
             headers={"Authorization": f"Bearer {_api_key}"},
             timeout=10,


### PR DESCRIPTION
Fixes #8651 

Documents community-discovered tip that adding an empty string as a background class can improve YOLO-World detection performance.

Based on user feedback where this approach helped with prediction scoring during non-maximum suppression, though the exact mechanism isn't fully understood.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a documentation note explaining that including an empty-string background class may improve some YOLO-World detection results. 📝

### 📊 Key Changes
- Adds a new **“Background Class”** note to `docs/en/models/yolo-world.md`.
- Documents a community-observed tip: appending `""` as a background class when calling `model.set_classes([...])`.
- Briefly explains a possible reason (prediction scoring behavior during NMS) and provides a small code snippet. 💡

### 🎯 Purpose & Impact
- Helps users troubleshoot and potentially improve YOLO-World performance in certain edge cases (especially when using a small custom class list). 🎯
- Sets expectations by clarifying the behavior is scenario-dependent and not fully explained, reducing confusion and support load. ✅