### PR TITLE
Fix incorrect width/height indexing in v8OBBLoss

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -702,7 +702,7 @@ class v8OBBLoss(v8DetectionLoss):
         try:
             batch_idx = batch["batch_idx"].view(-1, 1)
             targets = torch.cat((batch_idx, batch["cls"].view(-1, 1), batch["bboxes"].view(-1, 5)), 1)
-            rw, rh = targets[:, 4] * imgsz[1].item(), targets[:, 5] * imgsz[0].item()
+            rw, rh = targets[:, 4] * float(imgsz[1]), targets[:, 5] * float(imgsz[0])
             targets = targets[(rw >= 2) & (rh >= 2)]  # filter rboxes of tiny size to stabilize training
             targets = self.preprocess(targets, batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
             gt_labels, gt_bboxes = targets.split((1, 5), 2)  # cls, xywhr

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -702,7 +702,7 @@ class v8OBBLoss(v8DetectionLoss):
         try:
             batch_idx = batch["batch_idx"].view(-1, 1)
             targets = torch.cat((batch_idx, batch["cls"].view(-1, 1), batch["bboxes"].view(-1, 5)), 1)
-            rw, rh = targets[:, 4] * imgsz[0].item(), targets[:, 5] * imgsz[1].item()
+            rw, rh = targets[:, 4] * imgsz[1].item(), targets[:, 5] * imgsz[0].item()
             targets = targets[(rw >= 2) & (rh >= 2)]  # filter rboxes of tiny size to stabilize training
             targets = self.preprocess(targets, batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
             gt_labels, gt_bboxes = targets.split((1, 5), 2)  # cls, xywhr


### PR DESCRIPTION
Fixed swapped dimension indexing when filtering rotated bounding boxes in v8OBBLoss.__call__().

Changes:
- Line 705: Corrected rw, rh calculation to use proper indices from imgsz (h, w) format
- Before: width × height, height × width
- After: width × width, height × height

Aligns with line 707 usage of imgsz[[1, 0, 1, 0]] and v8PoseLoss keypoint scaling pattern.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes swapped image width/height scaling when filtering tiny rotated boxes in `v8OBBLoss` 🧭

### 📊 Key Changes
- Corrected `imgsz` indexing when computing rotated box width/height (`rw`, `rh`) in `ultralytics/utils/loss.py`
- Ensures rbox size filtering uses the proper image dimension scaling before preprocessing

### 🎯 Purpose & Impact
- Prevents incorrect filtering of valid (or invalid) tiny OBB targets due to width/height being scaled against the wrong image side ✅
- Improves training stability and label handling consistency for OBB models, especially on non-square inputs 📦