### PR TITLE
Fix incorrect return type in _get_covariance_matrix docstring

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -194,8 +194,8 @@ def _get_covariance_matrix(boxes: torch.Tensor) -> tuple[torch.Tensor, torch.Ten
         boxes (torch.Tensor): A tensor of shape (N, 5) representing rotated bounding boxes, with xywhr format.
 
     Returns:
-        (tuple[torch.Tensor, torch.Tensor, torch.Tensor]): Covariance matrix components (a, b, c) where the
-            covariance matrix is [[a, c], [c, b]], each of shape (N, 1).
+        (tuple[torch.Tensor, torch.Tensor, torch.Tensor]): Covariance matrix components (a, b, c) where the covariance
+            matrix is [[a, c], [c, b]], each of shape (N, 1).
     """
     # Gaussian bounding boxes, ignore the center points (the first two columns) because they are not needed here.
     gbbs = torch.cat((boxes[:, 2:4].pow(2) / 12, boxes[:, 4:]), dim=-1)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -194,7 +194,8 @@ def _get_covariance_matrix(boxes: torch.Tensor) -> tuple[torch.Tensor, torch.Ten
         boxes (torch.Tensor): A tensor of shape (N, 5) representing rotated bounding boxes, with xywhr format.
 
     Returns:
-        (torch.Tensor): Covariance matrices corresponding to original rotated bounding boxes.
+        (tuple[torch.Tensor, torch.Tensor, torch.Tensor]): Covariance matrix components (a, b, c) where the
+            covariance matrix is [[a, c], [c, b]], each of shape (N, 1).
     """
     # Gaussian bounding boxes, ignore the center points (the first two columns) because they are not needed here.
     gbbs = torch.cat((boxes[:, 2:4].pow(2) / 12, boxes[:, 4:]), dim=-1)


### PR DESCRIPTION
Fixed incorrect return type documentation in _get_covariance_matrix().

Changes:
- Updated Returns section to correctly document tuple of 3 tensors
- Added description of covariance matrix components (a, b, c) and their shapes

The function signature already specified tuple[torch.Tensor, torch.Tensor, torch.Tensor], but the docstring incorrectly stated it returns a single Tensor.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes the `_get_covariance_matrix` docstring to correctly describe its return type and structure 📝✅

### 📊 Key Changes
- Updates the `Returns:` docstring in `ultralytics/utils/metrics.py` to reflect that the function returns a tuple of three tensors
- Clarifies the meaning of returned components `(a, b, c)` and how they compose the 2×2 covariance matrix

### 🎯 Purpose & Impact
- Improves API clarity for developers using/reading OBB metric utilities 🧭
- Reduces confusion and potential misuse caused by an incorrect documented return type
- No runtime behavior changes; documentation-only update with minimal risk ⚙️