### PR TITLE
Fix misleading comment in v8OBBLoss.__call__()

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -684,7 +684,7 @@ class v8OBBLoss(v8DetectionLoss):
         """Calculate and return the loss for oriented bounding box detection."""
         loss = torch.zeros(3, device=self.device)  # box, cls, dfl
         feats, pred_angle = preds if isinstance(preds[0], list) else preds[1]
-        batch_size = pred_angle.shape[0]  # batch size, number of masks, mask height, mask width
+        batch_size = pred_angle.shape[0]  # batch size
         pred_distri, pred_scores = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
             (self.reg_max * 4, self.nc), 1
         )


### PR DESCRIPTION
Fixed copy-pasted comment that incorrectly described pred_angle dimensions.

Changes:
- Line 687: Corrected comment from "batch size, number of masks, mask height, mask width" to "batch size"

The comment was copy-pasted from v8SegmentationLoss (line 317) where it correctly describes proto.shape (4D tensor). However, pred_angle is a 3D tensor with shape (bs, 1, h*w), so only shape[0] = batch size.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fix a misleading inline comment in `v8OBBLoss.__call__()` to correctly describe `batch_size`. 🛠️

### 📊 Key Changes
- Updated the comment on `batch_size = pred_angle.shape[0]` to reflect that it represents only the batch size
- Removed incorrect references to masks and mask dimensions (not applicable to OBB loss) 🧹

### 🎯 Purpose & Impact
- Reduces confusion for contributors reading/debugging the OBB loss path 📚
- Improves code clarity without changing runtime behavior or outputs ✅