### PR TITLE
Fix the empty prediction issue on ARM Jetpack5

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1469,7 +1469,9 @@ def load_checkpoint(weight, device=None, inplace=True, fuse=False):
     if not hasattr(model, "stride"):
         model.stride = torch.tensor([32.0])
 
-    model = (model.fuse() if fuse and hasattr(model, "fuse") else model).eval().to(device)  # model in eval mode
+    # fix the issue: https://github.com/ultralytics/ultralytics/pull/21028
+    model = model.to(device)
+    model = (model.fuse() if fuse and hasattr(model, "fuse") else model).eval()  # model in eval mode
 
     # Module updates
     for m in model.modules():

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1470,7 +1470,7 @@ def load_checkpoint(weight, device=None, inplace=True, fuse=False):
         model.stride = torch.tensor([32.0])
 
     model = model.to(device)    # fix the empty prediction result issue on Jetpack 5
-    model = (model.fuse() if fuse and hasattr(model, "fuse") else model).eval()  # model in eval mode
+    model = (model.fuse() if fuse and hasattr(model, "fuse") else model).eval().to(device)  # model in eval mode
 
     # Module updates
     for m in model.modules():

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1469,8 +1469,7 @@ def load_checkpoint(weight, device=None, inplace=True, fuse=False):
     if not hasattr(model, "stride"):
         model.stride = torch.tensor([32.0])
 
-    # fix the issue: https://github.com/ultralytics/ultralytics/pull/21028
-    model = model.to(device)
+    model = model.to(device)    # fix the empty prediction result issue on Jetpack 5
     model = (model.fuse() if fuse and hasattr(model, "fuse") else model).eval()  # model in eval mode
 
     # Module updates


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

This bug fix is related to https://github.com/ultralytics/ultralytics/pull/21028.

To reproduce the issue:
```python
    from ultralytics.nn.autobackend import AutoBackend
    import torchvision.transforms.v2 as transforms
    from torchvision.io import read_image

    model_path = "./model.pt"
    im_path = "./image.jpg"
    model = AutoBackend(model_path, device=torch.device('cuda')).eval()
    
    img_tensor = read_image(im_path) 

    preprocess = transforms.Compose([
        transforms.Resize((640, 640)),
        transforms.ToDtype(torch.float32, scale=True), 
    ])
    input_tensor = preprocess(img_tensor)
    input_tensor = input_tensor.unsqueeze(0).to('cuda')

    preds = model(input_tensor)
    print(preds)
```
You will see `preds` is full of nans.

However, if change fuse to False, the issue would disappear:
```python
model = AutoBackend(model_path, device=torch.device('cuda'), fuse=False).eval()
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an ARM Jetpack 5 inference issue where predictions could come back empty by adjusting device transfer timing in checkpoint loading 🛠️

### 📊 Key Changes
- Moves `model.to(device)` to occur before optional `fuse()` and `eval()` in `load_checkpoint()`
- Keeps fusion behavior unchanged while ensuring the model is already on the target device (e.g., Jetson) prior to eval/fuse ⚙️

### 🎯 Purpose & Impact
- Prevents “empty prediction” results observed on Jetpack 5 / ARM deployments 🧩
- Improves reliability of inference initialization on embedded GPU systems without changing public APIs or model outputs in typical environments 🚀