### PR TITLE
`ultralytics 8.3.242` New `ultralytics-opencv-headless` PyPI package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v7
       - run: uv pip install --system --no-cache build
-      - run: python -m build
+      - run: python -m build --outdir dist/
       - name: Build ultralytics-opencv-headless
         run: |
           python - <<'PY'
@@ -78,10 +78,11 @@ jobs:
           path = Path("pyproject.toml")
           text = path.read_text()
           text = text.replace('name = "ultralytics"', 'name = "ultralytics-opencv-headless"', 1)
-          text = text.replace('"opencv-python', '"opencv-python-headless', 1)
+          text = text.replace('"opencv-python>=', '"opencv-python-headless>=', 1)
           path.write_text(text)
           PY
-          python -m build
+          python -m build --outdir dist/
+          git checkout pyproject.toml
       - uses: actions/upload-artifact@v6
         with:
           name: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,18 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv pip install --system --no-cache build
       - run: python -m build
+      - name: Build ultralytics-opencv-headless
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text()
+          text = text.replace('name = "ultralytics"', 'name = "ultralytics-opencv-headless"', 1)
+          text = text.replace('"opencv-python', '"opencv-python-headless', 1)
+          path.write_text(text)
+          PY
+          python -m build
       - uses: actions/upload-artifact@v6
         with:
           name: dist

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.241"
+__version__ = "8.3.242"
 
 import importlib
 import os


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds an automated second build that publishes an `ultralytics-opencv-headless` package alongside the standard Ultralytics release 📦✨

### 📊 Key Changes
- 🏗️ Updates the GitHub Actions publish workflow to build wheels/sdists into `dist/` explicitly (`python -m build --outdir dist/`).
- 🧩 Adds a new CI step that temporarily edits `pyproject.toml` to:
  - rename the package from `ultralytics` → `ultralytics-opencv-headless`
  - swap dependency `opencv-python` → `opencv-python-headless`
- 🔄 Restores `pyproject.toml` after building via `git checkout pyproject.toml` to avoid persisting changes in the repo.
- 🔖 Bumps Ultralytics version from `8.3.241` → `8.3.242`.

### 🎯 Purpose & Impact
- 🖥️ Enables a headless-friendly distribution for servers/containers/CI where GUI OpenCV isn’t needed, reducing common install/runtime issues.
- 📉 Potentially lowers dependency bloat and avoids GUI-related OpenCV conflicts on minimal systems.
- 🔁 Keeps the primary `ultralytics` package unchanged while offering an alternative install path for headless environments.
- ⚠️ Workflow now builds two artifacts per release, which may slightly increase CI time and publishing complexity.