### PR TITLE
Add missing `--runtime=nvidia` usage description to Dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,13 +51,13 @@ RUN uv pip install --system -e "." albumentations faster-coco-eval wandb && \
 # t=ultralytics/ultralytics:latest && sudo docker build -f docker/Dockerfile -t $t . && sudo docker push $t
 
 # Pull and Run with access to all GPUs
-# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
+# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia --gpus all $t
 
 # Pull and Run with access to GPUs 2 and 3 (inside container CUDA devices will appear as 0 and 1)
-# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus '"device=2,3"' $t
+# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia --gpus '"device=2,3"' $t
 
 # Pull and Run with local directory access
-# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all -v "$(pwd)"/shared/datasets:/datasets $t
+# t=ultralytics/ultralytics:latest && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia --gpus all -v "$(pwd)"/shared/datasets:/datasets $t
 
 # Kill all
 # sudo docker kill $(sudo docker ps -q)

--- a/docker/Dockerfile-jetson-jetpack4
+++ b/docker/Dockerfile-jetson-jetpack4
@@ -64,10 +64,7 @@ RUN uv pip install --system \
 # t=ultralytics/ultralytics:latest-jetson-jetpack4 && sudo docker build --platform linux/arm64 -f docker/Dockerfile-jetson-jetpack4 -t $t . && sudo docker push $t
 
 # Run
-# t=ultralytics/ultralytics:latest-jetson-jetpack4 && sudo docker run -it --ipc=host $t
+# t=ultralytics/ultralytics:latest-jetson-jetpack4 && sudo docker run -it --ipc=host --runtime=nvidia $t
 
 # Pull and Run
-# t=ultralytics/ultralytics:latest-jetson-jetpack4 && sudo docker pull $t && sudo docker run -it --ipc=host $t
-
-# Pull and Run with NVIDIA runtime
 # t=ultralytics/ultralytics:latest-jetson-jetpack4 && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t

--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -53,10 +53,7 @@ RUN uv pip install --system \
 # t=ultralytics/ultralytics:latest-jetson-jetpack5 && sudo docker build --platform linux/arm64 -f docker/Dockerfile-jetson-jetpack5 -t $t . && sudo docker push $t
 
 # Run
-# t=ultralytics/ultralytics:latest-jetson-jetpack5 && sudo docker run -it --ipc=host $t
+# t=ultralytics/ultralytics:latest-jetson-jetpack5 && sudo docker run -it --ipc=host --runtime=nvidia $t
 
 # Pull and Run
-# t=ultralytics/ultralytics:latest-jetson-jetpack5 && sudo docker pull $t && sudo docker run -it --ipc=host $t
-
-# Pull and Run with NVIDIA runtime
 # t=ultralytics/ultralytics:latest-jetson-jetpack5 && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -50,10 +50,7 @@ RUN python3 -m pip install --upgrade pip uv && \
 # t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker build --platform linux/arm64 -f docker/Dockerfile-jetson-jetpack6 -t $t . && sudo docker push $t
 
 # Run
-# t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker run -it --ipc=host $t
+# t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker run -it --ipc=host --runtime=nvidia $t
 
 # Pull and Run
-# t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker pull $t && sudo docker run -it --ipc=host $t
-
-# Pull and Run with NVIDIA runtime
 # t=ultralytics/ultralytics:latest-jetson-jetpack6 && sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -35,4 +35,4 @@ ENTRYPOINT ["sh", "-c", "./config.sh --url https://github.com/ultralytics/ultral
 # t=ultralytics/ultralytics:latest-runner && sudo docker build -f docker/Dockerfile-runner -t $t . && sudo docker push $t
 
 # Pull and Run in detached mode with access to GPUs 0 and 1
-# t=ultralytics/ultralytics:latest-runner && sudo docker run -d -e GITHUB_RUNNER_TOKEN=TOKEN -e GITHUB_RUNNER_NAME=NAME --ipc=host --gpus '"device=0,1"' $t
+# t=ultralytics/ultralytics:latest-runner && sudo docker run -d -e GITHUB_RUNNER_TOKEN=TOKEN -e GITHUB_RUNNER_NAME=NAME --ipc=host --runtime=nvidia --gpus '"device=0,1"' $t

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -132,7 +132,7 @@ Ultralytics offers a variety of installation methods, including pip, conda, and 
 
         ```bash
         # Mount local directory to a directory inside the container
-        sudo docker run -it --ipc=host --gpus all -v /path/on/host:/path/in/container $t
+        sudo docker run -it --ipc=host --runtime=nvidia --gpus all -v /path/on/host:/path/in/container $t
         ```
 
         Replace `/path/on/host` with the directory path on your local machine, and `/path/in/container` with the desired path inside the Docker container.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates Ultralytics Docker run instructions to explicitly use the NVIDIA container runtime for more reliable GPU access 🐳⚡

### 📊 Key Changes
- Added `--runtime=nvidia` to example `docker run` commands in `docker/Dockerfile` (including multi-GPU and volume-mount examples) 🖥️
- Updated Jetson Dockerfiles (JetPack 4/5/6) to recommend `--runtime=nvidia` and removed redundant/non-NVIDIA run examples 🤖
- Updated the GitHub Actions runner Dockerfile example to include `--runtime=nvidia` for GPU-enabled self-hosted runners 🏃‍♂️
- Updated the [Quickstart documentation](docs/en/quickstart.md) Docker command to include `--runtime=nvidia` 📚

### 🎯 Purpose & Impact
- Improves consistency and reduces “GPU not found” / CUDA visibility issues when running Ultralytics containers with NVIDIA GPUs ✅
- Makes Jetson usage clearer by standardizing on the NVIDIA runtime in the recommended commands 🧠
- Helps teams running GPU-backed self-hosted CI runners avoid misconfigured GPU passthrough 🔧
- No functional code changes—this is primarily a documentation/usage guidance update, but it can significantly improve out-of-the-box Docker GPU reliability 🚀