### PR TITLE
Add visualize_image_annotations_multiformat to support YOLO detection and segmentation labels

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -804,9 +804,7 @@ def test_visualize_multiformat_segmentation(tmp_path):
     img.save(img_path)
 
     label_path = tmp_path / "label.txt"
-    label_path.write_text(
-        "0 0.1 0.1 0.9 0.1 0.9 0.9 0.1 0.9\n"
-    )
+    label_path.write_text("0 0.1 0.1 0.9 0.1 0.9 0.9 0.1 0.9\n")
 
     result = visualize_image_annotations_multiformat(
         img_path,
@@ -825,12 +823,7 @@ def test_visualize_multiformat_invalid_labels(tmp_path):
     img.save(img_path)
 
     label_path = tmp_path / "label.txt"
-    label_path.write_text(
-        "\n"
-        "invalid data\n"
-        "0 0.1 0.2 0.3\n"
-        "0 0.1 0.2 0.3 0.4\n"
-    )
+    label_path.write_text("\ninvalid data\n0 0.1 0.2 0.3\n0 0.1 0.2 0.3 0.4\n")
 
     result = visualize_image_annotations_multiformat(
         img_path,
@@ -838,4 +831,3 @@ def test_visualize_multiformat_invalid_labels(tmp_path):
     )
 
     assert result is not None
-    

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -778,6 +778,7 @@ def test_grayscale(task: str, model: str, data: str, tmp_path) -> None:
 
 
 def test_visualize_multiformat_detection(tmp_path):
+    """Test visualization with YOLO detection format labels."""
     from ultralytics.data.utils import visualize_image_annotations_multiformat
 
     img = Image.new("RGB", (100, 100))
@@ -797,6 +798,7 @@ def test_visualize_multiformat_detection(tmp_path):
 
 
 def test_visualize_multiformat_segmentation(tmp_path):
+    """Test visualization with YOLO segmentation format labels."""
     from ultralytics.data.utils import visualize_image_annotations_multiformat
 
     img = Image.new("RGB", (100, 100))
@@ -816,6 +818,7 @@ def test_visualize_multiformat_segmentation(tmp_path):
 
 
 def test_visualize_multiformat_invalid_labels(tmp_path):
+    """Test graceful handling of invalid YOLO label formats."""
     from ultralytics.data.utils import visualize_image_annotations_multiformat
 
     img = Image.new("RGB", (100, 100))

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -775,3 +775,67 @@ def test_grayscale(task: str, model: str, data: str, tmp_path) -> None:
 
     model = YOLO(export_model, task=task)
     model.predict(source=im, imgsz=32)
+
+
+def test_visualize_multiformat_detection(tmp_path):
+    from ultralytics.data.utils import visualize_image_annotations_multiformat
+
+    img = Image.new("RGB", (100, 100))
+    img_path = tmp_path / "img.jpg"
+    img.save(img_path)
+
+    label_path = tmp_path / "label.txt"
+    label_path.write_text("0 0.5 0.5 0.4 0.4\n")
+
+    result = visualize_image_annotations_multiformat(
+        img_path,
+        label_path,
+        label_map={0: "obj"},
+    )
+
+    assert result is not None
+
+
+def test_visualize_multiformat_segmentation(tmp_path):
+    from ultralytics.data.utils import visualize_image_annotations_multiformat
+
+    img = Image.new("RGB", (100, 100))
+    img_path = tmp_path / "img.jpg"
+    img.save(img_path)
+
+    label_path = tmp_path / "label.txt"
+    label_path.write_text(
+        "0 0.1 0.1 0.9 0.1 0.9 0.9 0.1 0.9\n"
+    )
+
+    result = visualize_image_annotations_multiformat(
+        img_path,
+        label_path,
+        label_map={0: "obj"},
+    )
+
+    assert result is not None
+
+
+def test_visualize_multiformat_invalid_labels(tmp_path):
+    from ultralytics.data.utils import visualize_image_annotations_multiformat
+
+    img = Image.new("RGB", (100, 100))
+    img_path = tmp_path / "img.jpg"
+    img.save(img_path)
+
+    label_path = tmp_path / "label.txt"
+    label_path.write_text(
+        "\n"
+        "invalid data\n"
+        "0 0.1 0.2 0.3\n"
+        "0 0.1 0.2 0.3 0.4\n"
+    )
+
+    result = visualize_image_annotations_multiformat(
+        img_path,
+        label_path,
+    )
+
+    assert result is not None
+    

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -302,8 +302,7 @@ def visualize_image_annotations_multiformat(
     segment_color=(0, 255, 0),
     line_width=2,
 ):
-    """
-    Displays YOLO Detection and YOLO Segmentation annotations automatically.
+    """Displays YOLO Detection and YOLO Segmentation annotations automatically.
 
     Supports both:
     - YOLO Detection format: class x_center y_center width height
@@ -320,12 +319,9 @@ def visualize_image_annotations_multiformat(
         line_width (int, optional): Line thickness for drawn shapes.
 
     Returns:
-        PIL.Image.Image:
-            Image object with rendered annotations (bounding boxes,
-            segmentation polygons, and class labels). The image is returned
-            in memory and is not saved to disk.
+        PIL.Image.Image: Image object with rendered annotations (bounding boxes, segmentation polygons, and class
+            labels). The image is returned in memory and is not saved to disk.
     """
-
     img = Image.open(image_path).convert("RGB")
     draw = ImageDraw.Draw(img)
     img_width, img_height = img.size
@@ -363,10 +359,7 @@ def visualize_image_annotations_multiformat(
                 coords = np.array(parts[1:]).reshape(-1, 2)
 
                 # Normalizado → pixel
-                polygon = [
-                    (x * img_width, y * img_height)
-                    for x, y in coords
-                ]
+                polygon = [(x * img_width, y * img_height) for x, y in coords]
 
                 if draw_segments:
                     draw.polygon(

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -330,17 +330,16 @@ def visualize_image_annotations_multiformat(
         for raw_line in file:
             line = raw_line.strip()
             if not line:
-                continue # skip empty lines
-            
+                continue  # skip empty lines
+
             parts = line.split()
             if len(parts) < 5:
-                continue # invalid label line
+                continue  # invalid label line
 
             try:
                 values = list(map(float, parts))
             except ValueError:
-                continue # non-numeric values
-
+                continue  # non-numeric values
 
             class_id = int(values[0])
             label = label_map.get(class_id, str(class_id)) if label_map else str(class_id)
@@ -372,12 +371,12 @@ def visualize_image_annotations_multiformat(
                 coords = values[1:]
 
                 if len(coords) % 2 != 0:
-                    continue # invalid number of coordinates
+                    continue  # invalid number of coordinates
 
                 coords = np.array(coords, dtype=np.float32).reshape(-1, 2)
 
                 if coords.shape[0] < 3:
-                    continue # not enough points for a polygon
+                    continue  # not enough points for a polygon
 
                 # Normalizado → pixel
                 polygon = [(x * img_width, y * img_height) for x, y in coords]

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import cv2
 import numpy as np
-from PIL import Image, ImageOps
+from PIL import Image, ImageDraw, ImageOps
 
 from ultralytics.nn.autobackend import check_class_names
 from ultralytics.utils import (
@@ -290,6 +290,112 @@ def visualize_image_annotations(image_path: str, txt_path: str, label_map: dict[
         ax.text(x, y - 5, label_map[label], color="white" if luminance < 0.5 else "black", backgroundcolor=color)
     ax.imshow(img)
     plt.show()
+
+
+def visualize_image_annotations_multiformat(
+    image_path,
+    txt_path,
+    label_map=None,
+    draw_boxes=True,
+    draw_segments=True,
+    box_color=(255, 0, 0),
+    segment_color=(0, 255, 0),
+    line_width=2,
+):
+    """
+    Displays YOLO Detection and YOLO Segmentation annotations automatically.
+
+    Supports both:
+    - YOLO Detection format: class x_center y_center width height
+    - YOLO Segmentation format: class x1 y1 x2 y2 ... xn yn
+
+    Args:
+        image_path (str): Path to the image file.
+        txt_path (str): Path to the YOLO label file (.txt).
+        label_map (dict, optional): Mapping from class_id to class_name.
+        draw_boxes (bool, optional): Whether to draw bounding boxes.
+        draw_segments (bool, optional): Whether to draw segmentation polygons.
+        box_color (tuple, optional): RGB color for bounding boxes.
+        segment_color (tuple, optional): RGB color for segmentation polygons.
+        line_width (int, optional): Line thickness for drawn shapes.
+
+    Returns:
+        PIL.Image.Image:
+            Image object with rendered annotations (bounding boxes,
+            segmentation polygons, and class labels). The image is returned
+            in memory and is not saved to disk.
+    """
+
+    img = Image.open(image_path).convert("RGB")
+    draw = ImageDraw.Draw(img)
+    img_width, img_height = img.size
+
+    with open(txt_path, encoding="utf-8") as file:
+        for line in file:
+            parts = list(map(float, line.split()))
+            class_id = int(parts[0])
+            label = label_map.get(class_id, str(class_id)) if label_map else str(class_id)
+
+            # ============================
+            # YOLO DETECTION FORMAT
+            # ============================
+            if len(parts) == 5:
+                _, x, y, w, h = parts
+
+                x1 = (x - w / 2) * img_width
+                y1 = (y - h / 2) * img_height
+                x2 = (x + w / 2) * img_width
+                y2 = (y + h / 2) * img_height
+
+                if draw_boxes:
+                    draw.rectangle(
+                        [x1, y1, x2, y2],
+                        outline=box_color,
+                        width=line_width,
+                    )
+
+                draw.text((x1, y1), label, fill=box_color)
+
+            # ============================
+            # YOLO SEGMENTATION FORMAT
+            # ============================
+            elif len(parts) > 5:
+                coords = np.array(parts[1:]).reshape(-1, 2)
+
+                # Normalizado → pixel
+                polygon = [
+                    (x * img_width, y * img_height)
+                    for x, y in coords
+                ]
+
+                if draw_segments:
+                    draw.polygon(
+                        polygon,
+                        outline=segment_color,
+                        width=line_width,
+                    )
+
+                if draw_boxes:
+                    bbox = segments2boxes([coords])[0]
+                    bx, by, bw, bh = bbox
+
+                    x1 = (bx - bw / 2) * img_width
+                    y1 = (by - bh / 2) * img_height
+                    x2 = (bx + bw / 2) * img_width
+                    y2 = (by + bh / 2) * img_height
+
+                    draw.rectangle(
+                        [x1, y1, x2, y2],
+                        outline=box_color,
+                        width=line_width,
+                    )
+
+                draw.text((polygon[0][0], polygon[0][1]), label, fill=segment_color)
+
+            else:
+                raise ValueError(f"Invalid label format: {line}")
+
+    return img
 
 
 def polygon2mask(


### PR DESCRIPTION
### Summary
This PR introduces a new utility function,
`visualize_image_annotations_multiformat`, which supports visualization of both
YOLO Detection and YOLO Segmentation label formats.

### Motivation
The existing `visualize_image_annotations` utility assumes YOLO Detection labels
(`class x_center y_center width height`) and raises an error when segmentation
labels are provided.

However, the `auto_annotate` pipeline (YOLO + SAM) generates segmentation labels
by default (`class x1 y1 x2 y2 ... xn yn`). Users currently need to implement
custom visualization logic to inspect auto-labeled datasets.

Adding a new function avoids breaking existing behavior while providing an
official and documented way to visualize multi-format YOLO annotations.

### Why a new function?
- Preserves strict backward compatibility
- Avoids changing semantics of an existing public API
- Makes segmentation support explicit and opt-in
- Keeps the original function lightweight and focused on detection

### Features
- Supports YOLO Detection labels
- Supports YOLO Segmentation labels
- Automatically detects label format
- Renders segmentation polygons
- Optionally derives and renders bounding boxes from segments
- Compatible with outputs from `auto_annotate`

### Backward Compatibility
- No existing APIs are modified
- No behavioral changes to `visualize_image_annotations`

### Related
- `ultralytics.data.annotator.auto_annotate`
- YOLO + SAM auto-labeling workflow

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a new helper to visualize YOLO annotations in both detection and segmentation label formats on a PIL image 🖼️

### 📊 Key Changes
-Introduces `visualize_image_annotations_multiformat()` in `ultralytics/data/utils.py` to auto-handle detection (`class x_center y_center width height`) vs segmentation (`class x1 y1 ... xn yn`) labels
-Adds drawing support for bounding boxes, segmentation polygons, and class text labels with configurable colors and line width 🎨
-Updates PIL imports to include `ImageDraw` for rendering shapes and text

### 🎯 Purpose & Impact
-Enables quick, in-memory inspection of mixed-format YOLO labels for debugging datasets ✅
-Improves segmentation label visualization by optionally drawing both polygon outlines and derived bounding boxes 🔍
-May require small follow-ups around input validation and edge cases (e.g., malformed lines, empty polygons), but is broadly useful for dataset QA workflows