### PR TITLE
`ultralytics 8.3.247` Improve Ray Tune trial names logged to W&B

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.246"
+__version__ = "8.3.247"
 
 import importlib
 import os

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -87,6 +87,7 @@ def run_ray_tune(
     # Put the model in ray store
     task = model.task
     model_in_store = ray.put(model)
+    base_name = train_args.get("name", "tune")
 
     def _tune(config):
         """Train the YOLO model with the specified hyperparameters and return results."""
@@ -132,9 +133,6 @@ def run_ray_tune(
 
     # Define the callbacks for the hyperparameter search
     tuner_callbacks = [WandbLoggerCallback(project="YOLOv8-tune")] if wandb else []
-
-    # Save base name before it's popped for trial naming in W&B
-    base_name = train_args.get("name", "tune")
 
     # Create the Ray Tune hyperparameter search tuner
     tune_dir = get_save_dir(


### PR DESCRIPTION
Fixes #23000

When using `model.tune(use_ray=True)`, all trials appeared in WandB with the default name 'train' instead of unique trial-specific names.

**Root cause:** `train_args.pop('name')` removed the base name before trials were created, so `config['name']` was never set.

**Solution:**
- Save `base_name` before it's popped from `train_args`
- Use `tune.get_trial_id()` to generate unique trial-specific names
- Format: `{base_name}_{trial_suffix}` (e.g., 'my_run_00000')

**Result:**
WandB run names now align with local directory structure:
- Local: `my_run/_tune_2c2fc_00000/`
- WandB: `my_run_00000`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fix Ray Tune hyperparameter tuning so each W&B run gets a unique, trial-specific name 🎛️📝

### 📊 Key Changes
- Adds Ray Tune `trial_id`-based suffixing to `config["name"]` inside `_tune()` so W&B logs don’t collide across trials
- Preserves a `base_name` from `train_args` before training args are consumed, then uses it for consistent trial naming
- Includes a safe fallback to the base name when not running under Ray Tune (or if trial ID retrieval fails)

### 🎯 Purpose & Impact
- Prevents W&B runs from overwriting/merging due to identical names across Ray Tune trials ✅
- Makes trial results easier to track and compare in W&B during tuning 🔎
- Improves reproducibility and debugging by keeping per-trial logging clearly separated 📌