### PR TITLE
`ultralytics 8.3.244` Reset YOLO predictor on device change

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.243"
+__version__ = "8.3.244"
 
 import importlib
 import os

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -523,8 +523,7 @@ class Model(torch.nn.Module):
         args = {**self.overrides, **custom, **kwargs}  # highest priority args on the right
         prompts = args.pop("prompts", None)  # for SAM-type models
 
-        device = self.predictor.args.device if self.predictor else ""
-        if not self.predictor or device != args.get("device", device):
+        if not self.predictor or self.predictor.args.device != args.get("device", self.predictor.args.device):
             self.predictor = (predictor or self._smart_load("predictor"))(overrides=args, _callbacks=self.callbacks)
             self.predictor.setup_model(model=self.model, verbose=is_cli)
         else:  # only update args if predictor is already setup

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -523,7 +523,8 @@ class Model(torch.nn.Module):
         args = {**self.overrides, **custom, **kwargs}  # highest priority args on the right
         prompts = args.pop("prompts", None)  # for SAM-type models
 
-        if not self.predictor:
+        device = self.predictor.args.device if self.predictor else ""
+        if not self.predictor or device != args.get("device", device):
             self.predictor = (predictor or self._smart_load("predictor"))(overrides=args, _callbacks=self.callbacks)
             self.predictor.setup_model(model=self.model, verbose=is_cli)
         else:  # only update args if predictor is already setup


### PR DESCRIPTION
Closes #23021 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves `model.predict()` to reinitialize the predictor when the requested device changes, preventing stale device usage 🔄🖥️

### 📊 Key Changes
- Bumped Ultralytics package version from `8.3.243` to `8.3.244` 🏷️
- Updated `ultralytics/engine/model.py` so `Model.predict()` recreates the predictor not only when it doesn’t exist, but also when the `device` argument differs from the predictor’s current device ⚙️

### 🎯 Purpose & Impact
- Prevents predictions from accidentally running on the wrong hardware when switching between CPU/GPU (or different GPU IDs) across calls ✅
- Makes device switching in the same Python session more reliable and predictable, especially in notebooks, services, and multi-stage pipelines 🚀
- Reduces confusing performance issues and runtime errors caused by a predictor being initialized on a different device than requested 🧠