### PR TITLE
Remove redundant bbox slice in plot_predictions

### DIFF
--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -353,8 +353,7 @@ class DetectionValidator(BaseValidator):
         keys = preds[0].keys()
         max_det = max_det or self.args.max_det
         batched_preds = {k: torch.cat([x[k][:max_det] for x in preds], dim=0) for k in keys}
-        # TODO: fix this
-        batched_preds["bboxes"][:, :4] = ops.xyxy2xywh(batched_preds["bboxes"][:, :4])  # convert to xywh format
+        batched_preds["bboxes"] = ops.xyxy2xywh(batched_preds["bboxes"])  # convert to xywh format
         plot_images(
             images=batch["img"],
             labels=batched_preds,


### PR DESCRIPTION
Removed redundant [:, :4] slice when converting bboxes to xywh format.

Changes:
- Simplified line 357: batched_preds["bboxes"] = ops.xyxy2xywh(batched_preds["bboxes"])
- Removed TODO comment as issue is now resolved

The batched_preds["bboxes"] tensor always has exactly 4 columns from postprocess() method (line 126), making the [:, :4] slice unnecessary. The ops.xyxy2xywh() function already asserts input has 4 columns, confirming this change is safe.

## Testing Commands

Validated with `plots=True` for detect/seg/pose - all `val_batch*_pred.jpg` outputs generated correctly:

```bash
# Detection
yolo val model=yolo11n.pt data=coco8.yaml plots=True

# Segmentation  
yolo val model=yolo11n-seg.pt data=coco8-seg.yaml plots=True

# Pose Estimation
yolo val model=yolo11n-pose.pt data=coco8-pose.yaml plots=True
```

Results saved to `runs/{detect,segment,pose}/val/` with correct bbox visualizations, mask overlays, and keypoint skeletons respectively.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Simplifies bbox format conversion in `plot_predictions` by removing an unnecessary slice and converting the full tensor directly ✅

### 📊 Key Changes
- Replaced in-place slicing assignment on `batched_preds["bboxes"][:, :4]` with a full-tensor conversion via `ops.xyxy2xywh(batched_preds["bboxes"])`
- Removed a stale `# TODO: fix this` comment tied to the redundant slicing logic

### 🎯 Purpose & Impact
- Reduces redundant indexing and in-place mutation, making the code clearer and less error-prone 🧹
- Ensures consistent bbox conversion behavior for the full `bboxes` tensor, which can improve maintainability and avoid subtle shape/format mismatches 🔧