### PR TITLE
Fix incorrect shape comments in tensor operations

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1078,9 +1078,9 @@ class RTDETRDecoder(nn.Module):
         enc_outputs_scores = self.enc_score_head(features)  # (bs, h*w, nc)
 
         # Query selection
-        # (bs, num_queries)
+        # (bs*num_queries,)
         topk_ind = torch.topk(enc_outputs_scores.max(-1).values, self.num_queries, dim=1).indices.view(-1)
-        # (bs, num_queries)
+        # (bs*num_queries,)
         batch_ind = torch.arange(end=bs, dtype=topk_ind.dtype).unsqueeze(-1).repeat(1, self.num_queries).view(-1)
 
         # (bs, num_queries, 256)

--- a/ultralytics/nn/modules/utils.py
+++ b/ultralytics/nn/modules/utils.py
@@ -147,7 +147,7 @@ def multi_scale_deformable_attn_pytorch(
         sampling_value_list.append(sampling_value_l_)
     # (bs, num_queries, num_heads, num_levels, num_points) ->
     # (bs, num_heads, num_queries, num_levels, num_points) ->
-    # (bs, num_heads, 1, num_queries, num_levels*num_points)
+    # (bs*num_heads, 1, num_queries, num_levels*num_points)
     attention_weights = attention_weights.transpose(1, 2).reshape(
         bs * num_heads, 1, num_queries, num_levels * num_points
     )


### PR DESCRIPTION
Fixed shape comments that incorrectly described tensor dimensions after reshape/view operations.

Changes:
- head.py:1081,1083: Fixed comments from `(bs, num_queries)` to `(bs*num_queries,)` after .view(-1)
- utils.py:150: Fixed comment from `(bs, num_heads, 1, ...)` to `(bs*num_heads, 1, ...)` after .reshape(bs*num_heads, ...)

The .view(-1) operation flattens to 1D, and .reshape(bs*num_heads, ...) merges the first two dimensions. Comments now correctly reflect actual tensor shapes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a couple of incorrect tensor shape comments in decoder query selection and deformable attention code paths 🧩

### 📊 Key Changes
- Corrected shape comment for `topk_ind` and `batch_ind` after `.view(-1)` in `ultralytics/nn/modules/head.py` (now noted as flattened `bs*num_queries,`).
- Corrected shape comment for `attention_weights` after `transpose` + `reshape` in `ultralytics/nn/modules/utils.py` (now noted as `bs*num_heads` in the leading dimension).

### 🎯 Purpose & Impact
- Improves code readability and reduces confusion during debugging/review 🔍
- Helps contributors and maintainers reason about tensor transforms more accurately without changing runtime behavior ✅