### PR TITLE
Log NVML init failures

### DIFF
--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -8,7 +8,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from ultralytics.utils import MACOS, RANK
+from ultralytics.utils import MACOS, RANK, LOGGER
 from ultralytics.utils.checks import check_requirements
 
 
@@ -336,7 +336,8 @@ class SystemLogger:
             self.pynvml = __import__("pynvml")
             self.pynvml.nvmlInit()
             return True
-        except Exception:
+        except Exception as e:
+            LOGGER.warning(f"SystemLogger NVML init failed: {e}")
             return False
 
     def get_metrics(self, rates=False):

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -8,7 +8,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from ultralytics.utils import MACOS, RANK, LOGGER
+from ultralytics.utils import LOGGER, MACOS, RANK
 from ultralytics.utils.checks import check_requirements
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves system logging by surfacing NVIDIA NVML initialization errors instead of silently ignoring them 🪵⚠️

### 📊 Key Changes
- Adds `LOGGER` import in `ultralytics/utils/logger.py` to enable standardized warning output 🧩
- Updates `SystemLogger._init_nvidia()` to capture the exception (`as e`) and emit a warning: `SystemLogger NVML init failed: {e}` 🖥️
- Keeps behavior the same otherwise: NVML init failure still returns `False` and metrics collection can continue without NVML ✅

### 🎯 Purpose & Impact
- Makes GPU telemetry issues easier to diagnose (e.g., missing `pynvml`, driver/library mismatches, container limitations) 🔍🧰
- Improves transparency for users running on NVIDIA systems by explaining why GPU stats may be unavailable 📉➡️📣
- Minimal risk to existing workflows since it only adds a warning and doesn’t change control flow or raise new errors 🧑‍💻✅