### PR TITLE
Fix incorrect shape comments in mask processing

### DIFF
--- a/ultralytics/models/yolo/segment/predict.py
+++ b/ultralytics/models/yolo/segment/predict.py
@@ -98,9 +98,9 @@ class SegmentationPredictor(DetectionPredictor):
             masks = None
         elif self.args.retina_masks:
             pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
-            masks = ops.process_mask_native(proto, pred[:, 6:], pred[:, :4], orig_img.shape[:2])  # HWC
+            masks = ops.process_mask_native(proto, pred[:, 6:], pred[:, :4], orig_img.shape[:2])  # NHW
         else:
-            masks = ops.process_mask(proto, pred[:, 6:], pred[:, :4], img.shape[2:], upsample=True)  # HWC
+            masks = ops.process_mask(proto, pred[:, 6:], pred[:, :4], img.shape[2:], upsample=True)  # NHW
             pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
         if masks is not None:
             keep = masks.amax((-2, -1)) > 0  # only keep predictions with masks

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -401,7 +401,7 @@ class Annotator:
             masks = masks.unsqueeze(3)  # shape(n,h,w,1)
             masks_color = masks * (colors * alpha)  # shape(n,h,w,3)
             inv_alpha_masks = (1 - masks * alpha).cumprod(0)  # shape(n,h,w,1)
-            mcs = masks_color.max(dim=0).values  # shape(n,h,w,3)
+            mcs = masks_color.max(dim=0).values  # shape(h,w,3)
 
             im_gpu = im_gpu.flip(dims=[0]).permute(1, 2, 0).contiguous()  # shape(h,w,3)
             im_gpu = im_gpu * inv_alpha_masks[-1] + mcs


### PR DESCRIPTION
Corrected misleading shape comments in mask processing functions that incorrectly labeled tensor dimensions.

**Changes:**
- **ops.py** (6 fixes):
  - Lines 487, 493, 495: `# CHW` → `# NHW` (masks have shape (N, H, W), not (C, H, W))
  - Line 509: Docstring `(H, W, N)` → `(N, H, W)` for `process_mask_native` return type
  - Lines 513, 514: `# CHW` → `# NHW`
  
- **segment/predict.py** (2 fixes):
  - Lines 101, 103: `# HWC` → `# NHW` (process_mask functions return (N, H, W))
  
- **plotting.py** (1 fix):
  - Line 404: `# shape(n,h,w,3)` → `# shape(h,w,3)` (max(dim=0) removes first dimension)

**Root cause:**
The comments incorrectly used C (channels) or swapped dimensions when the first dimension actually represents N (number of detected objects/masks after NMS). Throughout the mask processing pipeline, masks maintain shape (N, H, W) where:
- N = number of detections after NMS
- H, W = mask height/width
- C = mask prototype dimension (typically 32)

The existing docstrings already correctly document these shapes (e.g., process_mask: "shape [n, h, w]"), but inline comments were inconsistent.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes misleading mask tensor shape comments across segmentation prediction, mask ops, and plotting code. 🧩

### 📊 Key Changes
- Updates inline comments in `segment/predict.py` to reflect masks returned as `N,H,W` (not `H,W,C`).
- Corrects shape annotations in `utils/ops.py` for `process_mask()` and `process_mask_native()` (including return docstring).
- Fixes a plotting comment in `utils/plotting.py` to match the actual reduced shape after `max(dim=0)`. 🖼️

### 🎯 Purpose & Impact
- Prevents confusion for contributors/users reading or extending the segmentation pipeline. ✅
- Improves code readability and reduces the chance of incorrect downstream assumptions about mask layouts. 🔍
- No functional changes expected; comment/doc alignment only. 🧼