### PR TITLE
ci: 👷 update onnxslim version to 0.1.82

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ export = [
     "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS (tested up to onnx==1.20.0)
-    "onnxslim>=0.1.80",
+    "onnxslim<0.1.81",
     "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ export = [
     "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS (tested up to onnx==1.20.0)
-    "onnxslim<0.1.81",
+    "onnxslim>=0.1.82",
     "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -666,7 +666,7 @@ class Exporter:
         """Export YOLO model to ONNX format."""
         requirements = ["onnx>=1.12.0,<2.0.0"]
         if self.args.simplify:
-            requirements += ["onnxslim>=0.1.71", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
+            requirements += ["onnxslim<0.1.81", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
         import onnx
 
@@ -1040,7 +1040,7 @@ class Exporter:
                 "ai-edge-litert>=1.2.0" + (",<1.4.0" if MACOS else ""),  # required by 'onnx2tf' package
                 "onnx>=1.12.0,<2.0.0",
                 "onnx2tf>=1.26.3",
-                "onnxslim>=0.1.71",
+                "onnxslim<0.1.81",
                 "onnxruntime-gpu" if cuda else "onnxruntime",
                 "protobuf>=5",
             ),

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -666,7 +666,7 @@ class Exporter:
         """Export YOLO model to ONNX format."""
         requirements = ["onnx>=1.12.0,<2.0.0"]
         if self.args.simplify:
-            requirements += ["onnxslim<0.1.81", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
+            requirements += ["onnxslim>=0.1.71", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
         import onnx
 
@@ -1040,7 +1040,7 @@ class Exporter:
                 "ai-edge-litert>=1.2.0" + (",<1.4.0" if MACOS else ""),  # required by 'onnx2tf' package
                 "onnx>=1.12.0,<2.0.0",
                 "onnx2tf>=1.26.3",
-                "onnxslim<0.1.81",
+                "onnxslim>=0.1.71",
                 "onnxruntime-gpu" if cuda else "onnxruntime",
                 "protobuf>=5",
             ),


### PR DESCRIPTION
Debugging onnx errors and first attempt is set version constraint to onnxslim 
Because onnxslim made a new version : https://github.com/inisis/OnnxSlim/releases/tag/v0.1.81 


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps the `onnxslim` dependency to a newer minimum version to improve ONNX export tooling 🔧📦

### 📊 Key Changes
- ⬆️ Updated `pyproject.toml` export dependencies: `onnxslim>=0.1.80` → `onnxslim>=0.1.82`
- ✅ No code logic changes—this is a dependency/version requirement update only

### 🎯 Purpose & Impact
- 🛠️ Ensures users exporting to ONNX have a slightly newer `onnxslim`, which may include fixes and improvements in model slimming/optimization
- 📉 Reduces risk of running into issues that were present in older `onnxslim` versions during export workflows
- ⚠️ Minor potential impact: environments pinned to `onnxslim==0.1.80` or `0.1.81` will need to update to meet the new requirement