### PR TITLE
fix: 🐞 Add requirement for ruamel.yaml version for executorch

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1192,6 +1192,8 @@ class Exporter:
         # BUG executorch build on arm64 Docker requires packaging>=22.0 https://github.com/pypa/setuptools/issues/4483
         if LINUX and ARM64 and IS_DOCKER:
             check_requirements("packaging>=22.0")
+
+        check_requirements("ruamel.yaml<0.19.0")
         check_requirements("executorch==1.0.1", "flatbuffers")
         # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
         check_requirements("numpy<=2.3.5")


### PR DESCRIPTION
Executorch also pinned to lower than 0.19 https://github.com/pytorch/executorch/blob/913436a44b877259169e79e6a061f75638336b55/.ci/docker/requirements-ci.txt#L4

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a pinned dependency check for `ruamel.yaml` during ExecuTorch export to prevent version-related export failures 🛠️✅

### 📊 Key Changes
- Ensures ExecuTorch export installs/uses a compatible YAML library by adding `check_requirements("ruamel.yaml<0.19.0")` 🧩
- Keeps existing dependency guards intact, including:
  - `packaging>=22.0` workaround for ARM64 Docker builds 🐳🧱
  - Fixed ExecuTorch + FlatBuffers versions and pinned NumPy to avoid CoreML toolchain issues 📦🔒

### 🎯 Purpose & Impact
- Reduces export-time breakages caused by incompatible `ruamel.yaml` versions when exporting to ExecuTorch 🚫💥
- Improves reliability and reproducibility of `model.export(format="executorch")` across environments (especially CI/Docker setups) 🔁🧪
- May trigger a minor dependency downgrade/pin for users who already have newer `ruamel.yaml` installed, but helps ensure a smoother export experience 📉➡️✅