### PR TITLE
`ultralytics 8.3.246` Save training plots data for loggers

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -273,7 +273,7 @@ def test_export_axelera():
     shutil.rmtree(file, ignore_errors=True)  # cleanup
 
 
-@pytest.mark.skipif(True, reason="Disabled for debugging ruamel.yaml installation required by executorch")
+# @pytest.mark.skipif(True, reason="Disabled for debugging ruamel.yaml installation required by executorch")
 @pytest.mark.skipif(not checks.IS_PYTHON_MINIMUM_3_10 or not TORCH_2_9, reason="Requires Python>=3.10 and Torch>=2.9.0")
 @pytest.mark.skipif(WINDOWS, reason="Skipping test on Windows")
 def test_export_executorch():

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -274,6 +274,7 @@ def test_export_axelera():
     shutil.rmtree(file, ignore_errors=True)  # cleanup
 
 
+@pytest.mark.skipif(True, reason="Disabled for debugging ruamel.yaml installation required by executorch")
 @pytest.mark.skipif(not checks.IS_PYTHON_MINIMUM_3_10 or not TORCH_2_9, reason="Requires Python>=3.10 and Torch>=2.9.0")
 @pytest.mark.skipif(WINDOWS, reason="Skipping test on Windows")
 def test_export_executorch():

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -267,8 +267,7 @@ def test_export_imx():
 @pytest.mark.skipif(not checks.IS_PYTHON_3_10, reason="Axelera export requires Python 3.10")
 def test_export_axelera():
     """Test YOLO export to Axelera format."""
-    # For faster testing, use a smaller calibration dataset
-    # 32 image size crashes axelera export, so use 64
+    # For faster testing, use a smaller calibration dataset (32 image size crashes axelera export, so 64 is used)
     file = YOLO(MODEL).export(format="axelera", imgsz=64, data="coco8.yaml")
     assert Path(file).exists(), f"Axelera export failed, directory not found: {file}"
     shutil.rmtree(file, ignore_errors=True)  # cleanup

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.245"
+__version__ = "8.3.246"
 
 import importlib
 import os

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -252,11 +252,7 @@ def on_model_save(trainer):
 
 
 def _collect_plot_data(trainer):
-    """Collect validation plot data from trainer and validator for interactive frontend rendering.
-
-    Returns:
-        tuple: (class_names: list[str] | None, plots: list[dict])
-    """
+    """Collect validation plot data from trainer and validator for interactive frontend rendering."""
     plots = []
 
     # Collect from trainer.plots

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -568,7 +568,8 @@ class ConfusionMatrix(DataExportMixin):
         fig.savefig(plot_fname, dpi=250)
         plt.close(fig)
         if on_plot:
-            on_plot(plot_fname)
+            # Pass confusion matrix data for interactive plotting (raw counts only, normalization done on frontend)
+            on_plot(plot_fname, {"type": "confusion_matrix", "matrix": self.matrix.tolist()})
 
     def print(self):
         """Print the confusion matrix to the console."""
@@ -661,7 +662,8 @@ def plot_pr_curve(
     fig.savefig(save_dir, dpi=250)
     plt.close(fig)
     if on_plot:
-        on_plot(save_dir)
+        # Pass PR curve data for interactive plotting (class names stored at model level)
+        on_plot(save_dir, {"type": "pr_curve", "x": px.tolist(), "y": py.tolist(), "ap": ap.tolist()})
 
 
 @plt_settings()
@@ -706,7 +708,8 @@ def plot_mc_curve(
     fig.savefig(save_dir, dpi=250)
     plt.close(fig)
     if on_plot:
-        on_plot(save_dir)
+        # Pass metric-confidence curve data for interactive plotting (class names stored at model level)
+        on_plot(save_dir, {"type": f"{ylabel.lower()}_curve", "x": px.tolist(), "y": py.tolist()})
 
 
 def compute_ap(recall: list[float], precision: list[float]) -> tuple[float, np.ndarray, np.ndarray]:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Ultralytics HUB training completion reporting by sending class names and rich plot data for interactive visualizations 📈✨

### 📊 Key Changes
- Added collection and sending of **plot data** from both the trainer and validator at `on_train_end()` (e.g., confusion matrix, PR curves, metric-confidence curves) 🧩
- Included **class names** in the final `"training_complete"` payload to better label plots and results 🏷️
- Enhanced metrics plotting callbacks to pass **structured plot metadata** (type + raw arrays) via `on_plot`, enabling interactive plotting on the frontend 🖥️
  - Confusion matrix now sends raw matrix counts
  - PR curve now sends x/y arrays and per-class AP
  - Metric-confidence curves now send x/y arrays
- Minor cleanup/logging tweaks (e.g., log now reports how many plots were uploaded) 🧹
- Version bumped from `8.3.245` to `8.3.246` 🔖
- Small test comment adjustments; added an optional (commented) skip marker for ExecuTorch test debugging 🧪

### 🎯 Purpose & Impact
- Enables **richer Ultralytics HUB experiment pages** with interactive plots rather than relying only on saved images 📊🖱️
- Makes results **easier to interpret** by attaching **class labels** directly to the final training report 🧠🏷️
- Improves consistency by sending plot data from both **training and validation** outputs, increasing visibility into model performance 🔍✅
- Likely minimal impact on normal training, but may slightly increase the amount of data sent at training end due to plot arrays 📦📤