### PR TITLE
Fix plots logging

### DIFF
--- a/docs/en/reference/utils/callbacks/platform.md
+++ b/docs/en/reference/utils/callbacks/platform.md
@@ -11,6 +11,10 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 
 <br>
 
+## ::: ultralytics.utils.callbacks.platform._interp_plot
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.callbacks.platform._send
 
 <br><br><hr><br>

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -364,7 +364,10 @@ class BaseValidator:
         return []
 
     def on_plot(self, name, data=None):
-        """Register plots for visualization."""
+        """Register plots for visualization, deduplicating by type."""
+        plot_type = data.get("type") if data else None
+        if plot_type and any((v.get("data") or {}).get("type") == plot_type for v in self.plots.values()):
+            return  # Skip duplicate plot types
         self.plots[Path(name)] = {"data": data, "timestamp": time.time()}
 
     def plot_val_samples(self, batch, ni):

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -104,8 +104,7 @@ def _upload_model(model_path, project, name):
                 timeout=600,  # 10 min timeout for large models
             ).raise_for_status()
 
-        url = f"https://alpha.ultralytics.com/{project}/{name}"
-        LOGGER.info(f"{PREFIX}Model uploaded to {url} 🚀")
+        LOGGER.info(f"{PREFIX}Model uploaded")
         return data.get("gcsPath")
 
     except Exception as e:
@@ -334,7 +333,7 @@ def on_train_end(trainer):
         name,
     )
     url = f"https://alpha.ultralytics.com/{project}/{name}"
-    LOGGER.info(f"{PREFIX}Training complete, view results at {url} 🚀")
+    LOGGER.info(f"{PREFIX}View results at {url}")
 
 
 callbacks = (

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -104,7 +104,8 @@ def _upload_model(model_path, project, name):
                 timeout=600,  # 10 min timeout for large models
             ).raise_for_status()
 
-        LOGGER.info(f"{PREFIX}Model uploaded")
+        # url = f"https://alpha.ultralytics.com/{project}/{name}"
+        # LOGGER.info(f"{PREFIX}Model uploaded to {url}")
         return data.get("gcsPath")
 
     except Exception as e:

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -181,7 +181,7 @@ def on_pretrain_routine_start(trainer):
 
     project, name = str(trainer.args.project), str(trainer.args.name or "train")
     url = f"https://alpha.ultralytics.com/{project}/{name}"
-    LOGGER.info(f"{PREFIX}Streaming to {url} 🚀")
+    LOGGER.info(f"{PREFIX}Streaming to {url}")
 
     # Create callback to send console output to Platform
     def send_console_output(content, line_count, chunk_id):

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -330,14 +330,19 @@ class SystemLogger:
 
     def _init_nvidia(self):
         """Initialize NVIDIA GPU monitoring with pynvml."""
+        if MACOS:
+            return False
+
         try:
-            assert not MACOS
             check_requirements("nvidia-ml-py>=12.0.0")
             self.pynvml = __import__("pynvml")
             self.pynvml.nvmlInit()
             return True
         except Exception as e:
-            LOGGER.warning(f"SystemLogger NVML init failed: {e}")
+            import torch
+
+            if torch.cuda.is_available():
+                LOGGER.warning(f"SystemLogger NVML init failed: {e}")
             return False
 
     def get_metrics(self, rates=False):

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -568,7 +568,6 @@ class ConfusionMatrix(DataExportMixin):
         fig.savefig(plot_fname, dpi=250)
         plt.close(fig)
         if on_plot:
-            # Pass confusion matrix data for interactive plotting (raw counts only, normalization done on frontend)
             on_plot(plot_fname, {"type": "confusion_matrix", "matrix": self.matrix.tolist()})
 
     def print(self):
@@ -663,7 +662,8 @@ def plot_pr_curve(
     plt.close(fig)
     if on_plot:
         # Pass PR curve data for interactive plotting (class names stored at model level)
-        on_plot(save_dir, {"type": "pr_curve", "x": px.tolist(), "y": py.tolist(), "ap": ap.tolist()})
+        # Transpose py to match other curves: y[class][point] format
+        on_plot(save_dir, {"type": "pr_curve", "x": px.tolist(), "y": py.T.tolist(), "ap": ap.tolist()})
 
 
 @plt_settings()


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Ultralytics Platform/HUB training uploads by deduplicating plots, shrinking curve payloads, polishing logs, and reducing noisy GPU-monitoring warnings 📉🚀

### 📊 Key Changes
- Added `_interp_plot()` to downsample large curve datasets (e.g., PR curves) from ~1000 points to 101 points before uploading, reducing storage and payload size 📦
- Deduplicated plots by `type` in two places:
  - `Validator.on_plot()` now skips registering duplicate plot types 🧹
  - Platform `on_train_end()` merges trainer + validator plots into a single “one per type” set ✅
- Updated Platform logging with a colored `"Platform: "` prefix and direct “view results” URL messaging (pointing to `alpha.ultralytics.com`) 🔗
- Improved NVIDIA NVML initialization behavior in `SystemLogger`:
  - Skips NVML init on macOS 🍎
  - Only warns about NVML init failures when CUDA is actually available, reducing unnecessary warnings 🔇
- Adjusted PR curve upload format: PR curve `y` is now transposed to `y[class][point]` to align with other curve formats and simplify frontend handling 🔄
- Documentation updated to include the new `ultralytics.utils.callbacks.platform._interp_plot` reference entry 📝

### 🎯 Purpose & Impact
- Faster and lighter result uploads to Ultralytics Platform/HUB due to smaller curve data and fewer duplicate plots ⚡
- Cleaner, more consistent interactive plotting data for the frontend (especially PR curves) 📈
- Reduced confusion and log spam for users without NVML support (or on macOS), while still warning appropriately on CUDA systems 🛠️
- Clearer UX with direct “Streaming to …” and “View results at …” links during/after training 🔎