### PR TITLE
`ultralytics 8.3.249` Jetson AGX Thor and DGX Spark Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,10 @@ on:
         type: boolean
         description: Dockerfile-arm64
         default: true
+      Dockerfile-nvidia-arm64:
+        type: boolean
+        description: Dockerfile-nvidia-arm64
+        default: true
       Dockerfile-jetson-jetpack6:
         type: boolean
         description: Dockerfile-jetson-jetpack6
@@ -73,6 +77,9 @@ jobs:
             platforms: "linux/arm64"
             runs_on: "ubuntu-24.04-arm"
             derivatives: ""
+          - dockerfile: "Dockerfile-nvidia-arm64"
+            tags: "latest-nvidia-arm64"
+            platforms: "linux/arm64"
           - dockerfile: "Dockerfile-jetson-jetpack6"
             tags: "latest-jetson-jetpack6"
             platforms: "linux/arm64"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,6 +80,8 @@ jobs:
           - dockerfile: "Dockerfile-nvidia-arm64"
             tags: "latest-nvidia-arm64"
             platforms: "linux/arm64"
+            runs_on: "ubuntu-24.04-arm"
+            derivatives: ""
           - dockerfile: "Dockerfile-jetson-jetpack6"
             tags: "latest-jetson-jetpack6"
             platforms: "linux/arm64"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Run Tests
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ (matrix.tags == 'latest-python' && 'latest-python-export') || (matrix.tags == 'latest' && 'latest-export') || matrix.tags }} /bin/bash -c "uv pip install --system --break-system-packages pytest && pytest tests"
+        run: docker run ultralytics/ultralytics:${{ (matrix.tags == 'latest-python' && 'latest-python-export') || (matrix.tags == 'latest' && 'latest-export') || matrix.tags }} /bin/bash -c "uv pip install --system --break-system-packages pytest && pytest tests -vv"
 
       - name: Run Benchmarks
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Run Tests
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.platforms == 'linux/arm64') && matrix.dockerfile != 'Dockerfile-conda'
-        run: docker run ultralytics/ultralytics:${{ (matrix.tags == 'latest-python' && 'latest-python-export') || (matrix.tags == 'latest' && 'latest-export') || matrix.tags }} /bin/bash -c "uv pip install --system --break-system-packages pytest && pytest tests -vv"
+        run: docker run ultralytics/ultralytics:${{ (matrix.tags == 'latest-python' && 'latest-python-export') || (matrix.tags == 'latest' && 'latest-export') || matrix.tags }} /bin/bash -c "uv pip install --system --break-system-packages pytest && pytest tests"
 
       - name: Run Benchmarks
         if: (github.event_name == 'push' || github.event.inputs[matrix.dockerfile] == 'true') && (matrix.platforms == 'linux/amd64' || matrix.dockerfile == 'Dockerfile-arm64') && matrix.dockerfile != 'Dockerfile' && matrix.dockerfile != 'Dockerfile-conda'

--- a/docker/Dockerfile-nvidia-arm64
+++ b/docker/Dockerfile-nvidia-arm64
@@ -3,8 +3,8 @@
 # Builds ultralytics/ultralytics:latest-nvidia-arm64 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Supports JetPack 7.0 and DGX OS for YOLO on Jetson AGX Thor (T5000) and DGX Spark
 
-# Start FROM PyTorch image nvcr.io/nvidia/pytorch:25.11-py3
-FROM nvcr.io/nvidia/pytorch:25.11-py3
+# Start FROM PyTorch image nvcr.io/nvidia/pytorch:25.10-py3
+FROM nvcr.io/nvidia/pytorch:25.10-py3
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/Dockerfile-nvidia-arm64
+++ b/docker/Dockerfile-nvidia-arm64
@@ -34,8 +34,8 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 
 # Install pip packages (uv already installed in base image)
 RUN uv pip install --system \
-    https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl && \
-    uv pip install --system -e ".[export]" && \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl --break-system-packages && \
+    uv pip install --system -e ".[export]" --break-system-packages && \
     # Remove extra build files
     rm -rf *.whl /root/.config/Ultralytics/persistent_cache.json
 

--- a/docker/Dockerfile-nvidia-arm64
+++ b/docker/Dockerfile-nvidia-arm64
@@ -3,8 +3,8 @@
 # Builds ultralytics/ultralytics:latest-nvidia-arm64 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Supports JetPack 7.0 and DGX OS for YOLO on Jetson AGX Thor (T5000) and DGX Spark
 
-# Start FROM PyTorch image nvcr.io/nvidia/pytorch:25.11-py3
-FROM nvcr.io/nvidia/pytorch:25.11-py3
+# Start FROM PyTorch image nvcr.io/nvidia/pytorch:25.10-py3
+FROM nvcr.io/nvidia/pytorch:25.10-py3
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
@@ -35,6 +35,8 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
 # Install pip packages (uv already installed in base image)
 RUN uv pip install --system \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl --break-system-packages && \
+    # Reinstall torch and torchvision to ensure CUDA 13.0 compatibility
+    uv pip install --system --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu130 --break-system-packages && \
     uv pip install --system -e ".[export]" --break-system-packages && \
     # Remove extra build files
     rm -rf *.whl /root/.config/Ultralytics/persistent_cache.json

--- a/docker/Dockerfile-nvidia-arm64
+++ b/docker/Dockerfile-nvidia-arm64
@@ -3,8 +3,8 @@
 # Builds ultralytics/ultralytics:latest-nvidia-arm64 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Supports JetPack 7.0 and DGX OS for YOLO on Jetson AGX Thor (T5000) and DGX Spark
 
-# Start FROM PyTorch image nvcr.io/nvidia/pytorch:25.10-py3
-FROM nvcr.io/nvidia/pytorch:25.10-py3
+# Start FROM PyTorch image nvcr.io/nvidia/pytorch:25.11-py3
+FROM nvcr.io/nvidia/pytorch:25.11-py3
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/Dockerfile-nvidia-arm64
+++ b/docker/Dockerfile-nvidia-arm64
@@ -1,0 +1,49 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Builds ultralytics/ultralytics:latest-nvidia-arm64 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
+# Supports JetPack 7.0 and DGX OS for YOLO on Jetson AGX Thor (T5000) and DGX Spark
+
+# Start FROM PyTorch image nvcr.io/nvidia/pytorch:25.11-py3
+FROM nvcr.io/nvidia/pytorch:25.11-py3
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_BREAK_SYSTEM_PACKAGES=1
+
+# Downloads to user config dir
+ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.Unicode.ttf \
+    /root/.config/Ultralytics/
+
+# Install linux packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libgl1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create working directory
+WORKDIR /ultralytics
+
+# Copy contents and configure git
+COPY . .
+RUN sed -i '/^\[http "https:\/\/github\.com\/"\]/,+1d' .git/config && \
+    sed -i'' -e 's/"opencv-python/"opencv-python-headless/' pyproject.toml
+ADD https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt .
+
+# Install pip packages (uv already installed in base image)
+RUN uv pip install --system \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl && \
+    uv pip install --system -e ".[export]" && \
+    # Remove extra build files
+    rm -rf *.whl /root/.config/Ultralytics/persistent_cache.json
+
+# Usage --------------------------------------------------------------------------------------------------------------
+
+# Production builds: https://github.com/ultralytics/ultralytics/blob/main/.github/workflows/docker.yml
+# Example (build): t=ultralytics/ultralytics:latest-nvidia-arm64 && docker build --platform linux/arm64 -f docker/Dockerfile-nvidia-arm64 -t $t .
+# Example (push): docker push $t
+# Example (pull): t=ultralytics/ultralytics:latest-nvidia-arm64 && docker pull $t
+# Example (run): docker run -it --ipc=host --runtime=nvidia $t
+# Example (run-with-volume): docker run -it --ipc=host --runtime=nvidia -v "$PWD/shared/datasets:/datasets" $t && docker push $tnew

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -108,7 +108,10 @@ The fastest way to get started with Ultralytics YOLO11 on NVIDIA Jetson is to ru
 
 === "JetPack 7"
 
-    Coming soon.
+    ```bash
+    t=ultralytics/ultralytics:latest-nvidia-arm64
+    sudo docker pull $t && sudo docker run -it --ipc=host --runtime=nvidia $t
+    ```
 
 After this is done, skip to [Use TensorRT on NVIDIA Jetson section](#use-tensorrt-on-nvidia-jetson).
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.248"
+__version__ = "8.3.249"
 
 import importlib
 import os


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a new NVIDIA ARM64 Docker image build (for JetPack 7/DGX ARM) and updates Jetson docs accordingly 🚀🐳

### 📊 Key Changes
- 🐳 **GitHub Actions Docker workflow** now builds and publishes an additional image from `Dockerfile-nvidia-arm64` with tag **`latest-nvidia-arm64`** for **linux/arm64**.
- ➕ **New `docker/Dockerfile-nvidia-arm64`** based on NVIDIA PyTorch NGC image (`nvcr.io/nvidia/pytorch:25.10-py3`) to support **JetPack 7.0** and **DGX OS** on ARM devices (e.g., Jetson AGX Thor / DGX Spark).
- ⚙️ Dockerfile includes:
  - Headless OpenCV swap (`opencv-python` → `opencv-python-headless`) to reduce GUI deps 🧩
  - Preloads Ultralytics assets (fonts) and a default model (`yolo11n.pt`) 📦
  - Installs **ONNX Runtime GPU** for **aarch64** and **reinstalls torch/torchvision** for CUDA compatibility 🔥
  - Installs Ultralytics with `.[export]` extras for export workflows (e.g., ONNX/TensorRT) 🛠️
- 📝 **Jetson guide updated**: JetPack 7 section now provides a working `docker pull` + `docker run` command using the new image ✅
- 🔖 Version bump: **8.3.248 → 8.3.249** 🏷️

### 🎯 Purpose & Impact
- 🚀 **Faster JetPack 7 onboarding**: Jetson users can run YOLO11 immediately via Docker instead of waiting for “coming soon.”
- 🧠 **Better ARM NVIDIA compatibility**: A dedicated ARM64 NVIDIA base image reduces setup friction on new NVIDIA ARM platforms (JetPack 7 / DGX ARM).
- 📦 **More reliable exports**: Bundling `.[export]` and GPU runtime components makes it easier to export models (ONNX/TensorRT) inside the container.
- 🧰 **Cleaner dependencies**: Using headless OpenCV helps avoid unnecessary GUI dependencies and can improve container portability.