### PR TITLE
Remove incorrect TODO comment in `plot_images`

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -786,7 +786,6 @@ def plot_images(
                 boxes[..., 0] += x
                 boxes[..., 1] += y
                 is_obb = boxes.shape[-1] == 5  # xywhr
-                # TODO: this transformation might be unnecessary
                 boxes = ops.xywhr2xyxyxyxy(boxes) if is_obb else ops.xywh2xyxy(boxes)
                 for j, box in enumerate(boxes.astype(np.int64).tolist()):
                     c = classes[j]


### PR DESCRIPTION
## Summary

Remove TODO comment suggesting the `xywh2xyxy` transformation might be unnecessary in `plot_images()`.

## Why the transformation is required

- `plot_images()` receives boxes in `xywh` format (center_x, center_y, width, height)
- `Annotator.box_label()` expects `xyxy` format (x1, y1, x2, y2) for `cv2.rectangle()`
- Without conversion, width/height would be misinterpreted as corner coordinates

The TODO was added in #21009 during refactoring without verifying the data flow.

## Test commands

```bash
yolo val detect model=yolo11n.pt data=coco8.yaml plots=True
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 Removes an outdated TODO comment in `plot_images` to keep the plotting codebase clean and unambiguous.

### 📊 Key Changes
- Deleted an incorrect TODO note near the OBB (`xywhr`) transformation logic in `ultralytics/utils/plotting.py`.

### 🎯 Purpose & Impact
- Reduces confusion for contributors by removing misleading guidance around a necessary box conversion step.
- No functional or API changes; runtime behavior and outputs remain the same ✅