### PR TITLE
Fix YAML `channels` override in DetectionModel

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -379,7 +379,7 @@ class DetectionModel(BaseModel):
             self.yaml["backbone"][0][2] = "nn.Identity"
 
         # Define model
-        self.yaml["channels"] = ch  # save channels
+        ch = self.yaml["channels"] = self.yaml.get("channels", ch)  # input channels
         if nc and nc != self.yaml["nc"]:
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml["nc"] = nc  # override YAML value


### PR DESCRIPTION
## Summary

Fix custom `channels` value in YAML being overwritten by default `ch=3` parameter.

Closes #23083

## Changes

Updated `DetectionModel.__init__` to use `yaml.get("channels", ch)` pattern, consistent with `ClassificationModel._from_yaml`.

This allows users to define custom input channels (grayscale, multispectral, etc.) in YAML config without them being silently overwritten.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes input channel handling so `DetectionModel` respects `channels` defined in the model YAML when present 🛠️

### 📊 Key Changes
- Updates `DetectionModel.__init__` to read `channels` from the YAML config via `self.yaml.get("channels", ch)`
- Ensures the local `ch` variable and `self.yaml["channels"]` stay in sync when YAML overrides are provided

### 🎯 Purpose & Impact
- Prevents unintended overriding of YAML-defined input channels (useful for non-RGB or custom-input models) 🎯
- Improves config consistency and reduces surprises when switching between CLI/code overrides and YAML settings
- Low-risk change with targeted impact limited to model initialization logic for detection models ✅