### PR TITLE
Fix operator precedence in `ObjectCounter.display_counts`

### DIFF
--- a/ultralytics/solutions/object_counter.py
+++ b/ultralytics/solutions/object_counter.py
@@ -129,7 +129,7 @@ class ObjectCounter(BaseSolution):
             str.capitalize(key): f"{'IN ' + str(value['IN']) if self.show_in else ''} "
             f"{'OUT ' + str(value['OUT']) if self.show_out else ''}".strip()
             for key, value in self.classwise_count.items()
-            if value["IN"] != 0 or (value["OUT"] != 0 and (self.show_in or self.show_out))
+            if (value["IN"] != 0 and self.show_in) or (value["OUT"] != 0 and self.show_out)
         }
         if labels_dict:
             self.annotator.display_analytics(plot_im, labels_dict, (104, 31, 17), (255, 255, 255), self.margin)


### PR DESCRIPTION
Completes the fix started in #21047 for empty label display in `ObjectCounter`.

**Issue:**
PR #21047 changed the condition from:
```python
if value["IN"] != 0 or value["OUT"] != 0
```
to:
```python
if value["IN"] != 0 or value["OUT"] != 0 and (self.show_in or self.show_out)
```

Due to operator precedence (`and` > `or`), this parses as:
```python
if value["IN"] != 0 or (value["OUT"] != 0 and (self.show_in or self.show_out))
```

The `value["IN"] != 0` check bypasses `show_in` flag entirely.

**Fix:**
```python
if (value["IN"] != 0 and self.show_in) or (value["OUT"] != 0 and self.show_out)
```

**Example:**
`show_in=False`, `show_out=True`, `IN=5`, `OUT=0`
- Before: displays `"Person: "` (empty value)
- After: class not displayed