### PR TITLE
Fix type mismatch in `ConfusionMatrix` default parameter

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -315,7 +315,7 @@ class ConfusionMatrix(DataExportMixin):
         matches (dict): Contains the indices of ground truths and predictions categorized into TP, FP and FN.
     """
 
-    def __init__(self, names: dict[int, str] = [], task: str = "detect", save_matches: bool = False):
+    def __init__(self, names: dict[int, str] = {}, task: str = "detect", save_matches: bool = False):
         """Initialize a ConfusionMatrix instance.
 
         Args:


### PR DESCRIPTION
## Issue

In PR #18868, the type hint for `names` parameter in `ConfusionMatrix.__init__` was changed from `List[str]` to `Dict[int, str]`, but the default value was left as `[]` instead of `{}`:

```python
def __init__(self, names: dict[int, str] = [], ...):
```

This creates a type mismatch between the annotation and the default value.

## Fix

Change the default value from `[]` to `{}` to match the type hint:

```python
def __init__(self, names: dict[int, str] = {}, ...):
```

This aligns with other metrics classes in the same file (`DetMetrics`, `SegmentMetrics`, `PoseMetrics`, `OBBMetrics`) which all use `= {}` as the default.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a default-parameter type mismatch in `ConfusionMatrix` initialization 🧩

### 📊 Key Changes
- Updates `ConfusionMatrix.__init__` default for `names` from `[]` to `{}` to match the annotated type `dict[int, str]`
- Avoids using a mutable list as a default argument for a dict-typed parameter 🛠️

### 🎯 Purpose & Impact
- Prevents confusing behavior and improves correctness when `names` is omitted ✅
- Reduces risk of type-related issues in IDE/type-checking and runtime edge cases 🔍
- Keeps metrics utilities more reliable for detection workflows 📈