### PR TITLE
Respect imgsz in ProfileModels FLOPs calculation

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -403,7 +403,7 @@ class Model(torch.nn.Module):
         }
         torch.save({**self.ckpt, **updates}, filename)
 
-    def info(self, detailed: bool = False, verbose: bool = True, imgsz=640):
+    def info(self, detailed: bool = False, verbose: bool = True, imgsz: int | list[int, int] = 640):
         """Display model information.
 
         This method provides an overview or detailed information about the model, depending on the arguments
@@ -412,7 +412,7 @@ class Model(torch.nn.Module):
         Args:
             detailed (bool): If True, shows detailed information about the model layers and parameters.
             verbose (bool): If True, prints the information. If False, returns the information as a list.
-            imgsz (int | list): Input image size used for FLOPs calculation.
+            imgsz (int | list[int, int]): Input image size used for FLOPs calculation.
 
         Returns:
             (list[str]): A list of strings containing various types of information about the model, including model

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -403,7 +403,7 @@ class Model(torch.nn.Module):
         }
         torch.save({**self.ckpt, **updates}, filename)
 
-    def info(self, detailed: bool = False, verbose: bool = True):
+    def info(self, detailed: bool = False, verbose: bool = True, imgsz=640):
         """Display model information.
 
         This method provides an overview or detailed information about the model, depending on the arguments
@@ -412,6 +412,7 @@ class Model(torch.nn.Module):
         Args:
             detailed (bool): If True, shows detailed information about the model layers and parameters.
             verbose (bool): If True, prints the information. If False, returns the information as a list.
+            imgsz (int | list): Input image size used for FLOPs calculation.
 
         Returns:
             (list[str]): A list of strings containing various types of information about the model, including model
@@ -423,7 +424,7 @@ class Model(torch.nn.Module):
             >>> info_list = model.info(detailed=True, verbose=False)  # Returns detailed info as a list
         """
         self._check_is_pytorch_model()
-        return self.model.info(detailed=detailed, verbose=verbose)
+        return self.model.info(detailed=detailed, verbose=verbose, imgsz=imgsz)
 
     def fuse(self) -> None:
         """Fuse Conv2d and BatchNorm2d layers in the model for optimized inference.

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -460,7 +460,7 @@ class ProfileModels:
             if file.suffix in {".pt", ".yaml", ".yml"}:
                 model = YOLO(str(file))
                 model.fuse()  # to report correct params and GFLOPs in model.info()
-                model_info = model.info()
+                model_info = model.info(imgsz=self.imgsz)
                 if self.trt and self.device.type != "cpu" and not engine_file.is_file():
                     engine_file = model.export(
                         format="engine",

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -267,7 +267,13 @@ def on_pretrain_routine_start(trainer):
     # Create callback to send console output to Platform
     def send_console_output(content, line_count, chunk_id):
         """Send batched console output to Platform webhook."""
-        _send_async("console_output", {"chunkId": chunk_id, "content": content, "lineCount": line_count}, project, name, getattr(trainer, "_platform_model_id", None))
+        _send_async(
+            "console_output",
+            {"chunkId": chunk_id, "content": content, "lineCount": line_count},
+            project,
+            name,
+            getattr(trainer, "_platform_model_id", None),
+        )
 
     # Start console capture with batching (5 lines or 5 seconds)
     trainer._platform_console_logger = ConsoleLogger(batch_size=5, flush_interval=5.0, on_flush=send_console_output)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## Summary
FLOPs in `ProfileModels` were computed with the default image size (640) even when a custom `imgsz` was provided. This makes the reported FLOPs incorrect for non-default sizes.

## Fix
Use the requested `imgsz` when computing FLOPs so the table reflects the actual profiling size.

## Before
| Model | size<br><sup>(pixels) | mAP<sup>val<br>50-95 | Speed<br><sup>CPU (Apple M5) ONNX<br>(ms) | Speed<br><sup>GPU TensorRT<br>(ms) | params<br><sup>(M) | FLOPs<br><sup>(B) |
|-------|-----------------------|----------------------|-------------------------------------------|------------------------------------|--------------------|-------------------|
| yolo11n            | 480 | - | 14.7±0.5 ms | 0.0±0.0 ms | 2.6 | 6.5 |

## After
| Model | size<br><sup>(pixels) | mAP<sup>val<br>50-95 | Speed<br><sup>CPU (Apple M5) ONNX<br>(ms) | Speed<br><sup>GPU TensorRT<br>(ms) | params<br><sup>(M) | FLOPs<br><sup>(B) |
|-------|-----------------------|----------------------|-------------------------------------------|------------------------------------|--------------------|-------------------|
| yolo11n            | 480 | - | 14.7±0.5 ms | 0.0±0.0 ms | 2.6 | 3.6 |

## Testing
Not run (profiling output validated via `ProfileModels(paths=["yolo11n.pt"], imgsz=480).run()`).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds an `imgsz` option to `model.info()` so FLOPs/GFLOPs are reported using the correct input size 📐⚡

### 📊 Key Changes
- Exposed a new `imgsz` parameter on `ultralytics.engine.model.Model.info(detailed=False, verbose=True, imgsz=640)` 🧩
- Forwarded `imgsz` through to the underlying PyTorch model’s `info()` call to compute FLOPs based on that input size 🧠
- Updated the benchmarking workflow to call `model.info(imgsz=self.imgsz)` so benchmark reports match the benchmark image size 📊✅

### 🎯 Purpose & Impact
- More accurate compute reporting (FLOPs/GFLOPs) when users run models at non-default resolutions (e.g., 1280 instead of 640) 🎯
- Benchmark outputs become more trustworthy and consistent with the actual test configuration 🧪📈
- Backwards-compatible: default behavior remains `imgsz=640` unless explicitly changed 🔁👍