### PR TITLE
`ultralytics 8.3.251` Earlier trainer callback init

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.250"
+__version__ = "8.3.251"
 
 import importlib
 import os

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -728,7 +728,7 @@ def handle_yolo_solutions(args: list[str]) -> None:
             if solution_name == "analytics":  # analytical graphs follow fixed shape for output i.e w=1920, h=1080
                 w, h = 1280, 720
             save_dir = get_save_dir(SimpleNamespace(task="solutions", name="exp", exist_ok=False, project=None))
-            save_dir.mkdir(parents=True)  # create the output directory i.e. runs/solutions/exp
+            save_dir.mkdir(parents=True, exist_ok=True)  # create the output directory i.e. runs/solutions/exp
             vw = cv2.VideoWriter(str(save_dir / f"{solution_name}.avi"), cv2.VideoWriter_fourcc(*"mp4v"), fps, (w, h))
 
         try:  # Process video frames

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -414,7 +414,7 @@ def get_save_dir(args: SimpleNamespace, name: str | None = None) -> Path:
         nested = args.project and len(Path(args.project).parts) > 1  # e.g. "user/project" or "org\repo"
         project = runs / args.project if nested else args.project or runs
         name = name or args.name or f"{args.mode}"
-        save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True)
+        save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True, mkdir=True)
 
     return Path(save_dir).resolve()  # resolve to display full path in console
 

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -275,7 +275,7 @@ class Model(torch.nn.Module):
             >>> model._load("yolo11n.pt")
             >>> model._load("path/to/weights.pth", task="detect")
         """
-        if weights.lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://")):
+        if weights.lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://", "ul://")):
             weights = checks.check_file(weights, download_dir=SETTINGS["weights_dir"])  # download and return local file
         weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolo11n -> yolo11n.pt
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -157,6 +157,27 @@ class BaseTrainer:
         if self.device.type in {"cpu", "mps"}:
             self.args.workers = 0  # faster CPU training as time dominated by inference, not dataloading
 
+        # Callbacks - initialize early so on_pretrain_routine_start can capture original args.data
+        self.callbacks = _callbacks or callbacks.get_default_callbacks()
+
+        if isinstance(self.args.device, str) and len(self.args.device):  # i.e. device='0' or device='0,1,2,3'
+            world_size = len(self.args.device.split(","))
+        elif isinstance(self.args.device, (tuple, list)):  # i.e. device=[0, 1, 2, 3] (multi-GPU from CLI is list)
+            world_size = len(self.args.device)
+        elif self.args.device in {"cpu", "mps"}:  # i.e. device='cpu' or 'mps'
+            world_size = 0
+        elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number
+            world_size = 1  # default to device 0
+        else:  # i.e. device=None or device=''
+            world_size = 0
+
+        self.ddp = world_size > 1 and "LOCAL_RANK" not in os.environ
+        self.world_size = world_size
+        # Run on_pretrain_routine_start before get_dataset() to capture original args.data (e.g., ul:// URIs)
+        if RANK in {-1, 0} and not self.ddp:
+            callbacks.add_integration_callbacks(self)
+            self.run_callbacks("on_pretrain_routine_start")
+
         # Model and Dataset
         self.model = check_model_file_from_stem(self.args.model)  # add suffix, i.e. yolo11n -> yolo11n.pt
         with torch_distributed_zero_first(LOCAL_RANK):  # avoid auto-downloading dataset multiple times
@@ -179,28 +200,6 @@ class BaseTrainer:
             self.csv.unlink()
         self.plot_idx = [0, 1, 2]
         self.nan_recovery_attempts = 0
-
-        # Callbacks
-        self.callbacks = _callbacks or callbacks.get_default_callbacks()
-
-        if isinstance(self.args.device, str) and len(self.args.device):  # i.e. device='0' or device='0,1,2,3'
-            world_size = len(self.args.device.split(","))
-        elif isinstance(self.args.device, (tuple, list)):  # i.e. device=[0, 1, 2, 3] (multi-GPU from CLI is list)
-            world_size = len(self.args.device)
-        elif self.args.device in {"cpu", "mps"}:  # i.e. device='cpu' or 'mps'
-            world_size = 0
-        elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number
-            world_size = 1  # default to device 0
-        else:  # i.e. device=None or device=''
-            world_size = 0
-
-        self.ddp = world_size > 1 and "LOCAL_RANK" not in os.environ
-        self.world_size = world_size
-        # Run subprocess if DDP training, else train normally
-        if RANK in {-1, 0} and not self.ddp:
-            callbacks.add_integration_callbacks(self)
-            # Start console logging immediately at trainer initialization
-            self.run_callbacks("on_pretrain_routine_start")
 
     def add_callback(self, event: str, callback):
         """Append the given callback to the event's callback list."""

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -378,6 +378,7 @@ class Tuner:
             metrics = {}
             train_args = {**vars(self.args), **mutated_hyp}
             save_dir = get_save_dir(get_cfg(train_args))
+            train_args["save_dir"] = str(save_dir)  # pass save_dir to subprocess to ensure same path is used
             weights_dir = save_dir / "weights"
             try:
                 # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -267,7 +267,13 @@ def on_pretrain_routine_start(trainer):
     # Create callback to send console output to Platform
     def send_console_output(content, line_count, chunk_id):
         """Send batched console output to Platform webhook."""
-        _send_async("console_output", {"chunkId": chunk_id, "content": content, "lineCount": line_count}, project, name, getattr(trainer, "_platform_model_id", None))
+        _send_async(
+            "console_output",
+            {"chunkId": chunk_id, "content": content, "lineCount": line_count},
+            project,
+            name,
+            getattr(trainer, "_platform_model_id", None),
+        )
 
     # Start console capture with batching (5 lines or 5 seconds)
     trainer._platform_console_logger = ConsoleLogger(batch_size=5, flush_interval=5.0, on_flush=send_console_output)

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -75,8 +75,6 @@ def resolve_platform_uri(uri, hard=True):
     else:
         raise ValueError(f"Invalid platform URI: {uri}. Use ul://user/datasets/name or ul://user/project/model")
 
-    LOGGER.info(f"Resolving {uri} from Ultralytics Platform...")
-
     try:
         r = requests.head(url, headers=headers, allow_redirects=False, timeout=30)
 

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -288,11 +288,14 @@ def on_pretrain_routine_start(trainer):
     # Collect environment info (W&B-style metadata)
     environment = _get_environment_info()
 
+    # Build trainArgs - callback runs before get_dataset() so args.data is still original (e.g., ul:// URIs)
+    train_args = {k: str(v) for k, v in vars(trainer.args).items()}
+
     # Send synchronously to get modelId for subsequent webhooks
     response = _send(
         "training_started",
         {
-            "trainArgs": {k: str(v) for k, v in vars(trainer.args).items()},
+            "trainArgs": train_args,
             "epochs": trainer.epochs,
             "device": str(trainer.device),
             "modelInfo": model_info,

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -321,6 +321,7 @@ def on_fit_epoch_end(trainer):
             model_info = {
                 "parameters": info.get("model/parameters", 0),
                 "gflops": info.get("model/GFLOPs", 0),
+                "speedMs": info.get("model/speed_PyTorch(ms)", 0),
             }
         except Exception:
             pass

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -616,10 +616,13 @@ def check_file(file, suffix="", download=True, download_dir=".", hard=True):
         url = resolve_platform_uri(file, hard=hard)  # Convert to signed HTTPS URL
         if url is None:
             return []  # Not found, soft fail (consistent with file search behavior)
-        local_file = Path(download_dir) / url2file(url)
+        # Use URI path for unique directory structure: ul://user/project/model -> user/project/model/filename.pt
+        uri_path = file[5:]  # Remove "ul://"
+        local_file = Path(download_dir) / uri_path / url2file(url)
         if local_file.exists():
             LOGGER.info(f"Found {clean_url(url)} locally at {local_file}")
         else:
+            local_file.parent.mkdir(parents=True, exist_ok=True)
             downloads.safe_download(url=url, file=local_file, unzip=False)
         return str(local_file)
     elif download and file.lower().startswith(

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -972,6 +972,9 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
     if exclude_zero_fitness_points:
         mask = fitness > 0  # exclude zero-fitness points
         x, fitness = x[mask], fitness[mask]
+    if len(fitness) == 0:
+        LOGGER.warning("No valid fitness values to plot (all iterations may have failed)")
+        return
     # Iterative sigma rejection on lower bound only
     for _ in range(3):  # max 3 iterations
         mean, std = fitness.mean(), fitness.std()


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Ultralytics Platform (`ul://`) support, run directory creation reliability, and training/tuning logging behavior for smoother workflows 🚀

### 📊 Key Changes
- 🧩 **Added `ul://` URI support for model weights loading** in `Model._load()`, enabling direct loading from the Ultralytics Platform.
- 📁 **More reliable run directory creation**:
  - `get_save_dir()` now creates directories automatically via `increment_path(..., mkdir=True)`.
  - YOLO Solutions output directory creation now uses `exist_ok=True` to avoid failures on reruns.
- 🔁 **Trainer callback timing adjusted** so `on_pretrain_routine_start` runs *before* dataset resolution, preserving the original `args.data` (including `ul://` URIs) for integrations/logging 📝.
- 🧪 **Tuner subprocess consistency**: passes `save_dir` into `train_args` so tuning iterations and subprocess training use the same output path.
- 🌐 **Ultralytics Platform callback payload tweaks**:
  - Removed early “resolving” log noise.
  - Sends `trainArgs` early (with original URIs), and sends `modelInfo` later at epoch 0 (now includes parameters, GFLOPs, and speed).
- 🛡️ **Safer plotting for tuning results**: if all fitness values are invalid/zero, it logs a warning and skips plotting instead of erroring.
- 🔖 Version bump: `8.3.250` → `8.3.251`.

### 🎯 Purpose & Impact
- 🔗 **Better `ul://` workflow**: users can reference models/datasets with `ul://...` and get more predictable resolution + local caching structure.
- ✅ **Fewer “directory exists / missing directory” issues**: run folders are created more robustly across training, solutions, and tuning.
- 📡 **Cleaner and more accurate integration logging** (including Ultralytics Platform): original dataset/model references are captured correctly, and model metadata is reported when it’s actually available.
- 🧰 **More stable hyperparameter tuning runs**: consistent `save_dir` avoids mismatched output locations across subprocess executions.
- 📉 **Less fragile plotting** during tuning: avoids crashes when iterations fail and no valid fitness values exist.