### PR TITLE
`ultralytics 8.3.253` Add support to select Vulkan device when using NCNN

### DIFF
--- a/docs/en/integrations/ncnn.md
+++ b/docs/en/integrations/ncnn.md
@@ -1,16 +1,16 @@
 ---
 comments: true
 description: Optimize YOLO11 models for mobile and embedded devices by exporting to NCNN format. Enhance performance in resource-constrained environments.
-keywords: Ultralytics, YOLO11, NCNN, model export, machine learning, deployment, mobile, embedded systems, deep learning, AI models
+keywords: Ultralytics, YOLO11, NCNN, model export, machine learning, deployment, mobile, embedded systems, deep learning, AI models, Vulkan, GPU acceleration
 ---
 
-# How to Export to NCNN from YOLO11 for Smooth Deployment
+# Ultralytics YOLO NCNN Export   
 
-Deploying [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models on devices with limited computational power, such as mobile or embedded systems, can be tricky. You need to make sure you use a format optimized for optimal performance. This makes sure that even devices with limited processing power can handle advanced computer vision tasks well.
+Deploying [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models on devices with limited computational power, such as mobile or embedded systems, requires careful format selection. Using an optimized format ensures that even resource-constrained devices can handle advanced computer vision tasks efficiently.
 
-The export to NCNN format feature allows you to optimize your [Ultralytics YOLO11](https://github.com/ultralytics/ultralytics) models for lightweight device-based applications. In this guide, we'll walk you through how to convert your models to the NCNN format, making it easier for your models to perform well on various mobile and embedded devices.
+Exporting to NCNN format allows you to optimize your [Ultralytics YOLO11](https://github.com/ultralytics/ultralytics) models for lightweight device-based applications. This guide covers how to convert your models to NCNN format for improved performance on mobile and embedded devices.
 
-## Why should you export to NCNN?
+## Why Export to NCNN?
 
 <p align="center">
   <img width="100%" src="https://github.com/ultralytics/docs/releases/download/0/ncnn-overview.avif" alt="NCNN overview">
@@ -18,31 +18,69 @@ The export to NCNN format feature allows you to optimize your [Ultralytics YOLO1
 
 The [NCNN](https://github.com/Tencent/ncnn) framework, developed by Tencent, is a high-performance [neural network](https://www.ultralytics.com/glossary/neural-network-nn) inference computing framework optimized specifically for mobile platforms, including mobile phones, embedded devices, and IoT devices. NCNN is compatible with a wide range of platforms, including Linux, Android, iOS, and macOS.
 
-NCNN is known for its fast processing speed on mobile CPUs and enables rapid deployment of [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models to mobile platforms. This makes it easier to build smart apps, putting the power of AI right at your fingertips.
+NCNN is known for its fast processing speed on mobile CPUs and enables rapid deployment of [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models to mobile platforms, making it an excellent choice for building AI-powered applications.
 
 ## Key Features of NCNN Models
 
-NCNN models offer a wide range of key features that enable on-device [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) by helping developers run their models on mobile, embedded, and edge devices:
+NCNN models provide several key features that enable on-device [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml), helping developers deploy models on mobile, embedded, and edge devices:
 
-- **Efficient and High-Performance**: NCNN models are made to be efficient and lightweight, optimized for running on mobile and embedded devices like Raspberry Pi with limited resources. They can also achieve high performance with high [accuracy](https://www.ultralytics.com/glossary/accuracy) on various computer vision-based tasks.
+- **Efficient and High-Performance**: NCNN models are lightweight and optimized for mobile and embedded devices like Raspberry Pi with limited resources, while maintaining high [accuracy](https://www.ultralytics.com/glossary/accuracy) on computer vision tasks.
 
-- **Quantization**: NCNN models often support quantization which is a technique that reduces the [precision](https://www.ultralytics.com/glossary/precision) of the model's weights and activations. This leads to further improvements in performance and reduces memory footprint.
+- **Quantization**: NCNN supports quantization, a technique that reduces the [precision](https://www.ultralytics.com/glossary/precision) of model weights and activations to improve performance and reduce memory footprint.
 
-- **Compatibility**: NCNN models are compatible with popular deep learning frameworks like [TensorFlow](https://www.tensorflow.org/), [Caffe](https://caffe.berkeleyvision.org/), and [ONNX](https://onnx.ai/). This compatibility allows developers to use existing models and workflows easily.
+- **Compatibility**: NCNN models are compatible with popular deep learning frameworks including [TensorFlow](https://www.tensorflow.org/), [Caffe](https://caffe.berkeleyvision.org/), and [ONNX](https://onnx.ai/), allowing developers to leverage existing models and workflows.
 
-- **Easy to Use**: NCNN models are designed for easy integration into various applications, thanks to their compatibility with popular deep learning frameworks. Additionally, NCNN offers user-friendly tools for converting models between different formats, ensuring smooth interoperability across the development landscape.
+- **Ease of Use**: NCNN provides user-friendly tools for converting models between formats, ensuring smooth interoperability across different development environments.
+
+- **Vulkan GPU Acceleration**: NCNN supports Vulkan for GPU-accelerated inference across multiple vendors including AMD, Intel, and other non-NVIDIA GPUs, enabling high-performance deployment on a wider range of hardware.
 
 ## Deployment Options with NCNN
 
-Before we look at the code for exporting YOLO11 models to the NCNN format, let's understand how NCNN models are normally used.
+NCNN models are compatible with a variety of deployment platforms:
 
-NCNN models, designed for efficiency and performance, are compatible with a variety of deployment platforms:
+- **Mobile Deployment**: Optimized for Android and iOS, enabling seamless integration into mobile applications for efficient on-device inference.
 
-- **Mobile Deployment**: Specifically optimized for Android and iOS, allowing for seamless integration into mobile applications for efficient on-device inference.
+- **Embedded Systems and IoT Devices**: Ideal for resource-constrained devices like Raspberry Pi and NVIDIA Jetson. If standard inference on a Raspberry Pi with the [Ultralytics Guide](../guides/raspberry-pi.md) is insufficient, NCNN can provide significant performance improvements.
 
-- **Embedded Systems and IoT Devices**: If you find that running inference on a Raspberry Pi with the [Ultralytics Guide](../guides/raspberry-pi.md) isn't fast enough, switching to an NCNN exported model could help speed things up. NCNN is great for devices like Raspberry Pi and NVIDIA Jetson, especially in situations where you need quick processing right on the device.
+- **Desktop and Server Deployment**: Supports deployment across Linux, Windows, and macOS for development, training, and evaluation workflows.
 
-- **Desktop and Server Deployment**: Capable of being deployed in desktop and server environments across Linux, Windows, and macOS, supporting development, training, and evaluation with higher computational capacities.
+## Vulkan GPU Acceleration
+
+NCNN supports GPU acceleration through Vulkan, enabling high-performance inference on a wide range of GPUs including AMD, Intel, and other non-NVIDIA graphics cards. This is particularly useful for:
+
+- **Cross-Vendor GPU Support**: Unlike CUDA, which is limited to NVIDIA GPUs, Vulkan works across multiple GPU vendors.
+- **Multi-GPU Systems**: Select a specific Vulkan device in systems with multiple GPUs using `device="vulkan:0"`, `device="vulkan:1"`, etc.
+- **Edge and Desktop Deployments**: Leverage GPU acceleration on devices where CUDA is not available.
+
+To use Vulkan acceleration, specify the Vulkan device when running inference:
+
+!!! example "Vulkan Inference"
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        # Load the exported NCNN model
+        ncnn_model = YOLO("./yolo11n_ncnn_model")
+
+        # Run inference with Vulkan GPU acceleration (first Vulkan device)
+        results = ncnn_model("https://ultralytics.com/images/bus.jpg", device="vulkan:0")
+
+        # Use second Vulkan device in multi-GPU systems
+        results = ncnn_model("https://ultralytics.com/images/bus.jpg", device="vulkan:1")
+        ```
+
+    === "CLI"
+
+        ```bash
+        # Run inference with Vulkan GPU acceleration
+        yolo predict model='./yolo11n_ncnn_model' source='https://ultralytics.com/images/bus.jpg' device=vulkan:0
+        ```
+
+!!! tip "Vulkan Requirements"
+
+    Ensure you have Vulkan drivers installed for your GPU. Most modern GPU drivers include Vulkan support by default. You can verify Vulkan availability using tools like `vulkaninfo` on Linux or the Vulkan SDK on Windows.
 
 ## Export to NCNN: Converting Your YOLO11 Model
 
@@ -61,7 +99,7 @@ To install the required packages, run:
         pip install ultralytics
         ```
 
-For detailed instructions and best practices related to the installation process, check our [Ultralytics Installation guide](../quickstart.md). While installing the required packages for YOLO11, if you encounter any difficulties, consult our [Common Issues guide](../guides/yolo-common-issues.md) for solutions and tips.
+For detailed instructions and best practices, see the [Ultralytics Installation guide](../quickstart.md). If you encounter any difficulties, consult our [Common Issues guide](../guides/yolo-common-issues.md) for solutions.
 
 ### Usage
 
@@ -111,31 +149,29 @@ For more details about the export process, visit the [Ultralytics documentation 
 
 ## Deploying Exported YOLO11 NCNN Models
 
-After successfully exporting your Ultralytics YOLO11 models to NCNN format, you can now deploy them. The primary and recommended first step for running an NCNN model is to use the `YOLO("yolo11n_ncnn_model/")` method, as outlined in the previous usage code snippet. However, for in-depth instructions on deploying your NCNN models in various other settings, take a look at the following resources:
+After exporting your Ultralytics YOLO11 models to NCNN format, you can deploy them using the `YOLO("yolo11n_ncnn_model/")` method as shown in the usage example above. For platform-specific deployment instructions, see the following resources:
 
-- **[Android](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-android)**: This blog explains how to use NCNN models for performing tasks like [object detection](https://www.ultralytics.com/glossary/object-detection) through Android applications.
+- **[Android](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-android)**: Build and integrate NCNN models for [object detection](https://www.ultralytics.com/glossary/object-detection) in Android applications.
 
-- **[macOS](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-macos)**: Understand how to use NCNN models for performing tasks through macOS.
+- **[macOS](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-macos)**: Deploy NCNN models on macOS systems.
 
-- **[Linux](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux)**: Explore this page to learn how to deploy NCNN models on limited resource devices like Raspberry Pi and other similar devices.
+- **[Linux](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux)**: Deploy NCNN models on Linux devices including Raspberry Pi and similar embedded systems.
 
-- **[Windows x64 using VS2017](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-windows-x64-using-visual-studio-community-2017)**: Explore this blog to learn how to deploy NCNN models on Windows x64 using Visual Studio Community 2017.
+- **[Windows x64](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-windows-x64-using-visual-studio-community-2017)**: Deploy NCNN models on Windows x64 using Visual Studio.
 
 ## Summary
 
-In this guide, we've gone over exporting Ultralytics YOLO11 models to the NCNN format. This conversion step is crucial for improving the efficiency and speed of YOLO11 models, making them more effective and suitable for limited-resource computing environments.
+This guide covered exporting Ultralytics YOLO11 models to NCNN format for improved efficiency and speed on resource-constrained devices.
 
-For detailed instructions on usage, please refer to the [official NCNN documentation](https://ncnn.readthedocs.io/en/latest/index.html).
-
-Also, if you're interested in exploring other integration options for Ultralytics YOLO11, be sure to visit our [integration guide page](index.md) for further insights and information.
+For additional details, refer to the [official NCNN documentation](https://ncnn.readthedocs.io/en/latest/index.html). For other export options, visit our [integration guide page](index.md).
 
 ## FAQ
 
 ### How do I export Ultralytics YOLO11 models to NCNN format?
 
-To export your Ultralytics YOLO11 model to NCNN format, follow these steps:
+To export your Ultralytics YOLO11 model to NCNN format:
 
-- **Python**: Use the `export` function from the YOLO class.
+- **Python**: Use the `export` method from the YOLO class.
 
     ```python
     from ultralytics import YOLO
@@ -147,12 +183,13 @@ To export your Ultralytics YOLO11 model to NCNN format, follow these steps:
     model.export(format="ncnn")  # creates '/yolo11n_ncnn_model'
     ```
 
-- **CLI**: Use the `yolo` command with the `export` argument.
+- **CLI**: Use the `yolo export` command.
+
     ```bash
-    yolo export model=yolo11n.pt format=ncnn # creates '/yolo11n_ncnn_model'
+    yolo export model=yolo11n.pt format=ncnn  # creates '/yolo11n_ncnn_model'
     ```
 
-For detailed export options, check the [Export](../modes/export.md) page in the documentation.
+For detailed export options, see the [Export](../modes/export.md) documentation.
 
 ### What are the advantages of exporting YOLO11 models to NCNN?
 
@@ -161,8 +198,9 @@ Exporting your Ultralytics YOLO11 models to NCNN offers several benefits:
 - **Efficiency**: NCNN models are optimized for mobile and embedded devices, ensuring high performance even with limited computational resources.
 - **Quantization**: NCNN supports techniques like quantization that improve model speed and reduce memory usage.
 - **Broad Compatibility**: You can deploy NCNN models on multiple platforms, including Android, iOS, Linux, and macOS.
+- **Vulkan GPU Acceleration**: Leverage GPU acceleration on AMD, Intel, and other non-NVIDIA GPUs via Vulkan for faster inference.
 
-For more details, see the [Export to NCNN](#why-should-you-export-to-ncnn) section in the documentation.
+For more details, see the [Why Export to NCNN?](#why-export-to-ncnn) section.
 
 ### Why should I use NCNN for my mobile AI applications?
 
@@ -172,7 +210,7 @@ NCNN, developed by Tencent, is specifically optimized for mobile platforms. Key 
 - **Cross-Platform**: Compatible with popular frameworks such as [TensorFlow](https://www.ultralytics.com/glossary/tensorflow) and ONNX, making it easier to convert and deploy models across different platforms.
 - **Community Support**: Active community support ensures continual improvements and updates.
 
-To understand more, visit the [NCNN overview](#key-features-of-ncnn-models) in the documentation.
+For more information, see the [Key Features of NCNN Models](#key-features-of-ncnn-models) section.
 
 ### What platforms are supported for NCNN [model deployment](https://www.ultralytics.com/glossary/model-deployment)?
 
@@ -182,7 +220,7 @@ NCNN is versatile and supports various platforms:
 - **Embedded Systems and IoT Devices**: Devices like Raspberry Pi and NVIDIA Jetson.
 - **Desktop and Servers**: Linux, Windows, and macOS.
 
-If running models on a Raspberry Pi isn't fast enough, converting to the NCNN format could speed things up as detailed in our [Raspberry Pi Guide](../guides/raspberry-pi.md).
+For improved performance on Raspberry Pi, consider using NCNN format as detailed in our [Raspberry Pi Guide](../guides/raspberry-pi.md).
 
 ### How can I deploy Ultralytics YOLO11 NCNN models on Android?
 
@@ -191,6 +229,20 @@ To deploy your YOLO11 models on Android:
 1. **Build for Android**: Follow the [NCNN Build for Android](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-android) guide.
 2. **Integrate with Your App**: Use the NCNN Android SDK to integrate the exported model into your application for efficient on-device inference.
 
-For step-by-step instructions, refer to our guide on [Deploying YOLO11 NCNN Models](#deploying-exported-yolo11-ncnn-models).
+For detailed instructions, see [Deploying Exported YOLO11 NCNN Models](#deploying-exported-yolo11-ncnn-models).
 
-For more advanced guides and use cases, visit the [Ultralytics documentation page](../guides/model-deployment-options.md).
+For more advanced guides and use cases, visit the [Ultralytics deployment guide](../guides/model-deployment-options.md).
+
+### How do I use Vulkan GPU acceleration with NCNN models?
+
+NCNN supports Vulkan for GPU acceleration on AMD, Intel, and other non-NVIDIA GPUs. To use Vulkan:
+
+```python
+from ultralytics import YOLO
+
+# Load NCNN model and run with Vulkan GPU
+model = YOLO("yolo11n_ncnn_model")
+results = model("image.jpg", device="vulkan:0")  # Use first Vulkan device
+```
+
+For multi-GPU systems, specify the device index (e.g., `vulkan:1` for the second GPU). Ensure Vulkan drivers are installed for your GPU. See the [Vulkan GPU Acceleration](#vulkan-gpu-acceleration) section for more details.

--- a/docs/en/integrations/ncnn.md
+++ b/docs/en/integrations/ncnn.md
@@ -4,7 +4,7 @@ description: Optimize YOLO11 models for mobile and embedded devices by exporting
 keywords: Ultralytics, YOLO11, NCNN, model export, machine learning, deployment, mobile, embedded systems, deep learning, AI models, Vulkan, GPU acceleration
 ---
 
-# Ultralytics YOLO NCNN Export   
+# Ultralytics YOLO NCNN Export
 
 Deploying [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models on devices with limited computational power, such as mobile or embedded systems, requires careful format selection. Using an optimized format ensures that even resource-constrained devices can handle advanced computer vision tasks efficiently.
 
@@ -186,7 +186,7 @@ To export your Ultralytics YOLO11 model to NCNN format:
 - **CLI**: Use the `yolo export` command.
 
     ```bash
-    yolo export model=yolo11n.pt format=ncnn  # creates '/yolo11n_ncnn_model'
+    yolo export model=yolo11n.pt format=ncnn # creates '/yolo11n_ncnn_model'
     ```
 
 For detailed export options, see the [Export](../modes/export.md) documentation.

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.252"
+__version__ = "8.3.253"
 
 import importlib
 import os

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -549,7 +549,12 @@ class AutoBackend(nn.Module):
             import ncnn as pyncnn
 
             net = pyncnn.Net()
-            net.opt.use_vulkan_compute = cuda
+            if isinstance(cuda, torch.device):
+                net.opt.use_vulkan_compute = cuda
+            elif isinstance(device, str) and device.startswith("vulkan"):
+                net.opt.use_vulkan_compute = True
+                net.set_vulkan_device(int(device.split(":")[1]))
+                device=torch.device("cpu")
             w = Path(w)
             if not w.is_file():  # if not *.param
                 w = next(w.glob("*.param"))  # get *.param file from *_ncnn_model dir

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -554,7 +554,7 @@ class AutoBackend(nn.Module):
             elif isinstance(device, str) and device.startswith("vulkan"):
                 net.opt.use_vulkan_compute = True
                 net.set_vulkan_device(int(device.split(":")[1]))
-                device=torch.device("cpu")
+                device = torch.device("cpu")
             w = Path(w)
             if not w.is_file():  # if not *.param
                 w = next(w.glob("*.param"))  # get *.param file from *_ncnn_model dir

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -157,7 +157,7 @@ def select_device(device="", newline=False, verbose=True):
     Notes:
         Sets the 'CUDA_VISIBLE_DEVICES' environment variable for specifying which GPUs to use.
     """
-    if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel")):
+    if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
         return device
 
     s = f"Ultralytics {__version__} 🚀 Python-{PYTHON_VERSION} torch-{TORCH_VERSION} "


### PR DESCRIPTION
Hi,

thank you for your wonderful work and making it open source.

To be honest this PR is more a feature request with some POC code.

Basically I would like to be able to use and select a Vulkan device on non-NVIDIA GPUs, when using ncnn.

Would it be possible to add something like this?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds Vulkan device selection support for NCNN inference, enabling users to target a specific Vulkan GPU by device string. ⚡🖥️

### 📊 Key Changes
- Updates `select_device()` to accept device strings that start with `"vulkan"` and return them unchanged.
- Extends NCNN initialization in `ultralytics/nn/autobackend.py` to:
  - Enable Vulkan compute when `device` is passed as `"vulkan:<id>"`.
  - Call `net.set_vulkan_device(<id>)` to select the requested Vulkan device.
  - Force `device=torch.device("cpu")` afterward to keep the rest of the pipeline consistent.

### 🎯 Purpose & Impact
- Improves multi-GPU Vulkan workflows by allowing explicit device targeting (e.g., `vulkan:0`, `vulkan:1`). ✅
- Makes NCNN/Vulkan deployments more controllable on edge and desktop systems using Vulkan backends. 🚀
- Potential impact to watch: `net.opt.use_vulkan_compute` appears to be set to `cuda` when `cuda` is a `torch.device`, which may be unintended since NCNN expects a boolean option; this may need a quick follow-up adjustment or clarification. 🔍