### PR TITLE
NCNN source build and Paddle 3.3.0 exclusions

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -813,11 +813,11 @@ class Exporter:
         assert not IS_JETSON, "Jetson Paddle exports not supported yet"
         check_requirements(
             (
-                "paddlepaddle-gpu"
+                "paddlepaddle-gpu>=3.0.0,!=3.3.0"  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
                 if torch.cuda.is_available()
                 else "paddlepaddle==3.0.0"  # pin 3.0.0 for ARM64
                 if ARM64
-                else "paddlepaddle>=3.0.0",
+                else "paddlepaddle>=3.0.0,!=3.3.0",  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
                 "x2paddle",
             )
         )

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,8 +860,8 @@ class Exporter:
     @try_export
     def export_ncnn(self, prefix=colorstr("NCNN:")):
         """Export YOLO model to NCNN format using PNNX https://github.com/pnnx/pnnx."""
-        # excludes broken v1.0.20260113 https://github.com/Tencent/ncnn/issues/6509
-        check_requirements("ncnn!=1.0.20260113", cmds="--no-deps")  # no deps to avoid installing opencv-python
+        # use git source for ARM64 due to broken PyPI packages https://github.com/Tencent/ncnn/issues/6509
+        check_requirements("git+https://github.com/Tencent/ncnn.git" if ARM64 else "ncnn", cmds="--no-deps")
         check_requirements("pnnx")
         import ncnn
         import pnnx

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -860,7 +860,8 @@ class Exporter:
     @try_export
     def export_ncnn(self, prefix=colorstr("NCNN:")):
         """Export YOLO model to NCNN format using PNNX https://github.com/pnnx/pnnx."""
-        check_requirements("ncnn", cmds="--no-deps")  # no deps to avoid installing opencv-python
+        # excludes broken v1.0.20260113 https://github.com/Tencent/ncnn/issues/6509
+        check_requirements("ncnn!=1.0.20260113", cmds="--no-deps")  # no deps to avoid installing opencv-python
         check_requirements("pnnx")
         import ncnn
         import pnnx

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -497,11 +497,11 @@ class AutoBackend(nn.Module):
         elif paddle:
             LOGGER.info(f"Loading {w} for PaddlePaddle inference...")
             check_requirements(
-                "paddlepaddle-gpu"
+                "paddlepaddle-gpu>=3.0.0,!=3.3.0"  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
                 if torch.cuda.is_available()
                 else "paddlepaddle==3.0.0"  # pin 3.0.0 for ARM64
                 if ARM64
-                else "paddlepaddle>=3.0.0"
+                else "paddlepaddle>=3.0.0,!=3.3.0"  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
             )
             import paddle.inference as pdi
 
@@ -545,6 +545,7 @@ class AutoBackend(nn.Module):
         # NCNN
         elif ncnn:
             LOGGER.info(f"Loading {w} for NCNN inference...")
+            # use git source for ARM64 due to broken PyPI packages https://github.com/Tencent/ncnn/issues/6509
             check_requirements("git+https://github.com/Tencent/ncnn.git" if ARM64 else "ncnn", cmds="--no-deps")
             import ncnn as pyncnn
 


### PR DESCRIPTION
Updated ncnn requirement to exclude broken version 1.0.20260113.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves PaddlePaddle and NCNN dependency handling to avoid known broken versions and ARM64 install issues 🚀🛠️

### 📊 Key Changes
- 📌 **PaddlePaddle version safeguards**: Updates requirement checks for both export and inference to **exclude PaddlePaddle 3.3.0** (`!=3.3.0`) due to a known upstream issue (see [PaddlePaddle issue #77340](https://github.com/PaddlePaddle/Paddle/issues/77340)).
- 🧩 **Consistent Paddle requirements across paths**: Applies the same PaddlePaddle constraints in:
  - `ultralytics/engine/exporter.py` (Paddle export)
  - `ultralytics/nn/autobackend.py` (Paddle inference loading)
- 🧱 **NCNN on ARM64 uses Git source**: For **ARM64**, installs NCNN from the **GitHub source** instead of PyPI because the PyPI packages are broken (see [Tencent NCNN issue #6509](https://github.com/Tencent/ncnn/issues/6509)).
- ⚙️ **Keeps `--no-deps` for NCNN**: Maintains the `--no-deps` install behavior to avoid pulling in extra dependencies like `opencv-python`.

### 🎯 Purpose & Impact
- ✅ **Fewer installation failures**: Prevents users from landing on **PaddlePaddle 3.3.0**, reducing export/inference breakages 🧯
- 💻 **Better ARM64 compatibility**: Makes **NCNN workflows more reliable on ARM64** (e.g., ARM servers/dev boards) by bypassing problematic PyPI builds 🧩
- 🔄 **More consistent behavior**: Aligns dependency logic between **export** and **runtime inference**, reducing “works in one place but not the other” surprises 🎯