### PR TITLE
Fix `model.fuse()` statement

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -228,7 +228,7 @@ class BaseModel(torch.nn.Module):
         Returns:
             (torch.nn.Module): The fused model is returned.
         """
-        if True:
+        if not self.is_fused():
             for m in self.model.modules():
                 if isinstance(m, (Conv, Conv2, DWConv)) and hasattr(m, "bn"):
                     if isinstance(m, Conv2):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes model layer fusion so it only runs when needed, preventing redundant re-fusing 🔧✨

### 📊 Key Changes
- Updated `ultralytics/nn/tasks.py` to gate `fuse()` with `if not self.is_fused():` instead of an unconditional `if True:`
- Ensures Conv/BatchNorm fusion logic (e.g., `Conv`, `Conv2`, `DWConv` with `bn`) is applied only once during a model’s lifecycle

### 🎯 Purpose & Impact
- Avoids unnecessary repeated fusion passes, which can waste time during inference/export workflows ⏱️
- Reduces risk of unintended side effects from re-fusing already-fused layers, improving stability and predictability ✅
- Makes `model.fuse()` behavior more correct and user-friendly (idempotent), especially for users calling it multiple times or through pipelines 🔁