### PR TITLE
Fix undefined `sem_masks` error and incorrect `proto` unwrap

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -481,7 +481,7 @@ class v8SegmentationLoss(v8DetectionLoss):
         """Calculate and return the combined loss for detection and segmentation."""
         pred_masks, proto = preds["mask_coefficient"].permute(0, 2, 1).contiguous(), preds["proto"]
         loss = torch.zeros(5, device=self.device)  # box, seg, cls, dfl
-        if len(proto) == 2:
+        if isinstance(proto, tuple) and len(proto) == 2:
             proto, pred_semseg = proto
         else:
             pred_semseg = None
@@ -490,6 +490,7 @@ class v8SegmentationLoss(v8DetectionLoss):
         loss[0], loss[2], loss[3] = det_loss[0], det_loss[1], det_loss[2]
 
         batch_size, _, mask_h, mask_w = proto.shape  # batch size, number of masks, mask height, mask width
+        sem_masks = batch["sem_masks"].to(self.device)  # NxHxW
         if fg_mask.sum():
             # Masks loss
             masks = batch["masks"].to(self.device).float()
@@ -511,7 +512,6 @@ class v8SegmentationLoss(v8DetectionLoss):
                 imgsz,
             )
             if pred_semseg is not None:
-                sem_masks = batch["sem_masks"].to(self.device)  # NxHxW
                 mask_zero = sem_masks == 0  # NxHxW
                 sem_masks = F.one_hot(sem_masks.long(), num_classes=self.nc).permute(0, 3, 1, 2).float()  # NxCxHxW
                 sem_masks[mask_zero.unsqueeze(1).expand_as(sem_masks)] = 0
@@ -522,7 +522,6 @@ class v8SegmentationLoss(v8DetectionLoss):
         else:
             loss[1] += (proto * 0).sum() + (pred_masks * 0).sum()  # inf sums may lead to nan loss
             loss[4] += (pred_semseg * 0).sum() + (sem_masks * 0).sum()
-
         loss[1] *= self.hyp.box  # seg gain
         return loss * batch_size, loss.detach()  # loss(box, cls, dfl)
 


### PR DESCRIPTION
Closes https://github.com/ultralytics/ultralytics/issues/23194

**MRE**
```python
from ultralytics import YOLO
model = YOLO("yolo26l-seg.pt")
results = model.train(data="coco128-seg.yaml",
    imgsz=1088, 
    batch=4,
    epochs=100,
    overlap_mask=False,
    device=[0,1,2,3])
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes edge-case bugs in the segmentation loss to prevent crashes and ensure stable loss computation 🛠️✅

### 📊 Key Changes
- Improved `proto` handling by checking `isinstance(proto, tuple)` before unpacking `(proto, pred_semseg)` 🧩
- Ensured `sem_masks` is always moved to the correct device early (`sem_masks = batch["sem_masks"].to(self.device)`) 📦➡️🖥️
- Removed redundant `sem_masks` device transfer inside the semantic-segmentation branch 🧹
- Prevented potential “referenced before assignment” issues when there are no foreground masks (`fg_mask.sum() == 0`) by making `sem_masks` available for the fallback zero-sum path 🧯

### 🎯 Purpose & Impact
- Avoids runtime errors during training in edge cases (e.g., images/batches with no foreground objects) 🚫💥
- Makes mixed segmentation + semantic segmentation training more robust when `preds["proto"]` may be a tensor or a `(proto, pred_semseg)` tuple 🔄
- Improves training stability by ensuring the “zero-loss fallback” path can safely reference `sem_masks` 🧠📉