### PR TITLE
Amp check yolo26

### DIFF
--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -854,7 +854,9 @@ def check_amp(model):
         assert amp_allclose(YOLO(f"{model.model_name}"), im)
         LOGGER.info(f"{prefix}checks passed ✅")
     except ConnectionError:
-        LOGGER.warning(f"{prefix}checks skipped. Offline and unable to download {model.model_name} for AMP checks. {warning_msg}")
+        LOGGER.warning(
+            f"{prefix}checks skipped. Offline and unable to download {model.model_name} for AMP checks. {warning_msg}"
+        )
     except (AttributeError, ModuleNotFoundError):
         LOGGER.warning(
             f"{prefix}checks skipped. "

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -851,14 +851,14 @@ def check_amp(model):
     try:
         from ultralytics import YOLO
 
-        assert amp_allclose(YOLO("yolo11n.pt"), im)
+        assert amp_allclose(YOLO(f"{model.model_name}"), im)
         LOGGER.info(f"{prefix}checks passed ✅")
     except ConnectionError:
-        LOGGER.warning(f"{prefix}checks skipped. Offline and unable to download YOLO11n for AMP checks. {warning_msg}")
+        LOGGER.warning(f"{prefix}checks skipped. Offline and unable to download {model.model_name} for AMP checks. {warning_msg}")
     except (AttributeError, ModuleNotFoundError):
         LOGGER.warning(
             f"{prefix}checks skipped. "
-            f"Unable to load YOLO11n for AMP checks due to possible Ultralytics package modifications. {warning_msg}"
+            f"Unable to load {model.model_name} for AMP checks due to possible Ultralytics package modifications. {warning_msg}"
         )
     except AssertionError:
         LOGGER.error(


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
Change static download and use of YOLO11n for AMP check to dynamic depending on used mode.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates AMP validation in `checks.py` to use a configurable model name instead of a hardcoded YOLO11n checkpoint 🧪

### 📊 Key Changes
- Replaces `YOLO("yolo11n.pt")` with `YOLO(f"{model.model_name}")` in the AMP allclose check.
- Updates offline / load-failure warning messages to reference `{model.model_name}` rather than YOLO11n.

### 🎯 Purpose & Impact
- Makes AMP checks adaptable to different default model families (e.g., YOLO26) instead of being tied to YOLO11n ✅
- Improves log clarity by reporting the actual model being used/downloaded 📝
- Potential risk: `model` is referenced in this scope (inside `amp_allclose`) but isn’t shown as defined in the diff—this may raise a `NameError` at runtime unless `model` exists in the surrounding module context ⚠️