### PR TITLE
Update YOLO26 YAML comments

### DIFF
--- a/ultralytics/cfg/models/26/yolo26-cls.yaml
+++ b/ultralytics/cfg/models/26/yolo26-cls.yaml
@@ -6,7 +6,7 @@
 
 # Parameters
 nc: 1000 # number of classes
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yolo26n.yaml' will call yolo26-cls.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 86 layers, 2,812,104 parameters, 2,812,104 gradients, 0.5 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 86 layers, 6,724,008 parameters, 6,724,008 gradients, 1.6 GFLOPs

--- a/ultralytics/cfg/models/26/yolo26-cls.yaml
+++ b/ultralytics/cfg/models/26/yolo26-cls.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralytics YOLO26 object detection model with P3/8 - P5/32 outputs
+# Ultralytics YOLO26-cls image classification model
 # Model docs: https://docs.ultralytics.com/models/yolo26
 # Task docs: https://docs.ultralytics.com/tasks/classify
 

--- a/ultralytics/cfg/models/26/yolo26-cls.yaml
+++ b/ultralytics/cfg/models/26/yolo26-cls.yaml
@@ -6,7 +6,7 @@
 
 # Parameters
 nc: 1000 # number of classes
-scales: # model compound scaling constants, i.e. 'model=yolo26n.yaml' will call yolo26-cls.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yolo26n-cls.yaml' will call yolo26-cls.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 86 layers, 2,812,104 parameters, 2,812,104 gradients, 0.5 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 86 layers, 6,724,008 parameters, 6,724,008 gradients, 1.6 GFLOPs

--- a/ultralytics/cfg/models/26/yolo26-obb.yaml
+++ b/ultralytics/cfg/models/26/yolo26-obb.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralytics YOLO26 object detection model with P3/8 - P5/32 outputs
+# Ultralytics YOLO26-obb Oriented Bounding Boxes (OBB) model with P3/8 - P5/32 outputs
 # Model docs: https://docs.ultralytics.com/models/yolo26
 # Task docs: https://docs.ultralytics.com/tasks/obb
 

--- a/ultralytics/cfg/models/26/yolo26-obb.yaml
+++ b/ultralytics/cfg/models/26/yolo26-obb.yaml
@@ -8,7 +8,7 @@
 nc: 80 # number of classes
 end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yolo26n-obb.yaml' will call yolo26-obb.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 291 layers, 2,715,614 parameters, 2,715,614 gradients, 16.9 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 291 layers, 10,582,142 parameters, 10,582,142 gradients, 63.5 GFLOPs

--- a/ultralytics/cfg/models/26/yolo26-p2.yaml
+++ b/ultralytics/cfg/models/26/yolo26-p2.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralytics YOLO26 object detection model with P3/8 - P5/32 outputs
+# Ultralytics YOLO26 object detection model with P2/4 - P5/32 outputs
 # Model docs: https://docs.ultralytics.com/models/yolo26
 # Task docs: https://docs.ultralytics.com/tasks/detect
 
@@ -10,11 +10,11 @@ end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
 scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
   # [depth, width, max_channels]
-  n: [0.50, 0.25, 1024] # summary: 181 layers, 2624080 parameters, 2624064 gradients, 6.6 GFLOPs
-  s: [0.50, 0.50, 1024] # summary: 181 layers, 9458752 parameters, 9458736 gradients, 21.7 GFLOPs
-  m: [0.50, 1.00, 512] # summary: 231 layers, 20114688 parameters, 20114672 gradients, 68.5 GFLOPs
-  l: [1.00, 1.00, 512] # summary: 357 layers, 25372160 parameters, 25372144 gradients, 87.6 GFLOPs
-  x: [1.00, 1.50, 512] # summary: 357 layers, 56966176 parameters, 56966160 gradients, 196.0 GFLOPs
+  n: [0.50, 0.25, 1024] # summary: 329 layers, 2,662,400 parameters, 2,662,400 gradients, 9.5 GFLOPs
+  s: [0.50, 0.50, 1024] # summary: 329 layers, 9,765,856 parameters, 9,765,856 gradients, 27.8 GFLOPs
+  m: [0.50, 1.00, 512] # summary: 349 layers, 21,144,288 parameters, 21,144,288 gradients, 91.4 GFLOPs
+  l: [1.00, 1.00, 512] # summary: 489 layers, 25,815,520 parameters, 25,815,520 gradients, 115.3 GFLOPs
+  x: [1.00, 1.50, 512] # summary: 489 layers, 57,935,232 parameters, 57,935,232 gradients, 256.9 GFLOPs
 
 # YOLO26n backbone
 backbone:
@@ -42,12 +42,12 @@ head:
   - [-1, 2, C3k2, [256, True]] # 16 (P3/8-small)
 
   - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
-  - [[-1, 2], 1, Concat, [1]] # cat backbone P3
-  - [-1, 2, C3k2, [128, True]] # 19 (P3/8-small)
+  - [[-1, 2], 1, Concat, [1]] # cat backbone P2
+  - [-1, 2, C3k2, [128, True]] # 19 (P2/4-xsmall)
 
   - [-1, 1, Conv, [128, 3, 2]]
   - [[-1, 16], 1, Concat, [1]] # cat head P3
-  - [-1, 2, C3k2, [256, True]] # 22 (P4/16-medium)
+  - [-1, 2, C3k2, [256, True]] # 22 (P3/8-small)
 
   - [-1, 1, Conv, [256, 3, 2]]
   - [[-1, 13], 1, Concat, [1]] # cat head P4
@@ -57,4 +57,4 @@ head:
   - [[-1, 10], 1, Concat, [1]] # cat head P5
   - [-1, 1, C3k2, [1024, True, 0.5, True]] # 28 (P5/32-large)
 
-  - [[19, 22, 25, 28], 1, Detect, [nc]] # Detect(P3, P4, P5)
+  - [[19, 22, 25, 28], 1, Detect, [nc]] # Detect(P2, P3, P4, P5)

--- a/ultralytics/cfg/models/26/yolo26-p2.yaml
+++ b/ultralytics/cfg/models/26/yolo26-p2.yaml
@@ -8,7 +8,7 @@
 nc: 80 # number of classes
 end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yolo26n-p2.yaml' will call yolo26-p2.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 329 layers, 2,662,400 parameters, 2,662,400 gradients, 9.5 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 329 layers, 9,765,856 parameters, 9,765,856 gradients, 27.8 GFLOPs

--- a/ultralytics/cfg/models/26/yolo26-p6.yaml
+++ b/ultralytics/cfg/models/26/yolo26-p6.yaml
@@ -6,13 +6,15 @@
 
 # Parameters
 nc: 80 # number of classes
+end2end: True # whether to use end-to-end mode
+reg_max: 1 # DFL bins
 scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
   # [depth, width, max_channels]
-  n: [0.50, 0.25, 1024] # summary: 291 layers, 4,279,280 parameters, 4,279,264 gradients, 6.6 GFLOPs
-  s: [0.50, 0.50, 1024] # summary: 291 layers, 15,673,360 parameters, 15,673,344 gradients, 21.8 GFLOPs
-  m: [0.50, 1.00, 512] # summary: 311 layers, 30,395,792 parameters, 30,395,776 gradients, 70.6 GFLOPs
-  l: [1.00, 1.00, 512] # summary: 465 layers, 37,361,296 parameters, 37,361,280 gradients, 90.2 GFLOPs
-  x: [1.00, 1.50, 512] # summary: 465 layers, 83,898,544 parameters, 83,898,528 gradients, 201.9 GFLOPs
+  n: [0.50, 0.25, 1024] # summary: 349 layers, 4,063,872 parameters, 4,063,872 gradients, 6.0 GFLOPs
+  s: [0.50, 0.50, 1024] # summary: 349 layers, 15,876,448 parameters, 15,876,448 gradients, 22.3 GFLOPs
+  m: [0.50, 1.00, 512] # summary: 369 layers, 32,400,096 parameters, 32,400,096 gradients, 77.3 GFLOPs
+  l: [1.00, 1.00, 512] # summary: 523 layers, 39,365,600 parameters, 39,365,600 gradients, 97.0 GFLOPs
+  x: [1.00, 1.50, 512] # summary: 523 layers, 88,330,368 parameters, 88,330,368 gradients, 216.6 GFLOPs
 
 # YOLO26n backbone
 backbone:

--- a/ultralytics/cfg/models/26/yolo26-p6.yaml
+++ b/ultralytics/cfg/models/26/yolo26-p6.yaml
@@ -8,11 +8,11 @@
 nc: 80 # number of classes
 scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
   # [depth, width, max_channels]
-  n: [0.50, 0.25, 1024] # summary: 319 layers, 2624080 parameters, 2624064 gradients, 6.6 GFLOPs
-  s: [0.50, 0.50, 1024] # summary: 319 layers, 9458752 parameters, 9458736 gradients, 21.7 GFLOPs
-  m: [0.50, 1.00, 512] # summary: 409 layers, 20114688 parameters, 20114672 gradients, 68.5 GFLOPs
-  l: [1.00, 1.00, 512] # summary: 631 layers, 25372160 parameters, 25372144 gradients, 87.6 GFLOPs
-  x: [1.00, 1.50, 512] # summary: 631 layers, 56966176 parameters, 56966160 gradients, 196.0 GFLOPs
+  n: [0.50, 0.25, 1024] # summary: 291 layers, 4,279,280 parameters, 4,279,264 gradients, 6.6 GFLOPs
+  s: [0.50, 0.50, 1024] # summary: 291 layers, 15,673,360 parameters, 15,673,344 gradients, 21.8 GFLOPs
+  m: [0.50, 1.00, 512] # summary: 311 layers, 30,395,792 parameters, 30,395,776 gradients, 70.6 GFLOPs
+  l: [1.00, 1.00, 512] # summary: 465 layers, 37,361,296 parameters, 37,361,280 gradients, 90.2 GFLOPs
+  x: [1.00, 1.50, 512] # summary: 465 layers, 83,898,544 parameters, 83,898,528 gradients, 201.9 GFLOPs
 
 # YOLO26n backbone
 backbone:

--- a/ultralytics/cfg/models/26/yolo26-p6.yaml
+++ b/ultralytics/cfg/models/26/yolo26-p6.yaml
@@ -8,7 +8,7 @@
 nc: 80 # number of classes
 end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yolo26n-p6.yaml' will call yolo26-p6.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 349 layers, 4,063,872 parameters, 4,063,872 gradients, 6.0 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 349 layers, 15,876,448 parameters, 15,876,448 gradients, 22.3 GFLOPs

--- a/ultralytics/cfg/models/26/yolo26-pose.yaml
+++ b/ultralytics/cfg/models/26/yolo26-pose.yaml
@@ -9,7 +9,7 @@ nc: 80 # number of classes
 end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
 kpt_shape: [17, 3] # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yolo26n-pose.yaml' will call yolo26-pose.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 363 layers, 3,747,554 parameters, 3,747,554 gradients, 10.7 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 363 layers, 11,870,498 parameters, 11,870,498 gradients, 29.6 GFLOPs

--- a/ultralytics/cfg/models/26/yolo26-pose.yaml
+++ b/ultralytics/cfg/models/26/yolo26-pose.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralytics YOLO26 object detection model with P3/8 - P5/32 outputs
+# Ultralytics YOLO26-pose keypoints/pose estimation model with P3/8 - P5/32 outputs
 # Model docs: https://docs.ultralytics.com/models/yolo26
 # Task docs: https://docs.ultralytics.com/tasks/pose
 

--- a/ultralytics/cfg/models/26/yolo26-seg.yaml
+++ b/ultralytics/cfg/models/26/yolo26-seg.yaml
@@ -8,7 +8,7 @@
 nc: 80 # number of classes
 end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yolo26n-seg.yaml' will call yolo26-seg.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 309 layers, 3,126,280 parameters, 3,126,280 gradients, 10.5 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 309 layers, 11,505,800 parameters, 11,505,800 gradients, 37.4 GFLOPs

--- a/ultralytics/cfg/models/26/yolo26-seg.yaml
+++ b/ultralytics/cfg/models/26/yolo26-seg.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralytics YOLO26 object detection model with P3/8 - P5/32 outputs
+# Ultralytics YOLO26-seg instance segmentation model with P3/8 - P5/32 outputs
 # Model docs: https://docs.ultralytics.com/models/yolo26
 # Task docs: https://docs.ultralytics.com/tasks/segment
 

--- a/ultralytics/cfg/models/26/yolo26.yaml
+++ b/ultralytics/cfg/models/26/yolo26.yaml
@@ -8,7 +8,7 @@
 nc: 80 # number of classes
 end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yolo26n.yaml' will call yolo26.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 260 layers, 2,572,280 parameters, 2,572,280 gradients, 6.1 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 260 layers, 10,009,784 parameters, 10,009,784 gradients, 22.8 GFLOPs

--- a/ultralytics/cfg/models/26/yoloe-26-seg.yaml
+++ b/ultralytics/cfg/models/26/yoloe-26-seg.yaml
@@ -9,7 +9,7 @@ nc: 80 # number of classes
 end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
 text_model: mobileclip2:b
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yoloe-26n-seg.yaml' will call yoloe-26-seg.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 347 layers, 5,615,540 parameters, 5,615,540 gradients, 11.7 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 347 layers, 15,272,852 parameters, 15,272,852 gradients, 39.3 GFLOPs

--- a/ultralytics/cfg/models/26/yoloe-26-seg.yaml
+++ b/ultralytics/cfg/models/26/yoloe-26-seg.yaml
@@ -32,7 +32,7 @@ backbone:
   - [-1, 1, SPPF, [1024, 5, 3, True]] # 9
   - [-1, 2, C2PSA, [1024]] # 10
 
-# YOLO26n head
+# YOLOE26n head
 head:
   - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
   - [[-1, 6], 1, Concat, [1]] # cat backbone P4

--- a/ultralytics/cfg/models/26/yoloe-26-seg.yaml
+++ b/ultralytics/cfg/models/26/yoloe-26-seg.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralytics YOLO26 object detection model with P3/8 - P5/32 outputs
+# Ultralytics YOLOE-26 open-vocabulary instance segmentation model with P3/8 - P5/32 outputs
 # Model docs: https://docs.ultralytics.com/models/yolo26
 # Task docs: https://docs.ultralytics.com/tasks/segment
 
@@ -11,13 +11,13 @@ reg_max: 1 # DFL bins
 text_model: mobileclip2:b
 scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
   # [depth, width, max_channels]
-  n: [0.50, 0.25, 1024] # summary: 181 layers, 2624080 parameters, 2624064 gradients, 6.6 GFLOPs
-  s: [0.50, 0.50, 1024] # summary: 181 layers, 9458752 parameters, 9458736 gradients, 21.7 GFLOPs
-  m: [0.50, 1.00, 512] # summary: 231 layers, 20114688 parameters, 20114672 gradients, 68.5 GFLOPs
-  l: [1.00, 1.00, 512] # summary: 357 layers, 25372160 parameters, 25372144 gradients, 87.6 GFLOPs
-  x: [1.00, 1.50, 512] # summary: 357 layers, 56966176 parameters, 56966160 gradients, 196.0 GFLOPs
+  n: [0.50, 0.25, 1024] # summary: 347 layers, 5,615,540 parameters, 5,615,540 gradients, 11.7 GFLOPs
+  s: [0.50, 0.50, 1024] # summary: 347 layers, 15,272,852 parameters, 15,272,852 gradients, 39.3 GFLOPs
+  m: [0.50, 1.00, 512] # summary: 367 layers, 34,922,132 parameters, 34,922,132 gradients, 136.3 GFLOPs
+  l: [1.00, 1.00, 512] # summary: 479 layers, 39,325,588 parameters, 39,325,588 gradients, 154.7 GFLOPs
+  x: [1.00, 1.50, 512] # summary: 479 layers, 85,397,684 parameters, 85,397,684 gradients, 343.3 GFLOPs
 
-# YOLO26n backbone
+# YOLOE26n backbone
 backbone:
   # [from, repeats, module, args]
   - [-1, 1, Conv, [64, 3, 2]] # 0-P1/2
@@ -50,4 +50,4 @@ head:
   - [[-1, 10], 1, Concat, [1]] # cat head P5
   - [-1, 1, C3k2, [1024, True, 0.5, True]] # 22 (P5/32-large)
 
-  - [[16, 19, 22], 1, YOLOESegment26, [nc, 32, 256, 512, True]] # Detect(P3, P4, P5)
+  - [[16, 19, 22], 1, YOLOESegment26, [nc, 32, 256, 512, True]] # YOLOESegment26(P3, P4, P5)

--- a/ultralytics/cfg/models/26/yoloe-26.yaml
+++ b/ultralytics/cfg/models/26/yoloe-26.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralytics YOLOE-26 object detection model with P3/8 - P5/32 outputs
+# Ultralytics YOLOE-26 open-vocabulary object detection model with P3/8 - P5/32 outputs
 # Model docs: https://docs.ultralytics.com/models/yolo26
 # Task docs: https://docs.ultralytics.com/tasks/detect
 

--- a/ultralytics/cfg/models/26/yoloe-26.yaml
+++ b/ultralytics/cfg/models/26/yoloe-26.yaml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Ultralytics YOLO26 object detection model with P3/8 - P5/32 outputs
+# Ultralytics YOLOE-26 object detection model with P3/8 - P5/32 outputs
 # Model docs: https://docs.ultralytics.com/models/yolo26
 # Task docs: https://docs.ultralytics.com/tasks/detect
 
@@ -11,11 +11,11 @@ reg_max: 1 # DFL bins
 text_model: mobileclip2:b
 scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
   # [depth, width, max_channels]
-  n: [0.50, 0.25, 1024] # summary: 181 layers, 2624080 parameters, 2624064 gradients, 6.6 GFLOPs
-  s: [0.50, 0.50, 1024] # summary: 181 layers, 9458752 parameters, 9458736 gradients, 21.7 GFLOPs
-  m: [0.50, 1.00, 512] # summary: 231 layers, 20114688 parameters, 20114672 gradients, 68.5 GFLOPs
-  l: [1.00, 1.00, 512] # summary: 357 layers, 25372160 parameters, 25372144 gradients, 87.6 GFLOPs
-  x: [1.00, 1.50, 512] # summary: 357 layers, 56966176 parameters, 56966160 gradients, 196.0 GFLOPs
+  n: [0.50, 0.25, 1024] # summary: 298 layers, 5,061,540 parameters, 5,061,540 gradients, 7.3 GFLOPs
+  s: [0.50, 0.50, 1024] # summary: 298 layers, 13,776,836 parameters, 13,776,836 gradients, 24.8 GFLOPs
+  m: [0.50, 1.00, 512] # summary: 318 layers, 29,706,308 parameters, 29,706,308 gradients, 79.2 GFLOPs
+  l: [1.00, 1.00, 512] # summary: 430 layers, 34,109,764 parameters, 34,109,764 gradients, 97.6 GFLOPs
+  x: [1.00, 1.50, 512] # summary: 430 layers, 73,697,252 parameters, 73,697,252 gradients, 215.2 GFLOPs
 
 # YOLO26n backbone
 backbone:
@@ -50,4 +50,4 @@ head:
   - [[-1, 10], 1, Concat, [1]] # cat head P5
   - [-1, 1, C3k2, [1024, True, 0.5, True]] # 22 (P5/32-large)
 
-  - [[16, 19, 22], 1, YOLOEDetect, [nc, 512, True]] # Detect(P3, P4, P5)
+  - [[16, 19, 22], 1, YOLOEDetect, [nc, 512, True]] # YOLOEDetect(P3, P4, P5)

--- a/ultralytics/cfg/models/26/yoloe-26.yaml
+++ b/ultralytics/cfg/models/26/yoloe-26.yaml
@@ -9,7 +9,7 @@ nc: 80 # number of classes
 end2end: True # whether to use end-to-end mode
 reg_max: 1 # DFL bins
 text_model: mobileclip2:b
-scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call YOLO26.yaml with scale 'n'
+scales: # model compound scaling constants, i.e. 'model=yoloe-26n.yaml' will call yoloe-26.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.50, 0.25, 1024] # summary: 298 layers, 5,061,540 parameters, 5,061,540 gradients, 7.3 GFLOPs
   s: [0.50, 0.50, 1024] # summary: 298 layers, 13,776,836 parameters, 13,776,836 gradients, 24.8 GFLOPs

--- a/ultralytics/cfg/models/26/yoloe-26.yaml
+++ b/ultralytics/cfg/models/26/yoloe-26.yaml
@@ -17,7 +17,7 @@ scales: # model compound scaling constants, i.e. 'model=YOLO26n.yaml' will call 
   l: [1.00, 1.00, 512] # summary: 430 layers, 34,109,764 parameters, 34,109,764 gradients, 97.6 GFLOPs
   x: [1.00, 1.50, 512] # summary: 430 layers, 73,697,252 parameters, 73,697,252 gradients, 215.2 GFLOPs
 
-# YOLO26n backbone
+# YOLOE26n backbone
 backbone:
   # [from, repeats, module, args]
   - [-1, 1, Conv, [64, 3, 2]] # 0-P1/2
@@ -32,7 +32,7 @@ backbone:
   - [-1, 1, SPPF, [1024, 5, 3, True]] # 9
   - [-1, 2, C2PSA, [1024]] # 10
 
-# YOLO26n head
+# YOLOE26n head
 head:
   - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
   - [[-1, 6], 1, Concat, [1]] # cat backbone P4


### PR DESCRIPTION
Closes #23201 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refreshes YOLO26/YOLOE-26 model YAML configs with clearer task-specific naming, corrected scale-call examples, and updated architecture/summary metadata 🛠️✨

### 📊 Key Changes
- Updated header comments across YOLO26 configs to accurately describe each task (classification, OBB, pose, segmentation, P2/P6 detection) 🏷️
- Fixed the `scales` comment examples to reference the correct filenames (e.g., `model=yolo26n-seg.yaml` instead of `model=YOLO26n.yaml`) ✅
- **YOLO26-p2**: clarified it’s a P2/4–P5/32 model and updated head comments + detection comment to reflect **Detect(P2, P3, P4, P5)** 🔍
- **YOLO26-p2 / YOLO26-p6 / YOLOE-26 / YOLOE-26-seg**: updated the “summary” metadata (layer counts, parameter counts, GFLOPs) to new values 📈
- **YOLO26-p6**: added missing runtime parameters `end2end: True` and `reg_max: 1` to align with other detection configs ⚙️
- **YOLOE-26 & YOLOE-26-seg**: renamed comments from “YOLO26” to “YOLOE-26” and clarified head output comments (e.g., `# YOLOEDetect(P3, P4, P5)`) 🧠

### 🎯 Purpose & Impact
- Makes model YAMLs easier to understand and select correctly (less confusion between detect/seg/pose/cls/obb variants) 🧭
- Reduces user error when using compound scaling since the example filenames now match the actual config names 🧩
- Improves documentation accuracy for YOLO26-p2’s extra high-resolution detection head (P2), which can benefit small-object detection workflows 🎯
- Ensures YOLO26-p6 has consistent required settings (`end2end`, `reg_max`), lowering the chance of misconfigured training/inference ⚠️➡️✅
- Updated model “summary” stats help users better estimate compute cost and model size when choosing a variant 💻📊