### PR TITLE
Fix incorrect shape comment in Ensemble.forward

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1297,7 +1297,7 @@ class Ensemble(torch.nn.ModuleList):
         y = [module(x, augment, profile, visualize)[0] for module in self]
         # y = torch.stack(y).max(0)[0]  # max ensemble
         # y = torch.stack(y).mean(0)  # mean ensemble
-        y = torch.cat(y, 2)  # nms ensemble, y shape(B, HW, C)
+        y = torch.cat(y, 2)  # nms ensemble, y shape(B, HW, C*num_models)
         return y, None  # inference, train output
 
 


### PR DESCRIPTION
The shape comment stated `y shape(B, HW, C)` but after `torch.cat(y, 2)` the actual shape is `(B, HW, C*num_models)`.

Example: 3 models with output (1, 8400, 84) → after cat: (1, 8400, 252)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an incorrect inline tensor shape comment in `Ensemble.forward` for clarity 🛠️

### 📊 Key Changes
- Updates the `torch.cat(y, 2)` comment to reflect the correct output shape after concatenating predictions across models

### 🎯 Purpose & Impact
- Prevents confusion when debugging or extending ensemble inference by documenting that channels scale with the number of models 📌
- Improves code readability/maintainability with zero runtime or behavior change ✅