### PR TITLE
Skip dfl part for yolo26 export

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -785,16 +785,18 @@ class Exporter:
             if isinstance(self.model.model[-1], Detect):
                 # Includes all Detect subclasses like Segment, Pose, OBB, WorldDetect, YOLOEDetect
                 head_module_name = ".".join(list(self.model.named_modules())[-1][0].split(".")[:2])
-                ignored_scope = nncf.IgnoredScope(  # ignore operations
-                    patterns=[
-                        f".*{head_module_name}/.*/Add",
-                        f".*{head_module_name}/.*/Sub*",
-                        f".*{head_module_name}/.*/Mul*",
-                        f".*{head_module_name}/.*/Div*",
-                        f".*{head_module_name}\\.dfl.*",
-                    ],
-                    types=["Sigmoid"],
-                )
+                ignored_patterns = [
+                    f".*{head_module_name}/.*/Add",
+                    f".*{head_module_name}/.*/Sub*",
+                    f".*{head_module_name}/.*/Mul*",
+                    f".*{head_module_name}/.*/Div*",
+                ]
+                # yolo26 doesn't have that part
+                if "YOLO26" not in self.pretty_name:
+                    ignored_patterns.append(f".*{head_module_name}\\.dfl.*")
+
+                # Ignore operations
+                ignored_scope = nncf.IgnoredScope(patterns=ignored_patterns, types=["Sigmoid"])
 
             quantized_ov_model = nncf.quantize(
                 model=ov_model,


### PR DESCRIPTION
This fixes the OV export issue for YOLO26 models and int8 precision.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Skip adding the Detect head DFL ignore pattern during OpenVINO/NNCF quantization when exporting YOLO26 models to avoid applying non-existent layers. 🚀

### 📊 Key Changes
- Refactored NNCF ignored-scope creation to build `ignored_patterns` dynamically.
- Conditionally appends the `dfl` ignore pattern only when the exported model is **not** YOLO26.
- Kept existing ignore patterns for arithmetic ops (Add/Sub/Mul/Div) and type-based ignore (`Sigmoid`).

### 🎯 Purpose & Impact
- Prevents export/quantization issues for YOLO26 by not referencing a missing DFL module. ✅
- Improves robustness of OpenVINO exports across model variants with slightly different Detect heads.
- Keeps behavior unchanged for other YOLO models that still include the DFL path.
