### PR TITLE
Re-enable NCNN ARM64 exports in Tests CIs

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -240,7 +240,6 @@ def test_export_mnn_matrix(task, int8, half, batch):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(ARM64, reason="NCNN not supported on ARM64")  # https://github.com/Tencent/ncnn/issues/6509
 @pytest.mark.skipif(not TORCH_2_0, reason="NCNN inference causes segfault on PyTorch<2.0")
 def test_export_ncnn():
     """Test YOLO export to NCNN format."""
@@ -249,7 +248,6 @@ def test_export_ncnn():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(ARM64, reason="NCNN not supported on ARM64")  # https://github.com/Tencent/ncnn/issues/6509
 @pytest.mark.skipif(not TORCH_2_0, reason="NCNN inference causes segfault on PyTorch<2.0")
 @pytest.mark.parametrize("task, half, batch", list(product(TASKS, [True, False], [1])))
 def test_export_ncnn_matrix(task, half, batch):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enables NCNN export tests to run on ARM64 by removing an ARM64-specific skip condition ✅🧪

### 📊 Key Changes
- Removed `@pytest.mark.skipif(ARM64, ...)` from NCNN export tests in `tests/test_exports.py` 🚫🛑
- Kept the existing guard that skips NCNN tests on PyTorch versions below 2.0 to avoid known segfaults 🧯⚠️
- Affects both:
  - `test_export_ncnn()`
  - `test_export_ncnn_matrix(...)` 🔁

### 🎯 Purpose & Impact
- Expands CI/test coverage to include ARM64 environments (e.g., Apple Silicon, ARM servers) for NCNN exports 🧩💻
- Helps detect ARM64-specific regressions earlier instead of silently skipping these tests 🔍✅
- Potential impact: if NCNN truly remains unsupported or flaky on ARM64 (per the referenced NCNN issue), ARM64 test runs may start failing until upstream or environment fixes land 🧨🛠️