### PR TITLE
Return Classify top5 in Results summary

### DIFF
--- a/docs/en/datasets/explorer/explorer.md
+++ b/docs/en/datasets/explorer/explorer.md
@@ -32,7 +32,7 @@ keywords: Ultralytics Explorer, data exploration, semantic search, vector simila
     <br>
     <a href="https://console.paperspace.com/github/ultralytics/ultralytics"><img src="https://assets.paperspace.io/img/gradient-badge.svg" alt="Run Ultralytics on Gradient"></a>
     <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open Ultralytics In Colab"></a>
-    <a href="https://www.kaggle.com/models/ultralytics/yolo26"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
+    <a href="https://www.kaggle.com/models/ultralytics/yolo11"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
     <a href="https://mybinder.org/v2/gh/ultralytics/ultralytics/HEAD?labpath=examples%2Ftutorial.ipynb"><img src="https://mybinder.org/badge_logo.svg" alt="Open Ultralytics In Binder"></a>
 <br>
 </div>

--- a/docs/en/guides/security-alarm-system.md
+++ b/docs/en/guides/security-alarm-system.md
@@ -126,7 +126,7 @@ Yes, Ultralytics YOLO26 can be seamlessly integrated with your existing security
 
 ### What are the storage requirements for running Ultralytics YOLO26?
 
-Running Ultralytics YOLO26 on a standard setup typically requires around 5GB of free disk space. This includes space for storing the YOLO26 model and any additional dependencies. For cloud-based solutions, [Ultralytics Platform](https://docs.ultralytics.com/platform/) offers efficient project management and dataset handling, which can optimize storage needs. Learn more about the [Pro Plan](../platform/pro.md) for enhanced features including extended storage.
+Running Ultralytics YOLO26 on a standard setup typically requires around 5GB of free disk space. This includes space for storing the YOLO26 model and any additional dependencies. For cloud-based solutions, [Ultralytics Platform](https://docs.ultralytics.com/platform/) offers efficient project management and dataset handling, which can optimize storage needs. Learn more about the [Pro Plan](../platform/account/billing.md) for enhanced features including extended storage.
 
 ### What makes Ultralytics YOLO26 different from other object detection models like Faster R-CNN or SSD?
 

--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -141,7 +141,7 @@ Ultralytics supports a comprehensive range of YOLO (You Only Look Once) versions
 
 ### Why should I use Ultralytics Platform for [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) projects?
 
-[Ultralytics Platform](../platform/index.md) provides a no-code, end-to-end platform for training, deploying, and managing YOLO models. It simplifies complex workflows, enabling users to focus on model performance and application. The HUB also offers [cloud training capabilities](../platform/cloud-training.md), comprehensive dataset management, and user-friendly interfaces for both beginners and experienced developers.
+[Ultralytics Platform](../platform/index.md) provides a no-code, end-to-end platform for training, deploying, and managing YOLO models. It simplifies complex workflows, enabling users to focus on model performance and application. The HUB also offers [cloud training capabilities](../platform/train/cloud-training.md), comprehensive dataset management, and user-friendly interfaces for both beginners and experienced developers.
 
 ### What types of tasks can Ultralytics YOLO models perform?
 

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -140,7 +140,7 @@
   avatar: https://avatars.githubusercontent.com/u/78843978?v=4
   username: Skillnoob
 79740115+0xSynapse@users.noreply.github.com:
-  avatar: https://github.com/0xSynapse.png
+  avatar: https://avatars.githubusercontent.com/u/79740115?v=4
   username: 0xSynapse
 8401806+wangzhaode@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/8401806?v=4

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -750,8 +750,8 @@ class Results(SimpleClass, DataExportMixin):
         """Convert inference results to a summarized dictionary with optional normalization for box coordinates.
 
         This method creates a list of detection dictionaries, each containing information about a single detection or
-        classification result. For classification tasks, it returns the top class and its
-        confidence. For detection tasks, it includes class information, bounding box coordinates, and
+        classification result. For classification tasks, it returns the top 5 classes and their
+        confidences. For detection tasks, it includes class information, bounding box coordinates, and
         optionally mask segments and keypoints.
 
         Args:
@@ -772,14 +772,15 @@ class Results(SimpleClass, DataExportMixin):
         # Create list of detection dictionaries
         results = []
         if self.probs is not None:
-            class_id = self.probs.top1
-            results.append(
-                {
-                    "name": self.names[class_id],
-                    "class": class_id,
-                    "confidence": round(self.probs.top1conf.item(), decimals),
-                }
-            )
+            # Return top 5 classification results
+            for class_id, conf in zip(self.probs.top5, self.probs.top5conf.tolist()):
+                results.append(
+                    {
+                        "name": self.names[class_id],
+                        "class": class_id,
+                        "confidence": round(conf, decimals),
+                    }
+                )
             return results
 
         is_obb = self.obb is not None

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -774,6 +774,14 @@ class Results(SimpleClass, DataExportMixin):
         if self.probs is not None:
             # Return top 5 classification results
             for class_id, conf in zip(self.probs.top5, self.probs.top5conf.tolist()):
+                class_id = int(class_id)
+                results.append(
+                    {
+                        "name": self.names[class_id],
+                        "class": class_id,
+                        "confidence": round(conf, decimals),
+                    }
+                )
                 results.append(
                     {
                         "name": self.names[class_id],


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates docs links/branding and changes `Results.summary()` to return multiple classification predictions (but currently duplicates entries) 📚🔧

### 📊 Key Changes
- 🧾 **Docs: Kaggle badge updated** in Explorer docs from YOLO26 to **YOLO11**.
- 🔗 **Docs: Fixed/updated internal links**:
  - Security alarm guide “Pro Plan” link now points to the newer billing page path.
  - Models index “cloud training capabilities” link updated to the newer docs location.
- 👤 **Docs tooling: author avatar URL corrected** in `mkdocs_github_authors.yaml` for @0xSynapse to use the standard GitHub avatar URL.
- 🧠 **API behavior change: `Results.summary()` for classification** (`ultralytics/engine/results.py`)
  - Previously: returned **top-1** class + confidence.
  - Now: intended to return **top-5** classes + confidences.

### 🎯 Purpose & Impact
- ✅ **Better docs accuracy & navigation**: updated links reduce 404s and align references with current YOLO branding (YOLO11) 🧭
- ✅ **Richer classification output**: returning top-5 predictions makes it easier to inspect alternatives and build UI/analytics around multiple guesses 🧠
- ⚠️ **Potential bug / breaking behavior**: the new loop in `Results.summary()` currently appends **each top-5 result twice**, which may:
  - duplicate entries for classification summaries,
  - confuse downstream consumers parsing the summary output,
  - require filtering/deduping until fixed 🐛