### PR TITLE
`ultralytics 8.4.2` Fix Platform Classify training

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.1"
+__version__ = "8.4.2"
 
 import importlib
 import os

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -749,10 +749,10 @@ def convert_to_multispectral(path: str | Path, n_channels: int = 10, replace: bo
 async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Path | None = None) -> Path:
     """Convert NDJSON dataset format to Ultralytics YOLO11 dataset structure.
 
-    This function converts datasets stored in NDJSON (Newline Delimited JSON) format to the standard YOLO format.
-    For detection/segmentation/pose/obb tasks, it creates separate directories for images and labels.
-    For classification tasks, it creates the ImageNet-style {split}/{class_name}/ folder structure.
-    It supports parallel processing for efficient conversion of large datasets and can download images from URLs.
+    This function converts datasets stored in NDJSON (Newline Delimited JSON) format to the standard YOLO format. For
+    detection/segmentation/pose/obb tasks, it creates separate directories for images and labels. For classification
+    tasks, it creates the ImageNet-style {split}/{class_name}/ folder structure. It supports parallel processing for
+    efficient conversion of large datasets and can download images from URLs.
 
     The NDJSON format consists of:
     - First line: Dataset metadata with class names, task type, and configuration

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -749,12 +749,13 @@ def convert_to_multispectral(path: str | Path, n_channels: int = 10, replace: bo
 async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Path | None = None) -> Path:
     """Convert NDJSON dataset format to Ultralytics YOLO11 dataset structure.
 
-    This function converts datasets stored in NDJSON (Newline Delimited JSON) format to the standard YOLO format with
-    separate directories for images and labels. It supports parallel processing for efficient conversion of large
-    datasets and can download images from URLs if they don't exist locally.
+    This function converts datasets stored in NDJSON (Newline Delimited JSON) format to the standard YOLO format.
+    For detection/segmentation/pose/obb tasks, it creates separate directories for images and labels.
+    For classification tasks, it creates the ImageNet-style {split}/{class_name}/ folder structure.
+    It supports parallel processing for efficient conversion of large datasets and can download images from URLs.
 
     The NDJSON format consists of:
-    - First line: Dataset metadata with class names and configuration
+    - First line: Dataset metadata with class names, task type, and configuration
     - Subsequent lines: Individual image records with annotations and optional URLs
 
     Args:
@@ -763,7 +764,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
             None, uses the parent directory of the NDJSON file. Defaults to None.
 
     Returns:
-        (Path): Path to the generated data.yaml file that can be used for YOLO training.
+        (Path): Path to the generated data.yaml file (detection) or dataset directory (classification).
 
     Examples:
         Convert a local NDJSON file:
@@ -790,36 +791,51 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     dataset_dir = output_path / ndjson_path.stem
     splits = {record["split"] for record in image_records}
 
-    # Create directories and prepare YAML structure
-    dataset_dir.mkdir(parents=True, exist_ok=True)
-    data_yaml = dict(dataset_record)
-    data_yaml["names"] = {int(k): v for k, v in dataset_record.get("class_names", {}).items()}
-    data_yaml.pop("class_names")
+    # Check if this is a classification dataset
+    is_classification = dataset_record.get("task") == "classify"
+    class_names = {int(k): v for k, v in dataset_record.get("class_names", {}).items()}
 
-    for split in sorted(splits):
-        (dataset_dir / "images" / split).mkdir(parents=True, exist_ok=True)
-        (dataset_dir / "labels" / split).mkdir(parents=True, exist_ok=True)
-        data_yaml[split] = f"images/{split}"
+    # Create base directories
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    data_yaml = None
+
+    if not is_classification:
+        # Detection/segmentation/pose/obb: prepare YAML and create base structure
+        data_yaml = dict(dataset_record)
+        data_yaml["names"] = class_names
+        data_yaml.pop("class_names", None)
+        data_yaml.pop("type", None)  # Remove NDJSON-specific fields
+        for split in sorted(splits):
+            (dataset_dir / "images" / split).mkdir(parents=True, exist_ok=True)
+            (dataset_dir / "labels" / split).mkdir(parents=True, exist_ok=True)
+            data_yaml[split] = f"images/{split}"
 
     async def process_record(session, semaphore, record):
         """Process single image record with async session."""
         async with semaphore:
             split, original_name = record["split"], record["file"]
-            label_path = dataset_dir / "labels" / split / f"{Path(original_name).stem}.txt"
-            image_path = dataset_dir / "images" / split / original_name
-
             annotations = record.get("annotations", {})
-            lines_to_write = []
-            for key in annotations.keys():
-                lines_to_write = [" ".join(map(str, item)) for item in annotations[key]]
-                break
-            if "classification" in annotations:
-                lines_to_write = [str(cls) for cls in annotations["classification"]]
 
-            label_path.write_text("\n".join(lines_to_write) + "\n" if lines_to_write else "")
+            if is_classification:
+                # Classification: place image in {split}/{class_name}/ folder
+                class_ids = annotations.get("classification", [])
+                class_id = class_ids[0] if class_ids else 0
+                class_name = class_names.get(class_id, str(class_id))
+                image_path = dataset_dir / split / class_name / original_name
+            else:
+                # Detection: write label file and place image in images/{split}/
+                image_path = dataset_dir / "images" / split / original_name
+                label_path = dataset_dir / "labels" / split / f"{Path(original_name).stem}.txt"
+                lines_to_write = []
+                for key in annotations.keys():
+                    lines_to_write = [" ".join(map(str, item)) for item in annotations[key]]
+                    break
+                label_path.write_text("\n".join(lines_to_write) + "\n" if lines_to_write else "")
 
+            # Download image if URL provided and file doesn't exist
             if http_url := record.get("url"):
                 if not image_path.exists():
+                    image_path.parent.mkdir(parents=True, exist_ok=True)  # Ensure parent dir exists
                     try:
                         async with session.get(http_url, timeout=aiohttp.ClientTimeout(total=30)) as response:
                             response.raise_for_status()
@@ -848,8 +864,11 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         await asyncio.gather(*[tracked_process(record) for record in image_records])
         pbar.close()
 
-    # Write data.yaml
-    yaml_path = dataset_dir / "data.yaml"
-    YAML.save(yaml_path, data_yaml)
-
-    return yaml_path
+    if is_classification:
+        # Classification: return dataset directory (check_cls_dataset expects a directory path)
+        return dataset_dir
+    else:
+        # Detection: write data.yaml and return its path
+        yaml_path = dataset_dir / "data.yaml"
+        YAML.save(yaml_path, data_yaml)
+        return yaml_path


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves NDJSON dataset conversion to properly support **classification** datasets and streamlines trainer dataset loading, plus a version bump to **8.4.2** 🚀

### 📊 Key Changes
- ✅ **Version update:** `__version__` bumped from **8.4.1 → 8.4.2** 📦
- 🗂️ **NDJSON → YOLO conversion now supports classification:**
  - Detect/segment/pose/obb: keeps the usual `images/{split}` + `labels/{split}` layout and writes a `data.yaml`.
  - Classify: creates an **ImageNet-style** layout: `{split}/{class_name}/image.jpg` (no labels folder, no `data.yaml`).
- 🔁 **Return type adjusted for NDJSON conversion:**
  - Returns `data.yaml` path for detection-style tasks.
  - Returns the **dataset directory** for classification tasks (to match what classification dataset checks expect).
- 🧩 **Trainer dataset loading simplified and made more robust:**
  - If `data` is an `.ndjson` file (or a `ul://.../datasets/...` URI), it’s converted first, then the appropriate dataset checker runs.
- 🌐 **Safer image downloads during conversion:** ensures parent directories exist before saving downloaded images 📥

### 🎯 Purpose & Impact
- 🎓 **Classification NDJSON datasets “just work”**: they’re converted into the folder structure expected by Ultralytics classification training, reducing setup friction.
- 🧠 **More reliable training with platform datasets (`ul://`) and NDJSON**: conversion happens consistently before validation/loading, avoiding mismatched formats.
- ⚡ **Better UX and fewer edge-case failures**: directory creation before downloading prevents missing-folder errors during conversion.
- 🔄 **Clearer dataset outputs**: detection workflows still get a `data.yaml`, while classification workflows get a ready-to-train directory structure ✅