### PR TITLE
Update auto optimizer strategy and fix mismatched `warmup_lr`

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -411,7 +411,7 @@ class BaseTrainer:
                     for j, x in enumerate(self.optimizer.param_groups):
                         # Bias lr falls from 0.1 to lr0, all other lrs rise from 0.0 to lr0
                         x["lr"] = np.interp(
-                            ni, xi, [self.args.warmup_bias_lr if j == 0 else 0.0, x["initial_lr"] * self.lf(epoch)]
+                            ni, xi, [self.args.warmup_bias_lr if j == 2 else 0.0, x["initial_lr"] * self.lf(epoch)]
                         )
                         if "momentum" in x:
                             x["momentum"] = np.interp(ni, xi, [self.args.warmup_momentum, self.args.momentum])

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -16,8 +16,8 @@ import time
 import warnings
 from copy import copy, deepcopy
 from datetime import datetime, timedelta
-from pathlib import Path
 from functools import partial
+from pathlib import Path
 
 import numpy as np
 import torch

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -415,7 +415,7 @@ class BaseTrainer:
                             ni,
                             xi,
                             [
-                                self.args.warmup_bias_lr if x["param_group"] == "bias" else 0.0,
+                                self.args.warmup_bias_lr if x.get("param_group") == "bias" else 0.0,
                                 x["initial_lr"] * self.lf(epoch),
                             ],
                         )


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves optimizer setup and warmup logic by labeling parameter groups explicitly and refining MuSGD defaults for more reliable training ⚙️🚀

### 📊 Key Changes
- **Added explicit `param_group` labels** to optimizer parameter groups (`"bias"`, `"weight"`, `"bn"`, `"muon"`) to make group-specific behavior deterministic 🏷️
- **Warmup learning-rate logic now targets bias params by label** (`param_group == "bias"`) instead of assuming the first param group is bias (index-based) 🔥
- **Auto-optimizer selection simplified to always use MuSGD** (removes switching between `"SGD"` and `"MuSGD"` based on iteration count) 🤖
- **Introduced dynamic MuSGD mixing factors (`muon`, `sgd`) based on training length**, and passed them via `functools.partial` when constructing the optimizer 🎛️
- **Clarified MuSGD fine-tuning behavior** in comments for the “higher LR for certain parameters” logic 📝

### 🎯 Purpose & Impact
- **More robust training warmup**: avoids subtle bugs where bias warmup could be misapplied if param group ordering changes (common when optimizers or grouping logic evolves) ✅
- **More predictable optimizer behavior**: explicit group labeling makes training configs easier to reason about and reduces “works by coincidence” assumptions 🧩
- **Potential training-quality and stability improvements with MuSGD**: dynamic `muon/sgd` scaling adapts behavior for longer vs shorter runs, which may improve convergence and fine-tuning experience 📈
- **Minor behavior change**: runs that previously auto-selected plain SGD may now use MuSGD instead, which could slightly change learning dynamics and results (even with similar hyperparameters) ⚠️