### PR TITLE
Update `IMX` inference wrapper

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -170,7 +170,7 @@ class Detect(nn.Module):
     def _get_decode_boxes(self, x: dict[str, torch.Tensor]) -> torch.Tensor:
         """Get decoded boxes based on anchors and strides."""
         shape = x["feats"][0].shape  # BCHW
-        if self.format != "imx" and (self.dynamic or self.shape != shape):
+        if self.dynamic or self.shape != shape:
             self.anchors, self.strides = (a.transpose(0, 1) for a in make_anchors(x["feats"], self.stride, 0.5))
             self.shape = shape
 

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -104,7 +104,7 @@ class FXModel(torch.nn.Module):
         return x
 
 
-def _inference(self, x: list[torch.Tensor] | dict[str, torch.Tensor]) -> tuple[torch.Tensor]:
+def _inference(self, x: dict[str, torch.Tensor]) -> tuple[torch.Tensor]:
     """Decode boxes and cls scores for imx object detection."""
     dbox = self.decode_bboxes(self.dfl(x["boxes"]), self.anchors.unsqueeze(0)) * self.strides
     return dbox.transpose(1, 2), x["scores"].sigmoid().permute(0, 2, 1)

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -106,13 +106,8 @@ class FXModel(torch.nn.Module):
 
 def _inference(self, x: list[torch.Tensor] | dict[str, torch.Tensor]) -> tuple[torch.Tensor]:
     """Decode boxes and cls scores for imx object detection."""
-    if isinstance(x, dict):
-        box, cls = x["boxes"], x["scores"]
-    else:
-        x_cat = torch.cat([xi.view(x[0].shape[0], self.no, -1) for xi in x], 2)
-        box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
-    dbox = self.decode_bboxes(self.dfl(box), self.anchors.unsqueeze(0)) * self.strides
-    return dbox.transpose(1, 2), cls.sigmoid().permute(0, 2, 1)
+    dbox = self.decode_bboxes(self.dfl(x["boxes"]), self.anchors.unsqueeze(0)) * self.strides
+    return dbox.transpose(1, 2), x["scores"].sigmoid().permute(0, 2, 1)
 
 
 def pose_forward(self, x: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves IMX export/inference consistency by simplifying the decode path and ensuring anchors/strides refresh correctly for changing input shapes 🧩🚀

### 📊 Key Changes
- Updated YOLO head anchor/stride refresh logic to **always recompute** when running in dynamic mode or when the feature-map shape changes (removed the special-case skip for `format="imx"`) ⚙️
- Simplified IMX `_inference` to **only accept dict inputs** (`{"boxes": ..., "scores": ...}`), removing the alternative list-of-tensors concatenation path 🧹
- IMX decoding now directly uses `x["boxes"]` and `x["scores"]` (with sigmoid applied to scores), making the pipeline more explicit and consistent ✅

### 🎯 Purpose & Impact
- More reliable IMX behavior when input resolutions change (anchors/strides won’t become stale), reducing shape-related inference/export issues 📐🔒
- Clearer, more maintainable IMX inference code by enforcing a single input format, which can reduce ambiguity and bugs 🛠️
- Potential breaking change for any custom IMX usage that previously passed a `list[torch.Tensor]` into `_inference`—those callers must now provide the dict format 🧯