### PR TITLE
Attempt to clean up `kpts_decode`

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -623,23 +623,15 @@ class Pose(Detect):
     def kpts_decode(self, kpts: torch.Tensor) -> torch.Tensor:
         """Decode keypoints from predictions."""
         ndim = self.kpt_shape[1]
-        bs = kpts.shape[0]
-        if self.export:
-            y = kpts.view(bs, *self.kpt_shape, -1)
-            a = (y[:, :, :2] * 2.0 + (self.anchors - 0.5)) * self.strides
-            if ndim == 3:
-                a = torch.cat((a, y[:, :, 2:3].sigmoid()), 2)
-            return a.view(bs, self.nk, -1)
-        else:
-            y = kpts.clone()
-            if ndim == 3:
-                if NOT_MACOS14:
-                    y[:, 2::ndim].sigmoid_()
-                else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
-                    y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
-            y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
-            y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
-            return y
+        y = kpts.clone()
+        if ndim == 3:
+            if NOT_MACOS14:
+                y[:, 2::ndim].sigmoid_()
+            else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
+                y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
+        y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
+        y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
+        return y
 
 
 class Pose26(Pose):
@@ -739,24 +731,15 @@ class Pose26(Pose):
     def kpts_decode(self, kpts: torch.Tensor) -> torch.Tensor:
         """Decode keypoints from predictions."""
         ndim = self.kpt_shape[1]
-        bs = kpts.shape[0]
-        if self.export:
-            y = kpts.view(bs, *self.kpt_shape, -1)
-            # NCNN fix
-            a = (y[:, :, :2] + self.anchors) * self.strides
-            if ndim == 3:
-                a = torch.cat((a, y[:, :, 2:3].sigmoid()), 2)
-            return a.view(bs, self.nk, -1)
-        else:
-            y = kpts.clone()
-            if ndim == 3:
-                if NOT_MACOS14:
-                    y[:, 2::ndim].sigmoid_()
-                else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
-                    y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
-            y[:, 0::ndim] = (y[:, 0::ndim] + self.anchors[0]) * self.strides
-            y[:, 1::ndim] = (y[:, 1::ndim] + self.anchors[1]) * self.strides
-            return y
+        y = kpts.clone()
+        if ndim == 3:
+            if NOT_MACOS14:
+                y[:, 2::ndim].sigmoid_()
+            else:  # Apple macOS14 MPS bug https://github.com/ultralytics/ultralytics/pull/21878
+                y[:, 2::ndim] = y[:, 2::ndim].sigmoid()
+        y[:, 0::ndim] = (y[:, 0::ndim] + self.anchors[0]) * self.strides
+        y[:, 1::ndim] = (y[:, 1::ndim] + self.anchors[1]) * self.strides
+        return y
 
 
 class Classify(nn.Module):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Simplified pose keypoint decoding by removing export-specific code paths, unifying behavior across runtimes 🚀🧍

### 📊 Key Changes
- Removed the `self.export` conditional branches in `kpts_decode()` for both `Pose` and `Pose26`.
- Standardized decoding logic to always:
  - Clone predictions, apply confidence sigmoid for 3D keypoints (with a macOS14 MPS workaround 🍎)
  - Decode x/y keypoint coordinates using anchors and strides.
- Eliminated special export-only reshaping and “NCNN fix” handling inside the decode function.

### 🎯 Purpose & Impact
- More consistent keypoint decoding across training, inference, and export flows ✅
- Reduced code complexity and maintenance overhead (fewer branches, fewer edge cases) 🧹
- Potential export behavior change: exported models now follow the same decode path as non-export, which may affect outputs for certain export targets that previously relied on the specialized reshape/NCNN handling ⚠️
- Keeps the macOS14 MPS safety workaround intact to avoid known sigmoid issues on Apple GPUs 🍏🛠️