### PR TITLE
Use `yolo26n` in docs and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         # Temporarily disable windows-latest due to https://github.com/ultralytics/ultralytics/actions/runs/13020330819/job/36319338854?pr=18921
         os: [ubuntu-latest, macos-26, ubuntu-24.04-arm]
         python: ["3.12"]
-        model: [yolo11n]
+        model: [yolo26n]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -378,17 +378,17 @@ jobs:
           yolo checks
           uv pip list
       - name: Benchmark DetectionModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n.pt' imgsz=160 verbose=0.309
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n.pt' imgsz=160 verbose=0.309
       - name: Benchmark ClassificationModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-cls.pt' imgsz=160 verbose=0.249
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n-cls.pt' imgsz=160 verbose=0.249
       - name: Benchmark YOLOWorld DetectionModel
         run: python -m ultralytics.cfg.__init__ benchmark model='yolov8s-worldv2.pt' imgsz=160 verbose=0.337
       - name: Benchmark SegmentationModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-seg.pt' imgsz=160 verbose=0.195
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n-seg.pt' imgsz=160 verbose=0.195
       - name: Benchmark PoseModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-pose.pt' imgsz=160 verbose=0.197
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n-pose.pt' imgsz=160 verbose=0.197
       - name: Benchmark OBBModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-obb.pt' imgsz=160 verbose=0.597
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n-obb.pt' imgsz=160 verbose=0.597
       - name: Benchmark Summary
         run: |
           cat benchmarks.log
@@ -475,18 +475,18 @@ jobs:
         run: conda list
       - name: Test CLI
         run: |
-          yolo predict model=yolo11n.pt imgsz=320
-          yolo train model=yolo11n.pt data=coco8.yaml epochs=1 imgsz=32
-          yolo val model=yolo11n.pt data=coco8.yaml imgsz=32
-          yolo export model=yolo11n.pt format=torchscript imgsz=160
-          yolo benchmark model=yolo11n.pt data='coco8.yaml' imgsz=640 format=onnx
+          yolo predict model=yolo26n.pt imgsz=320
+          yolo train model=yolo26n.pt data=coco8.yaml epochs=1 imgsz=32
+          yolo val model=yolo26n.pt data=coco8.yaml imgsz=32
+          yolo export model=yolo26n.pt format=torchscript imgsz=160
+          yolo benchmark model=yolo26n.pt data='coco8.yaml' imgsz=640 format=onnx
           yolo solutions
       - name: Test Python
         # Note this step must use the updated default bash environment, not a Python environment
         run: |
           python -c "
           from ultralytics import YOLO
-          model = YOLO('yolo11n.pt')
+          model = YOLO('yolo26n.pt')
           results = model.train(data='coco8.yaml', epochs=3, imgsz=160)
           results = model.val(imgsz=160)
           results = model.predict(imgsz=160)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         # Temporarily disable windows-latest due to https://github.com/ultralytics/ultralytics/actions/runs/13020330819/job/36319338854?pr=18921
         os: [ubuntu-latest, macos-26, ubuntu-24.04-arm]
         python: ["3.12"]
-        model: [yolo26n]
+        model: [yolo11n]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -378,17 +378,17 @@ jobs:
           yolo checks
           uv pip list
       - name: Benchmark DetectionModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n.pt' imgsz=160 verbose=0.309
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n.pt' imgsz=160 verbose=0.309
       - name: Benchmark ClassificationModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n-cls.pt' imgsz=160 verbose=0.249
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-cls.pt' imgsz=160 verbose=0.249
       - name: Benchmark YOLOWorld DetectionModel
         run: python -m ultralytics.cfg.__init__ benchmark model='yolov8s-worldv2.pt' imgsz=160 verbose=0.337
       - name: Benchmark SegmentationModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n-seg.pt' imgsz=160 verbose=0.195
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-seg.pt' imgsz=160 verbose=0.195
       - name: Benchmark PoseModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n-pose.pt' imgsz=160 verbose=0.197
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-pose.pt' imgsz=160 verbose=0.197
       - name: Benchmark OBBModel
-        run: python -m ultralytics.cfg.__init__ benchmark model='yolo26n-obb.pt' imgsz=160 verbose=0.597
+        run: python -m ultralytics.cfg.__init__ benchmark model='yolo11n-obb.pt' imgsz=160 verbose=0.597
       - name: Benchmark Summary
         run: |
           cat benchmarks.log
@@ -475,18 +475,18 @@ jobs:
         run: conda list
       - name: Test CLI
         run: |
-          yolo predict model=yolo26n.pt imgsz=320
-          yolo train model=yolo26n.pt data=coco8.yaml epochs=1 imgsz=32
-          yolo val model=yolo26n.pt data=coco8.yaml imgsz=32
-          yolo export model=yolo26n.pt format=torchscript imgsz=160
-          yolo benchmark model=yolo26n.pt data='coco8.yaml' imgsz=640 format=onnx
+          yolo predict model=yolo11n.pt imgsz=320
+          yolo train model=yolo11n.pt data=coco8.yaml epochs=1 imgsz=32
+          yolo val model=yolo11n.pt data=coco8.yaml imgsz=32
+          yolo export model=yolo11n.pt format=torchscript imgsz=160
+          yolo benchmark model=yolo11n.pt data='coco8.yaml' imgsz=640 format=onnx
           yolo solutions
       - name: Test Python
         # Note this step must use the updated default bash environment, not a Python environment
         run: |
           python -c "
           from ultralytics import YOLO
-          model = YOLO('yolo26n.pt')
+          model = YOLO('yolo11n.pt')
           results = model.train(data='coco8.yaml', epochs=3, imgsz=160)
           results = model.val(imgsz=160)
           results = model.predict(imgsz=160)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -215,7 +215,7 @@ Here's example code for the Object Detection Task:
         from ultralytics import YOLO
 
         # Load a pretrained YOLO model (you can choose n, s, m, l, or x versions)
-        model = YOLO("yolo11n.pt")
+        model = YOLO("yolo26n.pt")
 
         # Start training on your custom dataset
         model.train(data="path/to/dataset.yaml", epochs=100, imgsz=640)
@@ -251,7 +251,7 @@ Ultralytics YOLO supports efficient and customizable multi-object tracking. To u
         from ultralytics import YOLO
 
         # Load a pretrained YOLO model
-        model = YOLO("yolo11n.pt")
+        model = YOLO("yolo26n.pt")
 
         # Start tracking objects in a video
         # You can also use live video streams or webcam input

--- a/docs/en/integrations/openvino.md
+++ b/docs/en/integrations/openvino.md
@@ -544,9 +544,9 @@ Ultralytics YOLO26 is optimized for real-time object detection with high accurac
 
 For in-depth performance analysis, check our detailed [YOLO11 benchmarks](#openvino-yolo11-benchmarks) on different hardware.
 
-### Can I benchmark YOLO11 models on different formats such as PyTorch, ONNX, and OpenVINO?
+### Can I benchmark YOLO26 models on different formats such as PyTorch, ONNX, and OpenVINO?
 
-Yes, you can benchmark YOLO11 models in various formats including PyTorch, TorchScript, ONNX, and OpenVINO. Use the following code snippet to run benchmarks on your chosen dataset:
+Yes, you can benchmark YOLO26 models in various formats including PyTorch, TorchScript, ONNX, and OpenVINO. Use the following code snippet to run benchmarks on your chosen dataset:
 
 !!! example
 
@@ -555,17 +555,17 @@ Yes, you can benchmark YOLO11 models in various formats including PyTorch, Torch
         ```python
         from ultralytics import YOLO
 
-        # Load a YOLO11n PyTorch model
+        # Load a YOLO26n PyTorch model
         model = YOLO("yolo26n.pt")
 
-        # Benchmark YOLO11n speed and [accuracy](https://www.ultralytics.com/glossary/accuracy) on the COCO8 dataset for all export formats
+        # Benchmark YOLO26n speed and [accuracy](https://www.ultralytics.com/glossary/accuracy) on the COCO8 dataset for all export formats
         results = model.benchmark(data="coco8.yaml")
         ```
 
     === "CLI"
 
         ```bash
-        # Benchmark YOLO11n speed and accuracy on the COCO8 dataset for all export formats
+        # Benchmark YOLO26n speed and accuracy on the COCO8 dataset for all export formats
         yolo benchmark model=yolo26n.pt data=coco8.yaml
         ```
 

--- a/docs/en/integrations/openvino.md
+++ b/docs/en/integrations/openvino.md
@@ -556,7 +556,7 @@ Yes, you can benchmark YOLO11 models in various formats including PyTorch, Torch
         from ultralytics import YOLO
 
         # Load a YOLO11n PyTorch model
-        model = YOLO("yolo11n.pt")
+        model = YOLO("yolo26n.pt")
 
         # Benchmark YOLO11n speed and [accuracy](https://www.ultralytics.com/glossary/accuracy) on the COCO8 dataset for all export formats
         results = model.benchmark(data="coco8.yaml")
@@ -566,7 +566,7 @@ Yes, you can benchmark YOLO11 models in various formats including PyTorch, Torch
 
         ```bash
         # Benchmark YOLO11n speed and accuracy on the COCO8 dataset for all export formats
-        yolo benchmark model=yolo11n.pt data=coco8.yaml
+        yolo benchmark model=yolo26n.pt data=coco8.yaml
         ```
 
 For detailed benchmark results, refer to our [benchmarks section](#openvino-yolo11-benchmarks) and [export formats](../modes/export.md) documentation.

--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -60,7 +60,7 @@ Note the below example spotlights YOLO11 [Detect](../tasks/detect.md) models for
         ```python
         from ultralytics import YOLO
 
-        # Load a COCO-pretrained YOLO11n model
+        # Load a COCO-pretrained YOLO26n model
         model = YOLO("yolo26n.pt")
 
         # Display model information (optional)
@@ -69,7 +69,7 @@ Note the below example spotlights YOLO11 [Detect](../tasks/detect.md) models for
         # Train the model on the COCO8 example dataset for 100 epochs
         results = model.train(data="coco8.yaml", epochs=100, imgsz=640)
 
-        # Run inference with the YOLO11n model on the 'bus.jpg' image
+        # Run inference with the YOLO26n model on the 'bus.jpg' image
         results = model("path/to/bus.jpg")
         ```
 
@@ -78,10 +78,10 @@ Note the below example spotlights YOLO11 [Detect](../tasks/detect.md) models for
         CLI commands are available to directly run the models:
 
         ```bash
-        # Load a COCO-pretrained YOLO11n model and train it on the COCO8 example dataset for 100 epochs
+        # Load a COCO-pretrained YOLO26n model and train it on the COCO8 example dataset for 100 epochs
         yolo train model=yolo26n.pt data=coco8.yaml epochs=100 imgsz=640
 
-        # Load a COCO-pretrained YOLO11n model and run inference on the 'bus.jpg' image
+        # Load a COCO-pretrained YOLO26n model and run inference on the 'bus.jpg' image
         yolo predict model=yolo26n.pt source=path/to/bus.jpg
         ```
 

--- a/docs/en/models/index.md
+++ b/docs/en/models/index.md
@@ -61,7 +61,7 @@ Note the below example spotlights YOLO11 [Detect](../tasks/detect.md) models for
         from ultralytics import YOLO
 
         # Load a COCO-pretrained YOLO11n model
-        model = YOLO("yolo11n.pt")
+        model = YOLO("yolo26n.pt")
 
         # Display model information (optional)
         model.info()
@@ -79,10 +79,10 @@ Note the below example spotlights YOLO11 [Detect](../tasks/detect.md) models for
 
         ```bash
         # Load a COCO-pretrained YOLO11n model and train it on the COCO8 example dataset for 100 epochs
-        yolo train model=yolo11n.pt data=coco8.yaml epochs=100 imgsz=640
+        yolo train model=yolo26n.pt data=coco8.yaml epochs=100 imgsz=640
 
         # Load a COCO-pretrained YOLO11n model and run inference on the 'bus.jpg' image
-        yolo predict model=yolo11n.pt source=path/to/bus.jpg
+        yolo predict model=yolo26n.pt source=path/to/bus.jpg
         ```
 
 ## Contributing New Models
@@ -121,7 +121,7 @@ Training a YOLO model on custom data can be easily accomplished using Ultralytic
         from ultralytics import YOLO
 
         # Load a YOLO model
-        model = YOLO("yolo11n.pt")  # or any other YOLO model
+        model = YOLO("yolo26n.pt")  # or any other YOLO model
 
         # Train the model on custom dataset
         results = model.train(data="custom_data.yaml", epochs=100, imgsz=640)
@@ -130,7 +130,7 @@ Training a YOLO model on custom data can be easily accomplished using Ultralytic
     === "CLI"
 
         ```bash
-        yolo train model=yolo11n.pt data='custom_data.yaml' epochs=100 imgsz=640
+        yolo train model=yolo26n.pt data='custom_data.yaml' epochs=100 imgsz=640
         ```
 
 For more detailed instructions, visit the [Train](../modes/train.md) documentation page.

--- a/docs/en/models/sam.md
+++ b/docs/en/models/sam.md
@@ -213,7 +213,7 @@ To auto-annotate your dataset with the Ultralytics framework, use the `auto_anno
         ```python
         from ultralytics.data.annotator import auto_annotate
 
-        auto_annotate(data="path/to/images", det_model="yolo11x.pt", sam_model="sam_b.pt")
+        auto_annotate(data="path/to/images", det_model="yolo26x.pt", sam_model="sam_b.pt")
         ```
 
 {% include "macros/sam-auto-annotate.md" %}

--- a/docs/en/models/yolov7.md
+++ b/docs/en/models/yolov7.md
@@ -101,7 +101,7 @@ To use YOLOv7 ONNX model with Ultralytics:
 
     ```bash
     pip install ultralytics
-    yolo export model=yolo11n.pt format=onnx
+    yolo export model=yolo26n.pt format=onnx
     ```
 
 2. Export the desired YOLOv7 model by using the exporter in the [YOLOv7 repo](https://github.com/WongKinYiu/yolov7):

--- a/docs/en/platform/account/api-keys.md
+++ b/docs/en/platform/account/api-keys.md
@@ -126,7 +126,7 @@ Enable metric streaming with your key.
 
 ```bash
 export ULTRALYTICS_API_KEY="ul_your_key_here"
-yolo train model=yolo11n.pt data=coco.yaml project=username/project name=exp1
+yolo train model=yolo26n.pt data=coco.yaml project=username/project name=exp1
 ```
 
 ## Manage Keys

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -676,7 +676,7 @@ from ultralytics import YOLO
 os.environ["ULTRALYTICS_API_KEY"] = "ul_your_key"
 
 # Train with Platform integration
-model = YOLO("yolo11n.pt")
+model = YOLO("yolo26n.pt")
 model.train(data="ul://username/datasets/my-dataset", project="username/my-project", name="experiment-1", epochs=100)
 ```
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -197,7 +197,7 @@ Use this URI to train models from anywhere:
 
 ```bash
 export ULTRALYTICS_API_KEY="your_api_key"
-yolo train model=yolo11n.pt data=ul://username/datasets/my-dataset epochs=100
+yolo train model=yolo26n.pt data=ul://username/datasets/my-dataset epochs=100
 ```
 
 !!! example "Train Anywhere with Platform Data"

--- a/docs/en/platform/deploy/inference.md
+++ b/docs/en/platform/deploy/inference.md
@@ -265,7 +265,7 @@ The API returns JSON predictions. To visualize:
 ```python
 from ultralytics import YOLO
 
-model = YOLO("yolo11n.pt")
+model = YOLO("yolo26n.pt")
 results = model("image.jpg")
 results[0].save("annotated.jpg")
 ```

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -192,7 +192,7 @@ You can train models anywhere and stream metrics to Platform.
 export ULTRALYTICS_API_KEY="your_api_key"
 
 # Train with project/name to stream metrics
-yolo train model=yolo11n.pt data=coco.yaml epochs=100 project=username/my-project name=exp1
+yolo train model=yolo26n.pt data=coco.yaml epochs=100 project=username/my-project name=exp1
 ```
 
 See [Cloud Training](train/cloud-training.md) for more details on remote training.

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -171,7 +171,7 @@ Use the `project` and `name` parameters to stream metrics:
 === "CLI"
 
     ```bash
-    yolo train model=yolo11n.pt data=coco.yaml epochs=100 \
+    yolo train model=yolo26n.pt data=coco.yaml epochs=100 \
       project=username/my-project name=experiment-1
     ```
 
@@ -180,7 +180,7 @@ Use the `project` and `name` parameters to stream metrics:
     ```python
     from ultralytics import YOLO
 
-    model = YOLO("yolo11n.pt")
+    model = YOLO("yolo26n.pt")
     model.train(
         data="coco.yaml",
         epochs=100,
@@ -194,7 +194,7 @@ Use the `project` and `name` parameters to stream metrics:
 Train with datasets stored on the Platform:
 
 ```bash
-yolo train model=yolo11n.pt data=ul://username/datasets/my-dataset epochs=100
+yolo train model=yolo26n.pt data=ul://username/datasets/my-dataset epochs=100
 ```
 
 The `ul://` URI format automatically downloads and configures your dataset.

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -333,9 +333,9 @@ The Ultralytics command-line interface (CLI) allows for simple single-line comma
     Arguments must be passed as `arg=value` pairs, split by an equals `=` sign and delimited by spaces. Do not use `--` argument prefixes or commas `,` between arguments.
 
     - `yolo predict model=yolo26n.pt imgsz=640 conf=0.25`  ✅
-    - `yolo predict model yolo11n.pt imgsz 640 conf 0.25`  ❌ (missing `=`)
+    - `yolo predict model yolo26n.pt imgsz 640 conf 0.25`  ❌ (missing `=`)
     - `yolo predict model=yolo26n.pt, imgsz=640, conf=0.25`  ❌ (do not use `,`)
-    - `yolo predict --model yolo11n.pt --imgsz 640 --conf 0.25`  ❌ (do not use `--`)
+    - `yolo predict --model yolo26n.pt --imgsz 640 --conf 0.25`  ❌ (do not use `--`)
     - `yolo solution model=yolo26n.pt imgsz=640 conf=0.25` ❌ (use `solutions`, not `solution`)
 
 [CLI Guide](usage/cli.md){ .md-button }

--- a/docs/macros/export-table.md
+++ b/docs/macros/export-table.md
@@ -1,6 +1,6 @@
 {%set tip1 = ':material-information-outline:{ title="conf, iou, agnostic_nms are also available when nms=True" }' %}
 {%set tip2 = ':material-information-outline:{ title="conf, iou are also available when nms=True" }' %}
-{%set tip3 = ':material-information-outline:{ title="IMX format is currently only supported for YOLOv8n, YOLO11n, and YOLO26n models" }' %}
+{%set tip3 = ':material-information-outline:{ title="IMX format is currently only supported for YOLOv8n, YOLO11n models" }' %}
 
 | Format                                             | `format` Argument | Model                                             | Metadata | Arguments                                                                                                           |
 | -------------------------------------------------- | ----------------- | ------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -263,7 +263,7 @@ def test_export_ncnn_matrix(task, half, batch):
 @pytest.mark.skipif(ARM64, reason="IMX export is not supported on ARM64 architectures.")
 def test_export_imx():
     """Test YOLO export to IMX format."""
-    model = YOLO("yolo11n.pt")  # IMX export only supports YOLO11
+    model = YOLO("yolo26n.pt")  # IMX export only supports YOLO11
     file = model.export(format="imx", imgsz=32)
     YOLO(file)(SOURCE, imgsz=32)
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -263,7 +263,7 @@ def test_export_ncnn_matrix(task, half, batch):
 @pytest.mark.skipif(ARM64, reason="IMX export is not supported on ARM64 architectures.")
 def test_export_imx():
     """Test YOLO export to IMX format."""
-    model = YOLO("yolo26n.pt")  # IMX export only supports YOLO11
+    model = YOLO("yolo11n.pt")  # IMX export only supports YOLO11
     file = model.export(format="imx", imgsz=32)
     YOLO(file)(SOURCE, imgsz=32)
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -127,7 +127,7 @@ CLI_HELP_MSG = f"""
         yolo val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640
 
     4. Export a YOLO11n classification model to ONNX format at image size 224 by 128 (no TASK required)
-        yolo export model=yolo11n-cls.pt format=onnx imgsz=224,128
+        yolo export model=yolo26n-cls.pt format=onnx imgsz=224,128
 
     5. Ultralytics solutions usage
         yolo solutions count or any of {list(SOLUTION_MAP.keys())[1:-1]} source="path/to/video.mp4"

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -90,10 +90,10 @@ SOLUTIONS_HELP_MSG = f"""
         yolo solutions count source="path/to/video.mp4" region="[(20, 400), (1080, 400), (1080, 360), (20, 360)]"
 
     2. Call heatmap solution
-        yolo solutions heatmap colormap=cv2.COLORMAP_PARULA model=yolo11n.pt
+        yolo solutions heatmap colormap=cv2.COLORMAP_PARULA model=yolo26n.pt
 
     3. Call queue management solution
-        yolo solutions queue region="[(20, 400), (1080, 400), (1080, 360), (20, 360)]" model=yolo11n.pt
+        yolo solutions queue region="[(20, 400), (1080, 400), (1080, 360), (20, 360)]" model=yolo26n.pt
 
     4. Call workout monitoring solution for push-ups
         yolo solutions workout model=yolo11n-pose.pt kpts=[6, 8, 10]
@@ -118,13 +118,13 @@ CLI_HELP_MSG = f"""
                     See all ARGS at https://docs.ultralytics.com/usage/cfg or with 'yolo cfg'
 
     1. Train a detection model for 10 epochs with an initial learning_rate of 0.01
-        yolo train data=coco8.yaml model=yolo11n.pt epochs=10 lr0=0.01
+        yolo train data=coco8.yaml model=yolo26n.pt epochs=10 lr0=0.01
 
     2. Predict a YouTube video using a pretrained segmentation model at image size 320:
         yolo predict model=yolo11n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
 
     3. Validate a pretrained detection model at batch-size 1 and image size 640:
-        yolo val model=yolo11n.pt data=coco8.yaml batch=1 imgsz=640
+        yolo val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640
 
     4. Export a YOLO11n classification model to ONNX format at image size 224 by 128 (no TASK required)
         yolo export model=yolo11n-cls.pt format=onnx imgsz=224,128
@@ -649,7 +649,7 @@ def handle_yolo_solutions(args: list[str]) -> None:
         >>> handle_yolo_solutions(["analytics", "conf=0.25", "source=path/to/video.mp4"])
 
         Run inference with custom configuration, requires Streamlit version 1.29.0 or higher.
-        >>> handle_yolo_solutions(["inference", "model=yolo11n.pt"])
+        >>> handle_yolo_solutions(["inference", "model=yolo26n.pt"])
 
     Notes:
         - Arguments can be provided in the format 'key=value' or as boolean flags
@@ -707,7 +707,7 @@ def handle_yolo_solutions(args: list[str]) -> None:
                 str(ROOT / "solutions/streamlit_inference.py"),
                 "--server.headless",
                 "true",
-                overrides.pop("model", "yolo11n.pt"),
+                overrides.pop("model", "yolo26n.pt"),
             ]
         )
     else:
@@ -758,9 +758,9 @@ def parse_key_value_pair(pair: str = "key=value") -> tuple:
         AssertionError: If the value is missing or empty.
 
     Examples:
-        >>> key, value = parse_key_value_pair("model=yolo11n.pt")
+        >>> key, value = parse_key_value_pair("model=yolo26n.pt")
         >>> print(f"Key: {key}, Value: {value}")
-        Key: model, Value: yolo11n.pt
+        Key: model, Value: yolo26n.pt
 
         >>> key, value = parse_key_value_pair("epochs=100")
         >>> print(f"Key: {key}, Value: {value}")
@@ -832,13 +832,13 @@ def entrypoint(debug: str = "") -> None:
 
     Examples:
         Train a detection model for 10 epochs with an initial learning_rate of 0.01:
-        >>> entrypoint("train data=coco8.yaml model=yolo11n.pt epochs=10 lr0=0.01")
+        >>> entrypoint("train data=coco8.yaml model=yolo26n.pt epochs=10 lr0=0.01")
 
         Predict a YouTube video using a pretrained segmentation model at image size 320:
         >>> entrypoint("predict model=yolo11n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320")
 
         Validate a pretrained detection model at batch-size 1 and image size 640:
-        >>> entrypoint("val model=yolo11n.pt data=coco8.yaml batch=1 imgsz=640")
+        >>> entrypoint("val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640")
 
     Notes:
         - If no arguments are passed, the function will display the usage help message.
@@ -933,7 +933,7 @@ def entrypoint(debug: str = "") -> None:
     # Model
     model = overrides.pop("model", DEFAULT_CFG.model)
     if model is None:
-        model = "yolo11n.pt"
+        model = "yolo26n.pt"
         LOGGER.warning(f"'model' argument is missing. Using default 'model={model}'.")
     overrides["model"] = model
     stem = Path(model).stem.lower()
@@ -1022,5 +1022,5 @@ def copy_default_cfg() -> None:
 
 
 if __name__ == "__main__":
-    # Example: entrypoint(debug='yolo predict model=yolo11n.pt')
+    # Example: entrypoint(debug='yolo predict model=yolo26n.pt')
     entrypoint(debug="")

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -126,7 +126,7 @@ CLI_HELP_MSG = f"""
     3. Validate a pretrained detection model at batch-size 1 and image size 640:
         yolo val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640
 
-    4. Export a YOLO11n classification model to ONNX format at image size 224 by 128 (no TASK required)
+    4. Export a YOLO26n classification model to ONNX format at image size 224 by 128 (no TASK required)
         yolo export model=yolo26n-cls.pt format=onnx imgsz=224,128
 
     5. Ultralytics solutions usage

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -121,7 +121,7 @@ CLI_HELP_MSG = f"""
         yolo train data=coco8.yaml model=yolo26n.pt epochs=10 lr0=0.01
 
     2. Predict a YouTube video using a pretrained segmentation model at image size 320:
-        yolo predict model=yolo11n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
+        yolo predict model=yolo26n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
 
     3. Validate a pretrained detection model at batch-size 1 and image size 640:
         yolo val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640
@@ -604,7 +604,7 @@ def handle_yolo_settings(args: list[str]) -> None:
 
     Examples:
         >>> handle_yolo_settings(["reset"])  # Reset YOLO settings
-        >>> handle_yolo_settings(["default_cfg_path=yolo11n.yaml"])  # Update a specific setting
+        >>> handle_yolo_settings(["default_cfg_path=yolo26n.yaml"])  # Update a specific setting
 
     Notes:
         - If no arguments are provided, the function will display the current settings.
@@ -835,7 +835,7 @@ def entrypoint(debug: str = "") -> None:
         >>> entrypoint("train data=coco8.yaml model=yolo26n.pt epochs=10 lr0=0.01")
 
         Predict a YouTube video using a pretrained segmentation model at image size 320:
-        >>> entrypoint("predict model=yolo11n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320")
+        >>> entrypoint("predict model=yolo26n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320")
 
         Validate a pretrained detection model at batch-size 1 and image size 640:
         >>> entrypoint("val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640")

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -96,7 +96,7 @@ SOLUTIONS_HELP_MSG = f"""
         yolo solutions queue region="[(20, 400), (1080, 400), (1080, 360), (20, 360)]" model=yolo26n.pt
 
     4. Call workout monitoring solution for push-ups
-        yolo solutions workout model=yolo11n-pose.pt kpts=[6, 8, 10]
+        yolo solutions workout model=yolo26n-pose.pt kpts=[6, 8, 10]
 
     5. Generate analytical graphs
         yolo solutions analytics analytics_type="pie"

--- a/ultralytics/data/annotator.py
+++ b/ultralytics/data/annotator.py
@@ -9,7 +9,7 @@ from ultralytics import SAM, YOLO
 
 def auto_annotate(
     data: str | Path,
-    det_model: str = "yolo11x.pt",
+    det_model: str = "yolo26x.pt",
     sam_model: str = "sam_b.pt",
     device: str = "",
     conf: float = 0.25,
@@ -39,7 +39,7 @@ def auto_annotate(
 
     Examples:
         >>> from ultralytics.data.annotator import auto_annotate
-        >>> auto_annotate(data="ultralytics/assets", det_model="yolo11n.pt", sam_model="mobile_sam.pt")
+        >>> auto_annotate(data="ultralytics/assets", det_model="yolo26n.pt", sam_model="mobile_sam.pt")
     """
     det_model = YOLO(det_model)
     sam_model = SAM(sam_model)

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -776,7 +776,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
         Use with YOLO training
         >>> from ultralytics import YOLO
-        >>> model = YOLO("yolo11n.pt")
+        >>> model = YOLO("yolo26n.pt")
         >>> model.train(data="https://github.com/ultralytics/assets/releases/download/v0.0.0/coco8-ndjson.ndjson")
     """
     check_requirements("aiohttp")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -4,38 +4,38 @@ Export a YOLO PyTorch model to other formats. TensorFlow exports authored by htt
 
 Format                  | `format=argument`         | Model
 ---                     | ---                       | ---
-PyTorch                 | -                         | yolo11n.pt
-TorchScript             | `torchscript`             | yolo11n.torchscript
-ONNX                    | `onnx`                    | yolo11n.onnx
-OpenVINO                | `openvino`                | yolo11n_openvino_model/
-TensorRT                | `engine`                  | yolo11n.engine
-CoreML                  | `coreml`                  | yolo11n.mlpackage
-TensorFlow SavedModel   | `saved_model`             | yolo11n_saved_model/
-TensorFlow GraphDef     | `pb`                      | yolo11n.pb
-TensorFlow Lite         | `tflite`                  | yolo11n.tflite
-TensorFlow Edge TPU     | `edgetpu`                 | yolo11n_edgetpu.tflite
-TensorFlow.js           | `tfjs`                    | yolo11n_web_model/
-PaddlePaddle            | `paddle`                  | yolo11n_paddle_model/
-MNN                     | `mnn`                     | yolo11n.mnn
-NCNN                    | `ncnn`                    | yolo11n_ncnn_model/
-IMX                     | `imx`                     | yolo11n_imx_model/
-RKNN                    | `rknn`                    | yolo11n_rknn_model/
-ExecuTorch              | `executorch`              | yolo11n_executorch_model/
-Axelera                 | `axelera`                 | yolo11n_axelera_model/
+PyTorch                 | -                         | yolo26n.pt
+TorchScript             | `torchscript`             | yolo26n.torchscript
+ONNX                    | `onnx`                    | yolo26n.onnx
+OpenVINO                | `openvino`                | yolo26n_openvino_model/
+TensorRT                | `engine`                  | yolo26n.engine
+CoreML                  | `coreml`                  | yolo26n.mlpackage
+TensorFlow SavedModel   | `saved_model`             | yolo26n_saved_model/
+TensorFlow GraphDef     | `pb`                      | yolo26n.pb
+TensorFlow Lite         | `tflite`                  | yolo26n.tflite
+TensorFlow Edge TPU     | `edgetpu`                 | yolo26n_edgetpu.tflite
+TensorFlow.js           | `tfjs`                    | yolo26n_web_model/
+PaddlePaddle            | `paddle`                  | yolo26n_paddle_model/
+MNN                     | `mnn`                     | yolo26n.mnn
+NCNN                    | `ncnn`                    | yolo26n_ncnn_model/
+IMX                     | `imx`                     | yolo26n_imx_model/
+RKNN                    | `rknn`                    | yolo26n_rknn_model/
+ExecuTorch              | `executorch`              | yolo26n_executorch_model/
+Axelera                 | `axelera`                 | yolo26n_axelera_model/
 
 Requirements:
     $ pip install "ultralytics[export]"
 
 Python:
     from ultralytics import YOLO
-    model = YOLO('yolo11n.pt')
+    model = YOLO('yolo26n.pt')
     results = model.export(format='onnx')
 
 CLI:
-    $ yolo mode=export model=yolo11n.pt format=onnx
+    $ yolo mode=export model=yolo26n.pt format=onnx
 
 Inference:
-    $ yolo predict model=yolo11n.pt                 # PyTorch
+    $ yolo predict model=yolo26n.pt                 # PyTorch
                          yolo11n.torchscript        # TorchScript
                          yolo11n.onnx               # ONNX Runtime or OpenCV DNN with dnn=True
                          yolo11n_openvino_model     # OpenVINO
@@ -930,7 +930,7 @@ class Exporter:
             model = IOSDetectModel(self.model, self.im, mlprogram=not mlmodel) if self.args.nms else self.model
         else:
             if self.args.nms:
-                LOGGER.warning(f"{prefix} 'nms=True' is only available for Detect models like 'yolo11n.pt'.")
+                LOGGER.warning(f"{prefix} 'nms=True' is only available for Detect models like 'yolo26n.pt'.")
                 # TODO CoreML Segment and Pose model pipelining
             model = self.model
         ts = torch.jit.trace(model.eval(), self.im, strict=False)  # TorchScript model

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -277,7 +277,7 @@ class Model(torch.nn.Module):
         """
         if weights.lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://", "ul://")):
             weights = checks.check_file(weights, download_dir=SETTINGS["weights_dir"])  # download and return local file
-        weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolo11n -> yolo26n.pt
+        weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolo26 -> yolo26n.pt
 
         if str(weights).rpartition(".")[-1] == "pt":
             self.model, self.ckpt = load_checkpoint(weights)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -242,7 +242,7 @@ class Model(torch.nn.Module):
 
         Examples:
             >>> model = Model()
-            >>> model._new("yolo11n.yaml", task="detect", verbose=True)
+            >>> model._new("yolo26n.yaml", task="detect", verbose=True)
         """
         cfg_dict = yaml_model_load(cfg)
         self.cfg = cfg

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -71,7 +71,7 @@ class Model(torch.nn.Module):
 
     Examples:
         >>> from ultralytics import YOLO
-        >>> model = YOLO("yolo11n.pt")
+        >>> model = YOLO("yolo26n.pt")
         >>> results = model.predict("image.jpg")
         >>> model.train(data="coco8.yaml", epochs=3)
         >>> metrics = model.val()
@@ -80,7 +80,7 @@ class Model(torch.nn.Module):
 
     def __init__(
         self,
-        model: str | Path | Model = "yolo11n.pt",
+        model: str | Path | Model = "yolo26n.pt",
         task: str | None = None,
         verbose: bool = False,
     ) -> None:
@@ -169,7 +169,7 @@ class Model(torch.nn.Module):
                 object.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> results = model("https://ultralytics.com/images/bus.jpg")
             >>> for r in results:
             ...     print(f"Detected {len(r)} objects in image")
@@ -192,7 +192,7 @@ class Model(torch.nn.Module):
         Examples:
             >>> Model.is_triton_model("http://localhost:8000/v2/models/yolo11n")
             True
-            >>> Model.is_triton_model("yolo11n.pt")
+            >>> Model.is_triton_model("yolo26n.pt")
             False
         """
         from urllib.parse import urlsplit
@@ -216,7 +216,7 @@ class Model(torch.nn.Module):
         Examples:
             >>> Model.is_hub_model("https://hub.ultralytics.com/models/MODEL")
             True
-            >>> Model.is_hub_model("yolo11n.pt")
+            >>> Model.is_hub_model("yolo26n.pt")
             False
         """
         from ultralytics.hub import HUB_WEB_ROOT
@@ -272,12 +272,12 @@ class Model(torch.nn.Module):
 
         Examples:
             >>> model = Model()
-            >>> model._load("yolo11n.pt")
+            >>> model._load("yolo26n.pt")
             >>> model._load("path/to/weights.pth", task="detect")
         """
         if weights.lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://", "ul://")):
             weights = checks.check_file(weights, download_dir=SETTINGS["weights_dir"])  # download and return local file
-        weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolo11n -> yolo11n.pt
+        weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolo11n -> yolo26n.pt
 
         if str(weights).rpartition(".")[-1] == "pt":
             self.model, self.ckpt = load_checkpoint(weights)
@@ -304,7 +304,7 @@ class Model(torch.nn.Module):
                 information about supported model formats and operations.
 
         Examples:
-            >>> model = Model("yolo11n.pt")
+            >>> model = Model("yolo26n.pt")
             >>> model._check_is_pytorch_model()  # No error raised
             >>> model = Model("yolo11n.onnx")
             >>> model._check_is_pytorch_model()  # Raises TypeError
@@ -334,7 +334,7 @@ class Model(torch.nn.Module):
             AssertionError: If the model is not a PyTorch model.
 
         Examples:
-            >>> model = Model("yolo11n.pt")
+            >>> model = Model("yolo26n.pt")
             >>> model.reset_weights()
         """
         self._check_is_pytorch_model()
@@ -345,7 +345,7 @@ class Model(torch.nn.Module):
             p.requires_grad = True
         return self
 
-    def load(self, weights: str | Path = "yolo11n.pt") -> Model:
+    def load(self, weights: str | Path = "yolo26n.pt") -> Model:
         """Load parameters from the specified weights file into the model.
 
         This method supports loading weights from a file or directly from a weights object. It matches parameters by
@@ -362,7 +362,7 @@ class Model(torch.nn.Module):
 
         Examples:
             >>> model = Model()
-            >>> model.load("yolo11n.pt")
+            >>> model.load("yolo26n.pt")
             >>> model.load(Path("path/to/weights.pt"))
         """
         self._check_is_pytorch_model()
@@ -385,7 +385,7 @@ class Model(torch.nn.Module):
             AssertionError: If the model is not a PyTorch model.
 
         Examples:
-            >>> model = Model("yolo11n.pt")
+            >>> model = Model("yolo26n.pt")
             >>> model.save("my_model.pt")
         """
         self._check_is_pytorch_model()
@@ -419,7 +419,7 @@ class Model(torch.nn.Module):
                 summary, layer details, and parameter counts. Empty if verbose is True.
 
         Examples:
-            >>> model = Model("yolo11n.pt")
+            >>> model = Model("yolo26n.pt")
             >>> model.info()  # Prints model summary
             >>> info_list = model.info(detailed=True, verbose=False)  # Returns detailed info as a list
         """
@@ -438,7 +438,7 @@ class Model(torch.nn.Module):
         performs both convolution and normalization in one step.
 
         Examples:
-            >>> model = Model("yolo11n.pt")
+            >>> model = Model("yolo26n.pt")
             >>> model.fuse()
             >>> # Model is now fused and ready for optimized inference
         """
@@ -466,7 +466,7 @@ class Model(torch.nn.Module):
             (list[torch.Tensor]): A list containing the image embeddings.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> image = "https://ultralytics.com/images/bus.jpg"
             >>> embeddings = model.embed(image)
             >>> print(embeddings[0].shape)
@@ -502,7 +502,7 @@ class Model(torch.nn.Module):
                 object.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> results = model.predict(source="path/to/image.jpg", conf=0.25)
             >>> for r in results:
             ...     print(r.boxes.data)  # print detection bounding boxes
@@ -559,7 +559,7 @@ class Model(torch.nn.Module):
             (list[ultralytics.engine.results.Results]): A list of tracking results, each a Results object.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> results = model.track(source="path/to/video.mp4", show=True)
             >>> for r in results:
             ...     print(r.boxes.id)  # print tracking IDs
@@ -601,7 +601,7 @@ class Model(torch.nn.Module):
             AssertionError: If the model is not a PyTorch model.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> results = model.val(data="coco8.yaml", imgsz=640)
             >>> print(results.box.map)  # Print mAP50-95
         """
@@ -639,7 +639,7 @@ class Model(torch.nn.Module):
             AssertionError: If the model is not a PyTorch model.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> results = model.benchmark(data="coco8.yaml", imgsz=640, half=True)
             >>> print(results)
         """
@@ -692,7 +692,7 @@ class Model(torch.nn.Module):
             RuntimeError: If the export process fails due to errors.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> model.export(format="onnx", dynamic=True, simplify=True)
             'path/to/exported/model.onnx'
         """
@@ -742,7 +742,7 @@ class Model(torch.nn.Module):
             (dict | None): Training metrics if available and training is successful; otherwise, None.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> results = model.train(data="coco8.yaml", epochs=3)
         """
         self._check_is_pytorch_model()
@@ -808,7 +808,7 @@ class Model(torch.nn.Module):
             TypeError: If the model is not a PyTorch model.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> results = model.tune(data="coco8.yaml", iterations=5)
             >>> print(results)
 
@@ -845,7 +845,7 @@ class Model(torch.nn.Module):
             AssertionError: If the model is not a PyTorch model.
 
         Examples:
-            >>> model = Model("yolo11n.pt")
+            >>> model = Model("yolo26n.pt")
             >>> model = model._apply(lambda t: t.cuda())  # Move model to GPU
         """
         self._check_is_pytorch_model()
@@ -870,7 +870,7 @@ class Model(torch.nn.Module):
             AttributeError: If the model or predictor does not have a 'names' attribute.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> print(model.names)
             {0: 'person', 1: 'bicycle', 2: 'car', ...}
         """
@@ -898,7 +898,7 @@ class Model(torch.nn.Module):
             AttributeError: If the model is not a torch.nn.Module instance.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> print(model.device)
             device(type='cuda', index=0)  # if CUDA is available
             >>> model = model.to("cpu")
@@ -919,7 +919,7 @@ class Model(torch.nn.Module):
             (object | None): The transform object of the model if available, otherwise None.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> transforms = model.transforms
             >>> if transforms:
             ...     print(f"Model transforms: {transforms}")
@@ -947,7 +947,7 @@ class Model(torch.nn.Module):
         Examples:
             >>> def on_train_start(trainer):
             ...     print("Training is starting!")
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> model.add_callback("on_train_start", on_train_start)
             >>> model.train(data="coco8.yaml", epochs=1)
         """
@@ -965,7 +965,7 @@ class Model(torch.nn.Module):
                 recognized by the Ultralytics callback system.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> model.add_callback("on_train_start", lambda: print("Training started"))
             >>> model.clear_callback("on_train_start")
             >>> # All callbacks for 'on_train_start' are now removed
@@ -994,7 +994,7 @@ class Model(torch.nn.Module):
         modifications, ensuring consistent behavior across different runs or experiments.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> model.add_callback("on_train_start", custom_function)
             >>> model.reset_callbacks()
             # All callbacks are now reset to their default functions
@@ -1076,7 +1076,7 @@ class Model(torch.nn.Module):
                 implementations for that task.
 
         Examples:
-            >>> model = Model("yolo11n.pt")
+            >>> model = Model("yolo26n.pt")
             >>> task_map = model.task_map
             >>> detect_predictor = task_map["detect"]["predictor"]
             >>> segment_trainer = task_map["segment"]["trainer"]
@@ -1094,7 +1094,7 @@ class Model(torch.nn.Module):
             (Model): The model instance with evaluation mode set.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> model.eval()
             >>> # Model is now in evaluation mode for inference
         """
@@ -1118,7 +1118,7 @@ class Model(torch.nn.Module):
             AttributeError: If the requested attribute does not exist in the model.
 
         Examples:
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> print(model.stride)  # Access model.stride attribute
             >>> print(model.names)  # Access model.names attribute
         """

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -3,7 +3,7 @@
 Run prediction on images, videos, directories, globs, YouTube, webcam, streams, etc.
 
 Usage - sources:
-    $ yolo mode=predict model=yolo11n.pt source=0                               # webcam
+    $ yolo mode=predict model=yolo26n.pt source=0                               # webcam
                                                 img.jpg                         # image
                                                 vid.mp4                         # video
                                                 screen                          # screenshot
@@ -15,22 +15,22 @@ Usage - sources:
                                                 'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP, TCP stream
 
 Usage - formats:
-    $ yolo mode=predict model=yolo11n.pt                 # PyTorch
-                              yolo11n.torchscript        # TorchScript
-                              yolo11n.onnx               # ONNX Runtime or OpenCV DNN with dnn=True
-                              yolo11n_openvino_model     # OpenVINO
-                              yolo11n.engine             # TensorRT
-                              yolo11n.mlpackage          # CoreML (macOS-only)
-                              yolo11n_saved_model        # TensorFlow SavedModel
-                              yolo11n.pb                 # TensorFlow GraphDef
-                              yolo11n.tflite             # TensorFlow Lite
-                              yolo11n_edgetpu.tflite     # TensorFlow Edge TPU
-                              yolo11n_paddle_model       # PaddlePaddle
-                              yolo11n.mnn                # MNN
-                              yolo11n_ncnn_model         # NCNN
-                              yolo11n_imx_model          # Sony IMX
-                              yolo11n_rknn_model         # Rockchip RKNN
-                              yolo11n.pte                # PyTorch Executorch
+    $ yolo mode=predict model=yolo26n.pt                 # PyTorch
+                              yolo26n.torchscript        # TorchScript
+                              yolo26n.onnx               # ONNX Runtime or OpenCV DNN with dnn=True
+                              yolo26n_openvino_model     # OpenVINO
+                              yolo26n.engine             # TensorRT
+                              yolo26n.mlpackage          # CoreML (macOS-only)
+                              yolo26n_saved_model        # TensorFlow SavedModel
+                              yolo26n.pb                 # TensorFlow GraphDef
+                              yolo26n.tflite             # TensorFlow Lite
+                              yolo26n_edgetpu.tflite     # TensorFlow Edge TPU
+                              yolo26n_paddle_model       # PaddlePaddle
+                              yolo26n.mnn                # MNN
+                              yolo26n_ncnn_model         # NCNN
+                              yolo26n_imx_model          # Sony IMX
+                              yolo26n_rknn_model         # Rockchip RKNN
+                              yolo26n.pte                # PyTorch Executorch
 """
 
 from __future__ import annotations

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -667,7 +667,7 @@ class Results(SimpleClass, DataExportMixin):
 
         Examples:
             >>> from ultralytics import YOLO
-            >>> model = YOLO("yolo11n.pt")
+            >>> model = YOLO("yolo26n.pt")
             >>> results = model("path/to/image.jpg")
             >>> for result in results:
             >>>     result.save_txt("output.txt")

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -1509,7 +1509,7 @@ class OBB(BaseTensor):
         Examples:
             >>> import torch
             >>> from ultralytics import YOLO
-            >>> model = YOLO("yolo11n-obb.pt")
+            >>> model = YOLO("yolo26n-obb.pt")
             >>> results = model("path/to/image.jpg")
             >>> for result in results:
             ...     obb = result.obb

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -3,7 +3,7 @@
 Train a model on a dataset.
 
 Usage:
-    $ yolo mode=train model=yolo11n.pt data=coco8.yaml imgsz=640 epochs=100 batch=16
+    $ yolo mode=train model=yolo26n.pt data=coco8.yaml imgsz=640 epochs=100 batch=16
 """
 
 from __future__ import annotations
@@ -181,7 +181,7 @@ class BaseTrainer:
             self.run_callbacks("on_pretrain_routine_start")
 
         # Model and Dataset
-        self.model = check_model_file_from_stem(self.args.model)  # add suffix, i.e. yolo11n -> yolo11n.pt
+        self.model = check_model_file_from_stem(self.args.model)  # add suffix, i.e. yolo26n -> yolo26n.pt
         with torch_distributed_zero_first(LOCAL_RANK):  # avoid auto-downloading dataset multiple times
             self.data = self.get_dataset()
 

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -10,7 +10,7 @@ where small changes in hyperparameters can lead to significant differences in mo
 Examples:
     Tune hyperparameters for YOLO11n on COCO8 at imgsz=640 and epochs=10 for 300 tuning iterations.
     >>> from ultralytics import YOLO
-    >>> model = YOLO("yolo11n.pt")
+    >>> model = YOLO("yolo26n.pt")
     >>> model.tune(data="coco8.yaml", epochs=10, iterations=300, optimizer="AdamW", plots=False, save=False, val=False)
 """
 
@@ -57,7 +57,7 @@ class Tuner:
     Examples:
         Tune hyperparameters for YOLO11n on COCO8 at imgsz=640 and epochs=10 for 300 tuning iterations.
         >>> from ultralytics import YOLO
-        >>> model = YOLO("yolo11n.pt")
+        >>> model = YOLO("yolo26n.pt")
         >>> model.tune(
         >>>     data="coco8.yaml",
         >>>     epochs=10,

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -8,7 +8,7 @@ that yield the best model performance. This is particularly crucial in deep lear
 where small changes in hyperparameters can lead to significant differences in model accuracy and efficiency.
 
 Examples:
-    Tune hyperparameters for YOLO11n on COCO8 at imgsz=640 and epochs=10 for 300 tuning iterations.
+    Tune hyperparameters for YOLO26n on COCO8 at imgsz=640 and epochs=10 for 300 tuning iterations.
     >>> from ultralytics import YOLO
     >>> model = YOLO("yolo26n.pt")
     >>> model.tune(data="coco8.yaml", epochs=10, iterations=300, optimizer="AdamW", plots=False, save=False, val=False)
@@ -55,7 +55,7 @@ class Tuner:
         __call__: Execute the hyperparameter evolution across multiple iterations.
 
     Examples:
-        Tune hyperparameters for YOLO11n on COCO8 at imgsz=640 and epochs=10 for 300 tuning iterations.
+        Tune hyperparameters for YOLO26n on COCO8 at imgsz=640 and epochs=10 for 300 tuning iterations.
         >>> from ultralytics import YOLO
         >>> model = YOLO("yolo26n.pt")
         >>> model.tune(

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -3,24 +3,24 @@
 Check a model's accuracy on a test or val split of a dataset.
 
 Usage:
-    $ yolo mode=val model=yolo11n.pt data=coco8.yaml imgsz=640
+    $ yolo mode=val model=yolo26n.pt data=coco8.yaml imgsz=640
 
 Usage - formats:
-    $ yolo mode=val model=yolo11n.pt                 # PyTorch
-                          yolo11n.torchscript        # TorchScript
-                          yolo11n.onnx               # ONNX Runtime or OpenCV DNN with dnn=True
-                          yolo11n_openvino_model     # OpenVINO
-                          yolo11n.engine             # TensorRT
-                          yolo11n.mlpackage          # CoreML (macOS-only)
-                          yolo11n_saved_model        # TensorFlow SavedModel
-                          yolo11n.pb                 # TensorFlow GraphDef
-                          yolo11n.tflite             # TensorFlow Lite
-                          yolo11n_edgetpu.tflite     # TensorFlow Edge TPU
-                          yolo11n_paddle_model       # PaddlePaddle
-                          yolo11n.mnn                # MNN
-                          yolo11n_ncnn_model         # NCNN
-                          yolo11n_imx_model          # Sony IMX
-                          yolo11n_rknn_model         # Rockchip RKNN
+    $ yolo mode=val model=yolo26n.pt                 # PyTorch
+                          yolo26n.torchscript        # TorchScript
+                          yolo26n.onnx               # ONNX Runtime or OpenCV DNN with dnn=True
+                          yolo26n_openvino_model     # OpenVINO
+                          yolo26n.engine             # TensorRT
+                          yolo26n.mlpackage          # CoreML (macOS-only)
+                          yolo26n_saved_model        # TensorFlow SavedModel
+                          yolo26n.pb                 # TensorFlow GraphDef
+                          yolo26n.tflite             # TensorFlow Lite
+                          yolo26n_edgetpu.tflite     # TensorFlow Edge TPU
+                          yolo26n_paddle_model       # PaddlePaddle
+                          yolo26n.mnn                # MNN
+                          yolo26n_ncnn_model         # NCNN
+                          yolo26n_imx_model          # Sony IMX
+                          yolo26n_rknn_model         # Rockchip RKNN
 """
 
 import json

--- a/ultralytics/models/yolo/classify/predict.py
+++ b/ultralytics/models/yolo/classify/predict.py
@@ -26,7 +26,7 @@ class ClassificationPredictor(BasePredictor):
     Examples:
         >>> from ultralytics.utils import ASSETS
         >>> from ultralytics.models.yolo.classify import ClassificationPredictor
-        >>> args = dict(model="yolo11n-cls.pt", source=ASSETS)
+        >>> args = dict(model="yolo26n-cls.pt", source=ASSETS)
         >>> predictor = ClassificationPredictor(overrides=args)
         >>> predictor.predict_cli()
 

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -44,7 +44,7 @@ class ClassificationTrainer(BaseTrainer):
     Examples:
         Initialize and train a classification model
         >>> from ultralytics.models.yolo.classify import ClassificationTrainer
-        >>> args = dict(model="yolo11n-cls.pt", data="imagenet10", epochs=3)
+        >>> args = dict(model="yolo26n-cls.pt", data="imagenet10", epochs=3)
         >>> trainer = ClassificationTrainer(overrides=args)
         >>> trainer.train()
     """

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -45,7 +45,7 @@ class ClassificationValidator(BaseValidator):
 
     Examples:
         >>> from ultralytics.models.yolo.classify import ClassificationValidator
-        >>> args = dict(model="yolo11n-cls.pt", data="imagenet10")
+        >>> args = dict(model="yolo26n-cls.pt", data="imagenet10")
         >>> validator = ClassificationValidator(args=args)
         >>> validator()
 

--- a/ultralytics/models/yolo/detect/predict.py
+++ b/ultralytics/models/yolo/detect/predict.py
@@ -25,7 +25,7 @@ class DetectionPredictor(BasePredictor):
     Examples:
         >>> from ultralytics.utils import ASSETS
         >>> from ultralytics.models.yolo.detect import DetectionPredictor
-        >>> args = dict(model="yolo11n.pt", source=ASSETS)
+        >>> args = dict(model="yolo26n.pt", source=ASSETS)
         >>> predictor = DetectionPredictor(overrides=args)
         >>> predictor.predict_cli()
     """
@@ -46,7 +46,7 @@ class DetectionPredictor(BasePredictor):
             (list): List of Results objects containing the post-processed predictions.
 
         Examples:
-            >>> predictor = DetectionPredictor(overrides=dict(model="yolo11n.pt"))
+            >>> predictor = DetectionPredictor(overrides=dict(model="yolo26n.pt"))
             >>> results = predictor.predict("path/to/image.jpg")
             >>> processed_results = predictor.postprocess(preds, img, orig_imgs)
         """

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -47,7 +47,7 @@ class DetectionTrainer(BaseTrainer):
 
     Examples:
         >>> from ultralytics.models.yolo.detect import DetectionTrainer
-        >>> args = dict(model="yolo11n.pt", data="coco8.yaml", epochs=3)
+        >>> args = dict(model="yolo26n.pt", data="coco8.yaml", epochs=3)
         >>> trainer = DetectionTrainer(overrides=args)
         >>> trainer.train()
     """

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -37,7 +37,7 @@ class DetectionValidator(BaseValidator):
 
     Examples:
         >>> from ultralytics.models.yolo.detect import DetectionValidator
-        >>> args = dict(model="yolo11n.pt", data="coco8.yaml")
+        >>> args = dict(model="yolo26n.pt", data="coco8.yaml")
         >>> validator = DetectionValidator(args=args)
         >>> validator()
     """

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -41,7 +41,7 @@ class YOLO(Model):
 
     Examples:
         Load a pretrained YOLO11n detection model
-        >>> model = YOLO("yolo11n.pt")
+        >>> model = YOLO("yolo26n.pt")
 
         Load a pretrained YOLO11n segmentation model
         >>> model = YOLO("yolo11n-seg.pt")
@@ -50,14 +50,14 @@ class YOLO(Model):
         >>> model = YOLO("yolo11n.yaml")
     """
 
-    def __init__(self, model: str | Path = "yolo11n.pt", task: str | None = None, verbose: bool = False):
+    def __init__(self, model: str | Path = "yolo26n.pt", task: str | None = None, verbose: bool = False):
         """Initialize a YOLO model.
 
         This constructor initializes a YOLO model, automatically switching to specialized model types (YOLOWorld or
         YOLOE) based on the model filename.
 
         Args:
-            model (str | Path): Model name or path to model file, i.e. 'yolo11n.pt', 'yolo11n.yaml'.
+            model (str | Path): Model name or path to model file, i.e. 'yolo26n.pt', 'yolo11n.yaml'.
             task (str, optional): YOLO task specification, i.e. 'detect', 'segment', 'classify', 'pose', 'obb'. Defaults
                 to auto-detection based on model.
             verbose (bool): Display model info on load.

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -40,10 +40,10 @@ class YOLO(Model):
         task_map: Map tasks to their corresponding model, trainer, validator, and predictor classes.
 
     Examples:
-        Load a pretrained YOLO11n detection model
+        Load a pretrained YOLO26n detection model
         >>> model = YOLO("yolo26n.pt")
 
-        Load a pretrained YOLO11n segmentation model
+        Load a pretrained YOLO26n segmentation model
         >>> model = YOLO("yolo26n-seg.pt")
 
         Initialize from a YAML configuration

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -44,10 +44,10 @@ class YOLO(Model):
         >>> model = YOLO("yolo26n.pt")
 
         Load a pretrained YOLO11n segmentation model
-        >>> model = YOLO("yolo11n-seg.pt")
+        >>> model = YOLO("yolo26n-seg.pt")
 
         Initialize from a YAML configuration
-        >>> model = YOLO("yolo11n.yaml")
+        >>> model = YOLO("yolo26n.yaml")
     """
 
     def __init__(self, model: str | Path = "yolo26n.pt", task: str | None = None, verbose: bool = False):
@@ -57,7 +57,7 @@ class YOLO(Model):
         YOLOE) based on the model filename.
 
         Args:
-            model (str | Path): Model name or path to model file, i.e. 'yolo26n.pt', 'yolo11n.yaml'.
+            model (str | Path): Model name or path to model file, i.e. 'yolo26n.pt', 'yolo26n.yaml'.
             task (str, optional): YOLO task specification, i.e. 'detect', 'segment', 'classify', 'pose', 'obb'. Defaults
                 to auto-detection based on model.
             verbose (bool): Display model info on load.

--- a/ultralytics/models/yolo/obb/predict.py
+++ b/ultralytics/models/yolo/obb/predict.py
@@ -20,7 +20,7 @@ class OBBPredictor(DetectionPredictor):
     Examples:
         >>> from ultralytics.utils import ASSETS
         >>> from ultralytics.models.yolo.obb import OBBPredictor
-        >>> args = dict(model="yolo11n-obb.pt", source=ASSETS)
+        >>> args = dict(model="yolo26n-obb.pt", source=ASSETS)
         >>> predictor = OBBPredictor(overrides=args)
         >>> predictor.predict_cli()
     """

--- a/ultralytics/models/yolo/obb/train.py
+++ b/ultralytics/models/yolo/obb/train.py
@@ -27,7 +27,7 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
 
     Examples:
         >>> from ultralytics.models.yolo.obb import OBBTrainer
-        >>> args = dict(model="yolo11n-obb.pt", data="dota8.yaml", epochs=3)
+        >>> args = dict(model="yolo26n-obb.pt", data="dota8.yaml", epochs=3)
         >>> trainer = OBBTrainer(overrides=args)
         >>> trainer.train()
     """
@@ -63,7 +63,7 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
 
         Examples:
             >>> trainer = OBBTrainer()
-            >>> model = trainer.get_model(cfg="yolo11n-obb.yaml", weights="yolo11n-obb.pt")
+            >>> model = trainer.get_model(cfg="yolo26n-obb.yaml", weights="yolo26n-obb.pt")
         """
         model = OBBModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
         if weights:

--- a/ultralytics/models/yolo/obb/val.py
+++ b/ultralytics/models/yolo/obb/val.py
@@ -38,7 +38,7 @@ class OBBValidator(DetectionValidator):
 
     Examples:
         >>> from ultralytics.models.yolo.obb import OBBValidator
-        >>> args = dict(model="yolo11n-obb.pt", data="dota8.yaml")
+        >>> args = dict(model="yolo26n-obb.pt", data="dota8.yaml")
         >>> validator = OBBValidator(args=args)
         >>> validator(model=args["model"])
     """

--- a/ultralytics/models/yolo/pose/predict.py
+++ b/ultralytics/models/yolo/pose/predict.py
@@ -20,7 +20,7 @@ class PosePredictor(DetectionPredictor):
     Examples:
         >>> from ultralytics.utils import ASSETS
         >>> from ultralytics.models.yolo.pose import PosePredictor
-        >>> args = dict(model="yolo11n-pose.pt", source=ASSETS)
+        >>> args = dict(model="yolo26n-pose.pt", source=ASSETS)
         >>> predictor = PosePredictor(overrides=args)
         >>> predictor.predict_cli()
     """

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -32,7 +32,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     Examples:
         >>> from ultralytics.models.yolo.pose import PoseTrainer
-        >>> args = dict(model="yolo11n-pose.pt", data="coco8-pose.yaml", epochs=3)
+        >>> args = dict(model="yolo26n-pose.pt", data="coco8-pose.yaml", epochs=3)
         >>> trainer = PoseTrainer(overrides=args)
         >>> trainer.train()
     """

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -42,7 +42,7 @@ class PoseValidator(DetectionValidator):
 
     Examples:
         >>> from ultralytics.models.yolo.pose import PoseValidator
-        >>> args = dict(model="yolo11n-pose.pt", data="coco8-pose.yaml")
+        >>> args = dict(model="yolo26n-pose.pt", data="coco8-pose.yaml")
         >>> validator = PoseValidator(args=args)
         >>> validator()
 

--- a/ultralytics/models/yolo/segment/predict.py
+++ b/ultralytics/models/yolo/segment/predict.py
@@ -24,7 +24,7 @@ class SegmentationPredictor(DetectionPredictor):
     Examples:
         >>> from ultralytics.utils import ASSETS
         >>> from ultralytics.models.yolo.segment import SegmentationPredictor
-        >>> args = dict(model="yolo11n-seg.pt", source=ASSETS)
+        >>> args = dict(model="yolo26n-seg.pt", source=ASSETS)
         >>> predictor = SegmentationPredictor(overrides=args)
         >>> predictor.predict_cli()
     """
@@ -56,7 +56,7 @@ class SegmentationPredictor(DetectionPredictor):
                 Results object includes both bounding boxes and segmentation masks.
 
         Examples:
-            >>> predictor = SegmentationPredictor(overrides=dict(model="yolo11n-seg.pt"))
+            >>> predictor = SegmentationPredictor(overrides=dict(model="yolo26n-seg.pt"))
             >>> results = predictor.postprocess(preds, img, orig_img)
         """
         # Extract protos - tuple if PyTorch model or array if exported

--- a/ultralytics/models/yolo/segment/train.py
+++ b/ultralytics/models/yolo/segment/train.py
@@ -21,7 +21,7 @@ class SegmentationTrainer(yolo.detect.DetectionTrainer):
 
     Examples:
         >>> from ultralytics.models.yolo.segment import SegmentationTrainer
-        >>> args = dict(model="yolo11n-seg.pt", data="coco8-seg.yaml", epochs=3)
+        >>> args = dict(model="yolo26n-seg.pt", data="coco8-seg.yaml", epochs=3)
         >>> trainer = SegmentationTrainer(overrides=args)
         >>> trainer.train()
     """
@@ -52,8 +52,8 @@ class SegmentationTrainer(yolo.detect.DetectionTrainer):
 
         Examples:
             >>> trainer = SegmentationTrainer()
-            >>> model = trainer.get_model(cfg="yolo11n-seg.yaml")
-            >>> model = trainer.get_model(weights="yolo11n-seg.pt", verbose=False)
+            >>> model = trainer.get_model(cfg="yolo26n-seg.yaml")
+            >>> model = trainer.get_model(weights="yolo26n-seg.pt", verbose=False)
         """
         model = SegmentationModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
         if weights:

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -30,7 +30,7 @@ class SegmentationValidator(DetectionValidator):
 
     Examples:
         >>> from ultralytics.models.yolo.segment import SegmentationValidator
-        >>> args = dict(model="yolo11n-seg.pt", data="coco8-seg.yaml")
+        >>> args = dict(model="yolo26n-seg.pt", data="coco8-seg.yaml")
         >>> validator = SegmentationValidator(args=args)
         >>> validator()
     """

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -132,14 +132,14 @@ class AutoBackend(nn.Module):
         _model_type: Determine the model type from file path.
 
     Examples:
-        >>> model = AutoBackend(model="yolo11n.pt", device="cuda")
+        >>> model = AutoBackend(model="yolo26n.pt", device="cuda")
         >>> results = model(img)
     """
 
     @torch.no_grad()
     def __init__(
         self,
-        model: str | torch.nn.Module = "yolo11n.pt",
+        model: str | torch.nn.Module = "yolo26n.pt",
         device: torch.device = torch.device("cpu"),
         dnn: bool = False,
         data: str | Path | None = None,

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1444,7 +1444,7 @@ def torch_safe_load(weight, safe_only=False):
                     f"with https://github.com/ultralytics/yolov5.\nThis model is NOT forwards compatible with "
                     f"YOLOv8 at https://github.com/ultralytics/ultralytics."
                     f"\nRecommend fixes are to train a new model using the latest 'ultralytics' package or to "
-                    f"run a command with an official Ultralytics model, i.e. 'yolo predict model=yolo11n.pt'"
+                    f"run a command with an official Ultralytics model, i.e. 'yolo predict model=yolo26n.pt'"
                 )
             ) from e
         elif e.name == "numpy._core":
@@ -1457,7 +1457,7 @@ def torch_safe_load(weight, safe_only=False):
             f"{weight} appears to require '{e.name}', which is not in Ultralytics requirements."
             f"\nAutoInstall will run now for '{e.name}' but this feature will be removed in the future."
             f"\nRecommend fixes are to train a new model using the latest 'ultralytics' package or to "
-            f"run a command with an official Ultralytics model, i.e. 'yolo predict model=yolo11n.pt'"
+            f"run a command with an official Ultralytics model, i.e. 'yolo predict model=yolo26n.pt'"
         )
         check_requirements(e.name)  # install missing module
         ckpt = torch_load(file, map_location="cpu")

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -361,11 +361,11 @@ class DetectionModel(BaseModel):
 
     Examples:
         Initialize a detection model
-        >>> model = DetectionModel("yolo11n.yaml", ch=3, nc=80)
+        >>> model = DetectionModel("yolo26n.yaml", ch=3, nc=80)
         >>> results = model.predict(image_tensor)
     """
 
-    def __init__(self, cfg="yolo11n.yaml", ch=3, nc=None, verbose=True):
+    def __init__(self, cfg="yolo26n.yaml", ch=3, nc=None, verbose=True):
         """Initialize the YOLO detection model with the given config and parameters.
 
         Args:
@@ -538,11 +538,11 @@ class SegmentationModel(DetectionModel):
 
     Examples:
         Initialize a segmentation model
-        >>> model = SegmentationModel("yolo11n-seg.yaml", ch=3, nc=80)
+        >>> model = SegmentationModel("yolo26n-seg.yaml", ch=3, nc=80)
         >>> results = model.predict(image_tensor)
     """
 
-    def __init__(self, cfg="yolo11n-seg.yaml", ch=3, nc=None, verbose=True):
+    def __init__(self, cfg="yolo26n-seg.yaml", ch=3, nc=None, verbose=True):
         """Initialize Ultralytics YOLO segmentation model with given config and parameters.
 
         Args:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -506,11 +506,11 @@ class OBBModel(DetectionModel):
 
     Examples:
         Initialize an OBB model
-        >>> model = OBBModel("yolo11n-obb.yaml", ch=3, nc=80)
+        >>> model = OBBModel("yolo26n-obb.yaml", ch=3, nc=80)
         >>> results = model.predict(image_tensor)
     """
 
-    def __init__(self, cfg="yolo11n-obb.yaml", ch=3, nc=None, verbose=True):
+    def __init__(self, cfg="yolo26n-obb.yaml", ch=3, nc=None, verbose=True):
         """Initialize YOLO OBB model with given config and parameters.
 
         Args:
@@ -573,11 +573,11 @@ class PoseModel(DetectionModel):
 
     Examples:
         Initialize a pose model
-        >>> model = PoseModel("yolo11n-pose.yaml", ch=3, nc=1, data_kpt_shape=(17, 3))
+        >>> model = PoseModel("yolo26n-pose.yaml", ch=3, nc=1, data_kpt_shape=(17, 3))
         >>> results = model.predict(image_tensor)
     """
 
-    def __init__(self, cfg="yolo11n-pose.yaml", ch=3, nc=None, data_kpt_shape=(None, None), verbose=True):
+    def __init__(self, cfg="yolo26n-pose.yaml", ch=3, nc=None, data_kpt_shape=(None, None), verbose=True):
         """Initialize Ultralytics YOLO Pose model.
 
         Args:
@@ -619,11 +619,11 @@ class ClassificationModel(BaseModel):
 
     Examples:
         Initialize a classification model
-        >>> model = ClassificationModel("yolo11n-cls.yaml", ch=3, nc=1000)
+        >>> model = ClassificationModel("yolo26n-cls.yaml", ch=3, nc=1000)
         >>> results = model.predict(image_tensor)
     """
 
-    def __init__(self, cfg="yolo11n-cls.yaml", ch=3, nc=None, verbose=True):
+    def __init__(self, cfg="yolo26n-cls.yaml", ch=3, nc=None, verbose=True):
         """Initialize ClassificationModel with YAML, channels, number of classes, verbose flag.
 
         Args:

--- a/ultralytics/solutions/ai_gym.py
+++ b/ultralytics/solutions/ai_gym.py
@@ -22,7 +22,7 @@ class AIGym(BaseSolution):
         process: Process a frame to detect poses, calculate angles, and count repetitions.
 
     Examples:
-        >>> gym = AIGym(model="yolo11n-pose.pt")
+        >>> gym = AIGym(model="yolo26n-pose.pt")
         >>> image = cv2.imread("gym_scene.jpg")
         >>> results = gym.process(image)
         >>> processed_image = results.plot_im
@@ -35,9 +35,9 @@ class AIGym(BaseSolution):
 
         Args:
             **kwargs (Any): Keyword arguments passed to the parent class constructor including:
-                - model (str): Model name or path, defaults to "yolo11n-pose.pt".
+                - model (str): Model name or path, defaults to "yolo26n-pose.pt".
         """
-        kwargs["model"] = kwargs.get("model", "yolo11n-pose.pt")
+        kwargs["model"] = kwargs.get("model", "yolo26n-pose.pt")
         super().__init__(**kwargs)
         self.states = defaultdict(lambda: {"angle": 0, "count": 0, "stage": "-"})  # Dict for count, angle and stage
 

--- a/ultralytics/solutions/config.py
+++ b/ultralytics/solutions/config.py
@@ -56,7 +56,7 @@ class SolutionConfig:
 
     Examples:
         >>> from ultralytics.solutions.config import SolutionConfig
-        >>> cfg = SolutionConfig(model="yolo11n.pt", region=[(0, 0), (100, 0), (100, 100), (0, 100)])
+        >>> cfg = SolutionConfig(model="yolo26n.pt", region=[(0, 0), (100, 0), (100, 100), (0, 100)])
         >>> cfg.update(show=False, conf=0.3)
         >>> print(cfg.model)
     """

--- a/ultralytics/solutions/heatmap.py
+++ b/ultralytics/solutions/heatmap.py
@@ -29,7 +29,7 @@ class Heatmap(ObjectCounter):
 
     Examples:
         >>> from ultralytics.solutions import Heatmap
-        >>> heatmap = Heatmap(model="yolo11n.pt", colormap=cv2.COLORMAP_JET)
+        >>> heatmap = Heatmap(model="yolo26n.pt", colormap=cv2.COLORMAP_JET)
         >>> frame = cv2.imread("frame.jpg")
         >>> processed_frame = heatmap.process(frame)
     """

--- a/ultralytics/solutions/instance_segmentation.py
+++ b/ultralytics/solutions/instance_segmentation.py
@@ -39,9 +39,9 @@ class InstanceSegmentation(BaseSolution):
 
         Args:
             **kwargs (Any): Keyword arguments passed to the BaseSolution parent class including:
-                - model (str): Model name or path, defaults to "yolo11n-seg.pt".
+                - model (str): Model name or path, defaults to "yolo26n-seg.pt".
         """
-        kwargs["model"] = kwargs.get("model", "yolo11n-seg.pt")
+        kwargs["model"] = kwargs.get("model", "yolo26n-seg.pt")
         super().__init__(**kwargs)
 
         self.show_conf = self.CFG.get("show_conf", True)

--- a/ultralytics/solutions/parking_management.py
+++ b/ultralytics/solutions/parking_management.py
@@ -195,7 +195,7 @@ class ParkingManagement(BaseSolution):
 
     Examples:
         >>> from ultralytics.solutions import ParkingManagement
-        >>> parking_manager = ParkingManagement(model="yolo11n.pt", json_file="parking_regions.json")
+        >>> parking_manager = ParkingManagement(model="yolo26n.pt", json_file="parking_regions.json")
         >>> print(f"Occupied spaces: {parking_manager.pr_info['Occupancy']}")
         >>> print(f"Available spaces: {parking_manager.pr_info['Available']}")
     """

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -64,7 +64,7 @@ class BaseSolution:
         process: Process method to be implemented by each Solution subclass.
 
     Examples:
-        >>> solution = BaseSolution(model="yolo11n.pt", region=[(0, 0), (100, 0), (100, 100), (0, 100)])
+        >>> solution = BaseSolution(model="yolo26n.pt", region=[(0, 0), (100, 0), (100, 100), (0, 100)])
         >>> solution.initialize_region()
         >>> image = cv2.imread("image.jpg")
         >>> solution.extract_tracks(image)
@@ -106,7 +106,7 @@ class BaseSolution:
 
         # Load Model and store additional information (classes, show_conf, show_label)
         if self.CFG["model"] is None:
-            self.CFG["model"] = "yolo11n.pt"
+            self.CFG["model"] = "yolo26n.pt"
         self.model = YOLO(self.CFG["model"])
         self.names = self.model.names
         self.classes = self.CFG["classes"]

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -50,7 +50,7 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
             and isinstance(predictor.model.model.model[-1], Detect)
             and not predictor.model.model.model[-1].end2end
         ):
-            cfg.model = "yolo11n-cls.pt"
+            cfg.model = "yolo26n-cls.pt"
         else:
             # Register hook to extract input of Detect layer
             def pre_hook(module, input):

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -110,7 +110,7 @@ HELP_MSG = """
             yolo detect val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640
 
         - Export a YOLO11n classification model to ONNX format at image size 224 by 128 (no TASK required)
-            yolo export model=yolo11n-cls.pt format=onnx imgsz=224,128
+            yolo export model=yolo26n-cls.pt format=onnx imgsz=224,128
 
         - Run special commands:
             yolo help

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -104,7 +104,7 @@ HELP_MSG = """
             yolo detect train data=coco8.yaml model=yolo26n.pt epochs=10 lr0=0.01
 
         - Predict a YouTube video using a pretrained segmentation model at image size 320:
-            yolo segment predict model=yolo11n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
+            yolo segment predict model=yolo26n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
 
         - Val a pretrained detection model at batch-size 1 and image size 640:
             yolo detect val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -80,8 +80,8 @@ HELP_MSG = """
         from ultralytics import YOLO
 
         # Load a model
-        model = YOLO("yolo11n.yaml")  # build a new model from scratch
-        model = YOLO("yolo11n.pt")  # load a pretrained model (recommended for training)
+        model = YOLO("yolo26n.yaml")  # build a new model from scratch
+        model = YOLO("yolo26n.pt")  # load a pretrained model (recommended for training)
 
         # Use the model
         results = model.train(data="coco8.yaml", epochs=3)  # train the model
@@ -101,13 +101,13 @@ HELP_MSG = """
                         See all ARGS at https://docs.ultralytics.com/usage/cfg or with "yolo cfg"
 
         - Train a detection model for 10 epochs with an initial learning_rate of 0.01
-            yolo detect train data=coco8.yaml model=yolo11n.pt epochs=10 lr0=0.01
+            yolo detect train data=coco8.yaml model=yolo26n.pt epochs=10 lr0=0.01
 
         - Predict a YouTube video using a pretrained segmentation model at image size 320:
             yolo segment predict model=yolo11n-seg.pt source='https://youtu.be/LNwODJXcvt4' imgsz=320
 
         - Val a pretrained detection model at batch-size 1 and image size 640:
-            yolo detect val model=yolo11n.pt data=coco8.yaml batch=1 imgsz=640
+            yolo detect val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640
 
         - Export a YOLO11n classification model to ONNX format at image size 224 by 128 (no TASK required)
             yolo export model=yolo11n-cls.pt format=onnx imgsz=224,128
@@ -161,7 +161,7 @@ class DataExportMixin:
         tojson: Deprecated alias for `to_json()`.
 
     Examples:
-        >>> model = YOLO("yolo11n.pt")
+        >>> model = YOLO("yolo26n.pt")
         >>> results = model("image.jpg")
         >>> df = results.to_df()
         >>> print(df)

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -109,7 +109,7 @@ HELP_MSG = """
         - Val a pretrained detection model at batch-size 1 and image size 640:
             yolo detect val model=yolo26n.pt data=coco8.yaml batch=1 imgsz=640
 
-        - Export a YOLO11n classification model to ONNX format at image size 224 by 128 (no TASK required)
+        - Export a YOLO26n classification model to ONNX format at image size 224 by 128 (no TASK required)
             yolo export model=yolo26n-cls.pt format=onnx imgsz=224,128
 
         - Run special commands:

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -4,28 +4,28 @@ Benchmark YOLO model formats for speed and accuracy.
 
 Usage:
     from ultralytics.utils.benchmarks import ProfileModels, benchmark
-    ProfileModels(['yolo11n.yaml', 'yolov8s.yaml']).run()
-    benchmark(model='yolo11n.pt', imgsz=160)
+    ProfileModels(['yolo26n.yaml', 'yolov8s.yaml']).run()
+    benchmark(model='yolo26n.pt', imgsz=160)
 
 Format                  | `format=argument`         | Model
 ---                     | ---                       | ---
-PyTorch                 | -                         | yolo11n.pt
-TorchScript             | `torchscript`             | yolo11n.torchscript
-ONNX                    | `onnx`                    | yolo11n.onnx
-OpenVINO                | `openvino`                | yolo11n_openvino_model/
-TensorRT                | `engine`                  | yolo11n.engine
-CoreML                  | `coreml`                  | yolo11n.mlpackage
-TensorFlow SavedModel   | `saved_model`             | yolo11n_saved_model/
-TensorFlow GraphDef     | `pb`                      | yolo11n.pb
-TensorFlow Lite         | `tflite`                  | yolo11n.tflite
-TensorFlow Edge TPU     | `edgetpu`                 | yolo11n_edgetpu.tflite
-TensorFlow.js           | `tfjs`                    | yolo11n_web_model/
-PaddlePaddle            | `paddle`                  | yolo11n_paddle_model/
-MNN                     | `mnn`                     | yolo11n.mnn
-NCNN                    | `ncnn`                    | yolo11n_ncnn_model/
-IMX                     | `imx`                     | yolo11n_imx_model/
-RKNN                    | `rknn`                    | yolo11n_rknn_model/
-ExecuTorch              | `executorch`              | yolo11n_executorch_model/
+PyTorch                 | -                         | yolo26n.pt
+TorchScript             | `torchscript`             | yolo26n.torchscript
+ONNX                    | `onnx`                    | yolo26n.onnx
+OpenVINO                | `openvino`                | yolo26n_openvino_model/
+TensorRT                | `engine`                  | yolo26n.engine
+CoreML                  | `coreml`                  | yolo26n.mlpackage
+TensorFlow SavedModel   | `saved_model`             | yolo26n_saved_model/
+TensorFlow GraphDef     | `pb`                      | yolo26n.pb
+TensorFlow Lite         | `tflite`                  | yolo26n.tflite
+TensorFlow Edge TPU     | `edgetpu`                 | yolo26n_edgetpu.tflite
+TensorFlow.js           | `tfjs`                    | yolo26n_web_model/
+PaddlePaddle            | `paddle`                  | yolo26n_paddle_model/
+MNN                     | `mnn`                     | yolo26n.mnn
+NCNN                    | `ncnn`                    | yolo26n_ncnn_model/
+IMX                     | `imx`                     | yolo26n_imx_model/
+RKNN                    | `rknn`                    | yolo26n_rknn_model/
+ExecuTorch              | `executorch`              | yolo26n_executorch_model/
 """
 
 from __future__ import annotations
@@ -52,7 +52,7 @@ from ultralytics.utils.torch_utils import get_cpu_info, select_device
 
 
 def benchmark(
-    model=WEIGHTS_DIR / "yolo11n.pt",
+    model=WEIGHTS_DIR / "yolo26n.pt",
     data=None,
     imgsz=160,
     half=False,
@@ -84,7 +84,7 @@ def benchmark(
     Examples:
         Benchmark a YOLO model with default settings:
         >>> from ultralytics.utils.benchmarks import benchmark
-        >>> benchmark(model="yolo11n.pt", imgsz=640)
+        >>> benchmark(model="yolo26n.pt", imgsz=640)
     """
     imgsz = check_imgsz(imgsz)
     assert imgsz[0] == imgsz[1] if isinstance(imgsz, list) else True, "benchmark() only supports square imgsz."
@@ -396,7 +396,7 @@ class ProfileModels:
     Examples:
         Profile models and print results
         >>> from ultralytics.utils.benchmarks import ProfileModels
-        >>> profiler = ProfileModels(["yolo11n.yaml", "yolov8s.yaml"], imgsz=640)
+        >>> profiler = ProfileModels(["yolo26n.yaml", "yolov8s.yaml"], imgsz=640)
         >>> profiler.run()
     """
 
@@ -444,7 +444,7 @@ class ProfileModels:
         Examples:
             Profile models and print results
             >>> from ultralytics.utils.benchmarks import ProfileModels
-            >>> profiler = ProfileModels(["yolo11n.yaml", "yolov8s.yaml"])
+            >>> profiler = ProfileModels(["yolo26n.yaml", "yolo11s.yaml"])
             >>> results = profiler.run()
         """
         files = self.get_files()

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -530,7 +530,7 @@ def check_torchvision():
             )
 
 
-def check_suffix(file="yolo11n.pt", suffix=".pt", msg=""):
+def check_suffix(file="yolo26n.pt", suffix=".pt", msg=""):
     """Check file(s) for acceptable suffix.
 
     Args:
@@ -584,7 +584,7 @@ def check_model_file_from_stem(model="yolo11n"):
     """
     path = Path(model)
     if not path.suffix and path.stem in downloads.GITHUB_ASSETS_STEMS:
-        return path.with_suffix(".pt")  # add suffix, i.e. yolo11n -> yolo11n.pt
+        return path.with_suffix(".pt")  # add suffix, i.e. yolo26n -> yolo26n.pt
     return model
 
 
@@ -812,7 +812,7 @@ def check_amp(model):
     Examples:
         >>> from ultralytics import YOLO
         >>> from ultralytics.utils.checks import check_amp
-        >>> model = YOLO("yolo11n.pt").model.cuda()
+        >>> model = YOLO("yolo26n.pt").model.cuda()
         >>> check_amp(model)
     """
     from ultralytics.utils.torch_utils import autocast
@@ -851,7 +851,7 @@ def check_amp(model):
     try:
         from ultralytics import YOLO
 
-        assert amp_allclose(YOLO("yolo11n.pt"), im)
+        assert amp_allclose(YOLO("yolo26n.pt"), im)
         LOGGER.info(f"{prefix}checks passed ✅")
     except ConnectionError:
         LOGGER.warning(f"{prefix}checks skipped. Offline and unable to download YOLO11n for AMP checks. {warning_msg}")

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -854,11 +854,11 @@ def check_amp(model):
         assert amp_allclose(YOLO("yolo26n.pt"), im)
         LOGGER.info(f"{prefix}checks passed ✅")
     except ConnectionError:
-        LOGGER.warning(f"{prefix}checks skipped. Offline and unable to download YOLO11n for AMP checks. {warning_msg}")
+        LOGGER.warning(f"{prefix}checks skipped. Offline and unable to download YOLO26n for AMP checks. {warning_msg}")
     except (AttributeError, ModuleNotFoundError):
         LOGGER.warning(
             f"{prefix}checks skipped. "
-            f"Unable to load YOLO11n for AMP checks due to possible Ultralytics package modifications. {warning_msg}"
+            f"Unable to load YOLO26n for AMP checks due to possible Ultralytics package modifications. {warning_msg}"
         )
     except AssertionError:
         LOGGER.error(

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -420,7 +420,7 @@ def get_github_assets(
         LOGGER.warning(f"GitHub assets check failure for {url}: {r.status_code} {r.reason}")
         return "", []
     data = r.json()
-    return data["tag_name"], [x["name"] for x in data["assets"]]  # tag, assets i.e. ['yolo11n.pt', 'yolov8s.pt', ...]
+    return data["tag_name"], [x["name"] for x in data["assets"]]  # tag, assets i.e. ['yolo26n.pt', 'yolo11s.pt', ...]
 
 
 def attempt_download_asset(
@@ -441,7 +441,7 @@ def attempt_download_asset(
         (str): The path to the downloaded file.
 
     Examples:
-        >>> file_path = attempt_download_asset("yolo11n.pt", repo="ultralytics/assets", release="latest")
+        >>> file_path = attempt_download_asset("yolo26n.pt", repo="ultralytics/assets", release="latest")
     """
     from ultralytics.utils import SETTINGS  # scoped for circular import
 

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -224,7 +224,7 @@ def torch2imx(
 
     Examples:
         >>> from ultralytics import YOLO
-        >>> model = YOLO("yolo26n.pt")
+        >>> model = YOLO("yolo11n.pt")
         >>> path, _ = export_imx(model, "model.imx", conf=0.25, iou=0.7, max_det=300)
 
     Notes:

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -224,7 +224,7 @@ def torch2imx(
 
     Examples:
         >>> from ultralytics import YOLO
-        >>> model = YOLO("yolo11n.pt")
+        >>> model = YOLO("yolo26n.pt")
         >>> path, _ = export_imx(model, "model.imx", conf=0.25, iou=0.7, max_det=300)
 
     Notes:

--- a/ultralytics/utils/files.py
+++ b/ultralytics/utils/files.py
@@ -180,7 +180,7 @@ def get_latest_run(search_dir: str = ".") -> str:
     return max(last_list, key=os.path.getctime) if last_list else ""
 
 
-def update_models(model_names: tuple = ("yolo11n.pt",), source_dir: Path = Path("."), update_names: bool = False):
+def update_models(model_names: tuple = ("yolo26n.pt",), source_dir: Path = Path("."), update_names: bool = False):
     """Update and re-save specified YOLO models in an 'updated_models' subdirectory.
 
     Args:
@@ -191,7 +191,7 @@ def update_models(model_names: tuple = ("yolo11n.pt",), source_dir: Path = Path(
     Examples:
         Update specified YOLO models and save them in 'updated_models' subdirectory:
         >>> from ultralytics.utils.files import update_models
-        >>> model_names = ("yolo11n.pt", "yolov8s.pt")
+        >>> model_names = ("yolo26n.pt", "yolo11s.pt")
         >>> update_models(model_names, source_dir=Path("/models"), update_names=True)
     """
     from ultralytics import YOLO

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1007,7 +1007,7 @@ class v8OBBLoss(v8DetectionLoss):
             raise TypeError(
                 "ERROR ❌ OBB dataset incorrectly formatted or not a OBB dataset.\n"
                 "This error can occur when incorrectly training a 'OBB' model on a 'detect' dataset, "
-                "i.e. 'yolo train model=yolo11n-obb.pt data=dota8.yaml'.\nVerify your dataset is a "
+                "i.e. 'yolo train model=yolo26n-obb.pt data=dota8.yaml'.\nVerify your dataset is a "
                 "correctly formatted 'OBB' dataset using 'data=dota8.yaml' "
                 "as an example.\nSee https://docs.ultralytics.com/datasets/obb/ for help."
             ) from e

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -29,9 +29,9 @@ def run_ray_tune(
 
     Examples:
         >>> from ultralytics import YOLO
-        >>> model = YOLO("yolo26n.pt")  # Load a YOLO11n model
+        >>> model = YOLO("yolo26n.pt")  # Load a YOLO26n model
 
-        Start tuning hyperparameters for YOLO11n training on the COCO8 dataset
+        Start tuning hyperparameters for YOLO26n training on the COCO8 dataset
         >>> result_grid = model.tune(data="coco8.yaml", use_ray=True)
     """
     LOGGER.info("💡 Learn about RayTune at https://docs.ultralytics.com/integrations/ray-tune")

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -29,7 +29,7 @@ def run_ray_tune(
 
     Examples:
         >>> from ultralytics import YOLO
-        >>> model = YOLO("yolo11n.pt")  # Load a YOLO11n model
+        >>> model = YOLO("yolo26n.pt")  # Load a YOLO11n model
 
         Start tuning hyperparameters for YOLO11n training on the COCO8 dataset
         >>> result_grid = model.tune(data="coco8.yaml", use_ray=True)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates Ultralytics docs and library defaults to use **YOLO26** model names (e.g., `yolo26n.pt`) instead of **YOLO11** across examples, CLI help, and default parameters 🚀

### 📊 Key Changes
- Swapped most documentation examples from `yolo11*.pt/.yaml` to `yolo26*.pt/.yaml` (training, prediction, tracking, export, Platform, OpenVINO, SAM auto-annotation) 📚
- Changed **default model arguments** in core code to YOLO26, including:
  - `YOLO()` / `Model()` default now `"yolo26n.pt"` 🧠
  - CLI entrypoint fallback model now `"yolo26n.pt"` 🖥️
  - `auto_annotate()` default detector now `"yolo26x.pt"` ✍️
  - Solutions defaults (Heatmap, AI Gym, instance segmentation, base solution) now use YOLO26 variants 🧩
  - Benchmark utilities default now reference `yolo26n.pt` / `yolo26n.yaml` 📈
- Updated many usage/help strings and error messages to reference YOLO26 examples (predict/train/val/export) 🧾
- Adjusted an export docs macro note: **IMX format support note no longer mentions YOLO26n** (now only YOLOv8n and YOLO11n) ⚠️

### 🎯 Purpose & Impact
- Makes **YOLO26 the “default” and most visible** model family throughout Ultralytics docs and APIs, guiding new users toward the latest recommended weights 🆕✅
- Users who rely on “no model specified” behavior (e.g., `YOLO()` or some CLI flows) may now **download/run YOLO26n instead of YOLO11n**, potentially changing speed/accuracy characteristics and results 🔄
- Reduces confusion by aligning examples across docs, CLI help, Solutions, and integrations around a single current model naming convention 🧭
- Highlights a potential deployment constraint: the IMX export/support note suggests **YOLO26 may not be supported for IMX** (per the updated documentation note) 🧷