### PR TITLE
fix(pose26): enable kpts_sigma generation during validation for RLE loss

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -725,7 +725,7 @@ class Pose26(Pose):
             bs = x[0].shape[0]  # batch size
             features = [pose_head[i](x[i]) for i in range(self.nl)]
             preds["kpts"] = torch.cat([kpts_head[i](features[i]).view(bs, self.nk, -1) for i in range(self.nl)], 2)
-            if self.training:
+            if self.training or not self.export:  # kpts_sigma required for RLE loss in validation
                 preds["kpts_sigma"] = torch.cat(
                     [kpts_sigma_head[i](features[i]).view(bs, self.nk_sigma, -1) for i in range(self.nl)], 2
                 )


### PR DESCRIPTION
## Description
This PR fixes a bug where `RLE Loss` calculation fails or is incorrect during validation mode in `Pose26` models.

## Issue
Currently, in `ultralytics/nn/modules/head.py`, the `kpts_sigma` (required for RLE loss) is only generated when `self.training` is `True`.
```python
if self.training:  # Current logic
    preds["kpts_sigma"] = ...
```
This causes the loss calculation to lack necessary sigma values during validation (when `self.training` is `False`).

## Fix
Updated the condition to generate `kpts_sigma` during both training and validation (non-export) modes:
```python
if self.training or not self.export:  # Fixed logic
    preds["kpts_sigma"] = ...
```

## Checklist
- [x] Changes validated on local machine (YOLO26 validation now computes RLE loss correctly).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes YOLO26 pose validation by generating `kpts_sigma` when needed (non-export), ensuring RLE loss has required inputs ✅

### 📊 Key Changes
- Updated `ultralytics/nn/modules/head.py` to compute and include `preds["kpts_sigma"]` not only during training, but also during validation when `not self.export`.
- Added an inline comment clarifying that `kpts_sigma` is required for RLE loss during validation.

### 🎯 Purpose & Impact
- Prevents validation-time failures or incorrect behavior when using RLE loss that depends on `kpts_sigma`.
- Keeps export behavior intact by avoiding unnecessary `kpts_sigma` generation in export mode.
- Improves consistency between training and validation outputs for pose models using sigma-based losses.
