### PR TITLE
Fix `YOLOv8/YOLO11` IMX export

### DIFF
--- a/docs/en/integrations/sony-imx500.md
+++ b/docs/en/integrations/sony-imx500.md
@@ -1,16 +1,16 @@
 ---
 comments: true
-description: Learn to export Ultralytics YOLO26 models to Sony's IMX500 format for efficient edge AI deployment on Raspberry Pi AI Camera with on-chip processing.
+description: Learn to export Ultralytics YOLO11 models to Sony's IMX500 format for efficient edge AI deployment on Raspberry Pi AI Camera with on-chip processing.
 keywords: Sony, IMX500, IMX 500, Atrios, MCT, model export, quantization, pruning, deep learning optimization, Raspberry Pi AI Camera, edge AI, PyTorch, IMX
 ---
 
-# Sony IMX500 Export for Ultralytics YOLO26
+# Sony IMX500 Export for Ultralytics YOLO11
 
-This guide covers exporting and deploying Ultralytics YOLO26 models to Raspberry Pi AI Cameras that feature the Sony IMX500 sensor.
+This guide covers exporting and deploying Ultralytics YOLO11 models to Raspberry Pi AI Cameras that feature the Sony IMX500 sensor.
 
 Deploying computer vision models on devices with limited computational power, such as [Raspberry Pi AI Camera](https://www.raspberrypi.com/products/ai-camera/), can be tricky. Using a model format optimized for faster performance makes a huge difference.
 
-The IMX500 model format is designed to use minimal power while delivering fast performance for neural networks. It allows you to optimize your [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics) models for high-speed and low-power inferencing. In this guide, we'll walk you through exporting and deploying your models to the IMX500 format while making it easier for your models to perform well on the [Raspberry Pi AI Camera](https://www.raspberrypi.com/products/ai-camera/).
+The IMX500 model format is designed to use minimal power while delivering fast performance for neural networks. It allows you to optimize your [Ultralytics YOLO11](https://github.com/ultralytics/ultralytics) models for high-speed and low-power inferencing. In this guide, we'll walk you through exporting and deploying your models to the IMX500 format while making it easier for your models to perform well on the [Raspberry Pi AI Camera](https://www.raspberrypi.com/products/ai-camera/).
 
 <p align="center">
   <img width="100%" src="https://github.com/ultralytics/docs/releases/download/0/imx500-ai-camera.avif" alt="Raspberry Pi AI Camera">
@@ -21,7 +21,7 @@ The IMX500 model format is designed to use minimal power while delivering fast p
 Sony's [IMX500 Intelligent Vision Sensor](https://www.aitrios.sony-semicon.com/edge-ai-devices/raspberry-pi-ai-camera) is a game-changing piece of hardware in edge AI processing. It's the world's first intelligent vision sensor with on-chip AI capabilities. This sensor helps overcome many challenges in edge AI, including data processing bottlenecks, privacy concerns, and performance limitations.
 While other sensors merely pass along images and frames, the IMX500 tells a whole story. It processes data directly on the sensor, allowing devices to generate insights in real-time.
 
-## Sony's IMX500 Export for YOLO26 Models
+## Sony's IMX500 Export for YOLO11 Models
 
 The IMX500 is designed to transform how devices handle data directly on the sensor, without needing to send it off to the cloud for processing.
 
@@ -33,7 +33,7 @@ The IMX500 works with quantized models. Quantization makes models smaller and fa
 - **Addresses Privacy Concerns:** By processing data on the device, the IMX500 addresses privacy concerns, ideal for human-centric applications like person counting and occupancy tracking.
 - **Real-time Processing:** Fast, on-sensor processing supports real-time decisions, perfect for edge AI applications such as autonomous systems.
 
-**Before You Begin:** For best results, ensure your YOLO26 model is well-prepared for export by following our [Model Training Guide](https://docs.ultralytics.com/modes/train/), [Data Preparation Guide](https://docs.ultralytics.com/datasets/), and [Hyperparameter Tuning Guide](https://docs.ultralytics.com/guides/hyperparameter-tuning/).
+**Before You Begin:** For best results, ensure your YOLO11 model is well-prepared for export by following our [Model Training Guide](https://docs.ultralytics.com/modes/train/), [Data Preparation Guide](https://docs.ultralytics.com/datasets/), and [Hyperparameter Tuning Guide](https://docs.ultralytics.com/guides/hyperparameter-tuning/).
 
 ## Supported Tasks
 
@@ -46,7 +46,7 @@ Currently, you can only export models that include the following tasks to IMX500
 
 ## Usage Examples
 
-Export an Ultralytics YOLO26 model to IMX500 format and run inference with the exported model.
+Export an Ultralytics YOLO11 model to IMX500 format and run inference with the exported model.
 
 !!! note
 
@@ -59,14 +59,14 @@ Export an Ultralytics YOLO26 model to IMX500 format and run inference with the e
          ```python
          from ultralytics import YOLO
 
-         # Load a YOLO26n PyTorch model
-         model = YOLO("yolo26n.pt")
+         # Load a YOLO11n PyTorch model
+         model = YOLO("yolo11n.pt")
 
          # Export the model
          model.export(format="imx", data="coco8.yaml")  # exports with PTQ quantization by default
 
          # Load the exported model
-         imx_model = YOLO("yolo26n_imx_model")
+         imx_model = YOLO("yolo11n_imx_model")
 
          # Run inference
          results = imx_model("https://ultralytics.com/images/bus.jpg")
@@ -75,11 +75,11 @@ Export an Ultralytics YOLO26 model to IMX500 format and run inference with the e
     === "CLI"
 
          ```bash
-         # Export a YOLO26n PyTorch model to imx format with Post-Training Quantization (PTQ)
-         yolo export model=yolo26n.pt format=imx data=coco8.yaml
+         # Export a YOLO11n PyTorch model to imx format with Post-Training Quantization (PTQ)
+         yolo export model=yolo11n.pt format=imx data=coco8.yaml
 
          # Run inference with the exported model
-         yolo predict model=yolo26n_imx_model source='https://ultralytics.com/images/bus.jpg'
+         yolo predict model=yolo11n_imx_model source='https://ultralytics.com/images/bus.jpg'
          ```
 
 !!! example "Pose Estimation"
@@ -89,14 +89,14 @@ Export an Ultralytics YOLO26 model to IMX500 format and run inference with the e
          ```python
          from ultralytics import YOLO
 
-         # Load a YOLO26n-pose PyTorch model
-         model = YOLO("yolo26n-pose.pt")
+         # Load a YOLO11n-pose PyTorch model
+         model = YOLO("yolo11n-pose.pt")
 
          # Export the model
          model.export(format="imx", data="coco8-pose.yaml")  # exports with PTQ quantization by default
 
          # Load the exported model
-         imx_model = YOLO("yolo26n-pose_imx_model")
+         imx_model = YOLO("yolo11n-pose_imx_model")
 
          # Run inference
          results = imx_model("https://ultralytics.com/images/bus.jpg")
@@ -105,11 +105,11 @@ Export an Ultralytics YOLO26 model to IMX500 format and run inference with the e
     === "CLI"
 
          ```bash
-         # Export a YOLO26n-pose PyTorch model to imx format with Post-Training Quantization (PTQ)
-         yolo export model=yolo26n-pose.pt format=imx data=coco8-pose.yaml
+         # Export a YOLO11n-pose PyTorch model to imx format with Post-Training Quantization (PTQ)
+         yolo export model=yolo11n-pose.pt format=imx data=coco8-pose.yaml
 
          # Run inference with the exported model
-         yolo predict model=yolo26n-pose_imx_model source='https://ultralytics.com/images/bus.jpg'
+         yolo predict model=yolo11n-pose_imx_model source='https://ultralytics.com/images/bus.jpg'
          ```
 
 !!! example "Classification"
@@ -119,14 +119,14 @@ Export an Ultralytics YOLO26 model to IMX500 format and run inference with the e
          ```python
          from ultralytics import YOLO
 
-         # Load a YOLO26n-cls PyTorch model
-         model = YOLO("yolo26n-cls.pt")
+         # Load a YOLO11n-cls PyTorch model
+         model = YOLO("yolo11n-cls.pt")
 
          # Export the model
          model.export(format="imx", data="imagenet10")  # exports with PTQ quantization by default
 
          # Load the exported model
-         imx_model = YOLO("yolo26n-cls_imx_model")
+         imx_model = YOLO("yolo11n-cls_imx_model")
 
          # Run inference
          results = imx_model("https://ultralytics.com/images/bus.jpg", imgsz=224)
@@ -135,11 +135,11 @@ Export an Ultralytics YOLO26 model to IMX500 format and run inference with the e
     === "CLI"
 
          ```bash
-         # Export a YOLO26n-cls PyTorch model to imx format with Post-Training Quantization (PTQ)
-         yolo export model=yolo26n-cls.pt format=imx data=imagenet10
+         # Export a YOLO11n-cls PyTorch model to imx format with Post-Training Quantization (PTQ)
+         yolo export model=yolo11n-cls.pt format=imx data=imagenet10
 
          # Run inference with the exported model
-         yolo predict model=yolo26n-cls_imx_model source='https://ultralytics.com/images/bus.jpg' imgsz=224
+         yolo predict model=yolo11n-cls_imx_model source='https://ultralytics.com/images/bus.jpg' imgsz=224
          ```
 
 !!! example "Instance Segmentation"
@@ -149,14 +149,14 @@ Export an Ultralytics YOLO26 model to IMX500 format and run inference with the e
          ```python
          from ultralytics import YOLO
 
-         # Load a YOLO26n-seg PyTorch model
-         model = YOLO("yolo26n-seg.pt")
+         # Load a YOLO11n-seg PyTorch model
+         model = YOLO("yolo11n-seg.pt")
 
          # Export the model
          model.export(format="imx", data="coco8-seg.yaml")  # exports with PTQ quantization by default
 
          # Load the exported model
-         imx_model = YOLO("yolo26n-seg_imx_model")
+         imx_model = YOLO("yolo11n-seg_imx_model")
 
          # Run inference
          results = imx_model("https://ultralytics.com/images/bus.jpg")
@@ -165,11 +165,11 @@ Export an Ultralytics YOLO26 model to IMX500 format and run inference with the e
     === "CLI"
 
          ```bash
-         # Export a YOLO26n-seg PyTorch model to imx format with Post-Training Quantization (PTQ)
-         yolo export model=yolo26n-seg.pt format=imx data=coco8-seg.yaml
+         # Export a YOLO11n-seg PyTorch model to imx format with Post-Training Quantization (PTQ)
+         yolo export model=yolo11n-seg.pt format=imx data=coco8-seg.yaml
 
          # Run inference with the exported model
-         yolo predict model=yolo26n-seg_imx_model source='https://ultralytics.com/images/bus.jpg'
+         yolo predict model=yolo11n-seg_imx_model source='https://ultralytics.com/images/bus.jpg'
          ```
 
 !!! warning
@@ -200,54 +200,54 @@ The export process will create an ONNX model for quantization validation, along 
     === "Object Detection"
 
         ```bash
-        yolo26n_imx_model
+        yolo11n_imx_model
         ├── dnnParams.xml
         ├── labels.txt
         ├── packerOut.zip
-        ├── yolo26n_imx.onnx
-        ├── yolo26n_imx_MemoryReport.json
-        └── yolo26n_imx.pbtxt
+        ├── yolo11n_imx.onnx
+        ├── yolo11n_imx_MemoryReport.json
+        └── yolo11n_imx.pbtxt
         ```
 
     === "Pose Estimation"
 
         ```bash
-        yolo26n-pose_imx_model
+        yolo11n-pose_imx_model
         ├── dnnParams.xml
         ├── labels.txt
         ├── packerOut.zip
-        ├── yolo26n-pose_imx.onnx
-        ├── yolo26n-pose_imx_MemoryReport.json
-        └── yolo26n-pose_imx.pbtxt
+        ├── yolo11n-pose_imx.onnx
+        ├── yolo11n-pose_imx_MemoryReport.json
+        └── yolo11n-pose_imx.pbtxt
         ```
 
     === "Classification"
 
         ```bash
-        yolo26n-cls_imx_model
+        yolo11n-cls_imx_model
         ├── dnnParams.xml
         ├── labels.txt
         ├── packerOut.zip
-        ├── yolo26n-cls_imx.onnx
-        ├── yolo26n-cls_imx_MemoryReport.json
-        └── yolo26n-cls_imx.pbtxt
+        ├── yolo11n-cls_imx.onnx
+        ├── yolo11n-cls_imx_MemoryReport.json
+        └── yolo11n-cls_imx.pbtxt
         ```
 
     === "Instance Segmentation"
 
         ```bash
-        yolo26n-seg_imx_model
+        yolo11n-seg_imx_model
         ├── dnnParams.xml
         ├── labels.txt
         ├── packerOut.zip
-        ├── yolo26n-seg_imx.onnx
-        ├── yolo26n-seg_imx_MemoryReport.json
-        └── yolo26n-seg_imx.pbtxt
+        ├── yolo11n-seg_imx.onnx
+        ├── yolo11n-seg_imx_MemoryReport.json
+        └── yolo11n-seg_imx.pbtxt
         ```
 
 ## Using IMX500 Export in Deployment
 
-After exporting Ultralytics YOLO26n model to IMX500 format, it can be deployed to Raspberry Pi AI Camera for inference.
+After exporting Ultralytics YOLO11n model to IMX500 format, it can be deployed to Raspberry Pi AI Camera for inference.
 
 ### Hardware Prerequisites
 
@@ -288,7 +288,7 @@ Step 4: Install [Aitrios Raspberry Pi application module library](https://github
 pip install git+https://github.com/SonySemiconductorSolutions/aitrios-rpi-application-module-library.git
 ```
 
-Step 5: Run YOLO26 object detection, pose estimation, classification and segmentation by using the below scripts which are available in [aitrios-rpi-application-module-library examples](https://github.com/SonySemiconductorSolutions/aitrios-rpi-application-module-library/tree/main/examples/aicam).
+Step 5: Run YOLO11 object detection, pose estimation, classification and segmentation by using the below scripts which are available in [aitrios-rpi-application-module-library examples](https://github.com/SonySemiconductorSolutions/aitrios-rpi-application-module-library/tree/main/examples/aicam).
 
 !!! note
 
@@ -312,14 +312,14 @@ Step 5: Run YOLO26 object detection, pose estimation, classification and segment
             def __init__(self):
                 """Initialize the YOLO model for IMX500 deployment."""
                 super().__init__(
-                    model_file="yolo26n_imx_model/packerOut.zip",  # replace with proper directory
+                    model_file="yolo11n_imx_model/packerOut.zip",  # replace with proper directory
                     model_type=MODEL_TYPE.CONVERTED,
                     color_format=COLOR_FORMAT.RGB,
                     preserve_aspect_ratio=False,
                 )
 
                 self.labels = np.genfromtxt(
-                    "yolo26n_imx_model/labels.txt",  # replace with proper directory
+                    "yolo11n_imx_model/labels.txt",  # replace with proper directory
                     dtype=str,
                     delimiter="\n",
                 )
@@ -359,7 +359,7 @@ Step 5: Run YOLO26 object detection, pose estimation, classification and segment
             def __init__(self):
                 """Initialize the YOLO pose estimation model for IMX500 deployment."""
                 super().__init__(
-                    model_file="yolo26n-pose_imx_model/packerOut.zip",  # replace with proper directory
+                    model_file="yolo11n-pose_imx_model/packerOut.zip",  # replace with proper directory
                     model_type=MODEL_TYPE.CONVERTED,
                     color_format=COLOR_FORMAT.RGB,
                     preserve_aspect_ratio=False,
@@ -402,13 +402,13 @@ Step 5: Run YOLO26 object detection, pose estimation, classification and segment
             def __init__(self):
                 """Initialize the YOLO classification model for IMX500 deployment."""
                 super().__init__(
-                    model_file="yolo26n-cls_imx_model/packerOut.zip",  # replace with proper directory
+                    model_file="yolo11n-cls_imx_model/packerOut.zip",  # replace with proper directory
                     model_type=MODEL_TYPE.CONVERTED,
                     color_format=COLOR_FORMAT.RGB,
                     preserve_aspect_ratio=False,
                 )
 
-                self.labels = np.genfromtxt("yolo26n-cls_imx_model/labels.txt", dtype=str, delimiter="\n")
+                self.labels = np.genfromtxt("yolo11n-cls_imx_model/labels.txt", dtype=str, delimiter="\n")
 
             def post_process(self, output_tensors):
                 """Post-process the output tensors for classification."""
@@ -446,14 +446,14 @@ Step 5: Run YOLO26 object detection, pose estimation, classification and segment
             def __init__(self):
                 """Initialize the YOLO segmentation model for IMX500 deployment."""
                 super().__init__(
-                    model_file="yolo26n-seg_imx_model/packerOut.zip",  # replace with proper directory
+                    model_file="yolo11n-seg_imx_model/packerOut.zip",  # replace with proper directory
                     model_type=MODEL_TYPE.CONVERTED,
                     color_format=COLOR_FORMAT.RGB,
                     preserve_aspect_ratio=False,
                 )
 
                 self.labels = np.genfromtxt(
-                    "yolo26n-seg_imx_model/labels.txt",  # replace with proper directory
+                    "yolo11n-seg_imx_model/labels.txt",  # replace with proper directory
                     dtype=str,
                     delimiter="\n",
                 )
@@ -550,7 +550,7 @@ MCT introduces structured, hardware-aware model pruning designed for specific ha
 
 ### IMX500 Converter Tool (Compiler)
 
-The IMX500 Converter Tool is integral to the IMX500 toolset, allowing the compilation of models for deployment on Sony's IMX500 sensor (for instance, Raspberry Pi AI Cameras). This tool facilitates the transition of Ultralytics YOLO26 models processed through Ultralytics software, ensuring they are compatible and perform efficiently on the specified hardware. The export procedure following model quantization involves the generation of binary files that encapsulate essential data and device-specific configurations, streamlining the deployment process on the Raspberry Pi AI Camera.
+The IMX500 Converter Tool is integral to the IMX500 toolset, allowing the compilation of models for deployment on Sony's IMX500 sensor (for instance, Raspberry Pi AI Cameras). This tool facilitates the transition of Ultralytics YOLO11 models processed through Ultralytics software, ensuring they are compatible and perform efficiently on the specified hardware. The export procedure following model quantization involves the generation of binary files that encapsulate essential data and device-specific configurations, streamlining the deployment process on the Raspberry Pi AI Camera.
 
 ## Real-World Use Cases
 
@@ -558,25 +558,25 @@ Export to IMX500 format has wide applicability across industries. Here are some 
 
 - **Edge AI and IoT**: Enable object detection on drones or security cameras, where real-time processing on low-power devices is essential.
 - **Wearable Devices**: Deploy models optimized for small-scale AI processing on health-monitoring wearables.
-- **Smart Cities**: Use IMX500-exported YOLO26 models for traffic monitoring and safety analysis with faster processing and minimal latency.
+- **Smart Cities**: Use IMX500-exported YOLO11 models for traffic monitoring and safety analysis with faster processing and minimal latency.
 - **Retail Analytics**: Enhance in-store monitoring by deploying optimized models in point-of-sale systems or smart shelves.
 
 ## Conclusion
 
-Exporting Ultralytics YOLO26 models to Sony's IMX500 format allows you to deploy your models for efficient inference on IMX500-based cameras. By leveraging advanced quantization techniques, you can reduce model size and improve inference speed without significantly compromising accuracy.
+Exporting Ultralytics YOLO11 models to Sony's IMX500 format allows you to deploy your models for efficient inference on IMX500-based cameras. By leveraging advanced quantization techniques, you can reduce model size and improve inference speed without significantly compromising accuracy.
 
 For more information and detailed guidelines, refer to Sony's [IMX500 website](https://www.aitrios.sony-semicon.com/edge-ai-devices/raspberry-pi-ai-camera).
 
 ## FAQ
 
-### How do I export a YOLO26 model to IMX500 format for Raspberry Pi AI Camera?
+### How do I export a YOLO11 model to IMX500 format for Raspberry Pi AI Camera?
 
-To export a YOLO26 model to IMX500 format, use either the Python API or CLI command:
+To export a YOLO11 model to IMX500 format, use either the Python API or CLI command:
 
 ```python
 from ultralytics import YOLO
 
-model = YOLO("yolo26n.pt")
+model = YOLO("yolo11n.pt")
 model.export(format="imx")  # Exports with PTQ quantization by default
 ```
 
@@ -606,11 +606,11 @@ Software:
 - Raspberry Pi OS Bookworm
 - IMX500 firmware and tools (`sudo apt install imx500-all`)
 
-### What performance can I expect from YOLO26 models on the IMX500?
+### What performance can I expect from YOLO11 models on the IMX500?
 
 Based on Ultralytics benchmarks on Raspberry Pi AI Camera:
 
-- YOLO26n achieves 62.50ms inference time per image
+- YOLO11n achieves 62.50ms inference time per image
 - mAP50-95 of 0.492 on COCO128 dataset
 - Model size of only 3.2MB after quantization
 

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -263,7 +263,7 @@ def torch2imx(
     mct_config = MCT_CONFIG["YOLO11" if "C2PSA" in model.__str__() else "YOLOv8"][model.task]
 
     # Check if the model has the expected number of layers
-    if len(list(model.modules())) != mct_config["n_layers"]:
+    if len(list(model.modules())) not in mct_config["n_layers"]:
         raise ValueError("IMX export only supported for YOLOv8n and YOLO11n models.")
 
     for layer_name in mct_config["layer_names"]:

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -23,25 +23,37 @@ MCT_CONFIG = {
         "detect": {
             "layer_names": ["sub", "mul_2", "add_14", "cat_19"],
             "weights_memory": 2585350.2439,
-            "n_layers": 238,
+            "n_layers": {238, 239},
         },
         "pose": {
             "layer_names": ["sub", "mul_2", "add_14", "cat_21", "cat_22", "mul_4", "add_15"],
             "weights_memory": 2437771.67,
-            "n_layers": 257,
+            "n_layers": {257, 258},
         },
-        "classify": {"layer_names": [], "weights_memory": np.inf, "n_layers": 112},
-        "segment": {"layer_names": ["sub", "mul_2", "add_14", "cat_21"], "weights_memory": 2466604.8, "n_layers": 265},
+        "classify": {"layer_names": [], "weights_memory": np.inf, "n_layers": {112}},
+        "segment": {
+            "layer_names": ["sub", "mul_2", "add_14", "cat_21"],
+            "weights_memory": 2466604.8,
+            "n_layers": {265, 266},
+        },
     },
     "YOLOv8": {
-        "detect": {"layer_names": ["sub", "mul", "add_6", "cat_15"], "weights_memory": 2550540.8, "n_layers": 168},
+        "detect": {
+            "layer_names": ["sub", "mul", "add_6", "cat_15"],
+            "weights_memory": 2550540.8,
+            "n_layers": {168, 169},
+        },
         "pose": {
             "layer_names": ["add_7", "mul_2", "cat_17", "mul", "sub", "add_6", "cat_18"],
             "weights_memory": 2482451.85,
-            "n_layers": 187,
+            "n_layers": {187, 188},
         },
-        "classify": {"layer_names": [], "weights_memory": np.inf, "n_layers": 73},
-        "segment": {"layer_names": ["sub", "mul", "add_6", "cat_17"], "weights_memory": 2580060.0, "n_layers": 195},
+        "classify": {"layer_names": [], "weights_memory": np.inf, "n_layers": {73}},
+        "segment": {
+            "layer_names": ["sub", "mul", "add_6", "cat_17"],
+            "weights_memory": 2580060.0,
+            "n_layers": {195, 196},
+        },
     },
 }
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Sony IMX500 integration to center on **YOLO11** and improves IMX export compatibility by accepting multiple valid model layer counts ✅📷

### 📊 Key Changes
- 📝 **Docs refresh:** Rebrands the IMX500 export guide from YOLO26 → **YOLO11** (titles, wording, examples, filenames, and deployment script paths).
- 🧪 **Example updates:** All Python/CLI snippets now use `yolo11n.pt` (plus `-pose/-seg/-cls`) and corresponding exported folder names like `yolo11n_imx_model`.
- 🛠️ **IMX exporter validation made more flexible:** In `ultralytics/utils/export/imx.py`, the expected module counts (`n_layers`) for supported models are changed from a single number to a **set of allowed values** (e.g., `{238, 239}`), and the check now accepts any of them.
- 🧩 **Task configs aligned:** The MCT config entries for detect/pose/segment/classify are restructured to use the new `n_layers` sets (for YOLO11 and YOLOv8).

### 🎯 Purpose & Impact
- 🚀 **Clearer guidance for users:** The IMX500 documentation now consistently points to **YOLO11**, reducing confusion and copy/paste errors when exporting and deploying to Raspberry Pi AI Camera.
- ✅ **Fewer “false failures” during export:** Allowing multiple valid layer counts makes IMX export **more robust to small architecture/module-count variations**, improving reliability across supported builds.
- 🔒 **No broad feature expansion:** Export is still limited to **YOLOv8n and YOLO11n** for IMX500, but should succeed more consistently when models match the supported variants.