### PR TITLE
Disable automatic directory creation with `mkdir`

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -412,7 +412,7 @@ def get_save_dir(args: SimpleNamespace, name: str | None = None) -> Path:
         nested = args.project and len(Path(args.project).parts) > 1  # e.g. "user/project" or "org\repo"
         project = runs / args.project if nested else args.project or runs
         name = name or args.name or f"{args.mode}"
-        save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True, mkdir=True)
+        save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True)
 
     return Path(save_dir).resolve()  # resolve to display full path in console
 


### PR DESCRIPTION
I checked the code and `get_save_dir()` is always followed by `mkdir()` wherever it's used. So not sure if it's required. It causes Ultralytics to create empty `predict` directories if running prediction with `save=False`

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Tweaks how Ultralytics chooses the run save directory by no longer auto-creating the folder during path incrementation 📁✨

### 📊 Key Changes
- Removed `mkdir=True` from the `increment_path(...)` call inside `ultralytics/cfg/__init__.py:get_save_dir()`
- As a result, `get_save_dir()` now computes an incremented/unique `save_dir` path without implicitly creating the directory on disk 🧭

### 🎯 Purpose & Impact
- Reduces unintended filesystem side effects: simply *resolving* a save path won’t create folders anymore 🧹
- Cleaner behavior for dry-runs, config inspection, or tooling that calls `get_save_dir()` just to display/plan paths 👀
- Potential breaking change for edge cases: any workflow that expected the directory to exist immediately after calling `get_save_dir()` may now need to create it explicitly (`save_dir.mkdir(parents=True, exist_ok=True)`) 🛠️