### PR TITLE
Fix TensorBoard error with OBB

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -456,7 +456,7 @@ class OBB(Detect):
     def _inference(self, x: dict[str, torch.Tensor]) -> torch.Tensor:
         """Decode predicted bounding boxes and class probabilities, concatenated with rotation angles."""
         # For decode_bboxes convenience
-        self.angle = x["angle"].detach()  # TODO: need to test obb
+        self.angle = x["angle"]  # TODO: need to test obb
         preds = super()._inference(x)
         return torch.cat([preds, x["angle"]], dim=1)
 

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -456,7 +456,7 @@ class OBB(Detect):
     def _inference(self, x: dict[str, torch.Tensor]) -> torch.Tensor:
         """Decode predicted bounding boxes and class probabilities, concatenated with rotation angles."""
         # For decode_bboxes convenience
-        self.angle = x["angle"]  # TODO: need to test obb
+        self.angle = x["angle"].detach()  # TODO: need to test obb
         preds = super()._inference(x)
         return torch.cat([preds, x["angle"]], dim=1)
 

--- a/ultralytics/utils/callbacks/tensorboard.py
+++ b/ultralytics/utils/callbacks/tensorboard.py
@@ -38,6 +38,7 @@ def _log_scalars(scalars: dict, step: int = 0) -> None:
             WRITER.add_scalar(k, v, step)
 
 
+@torch.no_grad()
 def _log_tensorboard_graph(trainer) -> None:
     """Log model graph to TensorBoard.
 

--- a/ultralytics/utils/callbacks/tensorboard.py
+++ b/ultralytics/utils/callbacks/tensorboard.py
@@ -1,6 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from ultralytics.utils import LOGGER, SETTINGS, TESTS_RUNNING, colorstr, torch_utils
+from ultralytics.utils.torch_utils import smart_inference_mode
 
 try:
     assert not TESTS_RUNNING  # do not log pytest
@@ -38,7 +39,7 @@ def _log_scalars(scalars: dict, step: int = 0) -> None:
             WRITER.add_scalar(k, v, step)
 
 
-@torch.no_grad()
+@smart_inference_mode()
 def _log_tensorboard_graph(trainer) -> None:
     """Log model graph to TensorBoard.
 


### PR DESCRIPTION
Closes #23265 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds `smart_inference_mode()` to the TensorBoard graph-logging callback to make graph export safer and more efficient 🚀📈

### 📊 Key Changes
- Imported `smart_inference_mode` from `ultralytics.utils.torch_utils`
- Decorated `_log_tensorboard_graph(trainer)` with `@smart_inference_mode()` so it runs in inference context (no gradients) 🧠⚡
- No changes to scalar logging behavior; only the model graph logging path is affected 📊

### 🎯 Purpose & Impact
- Reduces overhead when logging the model graph to TensorBoard by avoiding gradient tracking, which can improve speed and memory usage 🏎️💾
- Helps prevent accidental autograd-related side effects during graph logging, making training callbacks more robust 🛡️
- Users should see the same TensorBoard outputs, but with fewer chances of slowdowns or memory spikes when graph logging is enabled ✅📉