### PR TITLE
Pre post export diagnosis

### DIFF
--- a/diagnostic_tools/pre_post_export_diagnosis.py
+++ b/diagnostic_tools/pre_post_export_diagnosis.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 import numpy as np
+
 from ultralytics import YOLO
 
 
@@ -33,11 +34,13 @@ def iou(box_a, box_b):
 def extract_detections(results):
     dets = []
     for b in results.boxes.data.cpu().numpy():
-        dets.append({
-            "box": b[:4].tolist(),
-            "score": float(b[4]),
-            "cls": int(b[5]),
-        })
+        dets.append(
+            {
+                "box": b[:4].tolist(),
+                "score": float(b[4]),
+                "cls": int(b[5]),
+            }
+        )
     return dets
 
 
@@ -79,11 +82,13 @@ def pair_and_report(pre, post):
         if best_j is not None and best_iou > 0.5:
             matched_pre_idx.add(i)
             matched_post_idx.add(best_j)
-            matched.append({
-                "cls": p["cls"],
-                "iou": best_iou,
-                "score_diff": abs(p["score"] - post[best_j]["score"]),
-            })
+            matched.append(
+                {
+                    "cls": p["cls"],
+                    "iou": best_iou,
+                    "score_diff": abs(p["score"] - post[best_j]["score"]),
+                }
+            )
 
     unmatched_pre = [p for i, p in enumerate(pre) if i not in matched_pre_idx]
     unmatched_post = [q for j, q in enumerate(post) if j not in matched_post_idx]

--- a/diagnostic_tools/pre_post_export_diagnosis.py
+++ b/diagnostic_tools/pre_post_export_diagnosis.py
@@ -1,5 +1,5 @@
 """
-YOLO Pre/Post Export Diagnostic Tool
+YOLO Pre/Post Export Diagnostic Tool.
 
 Compares YOLO detection behavior before and after ONNX export.
 Focuses on numerical drift and missing detections.
@@ -8,6 +8,7 @@ Focuses on numerical drift and missing detections.
 import argparse
 import contextlib
 import io
+
 from ultralytics import YOLO
 
 
@@ -36,11 +37,13 @@ def extract_detections(result):
     detections = []
 
     for i in range(len(boxes)):
-        detections.append({
-            "box": boxes.xyxy[i].tolist(),
-            "score": float(boxes.conf[i]),
-            "cls": int(boxes.cls[i]),
-        })
+        detections.append(
+            {
+                "box": boxes.xyxy[i].tolist(),
+                "score": float(boxes.conf[i]),
+                "cls": int(boxes.cls[i]),
+            }
+        )
 
     return detections
 
@@ -65,13 +68,15 @@ def pair_detections(pre_dets, post_dets, iou_thresh=0.5):
                 best_idx = j
 
         if best_idx is not None and best_iou >= iou_thresh:
-            matches.append({
-                "cls": pre["cls"],
-                "iou": best_iou,
-                "score_diff": abs(pre["score"] - post_dets[best_idx]["score"]),
-                "pre": pre,
-                "post": post_dets[best_idx],
-            })
+            matches.append(
+                {
+                    "cls": pre["cls"],
+                    "iou": best_iou,
+                    "score_diff": abs(pre["score"] - post_dets[best_idx]["score"]),
+                    "pre": pre,
+                    "post": post_dets[best_idx],
+                }
+            )
             used_post.add(best_idx)
 
     unmatched_pre = [d for d in pre_dets if d not in [m["pre"] for m in matches]]

--- a/diagnostic_tools/pre_post_export_diagnosis.py
+++ b/diagnostic_tools/pre_post_export_diagnosis.py
@@ -1,6 +1,175 @@
 """
-Pre/Post Export Diagnosis Tool
+YOLO Pre/Post Export Diagnostic Tool
 
-Quantitative comparison of YOLO detection outputs
-before and after model export across inference backends.
+Compares YOLO detection behavior before and after ONNX export.
+Focuses on numerical drift and missing detections.
 """
+
+import argparse
+import contextlib
+import io
+from ultralytics import YOLO
+
+
+def compute_iou(box_a, box_b):
+    xA = max(box_a[0], box_b[0])
+    yA = max(box_a[1], box_b[1])
+    xB = min(box_a[2], box_b[2])
+    yB = min(box_a[3], box_b[3])
+
+    inter_w = max(0, xB - xA)
+    inter_h = max(0, yB - yA)
+    inter_area = inter_w * inter_h
+
+    area_a = (box_a[2] - box_a[0]) * (box_a[3] - box_a[1])
+    area_b = (box_b[2] - box_b[0]) * (box_b[3] - box_b[1])
+
+    union = area_a + area_b - inter_area
+    if union == 0:
+        return 0.0
+
+    return inter_area / union
+
+
+def extract_detections(result):
+    boxes = result.boxes
+    detections = []
+
+    for i in range(len(boxes)):
+        detections.append({
+            "box": boxes.xyxy[i].tolist(),
+            "score": float(boxes.conf[i]),
+            "cls": int(boxes.cls[i]),
+        })
+
+    return detections
+
+
+def pair_detections(pre_dets, post_dets, iou_thresh=0.5):
+    matches = []
+    used_post = set()
+
+    for pre in pre_dets:
+        best_iou = 0.0
+        best_idx = None
+
+        for j, post in enumerate(post_dets):
+            if j in used_post:
+                continue
+            if pre["cls"] != post["cls"]:
+                continue
+
+            iou = compute_iou(pre["box"], post["box"])
+            if iou > best_iou:
+                best_iou = iou
+                best_idx = j
+
+        if best_idx is not None and best_iou >= iou_thresh:
+            matches.append({
+                "cls": pre["cls"],
+                "iou": best_iou,
+                "score_diff": abs(pre["score"] - post_dets[best_idx]["score"]),
+                "pre": pre,
+                "post": post_dets[best_idx],
+            })
+            used_post.add(best_idx)
+
+    unmatched_pre = [d for d in pre_dets if d not in [m["pre"] for m in matches]]
+    unmatched_post = [d for i, d in enumerate(post_dets) if i not in used_post]
+
+    return matches, unmatched_pre, unmatched_post
+
+
+def compute_metrics(matches):
+    box_diffs = []
+    score_diffs = []
+
+    for m in matches:
+        for a, b in zip(m["pre"]["box"], m["post"]["box"]):
+            box_diffs.append(abs(a - b))
+        score_diffs.append(m["score_diff"])
+
+    return {
+        "box_mean": sum(box_diffs) / len(box_diffs) if box_diffs else 0.0,
+        "box_max": max(box_diffs) if box_diffs else 0.0,
+        "score_mean": sum(score_diffs) / len(score_diffs) if score_diffs else 0.0,
+        "score_max": max(score_diffs) if score_diffs else 0.0,
+    }
+
+
+def run_pre_inference():
+    model = YOLO("yolov8n.pt")
+    with contextlib.redirect_stdout(io.StringIO()):
+        results = model("bus.jpg", verbose=False)
+    return extract_detections(results[0])
+
+
+def run_post_inference():
+    model = YOLO("yolov8n.pt")
+    with contextlib.redirect_stdout(io.StringIO()):
+        onnx_path = model.export(format="onnx", imgsz=640, simplify=False, opset=20)
+        onnx_model = YOLO(onnx_path, task="detect")
+        results = onnx_model("bus.jpg", verbose=False)
+    return extract_detections(results[0])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="YOLO pre/post export diagnostic tool")
+    parser.add_argument(
+        "--verbose-detections",
+        action="store_true",
+        help="Print raw PRE and POST detections",
+    )
+    args = parser.parse_args()
+
+    print("======================================")
+    print("YOLO Pre/Post Export Diagnostic Report")
+    print("======================================\n")
+
+    pre = run_pre_inference()
+    post = run_post_inference()
+
+    matches, unmatched_pre, unmatched_post = pair_detections(pre, post)
+    metrics = compute_metrics(matches)
+
+    print("Paired detection comparison (CLS | IoU | Δscore):")
+    for m in matches:
+        print(f"CLS {m['cls']} | IoU: {m['iou']:.3f} | Score Δ: {m['score_diff']:.4f}")
+
+    print("\nSummary:")
+    print(f"Matched detections     : {len(matches)}")
+    print(f"Unmatched PRE          : {len(unmatched_pre)}")
+    print(f"Unmatched POST         : {len(unmatched_post)}\n")
+
+    print("Box drift (pixels):")
+    print(f"  Mean absolute diff   : {metrics['box_mean']:.3f}")
+    print(f"  Max absolute diff    : {metrics['box_max']:.3f}\n")
+
+    print("Confidence drift:")
+    print(f"  Mean score diff      : {metrics['score_mean']:.4f}")
+    print(f"  Max score diff       : {metrics['score_max']:.4f}\n")
+
+    verdict = "PASS"
+    if metrics["score_max"] > 0.15 or unmatched_pre or unmatched_post:
+        verdict = "WARN"
+
+    print(f"Verification verdict   : {verdict}\n")
+
+    if unmatched_pre:
+        print("Unmatched PRE detections:")
+        for d in unmatched_pre:
+            print(d)
+
+    if unmatched_post:
+        print("\nUnmatched POST detections:")
+        for d in unmatched_post:
+            print(d)
+
+    if args.verbose_detections:
+        print("\n--------------------------------------")
+        print("Raw PRE detections:")
+        for d in pre:
+            print(d)
+        print("\nRaw POST detections:")
+        for d in post:
+            print(d)

--- a/diagnostic_tools/pre_post_export_diagnosis.py
+++ b/diagnostic_tools/pre_post_export_diagnosis.py
@@ -1,0 +1,6 @@
+"""
+Pre/Post Export Diagnosis Tool
+
+Quantitative comparison of YOLO detection outputs
+before and after model export across inference backends.
+"""

--- a/diagnostic_tools/pre_post_export_diagnosis.py
+++ b/diagnostic_tools/pre_post_export_diagnosis.py
@@ -1,11 +1,19 @@
 """
 YOLO Pre/Post Export Diagnostic Tool
 
-Compares detection outputs before (PyTorch) and after (ONNX Runtime) export.
-Reports pairing IoU, confidence drift, and unmatched detections.
+Compares detection outputs before (PyTorch) and after (ONNX Runtime) export
+to help diagnose numerical and structural drift introduced during model export.
 
-Usage:
-  python pre_post_export_diagnosis.py [options]
+The tool pairs detections by class and IoU, reports confidence drift,
+and highlights unmatched detections across backends.
+
+All model weights and input sources are provided via CLI arguments.
+Default values are example placeholders only and can be overridden.
+
+Quick start:
+  python diagnostic_tools/pre_post_export_diagnosis.py \
+    --weights yolov8n.pt \
+    --source path/to/image.jpg
 
 Options:
   --weights PATH     Path to PyTorch weights (default: yolov8n.pt)

--- a/diagnostic_tools/pre_post_export_diagnosis.py
+++ b/diagnostic_tools/pre_post_export_diagnosis.py
@@ -32,6 +32,7 @@ from ultralytics import YOLO
 
 
 def iou(box_a, box_b):
+    """Compute intersection-over-union (IoU) between two bounding boxes."""
     xA = max(box_a[0], box_b[0])
     yA = max(box_a[1], box_b[1])
     xB = min(box_a[2], box_b[2])
@@ -49,6 +50,7 @@ def iou(box_a, box_b):
 
 
 def extract_detections(results):
+    """Extract bounding boxes, scores, and class IDs from YOLO results."""
     detections = []
     for b in results.boxes.data.cpu().numpy():
         detections.append(
@@ -62,12 +64,14 @@ def extract_detections(results):
 
 
 def run_pytorch(weights, source):
+    """Run inference using the PyTorch backend and return detections."""
     model = YOLO(weights)
     res = model(source)[0]
     return extract_detections(res)
 
 
 def run_onnx(weights, source, export, opset):
+    """Run inference using the ONNX Runtime backend and return detections."""
     onnx_path = Path(weights).with_suffix(".onnx")
 
     if export or not onnx_path.exists():
@@ -82,6 +86,7 @@ def run_onnx(weights, source, export, opset):
 
 
 def pair_detections(pre, post, iou_thresh=0.5):
+    """Pair pre- and post-export detections using class match and IoU threshold."""
     matched = []
     matched_pre_idx = set()
     matched_post_idx = set()
@@ -117,6 +122,7 @@ def pair_detections(pre, post, iou_thresh=0.5):
 
 
 def main():
+    """Parse CLI arguments and run the pre/post export diagnostic workflow."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--weights", default="yolov8n.pt")
     parser.add_argument("--source", default="bus.jpg")

--- a/tests/test_pre_post_export_diagnosis_smoke.py
+++ b/tests/test_pre_post_export_diagnosis_smoke.py
@@ -9,36 +9,34 @@ from PIL import Image
 
 @pytest.mark.slow
 def test_pre_post_export_diagnosis_smoke(tmp_path):
-    """
-    Smoke test to ensure the pre/post export diagnostic script
-    runs end-to-end and exits cleanly.
-    """
+    pytest.importorskip("onnxruntime")
 
-    # Create a tiny dummy image
+    weights_path = Path("yolov8n.pt")
+    if not weights_path.exists():
+        pytest.skip("yolov8n.pt not available locally")
+
     img_path = tmp_path / "dummy.jpg"
     img = Image.fromarray(np.zeros((1, 1, 3), dtype=np.uint8))
     img.save(img_path)
 
-    # Path to the diagnostic script
     script_path = (
         Path(__file__).resolve().parents[1]
         / "diagnostic_tools"
         / "pre_post_export_diagnosis.py"
     )
 
-    # Run the script as a subprocess
     result = subprocess.run(
         [
             sys.executable,
             str(script_path),
             "--weights",
-            "yolov8n.pt",
+            str(weights_path),
             "--source",
             str(img_path),
         ],
+        cwd=tmp_path,
         capture_output=True,
         text=True,
     )
 
-    # Assert clean exit
     assert result.returncode == 0, result.stderr

--- a/tests/test_pre_post_export_diagnosis_smoke.py
+++ b/tests/test_pre_post_export_diagnosis_smoke.py
@@ -1,0 +1,44 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+
+@pytest.mark.slow
+def test_pre_post_export_diagnosis_smoke(tmp_path):
+    """
+    Smoke test to ensure the pre/post export diagnostic script
+    runs end-to-end and exits cleanly.
+    """
+
+    # Create a tiny dummy image
+    img_path = tmp_path / "dummy.jpg"
+    img = Image.fromarray(np.zeros((1, 1, 3), dtype=np.uint8))
+    img.save(img_path)
+
+    # Path to the diagnostic script
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "diagnostic_tools"
+        / "pre_post_export_diagnosis.py"
+    )
+
+    # Run the script as a subprocess
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script_path),
+            "--weights",
+            "yolov8n.pt",
+            "--source",
+            str(img_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    # Assert clean exit
+    assert result.returncode == 0, result.stderr

--- a/tests/test_pre_post_export_diagnosis_smoke.py
+++ b/tests/test_pre_post_export_diagnosis_smoke.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 @pytest.mark.slow
 def test_pre_post_export_diagnosis_smoke(tmp_path):
+    """Smoke test for the pre/post export diagnostic CLI."""
     pytest.importorskip("onnxruntime")
 
     weights_path = Path("yolov8n.pt")


### PR DESCRIPTION
This PR adds a lightweight diagnostic script to compare YOLO detection outputs
before and after ONNX export.

The tool:
- Runs inference on the same input using PyTorch and ONNX Runtime
- Pairs detections by class and IoU
- Quantifies box drift and confidence drift
- Reports unmatched detections
- Supports optional verbose output for raw detections

No core code paths are modified.

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a standalone Python diagnostic script to compare YOLO detections before vs. after ONNX export to surface drift and missing detections 🔍

### 📊 Key Changes
-Introduces `diagnostic_tools/pre_post_export_diagnosis.py` as a new CLI-style diagnostic utility
-Runs inference on a baseline PyTorch model and an exported ONNX model, then pairs detections by class and IoU
-Reports box/score drift metrics, unmatched detections, and a simple PASS/WARN verdict with optional verbose dumps

### 🎯 Purpose & Impact
-Helps users quickly validate ONNX export fidelity and catch regressions (numerical drift, missing detections) ✅
-Provides actionable comparisons (paired detections + drift summaries) to debug export/runtime differences 🧪
-May improve export troubleshooting workflows, though it currently hardcodes sample assets/model and lives outside the main package interface ⚠️