### PR TITLE
Add YOLO26 Kaggle models

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <br>
     <a href="https://console.paperspace.com/github/ultralytics/ultralytics"><img src="https://assets.paperspace.io/img/gradient-badge.svg" alt="Run Ultralytics on Gradient"></a>
     <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open Ultralytics In Colab"></a>
-    <a href="https://www.kaggle.com/models/ultralytics/yolo11"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
+    <a href="https://www.kaggle.com/models/ultralytics/yolo26"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
     <a href="https://mybinder.org/v2/gh/ultralytics/ultralytics/HEAD?labpath=examples%2Ftutorial.ipynb"><img src="https://mybinder.org/badge_logo.svg" alt="Open Ultralytics In Binder"></a>
 </div>
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@
     <br>
     <a href="https://console.paperspace.com/github/ultralytics/ultralytics"><img src="https://assets.paperspace.io/img/gradient-badge.svg" alt="Run Ultralytics on Gradient"></a>
     <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open Ultralytics In Colab"></a>
-    <a href="https://www.kaggle.com/models/ultralytics/yolo11"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
+    <a href="https://www.kaggle.com/models/ultralytics/yolo26"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
     <a href="https://mybinder.org/v2/gh/ultralytics/ultralytics/HEAD?labpath=examples%2Ftutorial.ipynb"><img src="https://mybinder.org/badge_logo.svg" alt="Open Ultralytics In Binder"></a>
 </div>
 </div>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -29,7 +29,7 @@ keywords: Ultralytics, YOLO, YOLO26, YOLO11, object detection, image segmentatio
     <br>
     <a href="https://console.paperspace.com/github/ultralytics/ultralytics"><img src="https://assets.paperspace.io/img/gradient-badge.svg" alt="Run Ultralytics on Gradient"></a>
     <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open Ultralytics In Colab"></a>
-    <a href="https://www.kaggle.com/models/ultralytics/yolo11"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
+    <a href="https://www.kaggle.com/models/ultralytics/yolo26"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
     <a href="https://mybinder.org/v2/gh/ultralytics/ultralytics/HEAD?labpath=examples%2Ftutorial.ipynb"><img src="https://mybinder.org/badge_logo.svg" alt="Open Ultralytics In Binder"></a>
 <br><br>
 </div>

--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -170,7 +170,7 @@ Use trained YOLO models to automatically label images:
 
     You can use:
 
-    - Official Ultralytics models (YOLO11n, YOLO11s, etc.)
+    - Official Ultralytics models (YOLO26n, YOLO26s, etc.)
     - Your own trained models from the Platform
 
 ## Class Management

--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -276,9 +276,9 @@ Cold start varies by model size:
 
 | Model   | Cold Start |
 | ------- | ---------- |
-| YOLO11n | ~2 seconds |
-| YOLO11m | ~3 seconds |
-| YOLO11x | ~5 seconds |
+| YOLO26n | ~2 seconds |
+| YOLO26m | ~3 seconds |
+| YOLO26x | ~5 seconds |
 
 Set min instances > 0 to eliminate cold starts.
 

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -48,7 +48,7 @@ Ultralytics Platform is designed to replace fragmented ML tooling with a unified
 - **HuggingFace** - Model deployment
 - **Arize** - Monitoring
 
-All in one platform with native support for YOLO11 and YOLO26 models.
+All in one platform with native support for YOLO26 and YOLO11 models.
 
 ## Workflow: Data → Train → Deploy
 

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -135,17 +135,17 @@ From your project, click "Train Model" to start cloud training.
 ### Training Configuration
 
 1. **Select Dataset**: Choose from your uploaded datasets
-2. **Choose Model**: Select a base model (YOLO11n, YOLO11s, etc.)
+2. **Choose Model**: Select a base model (YOLO26n, YOLO26s, etc.)
 3. **Set Epochs**: Number of training iterations
 4. **Select GPU**: Choose compute resources
 
 | Model   | Size        | Speed    | Accuracy |
 | ------- | ----------- | -------- | -------- |
-| YOLO11n | Nano        | Fastest  | Good     |
-| YOLO11s | Small       | Fast     | Better   |
-| YOLO11m | Medium      | Moderate | High     |
-| YOLO11l | Large       | Slower   | Higher   |
-| YOLO11x | Extra Large | Slowest  | Best     |
+| YOLO26n | Nano        | Fastest  | Good     |
+| YOLO26s | Small       | Fast     | Better   |
+| YOLO26m | Medium      | Moderate | High     |
+| YOLO26l | Large       | Slower   | Higher   |
+| YOLO26x | Extra Large | Slowest  | Best     |
 
 ### Monitor Training
 

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -44,7 +44,7 @@ Select base model and parameters:
 
 | Parameter      | Description                             | Default |
 | -------------- | --------------------------------------- | ------- |
-| **Model**      | Base architecture (YOLO11n, s, m, l, x) | YOLO11n |
+| **Model**      | Base architecture (YOLO26n, s, m, l, x) | YOLO26n |
 | **Epochs**     | Number of training iterations           | 100     |
 | **Image Size** | Input resolution                        | 640     |
 | **Batch Size** | Samples per iteration                   | Auto    |
@@ -242,11 +242,11 @@ After training, view detailed costs in the **Billing** tab:
 
 | Model   | Parameters | Best For                |
 | ------- | ---------- | ----------------------- |
-| YOLO11n | 2.6M       | Real-time, edge devices |
-| YOLO11s | 9.4M       | Balanced speed/accuracy |
-| YOLO11m | 20.1M      | Higher accuracy         |
-| YOLO11l | 25.3M      | Production accuracy     |
-| YOLO11x | 56.9M      | Maximum accuracy        |
+| YOLO26n | 2.4M       | Real-time, edge devices |
+| YOLO26s | 9.5M       | Balanced speed/accuracy |
+| YOLO26m | 20.4M      | Higher accuracy         |
+| YOLO26l | 24.8M      | Production accuracy     |
+| YOLO26x | 55.7M      | Maximum accuracy        |
 
 ### Optimize Training Time
 
@@ -279,9 +279,9 @@ Typical times (1000 images, 100 epochs):
 
 | Model   | RTX 4090 | A100   |
 | ------- | -------- | ------ |
-| YOLO11n | 30 min   | 20 min |
-| YOLO11m | 60 min   | 40 min |
-| YOLO11x | 120 min  | 80 min |
+| YOLO26n | 30 min   | 20 min |
+| YOLO26m | 60 min   | 40 min |
+| YOLO26x | 120 min  | 80 min |
 
 ### Can I train overnight?
 

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -96,7 +96,7 @@ Training time depends on:
 - Number of epochs
 - GPU type selected
 
-A typical training run with 1000 images, YOLO11n, 100 epochs on RTX 4090 takes about 30-60 minutes.
+A typical training run with 1000 images, YOLO26n, 100 epochs on RTX 4090 takes about 30-60 minutes.
 
 ### Can I train multiple models simultaneously?
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -31,7 +31,7 @@ Supported model formats:
 After upload, the Platform parses model metadata:
 
 - Task type (detect, segment, pose, OBB, classify)
-- Architecture (YOLO11n, YOLO11s, etc.)
+- Architecture (YOLO26n, YOLO26s, etc.)
 - Class names and count
 - Input size and parameters
 
@@ -192,8 +192,8 @@ Remove a model you no longer need:
 
 Ultralytics Platform supports all YOLO architectures:
 
+- **YOLO26**: n, s, m, l, x variants (recommended)
 - **YOLO11**: n, s, m, l, x variants
-- **YOLO26**: Latest generation (when available)
 - **YOLOv10**: Legacy support
 - **YOLOv8**: Legacy support
 - **YOLOv5**: Legacy support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ logging = [
     "mlflow",  # https://docs.ultralytics.com/integrations/mlflow/
 ]
 extra = [
-    "hub-sdk>=0.0.12", # Ultralytics HUB
     "ipython", # interactive notebook
     "albumentations>=1.4.6", # training augmentations
     "faster-coco-eval>=1.6.7", # COCO mAP


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates docs and badges to highlight **YOLO26** as the primary current model family, and removes the optional `hub-sdk` extra dependency. 🚀📚

### 📊 Key Changes
- Switched Kaggle “Open in Kaggle” links from **YOLO11** to **YOLO26** across main README and docs. 🔗
- Updated Ultralytics Platform documentation to reference **YOLO26** variants (n/s/m/l/x) instead of **YOLO11** in examples, tables, and default selections (training, endpoints, annotation, etc.). 🧠⚙️
- Refreshed model stats in cloud training docs (parameter counts and model comparison tables) to **YOLO26** values. 📈
- Reordered/clarified supported architectures to mark **YOLO26** as “recommended” and keep **YOLO11** and legacy versions (YOLOv10/YOLOv8/YOLOv5) as supported. ✅
- Removed `hub-sdk>=0.0.12` from `pyproject.toml` optional `extra` dependencies. 🧹📦

### 🎯 Purpose & Impact
- Helps users discover and adopt the latest recommended **YOLO26** models by default in docs and entry points (Kaggle, Platform guides). 🏁
- Reduces confusion from mixed “latest/when available” messaging by clearly positioning **YOLO26** as recommended while keeping **YOLO11** supported. 🧭
- Slightly lighter optional installs: removing `hub-sdk` from extras can reduce dependency footprint and potential install issues for users who don’t need HUB-specific tooling. ⚡🛠️