### PR TITLE
Update NDJSON docs

### DIFF
--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -148,6 +148,8 @@ An NDJSON dataset file contains:
 
         Format: `[class_id, x_center, y_center, width, height, x1, y1, v1, x2, y2, v2, ...]`
 
+        Keypoints follow bbox as repeated `(x, y, v)` triplets where `v` is visibility: 0=not labeled, 1=labeled but occluded, 2=labeled and visible. The keypoint count is dataset-specific (e.g., COCO pose has 17 keypoints = 51 values after bbox).
+
     === "OBB"
 
         ```json
@@ -168,6 +170,8 @@ An NDJSON dataset file contains:
         ```
 
         Format: `[class_id, x1, y1, x2, y2, x3, y3, x4, y4]`
+
+        The four corner points define the oriented bounding box in clockwise order starting from the top-left corner. All coordinates are normalized (0-1).
 
     === "Classify"
 

--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -85,7 +85,7 @@ An NDJSON dataset file contains:
         }
         ```
 
-    === "Image record (lines 2+)"
+    === "Detect"
 
         ```json
         {
@@ -97,20 +97,95 @@ An NDJSON dataset file contains:
             "split": "train",
             "annotations": {
                 "boxes": [
-                    [0, 0.52481, 0.37629, 0.28394, 0.41832],
-                    [1, 0.73526, 0.29847, 0.19275, 0.33691]
+                    [0, 0.525, 0.376, 0.284, 0.418],
+                    [1, 0.735, 0.298, 0.193, 0.337]
                 ]
             }
         }
         ```
 
-**Annotation formats by task:**
+        Format: `[class_id, x_center, y_center, width, height]`
 
-- **Detection:** `"annotations": {"boxes": [[class_id, x_center, y_center, width, height], ...]}`
-- **Segmentation:** `"annotations": {"segments": [[class_id, x1, y1, x2, y2, ...], ...]}`
-- **Pose:** `"annotations": {"pose": [[class_id, x1, y1, v1, x2, y2, v2, ...], ...]}`
-- **OBB:** `"annotations": {"obb": [[class_id, x_center, y_center, width, height, angle], ...]}`
-- **Classification:** `"annotations": {"classification": [class_id]}`
+    === "Segment"
+
+        ```json
+        {
+            "type": "image",
+            "file": "image1.jpg",
+            "url": "https://www.url.com/path/to/image1.jpg",
+            "width": 640,
+            "height": 480,
+            "split": "train",
+            "annotations": {
+                "segments": [
+                    [0, 0.681, 0.485, 0.670, 0.487, 0.676, 0.487, 0.688, 0.515],
+                    [1, 0.422, 0.315, 0.438, 0.330, 0.445, 0.328, 0.450, 0.320]
+                ]
+            }
+        }
+        ```
+
+        Format: `[class_id, x1, y1, x2, y2, x3, y3, ...]`
+
+    === "Pose"
+
+        ```json
+        {
+            "type": "image",
+            "file": "image1.jpg",
+            "url": "https://www.url.com/path/to/image1.jpg",
+            "width": 640,
+            "height": 480,
+            "split": "train",
+            "annotations": {
+                "pose": [
+                    [0, 0.523, 0.376, 0.283, 0.418, 0.374, 0.169, 2, 0.364, 0.178, 2],
+                    [0, 0.735, 0.298, 0.193, 0.337, 0.412, 0.225, 2, 0.408, 0.231, 2]
+                ]
+            }
+        }
+        ```
+
+        Format: `[class_id, x_center, y_center, width, height, x1, y1, v1, x2, y2, v2, ...]`
+
+    === "OBB"
+
+        ```json
+        {
+            "type": "image",
+            "file": "image1.jpg",
+            "url": "https://www.url.com/path/to/image1.jpg",
+            "width": 640,
+            "height": 480,
+            "split": "train",
+            "annotations": {
+                "obb": [
+                    [0, 0.525, 0.376, 0.284, 0.418, 0.524],
+                    [1, 0.735, 0.298, 0.193, 0.337, 0.785]
+                ]
+            }
+        }
+        ```
+
+        Format: `[class_id, x_center, y_center, width, height, angle]`
+
+    === "Classify"
+
+        ```json
+        {
+            "type": "image",
+            "file": "image1.jpg",
+            "url": "https://www.url.com/path/to/image1.jpg",
+            "width": 640,
+            "height": 480,
+            "split": "train",
+            "annotations": {
+                "classification": [0, 2]
+            }
+        }
+        ```
+
+        Format: `[class_id, ...]` (supports multi-label)
 
 #### Usage Example
 

--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -160,14 +160,14 @@ An NDJSON dataset file contains:
             "split": "train",
             "annotations": {
                 "obb": [
-                    [0, 0.525, 0.376, 0.284, 0.418, 0.524],
-                    [1, 0.735, 0.298, 0.193, 0.337, 0.785]
+                    [0, 0.480, 0.352, 0.568, 0.356, 0.572, 0.400, 0.484, 0.396],
+                    [1, 0.711, 0.274, 0.759, 0.278, 0.755, 0.322, 0.707, 0.318]
                 ]
             }
         }
         ```
 
-        Format: `[class_id, x_center, y_center, width, height, angle]`
+        Format: `[class_id, x1, y1, x2, y2, x3, y3, x4, y4]`
 
     === "Classify"
 
@@ -180,12 +180,12 @@ An NDJSON dataset file contains:
             "height": 480,
             "split": "train",
             "annotations": {
-                "classification": [0, 2]
+                "classification": [0]
             }
         }
         ```
 
-        Format: `[class_id, ...]` (supports multi-label)
+        Format: `[class_id]`
 
 #### Usage Example
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 Improves the NDJSON dataset docs by adding clear, task-specific annotation examples and formats for all supported vision tasks.

### 📊 Key Changes
- 🏷️ Renamed the detection example tab from “Image record (lines 2+)” to **“Detect”** for clearer navigation.
- 🧩 Expanded the documentation from a single detection example into **separate tabs/examples** for:
  - 🔍 Detect (bounding boxes)
  - ✂️ Segment (polygons)
  - 🧍 Pose (bbox + keypoints with visibility flags)
  - 📐 OBB (oriented bounding boxes via 4 corners)
  - 🏷️ Classify (class ID only)
- 📝 Added explicit **per-task format definitions** directly under each example (e.g., box fields, segment point structure, pose keypoint triplets).
- 👁️ Clarified **pose keypoint visibility values** (`v`: 0/1/2) and noted that keypoint count is dataset-specific.
- 🔢 Minor example value formatting tweaks (rounded coordinates) for readability.

### 🎯 Purpose & Impact
- ✅ Makes it much easier for users (especially newcomers) to **author valid NDJSON annotations** for YOLO workflows across tasks.
- 🧠 Reduces confusion and implementation errors by providing **copy-pastable JSON structures** and clear field definitions per task.
- 🚀 Helps teams standardize datasets for Detect/Segment/Pose/OBB/Classify, speeding up dataset preparation and reducing support friction.