### PR TITLE
`ultralytics 8.4.5` 2D Pose `Result.summary()` support

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.4"
+__version__ = "8.4.5"
 
 import importlib
 import os

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -803,12 +803,17 @@ class Results(SimpleClass, DataExportMixin):
                     "y": (self.masks.xy[i][:, 1] / h).round(decimals).tolist(),
                 }
             if self.keypoints is not None:
-                x, y, visible = self.keypoints[i].data[0].cpu().unbind(dim=1)  # torch Tensor
+                kpt = self.keypoints[i]
+                if kpt.has_visible:
+                    x, y, visible = kpt.data[0].cpu().unbind(dim=1)
+                else:
+                    x, y = kpt.data[0].cpu().unbind(dim=1)
                 result["keypoints"] = {
-                    "x": (x / w).numpy().round(decimals).tolist(),  # decimals named argument required
+                    "x": (x / w).numpy().round(decimals).tolist(),
                     "y": (y / h).numpy().round(decimals).tolist(),
-                    "visible": visible.numpy().round(decimals).tolist(),
                 }
+                if kpt.has_visible:
+                    result["keypoints"]["visible"] = visible.numpy().round(decimals).tolist()
             results.append(result)
 
         return results


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps Ultralytics to `8.4.5` and makes `Results.summary()` handle keypoints with or without visibility flags more safely 🛠️📌

### 📊 Key Changes
- 🔖 Version update in `ultralytics/__init__.py`: `8.4.4` → `8.4.5`
- 🧩 Improved keypoints serialization in `ultralytics/engine/results.py`:
  - Uses `kpt = self.keypoints[i]` and checks `kpt.has_visible`
  - If visibility exists, includes `"visible"` in the summary output
  - If not, outputs only `"x"` and `"y"` instead of failing when `"visible"` is missing

### 🎯 Purpose & Impact
- ✅ Prevents errors when summarizing models/datasets where keypoints don’t include visibility/confidence values (common across different keypoint formats) 🚫💥
- 📤 Makes `Results.summary()` output more robust and consistent for downstream uses like JSON export, logging, analytics, and API responses 🔄📋
- 🧠 Improves compatibility across various pose/keypoint pipelines without requiring user-side conditionals 🙌