### PR TITLE
Fix typos in YOLO26 and YOLOE docs

### DIFF
--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -229,7 +229,7 @@ YOLOE-26 supports both text-based and visual prompting. Using prompts is straigh
             cls=np.array(
                 [
                     0,  # ID to be assigned for person
-                    1,  # ID to be assigned for glassses
+                    1,  # ID to be assigned for glasses
                 ]
             ),
         )

--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -301,7 +301,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
             cls=np.array(
                 [
                     0,  # ID to be assigned for person
-                    1,  # ID to be assigned for glassses
+                    1,  # ID to be assigned for glasses
                 ]
             ),
         )
@@ -441,7 +441,7 @@ Model validation on a dataset is streamlined as follows:
 
     === "Visual Prompt"
 
-        Be default it's using the provided dataset to extract visual embeddings for each category.
+        By default it's using the provided dataset to extract visual embeddings for each category.
 
         ```python
         from ultralytics import YOLOE

--- a/docs/en/platform/account/activity.md
+++ b/docs/en/platform/account/activity.md
@@ -33,20 +33,20 @@ Navigate to the Activity Feed:
 
 The Platform tracks the following event types:
 
-| Event Type    | Description                                | Icon  |
-| ------------- | ------------------------------------------ | ----- |
-| **created**   | New resource created                       | +     |
-| **updated**   | Resource modified                          | edit  |
-| **deleted**   | Resource permanently removed               | trash |
-| **trashed**   | Resource moved to trash (recoverable)      | trash |
-| **restored**  | Resource restored from trash               | undo  |
-| **started**   | Training or export job started             | play  |
-| **completed** | Job finished successfully                  | check |
-| **failed**    | Job encountered an error                   | error |
-| **cancelled** | Job stopped by user                        | stop  |
-| **uploaded**  | File or dataset uploaded                   | cloud |
-| **exported**  | Model exported to format                   | save  |
-| **cloned**    | Resource duplicated                        | copy  |
+| Event Type    | Description                           | Icon  |
+| ------------- | ------------------------------------- | ----- |
+| **created**   | New resource created                  | +     |
+| **updated**   | Resource modified                     | edit  |
+| **deleted**   | Resource permanently removed          | trash |
+| **trashed**   | Resource moved to trash (recoverable) | trash |
+| **restored**  | Resource restored from trash          | undo  |
+| **started**   | Training or export job started        | play  |
+| **completed** | Job finished successfully             | check |
+| **failed**    | Job encountered an error              | error |
+| **cancelled** | Job stopped by user                   | stop  |
+| **uploaded**  | File or dataset uploaded              | cloud |
+| **exported**  | Model exported to format              | save  |
+| **cloned**    | Resource duplicated                   | copy  |
 
 ## Inbox and Archive
 
@@ -87,13 +87,13 @@ Use the search bar to find events by:
 
 Filter events by type:
 
-| Filter        | Shows                                     |
-| ------------- | ----------------------------------------- |
-| **All**       | All activity types                        |
-| **Training**  | Training started, completed, failed       |
-| **Uploads**   | Dataset and model uploads                 |
-| **Exports**   | Model export activity                     |
-| **System**    | Billing, storage, account events          |
+| Filter       | Shows                               |
+| ------------ | ----------------------------------- |
+| **All**      | All activity types                  |
+| **Training** | Training started, completed, failed |
+| **Uploads**  | Dataset and model uploads           |
+| **Exports**  | Model export activity               |
+| **System**   | Billing, storage, account events    |
 
 ### Date Range
 
@@ -110,13 +110,13 @@ Filter by time period:
 
 Click an event to view details:
 
-| Field           | Description                              |
-| --------------- | ---------------------------------------- |
-| **Timestamp**   | When the event occurred                  |
-| **User**        | Who triggered the event                  |
-| **Resource**    | What was affected (with link)            |
-| **Description** | Detailed event information               |
-| **Metadata**    | Additional context (job ID, etc.)        |
+| Field           | Description                       |
+| --------------- | --------------------------------- |
+| **Timestamp**   | When the event occurred           |
+| **User**        | Who triggered the event           |
+| **Resource**    | What was affected (with link)     |
+| **Description** | Detailed event information        |
+| **Metadata**    | Additional context (job ID, etc.) |
 
 ## Mark as Seen
 

--- a/docs/en/platform/account/trash.md
+++ b/docs/en/platform/account/trash.md
@@ -166,4 +166,3 @@ No. If a project is permanently deleted, all models that were inside it are also
 ### How do I know when an item will be permanently deleted?
 
 Each item in Trash shows an "Expires" date indicating when automatic permanent deletion will occur.
-

--- a/docs/en/platform/train/projects.md
+++ b/docs/en/platform/train/projects.md
@@ -140,4 +140,3 @@ Yes, deleted projects go to Trash and can be restored within 30 days:
 1. Go to Settings > Trash
 2. Find the project
 3. Click **Restore**
-


### PR DESCRIPTION
Fix minor typos in documentation:

- `glassses` → `glasses` (yolo26.md, yoloe.md)
- `Be default` → `By default` (yoloe.md)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes minor typos in the YOLO26 and YOLOE documentation pages. 📝

### 📊 Key Changes
- Corrected a comment typo: “glassses” → “glasses” in example code in `docs/en/models/yolo26.md` and `docs/en/models/yoloe.md`
- Fixed grammar in YOLOE docs: “Be default” → “By default”

### 🎯 Purpose & Impact
- Improves clarity and professionalism of the YOLO26/YOLOE docs 📚
- Reduces confusion when users copy/paste example snippets ✅
- No runtime or API behavior changes; documentation-only update 🧩