### PR TITLE
`ultralytics 8.4.6` Add missing PosixPath import in DDP train file gen

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.5"
+__version__ = "8.4.6"
 
 import importlib
 import os

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -49,7 +49,7 @@ def generate_ddp_file(trainer):
 
     content = f"""
 # Ultralytics Multi-GPU training temp file (should be automatically deleted after use)
-from pathlib import Path, PosixPath
+from pathlib import Path, PosixPath  # For model arguments stored as Path instead of str
 overrides = {vars(trainer.args)}
 
 if __name__ == "__main__":

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -49,6 +49,7 @@ def generate_ddp_file(trainer):
 
     content = f"""
 # Ultralytics Multi-GPU training temp file (should be automatically deleted after use)
+from pathlib import Path, PosixPath
 overrides = {vars(trainer.args)}
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

This fixes a NameError when training YOLO models with multi-GPU DDP (Distributed Data Parallel) on systems where model paths are stored as PosixPath objects:
```
Traceback (most recent call last):
  File "/home/user/.config/Ultralytics/DDP/_temp_*.py", line 3, in <module>
    overrides = {'model': PosixPath('yolo26n.pt'), ...}
                          ^^^^^^^^^
NameError: name 'PosixPath' is not defined
```
This happened after upgrading to the latest version 8.4.5 and training a yolo26n model.
As such, I added `from pathlib import Path, PosixPath` to the generated DDP file template to ensure PosixPath objects can be properly deserialized. I have tested the fix on the following machine:
2x NVIDIA RTX 5090
Ubuntu 24.04, Python 3.12, PyTorch 2.9.0+cu130
 and it's working.
Thank you

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a missing import in the temporary DDP training script generator to prevent runtime errors 🛠️

### 📊 Key Changes
- Adds `from pathlib import Path, PosixPath` to the generated multi-GPU (DDP) temp training file

### 🎯 Purpose & Impact
- Prevents `NameError`/import-related failures when the generated DDP script references `PosixPath`
- Improves reliability of multi-GPU training setup and reduces friction for users running DDP 🚀