### PR TITLE
Modernize type comments to inline annotations in `byte_tracker.py`

### DIFF
--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -270,9 +270,9 @@ class BYTETracker:
             args (Namespace): Command-line arguments containing tracking parameters.
             frame_rate (int): Frame rate of the video sequence.
         """
-        self.tracked_stracks = []  # type: list[STrack]
-        self.lost_stracks = []  # type: list[STrack]
-        self.removed_stracks = []  # type: list[STrack]
+        self.tracked_stracks: list[STrack] = []
+        self.lost_stracks: list[STrack] = []
+        self.removed_stracks: list[STrack] = []
 
         self.frame_id = 0
         self.args = args
@@ -304,7 +304,7 @@ class BYTETracker:
         detections = self.init_track(results, feats_keep)
         # Add newly detected tracklets to tracked_stracks
         unconfirmed = []
-        tracked_stracks = []  # type: list[STrack]
+        tracked_stracks: list[STrack] = []
         for track in self.tracked_stracks:
             if not track.is_activated:
                 unconfirmed.append(track)
@@ -423,9 +423,9 @@ class BYTETracker:
 
     def reset(self):
         """Reset the tracker by clearing all tracked, lost, and removed tracks and reinitializing the Kalman filter."""
-        self.tracked_stracks = []  # type: list[STrack]
-        self.lost_stracks = []  # type: list[STrack]
-        self.removed_stracks = []  # type: list[STrack]
+        self.tracked_stracks: list[STrack] = []
+        self.lost_stracks: list[STrack] = []
+        self.removed_stracks: list[STrack] = []
         self.frame_id = 0
         self.kalman_filter = self.get_kalmanfilter()
         self.reset_id()


### PR DESCRIPTION
## Summary
Replaced legacy type comments with modern inline type annotations in the `BYTETracker` class.

## Changes
Updated 7 instances where `# type:` comments were used:
- `self.tracked_stracks`, `self.lost_stracks`, `self.removed_stracks` (class attributes)
- Local `tracked_stracks` variables in `update()` method

**Before:**
```python
self.tracked_stracks = []  # type: list[STrack]
```

**After:**
```python
self.tracked_stracks: list[STrack] = []
```

## Motivation
The rest of the codebase already uses inline annotations (e.g., in `multi_predict()`, `joint_stracks()`). This brings `BYTETracker` in line with that style and improves IDE support.

## Testing
- No functional changes, purely syntactic update
- Existing tests should pass without modification

---

*First contribution to ultralytics - let me know if anything needs adjustment!*

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refactors `byte_tracker.py` to use modern inline type annotations for tracker state lists 🧹

### 📊 Key Changes
- Replaced legacy `# type: list[STrack]` comments with inline annotations like `self.tracked_stracks: list[STrack] = []`
- Updated annotations in both initialization and `reset()` paths to keep typing consistent
- Annotated a local `tracked_stracks` variable in `update()` for improved readability

### 🎯 Purpose & Impact
- Improves code clarity and aligns with modern Python typing practices ✨
- Enhances static analysis and IDE autocomplete without changing runtime behavior 🧠
- No user-facing functional impact expected; this is a safe refactor ✅