### PR TITLE
Longer NDJSON generation timeout

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -89,7 +89,8 @@ def resolve_platform_uri(uri, hard=True):
         raise ValueError(f"Invalid platform URI: {uri}. Use ul://user/datasets/name or ul://user/project/model")
 
     try:
-        r = requests.head(url, headers=headers, allow_redirects=False, timeout=30)
+        timeout = 3600 if "/datasets/" in url else 90  # NDJSON generation can be slow for large datasets
+        r = requests.head(url, headers=headers, allow_redirects=False, timeout=timeout)
 
         # Handle redirect responses (301, 302, 303, 307, 308)
         if 300 <= r.status_code < 400 and "location" in r.headers:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Ultralytics Platform URI resolution by using smarter request timeouts to better handle large dataset processing ⏱️📦

### 📊 Key Changes
- Adjusted the `requests.head()` timeout in `ultralytics/utils/callbacks/platform.py` based on the URL type:
  - Dataset URLs (`/datasets/`) now use a **3600s (1 hour)** timeout 🐢
  - Other Platform resources use a **90s** timeout ⚡
- Added an inline comment explaining that **NDJSON generation can be slow for large datasets** 📝

### 🎯 Purpose & Impact
- Reduces false failures/timeouts when resolving `ul://...` dataset URIs for **large datasets** that take longer to prepare on the server 🧰
- Makes dataset-related workflows (e.g., loading datasets from Ultralytics Platform) **more reliable** and less prone to intermittent errors ✅
- Maintains faster feedback for non-dataset URIs by keeping a shorter timeout, avoiding unnecessary long waits ⏳