### PR TITLE
Fix image link in YOLO26 documentation

### DIFF
--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -10,7 +10,7 @@ keywords: YOLO26, Ultralytics YOLO, object detection, end-to-end NMS-free, simpl
 
 [Ultralytics](https://www.ultralytics.com/) YOLO26 is the latest evolution in the YOLO series of real-time object detectors, engineered from the ground up for **edge and low-power devices**. It introduces a streamlined design that removes unnecessary complexity while integrating targeted innovations to deliver faster, lighter, and more accessible deployment.
 
-![Ultralytics YOLO26 Comparison Plots](https://github.com/ultralytics/assets/releases/download/v0.0.0/Ultralytics-YOLO26-Benchmark.jpg)
+![Ultralytics YOLO26 Comparison Plots](https://raw.githubusercontent.com/ultralytics/assets/refs/heads/main/yolov8/yolo-comparison-plots.png)
 
 !!! tip "Try on Ultralytics Platform"
 

--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -10,7 +10,7 @@ keywords: YOLO26, Ultralytics YOLO, object detection, end-to-end NMS-free, simpl
 
 [Ultralytics](https://www.ultralytics.com/) YOLO26 is the latest evolution in the YOLO series of real-time object detectors, engineered from the ground up for **edge and low-power devices**. It introduces a streamlined design that removes unnecessary complexity while integrating targeted innovations to deliver faster, lighter, and more accessible deployment.
 
-![Ultralytics YOLO26 Comparison Plots](https://raw.githubusercontent.com/ultralytics/assets/refs/heads/main/yolov8/yolo-comparison-plots.png)
+![Ultralytics YOLO26 Comparison Plots](https://raw.githubusercontent.com/ultralytics/assets/refs/tags/v8.4.0/yolov8/yolo-comparison-plots.png)
 
 !!! tip "Try on Ultralytics Platform"
 

--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -10,7 +10,7 @@ keywords: YOLO26, Ultralytics YOLO, object detection, end-to-end NMS-free, simpl
 
 [Ultralytics](https://www.ultralytics.com/) YOLO26 is the latest evolution in the YOLO series of real-time object detectors, engineered from the ground up for **edge and low-power devices**. It introduces a streamlined design that removes unnecessary complexity while integrating targeted innovations to deliver faster, lighter, and more accessible deployment.
 
-![Ultralytics YOLO26 Comparison Plots](https://raw.githubusercontent.com/ultralytics/assets/refs/tags/v8.4.0/yolov8/yolo-comparison-plots.png)
+![Ultralytics YOLO26 Comparison Plots](https://github.com/ultralytics/assets/blob/ae31f0a057edc380aa08e915e7e5febbce1ab892/yolov8/yolo-comparison-plots.png)
 
 !!! tip "Try on Ultralytics Platform"
 


### PR DESCRIPTION
Fixed to direct link because CDN links are ignored by crawlers:

> The URL returns a 302 redirect with no body, and many crawlers (including Google's) won't follow redirects for OG images, or they'll time out waiting for the redirect chain to resolve. GitHub release assets redirect to their CDN (`objects.githubusercontent.com`), and this extra hop is unreliable for metadata crawlers that expect a direct image response.
>
> The fix is to host the image somewhere that returns a 200 with the actual image bytes on the first request. Your options are to put it directly in your docs repo, use a CDN that doesn't redirect (like Cloudflare R2, or even just committing the image to the repo itself rather than using releases), or use GitHub's raw content URL instead of releases, though that also has redirect issues for large files.
> 
> Once you update the `og:image` URL to something that returns `HTTP 200` with `content-type: image/jpeg` directly, the thumbnail will work reliably across Google, Twitter, Slack, Discord, and every other platform that generates link previews.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the YOLO26 docs to use a new benchmark/comparison image link 🖼️🔗

### 📊 Key Changes
- Replaced the YOLO26 “Comparison Plots” image URL in `docs/en/models/yolo26.md`
- Switched from a GitHub Releases asset link to a GitHub repo blob image path (static commit-referenced) 📌

### 🎯 Purpose & Impact
- Improves documentation reliability/consistency by pointing to a specific, commit-pinned image source ✅
- Ensures the YOLO26 page displays the intended comparison plot for readers evaluating models 📊
- Potential downside: using a `blob` link (instead of a raw file/CDN) can be less optimal for direct image serving and may be more sensitive to GitHub rendering rules ⚠️