### PR TITLE
Add Executorch export dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ export = [
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
+    "executorch==1.0.1" # Executorch export
 ]
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds `executorch==1.0.1` as an export dependency to enable ExecuTorch export support 🚀📦

### 📊 Key Changes
- Added a new optional dependency: `executorch==1.0.1` under the `export` extras in `pyproject.toml` 🧩
- Labeled it specifically for “Executorch export” to clarify its role in the export workflow 🏷️

### 🎯 Purpose & Impact
- Enables/streamlines exporting Ultralytics models (e.g., YOLO11/YOLO26) to the ExecuTorch ecosystem for on-device/mobile deployment 📱⚙️
- Makes installs more predictable by pinning a known-good ExecuTorch version, reducing compatibility surprises 🧰✅
- Users who run `pip install ultralytics[export]` will now pull in ExecuTorch automatically, which may increase install size/time slightly but improves out-of-the-box export readiness ⏳📈