### PR TITLE
Retry NDSON download failures

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -838,14 +838,19 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
             if http_url := record.get("url"):
                 if not image_path.exists():
                     image_path.parent.mkdir(parents=True, exist_ok=True)
-                    try:
-                        async with session.get(http_url, timeout=aiohttp.ClientTimeout(total=30)) as response:
-                            response.raise_for_status()
-                            image_path.write_bytes(await response.read())
-                        return True
-                    except Exception as e:
-                        LOGGER.warning(f"Failed to download {http_url}: {e}")
-                        return False
+                    # Retry with exponential backoff (3 attempts: 0s, 2s, 4s delays)
+                    for attempt in range(3):
+                        try:
+                            async with session.get(http_url, timeout=aiohttp.ClientTimeout(total=30)) as response:
+                                response.raise_for_status()
+                                image_path.write_bytes(await response.read())
+                            return True
+                        except Exception as e:
+                            if attempt < 2:  # Don't sleep after last attempt
+                                await asyncio.sleep(2 ** attempt)  # 1s, 2s backoff
+                            else:
+                                LOGGER.warning(f"Failed to download {http_url} after 3 attempts: {e}")
+                                return False
             return True
 
     # Process all images with async downloads (limit connections for small datasets)
@@ -861,8 +866,15 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
             pbar.update(1)
             return result
 
-        await asyncio.gather(*[tracked_process(record) for record in image_records])
+        results = await asyncio.gather(*[tracked_process(record) for record in image_records])
         pbar.close()
+
+    # Validate images were downloaded successfully
+    success_count = sum(1 for r in results if r)
+    if success_count == 0:
+        raise RuntimeError(f"Failed to download any images from {ndjson_path}. Check network connection and URLs.")
+    if success_count < len(image_records):
+        LOGGER.warning(f"Downloaded {success_count}/{len(image_records)} images from {ndjson_path}")
 
     if is_classification:
         # Classification: return dataset directory (check_cls_dataset expects a directory path)

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -847,7 +847,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
                             return True
                         except Exception as e:
                             if attempt < 2:  # Don't sleep after last attempt
-                                await asyncio.sleep(2 ** attempt)  # 1s, 2s backoff
+                                await asyncio.sleep(2**attempt)  # 1s, 2s backoff
                             else:
                                 LOGGER.warning(f"Failed to download {http_url} after 3 attempts: {e}")
                                 return False


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves dataset image downloading reliability by adding retries with backoff and post-download validation ✅📥

### 📊 Key Changes
- Added **retry logic with exponential backoff** when downloading images from `record["url"]` (up to 3 attempts) 🔁⏳
- Updated async download flow to **capture per-image success/failure results** via `asyncio.gather(...)` 📋
- Added **post-download validation**:
  - Raises a **RuntimeError** if **zero** images were downloaded (hard fail) 🛑
  - Logs a **warning** if only a **partial** set of images was downloaded ⚠️

### 🎯 Purpose & Impact
- **More resilient downloads**: transient network/host issues are less likely to break dataset conversion 🌐💪
- **Clearer failure behavior**: if nothing downloads, users get an immediate, actionable error instead of silently proceeding 🚨
- **Better visibility**: partial download warnings help diagnose bad URLs or connectivity issues early 🔍📉
- Potential impact: conversions may take slightly longer in flaky networks due to retries, but should succeed more often ⏱️✅