### PR TITLE
Fix broken links in NVIDIA Jetson documentation

### DIFF
--- a/docs/en/guides/nvidia-dgx-spark.md
+++ b/docs/en/guides/nvidia-dgx-spark.md
@@ -146,7 +146,7 @@ The [onnxruntime-gpu](https://pypi.org/project/onnxruntime-gpu/) package hosted 
 Here we will download and install `onnxruntime-gpu 1.24.0` with `Python3.12` support.
 
 ```bash
-pip install https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl
 ```
 
 ## Use TensorRT on NVIDIA DGX Spark

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -162,7 +162,7 @@ The [onnxruntime-gpu](https://pypi.org/project/onnxruntime-gpu/) package hosted 
 Here we will download and install `onnxruntime-gpu 1.24.0` with `Python3.12` support.
 
 ```bash
-pip install https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.24.0-cp312-cp312-linux_aarch64.whl
 ```
 
 ### Run on JetPack 6.1
@@ -198,8 +198,8 @@ The above ultralytics installation will install Torch and Torchvision. However, 
 Install `torch 2.5.0` and `torchvision 0.20` according to JP6.1
 
 ```bash
-pip install https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/torch-2.5.0a0+872d972e41.nv24.08-cp310-cp310-linux_aarch64.whl
-pip install https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/torchvision-0.20.0a0+afc54f7-cp310-cp310-linux_aarch64.whl
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.5.0a0+872d972e41.nv24.08-cp310-cp310-linux_aarch64.whl
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.20.0a0+afc54f7-cp310-cp310-linux_aarch64.whl
 ```
 
 !!! note
@@ -224,13 +224,13 @@ You can find all available `onnxruntime-gpu` packages—organized by JetPack ver
 For **JetPack 6** with `Python 3.10` support, you can install `onnxruntime-gpu 1.23.0`:
 
 ```bash
-pip install https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/onnxruntime_gpu-1.23.0-cp310-cp310-linux_aarch64.whl
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.23.0-cp310-cp310-linux_aarch64.whl
 ```
 
 Alternatively, for `onnxruntime-gpu 1.20.0`:
 
 ```bash
-pip install https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/onnxruntime_gpu-1.20.0-cp310-cp310-linux_aarch64.whl
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.20.0-cp310-cp310-linux_aarch64.whl
 ```
 
 ### Run on JetPack 5.1.2
@@ -272,8 +272,8 @@ The above ultralytics installation will install Torch and Torchvision. However, 
 2. Install `torch 2.2.0` and `torchvision 0.17.2` according to JP5.1.2
 
     ```bash
-    pip install https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/torch-2.2.0-cp38-cp38-linux_aarch64.whl
-    pip install https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl
+    pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.2.0-cp38-cp38-linux_aarch64.whl
+    pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl
     ```
 
 !!! note


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates NVIDIA DGX Spark and Jetson setup guides to download prebuilt wheels from GitHub Releases instead of jsDelivr 📦🔗

### 📊 Key Changes
- Replaced `cdn.jsdelivr.net/gh/ultralytics/assets@main/...` wheel URLs with GitHub Releases URLs for:
  - `onnxruntime-gpu` (JetPack/DGX Spark instructions)
  - `torch` and `torchvision` (Jetson JetPack 6.1 and 5.1.2 instructions)
- Standardized all referenced wheel downloads to the same release-based hosting path (`ultralytics/assets` release `v0.0.0`) ✅

### 🎯 Purpose & Impact
- Improves reliability and consistency of downloads by using GitHub Releases (often more stable than CDN-backed “branch file” links) 🚀
- Reduces risk of broken install instructions if assets move or the `main/docs/` paths change 🧰
- Makes Jetson/DGX Spark onboarding smoother for users installing platform-specific wheels (ARM/aarch64) with fewer “link not found” surprises 🤝