### PR TITLE
Update `coco12-formats` predict tests

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -168,13 +168,13 @@ def test_predict_all_image_formats():
     dataset_path = Path(data["path"])
 
     # Collect all images from train and val
-    images = list((dataset_path / "images" / "train").glob("*.*"))
-    images += list((dataset_path / "images" / "val").glob("*.*"))
+    expected = {"avif", "bmp", "dng", "heic", "jp2", "jpeg", "jpg", "mpo", "png", "tif", "tiff", "webp"}
+    images = [im for im in (dataset_path / "images" / "train").glob("*.*") if im.suffix.lower().lstrip(".") in expected]
+    images += [im for im in (dataset_path / "images" / "val").glob("*.*") if im.suffix.lower().lstrip(".") in expected]
     assert len(images) == 12, f"Expected 12 images, found {len(images)}"
 
     # Verify all format extensions are represented
     extensions = {img.suffix.lower().lstrip(".") for img in images}
-    expected = {"avif", "bmp", "dng", "heic", "jp2", "jpeg", "jpg", "mpo", "png", "tif", "tiff", "webp"}
     assert extensions == expected, f"Missing formats: {expected - extensions}"
 
     # Run inference on all images


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves a Python test to only count valid image files by filtering dataset contents to a known set of supported image formats ✅🖼️

### 📊 Key Changes
- Filters `train/` and `val/` image glob results to include only files whose extensions match an explicit allowlist (`avif`, `bmp`, `dng`, `heic`, `jp2`, `jpeg`, `jpg`, `mpo`, `png`, `tif`, `tiff`, `webp`) 🔎
- Moves the `expected` extension set definition before image collection so it can be used for filtering 📋
- Keeps the test assertions the same (expects exactly 12 images and verifies all extensions are represented) ✅

### 🎯 Purpose & Impact
- Prevents the test from accidentally picking up non-image or unexpected files in the dataset directories (e.g., stray metadata files), reducing flaky CI failures 🧪🚦
- Makes the test more deterministic and aligned with the formats it’s actually validating, improving reliability for contributors and maintainers 🛠️
- Helps ensure Ultralytics inference remains verified across a broad range of common image formats without being affected by unrelated file clutter 🧩📷