### PR TITLE
Add https://youtu.be/7lZa3Yi2kbo to docs

### DIFF
--- a/docs/en/datasets/segment/carparts-seg.md
+++ b/docs/en/datasets/segment/carparts-seg.md
@@ -14,7 +14,7 @@ Whether you're working on [automotive research](https://www.ultralytics.com/solu
 
 <p align="center">
   <br>
-  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/HATMPgLYAPU"
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/7lZa3Yi2kbo"
     title="YouTube video player" frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -135,13 +135,13 @@ Explore the Ultralytics Docs, a comprehensive resource designed to help you unde
 
 <p align="center">
   <br>
-  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/ZN3nRZT7b24"
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/7lZa3Yi2kbo"
     title="YouTube video player" frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> How to Train a YOLO11 model on Your Custom Dataset in <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb" target="_blank">Google Colab</a>.
+  <strong>Watch:</strong> How to Train a YOLO26 model on Your Custom Dataset in <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb" target="_blank">Google Colab</a>.
 </p>
 
 ## YOLO: A Brief History


### PR DESCRIPTION
Ultralytics YOLO26 first video.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates embedded YouTube videos in the docs and refreshes the homepage training callout to reference YOLO26. 🎥✨

### 📊 Key Changes
- Replaced the embedded YouTube video on the CarParts Segmentation dataset page with `https://www.youtube.com/embed/7lZa3Yi2kbo`.
- Replaced the embedded YouTube video on the docs homepage with the same video.
- Updated the homepage “Watch” line from “Train a YOLO11 model” to “Train a YOLO26 model”.

### 🎯 Purpose & Impact
- Keeps documentation media current and consistent across key entry points. 📚
- Aligns the docs homepage messaging with YOLO26 as the latest recommended Ultralytics model. 🚀
- Improves user onboarding by pointing readers to a single, updated training video experience. 🎯