### PR TITLE
Fix `stride_val` type issue in STAL

### DIFF
--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -304,8 +304,11 @@ class TaskAlignedAssigner(nn.Module):
         """
         gt_bboxes_xywh = xyxy2xywh(gt_bboxes)
         wh_mask = gt_bboxes_xywh[..., 2:] < self.stride[0]  # the smallest stride
-        stride_val = torch.tensor(self.stride_val, dtype=gt_bboxes_xywh.dtype, device=gt_bboxes_xywh.device)
-        gt_bboxes_xywh[..., 2:] = torch.where((wh_mask * mask_gt).bool(), stride_val, gt_bboxes_xywh[..., 2:])
+        gt_bboxes_xywh[..., 2:] = torch.where(
+            (wh_mask * mask_gt).bool(),
+            torch.tensor(self.stride_val, dtype=gt_bboxes_xywh.dtype, device=gt_bboxes_xywh.device),
+            gt_bboxes_xywh[..., 2:],
+        )
         gt_bboxes = xywh2xyxy(gt_bboxes_xywh)
 
         n_anchors = xy_centers.shape[0]
@@ -371,8 +374,11 @@ class RotatedTaskAlignedAssigner(TaskAlignedAssigner):
             (torch.Tensor): Boolean mask of positive anchors with shape (b, n_boxes, h*w).
         """
         wh_mask = gt_bboxes[..., 2:4] < self.stride[0]
-        stride_val = torch.tensor(self.stride_val, dtype=gt_bboxes.dtype, device=gt_bboxes.device)
-        gt_bboxes[..., 2:4] = torch.where((wh_mask * mask_gt).bool(), stride_val, gt_bboxes[..., 2:4])
+        gt_bboxes[..., 2:4] = torch.where(
+            (wh_mask * mask_gt).bool(),
+            torch.tensor(self.stride_val, dtype=gt_bboxes.dtype, device=gt_bboxes.device),
+            gt_bboxes[..., 2:4],
+        )
 
         # (b, n_boxes, 5) --> (b, n_boxes, 4, 2)
         corners = xywhr2xyxyxyxy(gt_bboxes)

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -304,7 +304,8 @@ class TaskAlignedAssigner(nn.Module):
         """
         gt_bboxes_xywh = xyxy2xywh(gt_bboxes)
         wh_mask = gt_bboxes_xywh[..., 2:] < self.stride[0]  # the smallest stride
-        gt_bboxes_xywh[..., 2:] = torch.where((wh_mask * mask_gt).bool(), self.stride_val, gt_bboxes_xywh[..., 2:])
+        stride_val = torch.tensor(self.stride_val, dtype=gt_bboxes_xywh.dtype, device=gt_bboxes_xywh.device)
+        gt_bboxes_xywh[..., 2:] = torch.where((wh_mask * mask_gt).bool(), stride_val, gt_bboxes_xywh[..., 2:])
         gt_bboxes = xywh2xyxy(gt_bboxes_xywh)
 
         n_anchors = xy_centers.shape[0]
@@ -370,7 +371,8 @@ class RotatedTaskAlignedAssigner(TaskAlignedAssigner):
             (torch.Tensor): Boolean mask of positive anchors with shape (b, n_boxes, h*w).
         """
         wh_mask = gt_bboxes[..., 2:4] < self.stride[0]
-        gt_bboxes[..., 2:4] = torch.where((wh_mask * mask_gt).bool(), self.stride_val, gt_bboxes[..., 2:4])
+        stride_val = torch.tensor(self.stride_val, dtype=gt_bboxes.dtype, device=gt_bboxes.device)
+        gt_bboxes[..., 2:4] = torch.where((wh_mask * mask_gt).bool(), stride_val, gt_bboxes[..., 2:4])
 
         # (b, n_boxes, 5) --> (b, n_boxes, 4, 2)
         corners = xywhr2xyxyxyxy(gt_bboxes)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a dtype/device consistency issue in TAL anchor selection by ensuring `stride_val` is created as a proper PyTorch tensor 📦✅

### 📊 Key Changes
- Updated `select_candidates_in_gts()` in `ultralytics/utils/tal.py` (both bbox formats) to replace raw `self.stride_val` in `torch.where()` with a tensor created on the **same device** and with the **same dtype** as the target tensors.
- Added explicit construction: `torch.tensor(self.stride_val, dtype=..., device=...)` to avoid implicit casting or CPU/GPU mismatches.

### 🎯 Purpose & Impact
- Prevents potential runtime errors when training on GPU (or mixed precision) where `torch.where()` can fail or behave unexpectedly if inputs differ in dtype/device 🛡️
- Improves robustness and consistency of training across environments (CPU/GPU, FP16/FP32) with no expected change in model outputs beyond avoiding edge-case failures 🚀
- Helps ensure tiny ground-truth boxes (smaller than the smallest stride) are handled safely during target assignment, reducing training friction on small-object datasets 🔍