### PR TITLE
fix: add unwrap_model to fix DDP AttributeError

### DIFF
--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -9,6 +9,7 @@ from typing import Any
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import PoseModel
 from ultralytics.utils import DEFAULT_CFG
+from ultralytics.utils.torch_utils import unwrap_model
 
 
 class PoseTrainer(yolo.detect.DetectionTrainer):
@@ -91,7 +92,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
     def get_validator(self):
         """Return an instance of the PoseValidator class for validation."""
         self.loss_names = "box_loss", "pose_loss", "kobj_loss", "cls_loss", "dfl_loss"
-        if getattr(self.model.model[-1], "flow_model", None) is not None:
+        if getattr(unwrap_model(self.model).model[-1], "flow_model", None) is not None:
             self.loss_names += ("rle_loss",)
         return yolo.pose.PoseValidator(
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes pose training validation to correctly detect optional `flow_model` when the model is wrapped (e.g., multi-GPU), ensuring the right losses are reported 🧩✅

### 📊 Key Changes
- Added `unwrap_model` import from `ultralytics.utils.torch_utils` 🔓
- Updated the `PoseTrainer.get_validator()` check to use `unwrap_model(self.model)` before accessing `model[-1].flow_model` 🧠
- Keeps `loss_names` accurate by appending `"rle_loss"` only when a `flow_model` is actually present 📉➕

### 🎯 Purpose & Impact
- Prevents incorrect behavior when training with wrapped models (like `DataParallel`/`DistributedDataParallel`) where `self.model.model[...]` may not reflect the real underlying model 🖥️🔁
- Ensures validation logs/metrics include `"rle_loss"` reliably when using pose models that support it, improving transparency and debugging 🧪📋
- Reduces the risk of missing or inconsistent loss reporting across single-GPU vs multi-GPU setups, making training runs more consistent 🚀📌