### PR TITLE
Fix visual prompt training for YOLOE26

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1103,7 +1103,7 @@ class YOLOEDetect(Detect):
         boxes, scores, index = [], [], []
         bs = x[0].shape[0]
         cv2 = self.cv2 if not self.end2end else self.one2one_cv2
-        cv3 = self.cv3 if not self.end2end else self.one2one_cv2
+        cv3 = self.cv3 if not self.end2end else self.one2one_cv3
         for i in range(self.nl):
             cls_feat = cv3[i](x[i])
             loc_feat = cv2[i](x[i])

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1206,7 +1206,6 @@ class TVPDetectLoss:
 
     def _get_vp_features(self, preds: dict[str, torch.Tensor]) -> list[torch.Tensor]:
         """Extract visual-prompt features from the model output."""
-        # NOTE: remove empty placeholder
         scores = preds["scores"]
         vnc = scores.shape[1]
 

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1174,7 +1174,7 @@ class E2ELoss:
 class TVPDetectLoss:
     """Criterion class for computing training losses for text-visual prompt detection."""
 
-    def __init__(self, model, tal_topk=10,tal_topk2: int | None = None):
+    def __init__(self, model, tal_topk=10, tal_topk2: int | None = None):
         """Initialize TVPDetectLoss with task-prompt and visual-prompt criteria using the provided model."""
         self.vp_criterion = v8DetectionLoss(model, tal_topk, tal_topk2)
         # NOTE: store following info as it's changeable in __call__

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1174,9 +1174,9 @@ class E2ELoss:
 class TVPDetectLoss:
     """Criterion class for computing training losses for text-visual prompt detection."""
 
-    def __init__(self, model, tal_topk=10):
+    def __init__(self, model, tal_topk=10,tal_topk2: int | None = None):
         """Initialize TVPDetectLoss with task-prompt and visual-prompt criteria using the provided model."""
-        self.vp_criterion = v8DetectionLoss(model, tal_topk)
+        self.vp_criterion = v8DetectionLoss(model, tal_topk, tal_topk2)
         # NOTE: store following info as it's changeable in __call__
         self.hyp = self.vp_criterion.hyp
         self.ori_nc = self.vp_criterion.nc
@@ -1207,7 +1207,7 @@ class TVPDetectLoss:
     def _get_vp_features(self, preds: dict[str, torch.Tensor]) -> list[torch.Tensor]:
         """Extract visual-prompt features from the model output."""
         # NOTE: remove empty placeholder
-        scores = preds["scores"][:, self.ori_nc :, :]
+        scores = preds["scores"]
         vnc = scores.shape[1]
 
         self.vp_criterion.nc = vnc


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## Fix Visual Prompt Training and Typo in YOLOE26

### Summary
This PR fixes visual prompt training issues  YOLOE/YOLOE26 models.

### Changes

#### 1. Add `tal_topk2` parameter support to TVPDetectLoss
- Added `tal_topk2` parameter to `TVPDetectLoss.__init__()` for flexible task-aligned assignment configuration
- Passes `tal_topk2` through to the underlying `v8DetectionLoss` for better one-to-one assignment control
- Removed unnecessary score slicing in `_get_vp_features` to use the full score tensor

#### 2. Fix typo in YOLOEDetect forward_lrpc
- Corrected `self.one2one_cv2` to `self.one2one_cv3` in the `forward_lrpc` method

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes visual-prompt training behavior for YOLOe26 by correcting an end-to-end head routing bug and aligning TVP loss feature/parameter handling. 🛠️

### 📊 Key Changes
- Corrected `forward_lrpc()` to use `one2one_cv3` (not `one2one_cv2`) for classification features in end-to-end mode.
- Extended `TVPDetectLoss` to accept and forward an optional `tal_topk2` parameter into `v8DetectionLoss`.
- Updated VP feature extraction to use full `preds["scores"]` instead of slicing by `ori_nc`, preventing unintended channel dropping.

### 🎯 Purpose & Impact
- Prevents miswired heads during end-to-end training, improving correctness and stability for prompt-based detection. ✅
- Ensures TVP/visual-prompt loss uses the intended score tensor layout, avoiding shape/class mismatches. 🎯
- Improves configurability of task-aligned assignment via `tal_topk2`, helping advanced training setups behave as expected. ⚙️