### PR TITLE
feat: add save_after gating for periodic checkpoints

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -162,6 +162,7 @@ def test_nan_recovery():
 
 
 def _make_dummy_trainer(tmp_path: Path, save_period: int, save_after: int, epoch: int, best: bool):
+    """Create a minimal trainer-like object sufficient to call BaseTrainer.save_model()."""
     model = torch.nn.Linear(1, 1)
 
     t = SimpleNamespace()
@@ -191,6 +192,7 @@ def _make_dummy_trainer(tmp_path: Path, save_period: int, save_after: int, epoch
 
 
 def test_save_after_gates_periodic_checkpoints(tmp_path):
+    """Test save_after gates periodic epoch*.pt checkpoints while last.pt/best.pt remain unchanged."""
     save_period = 2
     save_after = 3
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -202,6 +202,7 @@ CFG_INT_KEYS = frozenset(
         "line_width",
         "nbs",
         "save_period",
+        "save_after",
     }
 )
 CFG_BOOL_KEYS = frozenset(

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -16,6 +16,7 @@ batch: 16 # (int) batch size; use -1 for AutoBatch
 imgsz: 640 # (int | list) train/val use int (square); predict/export may use [h,w]
 save: True # (bool) save train checkpoints and predict results
 save_period: -1 # (int) save checkpoint every N epochs; disabled if < 1
+save_after: 0 # (int) start periodic saving only after this epoch (1-based); 0 means no threshold
 cache: False # (bool | str) cache images in RAM (True/'ram') or on 'disk' to speed dataloading; False disables
 device: # (int | str | list) device: 0 or [0,1,2,3] for CUDA, 'cpu'/'mps', or -1/[-1,-1] to auto-select idle GPUs
 workers: 8 # (int) dataloader workers (per RANK if DDP)


### PR DESCRIPTION
Closes #22658
Refs #22665

- Adds `save_after` to delay periodic checkpoint saving until a specified 1-based epoch.
- Periodic checkpoint cadence and naming remain unchanged (0-based `epoch{self.epoch}.pt`).
- `last.pt` and `best.pt` behavior remains unchanged.
- Resume now allows overriding `save_after` (similar to `save_period`).


<img width="2488" height="930" alt="Screenshot from 2026-01-24 20-47-50" src="https://github.com/user-attachments/assets/d447feaf-6468-421a-95d3-ba97a1146f6f" />
