### PR TITLE
Disable shuffle only if batch shapes mismatch with `rect=True`

### DIFF
--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -92,7 +92,7 @@ class DetectionTrainer(BaseTrainer):
         with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
             dataset = self.build_dataset(dataset_path, mode, batch_size)
         shuffle = mode == "train"
-        if getattr(dataset, "rect", False) and shuffle:
+        if getattr(dataset, "rect", False) and shuffle and np.unique(dataset.batch_shapes).shape[0] == 1:
             LOGGER.warning("'rect=True' is incompatible with DataLoader shuffle, setting shuffle=False")
             shuffle = False
         return build_dataloader(

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -92,7 +92,7 @@ class DetectionTrainer(BaseTrainer):
         with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
             dataset = self.build_dataset(dataset_path, mode, batch_size)
         shuffle = mode == "train"
-        if getattr(dataset, "rect", False) and shuffle and np.unique(dataset.batch_shapes).shape[0] == 1:
+        if getattr(dataset, "rect", False) and shuffle and np.all(dataset.batch_shapes == dataset.batch_shapes[0]):
             LOGGER.warning("'rect=True' is incompatible with DataLoader shuffle, setting shuffle=False")
             shuffle = False
         return build_dataloader(

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -92,7 +92,7 @@ class DetectionTrainer(BaseTrainer):
         with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
             dataset = self.build_dataset(dataset_path, mode, batch_size)
         shuffle = mode == "train"
-        if getattr(dataset, "rect", False) and shuffle and np.all(dataset.batch_shapes == dataset.batch_shapes[0]):
+        if getattr(dataset, "rect", False) and shuffle and not np.all(dataset.batch_shapes == dataset.batch_shapes[0]):
             LOGGER.warning("'rect=True' is incompatible with DataLoader shuffle, setting shuffle=False")
             shuffle = False
         return build_dataloader(


### PR DESCRIPTION
Closes #20605 
Closes #8601 
Closes #23418 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an over-strict `rect=True` training check so DataLoader shuffling is only disabled when it’s actually incompatible ✅🔧

### 📊 Key Changes
- Updated the shuffle-disabling logic in `ultralytics/models/yolo/detect/train.py` for YOLO detection training.
- Previously, if `rect=True` and `mode=="train"`, shuffling was always turned off (with a warning).
- Now, shuffling is only turned off when `rect=True` **and** the dataset uses **multiple batch shapes** (i.e., `batch_shapes` vary across batches), which is the case that truly conflicts with shuffling 📐➡️🔀.

### 🎯 Purpose & Impact
- **More accurate behavior**: Avoids unnecessarily disabling shuffle when rectangular training uses a single consistent batch shape ✅.
- **Potential training quality improvement**: Preserving shuffle when safe can improve sample mixing and reduce ordering bias 🧠📈.
- **Less noisy warnings**: Users won’t see the “incompatible with shuffle” warning unless it’s genuinely relevant 🧾✨.
- **Better UX with `rect=True`**: Keeps the benefits of rectangular batching while still allowing shuffle in compatible setups 🚀.