### PR TITLE
Remove pin `torch<2.10.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,8 @@ dependencies = [
     "pyyaml>=5.3.1",
     "requests>=2.23.0",
     "scipy>=1.4.1",
-    "torch>=1.8.0,<2.10",
-    "torch>=1.8.0,<2.10,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
+    "torch>=1.8.0",
+    "torch>=1.8.0,!=2.4.0; sys_platform == 'win32'", # Windows CPU errors w/ 2.4.0 https://github.com/ultralytics/ultralytics/issues/15049
     "torchvision>=0.9.0",
     "psutil>=5.8.0", # system utilization
     "polars>=0.20.0",


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates Ultralytics’ PyTorch dependency constraints to remove the upper version cap, while keeping a Windows-specific exclusion for Torch 2.4.0 🧰🔥

### 📊 Key Changes
- Removed the global upper bound on PyTorch (`torch>=1.8.0,<2.10` → `torch>=1.8.0`) 🚀
- Kept a Windows-only safeguard to **exclude Torch 2.4.0** due to known CPU issues (`!=2.4.0` on `win32`) 🪟⚠️
- No runtime code changes—this is strictly a packaging/dependency update 📦

### 🎯 Purpose & Impact
- Enables users to install and use **newer PyTorch releases** without being blocked by Ultralytics’ version cap ✅✨
- Improves compatibility with modern environments (e.g., updated CUDA stacks, newer PyTorch features/perf improvements) ⚡
- Reduces install friction for users who already have newer Torch installed, especially in managed setups (Docker, Conda, enterprise images) 🧩
- Maintains stability on Windows by avoiding a known-bad Torch version that can cause CPU errors 🛡️