### PR TITLE
Feat: support multiple data config via yaml for YOLOE training

### DIFF
--- a/docs/en/models/yolo-world.md
+++ b/docs/en/models/yolo-world.md
@@ -321,6 +321,7 @@ This approach provides a powerful means of customizing state-of-the-art [object 
         from ultralytics import YOLOWorld
         from ultralytics.models.yolo.world.train_world import WorldTrainerFromScratch
 
+        # Option 1: Use Python dictionary
         data = dict(
             train=dict(
                 yolo_data=["Objects365.yaml"],
@@ -337,8 +338,27 @@ This approach provides a powerful means of customizing state-of-the-art [object 
             ),
             val=dict(yolo_data=["lvis.yaml"]),
         )
+
+        # Option 2: Use YAML file (yolo_world_data.yaml)
+        # train:
+        #   yolo_data:
+        #     - Objects365.yaml
+        #   grounding_data:
+        #     - img_path: flickr/full_images/
+        #       json_file: flickr/annotations/final_flickr_separateGT_train_segm.json
+        #     - img_path: mixed_grounding/gqa/images
+        #       json_file: mixed_grounding/annotations/final_mixed_train_no_coco_segm.json
+        # val:
+        #   yolo_data:
+        #     - lvis.yaml
+
         model = YOLOWorld("yolov8s-worldv2.yaml")
-        model.train(data=data, batch=128, epochs=100, trainer=WorldTrainerFromScratch)
+        model.train(
+            data=data,  # or data="yolo_world_data.yaml" if using YAML file
+            batch=128,
+            epochs=100,
+            trainer=WorldTrainerFromScratch,
+        )
         ```
 
 ## Citations and Acknowledgments

--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -541,6 +541,7 @@ The export process is similar to other YOLO models, with the added flexibility o
         from ultralytics import YOLOE
         from ultralytics.models.yolo.yoloe import YOLOESegTrainerFromScratch
 
+        # Option 1: Use Python dictionary
         data = dict(
             train=dict(
                 yolo_data=["Objects365.yaml"],
@@ -558,9 +559,22 @@ The export process is similar to other YOLO models, with the added flexibility o
             val=dict(yolo_data=["lvis.yaml"]),
         )
 
+        # Option 2: Use YAML file (yoloe_data.yaml)
+        # train:
+        #   yolo_data:
+        #     - Objects365.yaml
+        #   grounding_data:
+        #     - img_path: flickr/full_images/
+        #       json_file: flickr/annotations/final_flickr_separateGT_train_segm.json
+        #     - img_path: mixed_grounding/gqa/images
+        #       json_file: mixed_grounding/annotations/final_mixed_train_no_coco_segm.json
+        # val:
+        #   yolo_data:
+        #     - lvis.yaml
+
         model = YOLOE("yoloe-26l-seg.yaml")
         model.train(
-            data=data,
+            data=data,  # or data="yoloe_data.yaml" if using YAML file
             batch=128,
             epochs=30,
             close_mosaic=2,

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -697,7 +697,7 @@ def test_yolo_world():
     checks.IS_PYTHON_3_8 and LINUX and ARM64,
     reason="YOLOE with CLIP is not supported in Python 3.8 and aarch64 Linux",
 )
-def test_yoloe():
+def test_yoloe(tmp_path):
     """Test YOLOE models with MobileClip support."""
     # Predict
     # text-prompts
@@ -740,13 +740,18 @@ def test_yoloe():
     )
     # Train, from scratch
     model = YOLOE("yoloe-11s-seg.yaml")
-    model.train(
-        data=dict(train=dict(yolo_data=["coco128-seg.yaml"]), val=dict(yolo_data=["coco128-seg.yaml"])),
-        epochs=1,
-        close_mosaic=1,
-        trainer=YOLOESegTrainerFromScratch,
-        imgsz=32,
-    )
+
+    data_dict = dict(train=dict(yolo_data=["coco128-seg.yaml"]), val=dict(yolo_data=["coco128-seg.yaml"]))
+    data_yaml = tmp_path / f"yoloe-data.yaml"
+    YAML.save(data=data_dict, file=data_yaml)
+    for data in {data_dict, data_yaml}:
+        model.train(
+            data=data,
+            epochs=1,
+            close_mosaic=1,
+            trainer=YOLOESegTrainerFromScratch,
+            imgsz=32,
+        )
 
     # prompt-free
     # predict

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -742,7 +742,7 @@ def test_yoloe(tmp_path):
     model = YOLOE("yoloe-11s-seg.yaml")
 
     data_dict = dict(train=dict(yolo_data=["coco128-seg.yaml"]), val=dict(yolo_data=["coco128-seg.yaml"]))
-    data_yaml = tmp_path / f"yoloe-data.yaml"
+    data_yaml = tmp_path / "yoloe-data.yaml"
     YAML.save(data=data_dict, file=data_yaml)
     for data in {data_dict, data_yaml}:
         model.train(

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -701,7 +701,7 @@ def test_yoloe(tmp_path):
     """Test YOLOE models with MobileClip support."""
     # Predict
     # text-prompts
-    model = YOLO(WEIGHTS_DIR / "yoloe-11s-seg.pt")
+    model = YOLO(WEIGHTS_DIR / "yoloe-26s-seg.pt")
     names = ["person", "bus"]
     model.set_classes(names, model.get_text_pe(names))
     model(SOURCE, conf=0.01)
@@ -721,7 +721,7 @@ def test_yoloe(tmp_path):
     )
 
     # Val
-    model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg.pt")
+    model = YOLOE(WEIGHTS_DIR / "yoloe-26s-seg.pt")
     # text prompts
     model.val(data="coco128-seg.yaml", imgsz=32)
     # visual prompts
@@ -730,7 +730,7 @@ def test_yoloe(tmp_path):
     # Train, fine-tune
     from ultralytics.models.yolo.yoloe import YOLOEPESegTrainer, YOLOESegTrainerFromScratch
 
-    model = YOLOE("yoloe-11s-seg.pt")
+    model = YOLOE("yoloe-26s-seg.pt")
     model.train(
         data="coco128-seg.yaml",
         epochs=1,
@@ -739,7 +739,7 @@ def test_yoloe(tmp_path):
         imgsz=32,
     )
     # Train, from scratch
-    model = YOLOE("yoloe-11s-seg.yaml")
+    model = YOLOE("yoloe-26s-seg.yaml")
 
     data_dict = dict(train=dict(yolo_data=["coco128-seg.yaml"]), val=dict(yolo_data=["coco128-seg.yaml"]))
     data_yaml = tmp_path / "yoloe-data.yaml"
@@ -755,10 +755,10 @@ def test_yoloe(tmp_path):
 
     # prompt-free
     # predict
-    model = YOLOE(WEIGHTS_DIR / "yoloe-11s-seg-pf.pt")
+    model = YOLOE(WEIGHTS_DIR / "yoloe-26s-seg-pf.pt")
     model.predict(SOURCE)
     # val
-    model = YOLOE("yoloe-11s-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
+    model = YOLOE("yoloe-26s-seg.pt")  # or select yoloe-m/l-seg.pt for different sizes
     model.val(data="coco128-seg.yaml", imgsz=32)
 
 

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -1,4 +1,5 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -6,8 +6,9 @@ from ultralytics.data import YOLOConcatDataset, build_grounding, build_yolo_data
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.models.yolo.world import WorldTrainer
 from ultralytics.utils import DATASETS_DIR, DEFAULT_CFG, LOGGER
-from ultralytics.utils.torch_utils import unwrap_model
 from ultralytics.utils.checks import check_file
+from ultralytics.utils.torch_utils import unwrap_model
+
 
 class WorldTrainerFromScratch(WorldTrainer):
     """A class extending the WorldTrainer for training a world model from scratch on open-set datasets.
@@ -99,13 +100,13 @@ class WorldTrainerFromScratch(WorldTrainer):
         ]
         self.set_text_embeddings(datasets, batch)  # cache text embeddings to accelerate training
         return YOLOConcatDataset(datasets) if len(datasets) > 1 else datasets[0]
+
     def check_data_config(self):
-        """
-        Check and load the data configuration from a YAML file or dictionary.
-        
+        """Check and load the data configuration from a YAML file or dictionary.
+
         Returns:
             (dict): Data configuration dictionary loaded from YAML file or passed directly.
-            
+
         Raises:
             TypeError: If data is not a string path or dictionary.
             FileNotFoundError: If the specified YAML file does not exist.
@@ -115,33 +116,31 @@ class WorldTrainerFromScratch(WorldTrainer):
         if isinstance(self.args.data, dict):
             LOGGER.info("Using data config from dictionary")
             return self.args.data
-        
+
         # If string, load from YAML file
         if isinstance(self.args.data, str):
             data_path = self.args.data
-            check_file(data_path)  
+            check_file(data_path)
             # Load YAML with error handling
             try:
                 from ultralytics.utils import YAML
+
                 data_yaml = YAML.load(str(data_path))
-                
+
                 # Validate loaded data is a dictionary
                 if not isinstance(data_yaml, dict):
                     raise ValueError(f"YAML file must contain a dictionary, got {type(data_yaml).__name__}")
-                
+
                 LOGGER.info(f"Loaded data config from {data_path}")
-                
-                self.args.data=data_yaml  # update args.data to the loaded dict 
+
+                self.args.data = data_yaml  # update args.data to the loaded dict
                 return data_yaml
-                
+
             except Exception as e:
                 raise ValueError(f"Failed to load YAML file {data_path}: {e}")
-        
+
         # Invalid type
-        raise TypeError(
-            f"data must be a YAML file path (str) or dict, "
-            f"got {type(self.args.data).__name__}"
-        )
+        raise TypeError(f"data must be a YAML file path (str) or dict, got {type(self.args.data).__name__}")
 
     def get_dataset(self):
         """Get train and validation paths from data dictionary.
@@ -157,7 +156,7 @@ class WorldTrainerFromScratch(WorldTrainer):
             AssertionError: If train or validation datasets are not found, or if validation has multiple datasets.
         """
         final_data = {}
-        data_yaml=self.check_data_config()
+        data_yaml = self.check_data_config()
         assert data_yaml.get("train", False), "train dataset not found"  # object365.yaml
         assert data_yaml.get("val", False), "validation dataset not found"  # lvis.yaml
         data = {k: [check_det_dataset(d) for d in v.get("yolo_data", [])] for k, v in data_yaml.items()}
@@ -215,7 +214,6 @@ class WorldTrainerFromScratch(WorldTrainer):
         Returns:
             (dict): Dictionary containing evaluation metrics and results.
         """
-
         # Ensure self.args.data is a dict (should be after get_dataset call)
         assert isinstance(self.args.data, dict), "self.args.data should be a dict at this point"
         val = self.args.data["val"]["yolo_data"][0]

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -114,11 +114,9 @@ class WorldTrainerFromScratch(WorldTrainer):
         """
         # If string, load from YAML file
         if isinstance(data, str):
-            file = check_file(data)
-
             from ultralytics.utils import YAML
 
-            return YAML.load(file)
+            return YAML.load(check_file(data))
         return data
 
     def get_dataset(self):

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -7,7 +7,7 @@ from ultralytics.data.utils import check_det_dataset
 from ultralytics.models.yolo.world import WorldTrainer
 from ultralytics.utils import DATASETS_DIR, DEFAULT_CFG, LOGGER
 from ultralytics.utils.torch_utils import unwrap_model
-
+from ultralytics.utils.checks import check_file
 
 class WorldTrainerFromScratch(WorldTrainer):
     """A class extending the WorldTrainer for training a world model from scratch on open-set datasets.
@@ -118,23 +118,8 @@ class WorldTrainerFromScratch(WorldTrainer):
         
         # If string, load from YAML file
         if isinstance(self.args.data, str):
-            data_path = Path(self.args.data)
-            
-            # If data is just a filename (no path), look in default datasets dir
-            if not data_path.is_absolute() and data_path.parent == Path('.'):
-                from ultralytics.utils import ROOT
-                # Remove .yaml/.yml extension if present, then add .yaml
-                stem = data_path.stem if data_path.suffix in {'.yaml', '.yml'} else data_path.name
-                data_path = ROOT / 'cfg' / 'datasets' / f'{stem}.yaml'
-            
-            # Validate YAML file exists
-            if not data_path.exists():
-                raise FileNotFoundError(f"Data config file not found: {data_path}")
-            
-            # Validate YAML file extension
-            if data_path.suffix not in {'.yaml', '.yml'}:
-                raise ValueError(f"Data file must be YAML format (.yaml/.yml), got {data_path.suffix}")
-            
+            data_path = self.args.data
+            check_file(data_path)  
             # Load YAML with error handling
             try:
                 from ultralytics.utils import YAML

--- a/ultralytics/models/yolo/world/train_world.py
+++ b/ultralytics/models/yolo/world/train_world.py
@@ -192,8 +192,6 @@ class WorldTrainerFromScratch(WorldTrainer):
         Returns:
             (dict): Dictionary containing evaluation metrics and results.
         """
-        # Ensure self.args.data is a dict (should be after get_dataset call)
-        assert isinstance(self.args.data, dict), "self.args.data should be a dict at this point"
         val = self.args.data["val"]["yolo_data"][0]
         self.validator.args.data = val
         self.validator.args.split = "minival" if isinstance(val, str) and "lvis" in val else "val"


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
This pull request adds flexible support for specifying data configurations for YOLOE training, allowing users to provide either a Python dictionary or a YAML file. The documentation is updated to reflect these options, and new logic is introduced to robustly load and validate the data configuration. The changes also ensure that the internal state is consistent regardless of the input method.

**Flexible data configuration support:**

* Added a new `check_data_config` method in `train_world.py` that allows data configuration to be loaded from either a Python dictionary or a YAML file, with comprehensive validation and error handling. (`ultralytics/models/yolo/world/train_world.py`)
* Updated the `get_dataset` and `final_eval` methods to use the new `check_data_config` logic, ensuring that `self.args.data` is always a dictionary after loading. (`ultralytics/models/yolo/world/train_world.py`) [[1]](diffhunk://#diff-b3f76b6a162ec515ba8f681621fc9591b89dbd38bd61f193ff475bcaf1e99a73L117-R175) [[2]](diffhunk://#diff-b3f76b6a162ec515ba8f681621fc9591b89dbd38bd61f193ff475bcaf1e99a73R233-R235)

**Documentation improvements:**

* Updated the `yoloe.md` documentation to clearly show both dictionary and YAML file options for specifying training data, including example YAML structure and usage notes. (`docs/en/models/yoloe.md`) [[1]](diffhunk://#diff-0c40b228d0d420fbbcfcfa634c1c9ff2550fdbf21dc4548d65be8ce91bb29334R544) [[2]](diffhunk://#diff-0c40b228d0d420fbbcfcfa634c1c9ff2550fdbf21dc4548d65be8ce91bb29334R562-R577)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds YAML-based multi-dataset data config support for YOLOE/YOLO-World training, alongside updated docs for easier configuration 📄🚀

### 📊 Key Changes
- Introduces `check_data_config()` in `ultralytics/models/yolo/world/train_world.py` to accept `data` as either a dict or a YAML path
- Adds robust loading/validation for YAML configs (extension checks, default lookup under `cfg/datasets`, helpful errors)
- Updates `docs/en/models/yoloe.md` to document YAML-file data configs as an alternative to inline Python dictionaries
- Adds an assertion in `final_eval()` to ensure `self.args.data` is a dict after dataset setup

### 🎯 Purpose & Impact
- Enables cleaner multi-source dataset configs (YOLO + grounding data) via a single YAML file, improving usability for complex YOLOE training setups ✅
- Keeps backward compatibility with existing dict-based configs while expanding supported input types 🔁
- Reduces boilerplate in training scripts and improves reproducibility by making dataset definitions file-based 🧩