### PR TITLE
Fix/yoloe text model attribute in yoloe trainer from scratch

### DIFF
--- a/ultralytics/models/yolo/yoloe/train.py
+++ b/ultralytics/models/yolo/yoloe/train.py
@@ -196,7 +196,7 @@ class YOLOETrainerFromScratch(YOLOETrainer, WorldTrainerFromScratch):
         Returns:
             (dict): Dictionary mapping text samples to their embeddings.
         """
-        model = "mobileclip:blt"
+        model = unwrap_model(self.model).text_model
         cache_path = cache_dir / f"text_embeddings_{model.replace(':', '_').replace('/', '_')}.pt"
         if cache_path.exists():
             LOGGER.info(f"Reading existed cache from '{cache_path}'")
@@ -204,7 +204,6 @@ class YOLOETrainerFromScratch(YOLOETrainer, WorldTrainerFromScratch):
             if sorted(txt_map.keys()) == sorted(texts):
                 return txt_map
         LOGGER.info(f"Caching text embeddings to '{cache_path}'")
-        assert self.model is not None
         txt_feats = unwrap_model(self.model).get_text_pe(texts, batch, without_reprta=True, cache_clip_model=False)
         txt_map = dict(zip(texts, txt_feats.squeeze(0)))
         torch.save(txt_map, cache_path)


### PR DESCRIPTION
This pull request updates the way the text model is referenced and used in the `generate_text_embeddings` method, improving clarity and robustness. The most important change is using the unwrapped model's `text_model` attribute directly, which helps avoid ambiguity and potential errors when handling different model wrappers.

**Improvements to model handling:**

* Changed the model reference in `generate_text_embeddings` from a hardcoded string to dynamically use `unwrap_model(self.model).text_model`, ensuring the correct model is used and improving maintainability.<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fix YOLOE trainer text-embedding cache key to use the actual configured `text_model` instead of a hardcoded string 🧠

### 📊 Key Changes
- Updated `generate_text_embeddings()` to derive `model` from `unwrap_model(self.model).text_model` rather than the hardcoded `"mobileclip:blt"`
- Cache filename now reflects the active text model, preventing cache collisions across different configurations 📦
- Removed a redundant `assert self.model is not None` before calling `unwrap_model(self.model).get_text_pe(...)`

### 🎯 Purpose & Impact
- Ensures text-embedding caching is correct when training YOLOE from scratch with different text model settings ✅
- Avoids silently reusing incompatible cached embeddings that could degrade training quality or cause confusing behavior 🔍
- Improves robustness/consistency by relying on the model’s actual attributes rather than constants 🛠️