### PR TITLE
Save `close_mosaic` as integer in `best_hyperparameters.yaml`

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -448,9 +448,7 @@ class Tuner:
                 f"{self.prefix}Best fitness model is {best_save_dir}"
             )
             LOGGER.info("\n" + header)
-            data = {
-                k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx])
-            }
+            data = {k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx])}
             YAML.save(
                 self.tune_dir / "best_hyperparameters.yaml",
                 data=data,

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -448,7 +448,9 @@ class Tuner:
                 f"{self.prefix}Best fitness model is {best_save_dir}"
             )
             LOGGER.info("\n" + header)
-            data = {k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx, i + 1])}
+            data = {
+                k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx, i + 1])
+            }
             YAML.save(
                 self.tune_dir / "best_hyperparameters.yaml",
                 data=data,

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -27,7 +27,7 @@ import numpy as np
 import torch
 
 from ultralytics.cfg import get_cfg, get_save_dir
-from ultralytics.utils import DEFAULT_CFG, CFG_INT_KEYS, LOGGER, YAML, callbacks, colorstr, remove_colorstr
+from ultralytics.utils import CFG_INT_KEYS, DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.patches import torch_load
 from ultralytics.utils.plotting import plot_tune_results

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -26,8 +26,8 @@ from datetime import datetime
 import numpy as np
 import torch
 
-from ultralytics.cfg import get_cfg, get_save_dir
-from ultralytics.utils import CFG_INT_KEYS, DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
+from ultralytics.cfg import CFG_INT_KEYS, get_cfg, get_save_dir
+from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.patches import torch_load
 from ultralytics.utils.plotting import plot_tune_results

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -448,7 +448,7 @@ class Tuner:
                 f"{self.prefix}Best fitness model is {best_save_dir}"
             )
             LOGGER.info("\n" + header)
-            data = {k: float(x[best_idx, i + 1]) for i, k in enumerate(self.space.keys())}
+            data = {k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx, i + 1])}
             YAML.save(
                 self.tune_dir / "best_hyperparameters.yaml",
                 data=data,

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -27,7 +27,7 @@ import numpy as np
 import torch
 
 from ultralytics.cfg import get_cfg, get_save_dir
-from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
+from ultralytics.utils import DEFAULT_CFG, CFG_INT_KEYS, LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.patches import torch_load
 from ultralytics.utils.plotting import plot_tune_results
@@ -448,7 +448,7 @@ class Tuner:
                 f"{self.prefix}Best fitness model is {best_save_dir}"
             )
             LOGGER.info("\n" + header)
-            data = {k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx, 1:])}
+            data = {k: int(v) if k in CFG_INT_KEYS else float(v) for k, v in zip(self.space.keys(), x[best_idx, 1:])}
             YAML.save(
                 self.tune_dir / "best_hyperparameters.yaml",
                 data=data,

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -449,7 +449,7 @@ class Tuner:
             )
             LOGGER.info("\n" + header)
             data = {
-                k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx, i + 1])
+                k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx])
             }
             YAML.save(
                 self.tune_dir / "best_hyperparameters.yaml",

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -448,7 +448,7 @@ class Tuner:
                 f"{self.prefix}Best fitness model is {best_save_dir}"
             )
             LOGGER.info("\n" + header)
-            data = {k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx])}
+            data = {k: int(v) if k == "close_mosaic" else float(v) for k, v in zip(self.space.keys(), x[best_idx, 1:])}
             YAML.save(
                 self.tune_dir / "best_hyperparameters.yaml",
                 data=data,


### PR DESCRIPTION
Closes #23430 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes hyperparameter tuning output so integer-only config values are saved as integers (not floats) ✅🛠️

### 📊 Key Changes
- Imports `CFG_INT_KEYS` from `ultralytics.cfg` to identify which hyperparameters must remain integers 📌
- Updates the “best hyperparameters” export logic to cast values:
  - `int(...)` for keys in `CFG_INT_KEYS`
  - `float(...)` for all other tuned keys 🧾
- Ensures `best_hyperparameters.yaml` reflects correct types when saved 💾

### 🎯 Purpose & Impact
- Prevents type mismatches where integer parameters (e.g., counts, steps, sizes) were previously written as floats like `32.0` 🔧
- Improves reliability when reusing tuned configs—fewer surprises when loading YAML back into training/tuning workflows 🚀
- Makes tuned results clearer and more user-friendly for both CLI and programmatic use 📈