### PR TITLE
Fix SMTP port parameter syntax in SecurityAlarm

### DIFF
--- a/ultralytics/solutions/security_alarm.py
+++ b/ultralytics/solutions/security_alarm.py
@@ -62,7 +62,7 @@ class SecurityAlarm(BaseSolution):
         """
         import smtplib
 
-        self.server = smtplib.SMTP("smtp.gmail.com: 587")
+        self.server = smtplib.SMTP("smtp.gmail.com", 587)
         self.server.starttls()
         self.server.login(from_email, password)
         self.to_email = to_email


### PR DESCRIPTION
## Summary
- Fix incorrect SMTP port parameter syntax in \`security_alarm.py\`

## Problem
The SMTP constructor was called with port embedded in the host string:
\`\`\`
smtplib.SMTP(\"smtp.gmail.com: 587\")  # Wrong
\`\`\`

## Solution
Pass port as a separate integer argument:
\`\`\`
smtplib.SMTP(\"smtp.gmail.com\", 587)  # Correct
\`\`\`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes the SMTP initialization in `SecurityAlarm` by correctly passing host and port to `smtplib.SMTP` for reliable email alert delivery 📧🔐

### 📊 Key Changes
- Updated `smtplib.SMTP` call from a single malformed string (`"smtp.gmail.com: 587"`) to proper `(host, port)` arguments
- Keeps existing TLS startup and login flow unchanged

### 🎯 Purpose & Impact
- Prevents connection/parsing issues when creating the SMTP client
- Improves reliability of SecurityAlarm email notifications for users using Gmail SMTP
- Low-risk change with a clear bug-fix scope ✅