### PR TITLE
`ultralytics 8.4.9` Hyperspectral CopyPaste augmentation

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.8"
+__version__ = "8.4.9"
 
 import importlib
 import os

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1745,7 +1745,7 @@ class CopyPaste(BaseMixTransform):
         instances.convert_bbox(format="xyxy")
         instances.denormalize(w, h)
 
-        im_new = np.zeros(im.shape, np.uint8)
+        im_new = np.zeros(im.shape[:2], np.uint8)
         instances2 = labels2.pop("instances", None)
         if instances2 is None:
             instances2 = deepcopy(instances)
@@ -1758,7 +1758,7 @@ class CopyPaste(BaseMixTransform):
         for j in indexes[: round(self.p * n)]:
             cls = np.concatenate((cls, labels2.get("cls", cls)[[j]]), axis=0)
             instances = Instances.concatenate((instances, instances2[[j]]), axis=0)
-            cv2.drawContours(im_new, instances2.segments[[j]].astype(np.int32), -1, (1, 1, 1), cv2.FILLED)
+            cv2.drawContours(im_new, instances2.segments[[j]].astype(np.int32), -1, 1, cv2.FILLED)
 
         result = labels2.get("img", cv2.flip(im, 1))  # augment segments
         if result.ndim == 2:  # cv2.flip would eliminate the last dimension for grayscale images


### PR DESCRIPTION
Closes #23469 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps Ultralytics to `8.4.9` and fixes a segmentation augmentation mask bug (especially for grayscale inputs) 🛠️📷

### 📊 Key Changes
- 🔢 **Version update:** `__version__` increased from **8.4.8 → 8.4.9**.
- 🧩 **Segmentation augmentation fix (in `ultralytics/data/augment.py`):**
  - ✅ Creates the contour mask as a **2D array** (`im.shape[:2]`) instead of matching the full image shape.
  - 🎨 Adjusts `cv2.drawContours()` to draw on a **single-channel mask** using value `1` instead of `(1, 1, 1)`.

### 🎯 Purpose & Impact
- 🧠 **Prevents shape/channel mismatches** when building masks for segmentation augmentations, improving robustness across image types.
- 🌑 **Better grayscale compatibility:** avoids issues where grayscale images (2D arrays) could behave unexpectedly during mask creation/drawing.
- 📈 **More reliable training augmentations** for segmentation datasets, reducing the chance of subtle augmentation bugs that can hurt model quality.