### PR TITLE
Add repr for Instance Class for devlopers who needs better debugging …

### DIFF
--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -482,3 +482,16 @@ class Instances:
     def bboxes(self) -> np.ndarray:
         """Return bounding boxes."""
         return self._bboxes.bboxes
+
+    def __repr__(self) -> str:
+        """Return a string representation of the Instances object."""
+        # Map private to public names and include direct attributes
+        attr_map = {'_bboxes': 'bboxes'}
+        parts = []
+        for key, value in self.__dict__.items():
+            name = attr_map.get(key, key)
+            if name == 'bboxes':
+                value = self.bboxes  # Use the property
+            if value is not None:
+                parts.append(f'{name}={value!r}')
+        return "Instances({})".format('\n'.join(parts))

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -486,12 +486,12 @@ class Instances:
     def __repr__(self) -> str:
         """Return a string representation of the Instances object."""
         # Map private to public names and include direct attributes
-        attr_map = {'_bboxes': 'bboxes'}
+        attr_map = {"_bboxes": "bboxes"}
         parts = []
         for key, value in self.__dict__.items():
             name = attr_map.get(key, key)
-            if name == 'bboxes':
+            if name == "bboxes":
                 value = self.bboxes  # Use the property
             if value is not None:
-                parts.append(f'{name}={value!r}')
-        return "Instances({})".format('\n'.join(parts))
+                parts.append(f"{name}={value!r}")
+        return "Instances({})".format("\n".join(parts))


### PR DESCRIPTION
…info.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a more informative `__repr__` for the `Instances` object to improve readability and debugging 🛠️✨

### 📊 Key Changes
- Implemented `Instances.__repr__()` in `ultralytics/utils/instance.py` to return a structured string representation 🧾
- Maps internal/private attributes to user-facing names (e.g., `_bboxes` → `bboxes`) for clearer output 🔍
- Ensures `bboxes` uses the public `bboxes` property (so the printed value reflects the same data users access) ✅
- Skips attributes that are `None` to keep the output concise 🧹

### 🎯 Purpose & Impact
- Makes logs, debugging sessions, and interactive use (e.g., notebooks) much easier by showing what an `Instances` object contains at a glance 👀
- Reduces confusion by avoiding exposure of internal attribute names like `_bboxes`, presenting consistent public-facing fields 📦
- Low risk to existing workflows: primarily changes how `Instances` displays when printed/inspected, not its underlying behavior ⚙️