### PR TITLE
refactor: ♻️  Simplify requirement checks for executorch

### DIFF
--- a/docs/en/reference/utils/checks.md
+++ b/docs/en/reference/utils/checks.md
@@ -59,6 +59,10 @@ keywords: Ultralytics, YOLO, utility functions, version checks, requirements, im
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.checks.check_executorch_requirements
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.checks.check_torchvision
 
 <br><br><hr><br>

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1204,7 +1204,7 @@ class Exporter:
             check_requirements("packaging>=22.0")
 
         check_requirements("ruamel.yaml<0.19.0")
-        check_requirements("executorch", "flatbuffers", "torchao")
+        check_requirements("executorch")
         # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
         check_requirements("numpy<=2.3.5")
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1205,19 +1205,7 @@ class Exporter:
             check_requirements("packaging>=22.0")
 
         check_requirements("ruamel.yaml<0.19.0")
-
-        # Attempt stable first with the current torch version as forced guard for resolution
-        torch_version = TORCH_VERSION.split("+")[0]
-        if not check_requirements(
-            requirements=["executorch", "flatbuffers", "torchao"],
-            cmds=f"torch=={torch_version}",
-        ):
-            # Fallback to nightly if resolution fails
-            cmd_prerelease = "--prerelease=allow" if (not ARM64 and check_uv()) else "--pre"
-            check_requirements(
-                requirements=["executorch", "flatbuffers", "torchao"],
-                cmds=f"torch=={torch_version} --extra-index-url https://download.pytorch.org/whl/nightly {cmd_prerelease}",
-            )
+        check_requirements("executorch", "flatbuffers", "torchao")
         # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
         check_requirements("numpy<=2.3.5")
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -87,7 +87,6 @@ from ultralytics.utils import (
     IS_COLAB,
     IS_DEBIAN_BOOKWORM,
     IS_DEBIAN_TRIXIE,
-    IS_DOCKER,
     IS_JETSON,
     IS_RASPBERRYPI,
     IS_UBUNTU,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -108,6 +108,7 @@ from ultralytics.utils.checks import (
     IS_PYTHON_3_10,
     IS_PYTHON_MINIMUM_3_9,
     check_apt_requirements,
+    check_executorch_requirements,
     check_imgsz,
     check_requirements,
     check_version,
@@ -1197,16 +1198,9 @@ class Exporter:
         following Ultralytics conventions.
         """
         LOGGER.info(f"\n{prefix} starting export with ExecuTorch...")
-        assert TORCH_2_9, f"ExecuTorch export requires torch>=2.9.0 but torch=={TORCH_VERSION} is installed"
+        assert TORCH_2_9, f"ExecuTorch requires torch>=2.9.0 but torch=={TORCH_VERSION} is installed"
 
-        # BUG executorch build on arm64 Docker requires packaging>=22.0 https://github.com/pypa/setuptools/issues/4483
-        if LINUX and ARM64 and IS_DOCKER:
-            check_requirements("packaging>=22.0")
-
-        check_requirements("ruamel.yaml<0.19.0")
-        check_requirements("executorch")
-        # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
-        check_requirements("numpy<=2.3.5")
+        check_executorch_requirements()
 
         from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
         from executorch.exir import to_edge_transform_and_lower

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -110,7 +110,6 @@ from ultralytics.utils.checks import (
     check_apt_requirements,
     check_imgsz,
     check_requirements,
-    check_uv,
     check_version,
     is_intel,
     is_sudo_available,

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -632,7 +632,7 @@ class AutoBackend(nn.Module):
                 check_requirements("packaging>=22.0")
 
             check_requirements("ruamel.yaml<0.19.0")
-            check_requirements("executorch", "flatbuffers", "torchao")
+            check_requirements("executorch")
             # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
             check_requirements("numpy<=2.3.5")
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -18,7 +18,6 @@ from PIL import Image
 
 from ultralytics.utils import (
     ARM64,
-    IS_DOCKER,
     IS_JETSON,
     LINUX,
     LOGGER,

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -27,7 +27,14 @@ from ultralytics.utils import (
     YAML,
     is_jetson,
 )
-from ultralytics.utils.checks import check_requirements, check_suffix, check_version, check_yaml, is_rockchip
+from ultralytics.utils.checks import (
+    check_executorch_requirements,
+    check_requirements,
+    check_suffix,
+    check_version,
+    check_yaml,
+    is_rockchip,
+)
 from ultralytics.utils.downloads import attempt_download_asset, is_url
 from ultralytics.utils.nms import non_max_suppression
 
@@ -627,14 +634,7 @@ class AutoBackend(nn.Module):
         elif pte:
             LOGGER.info(f"Loading {w} for ExecuTorch inference...")
 
-            # BUG executorch build on arm64 Docker requires packaging>=22.0 https://github.com/pypa/setuptools/issues/4483
-            if LINUX and ARM64 and IS_DOCKER:
-                check_requirements("packaging>=22.0")
-
-            check_requirements("ruamel.yaml<0.19.0")
-            check_requirements("executorch")
-            # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
-            check_requirements("numpy<=2.3.5")
+            check_executorch_requirements()
 
             from executorch.runtime import Runtime
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -27,7 +27,7 @@ from ultralytics.utils import (
     YAML,
     is_jetson,
 )
-from ultralytics.utils.checks import check_requirements, check_suffix, check_uv, check_version, check_yaml, is_rockchip
+from ultralytics.utils.checks import check_requirements, check_suffix, check_version, check_yaml, is_rockchip
 from ultralytics.utils.downloads import attempt_download_asset, is_url
 from ultralytics.utils.nms import non_max_suppression
 

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -24,7 +24,6 @@ from ultralytics.utils import (
     LOGGER,
     PYTHON_VERSION,
     ROOT,
-    TORCH_VERSION,
     YAML,
     is_jetson,
 )
@@ -633,20 +632,7 @@ class AutoBackend(nn.Module):
                 check_requirements("packaging>=22.0")
 
             check_requirements("ruamel.yaml<0.19.0")
-
-            # Attempt stable first with the current torch version as forced guard for resolution
-            torch_version = TORCH_VERSION.split("+")[0]
-            if not check_requirements(
-                requirements=["executorch", "flatbuffers", "torchao"],
-                cmds=f"torch=={torch_version}",
-            ):
-                # Fallback to nightly if resolution fails
-                cmd_prerelease = "--prerelease=allow" if (not ARM64 and check_uv()) else "--pre"
-                check_requirements(
-                    requirements=["executorch", "flatbuffers", "torchao"],
-                    cmds=f"torch=={torch_version} --extra-index-url https://download.pytorch.org/whl/nightly {cmd_prerelease}",
-                )
-
+            check_requirements("executorch", "flatbuffers", "torchao")
             # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
             check_requirements("numpy<=2.3.5")
 

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -497,9 +497,7 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
 
 
 def check_executorch_requirements():
-    """Check and install ExecuTorch requirements including platform-specific dependencies.
-
-    """
+    """Check and install ExecuTorch requirements including platform-specific dependencies."""
     # BUG executorch build on arm64 Docker requires packaging>=22.0 https://github.com/pypa/setuptools/issues/4483
     if LINUX and ARM64 and IS_DOCKER:
         check_requirements("packaging>=22.0")

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -502,7 +502,6 @@ def check_executorch_requirements():
     if LINUX and ARM64 and IS_DOCKER:
         check_requirements("packaging>=22.0")
 
-    check_requirements("ruamel.yaml<0.19.0")
     check_requirements("executorch", cmds=f"torch=={TORCH_VERSION.split('+')[0]}")
     # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
     check_requirements("numpy<=2.3.5")

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -29,6 +29,7 @@ from ultralytics.utils import (
     AUTOINSTALL,
     GIT,
     IS_COLAB,
+    IS_DOCKER,
     IS_JETSON,
     IS_KAGGLE,
     IS_PIP_PACKAGE,
@@ -493,6 +494,20 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
             return False
 
     return True
+
+
+def check_executorch_requirements():
+    """Check and install ExecuTorch requirements including platform-specific dependencies.
+
+    """
+    # BUG executorch build on arm64 Docker requires packaging>=22.0 https://github.com/pypa/setuptools/issues/4483
+    if LINUX and ARM64 and IS_DOCKER:
+        check_requirements("packaging>=22.0")
+
+    check_requirements("ruamel.yaml<0.19.0")
+    check_requirements("executorch", cmds=f"torch=={TORCH_VERSION.split('+')[0]}")
+    # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
+    check_requirements("numpy<=2.3.5")
 
 
 def check_torchvision():


### PR DESCRIPTION
[Executorch 1.1.0](https://pypi.org/project/executorch/) released so I clean up most of the code for simpler installing and better torch 2.10 and upper support covered. Lowest version also covered. 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Centralizes ExecuTorch dependency checks into a single helper to simplify export/inference setup and reduce platform-specific issues 🧩⚙️

### 📊 Key Changes
- Added `check_executorch_requirements()` in `ultralytics/utils/checks.py` to handle ExecuTorch-related installs and pins ✅
- Updated ExecuTorch **export** (`ultralytics/engine/exporter.py`) to call `check_executorch_requirements()` instead of duplicating install logic 🔁
- Updated ExecuTorch **inference loading** (`ultralytics/nn/autobackend.py`) to use the same centralized requirements check 🧠
- Extended docs to include a reference entry for `ultralytics.utils.checks.check_executorch_requirements` 📚
- Removed scattered/duplicated logic around Docker ARM64 packaging workaround and numpy pin from multiple call sites 🧹

### 🎯 Purpose & Impact
- **More reliable ExecuTorch setup** across environments (especially Linux ARM64 Docker) by consistently applying known workarounds 🐳🛠️
- **Less maintenance and fewer regressions** since dependency logic lives in one place instead of being duplicated in exporter + runtime loader 🎯
- **Smoother user experience** when exporting or running ExecuTorch models—automatic checks/install steps are now standardized 🚀
- **Improved documentation discoverability** for users and contributors looking for how ExecuTorch requirements are handled 🔍📖