### PR TITLE
Fix training with `compile`

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -120,7 +120,7 @@ def test_train():
     device = tuple(DEVICES) if len(DEVICES) > 1 else DEVICES[0]
     # NVIDIA Jetson only has one GPU and therefore skipping checks
     if not IS_JETSON:
-        results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15)
+        results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, compile=True)
         results = YOLO(MODEL).train(data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
         visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
         assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -73,7 +73,7 @@ class DetectionTrainer(BaseTrainer):
         Returns:
             (Dataset): YOLO dataset object configured for the specified mode.
         """
-        gs = max(int(unwrap_model(self.model).stride.max() if self.model else 0), 32)
+        gs = max(int(unwrap_model(self.model).stride.max()), 32)
         return build_yolo_dataset(self.args, img_path, batch, self.data, mode=mode, rect=mode == "val", stride=gs)
 
     def get_dataloader(self, dataset_path: str, batch_size: int = 16, rank: int = 0, mode: str = "train"):


### PR DESCRIPTION
Closes #23477 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates CUDA training tests to cover `compile=True` and simplifies dataset stride calculation for more consistent training behavior ⚡✅

### 📊 Key Changes
- Enabled model compilation in the CUDA training test by adding `compile=True` to a `YOLO(MODEL).train(...)` call 🧪🚀
- Simplified the grid-stride (`gs`) calculation in `ultralytics/models/yolo/detect/train.py` by removing a fallback path and always reading stride from the unwrapped model 📏🛠️

### 🎯 Purpose & Impact
- Improves test coverage for PyTorch compile workflows, helping catch regressions when users train with `compile=True` (often used for speedups) ⚙️🔥
- Makes stride handling more predictable by relying on the model’s actual stride, reducing edge-case ambiguity during dataset construction and training setup 🧩✅
- Potential impact: if `build_dataset()` is called when `self.model` isn’t initialized, this change could surface errors earlier instead of silently falling back—useful for correctness, but may reveal previously hidden setup issues 🕵️‍♂️⚠️