### PR TITLE
Print error on CLI tests subprocess failure

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def run(cmd: str) -> None:
     if result.returncode != 0:
         LOGGER.error(result.stdout)
         LOGGER.error(result.stderr)
-        raise subprocess.CalledProcessError(result.returncode, cmd)
+        raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)
 
 
 def test_special_modes() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,14 +7,17 @@ import pytest
 from PIL import Image
 
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODELS, TASK_MODEL_DATA
-from ultralytics.utils import ARM64, ASSETS, LINUX, WEIGHTS_DIR, checks
+from ultralytics.utils import ARM64, ASSETS, LINUX, LOGGER, WEIGHTS_DIR, checks
 from ultralytics.utils.torch_utils import TORCH_1_11
 
 
 def run(cmd: str) -> None:
     """Execute a shell command using subprocess."""
     subprocess.run(cmd.split(), check=True)
-
+    if result.returncode != 0:
+        LOGGER.error(result.stdout)
+        LOGGER.error(result.stderr)
+        raise subprocess.CalledProcessError(result.returncode, cmd)
 
 def test_special_modes() -> None:
     """Test various special command-line modes for YOLO functionality."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ def run(cmd: str) -> None:
         LOGGER.error(result.stderr)
         raise subprocess.CalledProcessError(result.returncode, cmd)
 
+
 def test_special_modes() -> None:
     """Test various special command-line modes for YOLO functionality."""
     run("yolo help")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from ultralytics.utils.torch_utils import TORCH_1_11
 
 def run(cmd: str) -> None:
     """Execute a shell command using subprocess."""
-    result = subprocess.run(cmd.split(), check=True)
+    result = subprocess.run(cmd.split(), capture_output=True, text=True)
     if result.returncode != 0:
         LOGGER.error(result.stdout)
         LOGGER.error(result.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from ultralytics.utils.torch_utils import TORCH_1_11
 
 def run(cmd: str) -> None:
     """Execute a shell command using subprocess."""
-    subprocess.run(cmd.split(), check=True)
+    result = subprocess.run(cmd.split(), check=True)
     if result.returncode != 0:
         LOGGER.error(result.stdout)
         LOGGER.error(result.stderr)


### PR DESCRIPTION
Not able to see the reason for Conda tests failing at `yolo checks`

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves CLI test command execution by capturing and logging subprocess output on failures for easier debugging 🧪🔍

### 📊 Key Changes
- Updated `tests/test_cli.py` `run()` helper to use `subprocess.run(..., capture_output=True, text=True)` instead of `check=True`
- On non-zero exit codes, logs both `stdout` and `stderr` via Ultralytics `LOGGER` before raising `CalledProcessError`
- Added `LOGGER` import from `ultralytics.utils` to support consistent test-time logging 📝

### 🎯 Purpose & Impact
- Makes failing CLI tests far easier to diagnose by surfacing the exact error output in logs (instead of silent/limited failure info) ✅
- Improves developer productivity and CI troubleshooting by preserving subprocess output context 🛠️
- No change to user-facing CLI behavior—this is test infrastructure only, with safer and clearer failure reporting 📦