### PR TITLE
fix: 🐞 Add requirement check for TensorRT in `test_export_engine_matrix`

### DIFF
--- a/docs/en/reference/utils/checks.md
+++ b/docs/en/reference/utils/checks.md
@@ -63,6 +63,10 @@ keywords: Ultralytics, YOLO, utility functions, version checks, requirements, im
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.checks.check_tensorrt
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.checks.check_torchvision
 
 <br><br><hr><br>

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -12,7 +12,7 @@ from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.utils import ASSETS, IS_JETSON, WEIGHTS_DIR
 from ultralytics.utils.autodevice import GPUInfo
-from ultralytics.utils.checks import check_amp
+from ultralytics.utils.checks import check_amp, check_requirements
 from ultralytics.utils.torch_utils import TORCH_1_13
 
 # Try to find idle devices if CUDA is available
@@ -91,6 +91,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
 )
 def test_export_engine_matrix(task, dynamic, int8, half, batch):
     """Test YOLO model export to TensorRT format for various configurations and run inference."""
+    check_requirements("tensorrt>=7.0.0,!=10.1.0")
     import tensorrt as trt
 
     is_trt10 = int(trt.__version__.split(".", 1)[0]) >= 10

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -12,7 +12,7 @@ from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.utils import ASSETS, IS_JETSON, LINUX, WEIGHTS_DIR
 from ultralytics.utils.autodevice import GPUInfo
-from ultralytics.utils.checks import check_amp, check_requirements
+from ultralytics.utils.checks import check_amp, check_tensorrt
 from ultralytics.utils.torch_utils import TORCH_1_13
 
 # Try to find idle devices if CUDA is available
@@ -91,9 +91,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
 )
 def test_export_engine_matrix(task, dynamic, int8, half, batch):
     """Test YOLO model export to TensorRT format for various configurations and run inference."""
-    if LINUX:
-        cuda_version = torch.version.cuda.split(".")[0]
-        check_requirements(f"tensorrt-cu{cuda_version}>7.0.0,!=10.1.0")
+    check_tensorrt()
     import tensorrt as trt
 
     is_trt10 = int(trt.__version__.split(".", 1)[0]) >= 10

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -10,7 +10,7 @@ import torch
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODEL, SOURCE
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
-from ultralytics.utils import ASSETS, IS_JETSON, WEIGHTS_DIR
+from ultralytics.utils import ASSETS, IS_JETSON, WEIGHTS_DIR, LINUX
 from ultralytics.utils.autodevice import GPUInfo
 from ultralytics.utils.checks import check_amp, check_requirements
 from ultralytics.utils.torch_utils import TORCH_1_13
@@ -91,7 +91,9 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
 )
 def test_export_engine_matrix(task, dynamic, int8, half, batch):
     """Test YOLO model export to TensorRT format for various configurations and run inference."""
-    check_requirements("tensorrt>=7.0.0,!=10.1.0")
+    if LINUX:
+        cuda_version = torch.version.cuda.split(".")[0]
+        check_requirements(f"tensorrt-cu{cuda_version}>7.0.0,!=10.1.0")
     import tensorrt as trt
 
     is_trt10 = int(trt.__version__.split(".", 1)[0]) >= 10

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -10,7 +10,7 @@ import torch
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODEL, SOURCE
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
-from ultralytics.utils import ASSETS, IS_JETSON, WEIGHTS_DIR, LINUX
+from ultralytics.utils import ASSETS, IS_JETSON, LINUX, WEIGHTS_DIR
 from ultralytics.utils.autodevice import GPUInfo
 from ultralytics.utils.checks import check_amp, check_requirements
 from ultralytics.utils.torch_utils import TORCH_1_13

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -10,7 +10,7 @@ import torch
 from tests import CUDA_DEVICE_COUNT, CUDA_IS_AVAILABLE, MODEL, SOURCE
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
-from ultralytics.utils import ASSETS, IS_JETSON, LINUX, WEIGHTS_DIR
+from ultralytics.utils import ASSETS, IS_JETSON, WEIGHTS_DIR
 from ultralytics.utils.autodevice import GPUInfo
 from ultralytics.utils.checks import check_amp, check_tensorrt
 from ultralytics.utils.torch_utils import TORCH_1_13

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -110,6 +110,7 @@ from ultralytics.utils.checks import (
     check_executorch_requirements,
     check_imgsz,
     check_requirements,
+    check_tensorrt,
     check_version,
     is_intel,
     is_sudo_available,
@@ -1005,9 +1006,7 @@ class Exporter:
         try:
             import tensorrt as trt
         except ImportError:
-            if LINUX:
-                cuda_version = torch.version.cuda.split(".")[0]
-                check_requirements(f"tensorrt-cu{cuda_version}>7.0.0,!=10.1.0")
+            check_tensorrt()
             import tensorrt as trt
         check_version(trt.__version__, ">=7.0.0", hard=True)
         check_version(trt.__version__, "!=10.1.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -507,6 +507,13 @@ def check_executorch_requirements():
     check_requirements("numpy<=2.3.5")
 
 
+def check_tensorrt():
+    """Check and install TensorRT requirements including platform-specific dependencies."""
+    if LINUX:
+        cuda_version = torch.version.cuda.split(".")[0]
+        check_requirements(f"tensorrt-cu{cuda_version}>7.0.0,!=10.1.0")
+
+
 def check_torchvision():
     """Check the installed versions of PyTorch and Torchvision to ensure they're compatible.
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a dedicated `check_tensorrt()` helper to standardize TensorRT dependency checks for YOLO exports and tests ⚙️✅

### 📊 Key Changes
- Introduced `ultralytics.utils.checks.check_tensorrt()` to validate/install TensorRT requirements on Linux (matching the installed CUDA major version) 🧩
- Updated TensorRT engine export flow to call `check_tensorrt()` when `tensorrt` isn’t installed, replacing inline Linux-only logic 🔁
- Updated CUDA/TensorRT export tests to run `check_tensorrt()` before importing TensorRT, reducing test failures due to missing deps 🧪
- Added API reference docs entry for `check_tensorrt` in the checks documentation 📚

### 🎯 Purpose & Impact
- Makes TensorRT setup more reliable and consistent across exports and CI tests 🛠️
- Improves user experience by automatically guiding/installing the correct `tensorrt-cuXX` package for your CUDA version on Linux 🐧
- Reduces duplicated logic and centralizes maintenance for TensorRT dependency handling 🧹
- Helps prevent known-bad TensorRT versions (e.g., excludes 10.1.0) from being installed/used 🚫