### PR TITLE
Force update `tensorrt` on CUDA 13 ARM to `10.15.x` to fix a bug with RT-DETR exports

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -88,6 +88,7 @@ from ultralytics.utils import (
     IS_DEBIAN_BOOKWORM,
     IS_DEBIAN_TRIXIE,
     IS_JETSON,
+    is_jetson,
     IS_RASPBERRYPI,
     IS_UBUNTU,
     LINUX,
@@ -1003,6 +1004,10 @@ class Exporter:
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
+        # Force re-install pre-installed TensorRT on CUDA 13 ARM devices to latest version to fix a bug with TensorRT RT-DETR exports https://github.com/ultralytics/ultralytics/issues/22873
+        if is_jetson(jetpack=7):
+            check_tensorrt()
+            
         try:
             import tensorrt as trt
         except ImportError:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1006,7 +1006,7 @@ class Exporter:
 
         # Force re-install pre-installed TensorRT on CUDA 13 ARM devices to latest version to fix a bug with TensorRT RT-DETR exports https://github.com/ultralytics/ultralytics/issues/22873
         if is_jetson(jetpack=7):
-            check_tensorrt()
+            check_tensorrt("10.15")
 
         try:
             import tensorrt as trt

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1007,7 +1007,7 @@ class Exporter:
         # Force re-install pre-installed TensorRT on CUDA 13 ARM devices to latest version to fix a bug with TensorRT RT-DETR exports https://github.com/ultralytics/ultralytics/issues/22873
         if is_jetson(jetpack=7):
             check_tensorrt()
-            
+
         try:
             import tensorrt as trt
         except ImportError:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1004,7 +1004,7 @@ class Exporter:
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
-        # Force re-install pre-installed TensorRT on CUDA 13 ARM devices to latest version to fix a bug with TensorRT RT-DETR exports https://github.com/ultralytics/ultralytics/issues/22873
+        # Force re-install pre-installed TensorRT on CUDA 13 ARM devices to 10.15.x+ versions to fix a bug with TensorRT RT-DETR exports https://github.com/ultralytics/ultralytics/issues/22873
         if is_jetson(jetpack=7):
             check_tensorrt("10.15")
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -88,7 +88,6 @@ from ultralytics.utils import (
     IS_DEBIAN_BOOKWORM,
     IS_DEBIAN_TRIXIE,
     IS_JETSON,
-    is_jetson,
     IS_RASPBERRYPI,
     IS_UBUNTU,
     LINUX,
@@ -103,6 +102,7 @@ from ultralytics.utils import (
     callbacks,
     colorstr,
     get_default_args,
+    is_jetson,
 )
 from ultralytics.utils.checks import (
     IS_PYTHON_3_10,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1004,7 +1004,8 @@ class Exporter:
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
-        # Force re-install pre-installed TensorRT on CUDA 13 ARM devices to 10.15.x versions to fix a bug with TensorRT RT-DETR exports https://github.com/ultralytics/ultralytics/issues/22873
+        # Force re-install TensorRT on CUDA 13 ARM devices to 10.15.x versions for RT-DETR exports
+        # https://github.com/ultralytics/ultralytics/issues/22873
         if is_jetson(jetpack=7):
             check_tensorrt("10.15")
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1004,7 +1004,7 @@ class Exporter:
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
-        # Force re-install pre-installed TensorRT on CUDA 13 ARM devices to 10.15.x+ versions to fix a bug with TensorRT RT-DETR exports https://github.com/ultralytics/ultralytics/issues/22873
+        # Force re-install pre-installed TensorRT on CUDA 13 ARM devices to 10.15.x versions to fix a bug with TensorRT RT-DETR exports https://github.com/ultralytics/ultralytics/issues/22873
         if is_jetson(jetpack=7):
             check_tensorrt("10.15")
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -762,7 +762,7 @@ def is_jetson(jetpack=None) -> bool:
     if jetson and jetpack:
         try:
             content = open("/etc/nv_tegra_release").read()
-            version_map = {4: "R32", 5: "R35", 6: "R36"}  # JetPack to L4T major version mapping
+            version_map = {4: "R32", 5: "R35", 6: "R36", 7: "R38"}  # JetPack to L4T major version mapping
             return jetpack in version_map and version_map[jetpack] in content
         except Exception:
             return False

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -505,13 +505,18 @@ def check_executorch_requirements():
     check_requirements("executorch", cmds=f"torch=={TORCH_VERSION.split('+')[0]}")
     # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
     check_requirements("numpy<=2.3.5")
+        
+def check_tensorrt(min_version: str = "7.0.0"):
+    """Check and install TensorRT requirements including platform-specific dependencies.
 
-
-def check_tensorrt():
-    """Check and install TensorRT requirements including platform-specific dependencies."""
+    Args:
+        min_version (str): Minimum supported TensorRT version (default: "7.0.0").
+    """
     if LINUX:
         cuda_version = torch.version.cuda.split(".")[0]
-        check_requirements(f"tensorrt-cu{cuda_version}>7.0.0,!=10.1.0")
+        check_requirements(
+            f"tensorrt-cu{cuda_version}>{min_version},!=10.1.0"
+        )
 
 
 def check_torchvision():

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -505,7 +505,8 @@ def check_executorch_requirements():
     check_requirements("executorch", cmds=f"torch=={TORCH_VERSION.split('+')[0]}")
     # Pin numpy to avoid coremltools errors with numpy>=2.4.0, must be separate
     check_requirements("numpy<=2.3.5")
-        
+
+
 def check_tensorrt(min_version: str = "7.0.0"):
     """Check and install TensorRT requirements including platform-specific dependencies.
 
@@ -514,9 +515,7 @@ def check_tensorrt(min_version: str = "7.0.0"):
     """
     if LINUX:
         cuda_version = torch.version.cuda.split(".")[0]
-        check_requirements(
-            f"tensorrt-cu{cuda_version}>{min_version},!=10.1.0"
-        )
+        check_requirements(f"tensorrt-cu{cuda_version}>{min_version},!=10.1.0")
 
 
 def check_torchvision():

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -515,7 +515,7 @@ def check_tensorrt(min_version: str = "7.0.0"):
     """
     if LINUX:
         cuda_version = torch.version.cuda.split(".")[0]
-        check_requirements(f"tensorrt-cu{cuda_version}>{min_version},!=10.1.0")
+        check_requirements(f"tensorrt-cu{cuda_version}>={min_version},!=10.1.0")
 
 
 def check_torchvision():


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves TensorRT export reliability on NVIDIA Jetson (JetPack 7) by enforcing a compatible TensorRT version during export 🚀🤖

### 📊 Key Changes
- Added JetPack 7 detection support by mapping JetPack 7 → L4T `R38` in `is_jetson()` 🧩
- Updated `check_tensorrt()` to accept a configurable minimum TensorRT version (`min_version`, default `7.0.0`) ⚙️
- During TensorRT engine export, detects Jetson JetPack 7 and forces TensorRT to a `10.15.x`-compatible requirement (specifically to fix RT-DETR exports) 🛠️📦

### 🎯 Purpose & Impact
- Reduces TensorRT export failures on CUDA 13 ARM/Jetson setups (notably RT-DETR) by pinning to known-good TensorRT versions ✅
- Improves “it just works” export behavior for Jetson users, avoiding manual dependency troubleshooting 🧑‍💻🔧
- Makes TensorRT version checks more flexible across platforms and future compatibility fixes by allowing a minimum version to be specified 🔄📈