### PR TITLE
Fix `autobackend.py` when using OpenVINO

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -339,7 +339,7 @@ class AutoBackend(nn.Module):
                 batch = metadata["batch"]
                 dynamic = metadata.get("args", {}).get("dynamic", dynamic)
             # OpenVINO inference modes are 'LATENCY', 'THROUGHPUT' (not recommended), or 'CUMULATIVE_THROUGHPUT'
-            inference_mode = "CUMULATIVE_THROUGHPUT" if batch > 1 and dynamic else "LATENCY"
+            inference_mode = "CUMULATIVE_THROUGHPUT" if dynamic and batch > 1 else "LATENCY"
             ov_compiled_model = core.compile_model(
                 ov_model,
                 device_name=device_name,


### PR DESCRIPTION
This error occurred with 8.3.227, but it's also present in 8.4.9:
```
ultralytics/nn/autobackend.py", line 316, in __init__
    inference_mode = "CUMULATIVE_THROUGHPUT" if batch > 1 and dynamic else "LATENCY"
                                                ^^^^^
UnboundLocalError: cannot access local variable 'batch' where it is not associated with a value
```
The problem is that `dynamic` is declared with False as its default value, but `batch` isn't declared.

The assignment that creates `batch` is just above the assignment to `inference_mode`, but it's conditionally executed if `metadata.yaml` exists.

Flip the order of the check, so `batch` is correctly ignored when `dynamic` is False.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes OpenVINO inference mode selection logic in `autobackend.py` to correctly prefer latency unless both dynamic shapes and batch > 1 warrant cumulative throughput 🚀

### 📊 Key Changes
- Adjusted the OpenVINO `inference_mode` conditional to consistently check `dynamic` and `batch > 1` in the intended order.
- Ensures `CUMULATIVE_THROUGHPUT` is only used when **both** dynamic input handling is enabled and batch size is greater than 1.

### 🎯 Purpose & Impact
- Prevents unintended OpenVINO performance mode selection in certain configurations 🧩
- Improves correctness and predictability of OpenVINO backend behavior for users running dynamic/batched inference ⚡
- Reduces risk of suboptimal runtime performance or confusing inference behavior when using OpenVINO
