### PR TITLE
Improve HUB session error handling with HUBModelError

### DIFF
--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -121,7 +121,7 @@ class HUBTrainingSession:
         """
         self.model = self.client.model(model_id)
         if not self.model.data:  # then model does not exist
-            raise ValueError(emojis("❌ The specified HUB model does not exist"))  # TODO: improve error handling
+            raise HUBModelError(f"❌ Model not found: '{model_id}'. Verify the model ID is correct.")
 
         self.model_url = f"{HUB_WEB_ROOT}/models/{self.model.id}"
         if self.model.is_trained():
@@ -167,10 +167,8 @@ class HUBTrainingSession:
 
         self.model.create_model(payload)
 
-        # Model could not be created
-        # TODO: improve error handling
         if not self.model.id:
-            return None
+            raise HUBModelError(f"❌ Failed to create model '{self.filename}' on Ultralytics HUB. Please try again.")
 
         self.model_url = f"{HUB_WEB_ROOT}/models/{self.model.id}"
 

--- a/ultralytics/hub/session.py
+++ b/ultralytics/hub/session.py
@@ -12,7 +12,7 @@ from urllib.parse import parse_qs, urlparse
 
 from ultralytics import __version__
 from ultralytics.hub.utils import HELP_MSG, HUB_WEB_ROOT, PREFIX
-from ultralytics.utils import IS_COLAB, LOGGER, SETTINGS, TQDM, checks, emojis
+from ultralytics.utils import IS_COLAB, LOGGER, SETTINGS, TQDM, checks
 from ultralytics.utils.errors import HUBModelError
 
 AGENT_NAME = f"python-{__version__}-colab" if IS_COLAB else f"python-{__version__}-local"


### PR DESCRIPTION
## Summary
- Replace generic `ValueError` with specific `HUBModelError` for model loading failures
- Add proper error handling for model creation failures (previously returned `None` silently)
- Include `model_id` and `filename` in error messages for better debugging

## Changes
- `load_model()`: Use `HUBModelError` instead of `ValueError` with model ID in message
- `create_model()`: Raise `HUBModelError` instead of returning `None` when creation fails

## Related
Resolves TODO comments in `ultralytics/hub/session.py`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Ultralytics HUB session error handling by raising a dedicated `HUBModelError` for missing or failed model creation scenarios ✅

### 📊 Key Changes
- Replaces a generic `ValueError` (with `emojis()`) in `load_model()` with a clearer `HUBModelError` when a HUB model ID is not found
- Updates `create_model()` to raise `HUBModelError` instead of returning `None` when model creation fails
- Removes the unused `emojis` import from `ultralytics/hub/session.py`

### 🎯 Purpose & Impact
- Provides more consistent, actionable exceptions for HUB-related failures (better debugging and UX)
- Avoids silent failure paths (`None` returns), making errors easier to detect and handle upstream
- Keeps HUB session logic cleaner and more aligned with existing `ultralytics.utils.errors` patterns
