### PR TITLE
Fix names generation for single object detection in SAM3SemanticPredictor

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2619,7 +2619,7 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         if not isinstance(orig_imgs, list):  # input images are a torch.Tensor, not a list
             orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
 
-        names = []
+        names = self.model.names
         if len(curr_obj_ids) == 0:
             pred_masks, pred_boxes = None, torch.zeros((0, 7), device=self.device)
         else:
@@ -2638,6 +2638,8 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
             pred_boxes = torch.cat(
                 [pred_boxes, pred_ids[keep][:, None], pred_scores[keep][..., None], pred_cls[keep][..., None]], dim=-1
             )
+            if pred_boxes.shape[0]:
+                names = names or dict(enumerate(str(i) for i in range(pred_boxes[:, 6].int().max() + 1)))
             if pred_masks.shape[0] > 1:
                 tracker_scores = torch.tensor(
                     [
@@ -2657,7 +2659,6 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
                         background_value=0,
                     ).squeeze(1)
                 ) > 0
-                names = self.model.names or dict(enumerate(str(i) for i in range(pred_boxes[:, 6].int().max())))
 
         results = []
         for masks, boxes, orig_img, img_path in zip([pred_masks], [pred_boxes], orig_imgs, self.batch[0]):

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2619,7 +2619,7 @@ class SAM3VideoSemanticPredictor(SAM3SemanticPredictor):
         if not isinstance(orig_imgs, list):  # input images are a torch.Tensor, not a list
             orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)
 
-        names = self.model.names
+        names = self.model.names if self.model.names != "visual" else {}
         if len(curr_obj_ids) == 0:
             pred_masks, pred_boxes = None, torch.zeros((0, 7), device=self.device)
         else:


### PR DESCRIPTION
https://github.com/ultralytics/ultralytics/issues/23272#issuecomment-3832335632

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves SAM prediction postprocessing by fixing how class `names` are initialized and auto-generated for results 🛠️✨

### 📊 Key Changes
- Adjusted `names` initialization to use `self.model.names`, but treat the special `"visual"` value as “no names” (falls back to `{}`) 👀
- Added a safer fallback that **auto-creates class names** (e.g., `"0"`, `"1"`, …) **only when there are predictions** and names aren’t already available ✅
- Removed the old fallback logic that could generate incorrect/incomplete class-name mappings in some cases 🧹

### 🎯 Purpose & Impact
- Prevents confusing or broken class-name metadata in SAM outputs, especially when the model uses `"visual"` naming mode 🏷️
- Ensures results always have a valid `names` mapping when boxes/classes exist, improving downstream visualization, logging, and export workflows 📈🖼️
- Reduces edge-case errors and mismatches when handling multiple predicted classes (more robust postprocessing) 🔒