### PR TITLE
Remove debug asserts from TVP loss classes

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1193,8 +1193,6 @@ class TVPDetectLoss:
 
     def loss(self, preds: dict[str, torch.Tensor], batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Calculate the loss for text-visual prompt detection."""
-        assert self.ori_reg_max == self.vp_criterion.reg_max  # TODO: remove it
-
         if self.ori_nc == preds["scores"].shape[1]:
             loss = torch.zeros(3, device=self.vp_criterion.device, requires_grad=True)
             return loss, loss.detach()
@@ -1230,8 +1228,6 @@ class TVPSegmentLoss(TVPDetectLoss):
 
     def loss(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Calculate the loss for text-visual prompt detection."""
-        assert self.ori_reg_max == self.vp_criterion.reg_max  # TODO: remove it
-
         if self.ori_nc == preds["scores"].shape[1]:
             loss = torch.zeros(4, device=self.vp_criterion.device, requires_grad=True)
             return loss, loss.detach()


### PR DESCRIPTION
## Summary
Remove debug `assert` statements from `TVPDetectLoss.loss()` and `TVPSegmentLoss.loss()` that were marked with `# TODO: remove it`.

These assertions verified that `reg_max` remains unchanged, which is guaranteed since `reg_max` is only set during `__init__` and never modified — unlike `nc`, `no`, and `assigner.num_classes` which are dynamically updated in `_get_vp_features()`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes leftover debug assertions from TVP loss implementations to avoid unnecessary runtime checks ✅

### 📊 Key Changes
-Removed `assert self.ori_reg_max == self.vp_criterion.reg_max` in two text-visual prompt (TVP) loss class `loss()` methods
-Left existing early-return behavior for `ori_nc == preds["scores"].shape[1]` unchanged

### 🎯 Purpose & Impact
-Prevents avoidable assertion failures in non-debug/production runs where the invariant may not strictly hold
-Reduces runtime overhead and noise from debug-only checks, keeping loss code cleaner and more robust
-No expected change to training outcomes when the values already match; behavior remains the same aside from removing the hard stop