### PR TITLE
`ultralytics 8.4.10` YOLOE-26 default `agnostic_nms=True`

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.9"
+__version__ = "8.4.10"
 
 import importlib
 import os

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -426,5 +426,6 @@ class YOLOE(Model):
                 self.predictor = None  # reset predictor
         elif isinstance(self.predictor, yolo.yoloe.YOLOEVPDetectPredictor):
             self.predictor = None  # reset predictor if no visual prompts
+        self.overrides["agnostic_nms"] = True  # use agnostic nms for YOLOE default
 
         return super().predict(source, stream, **kwargs)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps Ultralytics to `8.4.10` and makes YOLOE predictions default to class-agnostic NMS for more consistent results 🔧✨

### 📊 Key Changes
- 📦 Version update: `__version__` increased from `8.4.9` → `8.4.10`
- 🧠 YOLOE inference tweak: sets `self.overrides["agnostic_nms"] = True` in `ultralytics/models/yolo/model.py` during `predict()`
- 🔄 Keeps existing predictor reset behavior, then enforces the new YOLOE default NMS setting before calling the parent `predict()`

### 🎯 Purpose & Impact
- ✅ Improves YOLOE out-of-the-box behavior by using class-agnostic NMS by default (helps reduce duplicate overlapping detections across classes) 🎯
- 🔍 More predictable inference defaults for users running YOLOE without needing to manually set `agnostic_nms=True` ⚙️
- ⚠️ Potential behavior change: detection outputs for YOLOE may differ slightly vs. previous versions (some boxes may be suppressed differently), which could affect comparisons to older runs 📉➡️📈