### PR TITLE
Update YOLOE docs example

### DIFF
--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -237,8 +237,7 @@ YOLOE-26 supports both text-based and visual prompting. Using prompts is straigh
         model = YOLO("yoloe-26l-seg.pt")  # or select yoloe-26s/m-seg.pt for different sizes
 
         # Set text prompt to detect person and bus. You only need to do this once after you load the model.
-        names = ["person", "bus"]
-        model.set_classes(names, model.get_text_pe(names))
+        model.set_classes(["person", "bus"])
 
         # Run detection on the given image
         results = model.predict("path/to/image.jpg")

--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -260,8 +260,7 @@ YOLOE supports both text-based and visual prompting. Using prompts is straightfo
         model = YOLOE("yoloe-26l-seg.pt")  # or yoloe-26s/m-seg.pt for different sizes
 
         # Set text prompt to detect person and bus. You only need to do this once after you load the model.
-        names = ["person", "bus"]
-        model.set_classes(names, model.get_text_pe(names))
+        model.set_classes(["person", "bus"])
 
         # Run detection on the given image
         results = model.predict("path/to/image.jpg")
@@ -492,8 +491,7 @@ The export process is similar to other YOLO models, with the added flexibility o
     model = YOLOE("yoloe-26l-seg.pt")
 
     # Configure the set_classes() before exporting the model
-    names = ["person", "bus"]
-    model.set_classes(names, model.get_text_pe(names))
+    model.set_classes(["person", "bus"])
 
     export_model = model.export(format="onnx")
     model = YOLOE(export_model)
@@ -924,8 +922,7 @@ Quickly set up YOLOE with Ultralytics by following these steps:
         from ultralytics import YOLO
 
         model = YOLO("yoloe-26s-seg.pt")
-        names = ["bowl", "apple"]
-        model.set_classes(names, model.get_text_pe(names))
+        model.set_classes(["bowl", "apple"])
         results = model.predict("kitchen.jpg")
         results[0].save()
         ```
@@ -999,8 +996,7 @@ from ultralytics import YOLO
 model = YOLO("yoloe-26s-seg.pt")
 
 # Define custom classes
-names = ["person", "bus"]
-model.set_classes(names, model.get_text_pe(names))
+model.set_classes(["person", "bus"])
 
 # Execute prediction on an image
 results = model.predict("path/to/image.jpg")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -702,8 +702,7 @@ def test_yoloe(tmp_path):
     # Predict
     # text-prompts
     model = YOLO(WEIGHTS_DIR / "yoloe-11s-seg.pt")
-    names = ["person", "bus"]
-    model.set_classes(names, model.get_text_pe(names))
+    model.set_classes(["person", "bus"])
     model(SOURCE, conf=0.01)
 
     from ultralytics import YOLOE


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Simplified YOLOE class prompting examples/tests by updating `set_classes()` usage to accept just a list of class names 🧩✨

### 📊 Key Changes
- Updated **YOLO26/YOLOE documentation** examples to call `model.set_classes(["person", "bus"])` (and similar) instead of manually computing/passing text prompt embeddings via `model.get_text_pe(...)` 📚✅
- Updated the **Python test** for YOLOE text prompts to match the new/standardized API usage (`set_classes([...])`) 🧪🔄
- Removed intermediate `names = [...]` variables in several snippets for cleaner, more direct examples 🧹

### 🎯 Purpose & Impact
- Makes the **public API easier and less error-prone**: users no longer need to know about or manually handle text embedding generation for common prompting workflows 🎯
- Improves **documentation clarity** and aligns examples with the intended `set_classes()` behavior, reducing copy/paste friction for beginners and speeding up usage for experts ⚡
- Keeps **tests aligned with docs**, helping prevent regressions and ensuring the simpler call pattern stays supported over time 🛡️