### PR TITLE
Fix OpenVINO failures on Windows fast CI tests

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -70,7 +70,6 @@ def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms, end2end):
     )
     if WINDOWS:
         # Use unique filenames due to Windows file permissions bug possibly due to latent threaded use
-        # See https://github.com/ultralytics/ultralytics/actions/runs/8957949304/job/24601616830?pr=10423
         file = Path(file)
         file = file.rename(file.with_stem(f"{file.stem}-{uuid.uuid4()}"))
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch)  # exported model inference

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -37,7 +37,6 @@ def test_export_openvino(end2end):
     file = YOLO(MODEL).export(format="openvino", imgsz=32, end2end=end2end)
     if WINDOWS:
         # Ensure a unique export path per test to prevent OpenVINO file writes
-        # See https://github.com/ultralytics/ultralytics/actions/runs/21596675390/job/62230966755?pr=23525
         file = Path(file)
         file = file.rename(file.with_stem(f"{file.stem}-{uuid.uuid4()}"))
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -37,6 +37,7 @@ def test_export_openvino(end2end):
     file = YOLO(MODEL).export(format="openvino", imgsz=32, end2end=end2end)
     if WINDOWS:
         # Ensure a unique export path per test to prevent OpenVINO file writes
+        # See https://github.com/ultralytics/ultralytics/actions/runs/21596675390/job/62230966755?pr=23525
         file = Path(file)
         file = file.rename(file.with_stem(f"{file.stem}-{uuid.uuid4()}"))
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -35,6 +35,10 @@ def test_export_onnx(end2end):
 def test_export_openvino(end2end):
     """Test YOLO export to OpenVINO format for model inference compatibility."""
     file = YOLO(MODEL).export(format="openvino", imgsz=32, end2end=end2end)
+    if WINDOWS:
+        # Ensure a unique export path per test to prevent OpenVINO file writes
+        file = Path(file)
+        file = file.rename(file.with_stem(f"{file.stem}-{uuid.uuid4()}"))
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes flaky OpenVINO export tests on Windows by ensuring each test uses a unique exported model path 🪟✅

### 📊 Key Changes
- Added a Windows-only step in `test_export_openvino()` to rename the exported OpenVINO file with a unique UUID suffix to avoid file write conflicts 🔁🆔
- Kept the existing Windows-only unique rename logic in `test_export_openvino_matrix()`, but removed an outdated CI run link comment 🧹

### 🎯 Purpose & Impact
- Reduces intermittent CI/test failures on Windows caused by OpenVINO artifacts being written/locked across tests 🧪🔒
- Improves test isolation and reliability, especially when tests run in parallel or when file handles linger on Windows ⚙️📈
- No functional change to YOLO exports for end users—this is a test-suite stability improvement only 🧰👍