### PR TITLE
Add CUDA 13 ARM check to support AGX Thor and DGX Spark for RT-DETR `tensorrt` exports

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -104,6 +104,7 @@ from ultralytics.utils import (
     get_default_args,
 )
 from ultralytics.utils.checks import (
+    IS_CUDA_13,
     IS_PYTHON_3_10,
     IS_PYTHON_MINIMUM_3_9,
     check_apt_requirements,
@@ -114,7 +115,6 @@ from ultralytics.utils.checks import (
     check_version,
     is_intel,
     is_sudo_available,
-    IS_CUDA_13,
 )
 from ultralytics.utils.export import (
     keras2pb,

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -102,7 +102,6 @@ from ultralytics.utils import (
     callbacks,
     colorstr,
     get_default_args,
-    is_jetson,
 )
 from ultralytics.utils.checks import (
     IS_PYTHON_3_10,
@@ -115,6 +114,7 @@ from ultralytics.utils.checks import (
     check_version,
     is_intel,
     is_sudo_available,
+    IS_CUDA_13,
 )
 from ultralytics.utils.export import (
     keras2pb,
@@ -1006,7 +1006,7 @@ class Exporter:
 
         # Force re-install TensorRT on CUDA 13 ARM devices to 10.15.x versions for RT-DETR exports
         # https://github.com/ultralytics/ultralytics/issues/22873
-        if is_jetson(jetpack=7):
+        if ARM64 and IS_CUDA_13:
             check_tensorrt("10.15")
 
         try:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -52,6 +52,7 @@ ARM64 = platform.machine() in {"arm64", "aarch64"}  # ARM64 booleans
 PYTHON_VERSION = platform.python_version()
 TORCH_VERSION = str(torch.__version__)  # Normalize torch.__version__ (PyTorch>1.9 returns TorchVersion objects)
 TORCHVISION_VERSION = importlib.metadata.version("torchvision")  # faster than importing torchvision
+CUDA_VERSION = torch.version.cuda or ""  # version is None on non-CUDA builds
 IS_VSCODE = os.environ.get("TERM_PROGRAM", False) == "vscode"
 RKNN_CHIPS = frozenset(
     {
@@ -762,7 +763,7 @@ def is_jetson(jetpack=None) -> bool:
     if jetson and jetpack:
         try:
             content = open("/etc/nv_tegra_release").read()
-            version_map = {4: "R32", 5: "R35", 6: "R36", 7: "R38"}  # JetPack to L4T major version mapping
+            version_map = {4: "R32", 5: "R35", 6: "R36"}  # JetPack to L4T major version mapping
             return jetpack in version_map and version_map[jetpack] in content
         except Exception:
             return False

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -52,6 +52,7 @@ from ultralytics.utils import (
     downloads,
     is_github_action_running,
     url2file,
+    CUDA_VERSION,
 )
 
 
@@ -1044,3 +1045,5 @@ IS_PYTHON_3_13 = PYTHON_VERSION.startswith("3.13")
 IS_PYTHON_MINIMUM_3_9 = check_python("3.9", hard=False)
 IS_PYTHON_MINIMUM_3_10 = check_python("3.10", hard=False)
 IS_PYTHON_MINIMUM_3_12 = check_python("3.12", hard=False)
+
+IS_CUDA_13 = CUDA_VERSION.startswith("13")

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -27,6 +27,7 @@ from ultralytics.utils import (
     ASSETS,
     ASSETS_URL,
     AUTOINSTALL,
+    CUDA_VERSION,
     GIT,
     IS_COLAB,
     IS_DOCKER,
@@ -52,7 +53,6 @@ from ultralytics.utils import (
     downloads,
     is_github_action_running,
     url2file,
-    CUDA_VERSION,
 )
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves CUDA 13 + ARM64 detection to apply the correct TensorRT workaround during exports, making RT-DETR TensorRT export more reliable 🚀

### 📊 Key Changes
- Added `CUDA_VERSION` (from `torch.version.cuda`) to Ultralytics globals and introduced a new flag `IS_CUDA_13` in `ultralytics/utils/checks.py` 🧩
- Updated TensorRT export logic in `ultralytics/engine/exporter.py` to trigger the TensorRT re-install/workaround when **ARM64 + CUDA 13** is detected, instead of using `is_jetson(jetpack=7)` 🔧
- Removed the JetPack “7 → R38” mapping from `is_jetson()` in `ultralytics/utils/__init__.py`, avoiding an unsupported/incorrect JetPack detection path 🧹

### 🎯 Purpose & Impact
- Reduces mis-detection of Jetson/JetPack versions and replaces it with a clearer, more direct check for the real problematic environment (ARM64 + CUDA 13) 🎯
- Helps prevent TensorRT export failures (notably RT-DETR) on CUDA 13 ARM devices by ensuring the TensorRT version pin (`10.15.x`) is applied only when needed ✅
- Improves overall export stability and predictability across platforms by using PyTorch’s CUDA version info rather than OS-specific Jetson heuristics 🛠️