### PR TITLE
Fix disk caching with multispectral images

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -795,7 +795,7 @@ def test_grayscale(task: str, model: str, data: str, tmp_path) -> None:
             npy_file.unlink()
 
     model = YOLO(model)
-    model.train(data=grayscale_data, epochs=1, imgsz=32, close_mosaic=1)
+    model.train(data=grayscale_data, epochs=1, imgsz=32, close_mosaic=1, cache="disk")
     model.val(data=grayscale_data)
     im = np.zeros((32, 32, 1), dtype=np.uint8)
     model.predict(source=im, imgsz=32, save_txt=True, save_crop=True, augment=True)

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -280,7 +280,7 @@ class BaseDataset(Dataset):
         """Save an image as an *.npy file for faster loading."""
         f = self.npy_files[i]
         if not f.exists():
-            np.save(f.as_posix(), imread(self.im_files[i]), allow_pickle=False)
+            np.save(f.as_posix(), imread(self.im_files[i], flags=self.cv2_flag), allow_pickle=False)
 
     def check_cache_disk(self, safety_margin: float = 0.5) -> bool:
         """Check if there's enough disk space for caching images.


### PR DESCRIPTION
**MRE**

```
yolo train data=coco8-grayscale.yaml epochs=1 cache=disk
```
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes disk-cached image loading to respect grayscale (and other OpenCV read) modes, and updates a grayscale test to exercise disk caching 🧪💾

### 📊 Key Changes
- Updated disk caching to read images with the dataset’s configured OpenCV flag (`self.cv2_flag`) instead of always using the default read mode 🖼️➡️📦
- Adjusted the grayscale unit test to train with `cache="disk"` so this code path is tested directly ✅🧩

### 🎯 Purpose & Impact
- Ensures cached `.npy` images match the intended input format (e.g., grayscale) when using `cache="disk"` 🎛️🖤🤍
- Prevents subtle training/validation inconsistencies where cached images could differ from non-cached loading behavior 🔄🛡️
- Improves test coverage and reduces the chance of regressions for users training on grayscale or non-standard image loading configurations 🧪🚀