### PR TITLE
Fix AutoBatch with multispectral images

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -121,9 +121,9 @@ def test_train():
     device = tuple(DEVICES) if len(DEVICES) > 1 else DEVICES[0]
     # NVIDIA Jetson only has one GPU and therefore skipping checks
     if not IS_JETSON:
+        results = YOLO(MODEL).train(data="coco8-grayscale.yaml", imgsz=64, epochs=1, device=DEVICES[0], batch=-1)
         results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, compile=True)
         results = YOLO(MODEL).train(data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
-        results = YOLO(MODEL).train(data="coco8-grayscale.yaml", imgsz=64, epochs=1, device=DEVICES[0], batch=-1)
         visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
         assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
         # Note DDP training returns None, single-GPU returns metrics

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -123,7 +123,7 @@ def test_train():
     if not IS_JETSON:
         results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, compile=True)
         results = YOLO(MODEL).train(data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
-        results = YOLO(MODEL).train(data="coco8-grayscale.yaml", imgsz=64, epochs=1, device=DEVICES[0], batch=15, batch=-1)
+        results = YOLO(MODEL).train(data="coco8-grayscale.yaml", imgsz=64, epochs=1, device=DEVICES[0], batch=-1)
         visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
         assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
         # Note DDP training returns None, single-GPU returns metrics

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -123,6 +123,7 @@ def test_train():
     if not IS_JETSON:
         results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, compile=True)
         results = YOLO(MODEL).train(data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
+        results = YOLO(MODEL).train(data="coco8-grayscale.yaml", imgsz=64, epochs=1, device=DEVICES[0], batch=15, batch=-1)
         visible = eval(os.environ["CUDA_VISIBLE_DEVICES"])
         assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
         # Note DDP training returns None, single-GPU returns metrics

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -72,7 +72,7 @@ class BOTrack(STrack):
         self.curr_feat = None
         if feat is not None:
             self.update_features(feat)
-        self.features = deque([], maxlen=feat_history)
+        self.features = deque(maxlen=feat_history)
         self.alpha = 0.9
 
     def update_features(self, feat: np.ndarray) -> None:

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -84,8 +84,9 @@ def autobatch(
 
     # Profile batch sizes
     batch_sizes = [1, 2, 4, 8, 16] if t < 16 else [1, 2, 4, 8, 16, 32, 64]
+    ch = model.yaml.get("channels", 3)
     try:
-        img = [torch.empty(b, 3, imgsz, imgsz) for b in batch_sizes]
+        img = [torch.empty(b, ch, imgsz, imgsz) for b in batch_sizes]
         results = profile_ops(img, model, n=1, device=device, max_num_obj=max_num_obj)
 
         # Fit a solution


### PR DESCRIPTION
**MRE**
```
yolo train data=coco8-grayscale.yaml batch=-1
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds grayscale (non-3-channel) coverage to CUDA training tests and fixes AutoBatch to respect a model’s configured input channels 🧪⚡️

### 📊 Key Changes
- ✅ **Extended CUDA training tests** to run a quick training pass on `coco8-grayscale.yaml`, ensuring grayscale pipelines are exercised in CI.
- 🛠️ **Updated `autobatch()` to use the model’s configured input channels** (`model.yaml["channels"]`, defaulting to 3) instead of assuming RGB.
- 🔧 **AutoBatch profiling tensors now match real model inputs**, creating `torch.empty(b, ch, imgsz, imgsz)` rather than hardcoding `3` channels.

### 🎯 Purpose & Impact
- 📉 **Prevents AutoBatch mis-profiling and potential crashes** when training models/datasets with non-RGB inputs (e.g., grayscale medical/industrial imagery).
- 🎯 **Improves batch-size auto-selection accuracy** for custom channel configurations, leading to more reliable training setup on CUDA devices.
- 🧷 **Better regression protection**: CI will catch future changes that accidentally break grayscale or custom-channel training workflows.