### PR TITLE
Add basic trackers: IOU, Centroid

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -209,6 +209,7 @@ def test_track_stream(model, tmp_path):
     model = YOLO(model)
     model.track(video_url, imgsz=160, tracker="bytetrack.yaml")
     model.track(video_url, imgsz=160, tracker="ioutrack.yaml")
+    model.track(video_url, imgsz=160, tracker="centroidtrack.yaml")
     model.track(video_url, imgsz=160, tracker="botsort.yaml", save_frames=True)  # test frame saving also
 
     # Test Global Motion Compensation (GMC) methods and ReID

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -208,6 +208,7 @@ def test_track_stream(model, tmp_path):
     video_url = f"{ASSETS_URL}/decelera_portrait_min.mov"
     model = YOLO(model)
     model.track(video_url, imgsz=160, tracker="bytetrack.yaml")
+    model.track(video_url, imgsz=160, tracker="ioutrack.yaml")
     model.track(video_url, imgsz=160, tracker="botsort.yaml", save_frames=True)  # test frame saving also
 
     # Test Global Motion Compensation (GMC) methods and ReID

--- a/ultralytics/cfg/trackers/centroidtrack.yaml
+++ b/ultralytics/cfg/trackers/centroidtrack.yaml
@@ -1,0 +1,7 @@
+# Ultralytics YOLO, AGPL-3.0 license
+# Default YOLO tracker settings for Centroid tracker
+
+tracker_type: centroidtrack # tracker type, ['botsort', 'bytetrack', 'ioutrack', 'centroidtrack']
+track_thresh: 0.6 # threshold for confidence of all detections to be considered for tracking
+track_buffer: 30 # buffer to calculate the time when to remove tracks
+match_thresh: 0.2 # distance threshold between track centroids for matching (normalized)

--- a/ultralytics/cfg/trackers/ioutrack.yaml
+++ b/ultralytics/cfg/trackers/ioutrack.yaml
@@ -1,0 +1,7 @@
+# Ultralytics YOLO, AGPL-3.0 license
+# Default YOLO tracker settings for IOU tracker
+
+tracker_type: ioutrack # tracker type, ['botsort', 'bytetrack', 'ioutrack', 'centroidtrack']
+track_thresh: 0.6 # threshold for confidence of all detections to be considered for tracking
+track_buffer: 30 # buffer to calculate the time when to remove tracks
+match_thresh: 0.8 # threshold for matching tracks (1-min IOU)

--- a/ultralytics/trackers/__init__.py
+++ b/ultralytics/trackers/__init__.py
@@ -2,6 +2,8 @@
 
 from .bot_sort import BOTSORT
 from .byte_tracker import BYTETracker
+from .centroid_tracker import CentroidTracker
+from .iou_tracker import IOUTracker
 from .track import register_tracker
 
-__all__ = "BOTSORT", "BYTETracker", "register_tracker"  # allow simpler import
+__all__ = "BOTSORT", "BYTETracker", "CentroidTracker", "IOUTracker", "register_tracker"  # allow simpler import

--- a/ultralytics/trackers/centroid_tracker.py
+++ b/ultralytics/trackers/centroid_tracker.py
@@ -1,0 +1,95 @@
+# Ultralytics YOLO, AGPL-3.0 license
+
+import numpy as np
+from scipy.spatial.distance import cdist
+
+from ..utils import LOGGER
+from .basetrack import TrackState
+from .iou_tracker import IOUTracker, UTrack
+from .utils import matching
+
+
+class CentroidTrack(UTrack):
+    """
+    Single object tracking representation.
+
+    This class is responsible for storing all the information regarding individual tracklets. Uses simple IOU matching.
+    Lost tracks are not re-activated.
+
+    Attributes:
+        img_h (int): Pixel height of image used to initialize tracklet
+        img_w (int): Pixel width of image used to initialize tracklet
+    """
+
+    def __init__(self, xywh, score, cls, img):
+        """Initialize new centroidTrack instance."""
+        super().__init__(xywh, score, cls)
+        self.img_h, self.img_w, _ = img.shape
+
+    @property
+    def centroid(self):
+        """Get current position as normalized centroid of bounding box."""
+        xywh = self.xywh.copy()
+        xywh[..., [0, 2]] /= self.img_w
+        xywh[..., [1, 3]] /= self.img_h
+
+        return xywh[:2]
+
+
+class CentroidTracker(IOUTracker):
+    """
+    CentroidTracker: Basic Centroid tracking algorithm.
+
+    The class is responsible for initializing, updating, and managing the tracks for detected objects in a video
+    sequence. It maintains the state of tracked, lost, and removed tracks over frames.
+
+    Attributes:
+        tracked_utracks (list[UTrack]): List of successfully activated tracks.
+        lost_utracks (list[UTrack]): List of lost tracks.
+        removed_utracks (list[UTrack]): List of removed tracks.
+        frame_id (int): The current frame ID.
+        args (namespace): Command-line arguments.
+        max_time_lost (int): The maximum frames for a track to be considered as 'lost'.
+
+    Methods:
+        init_track(dets, scores, cls, img=None): Initialize object tracking with detections.
+        get_dists(tracks, detections): Calculates the euclidean distance between tracks and detections.
+        remove_duplicate_utracks(centroidtracksa, centroidtracksb): Removes duplicate centroidtracks based on euclidean distance
+    """
+
+    def __init__(self, args, frame_rate=30):
+        """Initialize a YOLOv8 object to track objects with given arguments and frame rate."""
+        super().__init__(args, frame_rate)
+
+    def init_track(self, dets, scores, cls, img):
+        """Initialize object tracking with detections and scores using centroid tracking algorithm."""
+        return (
+            [CentroidTrack(xyxy, s, c, img) for (xyxy, s, c) in zip(dets, scores, cls)] if len(dets) else []
+        )  # detections
+
+    def remove_duplicate_utracks(self, centroidtracksa, centroidtracksb):
+        """Remove duplicate centroidtracks with non-maximum euclidean distance."""
+        pdist = self.get_dists(centroidtracksa, centroidtracksb)
+        pairs = np.where(pdist < 0.0001)  # bit unclear what this should be
+        dupa, dupb = [], []
+        for p, q in zip(*pairs):
+            timep = centroidtracksa[p].frame_id - centroidtracksa[p].start_frame
+            timeq = centroidtracksb[q].frame_id - centroidtracksb[q].start_frame
+            if timep > timeq:
+                dupb.append(q)
+            else:
+                dupa.append(p)
+        resa = [t for i, t in enumerate(centroidtracksa) if i not in dupa]
+        resb = [t for i, t in enumerate(centroidtracksb) if i not in dupb]
+        return resa, resb
+
+    @staticmethod
+    def get_dists(tracks, detections):
+        """Calculates the distance between tracks and detections using euclidean distance."""
+        ctracks = [t.centroid for t in tracks]
+        cdets = [d.centroid for d in detections]
+        dists = np.zeros((len(ctracks), len(cdets)), dtype=np.float32)
+        if len(ctracks) and len(cdets):
+            dists = cdist(ctracks, cdets)
+
+        return dists

--- a/ultralytics/trackers/centroid_tracker.py
+++ b/ultralytics/trackers/centroid_tracker.py
@@ -3,15 +3,11 @@
 import numpy as np
 from scipy.spatial.distance import cdist
 
-from ..utils import LOGGER
-from .basetrack import TrackState
 from .iou_tracker import IOUTracker, UTrack
-from .utils import matching
 
 
 class CentroidTrack(UTrack):
-    """
-    Single object tracking representation.
+    """Single object tracking representation.
 
     This class is responsible for storing all the information regarding individual tracklets. Uses simple IOU matching.
     Lost tracks are not re-activated.
@@ -37,8 +33,7 @@ class CentroidTrack(UTrack):
 
 
 class CentroidTracker(IOUTracker):
-    """
-    CentroidTracker: Basic Centroid tracking algorithm.
+    """CentroidTracker: Basic Centroid tracking algorithm.
 
     The class is responsible for initializing, updating, and managing the tracks for detected objects in a video
     sequence. It maintains the state of tracked, lost, and removed tracks over frames.
@@ -54,7 +49,8 @@ class CentroidTracker(IOUTracker):
     Methods:
         init_track(dets, scores, cls, img=None): Initialize object tracking with detections.
         get_dists(tracks, detections): Calculates the euclidean distance between tracks and detections.
-        remove_duplicate_utracks(centroidtracksa, centroidtracksb): Removes duplicate centroidtracks based on euclidean distance
+        remove_duplicate_utracks(centroidtracksa, centroidtracksb): Removes duplicate centroidtracks based on euclidean
+            distance
     """
 
     def __init__(self, args, frame_rate=30):

--- a/ultralytics/trackers/iou_tracker.py
+++ b/ultralytics/trackers/iou_tracker.py
@@ -1,0 +1,298 @@
+# Ultralytics YOLO, AGPL-3.0 license
+
+import numpy as np
+
+from ..utils import LOGGER
+from ..utils.ops import xywh2ltwh
+from .basetrack import BaseTrack, TrackState
+from .utils import matching
+
+
+class UTrack(BaseTrack):
+    """
+    Single object tracking representation.
+
+    This class is responsible for storing all the information regarding individual tracklets. Uses simple IOU matching.
+    Lost tracks are not re-activated.
+
+    Attributes:
+        _count (int): Class-level counter for unique track IDs.
+        track_id (int): Unique identifier for the track.
+        is_activated (bool): Flag indicating whether the track is currently active.
+        state (TrackState): Current state of the track.
+        history (OrderedDict): Ordered history of the track's states.
+        score (float): The confidence score of the tracking.
+        start_frame (int): The frame number where tracking started.
+        frame_id (int): The most recent frame ID processed by the track.
+        time_since_update (int): Frames passed since the last update.
+        location (tuple): The location of the object in the context of multi-camera tracking.
+
+    Methods:
+        activate: Activate the track.
+        predict: Predict the next state of the track.
+        update: Update the track with new data.
+    """
+
+    def __init__(self, xywh, score, cls):
+        """Initialize new UTrack instance."""
+        super().__init__()
+        # xywh+idx or xywha+idx
+        assert len(xywh) in [5, 6], f"expected 5 or 6 values but got {len(xywh)}"
+        self._tlwh = np.asarray(xywh2ltwh(xywh[:4]), dtype=np.float32)
+        self.is_activated = False
+
+        self.score = score
+        self.tracklet_len = 0
+        self.cls = cls
+        self.idx = xywh[-1]
+        self.angle = xywh[4] if len(xywh) == 6 else None
+
+    def activate(self, frame_id):
+        """Start a new tracklet."""
+        self.track_id = self.next_id()
+
+        self.tracklet_len = 0
+        self.state = TrackState.Tracked
+        if frame_id == 1:
+            self.is_activated = True
+        self.frame_id = frame_id
+        self.start_frame = frame_id
+
+    def update(self, new_track, frame_id):
+        """
+        Update the state of a matched track.
+
+        Args:
+            new_track (STrack): The new track containing updated information.
+            frame_id (int): The ID of the current frame.
+        """
+        self.frame_id = frame_id
+        self.tracklet_len += 1
+
+        self._tlwh = new_track._tlwh  # updating box
+
+        self.state = TrackState.Tracked
+        self.is_activated = True
+
+        self.score = new_track.score
+        self.cls = new_track.cls
+        self.angle = new_track.angle
+        self.idx = new_track.idx
+
+    def convert_coords(self, tlwh):
+        """Convert a bounding box's top-left-width-height format to its x-y-aspect-height equivalent."""
+        return self.tlwh_to_xyah(tlwh)
+
+    @property
+    def tlwh(self):
+        """Get current position in bounding box format (top left x, top left y, width, height)."""
+        return self._tlwh.copy()
+
+    @property
+    def xyxy(self):
+        """Convert bounding box to format (min x, min y, max x, max y), i.e., (top left, bottom right)."""
+        ret = self.tlwh.copy()
+        ret[2:] += ret[:2]
+        return ret
+
+    @staticmethod
+    def tlwh_to_xyah(tlwh):
+        """Convert bounding box to format (center x, center y, aspect ratio, height), where the aspect ratio is width /
+        height.
+        """
+        ret = np.asarray(tlwh).copy()
+        ret[:2] += ret[2:] / 2
+        ret[2] /= ret[3]
+        return ret
+
+    @property
+    def xywh(self):
+        """Get current position in bounding box format (center x, center y, width, height)."""
+        ret = np.asarray(self.tlwh).copy()
+        ret[:2] += ret[2:] / 2
+        return ret
+
+    @property
+    def xywha(self):
+        """Get current position in bounding box format (center x, center y, width, height, angle)."""
+        if self.angle is None:
+            LOGGER.warning("WARNING: `angle` attr not found, returning `xywh` instead.")
+            return self.xywh
+        return np.concatenate([self.xywh, self.angle[None]])
+
+    @property
+    def result(self):
+        """Get current tracking results."""
+        coords = self.xyxy if self.angle is None else self.xywha
+        return coords.tolist() + [self.track_id, self.score, self.cls, self.idx]
+
+    def __repr__(self):
+        """Return a string representation of the IOUTracker object with start and end frames and track ID."""
+        return f"OT_{self.track_id}_({self.start_frame}-{self.end_frame})"
+
+
+class IOUTracker:
+    """
+    IOUTracker: Basic IOU tracking algorithm.
+
+    The class is responsible for initializing, updating, and managing the tracks for detected objects in a video
+    sequence. It maintains the state of tracked, lost, and removed tracks over frames.
+
+    Attributes:
+        tracked_utracks (list[UTrack]): List of successfully activated tracks.
+        lost_utracks (list[UTrack]): List of lost tracks.
+        removed_utracks (list[UTrack]): List of removed tracks.
+        frame_id (int): The current frame ID.
+        args (namespace): Command-line arguments.
+        max_time_lost (int): The maximum frames for a track to be considered as 'lost'.
+        match_thresh (float): 1 - Min iou overlap to match tracks
+
+    Methods:
+        update(results, img=None): Updates object tracker with new detections.
+        init_track(dets, scores, cls, img=None): Initialize object tracking with detections.
+        get_dists(tracks, detections): Calculates the distance between tracks and detections.
+        reset_id(): Resets the ID counter of STrack.
+        joint_utracks(tlista, tlistb): Combines two lists of utracks.
+        sub_utracks(tlista, tlistb): Filters out the utracks present in the second list from the first list.
+        remove_duplicate_utracks(utracksa, utracksb): Removes duplicate utracks based on IoU.
+    """
+
+    def __init__(self, args, frame_rate=30):
+        """Initialize a YOLOv8 object to track objects with given arguments and frame rate."""
+        self.tracked_utracks = []  # type: list[UTrack]
+        self.lost_utracks = []  # type: list[UTrack]
+        self.removed_utracks = []  # type: list[UTrack]
+
+        self.frame_id = 0
+        self.args = args
+        self.max_time_lost = int(frame_rate / 30.0 * args.track_buffer)
+        self.match_thresh = args.match_thresh
+        self.reset_id()
+
+    def update(self, results, img=None):
+        """Updates object tracker with new detections and returns tracked object bounding boxes."""
+        self.frame_id += 1
+        activated_utracks = []
+        refind_utracks = []
+        lost_utracks = []
+        removed_utracks = []
+
+        scores = results.conf
+        bboxes = results.xywhr if hasattr(results, "xywhr") else results.xywh
+        # Add index
+        bboxes = np.concatenate([bboxes, np.arange(len(bboxes)).reshape(-1, 1)], axis=-1)
+        cls = results.cls
+
+        # remove zero area bboxes
+        valid_inds = (bboxes[:, 2] > 0) & (bboxes[:, 3] > 0)
+        bboxes = bboxes[valid_inds]
+        scores = scores[valid_inds]
+        cls = cls[valid_inds]
+
+        remain_inds = scores > self.args.track_thresh
+        dets_keep = bboxes[remain_inds]
+        scores_keep = scores[remain_inds]
+        cls_keep = cls[remain_inds]
+
+        detections = self.init_track(dets_keep, scores_keep, cls_keep, img)  # list of CentroidTrack objects
+
+        # matching
+        dists = self.get_dists(self.tracked_utracks, detections)
+        matches, u_track, u_detection = matching.linear_assignment(dists, thresh=self.match_thresh)
+
+        for itracked, idet in matches:
+            mtrack = self.tracked_utracks[itracked]
+            mdet = detections[idet]
+            if mtrack.state == TrackState.Tracked:
+                mtrack.update(mdet, self.frame_id)
+                refind_utracks.append(mtrack)
+
+        for itracked in u_track:
+            utrack = self.tracked_utracks[itracked]
+            if utrack.state != TrackState.Lost:
+                utrack.mark_lost()
+                lost_utracks.append(utrack)
+
+        for idet in u_detection:  # create new tracks for all unmatched detections
+            udet = detections[idet]
+            udet.activate(self.frame_id)
+            activated_utracks.append(udet)
+
+        for ltrack in self.lost_utracks:
+            if self.frame_id - ltrack.end_frame > self.max_time_lost:
+                ltrack.mark_removed()
+                removed_utracks.append(ltrack)
+
+        self.tracked_utracks = [t for t in self.tracked_utracks if t.state == TrackState.Tracked]
+        self.tracked_utracks = self.joint_utracks(self.tracked_utracks, activated_utracks)
+        self.tracked_utracks = self.joint_utracks(self.tracked_utracks, refind_utracks)
+        self.lost_utracks = self.sub_utracks(self.lost_utracks, self.removed_utracks)
+        self.lost_utracks.extend(lost_utracks)
+        self.tracked_utracks, self.lost_utracks = self.remove_duplicate_utracks(
+            self.tracked_utracks, self.lost_utracks
+        )
+        self.removed_utracks.extend(removed_utracks)
+        if len(self.removed_utracks) > 1000:
+            self.removed_utracks = self.removed_utracks[-999:]  # clip remove utracks to 1000 maximum
+
+        return np.asarray([x.result for x in self.tracked_utracks if x.is_activated], dtype=np.float32)
+
+    def init_track(self, dets, scores, cls, img=None):
+        """Initialize object tracking with detections and scores using IOUTracker algorithm."""
+        return [UTrack(xyxy, s, c) for (xyxy, s, c) in zip(dets, scores, cls)] if len(dets) else []  # detections
+
+    @staticmethod
+    def reset_id():
+        """Resets the ID counter of STrack."""
+        UTrack.reset_id()
+
+    def reset(self):
+        """Reset tracker."""
+        self.tracked_utracks = []  # type: list[UTrack]
+        self.lost_utracks = []  # type: list[UTrack]
+        self.removed_utracks = []  # type: list[UTrack]
+        self.frame_id = 0
+        self.reset_id()
+
+    @staticmethod
+    def joint_utracks(tlista, tlistb):
+        """Combine two lists of utracks into a single one."""
+        exists = {}
+        res = []
+        for t in tlista:
+            exists[t.track_id] = 1
+            res.append(t)
+        for t in tlistb:
+            tid = t.track_id
+            if not exists.get(tid, 0):
+                exists[tid] = 1
+                res.append(t)
+        return res
+
+    @staticmethod
+    def sub_utracks(tlista, tlistb):
+        """Filter out the utracks present in the second list from the first list."""
+        track_ids_b = {t.track_id for t in tlistb}
+        return [t for t in tlista if t.track_id not in track_ids_b]
+
+    @staticmethod
+    def remove_duplicate_utracks(utracksa, utracksb):
+        """Remove duplicate utracks with non-maximum IoU distance."""
+        pdist = matching.iou_distance(utracksa, utracksb)
+        pairs = np.where(pdist < 0.15)
+        dupa, dupb = [], []
+        for p, q in zip(*pairs):
+            timep = utracksa[p].frame_id - utracksa[p].start_frame
+            timeq = utracksb[q].frame_id - utracksb[q].start_frame
+            if timep > timeq:
+                dupb.append(q)
+            else:
+                dupa.append(p)
+        resa = [t for i, t in enumerate(utracksa) if i not in dupa]
+        resb = [t for i, t in enumerate(utracksb) if i not in dupb]
+        return resa, resb
+
+    def get_dists(self, tracks, detections):
+        """Calculates the distance between tracks and detections using IoU."""
+        dists = matching.iou_distance(tracks, detections)
+        return dists

--- a/ultralytics/trackers/iou_tracker.py
+++ b/ultralytics/trackers/iou_tracker.py
@@ -169,7 +169,7 @@ class IOUTracker:
         self.match_thresh = args.match_thresh
         self.reset_id()
 
-    def update(self, results, img=None):
+    def update(self, results, img=None, feats=None):
         """Updates object tracker with new detections and returns tracked object bounding boxes."""
         self.frame_id += 1
         activated_utracks = []

--- a/ultralytics/trackers/iou_tracker.py
+++ b/ultralytics/trackers/iou_tracker.py
@@ -9,8 +9,7 @@ from .utils import matching
 
 
 class UTrack(BaseTrack):
-    """
-    Single object tracking representation.
+    """Single object tracking representation.
 
     This class is responsible for storing all the information regarding individual tracklets. Uses simple IOU matching.
     Lost tracks are not re-activated.
@@ -59,8 +58,7 @@ class UTrack(BaseTrack):
         self.start_frame = frame_id
 
     def update(self, new_track, frame_id):
-        """
-        Update the state of a matched track.
+        """Update the state of a matched track.
 
         Args:
             new_track (STrack): The new track containing updated information.
@@ -124,7 +122,7 @@ class UTrack(BaseTrack):
     def result(self):
         """Get current tracking results."""
         coords = self.xyxy if self.angle is None else self.xywha
-        return coords.tolist() + [self.track_id, self.score, self.cls, self.idx]
+        return [*coords.tolist(), self.track_id, self.score, self.cls, self.idx]
 
     def __repr__(self):
         """Return a string representation of the IOUTracker object with start and end frames and track ID."""
@@ -132,8 +130,7 @@ class UTrack(BaseTrack):
 
 
 class IOUTracker:
-    """
-    IOUTracker: Basic IOU tracking algorithm.
+    """IOUTracker: Basic IOU tracking algorithm.
 
     The class is responsible for initializing, updating, and managing the tracks for detected objects in a video
     sequence. It maintains the state of tracked, lost, and removed tracks over frames.
@@ -228,9 +225,7 @@ class IOUTracker:
         self.tracked_utracks = self.joint_utracks(self.tracked_utracks, refind_utracks)
         self.lost_utracks = self.sub_utracks(self.lost_utracks, self.removed_utracks)
         self.lost_utracks.extend(lost_utracks)
-        self.tracked_utracks, self.lost_utracks = self.remove_duplicate_utracks(
-            self.tracked_utracks, self.lost_utracks
-        )
+        self.tracked_utracks, self.lost_utracks = self.remove_duplicate_utracks(self.tracked_utracks, self.lost_utracks)
         self.removed_utracks.extend(removed_utracks)
         if len(self.removed_utracks) > 1000:
             self.removed_utracks = self.removed_utracks[-999:]  # clip remove utracks to 1000 maximum

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -10,9 +10,10 @@ from ultralytics.utils.checks import check_yaml
 
 from .bot_sort import BOTSORT
 from .byte_tracker import BYTETracker
+from .iou_tracker import IOUTracker
 
 # A mapping of tracker types to corresponding tracker classes
-TRACKER_MAP = {"bytetrack": BYTETracker, "botsort": BOTSORT}
+TRACKER_MAP = {"bytetrack": BYTETracker, "botsort": BOTSORT, "ioutrack": IOUTracker}
 
 
 def on_predict_start(predictor: object, persist: bool = False) -> None:
@@ -36,8 +37,10 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
     tracker = check_yaml(predictor.args.tracker)
     cfg = IterableSimpleNamespace(**YAML.load(tracker))
 
-    if cfg.tracker_type not in {"bytetrack", "botsort"}:
-        raise AssertionError(f"Only 'bytetrack' and 'botsort' are supported for now, but got '{cfg.tracker_type}'")
+    if cfg.tracker_type not in {"bytetrack", "botsort", "ioutrack"}:
+        raise AssertionError(
+            f"Only 'bytetrack', 'botsort', and 'ioutrack' are supported for now, but got '{cfg.tracker_type}'"
+        )
 
     predictor._feats = None  # reset in case used earlier
     if hasattr(predictor, "_hook"):

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -10,10 +10,11 @@ from ultralytics.utils.checks import check_yaml
 
 from .bot_sort import BOTSORT
 from .byte_tracker import BYTETracker
+from .centroid_tracker import CentroidTracker
 from .iou_tracker import IOUTracker
 
 # A mapping of tracker types to corresponding tracker classes
-TRACKER_MAP = {"bytetrack": BYTETracker, "botsort": BOTSORT, "ioutrack": IOUTracker}
+TRACKER_MAP = {"bytetrack": BYTETracker, "botsort": BOTSORT, "ioutrack": IOUTracker, "centroidtrack": CentroidTracker}
 
 
 def on_predict_start(predictor: object, persist: bool = False) -> None:
@@ -37,9 +38,9 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
     tracker = check_yaml(predictor.args.tracker)
     cfg = IterableSimpleNamespace(**YAML.load(tracker))
 
-    if cfg.tracker_type not in {"bytetrack", "botsort", "ioutrack"}:
+    if cfg.tracker_type not in {"bytetrack", "botsort", "ioutrack", "centroidtrack"}:
         raise AssertionError(
-            f"Only 'bytetrack', 'botsort', and 'ioutrack' are supported for now, but got '{cfg.tracker_type}'"
+            f"Only 'bytetrack', 'botsort', 'ioutrack', and 'centroidtrack' are supported for now, but got '{cfg.tracker_type}'"
         )
 
     predictor._feats = None  # reset in case used earlier


### PR DESCRIPTION
Hi all, I added two classic, basic trackers: IOU and centroid. ByteTrack is a very fancy IOU tracker, this adds a bare-bones IOU tracker without Kalman filters. The centroid tracker is another basic tracker that matches detections based on the euclidean distance between centroids of bounding boxes. These trackers are significantly faster than BoT-SORT and ByteTrack, particularly useful in situations where compute is limited (ie edge devices).

Added a centroid tracker. Performs basic multi-object tracking by matching detections based on euclidean distance of bounding box centroids.
Centroid tracker is 15% faster than ByteTrack and 30% faster than BoT-SORT as tested locally
Added IOU tracker. Performs basic multi-object tracking by matching detections based on IOU. (Note: ByteTrack and many other newer trackers use IOU in conjunction with Kalman filters and other post processing). This is a much simpler and faster tracker.
IOU tracker is 13% faster than ByteTrack and 28% faster than BoT-SORT
I have read the CLA Document and I hereby sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds two lightweight tracking backends (IOU and Centroid) to Ultralytics tracking and wires them into config + tests. 🧭

### 📊 Key Changes
-✨Added new tracker implementations: `IOUTracker` (`ultralytics/trackers/iou_tracker.py`) and `CentroidTracker` (`ultralytics/trackers/centroid_tracker.py`)
-🧩Registered new tracker types in `TRACKER_MAP` and expanded supported `tracker_type` validation in `ultralytics/trackers/track.py`
-⚙️Introduced new tracker config files: `ultralytics/cfg/trackers/ioutrack.yaml` and `ultralytics/cfg/trackers/centroidtrack.yaml`
-🧪Extended `tests/test_python.py` to run `model.track()` with the new tracker YAMLs
-📦Exported new trackers via `ultralytics/trackers/__init__.py`

### 🎯 Purpose & Impact
-🚀Enables simpler, dependency-light tracking options for users who don’t need ByteTrack/BOTSort complexity
-🔧Provides configurable defaults (thresholds/buffer/matching) via standard YAML tracker configs
-✅Improves coverage by ensuring basic tracking flows for the new trackers are exercised in the test suite