### PR TITLE
Fix issues in classify task and add support for --data YAML format

### DIFF
--- a/ultralytics/cfg/datasets/ImageNet.yaml
+++ b/ultralytics/cfg/datasets/ImageNet.yaml
@@ -9,8 +9,8 @@
 # └── datasets
 #     └── imagenet ← downloads here (144 GB)
 
-# Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
-path: imagenet # dataset root dir
+# Train/val/test sets as 1) dir: path/to/imgs, 2) list: [path/to/imgs1, path/to/imgs2, ..]
+path: imagenet # dataset root dir or dataset name
 train: train # train images (relative to 'path') 1281167 images
 val: val # val images (relative to 'path') 50000 images
 test: # test images (optional)

--- a/ultralytics/cfg/datasets/ImageNet10.yaml
+++ b/ultralytics/cfg/datasets/ImageNet10.yaml
@@ -1,0 +1,43 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# ImageNet-10 dataset-full https://www.image-net.org/index.php by Stanford University
+# Simplified class names from https://github.com/anishathalye/imagenet-simple-labels
+# Documentation: https://docs.ultralytics.com/datasets/classify/imagenet10
+# Applications: The ImageNet10 dataset is useful for quickly testing and debugging computer vision models and pipelines
+# Example usage: yolo train task=classify data=imagenet10
+# parent
+# ├── ultralytics
+# └── datasets
+#     └── imagenet10 ← downloads here (68 KB)
+
+# Train/val/test sets as 1) dir: path/to/imgs, 2) list: [path/to/imgs1, path/to/imgs2, ..]
+path: imagenet10 # dataset root dir or dataset name
+train: train # train images (relative to 'path') 10 images
+val: val # val images (relative to 'path') 10 images
+test: # test images (optional)
+
+# Classes
+names:
+  0: tench
+  1: goldfish
+  2: great white shark
+  3: tiger shark
+  4: hammerhead shark
+  5: electric ray
+  6: stingray
+  7: cock
+  8: hen
+  9: ostrich
+
+# Imagenet class codes to human-readable names
+map:
+  n01440764: tench
+  n01443537: goldfish
+  n01484850: great_white_shark
+  n01491361: tiger_shark
+  n01494475: hammerhead
+  n01496331: electric_ray
+  n01498041: stingray
+  n01514668: cock
+  n01514859: hen
+  n01518878: ostrich

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -709,11 +709,12 @@ class ClassificationDataset:
         verify_images: Verify all images in dataset.
     """
 
-    def __init__(self, root: str, args, augment: bool = False, prefix: str = ""):
+    def __init__(self, root: str, names: dict, args, augment: bool = False, prefix: str = ""):
         """Initialize YOLO classification dataset with root directory, arguments, augmentations, and cache settings.
 
         Args:
             root (str): Path to the dataset directory where images are stored in a class-specific folder structure.
+            names (dict): Class names loaded from training labels.
             args (Namespace): Configuration containing dataset-related settings such as image size, augmentation
                 parameters, and cache settings.
             augment (bool, optional): Whether to apply augmentations to the dataset.
@@ -721,17 +722,41 @@ class ClassificationDataset:
         """
         import torchvision  # scope for faster 'import ultralytics'
 
+        if not isinstance(root, (list, tuple)):
+            root = [root]
+
         # Base class assigned as attribute rather than used as base class to allow for scoping slow torchvision import
         if TORCHVISION_0_18:  # 'allow_empty' argument first introduced in torchvision 0.18
-            self.base = torchvision.datasets.ImageFolder(root=root, allow_empty=True)
+            self.base = [torchvision.datasets.ImageFolder(root=r, allow_empty=True) for r in root]
         else:
-            self.base = torchvision.datasets.ImageFolder(root=root)
-        self.samples = self.base.samples
-        self.root = self.base.root
+            self.base = [torchvision.datasets.ImageFolder(root=r) for r in root]
+
+        # Filter out and align samples with instance class (prevents CUDA assertion errors)
+        if names is None or not isinstance(names, dict) or len(names) == 0:
+            raise ValueError("ClassificationDataset must set names, but got {}.".format(names))
+        class_to_idx = {v: k for k, v in names.items()}
+        for subbase in self.base:
+            # Aligning torchvision ImageFolder attribute classes and class_to_idx to names
+            if subbase.class_to_idx == class_to_idx:
+                continue
+            imgs, targets = [], []
+            for f, i in subbase.samples:
+                sample_class = subbase.classes[i]
+                if class_to_idx.get(sample_class) is not None:
+                    targets.append(class_to_idx[sample_class])
+                    imgs.append(f)
+            subbase.class_to_idx = class_to_idx
+            subbase.classes = list(class_to_idx.keys())
+            subbase.imgs = list(zip(imgs, targets))
+            subbase.samples = list(zip(imgs, targets))
+            subbase.targets = targets
+
+        self.samples = [b.samples for b in self.base]
+        self.root = [b.root for b in self.base]
 
         # Initialize attributes
         if augment and args.fraction < 1.0:  # reduce training fraction
-            self.samples = self.samples[: round(len(self.samples) * args.fraction)]
+            self.samples = [s[: round(len(s) * args.fraction)] for s in self.samples]
         self.prefix = colorstr(f"{prefix}: ") if prefix else ""
         self.cache_ram = args.cache is True or str(args.cache).lower() == "ram"  # cache images into RAM
         if self.cache_ram:
@@ -741,7 +766,7 @@ class ClassificationDataset:
             )
             self.cache_ram = False
         self.cache_disk = str(args.cache).lower() == "disk"  # cache images on hard drive as uncompressed *.npy files
-        self.samples = self.verify_images()  # filter out bad images
+        self.samples = self.verify_images(prefix)  # filter out bad images and cache images
         self.samples = [[*list(x), Path(x[0]).with_suffix(".npy"), None] for x in self.samples]  # file, index, npy, im
         scale = (1.0 - args.scale, 1.0)  # (0.08, 1.0)
         self.torch_transforms = (
@@ -788,20 +813,24 @@ class ClassificationDataset:
         """Return the total number of samples in the dataset."""
         return len(self.samples)
 
-    def verify_images(self) -> list[tuple]:
+    def verify_images(self, prefix: str = "") -> list[tuple]:
         """Verify all images in dataset.
+
+        Args:
+            prefix (str): File name of cache with prefix (train, val, test),
+              it will use self.root[0] of folder name for cache if prefix not set.
 
         Returns:
             (list): List of valid samples after verification.
         """
-        desc = f"{self.prefix}Scanning {self.root}..."
-        path = Path(self.root).with_suffix(".cache")  # *.cache file path
+        desc = f"{self.prefix}Scanning {f'all ({len(self.root)}) subdataset' if len(self.root) > 1 else self.root[0]}..."
+        path = (Path(self.root[0]).parent / prefix if prefix else Path(self.root[0])).with_suffix(".cache")  # *.cache file path
 
         try:
-            check_file_speeds([file for (file, _) in self.samples[:5]], prefix=self.prefix)  # check image read speeds
+            check_file_speeds([f for (f, _) in self.samples[0][:5]], prefix=self.prefix)  # check image read speeds
             cache = load_dataset_cache_file(path)  # attempt to load a *.cache file
             assert cache["version"] == DATASET_CACHE_VERSION  # matches current version
-            assert cache["hash"] == get_hash([x[0] for x in self.samples])  # identical hash
+            assert cache["hash"] == get_hash([x[0] for s in self.samples for x in s])  # identical hash
             nf, nc, n, samples = cache.pop("results")  # found, missing, empty, corrupt, total
             if LOCAL_RANK in {-1, 0}:
                 d = f"{desc} {nf} images, {nc} corrupt"
@@ -809,13 +838,13 @@ class ClassificationDataset:
                 if cache["msgs"]:
                     LOGGER.info("\n".join(cache["msgs"]))  # display warnings
             return samples
-
         except (FileNotFoundError, AssertionError, AttributeError):
             # Run scan if *.cache retrieval failed
             nf, nc, msgs, samples, x = 0, 0, [], [], {}
             with ThreadPool(NUM_THREADS) as pool:
-                results = pool.imap(func=verify_image, iterable=zip(self.samples, repeat(self.prefix)))
-                pbar = TQDM(results, desc=desc, total=len(self.samples))
+                results = pool.imap(func=verify_image, iterable=zip(
+                    (x for s in self.samples for x in s), repeat(self.prefix)))
+                pbar = TQDM(results, desc=desc, total=sum(len(s) for s in self.samples))
                 for sample, nf_f, nc_f, msg in pbar:
                     if nf_f:
                         samples.append(sample)
@@ -827,7 +856,7 @@ class ClassificationDataset:
                 pbar.close()
             if msgs:
                 LOGGER.info("\n".join(msgs))
-            x["hash"] = get_hash([x[0] for x in self.samples])
+            x["hash"] = get_hash([x[0] for s in self.samples for x in s])
             x["results"] = nf, nc, len(samples), samples
             x["msgs"] = msgs  # warnings
             save_dataset_cache_file(self.prefix, path, x, DATASET_CACHE_VERSION)

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -733,7 +733,7 @@ class ClassificationDataset:
 
         # Filter out and align samples with instance class (prevents CUDA assertion errors)
         if names is None or not isinstance(names, dict) or len(names) == 0:
-            raise ValueError("ClassificationDataset must set names, but got {}.".format(names))
+            raise ValueError(f"ClassificationDataset must set names, but got {names}.")
         class_to_idx = {v: k for k, v in names.items()}
         for subbase in self.base:
             # Aligning torchvision ImageFolder attribute classes and class_to_idx to names
@@ -817,14 +817,18 @@ class ClassificationDataset:
         """Verify all images in dataset.
 
         Args:
-            prefix (str): File name of cache with prefix (train, val, test),
-              it will use self.root[0] of folder name for cache if prefix not set.
+            prefix (str): File name of cache with prefix (train, val, test), it will use self.root[0] of folder name for
+                cache if prefix not set.
 
         Returns:
             (list): List of valid samples after verification.
         """
-        desc = f"{self.prefix}Scanning {f'all ({len(self.root)}) subdataset' if len(self.root) > 1 else self.root[0]}..."
-        path = (Path(self.root[0]).parent / prefix if prefix else Path(self.root[0])).with_suffix(".cache")  # *.cache file path
+        desc = (
+            f"{self.prefix}Scanning {f'all ({len(self.root)}) subdataset' if len(self.root) > 1 else self.root[0]}..."
+        )
+        path = (Path(self.root[0]).parent / prefix if prefix else Path(self.root[0])).with_suffix(
+            ".cache"
+        )  # *.cache file path
 
         try:
             check_file_speeds([f for (f, _) in self.samples[0][:5]], prefix=self.prefix)  # check image read speeds
@@ -842,8 +846,9 @@ class ClassificationDataset:
             # Run scan if *.cache retrieval failed
             nf, nc, msgs, samples, x = 0, 0, [], [], {}
             with ThreadPool(NUM_THREADS) as pool:
-                results = pool.imap(func=verify_image, iterable=zip(
-                    (x for s in self.samples for x in s), repeat(self.prefix)))
+                results = pool.imap(
+                    func=verify_image, iterable=zip((x for s in self.samples for x in s), repeat(self.prefix))
+                )
                 pbar = TQDM(results, desc=desc, total=sum(len(s) for s in self.samples))
                 for sample, nf_f, nc_f, msg in pbar:
                     if nf_f:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -496,8 +496,9 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
             - 'nc' (int): The number of classes in the dataset.
             - 'names' (dict[int, str]): A dictionary of class names in the dataset.
     """
+
     def download_dataset(d: str | Path):
-        """download dataset by dataset name from ASSERTS_URL
+        """Download dataset by dataset name from ASSERTS_URL.
 
         Args:
             d (str | Path): The name of the dataset.
@@ -509,8 +510,7 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
             subprocess.run(["bash", str(ROOT / "data/scripts/get_imagenet.sh")], check=True)
         else:
             download(f"{ASSETS_URL}/{d}.zip", dir=data_dir.parent)
-        LOGGER.info(
-            f"Dataset download success ✅ ({time.time() - t:.1f}s), saved to {colorstr('bold', data_dir)}\n")
+        LOGGER.info(f"Dataset download success ✅ ({time.time() - t:.1f}s), saved to {colorstr('bold', data_dir)}\n")
 
     # Download (optional if dataset=https://file.zip is passed directly)
     if str(dataset).startswith(("http:/", "https:/")):
@@ -526,7 +526,7 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
         data = YAML.load(dataset, append_filename=True)
         path = data.get("path", "").replace("\\", "/")
         data_dir = Path(path).resolve()
-        if not data_dir.is_dir() and len(path) > 0 and '/' not in path:
+        if not data_dir.is_dir() and len(path) > 0 and "/" not in path:
             data_dir = (DATASETS_DIR / path).resolve()
             if not data_dir.is_dir():
                 download_dataset(path)
@@ -543,14 +543,15 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
         test_set = data.get("test")  # data/val or data/test
         train_set, test_set, val_set = [
             [(data_dir / p).resolve() for p in ([ds] if isinstance(ds, str) else ds)] if ds else []
-            for ds in (train_set, test_set, val_set)]  # match each dataset
+            for ds in (train_set, test_set, val_set)
+        ]  # match each dataset
     else:
         data_dir = (dataset if dataset.is_dir() else (DATASETS_DIR / dataset)).resolve()
         if not data_dir.is_dir():
             if data_dir.suffix != "":
                 raise ValueError(
                     f'Classification datasets must be a directory (data="path/to/dir") not a file (data="{dataset}"), '
-                     "See https://docs.ultralytics.com/datasets/classify/"
+                    "See https://docs.ultralytics.com/datasets/classify/"
                 )
             download_dataset(dataset)
         train_set = data_dir / "train"
@@ -588,8 +589,7 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
     #   will rename labels when loading a trained model, so training must use n0* origin style labels.
     if data.get("names") and data.get("path") not in ("imagenet", "imagenet10"):
         names = data["names"]  # Specify labels manually
-        assert isinstance(names, (list, dict)), \
-            f"Dataset (type(names)={type(names)}) only support list or dict."
+        assert isinstance(names, (list, dict)), f"Dataset (type(names)={type(names)}) only support list or dict."
     else:  # Specify all labels automatically
         names = sorted(list(set(n.name for sf in train_set if sf.is_dir() for n in sf.glob("*") if n.is_dir())))
     if isinstance(names, list):  # class names list
@@ -605,8 +605,11 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
             for subfolder in v:
                 sublabels = {l.name for l in subfolder.iterdir() if l.is_dir() and l.name in names.values()}
                 files = [
-                    path for l in subfolder.iterdir() if l.is_dir() and l.name in names.values()
-                    for path in l.glob("*") if path.suffix[1:].lower() in IMG_FORMATS
+                    path
+                    for l in subfolder.iterdir()
+                    if l.is_dir() and l.name in names.values()
+                    for path in l.glob("*")
+                    if path.suffix[1:].lower() in IMG_FORMATS
                 ]  # Filter out files that label in names and suffix in IMG_FORMATS
                 subnf = len(files)  # number of files in subfolder
                 subnd = len(sublabels)  # number of classes directories in subfolder

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -606,9 +606,9 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
                 sublabels = {sf.name for sf in subfolder.iterdir() if sf.is_dir() and sf.name in names.values()}
                 files = [
                     path
-                    for l in subfolder.iterdir()
-                    if l.is_dir() and l.name in names.values()
-                    for path in l.glob("*")
+                    for sf in subfolder.iterdir()
+                    if sf.is_dir() and sf.name in names.values()
+                    for path in sf.glob("*")
                     if path.suffix[1:].lower() in IMG_FORMATS
                 ]  # Filter out files that label in names and suffix in IMG_FORMATS
                 subnf = len(files)  # number of files in subfolder

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -603,7 +603,7 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
         else:
             labels, nf = set(), 0  # all subfolder names, number of files in all subfolder
             for subfolder in v:
-                sublabels = {l.name for l in subfolder.iterdir() if l.is_dir() and l.name in names.values()}
+                sublabels = {sf.name for sf in subfolder.iterdir() if sf.is_dir() and sf.name in names.values()}
                 files = [
                     path
                     for l in subfolder.iterdir()

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -496,6 +496,22 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
             - 'nc' (int): The number of classes in the dataset.
             - 'names' (dict[int, str]): A dictionary of class names in the dataset.
     """
+    def download_dataset(d: str | Path):
+        """download dataset by dataset name from ASSERTS_URL
+
+        Args:
+            d (str | Path): The name of the dataset.
+        """
+        LOGGER.info("")
+        LOGGER.warning(f"Dataset not found, missing path {data_dir}, attempting download...")
+        t = time.time()
+        if str(d) == "imagenet":
+            subprocess.run(["bash", str(ROOT / "data/scripts/get_imagenet.sh")], check=True)
+        else:
+            download(f"{ASSETS_URL}/{d}.zip", dir=data_dir.parent)
+        LOGGER.info(
+            f"Dataset download success ✅ ({time.time() - t:.1f}s), saved to {colorstr('bold', data_dir)}\n")
+
     # Download (optional if dataset=https://file.zip is passed directly)
     if str(dataset).startswith(("http:/", "https:/")):
         dataset = safe_download(dataset, dir=DATASETS_DIR, unzip=True, delete=False)
@@ -503,43 +519,63 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
         file = check_file(dataset)
         dataset = safe_download(file, dir=DATASETS_DIR, unzip=True, delete=False)
 
-    dataset = Path(dataset)
-    data_dir = (dataset if dataset.is_dir() else (DATASETS_DIR / dataset)).resolve()
-    if not data_dir.is_dir():
-        if data_dir.suffix != "":
-            raise ValueError(
-                f'Classification datasets must be a directory (data="path/to/dir") not a file (data="{dataset}"), '
-                "See https://docs.ultralytics.com/datasets/classify/"
-            )
-        LOGGER.info("")
-        LOGGER.warning(f"Dataset not found, missing path {data_dir}, attempting download...")
-        t = time.time()
-        if str(dataset) == "imagenet":
-            subprocess.run(["bash", str(ROOT / "data/scripts/get_imagenet.sh")], check=True)
-        else:
-            download(f"{ASSETS_URL}/{dataset}.zip", dir=data_dir.parent)
-        LOGGER.info(f"Dataset download success ✅ ({time.time() - t:.1f}s), saved to {colorstr('bold', data_dir)}\n")
-    train_set = data_dir / "train"
-    if not train_set.is_dir():
-        LOGGER.warning(f"Dataset 'split=train' not found at {train_set}")
-        if image_files := list(data_dir.rglob("*.jpg")) + list(data_dir.rglob("*.png")):
-            from ultralytics.data.split import split_classify_dataset
+    # Loading train_set, val_set, test_set paths
+    dataset, data = Path(dataset), dict()
+    if dataset.suffix in (".yaml", ".yml"):
+        dataset = check_file(str(dataset))
+        data = YAML.load(dataset, append_filename=True)
+        path = data.get("path", "").replace("\\", "/")
+        data_dir = Path(path).resolve()
+        if not data_dir.is_dir() and len(path) > 0 and '/' not in path:
+            data_dir = (DATASETS_DIR / path).resolve()
+            if not data_dir.is_dir():
+                download_dataset(path)
+        train_set = data.get("train")
+        val_set = (
+            data.get("val")
+            if data.get("val")
+            else data.get("validation")
+            if data.get("validation")
+            else data.get("valid")
+            if data.get("valid")
+            else None
+        )  # data/test or data/val
+        test_set = data.get("test")  # data/val or data/test
+        train_set, test_set, val_set = [
+            [(data_dir / p).resolve() for p in ([ds] if isinstance(ds, str) else ds)] if ds else []
+            for ds in (train_set, test_set, val_set)]  # match each dataset
+    else:
+        data_dir = (dataset if dataset.is_dir() else (DATASETS_DIR / dataset)).resolve()
+        if not data_dir.is_dir():
+            if data_dir.suffix != "":
+                raise ValueError(
+                    f'Classification datasets must be a directory (data="path/to/dir") not a file (data="{dataset}"), '
+                     "See https://docs.ultralytics.com/datasets/classify/"
+                )
+            download_dataset(dataset)
+        train_set = data_dir / "train"
+        if not train_set.is_dir():
+            LOGGER.warning(f"Dataset 'split=train' not found at {train_set}")
+            if image_files := list(data_dir.rglob("*.jpg")) + list(data_dir.rglob("*.png")):
+                from ultralytics.data.split import split_classify_dataset
 
-            LOGGER.info(f"Found {len(image_files)} images in subdirectories. Attempting to split...")
-            data_dir = split_classify_dataset(data_dir, train_ratio=0.8)
-            train_set = data_dir / "train"
-        else:
-            LOGGER.error(f"No images found in {data_dir} or its subdirectories.")
-    val_set = (
-        data_dir / "val"
-        if (data_dir / "val").exists()
-        else data_dir / "validation"
-        if (data_dir / "validation").exists()
-        else data_dir / "valid"
-        if (data_dir / "valid").exists()
-        else None
-    )  # data/test or data/val
-    test_set = data_dir / "test" if (data_dir / "test").exists() else None  # data/val or data/test
+                LOGGER.info(f"Found {len(image_files)} images in subdirectories. Attempting to split...")
+                data_dir = split_classify_dataset(data_dir, train_ratio=0.8)
+                train_set = data_dir / "train"
+            else:
+                LOGGER.error(f"No images found in {data_dir} or its subdirectories.")
+        val_set = (
+            data_dir / "val"
+            if (data_dir / "val").exists()
+            else data_dir / "validation"
+            if (data_dir / "validation").exists()
+            else data_dir / "valid"
+            if (data_dir / "valid").exists()
+            else None
+        )  # data/test or data/val
+        test_set = data_dir / "test" if (data_dir / "test").exists() else None  # data/val or data/test
+        train_set, val_set, test_set = [[i] if i else [] for i in (train_set, val_set, test_set)]
+
     if split == "val" and not val_set:
         LOGGER.warning("Dataset 'split=val' not found, using 'split=test' instead.")
         val_set = test_set
@@ -547,24 +583,42 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
         LOGGER.warning("Dataset 'split=test' not found, using 'split=val' instead.")
         test_set = val_set
 
-    nc = len([x for x in (data_dir / "train").glob("*") if x.is_dir()])  # number of classes
-    names = [x.name for x in (data_dir / "train").iterdir() if x.is_dir()]  # class names list
-    names = dict(enumerate(sorted(names)))
+    # When dataset format is imagenet or imagenet10, force class names to be loaded from subfolder names.
+    # This is required because ultralytics/nn/autobackend.py (__init__)
+    #   will rename labels when loading a trained model, so training must use n0* origin style labels.
+    if data.get("names") and data.get("path") not in ("imagenet", "imagenet10"):
+        names = data["names"]  # Specify labels manually
+        assert isinstance(names, (list, dict)), \
+            f"Dataset (type(names)={type(names)}) only support list or dict."
+    else:  # Specify all labels automatically
+        names = sorted(list(set(n.name for sf in train_set if sf.is_dir() for n in sf.glob("*") if n.is_dir())))
+    if isinstance(names, list):  # class names list
+        names = dict(enumerate(names))
+    nc = len(names)  # number of classes
 
     # Print to console
     for k, v in {"train": train_set, "val": val_set, "test": test_set}.items():
-        prefix = f"{colorstr(f'{k}:')} {v}..."
-        if v is None:
-            LOGGER.info(prefix)
+        if len(v) == 0:
+            LOGGER.info(f"{colorstr(f'{k}:')} None...")
         else:
-            files = [path for path in v.rglob("*.*") if path.suffix[1:].lower() in IMG_FORMATS]
-            nf = len(files)  # number of files
-            nd = len({file.parent for file in files})  # number of directories
-            if nf == 0:
-                if k == "train":
-                    raise FileNotFoundError(f"{dataset} '{k}:' no training images found")
-                else:
-                    LOGGER.warning(f"{prefix} found {nf} images in {nd} classes (no images found)")
+            labels, nf = set(), 0  # all subfolder names, number of files in all subfolder
+            for subfolder in v:
+                sublabels = {l.name for l in subfolder.iterdir() if l.is_dir() and l.name in names.values()}
+                files = [
+                    path for l in subfolder.iterdir() if l.is_dir() and l.name in names.values()
+                    for path in l.glob("*") if path.suffix[1:].lower() in IMG_FORMATS
+                ]  # Filter out files that label in names and suffix in IMG_FORMATS
+                subnf = len(files)  # number of files in subfolder
+                subnd = len(sublabels)  # number of classes directories in subfolder
+                nf += subnf
+                labels |= sublabels
+                if subnf == 0:
+                    prefix = f"{colorstr(f'{k}:')} {subfolder}..."
+                    LOGGER.warning(f"{prefix} found {subnf} images in {subnd} classes (no images found)")
+            nd = len(labels)  # number of classes directories in all subfolder
+            prefix = f"{colorstr(f'{k}:')} {f'all ({len(v)}) subfolder' if len(v) > 1 else v[0]}..."
+            if nf == 0 and k == "train":
+                raise FileNotFoundError(f"{dataset} '{k}:' no training images found")
             elif nd != nc:
                 LOGGER.error(f"{prefix} found {nf} images in {nd} classes (requires {nc} classes, not {nd})")
             else:

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -176,7 +176,7 @@ class BaseValidator:
                 self.args.batch = model.metadata.get("batch", 1)  # export.py models default to batch-size 1
                 LOGGER.info(f"Setting batch={self.args.batch} input of shape ({self.args.batch}, 3, {imgsz}, {imgsz})")
 
-            if str(self.args.data).rsplit(".", 1)[-1] in {"yaml", "yml"}:
+            if self.args.task != "classify" and str(self.args.data).rsplit(".", 1)[-1] in {"yaml", "yml"}:
                 self.data = check_det_dataset(self.args.data)
             elif self.args.task == "classify":
                 self.data = check_cls_dataset(self.args.data, split=self.args.split)

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -11,7 +11,7 @@ from ultralytics.data import ClassificationDataset, build_dataloader
 from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import ClassificationModel
-from ultralytics.utils import DEFAULT_CFG, LOGGER, RANK
+from ultralytics.utils import DEFAULT_CFG, RANK
 from ultralytics.utils.plotting import plot_images
 from ultralytics.utils.torch_utils import is_parallel, torch_distributed_zero_first
 
@@ -122,7 +122,8 @@ class ClassificationTrainer(BaseTrainer):
             (ClassificationDataset): Dataset for the specified mode.
         """
         return ClassificationDataset(
-            root=img_path, names=self.data["names"], args=self.args, augment=mode == "train", prefix=mode)
+            root=img_path, names=self.data["names"], args=self.args, augment=mode == "train", prefix=mode
+        )
 
     def get_dataloader(self, dataset_path: str, batch_size: int = 16, rank: int = 0, mode: str = "train"):
         """Return PyTorch DataLoader with transforms to preprocess images.

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -148,7 +148,9 @@ class ClassificationValidator(BaseValidator):
 
     def build_dataset(self, img_path: str) -> ClassificationDataset:
         """Create a ClassificationDataset instance for validation."""
-        return ClassificationDataset(root=img_path, args=self.args, augment=False, prefix=self.args.split)
+        return ClassificationDataset(
+            root=img_path, names=self.data["names"], args=self.args, augment=False, prefix=self.args.split
+        )
 
     def get_dataloader(self, dataset_path: Path | str, batch_size: int) -> torch.utils.data.DataLoader:
         """Build and return a data loader for classification validation.


### PR DESCRIPTION
## fix Issue:

When training a classify model, I found that if the class labels in the validation set are not aligned with those in the training set, the validation labels become incorrect.

Because [Ultralytics:torchvision.datasets.ImageFolder](https://github.com/ultralytics/ultralytics/blob/1da4e933181f0dfe983349c2b1dcda81dba094f8/ultralytics/data/dataset.py#L726) didn't know full names when loaded validation set.

**Minimal reproducible example：**

1. download `Imagenet10` dataset.
2. change val dataset folder to:

    origin:
    
    ```
    somewhere
    └── datasets
         └── imagenet10
              └── train
              └── val # total 10 folders
                   └── n01440764
                   └── n01443537
                   └── ...
                   └── n01518878
    ```

    changed:
    
    ```
    somewhere
    └── datasets
         └── imagenet10
              └── train
              └── val # total 8 folders
                   └── n01440764
                   └── n01443537  # remove
                   └── ...
                   └── n01514668  # remove
                   └── ...
                   └── n01518878
    ```

3. debug here [Ultralytics:torchvision.datasets.ImageFolder](https://github.com/ultralytics/ultralytics/blob/1da4e933181f0dfe983349c2b1dcda81dba094f8/ultralytics/data/dataset.py#L729) and observe `torchvision.datasets.ImageFolder` attribute

    It can found that:
    
    - trainer dataset self.base.class_to_idx is:
    
    ```python
    self.base.class_to_idx == {'n01440764': 0, 'n01443537': 1, 'n01484850': 2, 'n01491361': 3, 'n01494475': 4, 'n01496331': 5, 'n01498041': 6, 'n01514668': 7, 'n01514859': 8, 'n01518878': 9}
    ```
    
    - val dataset self.base.class_to_idx is:
    
    ```python
    self.base.class_to_idx == {'n01440764': 0, 'n01484850': 1, 'n01491361': 2, 'n01494475': 3, 'n01496331': 4, 'n01498041': 5, 'n01514859': 6, 'n01518878': 7}
    ```

### Solution:

I noticed that [This code snippet](https://github.com/ultralytics/ultralytics/blob/da1080ecaae1cd8a0be17df9d9a70a8a6d80e4ff/ultralytics/models/yolo/classify/train.py#L141) have been solved some compatibility issues, but it does not work for the case mentioned above.

Therefore, I resolved this issue by passing `data["names"]` from [def check_cls_dataset -> result](https://github.com/Yakuho/ultralytics/blob/d88598e24a77d7367e6659d973659c0a82040ffc/ultralytics/data/utils.py#L480)
to [ClassificationDataset](https://github.com/Yakuho/ultralytics/blob/d88598e24a77d7367e6659d973659c0a82040ffc/ultralytics/data/dataset.py#L712) and remapping the labels accordingly [here](https://github.com/Yakuho/ultralytics/blob/d88598e24a77d7367e6659d973659c0a82040ffc/ultralytics/data/dataset.py#L738).

## New Feature:

In addition, I also added support for the YAML format to train classify task.

**Minimal reproducible example for `imagenet10`：**

```yaml
# Train/val/test sets as 1) dir: path/to/imgs, 2) list: [path/to/imgs1, path/to/imgs2, ..]
path: imagenet10 # dataset root dir or dataset name
train: train # train images (relative to 'path') 12 images
val: val # val images (relative to 'path') 12 images
test: # test images (optional)

# Classes
names:
  0: tench
  1: goldfish
  2: great white shark
  3: tiger shark
  4: hammerhead shark
  5: electric ray
  6: stingray
  7: cock
  8: hen
  9: ostrich
```

1. `Path` has been set but not a path dir (depends contains '/' or not e.g. `"imagenet"`)
  behaves: `Ultralytics` will download dataset from [download(ultralytics/utils/downloads.py)](https://github.com/ultralytics/ultralytics/blob/da1080ecaae1cd8a0be17df9d9a70a8a6d80e4ff/ultralytics/utils/downloads.py#L481) by keyword (`path`), and `train_set`, `val_set`, and `test_set` are appended to `path`
2. `Path` has been set and is a path dir (contains '/' e.g., `/nasdata/path/to/dataset`)
  behaves: `train_set`, `val_set`, and `test_set` are appended to `path`, e.g. `/nasdata/path/to/dataset/train`
3. `Path` has been set null
  behaves: `train_set`, `val_set`, and `test_set` are treated as full paths when accessed, so those `data_set` should set e.g. `train_set: \path\to\dataset\train`
4. `train_set`, `val_set`, and `test_set` are support set more than one path and each subpath dataset format still as [origin format](https://docs.ultralytics.com/zh/datasets/classify/#folder-structure-example) style. It is noting that label class will get union if set more than one path. example:
    ```
    somewhere
    └── datasets
         └── example_dataset
              └── train0
                   └── class-00
                   └── class-01
                   └── class-02
                   └── class-03
              └── train1
                   └── class-00
                   └── class-04
                   └── class-05
                   └── class-06
    ```
    - If `names` was set in the YAML (as a list or dict), model class names are loaded in that order:
      ```yaml
      path: example_dataset
      train:  
        - train0 
        - train1
      val: val 
      test: # test images (optional)
       
      names: ["class-00", "class-01", "class-02", "class-03", "class-04", "class-05", "class-06"]  # as list
      names: {0: 'class-00', 1: 'class-01', 2: 'class-02', 3: 'class-03', 4: 'class-04', 5: 'class-05', 6: 'class-06'}  # as dict
      names: # or set null
      ```
    - otherwise, they are sorted automatically based on subfolder names:
      ```python
      sorted(list(set(n.name for sf in map(Path, ("/path/to/train0", "/path/to/train1")) if sf.is_dir() for n in sf.glob("*") if n.is_dir())))
      ```
5. `names` support `dict` and `list`, as explained above. It can also be set to null; when `names` is empty, all labels under the `train_set` directories are automatically collected as a union and sorted to `names`. Beside, model train task can select only the labels to include for training via the YAML configuration. example:
    ```yaml
    names: ["class-00", "class-01", "class-02", "class-03", "class-04"]  # as list
    names: {0: 'class-00', 1: 'class-01', 2: 'class-02', 3: 'class-03', 4: 'class-04'}  # as dict
    # the other label [class-05, class-06] will be ignore
    ```

## Declaration:

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves classification dataset handling and adds YAML-based `--data` support for classify workflows 🧩📄

### 📊 Key Changes
-Adds `ImageNet10.yaml` dataset config and updates `ImageNet.yaml` guidance for directory/list-based splits.
-Extends `check_cls_dataset()` to accept `--data` as a YAML file, resolving paths/splits (including list-of-roots) and supporting dataset-name downloads.
-Refactors `ClassificationDataset` to accept `names`, support multiple roots, align `ImageFolder` class indices to provided names, and update caching/verification for multi-subdataset scans.
-Fixes validator routing so classification uses `check_cls_dataset()` even when `--data` is a YAML file.
-Removes train-time filtering workaround in `classify/train.py` now that dataset class alignment is handled centrally.

### 🎯 Purpose & Impact
-Enables `yolo train task=classify data=...yaml` workflows and consistent dataset configuration across tasks ✅
-Prevents CUDA assertion errors caused by mismatched class indices by enforcing alignment to `names` at dataset construction time 🔒
-Adds a tiny ImageNet10 config for fast smoke tests/debugging and improves dataset download/scan behavior for multi-root splits ⚡
