### PR TITLE
Force `simplify=True` for OBB export with NMS

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -703,6 +703,7 @@ class Exporter:
                 dynamic["output0"].pop(2)
         if self.args.nms and self.model.task == "obb":
             self.args.opset = opset  # for NMSModel
+            self.args.simplify = True  # fix OBB runtime error related to topk
 
         with arange_patch(self.args):
             torch2onnx(


### PR DESCRIPTION
Fix error with `onnxruntime==1.24.1`

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enables ONNX graph simplification by default for OBB exports with NMS to prevent a TopK-related runtime error 🛠️✅

### 📊 Key Changes
- 🔧 In `ultralytics/engine/exporter.py`, when exporting **ONNX** with `nms=True` and the task is **OBB** (oriented bounding boxes), the exporter now forces `self.args.simplify = True`.
- 🧩 Comment added to clarify the intent: this targets an **OBB runtime error related to `topk`** during ONNX execution.

### 🎯 Purpose & Impact
- ✅ **More reliable ONNX exports for OBB models** (especially when NMS is embedded), reducing the chance of runtime failures in ONNX runtimes.
- 🚀 **Improved out-of-the-box experience**: users exporting OBB models with NMS no longer need to manually enable simplification to avoid this issue.
- ⚠️ Potential tradeoff: ONNX simplification can slightly change the exported graph structure (typically beneficial), but may add a small extra step/time during export.