### PR TITLE
`ultralytics 8.4.13` Retry smaller batch on training CUDA OOM

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.12"
+__version__ = "8.4.13"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -467,9 +467,9 @@ class BaseTrainer:
                     )
                     self.accumulate = max(round(self.args.nbs / self.batch_size), 1)
                     weight_decay = self.args.weight_decay * self.batch_size * self.accumulate / self.args.nbs
-                    iterations = math.ceil(
-                        len(self.train_loader.dataset) / max(self.batch_size, self.args.nbs)
-                    ) * self.epochs
+                    iterations = (
+                        math.ceil(len(self.train_loader.dataset) / max(self.batch_size, self.args.nbs)) * self.epochs
+                    )
                     self.optimizer = self.build_optimizer(
                         model=self.model,
                         name=self.args.optimizer,

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -450,7 +450,7 @@ class BaseTrainer:
                     old_batch = self.batch_size
                     self.args.batch = self.batch_size = max(self.batch_size // 2, 1)
                     LOGGER.warning(
-                        f"WARNING ⚠️ CUDA out of memory with batch={old_batch}. "
+                        f"CUDA out of memory with batch={old_batch}. "
                         f"Reducing to batch={self.batch_size} and retrying ({self._oom_retries}/3)."
                     )
                     self._clear_memory()

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -445,8 +445,8 @@ class BaseTrainer:
                     # Backward
                     self.scaler.scale(self.loss).backward()
                 except torch.cuda.OutOfMemoryError:
-                    if epoch > self.start_epoch or self._oom_retries >= 3:
-                        raise  # only auto-reduce during the first epoch, max 3 retries
+                    if epoch > self.start_epoch or self._oom_retries >= 3 or RANK != -1:
+                        raise  # only auto-reduce during first epoch on single GPU, max 3 retries
                     self._oom_retries += 1
                     old_batch = self.batch_size
                     self.args.batch = self.batch_size = max(self.batch_size // 2, 1)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -437,9 +437,7 @@ class BaseTrainer:
                         if RANK != -1:
                             self.loss *= self.world_size
                         self.tloss = (
-                            self.loss_items
-                            if self.tloss is None
-                            else (self.tloss * i + self.loss_items) / (i + 1)
+                            self.loss_items if self.tloss is None else (self.tloss * i + self.loss_items) / (i + 1)
                         )
 
                     # Backward
@@ -457,11 +455,7 @@ class BaseTrainer:
                     self._clear_memory()
                     self._setup_train()  # rebuild dataloaders, optimizer, scheduler with new batch size
                     nb = len(self.train_loader)
-                    nw = (
-                        max(round(self.args.warmup_epochs * nb), 100)
-                        if self.args.warmup_epochs > 0
-                        else -1
-                    )
+                    nw = max(round(self.args.warmup_epochs * nb), 100) if self.args.warmup_epochs > 0 else -1
                     last_opt_step = -1
                     self.optimizer.zero_grad()
                     break  # restart epoch loop with reduced batch size

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -189,7 +189,7 @@ def _upload_model(model_path, project, name, progress=False, retry=1):
         LOGGER.warning(f"{PREFIX}Model file not found: {model_path}")
         return None
 
-    # Get signed upload URL from Platform
+    # Get signed upload URL from Platform (server sanitizes filename for storage safety)
     @Retry(times=3, delay=2)
     def get_signed_url():
         r = requests.post(


### PR DESCRIPTION
@ultralytics/yolo retries CUDA OOM up to 3 times, dividing batch size in half each time:
<img width="1292" height="720" alt="Screenshot 2026-02-08 at 22 50 37" src="https://github.com/user-attachments/assets/39cbccab-d38d-4b21-a3ce-f44a288ce9a7" />

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves training robustness by auto-reducing batch size on first-epoch CUDA OOM and refactors trainer setup into a reusable pipeline 🧠🔥

### 📊 Key Changes
- ✅ Bumped Ultralytics package version from `8.4.12` to `8.4.13`.
- 🧩 Refactored trainer setup by introducing `_build_train_pipeline()` to rebuild:
  - training/validation dataloaders
  - gradient accumulation + scaled weight decay
  - optimizer and scheduler
- 🛡️ Added automatic CUDA Out-Of-Memory recovery during training:
  - catches `torch.cuda.OutOfMemoryError` during forward/backward
  - on **single-GPU only** and **only in the first epoch**, it halves `batch` (up to 3 retries), clears memory, rebuilds the pipeline, and restarts the epoch
- ☁️ Clarified Ultralytics Platform upload behavior with a comment noting the server sanitizes filenames for safe storage.

### 🎯 Purpose & Impact
- 🚀 **More “it just works” training**: users hitting unexpected GPU memory limits (common with large images or dense-label datasets) may no longer need to manually restart with a smaller batch size.
- 🔁 **Faster recovery with less wasted time**: training can automatically retry instead of crashing immediately on the first epoch OOM.
- 🧱 **Cleaner internal architecture**: centralizing dataloader/optimizer/scheduler creation makes it easier to safely rebuild training state after changes (like batch size reduction), improving maintainability.
- ⚠️ **Behavioral note**: auto-reduce triggers only on **single GPU**, **first epoch**, and **max 3 times**—DDP/multi-GPU OOMs will still raise immediately to avoid inconsistent distributed state.