### PR TITLE
Improved handling of object segmentation for better accuracy when parts of a segment fall outside image boundaries.

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -89,7 +89,8 @@ def segment2box(segment, width: int = 640, height: int = 640):
     if np.array([x.min() < 0, y.min() < 0, x.max() > width, y.max() > height]).sum() >= 3:
         x = x.clip(0, width)
         y = y.clip(0, height)
-    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
+    # inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
+    inside = (x > 0) & (y > 0) & (x < width) & (y < height)
     x = x[inside]
     y = y[inside]
     return (

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -90,7 +90,7 @@ def segment2box(segment, width: int = 640, height: int = 640):
         x = x.clip(0, width)
         y = y.clip(0, height)
     # inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
-    inside = (x > 0) & (y > 0) & (x < width) & (y < height)
+    inside = (x > 0) & (y > 0) & (x < width) & (y < height) 
     x = x[inside]
     y = y[inside]
     return (

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -90,7 +90,7 @@ def segment2box(segment, width: int = 640, height: int = 640):
         x = x.clip(0, width)
         y = y.clip(0, height)
     # inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
-    inside = (x > 0) & (y > 0) & (x < width) & (y < height) 
+    inside = (x > 0) & (y > 0) & (x < width) & (y < height)
     x = x[inside]
     y = y[inside]
     return (


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
mproved handling of object segmentation for better accuracy when parts of a segment fall outside image boundaries.
After RandomPerspective, the segment points are set to the 0 axis, but there are actually no pixels to be detected there. I think this will affect the regression of bboxloss and the learning of segments.
original image
<img width="647" height="673" alt="2" src="https://github.com/user-attachments/assets/736ca393-5c11-4fef-8201-0e93b5db9deb" />

RandomPerspective

<img width="642" height="673" alt="1" src="https://github.com/user-attachments/assets/06e8873b-3cc0-418e-8f39-6058b6130efb" />

Improved results

<img width="641" height="670" alt="3" src="https://github.com/user-attachments/assets/78b9d630-c30b-4c75-81f4-62fe235a497b" />



The solution only needs to modify the inside=(x>=0)&(y>=0)&(x<=width)&(y<=height) in the segment2box function of ops. py to inside=(x>0)&(y>0)&(x<width)&(y<height)

Environment
Ultralytics 8.3.253 🚀 Python-3.8.10 torch-2.3.0+cu118 CUDA:0 (NVIDIA RTXA6000, 24576MiB)
Setup complete ✅ (16 CPUs, 64.0 GB RAM, 449.6/449.3 GB disk)

OS Windows-10-10.0.1945-SP0
Environment Windows
Python 3.8.10
Install pip
RAM 64.00 GB
Disk 449.6/449.3 GB
CPU Intel Xeon Silver 4216 2.10GHz
CPU count 16
GPU NVIDIA RTXA6000, 24576MiB
GPU 1
CUDA 11.8

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Tighten `segment2box()` boundary filtering to improve segmentation box accuracy when polygon points touch or exceed image edges 🧩📦

### 📊 Key Changes
- Adjusted the `inside` mask in `ultralytics/utils/ops.py` from inclusive bounds (`>= 0`, `<= width/height`) to strict bounds (`> 0`, `< width/height`)
- Left the prior inclusive logic commented for reference

### 🎯 Purpose & Impact
- Reduces the chance of edge-clamped or exactly-on-boundary polygon points skewing the derived bounding box near image borders 🎯
- Can improve stability/accuracy for segments that partially fall outside the image, especially for tight crops or objects touching the frame 🖼️
- Potential behavioral change: points exactly at `0` or exactly at `width/height` are now excluded, which may slightly shrink boxes for border-touching segments