### PR TITLE
Add footnote clarifying param/FLOP counts after `model.fuse()`

### DIFF
--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -105,7 +105,7 @@ This unified framework ensures YOLO26 is applicable across real-time detection, 
 
         --8<-- "docs/macros/yolo-obb-perf.md"
 
-*Params and FLOPs values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts.*
+_Params and FLOPs values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts._
 
 ---
 

--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -105,6 +105,8 @@ This unified framework ensures YOLO26 is applicable across real-time detection, 
 
         --8<-- "docs/macros/yolo-obb-perf.md"
 
+*Params and FLOPs values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts.*
+
 ---
 
 ## Usage Examples

--- a/docs/en/models/yolov10.md
+++ b/docs/en/models/yolov10.md
@@ -149,7 +149,7 @@ Compared to other state-of-the-art detectors:
         [5]: https://github.com/ultralytics/assets/releases/download/v8.4.0/yolov10l.pt
         [6]: https://github.com/ultralytics/assets/releases/download/v8.4.0/yolov10x.pt
 
-*Params and FLOPs values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts.*
+_Params and FLOPs values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts._
 
 ## Usage Examples
 

--- a/docs/en/models/yolov10.md
+++ b/docs/en/models/yolov10.md
@@ -149,6 +149,8 @@ Compared to other state-of-the-art detectors:
         [5]: https://github.com/ultralytics/assets/releases/download/v8.4.0/yolov10l.pt
         [6]: https://github.com/ultralytics/assets/releases/download/v8.4.0/yolov10x.pt
 
+*Params and FLOPs values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts.*
+
 ## Usage Examples
 
 For predicting new images with YOLOv10:

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -38,6 +38,7 @@ YOLO26 pretrained Classify models are shown here. Detect, Segment, and Pose mode
 
 - **acc** values are model accuracies on the [ImageNet](https://www.image-net.org/) dataset validation set. <br>Reproduce by `yolo val classify data=path/to/ImageNet device=0`
 - **Speed** averaged over ImageNet val images using an [Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instance. <br>Reproduce by `yolo val classify data=path/to/ImageNet batch=1 device=0|cpu`
+- **Params** and **FLOPs** values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers. Pretrained checkpoints retain the full training architecture and may show higher counts.
 
 ## Train
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -37,6 +37,7 @@ YOLO26 pretrained Detect models are shown here. Detect, Segment, and Pose models
 
 - **mAP<sup>val</sup>** values are for single-model single-scale on [COCO val2017](https://cocodataset.org/) dataset. <br>Reproduce by `yolo val detect data=coco.yaml device=0`
 - **Speed** averaged over COCO val images using an [Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instance. <br>Reproduce by `yolo val detect data=coco.yaml batch=1 device=0|cpu`
+- **Params** and **FLOPs** values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and, for end2end models, removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts.
 
 ## Train
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -46,6 +46,7 @@ YOLO26 pretrained OBB models are shown here, which are pretrained on the [DOTAv1
 
 - **mAP<sup>test</sup>** values are for single-model multiscale on [DOTAv1](https://captain-whu.github.io/DOTA/index.html) dataset. <br>Reproduce by `yolo val obb data=DOTAv1.yaml device=0 split=test` and submit merged results to [DOTA evaluation](https://captain-whu.github.io/DOTA/evaluation.html).
 - **Speed** averaged over DOTAv1 val images using an [Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instance. <br>Reproduce by `yolo val obb data=DOTAv1.yaml batch=1 device=0|cpu`
+- **Params** and **FLOPs** values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and, for end2end models, removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts.
 
 ## Train
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -58,6 +58,7 @@ Ultralytics YOLO26 pretrained Pose models are shown here. Detect, Segment and Po
 
 - **mAP<sup>val</sup>** values are for single-model single-scale on [COCO Keypoints val2017](https://cocodataset.org/) dataset. <br>Reproduce by `yolo val pose data=coco-pose.yaml device=0`
 - **Speed** averaged over COCO val images using an [Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instance. <br>Reproduce by `yolo val pose data=coco-pose.yaml batch=1 device=0|cpu`
+- **Params** and **FLOPs** values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and, for end2end models, removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts.
 
 ## Train
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -38,6 +38,7 @@ YOLO26 pretrained Segment models are shown here. Detect, Segment and Pose models
 
 - **mAP<sup>val</sup>** values are for single-model single-scale on [COCO val2017](https://cocodataset.org/) dataset. <br>Reproduce by `yolo val segment data=coco.yaml device=0`
 - **Speed** averaged over COCO val images using an [Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instance. <br>Reproduce by `yolo val segment data=coco.yaml batch=1 device=0|cpu`
+- **Params** and **FLOPs** values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers and, for end2end models, removes the auxiliary one-to-many detection head. Pretrained checkpoints retain the full training architecture and may show higher counts.
 
 ## Train
 


### PR DESCRIPTION
## Description

Adds a footnote to docs explaining that documented Params/FLOPs are measured on the fused inference model after `model.fuse()`, which merges Conv+BatchNorm layers and, for end2end models, removes the auxiliary one-to-many detection head. Pretrained `.pt` checkpoints retain the full training architecture, so `Model.info()` will report higher counts.

Fixes #23593

## Testing

- `mkdocs build` passes with no new errors
- Verified parameter count differences experimentally (YOLO26n: 6.35%, YOLOv10n: 17.16%, non-end2end models <0.5%)
- Footnote renders correctly on local `mkdocs serve`

## Checklist

- [x] I have read the [Contributing Guide](https://docs.ultralytics.com/help/contributing/) and [CLA](https://docs.ultralytics.com/help/CLA/)
- [x] I have commented `I have read the CLA Document and I sign the CLA` to sign the CLA (required before merge)
- [x] CI passes
- [x] Tests not applicable

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies that reported Params/FLOPs are measured *after* `model.fuse()` in YOLO26 and task docs to prevent confusion when users compare pretrained checkpoints. 📝

### 📊 Key Changes
- Adds a footnote to `docs/en/models/yolo26.md` explaining Params/FLOPs are for the fused model after `model.fuse()` (Conv+BN fused and auxiliary one-to-many head removed).
- Adds the same clarification to `docs/en/models/yolov10.md` for consistency.
- Updates task pages (`detect.md`, `segment.md`, `pose.md`, `obb.md`) to explicitly define Params/FLOPs as fused-model values, noting pretrained checkpoints may show higher counts.

### 🎯 Purpose & Impact
- Reduces user confusion when Params/FLOPs differ between tables and locally inspected pretrained checkpoints.
- Sets consistent expectations across model and task documentation for end2end architectures and fusion behavior.
- Improves reproducibility and interpretability of published model stats. ✅