### PR TITLE
Fix `segment2box` boundary condition for edge-snapped segment points

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -89,7 +89,7 @@ def segment2box(segment, width: int = 640, height: int = 640):
     if np.array([x.min() < 0, y.min() < 0, x.max() > width, y.max() > height]).sum() >= 3:
         x = x.clip(0, width)
         y = y.clip(0, height)
-    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
+    inside = (x > 0) & (y > 0) & (x < width) & (y < height)
     x = x[inside]
     y = y[inside]
     return (


### PR DESCRIPTION
## Summary

After `RandomPerspective` augmentation, segment coordinates that fall outside the image are clipped to the boundary (0 or width/height). The current `segment2box()` boundary check uses inclusive comparisons (`>=`, `<=`), which treats these clipped edge coordinates as valid interior points. This causes the resulting bounding box to incorrectly snap to the image border, degrading both bbox-loss regression and segmentation mask quality.

This PR switches the boundary check from inclusive to strict inequalities (`>`, `<`), so that points sitting exactly on the image edge are correctly excluded from the inside-image set.

### Before (inclusive — edge points kept)
```python
inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
```

### After (strict — edge points excluded)
```python
inside = (x > 0) & (y > 0) & (x < width) & (y < height)
```

## Why this matters

When a segment partially extends outside the image, `RandomPerspective` clips its points to the 0/width/height boundary. Keeping those clipped points as "inside" artificially extends the bounding box to the image edge, even though no real object pixels exist at that coordinate. Excluding them produces tighter, more accurate boxes that better reflect the actual visible portion of the object.

Fixes https://github.com/ultralytics/ultralytics/issues/23596

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fix `segment2box()` to treat boundary-snapped segment points as outside the image bounds 🧩

### 📊 Key Changes
- Updated the `inside` mask in `ultralytics/utils/ops.py::segment2box()` from inclusive bounds (`>= 0`, `<= width/height`) to strict bounds (`> 0`, `< width/height`).

### 🎯 Purpose & Impact
- Prevents edge-snapped segment points (exactly on `0` or `width/height`) from being included when filtering points before box computation 🎯
- Reduces boundary-condition artifacts that can lead to inaccurate boxes for segmentation masks touching image edges 📦
- Improves robustness of segment-to-box conversion for datasets with clipped/edge-aligned polygons ✅