### PR TITLE
Fix TypeError when fitness is None during hyperparameter tuning

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -253,7 +253,7 @@ class Tuner:
             with open(self.tune_csv, "w", encoding="utf-8") as f:
                 f.write(headers)
                 for result in all_results:
-                    fitness = result["fitness"]
+                    fitness = result["fitness"] or 0.0
                     hyp_values = [result["hyperparameters"].get(k, self.args.get(k)) for k in self.space.keys()]
                     log_row = [round(fitness, 5), *hyp_values]
                     f.write(",".join(map(str, log_row)) + "\n")
@@ -406,7 +406,7 @@ class Tuner:
                 LOGGER.error(f"training failure for hyperparameter tuning iteration {i + 1}\n{e}")
 
             # Save results - MongoDB takes precedence
-            fitness = metrics.get("fitness", 0.0)
+            fitness = metrics.get("fitness") or 0.0
             if self.mongodb:
                 self._save_to_mongodb(fitness, mutated_hyp, metrics, i + 1)
                 self._sync_mongodb_to_csv()


### PR DESCRIPTION
## Summary

Fixes #23461

During hyperparameter tuning, `metrics.get("fitness", 0.0)` can still return `None` when the key exists but is explicitly set to `None`. The `.get()` default only applies for missing keys. This causes `round(fitness, 5)` to throw:

```
TypeError: type NoneType doesn't define __round__ method
```

## Changes

Replaced `.get("fitness", 0.0)` with `.get("fitness") or 0.0` so that both missing and `None` values fall back to `0.0`. Applied the same guard in `_sync_mongodb_to_csv()` where `result["fitness"]` is used directly with `round()`.

## Test plan

- Verified that `None or 0.0` evaluates to `0.0`
- Verified that `0.0 or 0.0` evaluates to `0.0` (no change in behavior for valid zero fitness)
- Verified that a normal float like `0.85` passes through unchanged (`0.85 or 0.0` evaluates to `0.85`)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevents `TypeError` during hyperparameter tuning by safely defaulting missing `fitness` values to `0.0` 🛠️

### 📊 Key Changes
- Normalizes MongoDB-synced results by converting falsy `result["fitness"]` values to `0.0`
- Guards tuner run result saving by converting falsy `metrics.get("fitness")` values to `0.0`

### 🎯 Purpose & Impact
- Avoids crashes when `fitness` is `None` during tuning workflows ✅
- Improves robustness of CSV logging and MongoDB→CSV sync, keeping tuning runs and exports stable 📈