### PR TITLE
Clamp negative rle_loss to zero in Pose26 training

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -941,6 +941,7 @@ class PoseLoss26(v8PoseLoss):
 
             if self.rle_loss is not None and (pred_kpt.shape[-1] == 4 or pred_kpt.shape[-1] == 5):
                 rle_loss = self.calculate_rle_loss(pred_kpt, gt_kpt, kpt_mask)
+                rle_loss = rle_loss.clamp(min=0)
             if pred_kpt.shape[-1] == 3 or pred_kpt.shape[-1] == 5:
                 kpts_obj_loss = self.bce_pose(pred_kpt[..., 2], kpt_mask.float())  # keypoint obj loss
 


### PR DESCRIPTION
## Summary

Fixes #23577

The `rle_loss` in the YOLO26 Pose head uses a log-likelihood formulation (`log_sigma - log_phi + residual terms`) that can produce increasingly negative values during training. As reported in the issue, this causes the negative loss to dominate the optimization objective, leading to progressive mAP degradation across epochs (e.g., Pose mAP50-95 dropping from 0.648 to 0.445 over just a few epochs).

This PR adds a `rle_loss.clamp(min=0)` call immediately after the RLE loss computation in `calculate_keypoints_loss`. This prevents the negative loss from pulling the total loss downward and destabilizing training, while preserving the normal gradient signal when the loss is positive.

The issue reporter confirmed that clamping negative `rle_loss` to zero stabilized training and produced consistently improving metrics across epochs, with Pose mAP50-95 reaching 0.957 by epoch 14.

## Changes

- **`ultralytics/utils/loss.py`**: Added `rle_loss = rle_loss.clamp(min=0)` after `calculate_rle_loss()` in the `calculate_keypoints_loss` method of `v8PoseLoss`.

## Test plan

- [x] Verified the change is a single-line addition that only affects the RLE loss path (gated behind `self.rle_loss is not None`)
- [ ] Train a YOLO26 Pose model and confirm `rle_loss` no longer goes negative
- [ ] Verify Pose mAP metrics improve consistently across epochs without degradation

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fix Pose26 training stability by clamping negative `rle_loss` values to zero ✅

### 📊 Key Changes
-Added `rle_loss = rle_loss.clamp(min=0)` after RLE loss computation in `ultralytics/utils/loss.py`.
-Applies only when RLE loss is enabled and keypoint prediction format includes RLE params (last dim 4 or 5).

### 🎯 Purpose & Impact
-Prevents unexpected negative RLE loss values from propagating into the total pose loss, improving training stability 🛡️
-Reduces risk of destabilized gradients/logging confusion during Pose26 keypoint training runs 📉
-Minimal, low-risk change localized to pose loss computation with no impact on non-pose tasks 🎯