### PR TITLE
`ultralytics 8.4.14` Platform training cancel feature

### DIFF
--- a/docs/en/reference/utils/callbacks/platform.md
+++ b/docs/en/reference/utils/callbacks/platform.md
@@ -51,6 +51,10 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.callbacks.platform.on_pretrain_routine_end
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.callbacks.platform.on_fit_epoch_end
 
 <br><br><hr><br>

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.13"
+__version__ = "8.4.14"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -493,6 +493,8 @@ class BaseTrainer:
                         self.plot_training_samples(batch, ni)
 
                 self.run_callbacks("on_train_batch_end")
+                if self.stop:
+                    break  # allow external stop (e.g. platform cancellation) between batches
             else:
                 # for/else: this block runs only when the for loop completes without break (no OOM retry)
                 self._oom_retries = 0  # reset OOM counter after successful first epoch

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -328,7 +328,7 @@ def on_pretrain_routine_start(trainer):
     if response and response.get("modelId"):
         trainer._platform_model_id = response["modelId"]
         # Check for immediate cancellation (cancelled before training started)
-        if response.get("cancelled"):
+        if response and response.get("cancelled"):
             LOGGER.info(f"{PREFIX}Training cancelled from Platform before starting")
             trainer.stop = True
             trainer._platform_cancelled = True

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -328,12 +328,18 @@ def on_pretrain_routine_start(trainer):
     if response and response.get("modelId"):
         trainer._platform_model_id = response["modelId"]
         # Check for immediate cancellation (cancelled before training started)
+        # Note: trainer.stop is set in on_pretrain_routine_end (after _setup_train resets it)
         if response.get("cancelled"):
-            LOGGER.info(f"{PREFIX}Training cancelled from Platform before starting")
-            trainer.stop = True
             trainer._platform_cancelled = True
     else:
         LOGGER.warning(f"{PREFIX}Failed to register training session - metrics may not sync to Platform")
+
+
+def on_pretrain_routine_end(trainer):
+    """Apply pre-start cancellation after _setup_train resets trainer.stop."""
+    if getattr(trainer, "_platform_cancelled", False):
+        LOGGER.info(f"{PREFIX}Training cancelled from Platform before starting ✅")
+        trainer.stop = True
 
 
 def on_fit_epoch_end(trainer):
@@ -379,20 +385,15 @@ def on_fit_epoch_end(trainer):
     if model_info:
         payload["modelInfo"] = model_info
 
-    response = _send(
-        "epoch_end",
-        payload,
-        project,
-        name,
-        getattr(trainer, "_platform_model_id", None),
-        retry=1,
-    )
+    def _send_and_check_cancel():
+        """Send epoch_end and check response for cancellation (runs in background thread)."""
+        response = _send("epoch_end", payload, project, name, getattr(trainer, "_platform_model_id", None), retry=1)
+        if response and response.get("cancelled"):
+            LOGGER.info(f"{PREFIX}Training cancelled from Platform ✅")
+            trainer.stop = True
+            trainer._platform_cancelled = True
 
-    # Check for cancellation signal from Platform
-    if response and response.get("cancelled"):
-        LOGGER.info(f"{PREFIX}Training cancelled from Platform ✅")
-        trainer.stop = True
-        trainer._platform_cancelled = True
+    _executor.submit(_send_and_check_cancel)
 
 
 def on_model_save(trainer):
@@ -476,6 +477,7 @@ def on_train_end(trainer):
 callbacks = (
     {
         "on_pretrain_routine_start": on_pretrain_routine_start,
+        "on_pretrain_routine_end": on_pretrain_routine_end,
         "on_fit_epoch_end": on_fit_epoch_end,
         "on_model_save": on_model_save,
         "on_train_end": on_train_end,

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -328,7 +328,7 @@ def on_pretrain_routine_start(trainer):
     if response and response.get("modelId"):
         trainer._platform_model_id = response["modelId"]
         # Check for immediate cancellation (cancelled before training started)
-        if response and response.get("cancelled"):
+        if response.get("cancelled"):
             LOGGER.info(f"{PREFIX}Training cancelled from Platform before starting")
             trainer.stop = True
             trainer._platform_cancelled = True


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Ultralytics Platform training cancellation handling so YOLO training can stop cleanly (even before it starts) and still sync partial results ✅🛑

### 📊 Key Changes
- Added a new Platform callback hook: `on_pretrain_routine_end` (and documented it) to apply cancellation **after** trainer setup resets `trainer.stop` 🧩
- Trainer loop now checks `self.stop` **between batches** and breaks early, enabling faster response to external stop requests (e.g., Platform cancel) ⚡
- Platform `epoch_end` sync now sends metrics and **checks the server response for `cancelled`** in a background task; if cancelled, it sets `trainer.stop=True` and flags `_platform_cancelled` 📡
- Platform session registration now records “cancelled before training started” state (`_platform_cancelled`) if returned by the API 🧾
- `on_train_end` logs that it’s uploading partial results when training was cancelled, improving visibility of what happens after a stop 📤
- Bumped package version from `8.4.13` to `8.4.14` 🔖

### 🎯 Purpose & Impact
- Faster, cleaner cancellation from the [Ultralytics Platform](https://platform.ultralytics.com) 🛑➡️✅
- Prevents “missed” cancels that happen right before training begins (when setup previously reset stop flags) 🧯
- Reduces wasted compute by allowing stops **mid-epoch** (between batches), not just at epoch boundaries 💸
- Keeps users informed and preserves work by syncing/uploading **partial results** for cancelled runs 📊📤
- Improves reliability of Platform↔training coordination without changing typical local training workflows 🤝