### PR TITLE
refactor: gather operations to use expand instead of repeat

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -219,7 +219,7 @@ class Detect(nn.Module):
         """
         boxes, scores = preds.split([4, self.nc], dim=-1)
         scores, conf, idx = self.get_topk_index(scores, self.max_det)
-        boxes = boxes.gather(dim=1, index=idx.expand(-1, -1, 4))
+        boxes = torch.cat([boxes.narrow(-1, i, 1).gather(1, idx) for i in range(4)], dim=-1)
         return torch.cat([boxes, scores, conf], dim=-1)
 
     def get_topk_index(self, scores: torch.Tensor, max_det: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -347,8 +347,8 @@ class Segment(Detect):
         """
         boxes, scores, mask_coefficient = preds.split([4, self.nc, self.nm], dim=-1)
         scores, conf, idx = self.get_topk_index(scores, self.max_det)
-        boxes = boxes.gather(dim=1, index=idx.expand(-1, -1, 4))
-        mask_coefficient = mask_coefficient.gather(dim=1, index=idx.expand(-1, -1, self.nm))
+        boxes = torch.cat([boxes.narrow(-1, i, 1).gather(1, idx) for i in range(4)], dim=-1)
+        mask_coefficient = torch.cat([mask_coefficient.narrow(-1, i, 1).gather(1, idx) for i in range(self.nm)], dim=-1)
         return torch.cat([boxes, scores, conf, mask_coefficient], dim=-1)
 
     def fuse(self) -> None:
@@ -502,8 +502,8 @@ class OBB(Detect):
         """
         boxes, scores, angle = preds.split([4, self.nc, self.ne], dim=-1)
         scores, conf, idx = self.get_topk_index(scores, self.max_det)
-        boxes = boxes.gather(dim=1, index=idx.expand(-1, -1, 4))
-        angle = angle.gather(dim=1, index=idx.expand(-1, -1, self.ne))
+        boxes = torch.cat([boxes.narrow(-1, i, 1).gather(1, idx) for i in range(4)], dim=-1)
+        angle = torch.cat([angle.narrow(-1, i, 1).gather(1, idx) for i in range(self.ne)], dim=-1)
         return torch.cat([boxes, scores, conf, angle], dim=-1)
 
     def fuse(self) -> None:
@@ -623,8 +623,8 @@ class Pose(Detect):
         """
         boxes, scores, kpts = preds.split([4, self.nc, self.nk], dim=-1)
         scores, conf, idx = self.get_topk_index(scores, self.max_det)
-        boxes = boxes.gather(dim=1, index=idx.expand(-1, -1, 4))
-        kpts = kpts.gather(dim=1, index=idx.expand(-1, -1, self.nk))
+        boxes = torch.cat([boxes.narrow(-1, i, 1).gather(1, idx) for i in range(4)], dim=-1)
+        kpts = torch.cat([kpts.narrow(-1, i, 1).gather(1, idx) for i in range(self.nk)], dim=-1)
         return torch.cat([boxes, scores, conf, kpts], dim=-1)
 
     def fuse(self) -> None:

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -219,7 +219,7 @@ class Detect(nn.Module):
         """
         boxes, scores = preds.split([4, self.nc], dim=-1)
         scores, conf, idx = self.get_topk_index(scores, self.max_det)
-        boxes = boxes.gather(dim=1, index=idx.repeat(1, 1, 4))
+        boxes = boxes.gather(dim=1, index=idx.expand(-1, -1, 4))
         return torch.cat([boxes, scores, conf], dim=-1)
 
     def get_topk_index(self, scores: torch.Tensor, max_det: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -347,8 +347,8 @@ class Segment(Detect):
         """
         boxes, scores, mask_coefficient = preds.split([4, self.nc, self.nm], dim=-1)
         scores, conf, idx = self.get_topk_index(scores, self.max_det)
-        boxes = boxes.gather(dim=1, index=idx.repeat(1, 1, 4))
-        mask_coefficient = mask_coefficient.gather(dim=1, index=idx.repeat(1, 1, self.nm))
+        boxes = boxes.gather(dim=1, index=idx.expand(-1, -1, 4))
+        mask_coefficient = mask_coefficient.gather(dim=1, index=idx.expand(-1, -1, self.nm))
         return torch.cat([boxes, scores, conf, mask_coefficient], dim=-1)
 
     def fuse(self) -> None:
@@ -502,8 +502,8 @@ class OBB(Detect):
         """
         boxes, scores, angle = preds.split([4, self.nc, self.ne], dim=-1)
         scores, conf, idx = self.get_topk_index(scores, self.max_det)
-        boxes = boxes.gather(dim=1, index=idx.repeat(1, 1, 4))
-        angle = angle.gather(dim=1, index=idx.repeat(1, 1, self.ne))
+        boxes = boxes.gather(dim=1, index=idx.expand(-1, -1, 4))
+        angle = angle.gather(dim=1, index=idx.expand(-1, -1, self.ne))
         return torch.cat([boxes, scores, conf, angle], dim=-1)
 
     def fuse(self) -> None:
@@ -623,8 +623,8 @@ class Pose(Detect):
         """
         boxes, scores, kpts = preds.split([4, self.nc, self.nk], dim=-1)
         scores, conf, idx = self.get_topk_index(scores, self.max_det)
-        boxes = boxes.gather(dim=1, index=idx.repeat(1, 1, 4))
-        kpts = kpts.gather(dim=1, index=idx.repeat(1, 1, self.nk))
+        boxes = boxes.gather(dim=1, index=idx.expand(-1, -1, 4))
+        kpts = kpts.gather(dim=1, index=idx.expand(-1, -1, self.nk))
         return torch.cat([boxes, scores, conf, kpts], dim=-1)
 
     def fuse(self) -> None:


### PR DESCRIPTION

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refactors YOLO head postprocessing to gather top-k detections more safely/compatibly across tasks 🛠️⚡

### 📊 Key Changes
- Replaced `idx.repeat(..., 4)` + `tensor.gather(...)` with a per-channel gather using `narrow(...).gather(...)` and `torch.cat(...)` for bounding boxes 📦
- Applied the same pattern to extra per-detection outputs:
  - Segmentation `mask_coefficient` 🧩
  - Oriented bounding box `angle` 🧭
  - Pose/keypoints `kpts` 🦴
- Updated all affected `postprocess()` implementations in `ultralytics/nn/modules/head.py` to use consistent indexing behavior across heads 🔁

### 🎯 Purpose & Impact
- Improves robustness of top-k selection/gathering, reducing the chance of shape/indexing issues across different heads and export/backends ✅📤
- Makes postprocessing logic more consistent across detection, segmentation, OBB, and pose models, which can simplify maintenance and debugging 🧰
- Potentially slightly changes performance characteristics (more ops via per-channel concatenation), but should keep outputs equivalent while being safer and more portable 🚀