### PR TITLE
Skip callbacks on training cancellation

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -344,7 +344,7 @@ def on_pretrain_routine_end(trainer):
 
 def on_fit_epoch_end(trainer):
     """Log training and system metrics at epoch end."""
-    if RANK not in {-1, 0} or not trainer.args.project:
+    if RANK not in {-1, 0} or not trainer.args.project or getattr(trainer, "_platform_cancelled", False):
         return
 
     project, name = _get_project_name(trainer)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Prevents Ultralytics Platform epoch-end logging callbacks from running when training is cancelled 🛑

### 📊 Key Changes
-Added a guard in `on_fit_epoch_end()` to early-return when `trainer._platform_cancelled` is set
-Keeps existing rank and project checks intact while extending cancellation handling

### 🎯 Purpose & Impact
-Reduces noisy/undesired callback execution after a user-initiated cancellation
-Helps avoid redundant metrics/log uploads and potential side effects during shutdown
-Improves overall training cancellation behavior consistency for Platform-integrated runs ⚙️