### PR TITLE
Add YOLO26 vs YOLO11 performance charts for Raspberry Pi 5

### DIFF
--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -164,7 +164,7 @@ YOLO26 is specifically designed to run on hardware-constrained devices such as t
         | YOLO11n 	| 39.5        	| 147.20                 	|
         | YOLO11s 	| 47.0        	| 366.83                 	|
         | YOLO11m 	| 51.5        	| 997.46                 	|
-        | YYOLO11l 	| 53.4        	| 1274.95                	|
+        | YOLO11l 	| 53.4        	| 1274.95                	|
         | YOLO11x 	| 54.7        	| 2646.76                	|
 
     Benchmarked with Ultralytics 8.4.14.

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -137,7 +137,7 @@ The YOLO26n model in PyTorch format is converted to NCNN to run inference with t
 
 ## YOLO26 Performance Improvements over YOLO11
 
-YOLO26 is specifically designed to run on hardware-constrained devices such as the Raspberry Pi 5. Compared to YOLO11, YOLO26n achieves a ~15% increase in FPS (6.79 → 7.79) while also delivering better mAP with ONNX-exported models on the Raspberry Pi 5. The table and chart below showcase this comparison.
+YOLO26 is specifically designed to run on hardware-constrained devices such as the Raspberry Pi 5. Compared to YOLO11, YOLO26n achieves a ~15% increase in FPS (6.79 → 7.79) while also delivering better mAP at 640 input size with ONNX-exported models on the Raspberry Pi 5. The table and chart below showcase this comparison.
 
 <figure style="text-align: center;">
     <img width="800" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/yolo26-vs-yolo11-rpi5-onnx-benchmarks.avif" alt="YOLO26 benchmarks on RPi 5">
@@ -146,15 +146,28 @@ YOLO26 is specifically designed to run on hardware-constrained devices such as t
 
 !!! tip "Performance"
 
-    | Model   	| mAP50-95(B) 	| Inference time (ms/im) 	| Model   	| mAP50-95(B) 	| Inference time (ms/im) 	|
-    |---------	|-------------	|------------------------	|---------	|-------------	|------------------------	|
-    | YOLO26n 	| 40.1        	| 128.42                 	| YOLO11n 	| 39.5        	| 147.20                 	|
-    | YOLO26s 	| 47.8        	| 352.84                 	| YOLO11s 	| 47.0        	| 366.83                 	|
-    | YOLO26m 	| 52.5        	| 993.78                 	| YOLO11m 	| 51.5        	| 997.46                 	|
-    | YOLO26l 	| 54.4        	| 1259.46                	| YOLO11l 	| 53.4        	| 1274.95                	|
-    | YOLO26x 	| 56.9        	| 2636.26                	| YOLO11x 	| 54.7        	| 2646.76                	|
+    === "YOLO26 (ONNX)"
 
-    Benchmarked with Ultralytics 8.4.14
+        | Model   	| mAP50-95(B) 	| Inference time (ms/im) 	|
+        |---------	|-------------	|------------------------	|
+        | YOLO26n 	| 40.1        	| 128.42                 	|
+        | YOLO26s 	| 47.8        	| 352.84                 	|
+        | YOLO26m 	| 52.5        	| 993.78                 	|
+        | YOLO26l 	| 54.4        	| 1259.46                	|
+        | YOLO26x 	| 56.9        	| 2636.26                	|
+
+
+    === "YOLO11 (ONNX)"
+
+        | Model   	| mAP50-95(B) 	| Inference time (ms/im) 	|
+        |---------	|-------------	|------------------------	|
+        | YOLO11n 	| 39.5        	| 147.20                 	|
+        | YOLO11s 	| 47.0        	| 366.83                 	|
+        | YOLO11m 	| 51.5        	| 997.46                 	|
+        | YYOLO11l 	| 53.4        	| 1274.95                	|
+        | YOLO11x 	| 54.7        	| 2646.76                	|
+
+    Benchmarked with Ultralytics 8.4.14.
 
     !!! note
 

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -169,10 +169,6 @@ YOLO26 is specifically designed to run on hardware-constrained devices such as t
 
     Benchmarked with Ultralytics 8.4.14.
 
-    !!! note
-
-        Inference time does not include pre/ post-processing.
-
 ## Raspberry Pi 5 YOLO26 Benchmarks
 
 YOLO26 benchmarks were run by the Ultralytics team on ten different model formats measuring speed and [accuracy](https://www.ultralytics.com/glossary/accuracy): PyTorch, TorchScript, ONNX, OpenVINO, TF SavedModel, TF GraphDef, TF Lite, MNN, NCNN, ExecuTorch. Benchmarks were run on a Raspberry Pi 5 at FP32 [precision](https://www.ultralytics.com/glossary/precision) with default input image size of 640.

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -137,7 +137,7 @@ The YOLO26n model in PyTorch format is converted to NCNN to run inference with t
 
 ## YOLO26 Performance Improvements over YOLO11
 
-YOLO26 is specifically designed to run on hardware-constrained devices such as the Raspberry Pi 5. Compared to YOLO11, YOLO26n achieves a ~15% increase in FPS (6.79 → 7.79) while also delivering better mAP at 640 input size with ONNX-exported models on the Raspberry Pi 5. The table and chart below showcase this comparison.
+YOLO26 is specifically designed to run on hardware-constrained devices such as the Raspberry Pi 5. Compared to YOLO11n, YOLO26n achieves a ~15% increase in FPS (6.79 → 7.79) while also delivering better mAP at 640 input size with ONNX-exported models on the Raspberry Pi 5. The table and chart below showcase this comparison.
 
 <figure style="text-align: center;">
     <img width="800" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/yolo26-vs-yolo11-rpi5-onnx-benchmarks.avif" alt="YOLO26 benchmarks on RPi 5">

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -137,7 +137,7 @@ The YOLO26n model in PyTorch format is converted to NCNN to run inference with t
 
 ## YOLO26 Performance Improvements over YOLO11
 
-YOLO26 is specifically designed to run on hardware-constrained devices such as the Raspberry Pi 5. Compared to YOLO11n, YOLO26n achieves a ~15% increase in FPS (6.79 → 7.79) while also delivering better mAP at 640 input size with ONNX-exported models on the Raspberry Pi 5. The table and chart below showcase this comparison.
+YOLO26 is specifically designed to run on hardware-constrained devices such as the Raspberry Pi 5. Compared to YOLO11n, YOLO26n achieves a ~15% increase in FPS (6.79 → 7.79) while also delivering higher mAP (40.1 vs 39.5) at 640 input size with ONNX-exported models on the Raspberry Pi 5. The table and chart below showcase this comparison.
 
 <figure style="text-align: center;">
     <img width="800" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/yolo26-vs-yolo11-rpi5-onnx-benchmarks.avif" alt="YOLO26 benchmarks on RPi 5">

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -135,6 +135,31 @@ The YOLO26n model in PyTorch format is converted to NCNN to run inference with t
 
     For more details about supported export options, visit the [Ultralytics documentation page on deployment options](https://docs.ultralytics.com/guides/model-deployment-options/).
 
+## YOLO26 Performance Improvements over YOLO11
+
+YOLO26 is specifically designed to run on hardware-constrained devices such as the Raspberry Pi 5. Compared to YOLO11, YOLO26n achieves a ~15% increase in FPS (6.79 → 7.79) while also delivering better mAP with ONNX-exported models on the Raspberry Pi 5. The table and chart below showcase this comparison.
+
+<figure style="text-align: center;">
+    <img width="800" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/yolo26-vs-yolo11-rpi5-onnx-benchmarks.avif" alt="YOLO26 benchmarks on RPi 5">
+    <figcaption style="font-style: italic; color: gray;">Benchmarked with Ultralytics 8.4.14</figcaption>
+</figure>
+
+!!! tip "Performance"
+
+    | Model   	| mAP50-95(B) 	| Inference time (ms/im) 	| Model   	| mAP50-95(B) 	| Inference time (ms/im) 	|
+    |---------	|-------------	|------------------------	|---------	|-------------	|------------------------	|
+    | YOLO26n 	| 40.1        	| 128.42                 	| YOLO11n 	| 39.5        	| 147.20                 	|
+    | YOLO26s 	| 47.8        	| 352.84                 	| YOLO11s 	| 47.0        	| 366.83                 	|
+    | YOLO26m 	| 52.5        	| 993.78                 	| YOLO11m 	| 51.5        	| 997.46                 	|
+    | YOLO26l 	| 54.4        	| 1259.46                	| YOLO11l 	| 53.4        	| 1274.95                	|
+    | YOLO26x 	| 56.9        	| 2636.26                	| YOLO11x 	| 54.7        	| 2646.76                	|
+
+    Benchmarked with Ultralytics 8.4.14
+
+    !!! note
+
+        Inference time does not include pre/ post-processing.
+
 ## Raspberry Pi 5 YOLO26 Benchmarks
 
 YOLO26 benchmarks were run by the Ultralytics team on ten different model formats measuring speed and [accuracy](https://www.ultralytics.com/glossary/accuracy): PyTorch, TorchScript, ONNX, OpenVINO, TF SavedModel, TF GraphDef, TF Lite, MNN, NCNN, ExecuTorch. Benchmarks were run on a Raspberry Pi 5 at FP32 [precision](https://www.ultralytics.com/glossary/precision) with default input image size of 640.
@@ -190,7 +215,7 @@ The below table represents the benchmark results for two different models (YOLO2
 
         Inference time does not include pre/ post-processing.
 
-## Reproduce Our Results
+### Reproduce Our Results
 
 To reproduce the above Ultralytics benchmarks on all [export formats](../modes/export.md), run this code:
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a new section to the Raspberry Pi guide highlighting YOLO26’s speed/accuracy gains over YOLO11 on Raspberry Pi 5 🚀🍓

### 📊 Key Changes
- Added a **“YOLO26 Performance Improvements over YOLO11”** section to `docs/en/guides/raspberry-pi.md` 📝
- Included a **benchmark image + tables** comparing **YOLO26 vs YOLO11 (ONNX)** on Raspberry Pi 5, showing FPS, inference time, and mAP results 📈
- Updated the heading **“Reproduce Our Results”** from `##` to `###` to better fit the document structure 🧭

### 🎯 Purpose & Impact
- Helps users quickly see why **YOLO26 is the recommended choice** for hardware-constrained devices like **Raspberry Pi 5** ⚡
- Provides **evidence-based guidance** (measured benchmarks) for model selection, especially for users deciding between YOLO11 and YOLO26 ✅
- Improves documentation readability and trust by clearly stating the **benchmark environment/version (Ultralytics 8.4.14)** and presenting results in an easy-to-scan format 🔍