### PR TITLE
Enable IMX export for ARM64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ export = [
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package
-    "packaging>26.0; platform_machine == 'aarch64' and platform_system != 'Linux'", # IMX export bug
+    "packaging>26.0; platform_machine == 'aarch64' and platform_system == 'Linux'", # IMX export bug
 ]
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ export = [
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package
-    "packaging>26.0"; platform_machine == 'aarch64' and platform_system != 'Linux', # IMX export bug
+    "packaging>26.0; platform_machine == 'aarch64' and platform_system != 'Linux'", # IMX export bug
 ]
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ export = [
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package
-    "packaging>26.0; platform_machine == 'aarch64' and platform_system == 'Linux'", # IMX export bug
+    "packaging>=26.0; platform_machine == 'aarch64' and platform_system == 'Linux'", # IMX export bug
 ]
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ export = [
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package
+    "packaging>26.0"; platform_machine == 'aarch64' and platform_system != 'Linux', # IMX export bug
 ]
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ export = [
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package
-    "packaging>=26.0; platform_machine == 'aarch64' and platform_system == 'Linux'", # IMX export bug
+    "packaging>=26.0; platform_machine == 'aarch64' and platform_system == 'Linux' and python_version >= '3.9'", # IMX export bug
 ]
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -284,7 +284,8 @@ def test_export_ncnn_matrix(task, half, batch):
 
 @pytest.mark.skipif(not TORCH_2_9, reason="IMX export requires torch>=2.9.0")
 @pytest.mark.skipif(not checks.IS_PYTHON_MINIMUM_3_9, reason="Requires Python>=3.9")
-@pytest.mark.skipif(WINDOWS or MACOS, reason="Skipping test on Windows and Macos")
+@pytest.mark.skipif(not LINUX, reason="IMX export only supported on Linux")
+@pytest.mark.skipif(IS_RASPBERRYPI, reason="Test disabled as IMX export suffers from OOM (Out of Memory) on Raspberry Pi 5 16GB")
 def test_export_imx():
     """Test YOLO export to IMX format."""
     model = YOLO("yolo11n.pt")  # IMX export only supports YOLO11

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -285,7 +285,9 @@ def test_export_ncnn_matrix(task, half, batch):
 @pytest.mark.skipif(not TORCH_2_9, reason="IMX export requires torch>=2.9.0")
 @pytest.mark.skipif(not checks.IS_PYTHON_MINIMUM_3_9, reason="Requires Python>=3.9")
 @pytest.mark.skipif(not LINUX, reason="IMX export only supported on Linux")
-@pytest.mark.skipif(IS_RASPBERRYPI, reason="Test disabled as IMX export suffers from OOM (Out of Memory) on Raspberry Pi 5 16GB")
+@pytest.mark.skipif(
+    IS_RASPBERRYPI, reason="Test disabled as IMX export suffers from OOM (Out of Memory) on Raspberry Pi 5 16GB"
+)
 def test_export_imx():
     """Test YOLO export to IMX format."""
     model = YOLO("yolo11n.pt")  # IMX export only supports YOLO11

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -285,7 +285,6 @@ def test_export_ncnn_matrix(task, half, batch):
 @pytest.mark.skipif(not TORCH_2_9, reason="IMX export requires torch>=2.9.0")
 @pytest.mark.skipif(not checks.IS_PYTHON_MINIMUM_3_9, reason="Requires Python>=3.9")
 @pytest.mark.skipif(WINDOWS or MACOS, reason="Skipping test on Windows and Macos")
-@pytest.mark.skipif(ARM64, reason="IMX export is not supported on ARM64 architectures.")
 def test_export_imx():
     """Test YOLO export to IMX format."""
     model = YOLO("yolo11n.pt")  # IMX export only supports YOLO11

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1302,7 +1302,6 @@ class Exporter:
             "Export only supported on Linux."
             "See https://developer.aitrios.sony-semicon.com/en/docs/raspberry-pi-ai-camera/imx500-converter?version=3.17.3&progLang="
         )
-        assert not ARM64, "IMX export is not supported on ARM64 architectures."
         assert IS_PYTHON_MINIMUM_3_9, "IMX export is only supported on Python 3.9 or above."
 
         if getattr(self.model, "end2end", False):

--- a/ultralytics/models/fastsam/utils.py
+++ b/ultralytics/models/fastsam/utils.py
@@ -1,6 +1,5 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-
 def adjust_bboxes_to_image_border(boxes, image_shape, threshold=20):
     """Adjust bounding boxes to stick to image border if they are within a certain threshold.
 

--- a/ultralytics/models/fastsam/utils.py
+++ b/ultralytics/models/fastsam/utils.py
@@ -1,5 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+
 def adjust_bboxes_to_image_border(boxes, image_shape, threshold=20):
     """Adjust bounding boxes to stick to image border if they are within a certain threshold.
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes and stabilizes IMX (Sony IMX500) export support on Linux ARM64 by adjusting dependencies and test gating 🛠️🐧

### 📊 Key Changes
- ✅ Added `packaging>=26.0` as an **export extra** dependency specifically for **Linux aarch64 (ARM64) + Python ≥ 3.9** to address an IMX export bug.
- 🧪 Updated IMX export tests to:
  - Run **only on Linux** (instead of “skip Windows/Mac”).
  - Skip **Raspberry Pi** devices due to reported **out-of-memory (OOM)** issues (e.g., Raspberry Pi 5 16GB).
- 🔓 Removed the hard restriction in the exporter that blocked IMX export on **ARM64** (deleted the `assert not ARM64` check).

### 🎯 Purpose & Impact
- 🚀 **Enables IMX export on Linux ARM64** platforms where it was previously blocked, improving support for ARM-based Linux environments.
- 🧩 **Reduces export failures** by ensuring a needed dependency (`packaging`) is installed for affected platforms.
- 🧪 **Improves CI/test reliability** by avoiding known-problem environments (Raspberry Pi OOM) while still validating IMX export where it’s supported (Linux).
- ⚠️ Raspberry Pi users may still face limitations: IMX export tests are disabled there due to memory constraints, indicating potential runtime issues on that hardware.