### PR TITLE
Create parent folder when call result.save("path/to/image.jpg")

### DIFF
--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -534,6 +534,7 @@ class Annotator:
 
     def save(self, filename: str = "image.jpg"):
         """Save the annotated image to 'filename'."""
+        Path(filename).parent.mkdir(exist_ok=True, parents=True) # Create directory to prevent it from not existing.
         cv2.imwrite(filename, np.asarray(self.im))
 
     @staticmethod

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -534,7 +534,7 @@ class Annotator:
 
     def save(self, filename: str = "image.jpg"):
         """Save the annotated image to 'filename'."""
-        Path(filename).parent.mkdir(exist_ok=True, parents=True) # Create directory to prevent it from not existing.
+        Path(filename).parent.mkdir(exist_ok=True, parents=True)  # Create directory to prevent it from not existing.
         cv2.imwrite(filename, np.asarray(self.im))
 
     @staticmethod


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

Fix bug in https://github.com/ultralytics/ultralytics/issues/23626

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📁 Automatically create missing parent directories when saving annotated results via `result.save("path/to/image.jpg")`.

### 📊 Key Changes
- Adds a `Path(filename).parent.mkdir(exist_ok=True, parents=True)` call in `ultralytics/utils/plotting.py` before `cv2.imwrite()`.
- Ensures `Result.save()` no longer fails when the target output folder does not exist.

### 🎯 Purpose & Impact
- Prevents save-time errors for users writing outputs to nested paths (e.g., `runs/exp/outputs/img.jpg`).
- Improves robustness and user experience with a minimal, low-risk change.
- Makes batch/automated pipelines more reliable by removing the need for manual directory creation.