### PR TITLE
docs: 📝 update hyperlink for hyperparameter tuning in custom trainer guide

### DIFF
--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -402,7 +402,7 @@ Yes, for simpler customizations, [callbacks](../usage/callbacks.md) are often su
 
 ### How do I customize the loss function without subclassing the model?
 
-If your change is simpler (such as adjusting loss gains), you can modify the [hyperparameters](https://www.ultralytics.com/glossary/hyperparameters) directly:
+If your change is simpler (such as adjusting loss gains), you can modify the [hyperparameters](https://www.ultralytics.com/glossary/hyperparameter-tuning) directly:
 
 ```python
 model.train(data="coco8.yaml", box=10.0, cls=1.5, dfl=2.0)


### PR DESCRIPTION
Broken hyperparameter link fixed  https://www.ultralytics.com/glossary/hyperparameters and updated with live one 
https://www.ultralytics.com/glossary/hyperparameter-tuning

This should be stop docs URL error  and that is the only link I found in glossary about hyperparameters and looks fine. 


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the custom trainer guide to point to the correct Ultralytics documentation page for hyperparameter tuning 🔗✨

### 📊 Key Changes
- Updated the docs link in `docs/en/guides/custom-trainer.md` from the Hyperparameters glossary page to the Hyperparameter Tuning page.
- Kept the surrounding guidance and training example unchanged (`model.train(..., box=..., cls=..., dfl=...)`).

### 🎯 Purpose & Impact
- Improves documentation accuracy and directs users to more relevant info when adjusting training settings like loss gains 📚✅
- Reduces confusion for newcomers following the guide to customize training without subclassing models 🧭
- No code or behavior changes—this is a documentation-only fix, so there’s no impact on training results or APIs 🛠️➡️😌