### PR TITLE
Fix broken YOLO26 documentation link in vision-eye guide

### DIFF
--- a/docs/en/guides/vision-eye.md
+++ b/docs/en/guides/vision-eye.md
@@ -171,7 +171,7 @@ Ultralytics YOLO26 is renowned for its speed, [accuracy](https://www.ultralytics
 3. **Community and Support**: Extensive documentation and active GitHub community for troubleshooting and enhancements.
 4. **Ease of Use**: Intuitive API simplifies complex tasks, allowing for rapid deployment and iteration.
 
-For more information on applications and benefits, check out the [Ultralytics YOLO26 documentation](https://docs.ultralytics.com/models/yolov8/).
+For more information on applications and benefits, check out the [Ultralytics YOLO26 documentation](https://docs.ultralytics.com/models/yolo26/).
 
 ### How can I integrate VisionEye with other [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) tools like Comet or ClearML?
 


### PR DESCRIPTION
## Summary

- Fixed hyperlink in `docs/en/guides/vision-eye.md` FAQ section: link text says "Ultralytics YOLO26 documentation" but URL pointed to `/models/yolov8/` instead of `/models/yolo26/`. The stale URL was carried over from the YOLO11 → YOLO26 rename in #23176.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an incorrect documentation link in the VisionEye guide to point to the correct YOLO26 docs 🔗

### 📊 Key Changes
- Updated the VisionEye guide’s “Ultralytics YOLO26 documentation” link from the YOLOv8 docs path to the YOLO26 docs path

### 🎯 Purpose & Impact
- Prevents users from landing on outdated/incorrect model documentation ✅
- Improves documentation accuracy and user navigation when learning about YOLO26 in the VisionEye guide 📚