### PR TITLE
Added max concurrency 16 to link checker workflow for the HTTP/2 error

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -40,6 +40,7 @@ jobs:
             --scheme https \
             --timeout 60 \
             --insecure \
+            --max-concurrency 16 \
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
@@ -75,6 +76,7 @@ jobs:
             --scheme https \
             --timeout 60 \
             --insecure \
+            --max-concurrency 16 \
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \


### PR DESCRIPTION
Added --max-concurrency 16 to the link checker workflow to address HTTP/2 errors in the GitHub Action. The errors were likely caused by too many simultaneous requests, so limiting concurrency should fix it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Throttle link-checker concurrency to reduce HTTP/2 errors in CI 🚦

### 📊 Key Changes
-Added `--max-concurrency 16` to the link checker workflow in `.github/workflows/links.yml` (applied in both link-check steps)

### 🎯 Purpose & Impact
-Improves CI reliability by limiting parallel HTTP requests, helping prevent intermittent HTTP/2-related failures
-Reduces flaky link-check runs without changing link coverage or accepted status codes