### PR TITLE
Add YOLOE agnostic_nms default behavior note

### DIFF
--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -930,6 +930,7 @@ Quickly set up YOLOE with Ultralytics by following these steps:
 6. **Integration Tips**:
     - **Class names**: Default YOLOE outputs use LVIS categories; use `set_classes()` to specify your own labels.
     - **Speed**: YOLOE has no overhead unless using prompts. Text prompts have minimal impact; visual prompts slightly more.
+    - **NMS behavior**: YOLOE automatically uses `agnostic_nms=True` during prediction, merging overlapping boxes across classes. This prevents duplicate detections when the same object matches multiple categories in YOLOE's large vocabulary (1200+ LVIS classes). You can override this by passing `agnostic_nms=False` explicitly.
     - **Batch inference**: Supported directly (`model.predict([img1, img2])`). For image-specific prompts, run images individually.
 
 The [Ultralytics documentation](https://docs.ultralytics.com/) provides further resources. YOLOE lets you easily explore powerful open-world capabilities within the familiar YOLO ecosystem.


### PR DESCRIPTION
Since [#23525](https://github.com/ultralytics/ultralytics/pull/23525), YOLOE automatically sets `agnostic_nms=True` during prediction to prevent duplicate detections across its large vocabulary (1200+ LVIS classes). This behavior is not documented in the YOLOE model page.

This PR adds a brief note to the **Integration Tips** section of `yoloe.md` explaining the default NMS behavior and how to override it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a documentation note clarifying YOLOE’s default `agnostic_nms=True` behavior during prediction. 📝

### 📊 Key Changes
- Documents that YOLOE automatically enables class-agnostic NMS (`agnostic_nms=True`) at predict time.
- Explains that this merges overlapping boxes across classes to reduce duplicate detections in YOLOE’s large (1200+ LVIS) vocabulary.
- Notes users can override the default by explicitly passing `agnostic_nms=False`.

### 🎯 Purpose & Impact
- Improves clarity for users surprised by cross-class box merging during YOLOE inference.
- Helps prevent confusion around “missing” multi-class duplicates when the same object matches multiple categories.
- Provides an explicit knob to restore per-class NMS behavior when desired, improving usability and debugging. 🔧