### PR TITLE
Document CUDA OOM auto-retry in batch-size settings

### DIFF
--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -235,6 +235,7 @@ The training settings for YOLO models encompass various hyperparameters and conf
     - **Fixed [Batch Size](https://www.ultralytics.com/glossary/batch-size)**: Set an integer value (e.g., `batch=16`), specifying the number of images per batch directly.
     - **Auto Mode (60% GPU Memory)**: Use `batch=-1` to automatically adjust batch size for approximately 60% CUDA memory utilization.
     - **Auto Mode with Utilization Fraction**: Set a fraction value (e.g., `batch=0.70`) to adjust batch size based on the specified fraction of GPU memory usage.
+    - **OOM Auto-Retry**: If a CUDA out-of-memory error occurs during the first epoch, the trainer automatically halves the batch size and retries (up to 3 times). This only applies to single-GPU training; multi-GPU (DDP) training will raise the error immediately.
 
 ## Augmentation Settings and Hyperparameters
 


### PR DESCRIPTION
Since [#23590](https://github.com/ultralytics/ultralytics/pull/23590) (v8.4.13), the trainer automatically halves batch size and retries on CUDA OOM during the first epoch (up to 3 times, single-GPU only). This is not mentioned in the training docs.

This PR adds a note to the **Batch-size Settings** section of `train.md` describing this behavior.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documents CUDA OOM auto-retry behavior for batch-size auto-tuning during training to clarify what happens on early out-of-memory failures. 📝

### 📊 Key Changes
- Added a new **OOM Auto-Retry** bullet to the training batch-size settings docs.
- Described the retry logic: halve batch size and retry up to 3 times if OOM occurs during the first epoch.
- Clarified scope/limitations: applies only to single-GPU training; DDP/multi-GPU raises immediately.

### 🎯 Purpose & Impact
- Helps users quickly understand why training may “recover” from an initial CUDA OOM by reducing batch size automatically. 🔁
- Reduces confusion and support load by clearly stating the single-GPU vs multi-GPU (DDP) behavior.
- Improves troubleshooting guidance for batch-size configuration choices in the training docs. 📚