### PR TITLE
Document Results.save() automatic directory creation

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -872,4 +872,4 @@ The `model.predict()` method in YOLO supports various arguments such as `conf`, 
 
 ### How can I visualize and save the results of YOLO predictions?
 
-After running inference with YOLO, the `Results` objects contain methods for displaying and saving annotated images. You can use methods like `result.show()` and `result.save(filename="result.jpg")` to visualize and save the results. For a comprehensive list of these methods, refer to the [working with results](#working-with-results) section.
+After running inference with YOLO, the `Results` objects contain methods for displaying and saving annotated images. You can use methods like `result.show()` and `result.save(filename="result.jpg")` to visualize and save the results. Any missing parent directories in the filename path are created automatically (e.g., `result.save("path/to/result.jpg")`). For a comprehensive list of these methods, refer to the [working with results](#working-with-results) section.


### PR DESCRIPTION
Since [#23592](https://github.com/ultralytics/ultralytics/pull/23592), `Results.save()` automatically creates missing parent directories in the filename path. This is not mentioned in the predict docs.

This PR adds a brief note in the FAQ section of `predict.md` clarifying that `result.save("path/to/result.jpg")` creates directories automatically.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 Clarifies in the Predict docs that `Results.save()` will automatically create any missing parent directories when given a nested output path.

### 📊 Key Changes
-Updated `docs/en/modes/predict.md` to explicitly state that missing parent directories are created automatically for `result.save("path/to/result.jpg")`.

### 🎯 Purpose & Impact
-Reduces confusion and user friction when saving prediction outputs to new folders
-Sets correct expectations for `Results.save()` behavior, improving docs accuracy and usability