### PR TITLE
Banica ultralytics http2 changes undone

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -40,7 +40,6 @@ jobs:
             --scheme https \
             --timeout 60 \
             --insecure \
-            --max-concurrency 16 \
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
@@ -76,7 +75,6 @@ jobs:
             --scheme https \
             --timeout 60 \
             --insecure \
-            --max-concurrency 16 \
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \


### PR DESCRIPTION
Removed last change made, lychee max-concurrency 16/ from workflows/links.yaml

meant to have added it in docs, PR made for docs as well.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Reverts link-check workflow concurrency settings to run without an explicit `--max-concurrency` limit 🧩

### 📊 Key Changes
-Removed `--max-concurrency 16` from the link checker invocation in `.github/workflows/links.yml` (in both job steps)

### 🎯 Purpose & Impact
-May reduce HTTP/2-related flakiness/timeouts by avoiding aggressive parallel link checks 🌐
-Changes CI behavior for link validation runs (potentially slower, but more stable) ⚙️