### PR TITLE
`ultralytics 8.4.15` HEIC/HEIF image support

### DIFF
--- a/docs/en/reference/utils/patches.md
+++ b/docs/en/reference/utils/patches.md
@@ -15,6 +15,10 @@ keywords: Ultralytics, utils, patches, imread, imwrite, imshow, torch_save, Open
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.patches.image_open
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.patches._imread_pil
 
 <br><br><hr><br>

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.14"
+__version__ = "8.4.15"
 
 import importlib
 import os

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -442,19 +442,9 @@ class LoadImagesAndVideos:
                     if self.count < self.nf:
                         self._new_video(self.files[self.count])
             else:
-                # Handle image files (including HEIC)
+                # Handle image files
                 self.mode = "image"
-                if path.rpartition(".")[-1].lower() == "heic":
-                    # Load HEIC image using Pillow with pillow-heif
-                    check_requirements("pi-heif")
-
-                    from pi_heif import register_heif_opener
-
-                    register_heif_opener()  # Register HEIF opener with Pillow
-                    with Image.open(path) as img:
-                        im0 = cv2.cvtColor(np.asarray(img), cv2.COLOR_RGB2BGR)  # convert image to BGR nparray
-                else:
-                    im0 = imread(path, flags=self.cv2_flag)  # BGR
+                im0 = imread(path, flags=self.cv2_flag)  # BGR
                 if im0 is None:
                     LOGGER.warning(f"Image Read Error {path}")
                 else:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -37,7 +37,22 @@ from ultralytics.utils.downloads import download, safe_download, unzip_file
 from ultralytics.utils.ops import segments2boxes
 
 HELP_URL = "See https://docs.ultralytics.com/datasets for dataset formatting guidance."
-IMG_FORMATS = {"avif", "bmp", "dng", "heic", "heif", "jp2", "jpeg", "jpeg2000", "jpg", "mpo", "png", "tif", "tiff", "webp"}
+IMG_FORMATS = {
+    "avif",
+    "bmp",
+    "dng",
+    "heic",
+    "heif",
+    "jp2",
+    "jpeg",
+    "jpeg2000",
+    "jpg",
+    "mpo",
+    "png",
+    "tif",
+    "tiff",
+    "webp",
+}
 VID_FORMATS = {"asf", "avi", "gif", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ts", "wmv", "webm"}  # videos
 FORMATS_HELP_MSG = f"Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID_FORMATS}"
 

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -37,7 +37,7 @@ from ultralytics.utils.downloads import download, safe_download, unzip_file
 from ultralytics.utils.ops import segments2boxes
 
 HELP_URL = "See https://docs.ultralytics.com/datasets for dataset formatting guidance."
-IMG_FORMATS = {"avif", "bmp", "dng", "heic", "jp2", "jpeg", "jpeg2000", "jpg", "mpo", "png", "tif", "tiff", "webp"}
+IMG_FORMATS = {"avif", "bmp", "dng", "heic", "heif", "jp2", "jpeg", "jpeg2000", "jpg", "mpo", "png", "tif", "tiff", "webp"}
 VID_FORMATS = {"asf", "avi", "gif", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ts", "wmv", "webm"}  # videos
 FORMATS_HELP_MSG = f"Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID_FORMATS}"
 

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -391,7 +391,7 @@ def plt_settings(rcparams=None, backend="Agg"):
                             if str(font_path) not in {f.fname for f in font_manager.fontManager.ttflist}:
                                 font_manager.fontManager.addfont(str(font_path))
                             prop = font_manager.FontProperties(fname=str(font_path))
-                            _matplotlib_font_sans_serif = [prop.get_name()] + plt.rcParams.get("font.sans-serif", [])
+                            _matplotlib_font_sans_serif = [prop.get_name(), *plt.rcParams.get("font.sans-serif", [])]
                     except Exception:
                         pass
                 if _matplotlib_font_sans_serif:

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -338,6 +338,9 @@ class IterableSimpleNamespace(SimpleNamespace):
         return getattr(self, key, default)
 
 
+_matplotlib_font_sans_serif = None  # cached font.sans-serif list with Arial Unicode
+
+
 def plt_settings(rcparams=None, backend="Agg"):
     """Decorator to temporarily set rc parameters and the backend for a plotting function.
 
@@ -369,6 +372,30 @@ def plt_settings(rcparams=None, backend="Agg"):
         def wrapper(*args, **kwargs):
             """Set rc parameters and backend, call the original function, and restore the settings."""
             import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
+
+            # Ensure Arial Unicode font is available for non-Latin text (CJK, Arabic, Cyrillic, etc.)
+            global _matplotlib_font_sans_serif
+            if "font.sans-serif" not in rcparams:
+                if _matplotlib_font_sans_serif is None:
+                    _matplotlib_font_sans_serif = []  # default: skip
+                    try:
+                        from matplotlib import font_manager
+
+                        # Check if Arial Unicode already exists (system fonts or Ultralytics config dir)
+                        font_path = USER_CONFIG_DIR / "Arial.Unicode.ttf"
+                        if not font_path.exists():
+                            # Search system fonts
+                            matches = [f.fname for f in font_manager.fontManager.ttflist if "Unicode" in f.name]
+                            font_path = Path(matches[0]) if matches else None
+                        if font_path and font_path.exists():
+                            if str(font_path) not in {f.fname for f in font_manager.fontManager.ttflist}:
+                                font_manager.fontManager.addfont(str(font_path))
+                            prop = font_manager.FontProperties(fname=str(font_path))
+                            _matplotlib_font_sans_serif = [prop.get_name()] + plt.rcParams.get("font.sans-serif", [])
+                    except Exception:
+                        pass
+                if _matplotlib_font_sans_serif:
+                    rcparams["font.sans-serif"] = _matplotlib_font_sans_serif
 
             original_backend = plt.get_backend()
             switch = backend.lower() != original_backend.lower()

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -338,9 +338,6 @@ class IterableSimpleNamespace(SimpleNamespace):
         return getattr(self, key, default)
 
 
-_matplotlib_font_sans_serif = None  # cached font.sans-serif list with Arial Unicode
-
-
 def plt_settings(rcparams=None, backend="Agg"):
     """Decorator to temporarily set rc parameters and the backend for a plotting function.
 
@@ -373,29 +370,17 @@ def plt_settings(rcparams=None, backend="Agg"):
             """Set rc parameters and backend, call the original function, and restore the settings."""
             import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
 
-            # Ensure Arial Unicode font is available for non-Latin text (CJK, Arabic, Cyrillic, etc.)
-            global _matplotlib_font_sans_serif
-            if "font.sans-serif" not in rcparams:
-                if _matplotlib_font_sans_serif is None:
-                    _matplotlib_font_sans_serif = []  # default: skip
-                    try:
-                        from matplotlib import font_manager
+            # Prepend Arial Unicode for non-Latin text (CJK, Arabic, etc.); matplotlib falls back if missing
+            if "font.sans-serif" not in rcparams and not wrapper._fonts_registered:
+                from matplotlib import font_manager
 
-                        # Check if Arial Unicode already exists (system fonts or Ultralytics config dir)
-                        font_path = USER_CONFIG_DIR / "Arial.Unicode.ttf"
-                        if not font_path.exists():
-                            # Search system fonts
-                            matches = [f.fname for f in font_manager.fontManager.ttflist if "Unicode" in f.name]
-                            font_path = Path(matches[0]) if matches else None
-                        if font_path and font_path.exists():
-                            if str(font_path) not in {f.fname for f in font_manager.fontManager.ttflist}:
-                                font_manager.fontManager.addfont(str(font_path))
-                            prop = font_manager.FontProperties(fname=str(font_path))
-                            _matplotlib_font_sans_serif = [prop.get_name(), *plt.rcParams.get("font.sans-serif", [])]
-                    except Exception:
-                        pass
-                if _matplotlib_font_sans_serif:
-                    rcparams["font.sans-serif"] = _matplotlib_font_sans_serif
+                # Register any fonts in Ultralytics config dir (e.g. Arial.Unicode.ttf) with matplotlib
+                known = {f.fname for f in font_manager.fontManager.ttflist}
+                for f in USER_CONFIG_DIR.glob("*.ttf"):
+                    if str(f) not in known:
+                        font_manager.fontManager.addfont(str(f))
+                wrapper._fonts_registered = True
+            rc = rcparams if "font.sans-serif" in rcparams else {**rcparams, "font.sans-serif": ["Arial Unicode MS", *plt.rcParams.get("font.sans-serif", [])]}
 
             original_backend = plt.get_backend()
             switch = backend.lower() != original_backend.lower()
@@ -405,7 +390,7 @@ def plt_settings(rcparams=None, backend="Agg"):
 
             # Plot with backend and always revert to original backend
             try:
-                with plt.rc_context(rcparams):
+                with plt.rc_context(rc):
                     result = func(*args, **kwargs)
             finally:
                 if switch:
@@ -413,6 +398,7 @@ def plt_settings(rcparams=None, backend="Agg"):
                     plt.switch_backend(original_backend)
             return result
 
+        wrapper._fonts_registered = False
         return wrapper
 
     return decorator

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -380,7 +380,11 @@ def plt_settings(rcparams=None, backend="Agg"):
                     if str(f) not in known:
                         font_manager.fontManager.addfont(str(f))
                 wrapper._fonts_registered = True
-            rc = rcparams if "font.sans-serif" in rcparams else {**rcparams, "font.sans-serif": ["Arial Unicode MS", *plt.rcParams.get("font.sans-serif", [])]}
+            rc = (
+                rcparams
+                if "font.sans-serif" in rcparams
+                else {**rcparams, "font.sans-serif": ["Arial Unicode MS", *plt.rcParams.get("font.sans-serif", [])]}
+            )
 
             original_backend = plt.get_backend()
             switch = backend.lower() != original_backend.lower()

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -56,9 +56,9 @@ _pil_plugins_registered = False
 def image_open(filename, *args, **kwargs):
     """Open an image with PIL, lazily registering the HEIF plugin on first failure.
 
-    This monkey-patches PIL.Image.open to add HEIC/HEIF support via pi-heif (lightweight, decode-only),
-    avoiding the ~800ms startup cost of importing the package unless actually needed.
-    AVIF is supported natively by Pillow 12+ and does not require a plugin.
+    This monkey-patches PIL.Image.open to add HEIC/HEIF support via pi-heif (lightweight, decode-only), avoiding the
+    ~800ms startup cost of importing the package unless actually needed. AVIF is supported natively by Pillow 12+ and
+    does not require a plugin.
 
     Args:
         filename (str): Path to the image file.

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -56,8 +56,8 @@ _pil_plugins_registered = False
 def image_open(filename, *args, **kwargs):
     """Open an image with PIL, lazily registering HEIF/AVIF plugins on first failure.
 
-    This monkey-patches PIL.Image.open to add HEIC/AVIF support via pillow_heif/pillow_avif plugins,
-    avoiding the ~800ms startup cost of importing these packages unless actually needed.
+    This monkey-patches PIL.Image.open to add HEIC/AVIF support via pillow_heif/pillow_avif plugins, avoiding the ~800ms
+    startup cost of importing these packages unless actually needed.
 
     Args:
         filename (str): Path to the image file.

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -46,7 +46,48 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
         return im[..., None] if im is not None and im.ndim == 2 else im  # Always ensure 3 dimensions
 
 
+# PIL patches ---------------------------------------------------------------------------------------------------------
+from PIL import Image
+
+_image_open = Image.open  # copy to avoid recursion errors
 _pil_plugins_registered = False
+
+
+def image_open(filename, *args, **kwargs):
+    """Open an image with PIL, lazily registering HEIF/AVIF plugins on first failure.
+
+    This monkey-patches PIL.Image.open to add HEIC/AVIF support via pillow_heif/pillow_avif plugins,
+    avoiding the ~800ms startup cost of importing these packages unless actually needed.
+
+    Args:
+        filename (str): Path to the image file.
+        *args (Any): Additional positional arguments passed to PIL.Image.open.
+        **kwargs (Any): Additional keyword arguments passed to PIL.Image.open.
+
+    Returns:
+        (PIL.Image.Image): The opened PIL image.
+    """
+    global _pil_plugins_registered
+    if _pil_plugins_registered:
+        return _image_open(filename, *args, **kwargs)
+    try:
+        return _image_open(filename, *args, **kwargs)
+    except Exception:
+        try:
+            import pillow_heif
+
+            pillow_heif.register_heif_opener()
+        except ImportError:
+            pass
+        try:
+            import pillow_avif  # noqa: F401
+        except ImportError:
+            pass
+        _pil_plugins_registered = True
+        return _image_open(filename, *args, **kwargs)
+
+
+Image.open = image_open  # apply patch
 
 
 def _imread_pil(filename: str, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
@@ -59,24 +100,7 @@ def _imread_pil(filename: str, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | No
     Returns:
         (np.ndarray | None): The read image array in BGR format, or None if reading fails.
     """
-    global _pil_plugins_registered
     try:
-        from PIL import Image
-
-        # Register HEIF/AVIF plugins once
-        if not _pil_plugins_registered:
-            try:
-                import pillow_heif
-
-                pillow_heif.register_heif_opener()
-            except ImportError:
-                pass
-            try:
-                import pillow_avif  # noqa: F401
-            except ImportError:
-                pass
-            _pil_plugins_registered = True
-
         with Image.open(filename) as img:
             if flags == cv2.IMREAD_GRAYSCALE:
                 return np.asarray(img.convert("L"))

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -54,10 +54,11 @@ _pil_plugins_registered = False
 
 
 def image_open(filename, *args, **kwargs):
-    """Open an image with PIL, lazily registering HEIF/AVIF plugins on first failure.
+    """Open an image with PIL, lazily registering the HEIF plugin on first failure.
 
-    This monkey-patches PIL.Image.open to add HEIC/AVIF support via pillow_heif/pillow_avif plugins,
-    avoiding the ~800ms startup cost of importing these packages unless actually needed.
+    This monkey-patches PIL.Image.open to add HEIC/HEIF support via pillow-heif,
+    avoiding the ~800ms startup cost of importing the package unless actually needed.
+    AVIF is supported natively by Pillow 12+ and does not require a plugin.
 
     Args:
         filename (str): Path to the image file.
@@ -73,16 +74,12 @@ def image_open(filename, *args, **kwargs):
     try:
         return _image_open(filename, *args, **kwargs)
     except Exception:
-        try:
-            import pillow_heif
+        from ultralytics.utils.checks import check_requirements
 
-            pillow_heif.register_heif_opener()
-        except ImportError:
-            pass
-        try:
-            import pillow_avif  # noqa: F401
-        except ImportError:
-            pass
+        check_requirements("pillow-heif")
+        import pillow_heif
+
+        pillow_heif.register_heif_opener()
         _pil_plugins_registered = True
         return _image_open(filename, *args, **kwargs)
 

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -56,7 +56,7 @@ _pil_plugins_registered = False
 def image_open(filename, *args, **kwargs):
     """Open an image with PIL, lazily registering the HEIF plugin on first failure.
 
-    This monkey-patches PIL.Image.open to add HEIC/HEIF support via pillow-heif,
+    This monkey-patches PIL.Image.open to add HEIC/HEIF support via pi-heif (lightweight, decode-only),
     avoiding the ~800ms startup cost of importing the package unless actually needed.
     AVIF is supported natively by Pillow 12+ and does not require a plugin.
 
@@ -76,10 +76,10 @@ def image_open(filename, *args, **kwargs):
     except Exception:
         from ultralytics.utils.checks import check_requirements
 
-        check_requirements("pillow-heif")
-        import pillow_heif
+        check_requirements("pi-heif")
+        from pi_heif import register_heif_opener
 
-        pillow_heif.register_heif_opener()
+        register_heif_opener()
         _pil_plugins_registered = True
         return _image_open(filename, *args, **kwargs)
 

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -12,6 +12,7 @@ from typing import Any
 import cv2
 import numpy as np
 import torch
+from PIL import Image
 
 # OpenCV Multilanguage-friendly functions ------------------------------------------------------------------------------
 _imshow = cv2.imshow  # copy to avoid recursion errors
@@ -47,8 +48,6 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
 
 
 # PIL patches ---------------------------------------------------------------------------------------------------------
-from PIL import Image
-
 _image_open = Image.open  # copy to avoid recursion errors
 _pil_plugins_registered = False
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves image format handling (HEIC/HEIF) with a lazy-loading PIL patch, adds `heif` support, enhances matplotlib font defaults for non‑Latin text, and bumps the Ultralytics version to 8.4.15 🚀🖼️🈶

### 📊 Key Changes
- Added a new `ultralytics.utils.patches.image_open` function and documented it in the reference docs 📚
- Monkey-patched `PIL.Image.open` to **lazily** enable HEIC/HEIF decoding via `pi-heif` *only when needed* (on first failure) ⏱️
- Removed HEIC-specific loading logic from `ultralytics/data/loaders.py` (now relies on the unified `imread()`/PIL pathway) 🧹
- Expanded supported image extensions to include **`heif`** (in addition to `heic`) ✅
- Improved plotting defaults by prepending **Arial Unicode MS** to matplotlib’s sans-serif list and auto-registering any `.ttf` fonts found in the Ultralytics user config directory, improving non‑Latin text rendering (CJK/Arabic/etc.) 📝🌍
- Version bump: `8.4.14` → `8.4.15` 🔖

### 🎯 Purpose & Impact
- Faster startup and smoother UX when HEIC/HEIF isn’t used: avoids importing heavy image plugins unless required ⚡
- More consistent, centralized image loading: less duplicated/special-case code in dataloaders, fewer edge cases 🧩
- Better out-of-the-box support for modern Apple-style formats (`.heic` / `.heif`) across datasets and inference workflows 📷
- Clearer plots for international users: improved font fallback and optional custom font registration reduces “missing glyph” issues in charts 📈🌐