### PR TITLE
Update HEIC/HEIF dependency info and add .heif format to docs

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -442,7 +442,7 @@ The below table contains valid Ultralytics image formats.
 
 !!! note
 
-    AVIF and HEIC formats require additional dependencies: `pip install pillow-avif-plugin pillow-heif`
+    HEIC/HEIF formats require `pi-heif`, which is installed automatically on first use. AVIF is supported natively by Pillow.
 
 | Image Suffixes | Example Predict Command          | Reference                                                                  |
 | -------------- | -------------------------------- | -------------------------------------------------------------------------- |
@@ -450,6 +450,7 @@ The below table contains valid Ultralytics image formats.
 | `.bmp`         | `yolo predict source=image.bmp`  | [Microsoft BMP File Format](https://en.wikipedia.org/wiki/BMP_file_format) |
 | `.dng`         | `yolo predict source=image.dng`  | [Adobe DNG](https://en.wikipedia.org/wiki/Digital_Negative)                |
 | `.heic`        | `yolo predict source=image.heic` | [High Efficiency Image Format](https://en.wikipedia.org/wiki/HEIF)         |
+| `.heif`        | `yolo predict source=image.heif` | [High Efficiency Image Format](https://en.wikipedia.org/wiki/HEIF)         |
 | `.jp2`         | `yolo predict source=image.jp2`  | [JPEG 2000](https://en.wikipedia.org/wiki/JPEG_2000)                       |
 | `.jpeg`        | `yolo predict source=image.jpeg` | [JPEG](https://en.wikipedia.org/wiki/JPEG)                                 |
 | `.jpg`         | `yolo predict source=image.jpg`  | [JPEG](https://en.wikipedia.org/wiki/JPEG)                                 |

--- a/docs/en/usage/simple-utilities.md
+++ b/docs/en/usage/simple-utilities.md
@@ -690,7 +690,7 @@ Need to programmatically use the supported [image or video formats](../modes/pre
 from ultralytics.data.utils import IMG_FORMATS, VID_FORMATS
 
 print(IMG_FORMATS)
-# {'avif', 'bmp', 'dng', 'heic', 'jp2', 'jpeg', 'jpeg2000', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp'}
+# {'avif', 'bmp', 'dng', 'heic', 'heif', 'jp2', 'jpeg', 'jpeg2000', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp'}
 
 print(VID_FORMATS)
 # {'asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ts', 'wmv', 'webm'}


### PR DESCRIPTION
Since [#23714](https://github.com/ultralytics/ultralytics/pull/23714) (v8.4.15):

- HEIC/HEIF support now uses `pi-heif` (installed automatically on first use) instead of `pillow-heif`
- AVIF is supported natively by Pillow and no longer requires `pillow-avif-plugin`
- `.heif` was added to `IMG_FORMATS` alongside `.heic`

This PR updates `predict.md` and `simple-utilities.md` to reflect these changes:

- Fix outdated dependency note (`pillow-avif-plugin pillow-heif` → `pi-heif` auto-installed, AVIF native)
- Add `.heif` row to the image formats table
- Update `IMG_FORMATS` comment to include `heif`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates Ultralytics docs to clarify HEIC/HEIF dependency handling and adds explicit `.heif` format support documentation 📸

### 📊 Key Changes
- Updates the Predict docs note to state HEIC/HEIF uses `pi-heif` (auto-installed on first use) and that AVIF is supported natively by Pillow.
- Adds `.heif` to the supported image suffix table in `docs/en/modes/predict.md`.
- Updates the `IMG_FORMATS` example output in `docs/en/usage/simple-utilities.md` to include `heif`.

### 🎯 Purpose & Impact
- Reduces user confusion around required dependencies for HEIC/HEIF vs AVIF 🧩
- Improves discoverability of `.heif` support in Predict documentation ✅
- Keeps documentation examples aligned with supported format lists, helping users avoid format-related runtime surprises 📚