### PR TITLE
`ultralytics 8.4.16` Windows<>Linux model compatibility fix

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.15"
+__version__ = "8.4.16"
 
 import importlib
 import os

--- a/ultralytics/models/nas/model.py
+++ b/ultralytics/models/nas/model.py
@@ -75,7 +75,7 @@ class NAS(Model):
         self.model.names = dict(enumerate(self.model._class_names))
         self.model.is_fused = lambda: False  # for info()
         self.model.yaml = {}  # for info()
-        self.model.pt_path = weights  # for export()
+        self.model.pt_path = str(weights)  # for export()
         self.model.task = "detect"  # for export()
         self.model.args = {**DEFAULT_CFG_DICT, **self.overrides}  # for export()
         self.model.eval()

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1444,7 +1444,8 @@ def torch_safe_load(weight, safe_only=False):
                 "ultralytics.nn.modules.block.Silence": "torch.nn.Identity",  # YOLOv9e
                 "ultralytics.nn.tasks.YOLOv10DetectionModel": "ultralytics.nn.tasks.DetectionModel",  # YOLOv10
                 "ultralytics.utils.loss.v10DetectLoss": "ultralytics.utils.loss.E2EDetectLoss",  # YOLOv10
-                **(  # resolve cross-platform pathlib pickle incompatibility
+                # resolve cross-platform pathlib pickle incompatibility
+                **(
                     {"pathlib.PosixPath": "pathlib.WindowsPath"}
                     if WINDOWS
                     else {"pathlib.WindowsPath": "pathlib.PosixPath"}

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1517,7 +1517,7 @@ def load_checkpoint(weight, device=None, inplace=True, fuse=False):
 
     # Model compatibility updates
     model.args = args  # attach args to model
-    model.pt_path = weight  # attach *.pt file path to model
+    model.pt_path = str(weight)  # attach *.pt file path to model as string (avoids WindowsPath pickle issues)
     model.task = getattr(model, "task", guess_model_task(model))
     if not hasattr(model, "stride"):
         model.stride = torch.tensor([32.0])

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1444,7 +1444,11 @@ def torch_safe_load(weight, safe_only=False):
                 "ultralytics.nn.modules.block.Silence": "torch.nn.Identity",  # YOLOv9e
                 "ultralytics.nn.tasks.YOLOv10DetectionModel": "ultralytics.nn.tasks.DetectionModel",  # YOLOv10
                 "ultralytics.utils.loss.v10DetectLoss": "ultralytics.utils.loss.E2EDetectLoss",  # YOLOv10
-                **({"pathlib.WindowsPath": "pathlib.PosixPath"} if not WINDOWS else {}),  # Windows .pt on Linux/macOS
+                **(  # resolve cross-platform pathlib pickle incompatibility
+                    {"pathlib.PosixPath": "pathlib.WindowsPath"}
+                    if WINDOWS
+                    else {"pathlib.WindowsPath": "pathlib.PosixPath"}
+                ),
             },
         ):
             if safe_only:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -73,7 +73,7 @@ from ultralytics.nn.modules import (
     YOLOESegment26,
     v10Detect,
 )
-from ultralytics.utils import DEFAULT_CFG_DICT, LOGGER, YAML, colorstr, emojis
+from ultralytics.utils import DEFAULT_CFG_DICT, LOGGER, WINDOWS, YAML, colorstr, emojis
 from ultralytics.utils.checks import check_requirements, check_suffix, check_yaml
 from ultralytics.utils.loss import (
     E2ELoss,
@@ -1444,6 +1444,7 @@ def torch_safe_load(weight, safe_only=False):
                 "ultralytics.nn.modules.block.Silence": "torch.nn.Identity",  # YOLOv9e
                 "ultralytics.nn.tasks.YOLOv10DetectionModel": "ultralytics.nn.tasks.DetectionModel",  # YOLOv10
                 "ultralytics.utils.loss.v10DetectLoss": "ultralytics.utils.loss.E2EDetectLoss",  # YOLOv10
+                **({"pathlib.WindowsPath": "pathlib.PosixPath"} if not WINDOWS else {}),  # Windows .pt on Linux/macOS
             },
         ):
             if safe_only:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Bumps Ultralytics to `8.4.16` and improves cross-platform `.pt` loading/export by avoiding Windows/Posix `pathlib` pickle incompatibilities 🧩💾

### 📊 Key Changes
- 🔢 Version update: `__version__` from `8.4.15` → `8.4.16`.
- 🧵 Safer checkpoint metadata: store `model.pt_path` as a plain string (`str(weights)` / `str(weight)`) instead of a `Path` object (affects NAS models and general checkpoint loading).
- 🪟🖥️ Cross-platform pickle fix in `torch_safe_load()`: adds a Windows/Posix `pathlib` class remap so models pickled on one OS can be loaded on the other.

### 🎯 Purpose & Impact
- ✅ More reliable model loading across Windows and Linux/macOS when sharing `.pt` files (fewer “can’t unpickle WindowsPath/PosixPath” errors).
- 📦 Smoother export and tooling workflows that rely on `model.pt_path`, since it’s now consistently a string.
- 🔄 Better portability for teams training on one OS and deploying on another, improving reproducibility and reducing environment-specific friction 🚀