### PR TITLE
Add first-class Intel XPU (Arc GPU) device support

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -338,7 +338,9 @@ class BaseTrainer:
             dist.broadcast(self.amp.int(), src=0)  # broadcast from rank 0 to all other ranks; gloo errors with boolean
         self.amp = bool(self.amp)  # as boolean
         self.scaler = (
-            torch.amp.GradScaler("cuda", enabled=self.amp) if TORCH_2_4 else torch.cuda.amp.GradScaler(enabled=self.amp)
+            torch.amp.GradScaler(self.device.type, enabled=self.amp)
+            if TORCH_2_4
+            else torch.cuda.amp.GradScaler(enabled=self.amp)
         )
         # Check imgsz
         gs = max(int(self.model.stride.max() if hasattr(self.model, "stride") else 32), 32)  # grid size (max stride)
@@ -440,7 +442,7 @@ class BaseTrainer:
 
                 # Forward
                 try:
-                    with autocast(self.amp):
+                    with autocast(self.amp, device=self.device.type):
                         batch = self.preprocess_batch(batch)
                         if self.args.compile:
                             # Decouple inference and loss calculations for improved compile performance
@@ -457,14 +459,21 @@ class BaseTrainer:
 
                     # Backward
                     self.scaler.scale(self.loss).backward()
-                except torch.cuda.OutOfMemoryError:
+                except (
+                    torch.cuda.OutOfMemoryError,
+                    *(
+                        (torch.xpu.OutOfMemoryError,)
+                        if hasattr(torch, "xpu") and hasattr(torch.xpu, "OutOfMemoryError")
+                        else ()
+                    ),
+                ):
                     if epoch > self.start_epoch or self._oom_retries >= 3 or RANK != -1:
                         raise  # only auto-reduce during first epoch on single GPU, max 3 retries
                     self._oom_retries += 1
                     old_batch = self.batch_size
                     self.args.batch = self.batch_size = max(self.batch_size // 2, 1)
                     LOGGER.warning(
-                        f"CUDA out of memory with batch={old_batch}. "
+                        f"{self.device.type.upper()} out of memory with batch={old_batch}. "
                         f"Reducing to batch={self.batch_size} and retrying ({self._oom_retries}/3)."
                     )
                     batch = loss = preds = None
@@ -602,6 +611,10 @@ class BaseTrainer:
             memory = torch.mps.driver_allocated_memory()
             if fraction:
                 return __import__("psutil").virtual_memory().percent / 100
+        elif self.device.type == "xpu":
+            memory = torch.xpu.memory_reserved()
+            if fraction:
+                total = torch.xpu.get_device_properties(self.device).total_memory
         elif self.device.type != "cpu":
             memory = torch.cuda.memory_reserved()
             if fraction:
@@ -617,6 +630,8 @@ class BaseTrainer:
         gc.collect()
         if self.device.type == "mps":
             torch.mps.empty_cache()
+        elif self.device.type == "xpu":
+            torch.xpu.empty_cache()
         elif self.device.type == "cpu":
             return
         else:

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -869,27 +869,31 @@ def check_amp(model):
     device = next(model.parameters()).device  # get model device
     prefix = colorstr("AMP: ")
     if device.type in {"cpu", "mps"}:
-        return False  # AMP only used on CUDA devices
+        return False  # AMP only used on CUDA/XPU devices
     else:
-        # GPUs that have issues with AMP
-        pattern = re.compile(
-            r"(nvidia|geforce|quadro|tesla).*?(1660|1650|1630|t400|t550|t600|t1000|t1200|t2000|k40m)", re.IGNORECASE
-        )
-
-        gpu = torch.cuda.get_device_name(device)
-        if bool(pattern.search(gpu)):
-            LOGGER.warning(
-                f"{prefix}checks failed ❌. AMP training on {gpu} GPU may cause "
-                f"NaN losses or zero-mAP results, so AMP will be disabled during training."
+        if device.type == "xpu":
+            # Intel XPU (Arc / Data Center GPU) — no known AMP-incompatible models
+            gpu = torch.xpu.get_device_name(device)
+        else:
+            # GPUs that have issues with AMP
+            pattern = re.compile(
+                r"(nvidia|geforce|quadro|tesla).*?(1660|1650|1630|t400|t550|t600|t1000|t1200|t2000|k40m)", re.IGNORECASE
             )
-            return False
+
+            gpu = torch.cuda.get_device_name(device)
+            if bool(pattern.search(gpu)):
+                LOGGER.warning(
+                    f"{prefix}checks failed ❌. AMP training on {gpu} GPU may cause "
+                    f"NaN losses or zero-mAP results, so AMP will be disabled during training."
+                )
+                return False
 
     def amp_allclose(m, im):
         """All close FP32 vs AMP results."""
         batch = [im] * 8
         imgsz = max(256, int(model.stride.max() * 4))  # max stride P5-32 and P6-64
         a = m(batch, imgsz=imgsz, device=device, verbose=False)[0].boxes.data  # FP32 inference
-        with autocast(enabled=True):
+        with autocast(enabled=True, device=device.type):
             b = m(batch, imgsz=imgsz, device=device, verbose=False)[0].boxes.data  # AMP inference
         del m
         return a.shape == b.shape and torch.allclose(a, b.float(), atol=0.5)  # close to 0.5 absolute tolerance

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -143,8 +143,8 @@ def select_device(device="", newline=False, verbose=True):
 
     Args:
         device (str | torch.device, optional): Device string or torch.device object. Options include 'cpu', 'cuda', '0',
-            '0,1,2,3', 'mps', 'npu', 'npu:0', or '-1' for auto-select. Defaults to auto-selecting the first available
-            GPU, or CPU if no GPU is available.
+            '0,1,2,3', 'mps', 'npu', 'npu:0', 'xpu', 'xpu:0', or '-1' for auto-select. Defaults to auto-selecting
+            the first available GPU (CUDA, NPU, or XPU), or CPU if no GPU is available.
         newline (bool, optional): If True, adds a newline at the end of the log string.
         verbose (bool, optional): If True, logs the device information.
 
@@ -197,6 +197,31 @@ def select_device(device="", newline=False, verbose=True):
             LOGGER.info(f"{s}NPU:{idx} ({torch.npu.get_device_name(idx)})\n")
         return torch.device(f"npu:{idx}")
 
+    # Intel XPU (Arc / Data Center GPU) support
+    xpu = device.startswith("xpu")
+    if xpu:
+        if not hasattr(torch, "xpu") or not torch.xpu.is_available():
+            raise ValueError(
+                f"Invalid XPU 'device={device}' requested. "
+                f"torch.xpu is not available. Install Intel Extension for PyTorch (IPEX) "
+                f"or use a PyTorch build with XPU support.\n"
+                f"\ntorch.xpu available: {hasattr(torch, 'xpu')}"
+                f"\ntorch.xpu.is_available(): {getattr(torch.xpu, 'is_available', lambda: False)()}"
+            )
+        # Parse "xpu", "xpu:0", "xpu:1" etc.
+        idx = 0
+        if ":" in device:
+            idx = int(device.split(":")[1])
+        if idx >= torch.xpu.device_count():
+            raise ValueError(
+                f"Invalid XPU 'device={device}' requested. Only {torch.xpu.device_count()} XPU device(s) available."
+            )
+        s += f"XPU:{idx} ({torch.xpu.get_device_name(idx)})\n"
+        arg = f"xpu:{idx}"
+        if verbose:
+            LOGGER.info(s if newline else s.rstrip())
+        return torch.device(arg)
+
     # Auto-select GPUs
     if "-1" in device:
         from ultralytics.utils.autodevice import GPUInfo
@@ -244,6 +269,10 @@ def select_device(device="", newline=False, verbose=True):
         for i, d in enumerate(devices):
             s += f"{'' if i == 0 else space}CUDA:{d} ({get_gpu_info(i)})\n"  # bytes to MB
         arg = "cuda:0"
+    elif not cpu and not mps and hasattr(torch, "xpu") and torch.xpu.is_available():
+        # Auto-detect XPU when no specific device is requested
+        s += f"XPU:0 ({torch.xpu.get_device_name(0)})\n"
+        arg = "xpu:0"
     elif mps and TORCH_2_0 and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f"MPS ({get_cpu_info()})\n"


### PR DESCRIPTION
Reopened from #23682 (could not reopen after branch recreation). Relates to #16930.

## Summary

- Teach `select_device()` to accept `device="xpu"` / `"xpu:0"` without treating it as a CUDA index, and auto-detect XPU when no device is specified
- Remove hard-coded `"cuda"` strings in AMP/training setup by threading `self.device.type` through `GradScaler` and `autocast`
- Add XPU branches for memory reporting, cache clearing, OOM handling, and AMP compatibility checks

This follows up on @human-01's [comment on #16930](https://github.com/ultralytics/ultralytics/issues/16930#issuecomment-2794700981) identifying the specific fix points, and @glenn-jocher's [invitation to submit a PR](https://github.com/ultralytics/ultralytics/issues/16930#issuecomment-2801283705).

## Changes (3 files, 7 fix points)

### `ultralytics/utils/torch_utils.py` — `select_device()`

1. **Explicit XPU branch** — parses `"xpu"`, `"xpu:0"`, `"xpu:1"` etc., validates availability and device index, returns `torch.device("xpu:N")`
2. **Auto-detect fallback** — when no device is specified and no CUDA GPUs are found, checks `torch.xpu.is_available()` before falling back to MPS/CPU

### `ultralytics/engine/trainer.py` — `BaseTrainer`

3. **`GradScaler(self.device.type)`** instead of `GradScaler("cuda")` — device-generic, works for both CUDA and XPU
4. **`autocast(self.amp, device=self.device.type)`** — passes device type through instead of defaulting to `"cuda"`
5. **OOM handler** — catches `torch.xpu.OutOfMemoryError` alongside `torch.cuda.OutOfMemoryError` (guarded by `hasattr` check)
6. **`_get_memory()`** — XPU branch using `torch.xpu.memory_reserved()` and `torch.xpu.get_device_properties()`
7. **`_clear_memory()`** — XPU branch using `torch.xpu.empty_cache()`

### `ultralytics/utils/checks.py` — `check_amp()`

- XPU devices skip the NVIDIA-specific AMP incompatibility check (no known AMP-incompatible Intel GPUs)
- Uses `torch.xpu.get_device_name()` for XPU device identification
- Passes `device=device.type` to `autocast()` in the AMP validation test

## Environment

```
Ultralytics 8.4.14 🚀 Python-3.12.12 torch-2.10.0+xpu XPU:0 (Intel(R) Graphics [0x56a0])
Setup complete ✅ (24 CPUs, 39.1 GB RAM, 71.7/1006.9 GB disk)
```

- Intel Arc A770 16GB
- torch 2.10.0+xpu (`pip install torch --index-url https://download.pytorch.org/whl/xpu`)
- Python 3.12, Linux (WSL2)

## Minimum Reproducible Example

```python
from ultralytics.utils.torch_utils import select_device

# Explicit XPU selection
dev = select_device("xpu")
print(f'select_device("xpu") -> {dev}')
# Output: select_device("xpu") -> xpu:0

# Auto-detect (finds XPU when no CUDA available)
dev = select_device("")
print(f'select_device("") -> {dev}')
# Output: select_device("") -> xpu:0
```

YOLOv8n training completes successfully on Arc A770 with these changes (100 epochs, 225-image dataset, ~23 minutes, ~4.2GB VRAM reported correctly).

## Design notes

- Fix points 3 and 4 (`GradScaler` and `autocast`) are device-generic — they use `self.device.type` which works for CUDA, XPU, and any future device that PyTorch's AMP subsystem supports
- Fix points 5-7 (memory/OOM) require device-specific API calls since PyTorch doesn't yet have a unified memory API; these follow the existing MPS pattern in the codebase
- All XPU-specific code is guarded by `hasattr(torch, "xpu")` checks so it's safe on systems without XPU support

## Disclosure

This PR was authored by an AI agent ([rsn-opencode](https://github.com/rsn-opencode)) on behalf of @human-01, who identified the fix points and verified the changes on physical hardware. We believe in transparency about AI-assisted contributions.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enable first-class Intel XPU (Arc GPU) support across device selection, AMP/autocast, and memory/OOM handling. ⚡️

### 📊 Key Changes
- Add `xpu`/`xpu:0` parsing and auto-detection to `select_device()` for Intel XPU-capable PyTorch builds.
- Update training AMP plumbing to use `device.type` for `GradScaler` and `autocast`, improving compatibility beyond CUDA.
- Extend OOM handling to catch Intel XPU OOM errors (when available) and make the retry log device-aware.
- Add XPU memory querying and cache clearing paths (`_get_memory()`, `_clear_memory()`).
- Update AMP checks to support XPU devices and run AMP inference with device-aware autocast.

### 🎯 Purpose & Impact
- Improve out-of-the-box training/inference usability on Intel Arc/Data Center GPUs using `device=xpu`. 🚀
- Make mixed precision and memory management behavior consistent across CUDA, MPS, and XPU backends.
- Reduce friction for users by auto-selecting XPU when available and no explicit device is provided.
