### PR TITLE
Add version constraint support for git URL requirements

### DIFF
--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -459,10 +459,9 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
 
         if not satisfied:
             pkg = candidates[0]
-            if "git+" in pkg:
-                parts = pkg.split(";", 1)  # preserve environment markers after ';'
-                parts[0] = re.sub(r"[<>!=~]+.*$", "", parts[0])  # strip version constraints from git URL
-                pkg = ";".join(parts)
+            if "git+" in pkg:  # strip version constraints from git URLs for pip
+                url, sep, marker = pkg.partition(";")
+                pkg = re.sub(r"[<>!=~]+.*$", "", url) + sep + marker
             pkgs.append(pkg)
 
     @Retry(times=2, delay=1)

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -458,7 +458,10 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
                 continue
 
         if not satisfied:
-            pkgs.append(candidates[0])
+            pkg = candidates[0]
+            if "git+" in pkg:
+                pkg = re.sub(r"[<>!=~]+.*$", "", pkg)  # strip version constraints from git URLs for pip
+            pkgs.append(pkg)
 
     @Retry(times=2, delay=1)
     def attempt_install(packages, commands, use_uv):

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -460,7 +460,9 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         if not satisfied:
             pkg = candidates[0]
             if "git+" in pkg:
-                pkg = re.sub(r"[<>!=~]+.*$", "", pkg)  # strip version constraints from git URLs for pip
+                parts = pkg.split(";", 1)  # preserve environment markers after ';'
+                parts[0] = re.sub(r"[<>!=~]+.*$", "", parts[0])  # strip version constraints from git URL
+                pkg = ";".join(parts)
             pkgs.append(pkg)
 
     @Retry(times=2, delay=1)


### PR DESCRIPTION
## Before (installed: diffusers==0.36.0)

```
>>> check_requirements("git+https://github.com/huggingface/diffusers.git>=0.37.0")
# Parsing: name="diffusers", required=">=0.37.0" ✓
# Install: pip install "git+https://github.com/huggingface/diffusers.git>=0.37.0"
# ERROR: git clone 'https://github.com/huggingface/diffusers.git>=0.37.0' failed (invalid URL)
```

## After (installed: diffusers==0.36.0)

```
>>> check_requirements("git+https://github.com/huggingface/diffusers.git>=0.37.0")
requirements: Ultralytics requirement ['git+https://github.com/huggingface/diffusers.git'] not found, attempting AutoUpdate...
 - diffusers==0.36.0
 + diffusers==0.37.0.dev0 (from git+https://github.com/huggingface/diffusers.git)
requirements: AutoUpdate success ✅ 5.1s
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves dependency auto-install by cleaning up `git+` requirement strings before passing them to `pip` 🧩🛠️

### 📊 Key Changes
- Strips version constraints from `git+...` requirement entries when a dependency is missing, ensuring `pip` receives a valid install target 🔗
- Preserves environment markers (e.g., `; python_version < ...`) while sanitizing the Git URL requirement 🧼
- Applies this cleanup only to unsatisfied requirements that are candidates for auto-install ✅

### 🎯 Purpose & Impact
- Prevents failed installs caused by invalid version specifiers attached to Git-based dependencies (e.g., `git+https://...>=1.2.3`) 🚫❌
- Makes `ultralytics` setup and runtime dependency checks more reliable across dev and CI environments 🤖⚙️
- Reduces friction for users installing from source or using Git-pinned dependencies, leading to smoother first-run experiences 🚀🙂