### PR TITLE
Fix division by zero in PSABlock `num_heads`

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1524,7 +1524,7 @@ class C2fPSA(C2f):
         """
         assert c1 == c2
         super().__init__(c1, c2, n=n, e=e)
-        self.m = nn.ModuleList(PSABlock(self.c, attn_ratio=0.5, num_heads=self.c // 64) for _ in range(n))
+        self.m = nn.ModuleList(PSABlock(self.c, attn_ratio=0.5, num_heads=max(self.c // 64, 1)) for _ in range(n))
 
 
 class SCDown(nn.Module):


### PR DESCRIPTION
Fix error when width is less than 0.25.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes a small but important attention-module edge case by ensuring the number of attention heads is never zero in `C2PSA` blocks.

### 📊 Key Changes
- Updated `ultralytics/nn/modules/block.py` in the `C2PSA` initialization logic.
- Changed `num_heads` calculation in `PSABlock` from:
  - `self.c // 64`
  to
  - `max(self.c // 64, 1)`
- This guarantees at least **1 attention head** even when channel counts are low (`self.c < 64`).

### 🎯 Purpose & Impact
- ✅ Prevents invalid model configurations that could occur with small channel sizes.
- ✅ Improves robustness and reliability of PSA-based blocks across more model scales.
- ✅ Reduces risk of runtime errors during model build/train for lightweight or custom architectures.
- 🚀 Makes the codebase safer for broader usage without changing behavior for normal/high-channel settings.