### PR TITLE
Fix for #23765 FastSAM CLIP prompting

### DIFF
--- a/ultralytics/models/fastsam/predict.py
+++ b/ultralytics/models/fastsam/predict.py
@@ -134,10 +134,7 @@ class FastSAMPredictor(SegmentationPredictor):
                     if (masks[i].sum() if TORCH_1_10 else masks[i].sum(0).sum()) <= 100:  # torch 1.9 bug workaround
                         filter_idx.append(i)
                         continue
-                    crop = result.orig_img[y1:y2, x1:x2].copy()
-                    crop[masks[i, y1:y2, x1:x2].cpu().numpy() == 0] = (
-                        255  # Mask off other segments before passing to CLIP
-                    )
+                    crop = result.orig_img[y1:y2, x1:x2] * masks[i, y1:y2, x1:x2, None].cpu().numpy()
                     crop_ims.append(Image.fromarray(crop[:, :, ::-1]))
                 similarity = self._clip_inference(crop_ims, texts)
                 text_idx = torch.argmax(similarity, dim=-1)  # (M, )

--- a/ultralytics/models/fastsam/predict.py
+++ b/ultralytics/models/fastsam/predict.py
@@ -134,7 +134,9 @@ class FastSAMPredictor(SegmentationPredictor):
                     if (masks[i].sum() if TORCH_1_10 else masks[i].sum(0).sum()) <= 100:  # torch 1.9 bug workaround
                         filter_idx.append(i)
                         continue
-                    crop_ims.append(Image.fromarray(result.orig_img[y1:y2, x1:x2, ::-1]))
+                    crop = result.orig_img[y1:y2, x1:x2].copy()
+                    crop[masks[i, y1:y2, x1:x2].cpu().numpy() == 0] = 255  # Mask off other segments before passing to CLIP
+                    crop_ims.append(Image.fromarray(crop[:, :, ::-1]))
                 similarity = self._clip_inference(crop_ims, texts)
                 text_idx = torch.argmax(similarity, dim=-1)  # (M, )
                 if len(filter_idx):

--- a/ultralytics/models/fastsam/predict.py
+++ b/ultralytics/models/fastsam/predict.py
@@ -135,7 +135,9 @@ class FastSAMPredictor(SegmentationPredictor):
                         filter_idx.append(i)
                         continue
                     crop = result.orig_img[y1:y2, x1:x2].copy()
-                    crop[masks[i, y1:y2, x1:x2].cpu().numpy() == 0] = 255  # Mask off other segments before passing to CLIP
+                    crop[masks[i, y1:y2, x1:x2].cpu().numpy() == 0] = (
+                        255  # Mask off other segments before passing to CLIP
+                    )
                     crop_ims.append(Image.fromarray(crop[:, :, ::-1]))
                 similarity = self._clip_inference(crop_ims, texts)
                 text_idx = torch.argmax(similarity, dim=-1)  # (M, )


### PR DESCRIPTION
Fixes prompt-based FastSAM segmentation for cases where segments are convex and have inclusions of other segments inside them.

Example - a head backed by sky will produce a segment on sky, and a segment on head. The head segment is surrounded by the sky segment. If you pass just the bounding box of sky to CLIP, the bounding box will contain the head as well - now if you prompt for head, CLIP will return a positive for head.

And voila - now your sky segment is returning a false positive for head.

This fix uses masks to mask out the neighbouring segments. No massive effort has been made to make this efficient, because CLIP is by far the biggest bottleneck.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves FastSAM text prompting by masking non-target pixels before CLIP inference, fixing incorrect similarity scoring in segmented crops. 🛠️🎯

### 📊 Key Changes
- Updated `ultralytics/models/fastsam/predict.py` in `prompt()` crop preparation logic.
- Replaced direct bbox crop input to CLIP with a masked crop based on the current segment mask.
- Added `copy()` on the image crop before editing pixel values.
- Set pixels outside the active mask region to white (`255`) before converting to PIL for CLIP.
- Kept existing small-mask filtering and similarity selection flow intact.

### 🎯 Purpose & Impact
- Reduces prompt confusion by preventing background and neighboring objects from influencing CLIP text matching.
- Improves FastSAM text-prompt reliability, especially in crowded scenes with overlapping objects.
- Provides a focused bug fix with minimal code changes and low integration risk for users relying on FastSAM segmentation prompts. 🚀