### PR TITLE
Add `hard` param to `check_suffix` for boolean mode

### DIFF
--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -566,20 +566,28 @@ def check_torchvision():
             )
 
 
-def check_suffix(file="yolo26n.pt", suffix=".pt", msg=""):
+def check_suffix(file: str = "yolo26n.pt", suffix: str | tuple = ".pt", msg: str = "", hard: bool = True) -> bool:
     """Check file(s) for acceptable suffix.
 
     Args:
         file (str | list[str]): File or list of files to check.
         suffix (str | tuple): Acceptable suffix or tuple of suffixes.
         msg (str): Additional message to display in case of error.
+        hard (bool): Whether to raise an error if the suffix doesn't match.
+
+    Returns:
+        (bool): True if suffix is valid, False otherwise (when hard=False).
     """
     if file and suffix:
         if isinstance(suffix, str):
             suffix = {suffix}
         for f in file if isinstance(file, (list, tuple)) else [file]:
             if s := str(f).rpartition(".")[-1].lower().strip():  # file suffix
-                assert f".{s}" in suffix, f"{msg}{f} acceptable suffix is {suffix}, not .{s}"
+                if f".{s}" not in suffix:
+                    if hard:
+                        raise AssertionError(f"{msg}{f} acceptable suffix is {suffix}, not .{s}")
+                    return False
+    return True
 
 
 def check_yolov5u_filename(file: str, verbose: bool = True) -> str:

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -566,7 +566,12 @@ def check_torchvision():
             )
 
 
-def check_suffix(file: str = "yolo26n.pt", suffix: str | tuple = ".pt", msg: str = "", hard: bool = True) -> bool:
+def check_suffix(
+    file: str | list[str] | tuple[str, ...] = "yolo26n.pt",
+    suffix: str | tuple[str, ...] = ".pt",
+    msg: str = "",
+    hard: bool = True,
+) -> bool:
     """Check file(s) for acceptable suffix.
 
     Args:


### PR DESCRIPTION
Add `hard` param to `check_suffix()` (default `True`, fully backwards compatible). When `hard=False`, returns `True`/`False` instead of raising `AssertionError`, allowing suffix checks without exception handling.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
`check_suffix()` in `ultralytics/utils/checks.py` was upgraded to be more flexible and safer, adding optional non-throwing validation while keeping existing default behavior ✅

### 📊 Key Changes
- Added richer type hints to `check_suffix()` for clearer input support:
  - `file`: `str | list[str] | tuple[str, ...]`
  - `suffix`: `str | tuple[str, ...]`
- Added a new parameter: `hard: bool = True` ⚙️
  - `hard=True` (default): behaves like before, raising an error on invalid suffix.
  - `hard=False`: returns `False` instead of raising.
- Updated function return behavior to explicitly return `bool`:
  - Returns `True` when suffixes are valid.
  - Returns `False` on invalid suffix only when `hard=False`.
- Expanded docstring to document the new parameter and return values 📘.
- Replaced inline assertion with explicit conditional error handling (`raise AssertionError(...)`) for clearer control flow.

### 🎯 Purpose & Impact
- Makes suffix checking more reusable across different workflows 🧩:
  - Strict mode for hard validation.
  - Soft mode for graceful handling in pipelines/UI logic.
- Improves developer experience with clearer typing and documented behavior 👨‍💻.
- Preserves backward compatibility for existing code paths since default behavior is unchanged (`hard=True`) 🔒.
- Enables cleaner error handling in user-facing tools where crashes should be avoided 🚀.