### PR TITLE
 Apply  to ByteTracker second association

### DIFF
--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -338,8 +338,9 @@ class BYTETracker:
         # Step 3: Second association, with low score detection boxes association the untrack to the low score detections
         detections_second = self.init_track(results_second, feats_second)
         r_tracked_stracks = [strack_pool[i] for i in u_track if strack_pool[i].state == TrackState.Tracked]
-        # TODO: consider fusing scores or appearance features for second association.
         dists = matching.iou_distance(r_tracked_stracks, detections_second)
+        if self.args.fuse_score:
+            dists = matching.fuse_score(dists, detections_second)
         matches, u_track, _u_detection_second = matching.linear_assignment(dists, thresh=0.5)
         for itracked, idet in matches:
             track = r_tracked_stracks[itracked]


### PR DESCRIPTION
## Description

ByteTracker's second association step (low-score detections) was using plain
IoU distance while the first association already supported score fusion via
the `fuse_score` argument. This inconsistency was noted in a `TODO` comment.

This PR applies `fuse_score` to the second association as well, making both
steps consistent and allowing detection confidence to inform the cost matrix
when `fuse_score=True`.

## Changes

- Remove `TODO` comment in `byte_tracker.py`
- Apply `matching.fuse_score()` to second association when `self.args.fuse_score` is enabled

## Notes

Behaviour is unchanged when `fuse_score=False` (default). No new arguments
or imports introduced.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves ByteTracker’s second association step by optionally applying score fusion to low-confidence detection matching for more consistent tracking behavior. 🔧🎯

### 📊 Key Changes
- Added conditional score fusion in `ultralytics/trackers/byte_tracker.py` during ByteTracker Step 3 (second association).
- New logic applies `matching.fuse_score(dists, detections_second)` when `self.args.fuse_score` is enabled.
- Removed the prior TODO comment and implemented the score-fusion path directly. ✅

### 🎯 Purpose & Impact
- Aligns second-association matching behavior with configurable score-aware distance fusion.
- Can improve robustness when reconnecting tracked objects using low-score detections.
- Keeps behavior backward-compatible by gating the change behind `self.args.fuse_score`.