### PR TITLE
`ultralytics 8.4.20` Remove redundant hardcoded `tuner_callbacks`

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.19"
+__version__ = "8.4.20"
 
 import importlib
 import os

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -41,7 +41,6 @@ def run_ray_tune(
         import ray
         from ray import tune
         from ray.air import RunConfig
-        from ray.air.integrations.wandb import WandbLoggerCallback
         from ray.tune.schedulers import ASHAScheduler
     except ImportError:
         raise ModuleNotFoundError('Ray Tune required but not found. To install run: pip install "ray[tune]"')

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -128,9 +128,6 @@ def run_ray_tune(
         reduction_factor=3,
     )
 
-    # Define the callbacks for the hyperparameter search
-    tuner_callbacks = [WandbLoggerCallback(project="YOLOv8-tune")] if wandb else []
-
     # Create the Ray Tune hyperparameter search tuner
     tune_dir = get_save_dir(
         get_cfg(
@@ -153,7 +150,7 @@ def run_ray_tune(
                 trial_name_creator=lambda trial: f"{trial.trainable_name}_{trial.trial_id}",
                 trial_dirname_creator=lambda trial: f"{trial.trainable_name}_{trial.trial_id}",
             ),
-            run_config=RunConfig(callbacks=tuner_callbacks, storage_path=tune_dir.parent, name=tune_dir.name),
+            run_config=RunConfig(storage_path=tune_dir.parent, name=tune_dir.name),
         )
 
     # Run the hyperparameter search


### PR DESCRIPTION
@lmycross see if this fix the issue

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR bumps Ultralytics to `v8.4.20` and simplifies Ray Tune integration by removing the Weights & Biases callback from hyperparameter tuning runs. 🚀

### 📊 Key Changes
- Updated package version in `ultralytics/__init__.py`:
  - `8.4.19` ➜ `8.4.20` 🔖
- In `ultralytics/utils/tuner.py`, removed Ray AIR W&B callback integration:
  - Deleted import of `WandbLoggerCallback` from `ray.air.integrations.wandb`
  - Removed creation of `tuner_callbacks` tied to the `wandb` flag
  - Updated `RunConfig(...)` to no longer pass `callbacks=...`, keeping only storage path and run name 🧹

### 🎯 Purpose & Impact
- Reduces dependency coupling between Ray Tune and W&B, making tuning setup cleaner and less fragile. ✅
- Lowers risk of callback-related issues when running distributed hyperparameter searches with Ray. ⚙️
- Users relying on automatic W&B logging via Ray Tune callbacks may see changed logging behavior and may need alternative logging setup if required. 📉
- Overall, this is a maintenance-focused cleanup release that improves robustness with minimal user-facing disruption. 👍