### PR TITLE
Update JetPack 6 Docker image with `torch 2.10`

### DIFF
--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -18,13 +18,14 @@ ADD https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf \
     /root/.config/Ultralytics/
 
 # Install dependencies and cleanup
-ADD https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb .
-RUN dpkg -i cuda-keyring_1.1-1_all.deb && \
+ADD https://developer.download.nvidia.com/compute/cudss/0.7.1/local_installers/cudss-local-tegra-repo-ubuntu2204-0.7.1_0.7.1-1_arm64.deb .
+RUN dpkg -i cudss-local-tegra-repo-ubuntu2204-0.7.1_0.7.1-1_arm64.deb && \
+    cp /var/cudss-local-tegra-repo-ubuntu2204-0.7.1/cudss-*-keyring.gpg /usr/share/keyrings/ && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    git python3-pip libopenmpi-dev libopenblas-base libomp-dev libcusparselt0 libcusparselt-dev && \
+    git python3-pip libopenmpi-dev libopenblas-base libomp-dev cudss && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* cuda-keyring_1.1-1_all.deb
+    rm -rf /var/lib/apt/lists/* 
 
 # Create working directory
 WORKDIR /ultralytics
@@ -39,8 +40,8 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 RUN python3 -m pip install --upgrade pip uv && \
     uv pip install --system \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.20.0-cp310-cp310-linux_aarch64.whl \
-    https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.5.0a0+872d972e41.nv24.08-cp310-cp310-linux_aarch64.whl \
-    https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.20.0a0+afc54f7-cp310-cp310-linux_aarch64.whl && \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.10.0-cp310-cp310-linux_aarch64.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.25.0-cp310-cp310-linux_aarch64.whl && \
     uv pip install --system -e ".[export]" && \
     # Remove extra build files
     rm -rf *.whl /root/.config/Ultralytics/persistent_cache.json

--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -39,7 +39,7 @@ ADD https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n.pt .
 # Pip install onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files
 RUN python3 -m pip install --upgrade pip uv && \
     uv pip install --system \
-    https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.20.0-cp310-cp310-linux_aarch64.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.23.0-cp310-cp310-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.10.0-cp310-cp310-linux_aarch64.whl \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.25.0-cp310-cp310-linux_aarch64.whl && \
     uv pip install --system -e ".[export]" && \

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -195,25 +195,16 @@ Here we will install Ultralytics package on the Jetson with optional dependencie
 
 The above ultralytics installation will install Torch and Torchvision. However, these two packages installed via pip are not compatible with the Jetson platform, which is based on ARM64 architecture. Therefore, we need to manually install a pre-built PyTorch pip wheel and compile or install Torchvision from source.
 
-Install `torch 2.5.0` and `torchvision 0.20` according to JP6.1
+Install `torch 2.10.0` and `torchvision 0.25.0` according to JP6.1
 
 ```bash
-pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.5.0a0+872d972e41.nv24.08-cp310-cp310-linux_aarch64.whl
-pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.20.0a0+afc54f7-cp310-cp310-linux_aarch64.whl
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.10.0-cp310-cp310-linux_aarch64.whl
+pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.25.0-cp310-cp310-linux_aarch64.whl
 ```
 
 !!! note
 
     Visit the [PyTorch for Jetson page](https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048) to access all different versions of PyTorch for different JetPack versions. For a more detailed list on the PyTorch, Torchvision compatibility, visit the [PyTorch and Torchvision compatibility page](https://github.com/pytorch/vision).
-
-Install [`cuSPARSELt`](https://developer.nvidia.com/cusparselt-downloads?target_os=Linux&target_arch=aarch64-jetson&Compilation=Native&Distribution=Ubuntu&target_version=22.04&target_type=deb_network) to fix a dependency issue with `torch 2.5.0`
-
-```bash
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb
-sudo dpkg -i cuda-keyring_1.1-1_all.deb
-sudo apt-get update
-sudo apt-get -y install libcusparselt0 libcusparselt-dev
-```
 
 #### Install `onnxruntime-gpu`
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refreshes Jetson JetPack 6 support by upgrading core AI runtime packages and simplifying CUDA-related dependencies for a cleaner, more reliable Ultralytics setup 🚀

### 📊 Key Changes
- Updated `docker/Dockerfile-jetson-jetpack6` to install newer Jetson-compatible wheels:
  - `torch` → `2.10.0` (from `2.5.0a0...`)
  - `torchvision` → `0.25.0` (from `0.20.0a0...`)
  - `onnxruntime-gpu` → `1.23.0` (from `1.20.0`) 📦
- Replaced old CUDA keyring setup with a cuDSS local Tegra repo installer and keyring copy step for package trust/availability 🔐
- Swapped cuSPARSELt packages (`libcusparselt0`, `libcusparselt-dev`) for direct `cudss` installation in the Jetson Docker image 🛠️
- Simplified cleanup in Docker build steps (removed deletion of old keyring `.deb` file reference)
- Updated Jetson documentation (`docs/en/guides/nvidia-jetson.md`) to match the new PyTorch/Torchvision versions and removed now-unneeded cuSPARSELt manual install instructions 🧾

### 🎯 Purpose & Impact
- Improves compatibility and stability for Jetson JP6.1 users by aligning with newer prebuilt ARM64 packages ✅
- Reduces setup friction by removing outdated dependency workaround steps, making installs easier for both new and experienced users 🙌
- Keeps docs and Docker behavior in sync, lowering confusion and support burden 📘
- Likely improves deployment readiness for YOLO models on Jetson edge devices through a more modern runtime stack ⚡