### PR TITLE
Reset trainer before each trial with Ray Tune

### DIFF
--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -89,6 +89,7 @@ def run_ray_tune(
     def _tune(config):
         """Train the YOLO model with the specified hyperparameters and return results."""
         model_to_train = ray.get(model_in_store)  # get the model from ray store for tuning
+        model_to_train.trainer = None
         model_to_train.reset_callbacks()
         config.update(train_args)
 


### PR DESCRIPTION
Closes #23791 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds a small but important reset step in Ray Tune workflows to clear stale trainer state before each tuning run, improving reliability and isolation of hyperparameter trials 🛠️.

### 📊 Key Changes
- In `ultralytics/utils/tuner.py`, inside `run_ray_tune()` → `_tune(config)`, a new line was added: `model_to_train.trainer = None`.
- This reset happens right after retrieving the model from Ray object storage and before callback reset/training args update.
- Existing callback reset logic (`model_to_train.reset_callbacks()`) remains in place, now paired with explicit trainer-state clearing.

### 🎯 Purpose & Impact
- Prevents unintended reuse of prior trainer state across Ray Tune trials 🔁.
- Makes each hyperparameter trial more independent and reproducible ✅.
- Reduces risk of hard-to-debug tuning issues caused by lingering internal state 🧩.
- Improves stability of automated tuning pipelines for users training YOLO models at scale 🚀.