### PR TITLE
Docs: Add explanation for when MuSGD optimizer is used 

### DIFF
--- a/docs/en/guides/model-training-tips.md
+++ b/docs/en/guides/model-training-tips.md
@@ -147,20 +147,28 @@ You can also fine-tune optimizer parameters to improve model performance. Adjust
 Different optimizers have various strengths and weaknesses. Let's take a glimpse at a few common optimizers.
 
 - **SGD (Stochastic Gradient Descent)**:
-    - Updates model parameters using the gradient of the loss function with respect to the parameters.
-    - Simple and efficient but can be slow to converge and might get stuck in local minima.
+  - Updates model parameters using the gradient of the loss function with respect to the parameters.
+  - Simple and efficient but can be slow to converge and might get stuck in local minima.
 
 - **[Adam](https://www.ultralytics.com/glossary/adam-optimizer) (Adaptive Moment Estimation)**:
-    - Combines the benefits of both SGD with momentum and RMSProp.
-    - Adjusts the learning rate for each parameter based on estimates of the first and second moments of the gradients.
-    - Well-suited for noisy data and sparse gradients.
-    - Efficient and generally requires less tuning, making it a recommended optimizer for YOLO26.
+  - Combines the benefits of both SGD with momentum and RMSProp.
+  - Adjusts the learning rate for each parameter based on estimates of the first and second moments of the gradients.
+  - Well-suited for noisy data and sparse gradients.
+  - Efficient and generally requires less tuning, making it a recommended optimizer for YOLO26.
 
 - **RMSProp (Root Mean Square Propagation)**:
-    - Adjusts the learning rate for each parameter by dividing the gradient by a running average of the magnitudes of recent gradients.
-    - Helps in handling the vanishing gradient problem and is effective for [recurrent neural networks](https://www.ultralytics.com/glossary/recurrent-neural-network-rnn).
+  - Adjusts the learning rate for each parameter by dividing the gradient by a running average of the magnitudes of recent gradients.
+  - Helps in handling the vanishing gradient problem and is effective for [recurrent neural networks](https://www.ultralytics.com/glossary/recurrent-neural-network-rnn).
 
 For YOLO26, the `optimizer` parameter lets you choose from various optimizers, including SGD, Adam, AdamW, NAdam, RAdam, and RMSProp, or you can set it to `auto` for automatic selection based on model configuration.
+
+For longer YOLO26 training runs or larger datasets, the **MuSGD** optimizer can also be used.
+
+Example:
+
+```bash
+yolo train model=yolo26n.pt data=coco8.yaml optimizer=MuSGD
+```
 
 ## Connecting with the Community
 

--- a/docs/en/guides/model-training-tips.md
+++ b/docs/en/guides/model-training-tips.md
@@ -147,18 +147,18 @@ You can also fine-tune optimizer parameters to improve model performance. Adjust
 Different optimizers have various strengths and weaknesses. Let's take a glimpse at a few common optimizers.
 
 - **SGD (Stochastic Gradient Descent)**:
-  - Updates model parameters using the gradient of the loss function with respect to the parameters.
-  - Simple and efficient but can be slow to converge and might get stuck in local minima.
+    - Updates model parameters using the gradient of the loss function with respect to the parameters.
+    - Simple and efficient but can be slow to converge and might get stuck in local minima.
 
 - **[Adam](https://www.ultralytics.com/glossary/adam-optimizer) (Adaptive Moment Estimation)**:
-  - Combines the benefits of both SGD with momentum and RMSProp.
-  - Adjusts the learning rate for each parameter based on estimates of the first and second moments of the gradients.
-  - Well-suited for noisy data and sparse gradients.
-  - Efficient and generally requires less tuning, making it a recommended optimizer for YOLO26.
+    - Combines the benefits of both SGD with momentum and RMSProp.
+    - Adjusts the learning rate for each parameter based on estimates of the first and second moments of the gradients.
+    - Well-suited for noisy data and sparse gradients.
+    - Efficient and generally requires less tuning, making it a recommended optimizer for YOLO26.
 
 - **RMSProp (Root Mean Square Propagation)**:
-  - Adjusts the learning rate for each parameter by dividing the gradient by a running average of the magnitudes of recent gradients.
-  - Helps in handling the vanishing gradient problem and is effective for [recurrent neural networks](https://www.ultralytics.com/glossary/recurrent-neural-network-rnn).
+    - Adjusts the learning rate for each parameter by dividing the gradient by a running average of the magnitudes of recent gradients.
+    - Helps in handling the vanishing gradient problem and is effective for [recurrent neural networks](https://www.ultralytics.com/glossary/recurrent-neural-network-rnn).
 
 For YOLO26, the `optimizer` parameter lets you choose from various optimizers, including SGD, Adam, AdamW, NAdam, RAdam, and RMSProp, or you can set it to `auto` for automatic selection based on model configuration.
 

--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -226,6 +226,16 @@ Remember that checkpoints are saved at the end of every epoch by default, or at 
 
 The training settings for YOLO models encompass various hyperparameters and configurations used during the training process. These settings influence the model's performance, speed, and [accuracy](https://www.ultralytics.com/glossary/accuracy). Key training settings include batch size, learning rate, momentum, and weight decay. Additionally, the choice of optimizer, [loss function](https://www.ultralytics.com/glossary/loss-function), and training dataset composition can impact the training process. Careful tuning and experimentation with these settings are crucial for optimizing performance.
 
+### MuSGD Optimizer
+
+In YOLO26, **MuSGD** is a hybrid optimizer that combines standard **SGD** updates with **Muon-style orthogonalized updates**.
+
+Only parameters with `param.ndim >= 2` (such as convolutional weights) receive the Muon style update together with SGD, while lower dimensional parameters like batch normalization layers and bias terms remain on standard SGD.
+
+When `optimizer=auto` is used, Ultralytics automatically selects **MuSGD** for longer training runs (typically when iterations > 10000). For shorter runs, the trainer falls back to **AdamW**.
+
+See the implementation in `ultralytics/optim/muon.py` and the optimizer auto-selection logic in `BaseTrainer.build_optimizer`.
+
 {% include "macros/train-args.md" %}
 
 !!! info "Note on Batch-size Settings"

--- a/docs/en/modes/train.md
+++ b/docs/en/modes/train.md
@@ -230,9 +230,17 @@ The training settings for YOLO models encompass various hyperparameters and conf
 
 In YOLO26, **MuSGD** is a hybrid optimizer that combines standard **SGD** updates with **Muon-style orthogonalized updates**.
 
+It is **recommended for longer YOLO26 training runs and larger datasets**, where orthogonalized Muon updates can help stabilize optimization.
+
 Only parameters with `param.ndim >= 2` (such as convolutional weights) receive the Muon style update together with SGD, while lower dimensional parameters like batch normalization layers and bias terms remain on standard SGD.
 
 When `optimizer=auto` is used, Ultralytics automatically selects **MuSGD** for longer training runs (typically when iterations > 10000). For shorter runs, the trainer falls back to **AdamW**.
+
+Example usage:
+
+```bash
+yolo train model=yolo26n.pt data=coco8.yaml optimizer=MuSGD
+```
 
 See the implementation in `ultralytics/optim/muon.py` and the optimizer auto-selection logic in `BaseTrainer.build_optimizer`.
 


### PR DESCRIPTION
Adds a short explanation of the MuSGD optimizer in YOLO26 training.

This clarifies:
- which parameters receive Muon updates
- when MuSGD is selected automatically with optimizer=auto
- reference to the implementation and optimizer selection logic.

This was suggested during discussion about MuSGD usage.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds documentation to clarify when and how the MuSGD optimizer is used during YOLO26 training when `optimizer=auto`. 🚀

### 📊 Key Changes
- Added a new **MuSGD Optimizer** subsection in `docs/en/modes/train.md`.
- Explained that MuSGD in YOLO26 combines standard SGD behavior with Muon-style orthogonalized updates.
- Documented parameter handling behavior:
  - `param.ndim >= 2` uses Muon-style updates alongside SGD.
  - Lower-dimensional parameters (like BN and bias) remain on standard SGD.
- Clarified `optimizer=auto` behavior:
  - Uses **MuSGD** for longer runs (typically iterations > 10000).
  - Falls back to **AdamW** for shorter runs.
- Added pointers to relevant implementation locations:
  - `ultralytics/optim/muon.py`
  - `BaseTrainer.build_optimizer`

### 🎯 Purpose & Impact
- Improves training docs clarity by documenting optimizer auto-selection behavior. 📘
- Helps users better understand why different optimizers are chosen across training durations.
- Reduces confusion around MuSGD scope and expected behavior for different parameter types.
- Strengthens trust and reproducibility by connecting documentation directly to implementation references. 🔍