### PR TITLE
Fix RKNN exports to support YOLO26 models

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1264,7 +1264,7 @@ class Exporter:
 
         from rknn.api import RKNN
 
-        self.args.opset = 19  # rknn-toolkit expects opset<=19
+        self.args.opset = min(self.args.opset or 19, 19)  # rknn-toolkit expects opset<=19
         f = self.export_onnx()
         export_path = Path(f"{Path(f).stem}_rknn_model")
         export_path.mkdir(exist_ok=True)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1254,7 +1254,7 @@ class Exporter:
         """Export YOLO model to RKNN format."""
         LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
 
-        check_requirements("rknn-toolkit2")
+        check_requirements("rknn-toolkit2", cmds="--no-deps")
         if IS_COLAB:
             # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259
             import builtins
@@ -1263,6 +1263,7 @@ class Exporter:
 
         from rknn.api import RKNN
 
+        self.args.opset = 19 # rknn-toolkit expects opset<=19 
         f = self.export_onnx()
         export_path = Path(f"{Path(f).stem}_rknn_model")
         export_path.mkdir(exist_ok=True)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1254,8 +1254,8 @@ class Exporter:
         """Export YOLO model to RKNN format."""
         LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
 
-        check_requirements("rknn-toolkit2", cmds="--no-deps") # no deps to avoid downgrading pytorch
-        check_requirements("onnx<1.19.0") # fix AttributeError: module 'onnx' has no attribute 'mapping'
+        check_requirements("rknn-toolkit2", cmds="--no-deps")  # no deps to avoid downgrading pytorch
+        check_requirements("onnx<1.19.0")  # fix AttributeError: module 'onnx' has no attribute 'mapping'
         if IS_COLAB:
             # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259
             import builtins
@@ -1264,7 +1264,7 @@ class Exporter:
 
         from rknn.api import RKNN
 
-        self.args.opset = 19 # rknn-toolkit expects opset<=19 
+        self.args.opset = 19  # rknn-toolkit expects opset<=19
         f = self.export_onnx()
         export_path = Path(f"{Path(f).stem}_rknn_model")
         export_path.mkdir(exist_ok=True)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1255,6 +1255,7 @@ class Exporter:
         LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
 
         check_requirements("rknn-toolkit2", cmds="--no-deps")
+        check_requirements("onnx<1.19.0")
         if IS_COLAB:
             # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259
             import builtins

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1254,7 +1254,7 @@ class Exporter:
         """Export YOLO model to RKNN format."""
         LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
 
-        check_requirements("rknn-toolkit2", cmds="--no-deps")  # no deps to avoid downgrading pytorch
+        check_requirements("rknn-toolkit2")
         check_requirements("onnx<1.19.0")  # fix AttributeError: module 'onnx' has no attribute 'mapping'
         if IS_COLAB:
             # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1254,8 +1254,7 @@ class Exporter:
         """Export YOLO model to RKNN format."""
         LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
 
-        check_requirements("rknn-toolkit2", cmds="--no-deps")
-        check_requirements("onnx<1.19.0")
+        check_requirements("rknn-toolkit2", "onnx<1.19.0", cmds="--no-deps")
         if IS_COLAB:
             # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259
             import builtins

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1254,7 +1254,8 @@ class Exporter:
         """Export YOLO model to RKNN format."""
         LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
 
-        check_requirements("rknn-toolkit2", "onnx<1.19.0", cmds="--no-deps")
+        check_requirements("rknn-toolkit2", cmds="--no-deps") # no deps to avoid downgrading pytorch
+        check_requirements("onnx<1.19.0") # fix AttributeError: module 'onnx' has no attribute 'mapping'
         if IS_COLAB:
             # Prevent 'exit' from closing the notebook https://github.com/airockchip/rknn-toolkit2/issues/259
             import builtins


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves RKNN export reliability by pinning compatible ONNX versions and enforcing a supported ONNX opset before conversion ⚙️✅

### 📊 Key Changes
- Added a dependency check for `onnx<1.19.0` during RKNN export.
- Included an inline note explaining this prevents the known error: `AttributeError: module 'onnx' has no attribute 'mapping'`.
- Capped ONNX opset to `<=19` with:
  - `self.args.opset = min(self.args.opset or 19, 19)`
- Applied these safeguards specifically in `export_rknn()` in `ultralytics/engine/exporter.py`.

### 🎯 Purpose & Impact
- Reduces RKNN export failures caused by version incompatibilities between `rknn-toolkit2` and newer ONNX releases 🛠️
- Makes exports more predictable by automatically selecting a toolkit-compatible opset.
- Improves user experience for Rockchip deployment workflows by requiring less manual troubleshooting 🚀
- Helps both new and advanced users get stable RKNN exports with fewer environment-related errors.