### PR TITLE
docs: clarify MuSGD usage in training optimizer guide

### DIFF
--- a/docs/en/guides/model-training-tips.md
+++ b/docs/en/guides/model-training-tips.md
@@ -167,10 +167,6 @@ Different optimizers have various strengths and weaknesses. Let's take a glimpse
 
 For YOLO26, the `optimizer` parameter lets you choose from various optimizers, including SGD, MuSGD, Adam, AdamW, NAdam, RAdam, and RMSProp, or you can set it to `auto` for automatic selection based on model configuration.
 
-For longer YOLO26 training runs or larger datasets, the **MuSGD** optimizer can also be used.
-
-Example:
-
 ```bash
 yolo train model=yolo26n.pt data=coco8.yaml optimizer=MuSGD
 ```

--- a/docs/en/guides/model-training-tips.md
+++ b/docs/en/guides/model-training-tips.md
@@ -160,7 +160,12 @@ Different optimizers have various strengths and weaknesses. Let's take a glimpse
     - Adjusts the learning rate for each parameter by dividing the gradient by a running average of the magnitudes of recent gradients.
     - Helps in handling the vanishing gradient problem and is effective for [recurrent neural networks](https://www.ultralytics.com/glossary/recurrent-neural-network-rnn).
 
-For YOLO26, the `optimizer` parameter lets you choose from various optimizers, including SGD, Adam, AdamW, NAdam, RAdam, and RMSProp, or you can set it to `auto` for automatic selection based on model configuration.
+- **MuSGD (Muon + SGD hybrid)**:
+    - Combines SGD-style updates with Muon-inspired behavior for improved stability in large-scale training.
+    - A good choice when you want SGD-like generalization but need smoother convergence than vanilla SGD.
+    - Especially relevant for YOLO26 training recipes; if unsure, start with `optimizer=auto` and compare against MuSGD on your dataset.
+
+For YOLO26, the `optimizer` parameter lets you choose from various optimizers, including SGD, MuSGD, Adam, AdamW, NAdam, RAdam, and RMSProp, or you can set it to `auto` for automatic selection based on model configuration.
 
 ## Connecting with the Community
 


### PR DESCRIPTION
## Summary
- add a dedicated MuSGD bullet under common optimizers
- explain how MuSGD differs from vanilla SGD in practical terms
- add simple guidance on when to try MuSGD vs 
- include MuSGD in the optimizer list sentence for YOLO26

## Related
- Closes #23789

## Testing
- docs-only change

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates the YOLO26 training optimizer documentation to clearly introduce MuSGD and include it in the supported optimizer list. ✨

### 📊 Key Changes
-Added a new **MuSGD (Muon + SGD hybrid)** subsection in `docs/en/guides/model-training-tips.md`.
-Documented MuSGD’s intended behavior, positioning, and when users may want to try it.
-Added practical guidance to compare MuSGD with `optimizer=auto` on user datasets.
-Updated the optimizer list for YOLO26 to explicitly include **MuSGD** alongside existing options (SGD, Adam, AdamW, NAdam, RAdam, RMSProp, and `auto`).

### 🎯 Purpose & Impact
-Improves documentation clarity around optimizer selection for YOLO26 users. 📘
-Helps reduce ambiguity by explicitly naming MuSGD as an available option.
-Gives practitioners clearer experimentation guidance, which can improve training stability and convergence outcomes in real projects. 🚀