### PR TITLE
Fix docs: Change insecure HTTP link to HTTPS

### DIFF
--- a/docs/en/datasets/detect/homeobjects-3k.md
+++ b/docs/en/datasets/detect/homeobjects-3k.md
@@ -57,7 +57,7 @@ HomeObjects-3K enables a wide spectrum of applications in indoor computer vision
 
 - **Scene layout parsing**: In robotics and smart home systems, this helps devices understand how rooms are arranged, where objects like doors, windows, and furniture are, so they can navigate safely and interact with their environment properly.
 
-- **AR applications**: Power [object recognition](http://ultralytics.com/glossary/image-recognition) features in apps that use augmented reality. For example, detect TVs or wardrobes and show extra information or effects on them.
+- **AR applications**: Power [object recognition](https://www.ultralytics.com/glossary/image-recognition) features in apps that use augmented reality. For example, detect TVs or wardrobes and show extra information or effects on them.
 
 - **Education and research**: Support learning and academic projects by giving students and researchers a ready-to-use dataset for practicing indoor object detection with real-world examples.
 


### PR DESCRIPTION
Changes insecure HTTP link to HTTPS in HomeObjects-3K dataset documentation for better security practices.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated one documentation link in the HomeObjects-3K dataset page from insecure HTTP to secure HTTPS for the object recognition glossary reference. 🔒

### 📊 Key Changes
- Replaced `http://ultralytics.com/glossary/image-recognition` with `https://www.ultralytics.com/glossary/image-recognition` in `docs/en/datasets/detect/homeobjects-3k.md`.
- Kept all surrounding content unchanged to ensure a minimal, targeted docs fix. ✨

### 🎯 Purpose & Impact
- Improves security and trust by avoiding mixed/insecure HTTP links in docs. 🛡️
- Enhances user experience with a modern, secure URL format.
- Reduces potential browser warnings and helps maintain documentation quality consistency. 📚