### PR TITLE
Update RUNNER_VERSION to 2.332.0

### DIFF
--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -7,7 +7,7 @@
 FROM ultralytics/ultralytics:latest
 
 # Set additional environment variables for runner
-ARG RUNNER_VERSION=2.329.0
+ARG RUNNER_VERSION=2.332.0
 ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive
 

--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -6,7 +6,7 @@
 # Start FROM Ultralytics GPU image
 FROM ultralytics/ultralytics:latest
 
-# Set additional environment variables for runner
+# Set additional environment variables for runner (no "v" on the version)
 ARG RUNNER_VERSION=2.332.0
 ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions runner version in `docker/Dockerfile-runner` from `2.329.0` to `2.332.0`, with a small clarification in the version comment.

### 📊 Key Changes
- ⬆️ Bumped `RUNNER_VERSION` in `docker/Dockerfile-runner`:
  - From `2.329.0`
  - To `2.332.0`
- 📝 Updated the inline comment to clarify runner version formatting (no `"v"` prefix).

### 🎯 Purpose & Impact
- ✅ Keeps the Ultralytics runner image aligned with newer GitHub Actions runner releases.
- 🔒 May include upstream reliability, compatibility, and security improvements from the newer runner version.
- 🛠️ Low-risk infrastructure maintenance change with no direct effect on model training/inference code, but helps CI stay stable and up to date.