### PR TITLE
fix: prevent ClearML task.connect() from overriding Ray Tune hyperparam

### DIFF
--- a/ultralytics/utils/callbacks/clearml.py
+++ b/ultralytics/utils/callbacks/clearml.py
@@ -77,7 +77,7 @@ def on_pretrain_routine_start(trainer) -> None:
                 "ClearML Initialized a new task. If you want to run remotely, "
                 "please add clearml-init and connect your arguments before initializing YOLO."
             )
-        task.connect(vars(trainer.args), name="General")
+        task.connect(vars(trainer.args), name="General", ignore_remote_overrides=True)
     except Exception as e:
         LOGGER.warning(f"ClearML installed but not initialized correctly, not logging this run. {e}")
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
# Fix ClearML callback overriding Ray Tune hyperparameters during remote execution

## Bug

Closes https://github.com/ultralytics/ultralytics/issues/23814

When using `model.tune(use_ray=True)` with ClearML remote execution (`clearml_agent execute`), **all Ray Tune trials produce identical model weights** despite being assigned different hyperparameters.

### Root Cause

In [ultralytics/utils/callbacks/clearml.py:80](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/clearml.py#L80):

```python
task.connect(vars(trainer.args), name="General")
```

`Task.connect()` is a **two-way binding** ([ClearML docs](https://clear.ml/docs/latest/docs/references/sdk/task#connect)):

> _"When running remotely, the value of the connected object is overridden by the corresponding value found under the experiment's UI/backend."_

During remote execution under `clearml_agent execute`:

1. **Trial 1** starts → [`on_pretrain_routine_start`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/clearml.py#L56-L82) → `task.connect()` **uploads** `lr0=A` to ClearML server ✅
2. **Trial 2** starts → [`on_pretrain_routine_start`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/callbacks/clearml.py#L56-L82) → `task.connect()` **downloads** `lr0=A` from server → **overrides** the Ray Tune sampled value `lr0=B` ❌
3. All trials train with the same hyperparameters → identical weights

When running locally (without `clearml_agent`), `task.connect()` only uploads (one-way), so trials work correctly.

### Call chain

```
model.tune()
  └─ run_ray_tune()                         # tuner.py
       └─ _tune(config)                     # called per trial by Ray
            └─ model_to_train.train(**config)
                 └─ BaseTrainer.__init__()   # trainer.py:126
                      ├─ self.args = get_cfg(cfg, overrides)   # lr0=<B> ✅
                      ├─ add_integration_callbacks(self)       # registers ClearML callback
                      └─ run_callbacks("on_pretrain_routine_start")
                           └─ clearml.on_pretrain_routine_start(trainer)
                                └─ task.connect(vars(trainer.args))  # 🔴 overrides lr0
```

## Fix

```diff
- task.connect(vars(trainer.args), name="General")
+ task.connect(vars(trainer.args), name="General", ignore_remote_overrides=True)
```

`ignore_remote_overrides=True` keeps `task.connect()` as **upload-only**: hyperparameters are still visible on the ClearML UI, but values from the server no longer override `trainer.args` during remote execution.

### Verified

I have tested this fix by monkey-patching `ultralytics.utils.callbacks.clearml.on_pretrain_routine_start` at runtime (replacing both the function and the `callbacks` dict entry in the module). With the patch applied, each Ray Tune trial correctly uses its own sampled hyperparameters and produces different model weights as expected.

<details>
<summary>Monkey-patch workaround (for users who cannot modify ultralytics source)</summary>

```python
import ultralytics.utils.callbacks.clearml as _clearml_cb

def _patched_on_pretrain_routine_start(trainer) -> None:
    """Patched: adds ignore_remote_overrides=True to task.connect()."""
    from clearml import Task
    try:
        if task := Task.current_task():
            from clearml.binding.frameworks.pytorch_bind import PatchPyTorchModelIO
            from clearml.binding.matplotlib_bind import PatchedMatplotlib
            PatchPyTorchModelIO.update_current_task(None)
            PatchedMatplotlib.update_current_task(None)
        else:
            task = Task.init(
                project_name=trainer.args.project or "Ultralytics",
                task_name=trainer.args.name,
                tags=["Ultralytics"],
                output_uri=True,
                reuse_last_task_id=False,
                auto_connect_frameworks={"pytorch": False, "matplotlib": False},
            )
        task.connect(vars(trainer.args), name="General", ignore_remote_overrides=True)
    except Exception as e:
        print(f"ClearML patched callback error: {e}")

# Patch both the function AND the callbacks dict in the module
_clearml_cb.on_pretrain_routine_start = _patched_on_pretrain_routine_start
_clearml_cb.callbacks["on_pretrain_routine_start"] = _patched_on_pretrain_routine_start
```

</details>

## Suggestion for discussion

When running Ray Tune, multiple trials share the same ClearML task, so each trial's `task.connect()` overwrites the previous trial's hyperparameters in the `"General"` section. To preserve per-trial hyperparameters on the ClearML UI, the section name could include the trial name:

```python
task.connect(vars(trainer.args), name=f"General/{trainer.args.name}", ignore_remote_overrides=True)
```

This creates separate subsections (e.g. `General/tune2`, `General/tune3`), making it easy to compare hyperparameters across trials directly on the ClearML UI. However, this changes the default section name from `"General"`, which may affect standard (non-tuning) training workflows. Would appreciate maintainers' input on the best approach here.

---

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes a ClearML integration issue by preventing `task.connect()` from overriding Ray Tune hyperparameter values during training runs. 🔧

### 📊 Key Changes
- Updates `ultralytics/utils/callbacks/clearml.py` in `on_pretrain_routine_start()`.
- Changes the ClearML connection call from `task.connect(vars(trainer.args), name="General")` to `task.connect(vars(trainer.args), name="General", ignore_remote_overrides=True)`.
- Ensures trainer arguments are logged to ClearML without allowing remote overrides to modify Ray Tune-managed hyperparameters.

### 🎯 Purpose & Impact
- Prevents unintended hyperparameter changes when using ClearML together with Ray Tune. ✅
- Improves reliability and reproducibility of hyperparameter tuning workflows. 📈
- Reduces integration friction for users combining experiment tracking and distributed tuning tools. 🤝