### PR TITLE
Remove unused `task` attribute from metrics classes

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1016,7 +1016,6 @@ class DetMetrics(SimpleClass, DataExportMixin):
         names (dict[int, str]): A dictionary of class names.
         box (Metric): An instance of the Metric class for storing detection results.
         speed (dict[str, float]): A dictionary for storing execution times of different parts of the detection process.
-        task (str): The task type, set to 'detect'.
         stats (dict[str, list]): A dictionary containing lists for true positives, confidence scores, predicted classes,
             target classes, and target images.
         nt_per_class: Number of targets per class.
@@ -1047,7 +1046,6 @@ class DetMetrics(SimpleClass, DataExportMixin):
         self.names = names
         self.box = Metric()
         self.speed = {"preprocess": 0.0, "inference": 0.0, "loss": 0.0, "postprocess": 0.0}
-        self.task = "detect"
         self.stats = dict(tp=[], conf=[], pred_cls=[], target_cls=[], target_img=[])
         self.nt_per_class = None
         self.nt_per_image = None
@@ -1186,7 +1184,6 @@ class SegmentMetrics(DetMetrics):
         box (Metric): An instance of the Metric class for storing detection results.
         seg (Metric): An instance of the Metric class to calculate mask segmentation metrics.
         speed (dict[str, float]): A dictionary for storing execution times of different parts of the detection process.
-        task (str): The task type, set to 'segment'.
         stats (dict[str, list]): A dictionary containing lists for true positives, confidence scores, predicted classes,
             target classes, and target images.
         nt_per_class: Number of targets per class.
@@ -1212,7 +1209,6 @@ class SegmentMetrics(DetMetrics):
         """
         DetMetrics.__init__(self, names)
         self.seg = Metric()
-        self.task = "segment"
         self.stats["tp_m"] = []  # add additional stats for masks
 
     def process(self, save_dir: Path = Path("."), plot: bool = False, on_plot=None) -> dict[str, np.ndarray]:
@@ -1324,7 +1320,6 @@ class PoseMetrics(DetMetrics):
         pose (Metric): An instance of the Metric class to calculate pose metrics.
         box (Metric): An instance of the Metric class for storing detection results.
         speed (dict[str, float]): A dictionary for storing execution times of different parts of the detection process.
-        task (str): The task type, set to 'pose'.
         stats (dict[str, list]): A dictionary containing lists for true positives, confidence scores, predicted classes,
             target classes, and target images.
         nt_per_class: Number of targets per class.
@@ -1350,7 +1345,6 @@ class PoseMetrics(DetMetrics):
         """
         super().__init__(names)
         self.pose = Metric()
-        self.task = "pose"
         self.stats["tp_p"] = []  # add additional stats for pose
 
     def process(self, save_dir: Path = Path("."), plot: bool = False, on_plot=None) -> dict[str, np.ndarray]:
@@ -1464,7 +1458,6 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
         top1 (float): The top-1 accuracy.
         top5 (float): The top-5 accuracy.
         speed (dict[str, float]): A dictionary containing the time taken for each step in the pipeline.
-        task (str): The task type, set to 'classify'.
 
     Methods:
         process: Process target classes and predicted classes to compute metrics.
@@ -1481,7 +1474,6 @@ class ClassifyMetrics(SimpleClass, DataExportMixin):
         self.top1 = 0
         self.top5 = 0
         self.speed = {"preprocess": 0.0, "inference": 0.0, "loss": 0.0, "postprocess": 0.0}
-        self.task = "classify"
 
     def process(self, targets: torch.Tensor, pred: torch.Tensor):
         """Process target classes and predicted classes to compute metrics.
@@ -1545,7 +1537,6 @@ class OBBMetrics(DetMetrics):
         names (dict[int, str]): Dictionary of class names.
         box (Metric): An instance of the Metric class for storing detection results.
         speed (dict[str, float]): A dictionary for storing execution times of different parts of the detection process.
-        task (str): The task type, set to 'obb'.
         stats (dict[str, list]): A dictionary containing lists for true positives, confidence scores, predicted classes,
             target classes, and target images.
         nt_per_class: Number of targets per class.
@@ -1562,5 +1553,3 @@ class OBBMetrics(DetMetrics):
             names (dict[int, str], optional): Dictionary of class names.
         """
         DetMetrics.__init__(self, names)
-        # TODO: probably remove task as well
-        self.task = "obb"


### PR DESCRIPTION
removes `self.task` from `DetMetrics`, `SegmentMetrics`, `PoseMetrics`, `OBBMetrics`, and `ClassifyMetrics`. this attribute was set in each class but never read — the task type is already determined by the class itself, and `ConfusionMatrix` receives `task` through its own constructor independently.

resolves the TODO left in `OBBMetrics` from #21009.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR removes the unused `task` attribute from multiple metrics classes in `ultralytics/utils/metrics.py`, simplifying the metrics API and cleaning up redundant state.

### 📊 Key Changes
- Removed `self.task` assignments from `DetMetrics`, `SegmentMetrics`, `PoseMetrics`, `ClassifyMetrics`, and `OBBMetrics`.
- Updated class docstrings to remove references to the deleted `task` attribute.
- Removed an outdated OBB TODO comment related to retaining the `task` field.
- Kept all metric-processing logic unchanged, making this a focused internal cleanup.

### 🎯 Purpose & Impact
- Reduces unused attributes and keeps metrics classes leaner and easier to maintain.
- Improves code clarity by aligning implementation with actual class behavior.
- Low risk for end users unless external code was directly reading `metrics.task`.
- Helps standardize metrics objects across detect, segment, pose, classify, and OBB workflows.