### PR TITLE
Fix `callable` type hint to `Callable` in `BasePredictor.add_callback()`

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -88,8 +88,8 @@ class BasePredictor:
         windows (list[str]): List of window names for visualization.
         batch (tuple): Current batch data.
         results (list[Any]): Current batch results.
-        transforms (callable): Image transforms for classification.
-        callbacks (dict[str, list[callable]]): Callback functions for different events.
+        transforms (Callable): Image transforms for classification.
+        callbacks (dict[str, list[Callable]]): Callback functions for different events.
         txt_path (Path): Path to save text results.
         _lock (threading.Lock): Lock for thread-safe inference.
 
@@ -112,7 +112,7 @@ class BasePredictor:
         self,
         cfg=DEFAULT_CFG,
         overrides: dict[str, Any] | None = None,
-        _callbacks: dict[str, list[callable]] | None = None,
+        _callbacks: dict[str, list[Callable]] | None = None,
     ):
         """Initialize the BasePredictor class.
 

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -39,7 +39,7 @@ import platform
 import re
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import cv2
 import numpy as np
@@ -508,6 +508,6 @@ class BasePredictor:
         for callback in self.callbacks.get(event, []):
             callback(self)
 
-    def add_callback(self, event: str, func: callable):
+    def add_callback(self, event: str, func: Callable):
         """Add a callback function for a specific event."""
         self.callbacks[event].append(func)


### PR DESCRIPTION
### 🌟 Summary

Replace incorrect lowercase `callable` (a built-in runtime check function) with proper `typing.Callable` type annotation in `BasePredictor.add_callback()` method.

### 📊 Key Changes

- Updated `func: callable` → `func: Callable` in `BasePredictor.add_callback()` signature (`ultralytics/engine/predictor.py`).
- Added `Callable` to the existing `from typing import Any` import line.
- No functional changes — type annotation fix only.

### 🎯 Purpose & Impact

- **Purpose:** The built-in `callable` is a runtime function (`callable(obj) → bool`), not a valid type annotation. `typing.Callable` is the correct type for annotating callable parameters per [PEP 484](https://peps.python.org/pep-0484/).
- **Impact:** Improves type checker compatibility (mypy/pyright), IDE autocomplete, and code correctness.
- **Scope:** 2 lines changed in a single file — minimal, zero-risk fix.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes the type hint for `BasePredictor.add_callback()` by replacing the built-in `callable` with `typing.Callable` for accurate Python typing support. 🔧

### 📊 Key Changes
- Added `Callable` to the imports from `typing` in `ultralytics/engine/predictor.py`.
- Updated `BasePredictor.add_callback(self, event: str, func: callable)` to `BasePredictor.add_callback(self, event: str, func: Callable)`.
- Left runtime behavior unchanged; this is a type-hinting and developer experience improvement only. ✅

### 🎯 Purpose & Impact
- Improves correctness of type annotations in the predictor callback API. 🧠
- Helps static analysis tools, IDEs, and contributors better understand expected callback usage.
- Reduces confusion around Python typing without affecting inference behavior or user-facing functionality.