### PR TITLE
Fix incorrect link in ONNX integration docs FAQ

### DIFF
--- a/docs/en/integrations/onnx.md
+++ b/docs/en/integrations/onnx.md
@@ -238,7 +238,7 @@ Using ONNX format for Ultralytics YOLO26 models provides numerous benefits:
 - **Flexibility**: ONNX supports various deployment environments, enabling you to use the same model on different platforms without modification.
 - **Standardization**: ONNX provides a standardized format that is widely supported across the industry, ensuring long-term compatibility.
 
-Refer to the comprehensive guide on [exporting YOLO26 models to ONNX](https://www.ultralytics.com/blog/export-and-optimize-a-yolov8-model-for-inference-on-openvino).
+Refer to the comprehensive guide on [exporting YOLO models to ONNX](../modes/export.md).
 
 ### How can I troubleshoot issues when exporting YOLO26 models to ONNX?
 

--- a/docs/en/integrations/onnx.md
+++ b/docs/en/integrations/onnx.md
@@ -238,7 +238,7 @@ Using ONNX format for Ultralytics YOLO26 models provides numerous benefits:
 - **Flexibility**: ONNX supports various deployment environments, enabling you to use the same model on different platforms without modification.
 - **Standardization**: ONNX provides a standardized format that is widely supported across the industry, ensuring long-term compatibility.
 
-Refer to the comprehensive guide on [exporting YOLO models to ONNX](../modes/export.md).
+Refer to the comprehensive guide on [exporting YOLO26 models to ONNX](../integrations/onnx.md).
 
 ### How can I troubleshoot issues when exporting YOLO26 models to ONNX?
 


### PR DESCRIPTION
## Description

Fixed an incorrect link in the ONNX integration docs FAQ section.

The link text says 'exporting YOLO26 models to ONNX' but the URL pointed to an OpenVINO blog post (\export-and-optimize-a-yolov8-model-for-inference-on-openvino\), which is:
1. About OpenVINO, not ONNX
2. References the old YOLOv8 model name

Updated to link to the internal export mode documentation page (\../modes/export.md\), which is the correct and up-to-date reference for ONNX export.

## Changes
- \docs/en/integrations/onnx.md\: Fixed FAQ link to point to export docs instead of unrelated OpenVINO blog post

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes an incorrect FAQ link in the ONNX integration docs by replacing an outdated external blog URL with the correct internal export documentation reference. 🔗

### 📊 Key Changes
- Updated the ONNX FAQ link in `docs/en/integrations/onnx.md`
- Replaced an external blog post about YOLOv8/OpenVINO with the relevant internal docs page `../modes/export.md`
- Adjusted the link text from "exporting YOLO26 models to ONNX" to the broader "exporting YOLO models to ONNX"

### 🎯 Purpose & Impact
- Improves documentation accuracy and consistency for ONNX export guidance 📚
- Prevents users from being sent to an outdated or less relevant resource
- Keeps readers within the official docs flow, making export instructions easier to find and maintain ✅