### PR TITLE
Fix optimizer=auto incorrectly setting warmup_bias_lr=0.0 for MuSGD

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -980,8 +980,11 @@ class BaseTrainer:
             )
             nc = self.data.get("nc", 10)  # number of classes
             lr_fit = round(0.002 * 5 / (4 + nc), 6)  # lr0 fit equation to 6 decimal places
-            name, lr, momentum = ("MuSGD", 0.01, 0.9) if iterations > 10000 else ("AdamW", lr_fit, 0.9)
-            self.args.warmup_bias_lr = 0.0  # no higher than 0.01 for Adam
+            if iterations > 10000:
+                name, lr, momentum = "MuSGD", 0.01, 0.9
+            else:
+                name, lr, momentum = "AdamW", lr_fit, 0.9
+                self.args.warmup_bias_lr = 0.0  # no higher than 0.01 for Adam
 
         use_muon = name == "MuSGD"
         for module_name, module in unwrap_model(model).named_modules():


### PR DESCRIPTION
Fixes #23637

When optimizer=auto resolves to MuSGD (iterations > 10000), warmup_bias_lr was incorrectly forced to 0.0. This setting should only apply to Adam-family optimizers, not SGD/MuSGD. MuSGD benefits from the default warmup_bias_lr=0.1 for stable training.

The fix moves warmup_bias_lr=0.0 inside the AdamW branch only, preserving the default value when MuSGD is selected.