### PR TITLE
remove resolved TODO comment from OBB head

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -466,7 +466,7 @@ class OBB(Detect):
     def _inference(self, x: dict[str, torch.Tensor]) -> torch.Tensor:
         """Decode predicted bounding boxes and class probabilities, concatenated with rotation angles."""
         # For decode_bboxes convenience
-        self.angle = x["angle"]  # TODO: need to test obb
+        self.angle = x["angle"]
         preds = super()._inference(x)
         return torch.cat([preds, x["angle"]], dim=1)
 


### PR DESCRIPTION
removes the `# TODO: need to test obb` comment from `OBB._inference()` — the assignment `self.angle = x["angle"]` is correct and necessary for `decode_bboxes()` → `dist2rbox()`.

verified locally with predict, val, train (2 epochs on dota8), and torchscript export — all passing.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR removes a resolved TODO comment from the OBB head inference path in `ultralytics/nn/modules/head.py` 🧹

### 📊 Key Changes
- Removed the outdated inline comment `# TODO: need to test obb` from `self.angle = x["angle"]`
- Kept the underlying OBB inference logic unchanged
- Cleans up the codebase by reflecting the current implementation state

### 🎯 Purpose & Impact
- Improves code clarity and reduces confusion for contributors reviewing the OBB head implementation
- Signals that this part of the OBB flow is no longer considered pending work
- No functional impact expected for users, models, or inference behavior ✅