### PR TITLE
fix: 🐞 Enable Albumentations augmentations for DDP training by serializing and deserializing transforms

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -292,6 +292,9 @@ priytosh.revolution@live.com:
 raimbekov_m@auca.kg:
   avatar: https://avatars.githubusercontent.com/u/144048515?v=4
   username: raimbekovm
+rlatjdwls2528@gmail.com:
+  avatar: null
+  username: null
 ronald_eddy@yahoo.com:
   avatar: null
   username: null

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -53,14 +53,27 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
     """
     module, name = f"{trainer.__class__.__module__}.{trainer.__class__.__name__}".rsplit(".", 1)
 
+    # Serialize augmentations to JSON-safe dicts to avoid NameError in DDP subprocess
+    overrides = vars(trainer.args).copy()
+    has_augmentations = overrides.get("augmentations") is not None
+    if has_augmentations:
+        import albumentations as A
+
+        overrides["augmentations"] = [A.to_dict(t) for t in overrides["augmentations"]]
+
     content = f"""
 # Ultralytics Multi-GPU training temp file (should be automatically deleted after use)
 from pathlib import Path, PosixPath  # For model arguments stored as Path instead of str
-overrides = {vars(trainer.args)}
+overrides = {overrides}
 
 if __name__ == "__main__":
     from {module} import {name}
     from ultralytics.utils import DEFAULT_CFG_DICT
+
+    # Deserialize augmentations from dicts back to Albumentations transform objects
+    if overrides.get("augmentations") is not None:
+        import albumentations as A
+        overrides["augmentations"] = [A.from_dict(t) for t in overrides["augmentations"]]
 
     cfg = DEFAULT_CFG_DICT.copy()
     cfg.update(save_dir='')   # handle the extra key 'save_dir'

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -55,8 +55,7 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
 
     # Serialize augmentations to JSON-safe dicts to avoid NameError in DDP subprocess
     overrides = vars(trainer.args).copy()
-    has_augmentations = overrides.get("augmentations") is not None
-    if has_augmentations:
+    if overrides.get("augmentations") is not None:
         import albumentations as A
 
         overrides["augmentations"] = [A.to_dict(t) for t in overrides["augmentations"]]


### PR DESCRIPTION
Fix: #23847 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐛 This PR fixes a multi-GPU training issue by making custom Albumentations augmentations safely transferable to DDP subprocesses.

### 📊 Key Changes
- Added preprocessing in `ultralytics/utils/dist.py` to convert `trainer.args.augmentations` into JSON-safe dictionary format before generating the temporary DDP training file.
- Added matching deserialization logic in the generated DDP script to rebuild those dictionaries back into Albumentations transform objects.
- Kept the existing DDP launch flow intact, only extending how augmentation settings are passed between processes.
- Specifically avoids `NameError` problems that could happen when augmentation objects were written directly into the subprocess script. 🔧

### 🎯 Purpose & Impact
- Enables custom Albumentations pipelines to work more reliably during multi-GPU training. 🚀
- Prevents DDP subprocess failures caused by non-serializable Python augmentation objects.
- Improves robustness for users training YOLO models with advanced augmentation setups, especially in distributed environments.
- Reduces debugging friction by making distributed training behavior more consistent with single-GPU runs. ✅