### PR TITLE
fix: 🐞 update Conda installation to include libstdcxx-ng for openvino

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,11 @@ jobs:
       - name: test_engine.py
         run: pytest ultralytics/tests/test_engine.py -v -s
       - name: test_exports.py
+        env:
+          KMP_AFFINITY: "disabled"
+          TBB_MAX_NUM_THREADS: "1"
+          OMP_NUM_THREADS: "1"
+          OPENVINO_NUM_THREADS: "1"
         run: pytest ultralytics/tests/test_exports.py -v -s
       - name: test_integrations.py
         run: pytest ultralytics/tests/test_integrations.py -v -s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,7 +480,7 @@ jobs:
           channel-priority: true
           activate-environment: anaconda-client-env
       - name: Install Ultralytics package from conda-forge
-        run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics "openvino!=2026.0.0"
+        run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino libstdcxx-ng
       - name: Install pip packages
         run: uv pip install pytest
       - name: Check environment


### PR DESCRIPTION
Attempt to remove OpenVINO version restriction

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the CI setup for Conda-based testing to improve OpenVINO compatibility and make export tests more stable in automated environments.

### 📊 Key Changes
- 🔄 Updated the Conda install command in `.github/workflows/ci.yml`:
  - Removed the explicit exclusion of `openvino!=2026.0.0`
  - Added `libstdcxx-ng` to the installed packages
- ⚙️ Added environment variables for the `test_exports.py` CI step to limit threading:
  - `KMP_AFFINITY=disabled`
  - `TBB_MAX_NUM_THREADS=1`
  - `OMP_NUM_THREADS=1`
  - `OPENVINO_NUM_THREADS=1`
- 🧪 Applied these thread limits specifically to export-related tests, helping control runtime behavior during CI

### 🎯 Purpose & Impact
- ✅ Improves CI reliability by reducing thread-related instability during export tests
- 🚀 Helps OpenVINO-based export testing run more consistently across Conda environments
- 🔧 Adding `libstdcxx-ng` likely prevents missing system library issues, especially in Linux-based runners
- 📦 Makes dependency installation more robust by allowing the current OpenVINO package instead of pinning around a specific excluded version
- 👥 Benefits both maintainers and users by increasing confidence that model export features are tested in a cleaner, more reproducible environment