### PR TITLE
Update billing and cloud training docs with downgrade details and FAQ improvements

### DIFF
--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -270,16 +270,16 @@ Cancel anytime from the billing portal:
 
 When your Pro subscription ends (cancelled or expired), your account reverts to the Free plan. Here's what happens to your existing resources:
 
-| Resource                   | What Happens                                                          |
-| -------------------------- | --------------------------------------------------------------------- |
-| **Models**                 | All models preserved. Cannot create new models beyond 100-model limit |
-| **Deployments**            | All deployments preserved. Cannot create new beyond 3-deployment limit |
-| **Storage**                | All data preserved. Cannot upload new data beyond 100 GB limit        |
-| **Credit Balance**         | Existing credits preserved and usable                                 |
-| **Monthly Credits**        | $30/seat/month grants stop immediately                                |
-| **Team Members**           | Members notified and lose access to team resources                    |
-| **GPU Access**             | Standard GPUs remain available. Best GPUs (H200, B200) require Pro or Enterprise |
-| **Concurrent Trainings**   | Limit reduced from 10 to 3                                           |
+| Resource                 | What Happens                                                                     |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| **Models**               | All models preserved. Cannot create new models beyond 100-model limit            |
+| **Deployments**          | All deployments preserved. Cannot create new beyond 3-deployment limit           |
+| **Storage**              | All data preserved. Cannot upload new data beyond 100 GB limit                   |
+| **Credit Balance**       | Existing credits preserved and usable                                            |
+| **Monthly Credits**      | $30/seat/month grants stop immediately                                           |
+| **Team Members**         | Members notified and lose access to team resources                               |
+| **GPU Access**           | Standard GPUs remain available. Best GPUs (H200, B200) require Pro or Enterprise |
+| **Concurrent Trainings** | Limit reduced from 10 to 3                                                       |
 
 !!! tip "No Data Loss"
 

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -266,6 +266,25 @@ Cancel anytime from the billing portal:
 
     Pro features remain active until the end of your billing period. Monthly credits stop at cancellation.
 
+### Downgrading to Free
+
+When your Pro subscription ends (cancelled or expired), your account reverts to the Free plan. Here's what happens to your existing resources:
+
+| Resource                   | What Happens                                                          |
+| -------------------------- | --------------------------------------------------------------------- |
+| **Models**                 | All models preserved. Cannot create new models beyond 100-model limit |
+| **Deployments**            | All deployments preserved. Cannot create new beyond 3-deployment limit |
+| **Storage**                | All data preserved. Cannot upload new data beyond 100 GB limit        |
+| **Credit Balance**         | Existing credits preserved and usable                                 |
+| **Monthly Credits**        | $30/seat/month grants stop immediately                                |
+| **Team Members**           | Members notified and lose access to team resources                    |
+| **GPU Access**             | Standard GPUs remain available. Best GPUs (H200, B200) require Pro or Enterprise |
+| **Concurrent Trainings**   | Limit reduced from 10 to 3                                           |
+
+!!! tip "No Data Loss"
+
+    Downgrading never deletes your models, datasets, or deployments. Limits are only enforced when creating **new** resources — existing resources remain fully accessible.
+
 ## Transaction History
 
 View all transactions in `Settings > Billing`:
@@ -284,11 +303,11 @@ View all transactions in `Settings > Billing`:
 
 ### What happens when I run out of credits?
 
-- **Active training**: Cannot start new training jobs
-- **Deployments**: Continue running
-- **New training**: Requires credits to start
+- **Running training**: Continues to completion — your balance may go negative
+- **New training**: Cannot start new jobs until balance is positive
+- **Deployments**: Continue running regardless of balance
 
-Add credits or enable auto top-up to continue training.
+If a training run completes and the actual cost exceeds your remaining balance, your balance goes negative. Add credits to restore a positive balance before starting new training jobs. Enable [auto top-up](#auto-top-up) to avoid interruptions.
 
 ### Are unused credits refundable?
 
@@ -305,7 +324,7 @@ Transaction receipts are available in the transaction history. Click the receipt
 
 ### What if training fails?
 
-You're only charged for completed compute time. Failed jobs don't charge for unused time.
+**Failed training runs are not charged.** If a job fails due to a configuration error, out-of-memory issue, or any other reason, no credits are deducted. Only successfully completed or user-cancelled jobs incur charges (based on actual GPU time used). See [Cloud Training Billing](../train/cloud-training.md#billing-by-job-status) for a full breakdown by job status.
 
 ### Is there a free trial?
 

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -324,7 +324,7 @@ Transaction receipts are available in the transaction history. Click the receipt
 
 ### What if training fails?
 
-**Failed training runs are not charged.** If a job fails due to a configuration error, out-of-memory issue, or any other reason, no credits are deducted. Only successfully completed or user-cancelled jobs incur charges (based on actual GPU time used). See [Cloud Training Billing](../train/cloud-training.md#billing-by-job-status) for a full breakdown by job status.
+**Failed training runs are not charged.** If a job fails due to a configuration error, out-of-memory issue, or any other reason, no credits are deducted. Completed, user-cancelled, and auto-terminated stuck jobs may incur charges based on actual GPU time used. See [Cloud Training Billing](../train/cloud-training.md#billing-by-job-status) for a full breakdown by job status.
 
 ### Is there a free trial?
 

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -353,7 +353,20 @@ Cloud training billing flow:
 
 !!! success "Consumer Protection"
 
-    Billing tracks actual compute usage, including partial runs that are cancelled.
+    Billing tracks actual compute usage, including partial runs that are cancelled. **You are never charged for failed training runs.**
+
+### Billing by Job Status
+
+| Status        | Charged?                                    |
+| ------------- | ------------------------------------------- |
+| **Completed** | Yes — actual GPU time used                  |
+| **Cancelled** | Yes — GPU time from start to cancellation   |
+| **Failed**    | No — failed runs are not charged            |
+| **Stuck**     | Partial — only actual training time charged |
+
+!!! tip "No Charge for Errors"
+
+    If a training run fails due to a configuration error, out-of-memory issue, or any other failure, you are **not charged**. Only successful compute time is billed. Stuck jobs (no activity for 4+ hours) are automatically terminated and charged only for the time the GPU was actively training, not the idle time.
 
 ### Payment Methods
 
@@ -432,11 +445,37 @@ Yes, training continues until completion. You'll receive a notification when tra
 
 ### What happens if I run out of credits?
 
-Training pauses at the end of the current epoch. Your checkpoint is saved, and you can resume after adding credits.
+If your credit balance reaches zero during a training run, training **continues to completion** and your balance goes negative. This ensures your training job is never interrupted mid-run.
+
+After training completes, you'll need to add credits to bring your balance back to positive before starting new training jobs. Your completed model, checkpoints, and all training artifacts are fully preserved regardless of balance.
+
+!!! note "Negative Balance"
+
+    A negative balance only prevents starting **new** training jobs. Existing deployments and other platform features continue to work normally. Add credits via [Settings > Billing](../account/billing.md) or enable [auto top-up](../account/billing.md#auto-top-up) to avoid interruptions.
+
+### What happens if my training costs more than the estimate?
+
+Cost estimates are approximate — actual training time may vary due to factors like data loading speed, GPU warmup, and model convergence behavior. If the actual cost exceeds the estimate, your balance may go negative (see above). The platform **does not stop training** based on the estimate.
+
+To manage costs:
+
+- Monitor training progress in real-time and cancel early if needed
+- Enable [auto top-up](../account/billing.md#auto-top-up) to automatically replenish credits
+- Start with shorter runs (fewer epochs) to calibrate expectations
 
 ### Can I use custom training arguments?
 
 Yes, expand the **Advanced Settings** section in the training dialog to access a YAML editor with 40+ configurable parameters. Non-default values are included in both cloud and local training commands.
+
+The YAML editor also supports **importing configurations from previous training runs**:
+
+- **Copy from existing model**: On any completed model's page, the Training Configuration card has a **Copy as JSON** button. Copy the JSON and paste it directly into the YAML editor — it auto-detects JSON format and imports all parameters.
+- **Paste YAML or JSON**: Paste any valid YAML or JSON training configuration into the editor. Parameters are validated automatically, with out-of-range values clamped and warnings displayed.
+- **Drag and drop files**: Drag a `.yaml` or `.json` file directly into the editor to import its parameters.
+
+<!-- Screenshot: platform-training-dialog-copy-training-config-json.avif -->
+
+This makes it easy to reproduce or iterate on previous training configurations without manually re-entering each parameter.
 
 ### Can I train from a dataset page?
 

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -226,6 +226,9 @@ hnliu_2@stu.xidian.edu.cn:
 j@jshakespeare.com:
   avatar: https://avatars.githubusercontent.com/u/591884?v=4
   username: jshakes
+jin@ultralytics.com:
+  avatar: https://avatars.githubusercontent.com/u/4847103?v=4
+  username: laodouya
 job@laodouya.com:
   avatar: https://avatars.githubusercontent.com/u/4847103?v=4
   username: laodouya


### PR DESCRIPTION
Add "Downgrading to Free" section to billing docs explaining resource limits after Pro cancellation. Clarify credit depletion behavior (training continues to completion with negative balance). Document that failed training runs are never charged with a new "Billing by Job Status" table. Expand custom training arguments FAQ with configuration import options.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves Ultralytics Platform billing and cloud training docs by clarifying downgrade behavior, credit handling, failed-job billing, and training configuration import options.

### 📊 Key Changes
- Added a new **“Downgrading to Free”** section in billing docs that explains what happens to models, deployments, storage, credits, team access, GPU availability, and training concurrency after a Pro plan ends.
- Clearly states **no data is deleted** when moving from Pro to Free; limits only affect creating new resources. 🔒
- Updated billing guidance for **running out of credits**:
  - active training now **continues to completion**
  - account balance can go **negative**
  - new training jobs are blocked until credits are added
  - deployments continue running normally
- Clarified that **failed training runs are not charged** ❌💸, while completed, cancelled, and some stuck jobs may still incur charges based on actual GPU time used.
- Added a new **“Billing by Job Status”** table to cloud training docs, showing how completed, cancelled, failed, and stuck jobs are billed.
- Added documentation for when **actual training cost exceeds the estimate**, explaining that estimates are approximate and training is not stopped mid-run.
- Expanded cloud training docs to explain that users can **import previous training configs** into the YAML editor by:
  - pasting JSON or YAML
  - copying config JSON from an existing model
  - dragging and dropping `.yaml` or `.json` files 📂
- Updated GitHub author mappings to include @laodouya under an additional email entry.

### 🎯 Purpose & Impact
- Helps users better understand **billing behavior and plan limits**, reducing confusion around cancellations, downgrades, and credit usage. ✅
- Reassures users that **models, datasets, deployments, and training artifacts are preserved**, even after downgrade or negative balance.
- Makes cloud training costs feel more predictable by explaining **what is and is not billed**, especially for failed jobs. 💡
- Reduces the risk of interrupted workflows by clarifying that **training runs finish even if credits run out**, though new runs require a positive balance.
- Improves usability for experimentation and reproducibility by making it easier to **reuse past training settings** without manual re-entry. 🚀
- Overall, this is a **documentation-focused PR** with no product logic changes, but it should significantly improve user trust, supportability, and onboarding.