### PR TITLE
Docs: Dataset image context menu

### DIFF
--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -396,11 +396,25 @@ The NDJSON format stores one JSON object per line. The first line contains datas
 
 See the [Ultralytics NDJSON format documentation](../../datasets/detect/index.md#ultralytics-ndjson-format) for full specification.
 
-## Bulk Operations
+## Image Operations
 
-Manage images in bulk using the table view's context menu:
+### Quick Actions
 
-### Move to Split
+Right-click any image in **Grid** or **Compact** view to access quick actions:
+
+| Action            | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| **Move to Split** | Reassign the image to Train, Val, or Test split |
+| **Download**      | Download the original image file                |
+| **Delete**        | Delete the image from the dataset               |
+
+![Ultralytics Platform Datasets Image Card Context Menu](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-datasets-image-card-context-menu.avif)
+
+!!! tip "Single vs Bulk"
+
+    The image context menu operates on a **single image**. For bulk operations on multiple images, use **Table** view with checkbox selection.
+
+### Bulk Move to Split
 
 Reassign selected images to a different split within the same dataset:
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR updates the Ultralytics Platform dataset docs to better explain image-level and bulk image management actions.

### 📊 Key Changes
- Renames the documentation section from **Bulk Operations** to **Image Operations** for clearer scope.
- Adds a new **Quick Actions** subsection describing right-click actions available in **Grid** and **Compact** views.
- Documents three single-image actions:
  - **Move to Split**: reassign an image to Train, Val, or Test
  - **Download**: download the original image
  - **Delete**: remove the image from the dataset
- Adds a new screenshot showing the image card context menu in the Ultralytics Platform 🖼️
- Introduces a **tip** clarifying the difference between:
  - **single-image actions** via the image context menu
  - **bulk operations** via **Table** view with checkbox selection
- Renames **Move to Split** under bulk workflows to **Bulk Move to Split** to avoid confusion.

### 🎯 Purpose & Impact
- Improves documentation clarity so users can more easily understand how to manage dataset images ✅
- Reduces confusion between **single-image** actions and **multi-image bulk** actions.
- Makes the Ultralytics Platform workflow more discoverable, especially for newer users exploring dataset tools.
- Helps users work faster by clearly showing where to find common actions like moving, downloading, or deleting images 🚀
- Lowers the chance of mistakes when managing datasets by distinguishing per-image actions from batch operations.