### PR TITLE
Add Teams documentation

### DIFF
--- a/docs/en/platform/account/api-keys.md
+++ b/docs/en/platform/account/api-keys.md
@@ -163,7 +163,7 @@ API keys are scoped to the currently active workspace:
 - **Personal workspace**: Keys authenticate as your personal account
 - **Team workspace**: Keys authenticate within the team context
 
-When switching workspaces in the sidebar, the API Keys section shows keys for that workspace. Editor role or higher is required to manage workspace API keys. See [Teams](settings.md#teams-tab) for role details.
+When switching workspaces in the sidebar, the API Keys section shows keys for that workspace. Editor role or higher is required to manage workspace API keys. See [Teams](teams.md) for role details.
 
 ## Security Best Practices
 

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -59,7 +59,7 @@ For professionals and small teams ($29/month or $290/year):
 - 10 concurrent cloud trainings
 - 500 GB storage
 - 10 warm-start deployments (faster cold starts)
-- Team collaboration (up to 5 members)
+- [Team collaboration](teams.md) (up to 5 members)
 - Access to the best GPUs (H200, B200)
 - Priority support
 
@@ -249,7 +249,7 @@ After upgrading:
 - 500 models
 - 10 concurrent cloud trainings
 - 10 warm-start deployments
-- Team collaboration (up to 5 members)
+- [Team collaboration](teams.md) (up to 5 members)
 - Access to best GPUs
 - Priority support
 

--- a/docs/en/platform/account/index.md
+++ b/docs/en/platform/account/index.md
@@ -71,6 +71,7 @@ Ultralytics Platform implements multiple security measures:
 ## Quick Links
 
 - [**Settings**](settings.md): Profile, social links, data region, and account management
+- [**Teams**](teams.md): Team creation, roles, shared resources, and enterprise features
 - [**Billing**](billing.md): Credits, plans, and payment management
 - [**API Keys**](api-keys.md): Create and manage API keys
 - [**Activity**](activity.md): Track account events and notifications

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -207,49 +207,7 @@ Manage credits, payment methods, and view transaction history. See [Billing](bil
 
 ## Teams Tab
 
-Manage workspace members, roles, and invitations. Teams are available on [Pro and Enterprise plans](billing.md#plans).
-
-### Team Overview
-
-The Teams tab displays:
-
-- Workspace name and avatar
-- Seat usage summary (used / available)
-- Member list with roles
-- Pending invitations
-
-### Member Roles
-
-| Role       | Permissions                                            |
-| ---------- | ------------------------------------------------------ |
-| **Owner**  | Full control, transfer ownership, delete workspace     |
-| **Admin**  | Manage members, billing, settings, content             |
-| **Editor** | Create and manage projects, datasets, models, API keys |
-| **Viewer** | Read-only access to workspace resources                |
-
-!!! note "Role Availability"
-
-    Owner, Admin, Editor, and Viewer roles are available on all team plans (Pro and Enterprise).
-
-### Invite Members
-
-1. Go to **Settings > Teams**
-2. Click **Invite**
-3. Enter email address
-4. Select role
-5. Send invitation
-
-The invitee receives an email and can accept the invitation to join the workspace. Invitations expire after 7 days. Inviting members requires the Admin role or higher.
-
-### Manage Members
-
-Owners and admins can manage the team:
-
-- **Change roles**: Click the role dropdown next to a member (only the owner can assign/remove the admin role)
-- **Remove members**: Click the menu and select **Remove**
-- **Cancel invites**: Cancel pending invitations that haven't been accepted
-- **Resend invites**: Resend invitation emails
-- **Transfer ownership**: Transfer workspace ownership to another member (Owner only)
+Manage workspace members, roles, and invitations. Teams are available on [Pro and Enterprise plans](billing.md#plans). See [Teams](teams.md) for full documentation on team creation, roles, shared resources, and enterprise features.
 
 ## Trash Tab
 

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -209,6 +209,16 @@ Manage credits, payment methods, and view transaction history. See [Billing](bil
 
 Manage workspace members, roles, and invitations. Teams are available on [Pro and Enterprise plans](billing.md#plans). See [Teams](teams.md) for full documentation on team creation, roles, shared resources, and enterprise features.
 
+### Manage Members
+
+Owners and admins can manage the team:
+
+- **Change roles**: Click the role dropdown next to a member (only the owner can assign/remove the admin role)
+- **Remove members**: Click the menu and select **Remove**
+- **Cancel invites**: Cancel pending invitations that haven't been accepted
+- **Resend invites**: Resend invitation emails
+- **Transfer ownership**: Transfer workspace ownership to another member (Owner only)
+
 ## Trash Tab
 
 Manage deleted items. See [Trash](trash.md) for full documentation.

--- a/docs/en/platform/account/teams.md
+++ b/docs/en/platform/account/teams.md
@@ -17,20 +17,22 @@ Teams allow multiple users to work together under a shared workspace:
 - **Shared Resources**: Datasets, projects, models, and deployments are accessible to all team members
 - **Role-Based Access**: Four roles (Owner, Admin, Editor, Viewer) control what each member can do
 - **Shared Billing**: Team members share the workspace credit balance and resource limits
-- **Seat Management**: Pro teams support up to 5 members, Enterprise teams up to 50+
+- **Seat Management**: Pro teams support up to 5 members, Enterprise teams up to 50
 
 !!! note "Plan Requirement"
 
-    Any user can create a team, but inviting members requires upgrading the team to a [Pro or Enterprise plan](billing.md#plans).
+    Creating a team requires a [Pro or Enterprise plan](billing.md#plans). You can upgrade from Settings or when clicking **+ Create Team** in the workspace switcher.
 
 ## Creating a Team
 
 Create a new team workspace:
 
 1. Click on the workspace switcher in the sidebar
-2. Click **+ Create Team**
+2. Click **+ Create Team** to open the Teams tab in Settings
+3. Click **+ Upgrade to Pro** to open the upgrade dialog
+4. Enter your team name and username, then complete checkout
 
-The team is automatically created and you land on the Teams tab in Settings. The team starts on the Free plan. To invite members and unlock collaboration features, [upgrade to Pro or Enterprise](billing.md#upgrade-to-pro).
+Alternatively, [upgrade your personal account to Pro](billing.md#upgrade-to-pro) first, then create a team from the Teams tab. Once your team is created, you can [invite members](#inviting-members).
 
 <!-- Screenshot: settings-teams-create-team-landing.avif -->
 
@@ -85,7 +87,7 @@ Admins and Owners can invite new members to the team:
 
 <!-- Screenshot: settings-teams-invite-member-dialog.avif -->
 
-If the invitee already has a Platform account, they are added directly. Otherwise, they receive an email invitation with a link to sign up and join. Invitations expire after 7 days. Once accepted, the team workspace appears in the invitee's workspace switcher.
+The invitee receives an email invitation with a link to accept and join the team. Invitations expire after 7 days. Once accepted, the team workspace appears in the invitee's workspace switcher.
 
 !!! note "Admin Invites"
 

--- a/docs/en/platform/account/teams.md
+++ b/docs/en/platform/account/teams.md
@@ -46,12 +46,12 @@ When you switch to a team workspace, all resources you see and create belong to 
 
 Teams use a four-role hierarchy for access control. Each role inherits all permissions from the roles below it.
 
-| Role       | Description                                                              |
-| ---------- | ------------------------------------------------------------------------ |
-| **Owner**  | Full control, transfer ownership, assign admin role, remove any member   |
-| **Admin**  | Invite and remove members, manage billing, create and edit all content   |
-| **Editor** | Create and edit projects, datasets, models, start training, deploy       |
-| **Viewer** | Read-only access to all team resources                                   |
+| Role       | Description                                                            |
+| ---------- | ---------------------------------------------------------------------- |
+| **Owner**  | Full control, transfer ownership, assign admin role, remove any member |
+| **Admin**  | Invite and remove members, manage billing, create and edit all content |
+| **Editor** | Create and edit projects, datasets, models, start training, deploy     |
+| **Viewer** | Read-only access to all team resources                                 |
 
 !!! note "Single Owner"
 
@@ -92,7 +92,6 @@ If the invitee already has a Platform account, they are added directly. Otherwis
     Only the team Owner can invite members with the Admin role. Admins can invite Editors and Viewers.
 
 The seat limit includes both active members and pending invitations. If you've reached the limit, remove a member or cancel a pending invite before sending a new one.
-
 
 ## Enterprise
 

--- a/docs/en/platform/account/teams.md
+++ b/docs/en/platform/account/teams.md
@@ -1,0 +1,131 @@
+---
+comments: true
+description: Create and manage teams on Ultralytics Platform with role-based access control, shared resources, and enterprise features for collaborative computer vision workflows.
+keywords: Ultralytics Platform, teams, collaboration, enterprise, roles, permissions, RBAC, workspace, team management
+---
+
+# Teams
+
+[Ultralytics Platform](https://platform.ultralytics.com) team features enable collaborative computer vision workflows. Create a team workspace to share datasets, projects, models, and deployments with your colleagues using role-based access control.
+
+<!-- Screenshot: settings-teams-tab-member-list-with-roles.avif -->
+
+## Overview
+
+Teams allow multiple users to work together under a shared workspace:
+
+- **Shared Resources**: Datasets, projects, models, and deployments are accessible to all team members
+- **Role-Based Access**: Four roles (Owner, Admin, Editor, Viewer) control what each member can do
+- **Shared Billing**: Team members share the workspace credit balance and resource limits
+- **Seat Management**: Pro teams support up to 5 members, Enterprise teams up to 50+
+
+!!! note "Plan Requirement"
+
+    Any user can create a team, but inviting members requires upgrading the team to a [Pro or Enterprise plan](billing.md#plans).
+
+## Creating a Team
+
+Create a new team workspace:
+
+1. Click on the workspace switcher in the sidebar
+2. Click **+ Create Team**
+
+The team is automatically created and you land on the Teams tab in Settings. The team starts on the Free plan. To invite members and unlock collaboration features, [upgrade to Pro or Enterprise](billing.md#upgrade-to-pro).
+
+<!-- Screenshot: settings-teams-create-team-landing.avif -->
+
+## Switching Workspaces
+
+Switch between your personal account and team workspaces using the workspace switcher in the sidebar. All teams you belong to appear in the list.
+
+<!-- Screenshot: settings-teams-workspace-switcher-dropdown.avif -->
+
+When you switch to a team workspace, all resources you see and create belong to that team. Your personal workspace resources remain separate.
+
+## Roles and Permissions
+
+Teams use a four-role hierarchy for access control. Each role inherits all permissions from the roles below it.
+
+| Role       | Description                                                              |
+| ---------- | ------------------------------------------------------------------------ |
+| **Owner**  | Full control, transfer ownership, assign admin role, remove any member   |
+| **Admin**  | Invite and remove members, manage billing, create and edit all content   |
+| **Editor** | Create and edit projects, datasets, models, start training, deploy       |
+| **Viewer** | Read-only access to all team resources                                   |
+
+!!! note "Single Owner"
+
+    Each team has exactly one owner. To change the owner, transfer ownership from the Teams tab in Settings. Only the owner can assign or remove the admin role.
+
+## Shared Resources
+
+Resources created in a team workspace belong to the team, not the individual. All team members can view projects, datasets, models, and deployments. Editors and above can create and modify resources.
+
+!!! tip "Personal vs Team Resources"
+
+    Resources in your personal workspace are separate from team workspaces. To share a resource, create it while in the team workspace.
+
+## Shared Billing and Limits
+
+Team members share the workspace credit balance and resource limits. All members draw from the same wallet when running cloud training. See [Billing](billing.md#plans) for detailed plan limits.
+
+!!! note "Pro Plan Seat Billing"
+
+    On the Pro plan, each team member is a paid seat at $29/month (or $290/year). Monthly credits of $30/seat are added to the shared wallet.
+
+## Inviting Members
+
+Admins and Owners can invite new members to the team:
+
+1. Go to **Settings > Teams**
+2. Click **Invite**
+3. Enter the invitee's email address
+4. Select a role (Admin, Editor, or Viewer)
+5. Click **Send Invitation**
+
+<!-- Screenshot: settings-teams-invite-member-dialog.avif -->
+
+If the invitee already has a Platform account, they are added directly. Otherwise, they receive an email invitation with a link to sign up and join. Invitations expire after 7 days. Once accepted, the team workspace appears in the invitee's workspace switcher.
+
+!!! note "Admin Invites"
+
+    Only the team Owner can invite members with the Admin role. Admins can invite Editors and Viewers.
+
+The seat limit includes both active members and pending invitations. If you've reached the limit, remove a member or cancel a pending invite before sending a new one.
+
+
+## Enterprise
+
+Enterprise plans include additional capabilities for organizations with advanced needs, including unlimited resources, commercial licensing, SSO/SAML, and dedicated support. See [Billing > Enterprise](billing.md#enterprise) for the full feature comparison.
+
+!!! warning "License Expiration"
+
+    If your Enterprise license expires, workspace access is blocked until renewed. Contact [sales@ultralytics.com](mailto:sales@ultralytics.com) to renew.
+
+### Getting Started with Enterprise
+
+Enterprise plans are provisioned by the Ultralytics team:
+
+1. Contact [sales@ultralytics.com](mailto:sales@ultralytics.com)
+2. Discuss your team size, credit needs, and compliance requirements
+3. Receive a provisioning invite with your enterprise configuration
+4. Accept the invite to become the team Owner
+5. Invite your team members
+
+## FAQ
+
+### Can I be a member of multiple teams?
+
+Yes, you can belong to multiple teams simultaneously. Use the workspace switcher to move between them. Your role may differ in each team.
+
+### What happens to team resources if I leave?
+
+Resources you created in the team workspace stay with the team. They are not deleted or transferred to your personal account.
+
+### How are credits shared in a team?
+
+All team members share a single credit balance. The Owner and Admins can top up credits and manage billing from [Settings > Billing](billing.md).
+
+### How do I upgrade from Pro to Enterprise?
+
+Contact [sales@ultralytics.com](mailto:sales@ultralytics.com) to discuss Enterprise pricing and provisioning. The Ultralytics team will handle the upgrade and configuration.

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -44,7 +44,7 @@ graph LR
 | [Exports](../train/models.md#export-model) | Format conversion jobs        | Create, status, download                      |
 | [Training](../train/cloud-training.md)     | Cloud GPU training jobs       | Start, status, cancel                         |
 | [Billing](../account/billing.md)           | Credits and subscriptions     | Balance, top-up, payment methods              |
-| [Teams](../account/settings.md#teams-tab)  | Workspace collaboration       | Members, invites, roles                       |
+| [Teams](../account/teams.md)  | Workspace collaboration       | Members, invites, roles                       |
 
 ## Authentication
 
@@ -1773,7 +1773,7 @@ POST /api/members
     | `editor` | Create, edit, and delete resources          |
     | `admin`  | Full access including member management     |
 
-    See [Teams](../account/settings.md#teams-tab) for role details in the UI.
+    See [Teams](../account/teams.md) for role details in the UI.
 
 ### Update Member Role
 

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -44,7 +44,7 @@ graph LR
 | [Exports](../train/models.md#export-model) | Format conversion jobs        | Create, status, download                      |
 | [Training](../train/cloud-training.md)     | Cloud GPU training jobs       | Start, status, cancel                         |
 | [Billing](../account/billing.md)           | Credits and subscriptions     | Balance, top-up, payment methods              |
-| [Teams](../account/teams.md)  | Workspace collaboration       | Members, invites, roles                       |
+| [Teams](../account/teams.md)               | Workspace collaboration       | Members, invites, roles                       |
 
 ## Authentication
 

--- a/docs/en/platform/train/projects.md
+++ b/docs/en/platform/train/projects.md
@@ -126,7 +126,7 @@ Share private projects with other users:
 3. Set their role
 4. Click **Invite**
 
-Collaborators with editor access can upload models and start training within your project. See [Teams](../account/settings.md#teams-tab) for role permissions.
+Collaborators with editor access can upload models and start training within your project. See [Teams](../account/teams.md) for role permissions.
 
 ## Clone Project
 

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -319,6 +319,9 @@ stormsson@users.noreply.github.com:
 thunderbirdtr@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/1688848?v=4
   username: onuralpszr
+tigran@ultralytics.com:
+  avatar: https://avatars.githubusercontent.com/u/197762997?v=4
+  username: t-hakobyan
 vitali.lobanov@pm.me:
   avatar: null
   username: null

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -630,6 +630,7 @@ nav:
       - Account:
           - platform/account/index.md
           - API Keys: platform/account/api-keys.md
+          - Teams: platform/account/teams.md
           - Billing: platform/account/billing.md
           - Activity: platform/account/activity.md
           - Trash: platform/account/trash.md


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📘 This PR adds a dedicated **Teams** documentation page for Ultralytics Platform and updates related docs to link to it consistently.

### 📊 Key Changes
- Added a new [`Teams` documentation page](https://github.com/ultralytics/ultralytics) under Platform Account docs 🆕
- Moved detailed team-related guidance out of `settings.md` into the new standalone page for better organization
- Documented core team features, including:
  - team creation
  - workspace switching
  - roles and permissions
  - shared resources
  - shared billing and seat limits
  - member invitations
  - Enterprise onboarding
  - FAQ
- Updated multiple docs pages to point to the new Teams page instead of the old `Settings > Teams` section 🔗
  - API keys
  - billing
  - account index
  - platform API docs
  - projects docs
- Added the new Teams page to the MkDocs navigation so it appears in the docs sidebar 🧭
- Updated GitHub authors metadata to include @t-hakobyan

### 🎯 Purpose & Impact
- Improves documentation structure by giving team collaboration features their own clear, discoverable page ✨
- Makes it easier for users to understand how shared workspaces, permissions, and billing work in Ultralytics Platform
- Reduces confusion caused by scattered or outdated links, since all team-related references now point to one central guide ✅
- Helps new Pro and Enterprise users onboard faster, especially teams managing shared datasets, models, and deployments 🚀
- Lowers support friction by clarifying role rules, invite behavior, seat limits, and enterprise setup for a broad audience 👥