### PR TITLE
Disable `end2end` for TensorRT INT8 exports with `tensorrt<=10.3.0`

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -420,7 +420,7 @@ class Exporter:
                 # Disable end2end branch for certain export formats as they does not support topk
                 model.end2end = False
                 LOGGER.warning(f"{fmt.upper()} export does not support end2end models, disabling end2end branch.")
-            if engine:
+            if engine and self.args.int8:
                 # TensorRT <=10.3 has known end2end build issues
                 # https://github.com/ultralytics/ultralytics/issues/23841
                 try:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -429,7 +429,7 @@ class Exporter:
                     if check_version(trt.__version__, "<=10.3.0", hard=True):
                         model.end2end = False
                         LOGGER.warning(
-                            f"TensorRT<=10.3.0 with int8 has known end2end build issues, disabling end2end branch."
+                            "TensorRT<=10.3.0 with int8 has known end2end build issues, disabling end2end branch."
                         )
                 except ImportError:
                     pass

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -425,6 +425,7 @@ class Exporter:
                 # https://github.com/ultralytics/ultralytics/issues/23841
                 try:
                     import tensorrt as trt
+
                     if check_version(trt.__version__, "<=10.3.0", hard=True):
                         model.end2end = False
                         LOGGER.warning(

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -420,6 +420,19 @@ class Exporter:
                 # Disable end2end branch for certain export formats as they does not support topk
                 model.end2end = False
                 LOGGER.warning(f"{fmt.upper()} export does not support end2end models, disabling end2end branch.")
+            if engine:
+                # TensorRT <=10.3 has known end2end build issues
+                # https://github.com/ultralytics/ultralytics/issues/23841
+                try:
+                    import tensorrt as trt
+                    if check_version(trt.__version__, "<=10.3.0", hard=True):
+                        model.end2end = False
+                        LOGGER.warning(
+                            f"TensorRT {trt.__version__} detected. TensorRT<=10.3.0 has known end2end build issues, "
+                            "disabling end2end branch."
+                        )
+                except ImportError:
+                    pass
         if self.args.half and self.args.int8:
             LOGGER.warning("half=True and int8=True are mutually exclusive, setting half=False.")
             self.args.half = False

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -429,8 +429,7 @@ class Exporter:
                     if check_version(trt.__version__, "<=10.3.0", hard=True):
                         model.end2end = False
                         LOGGER.warning(
-                            f"TensorRT {trt.__version__} detected. TensorRT<=10.3.0 with int8 has known end2end build issues, "
-                            "disabling end2end branch."
+                            f"TensorRT<=10.3.0 with int8 has known end2end build issues, disabling end2end branch."
                         )
                 except ImportError:
                     pass

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -421,7 +421,7 @@ class Exporter:
                 model.end2end = False
                 LOGGER.warning(f"{fmt.upper()} export does not support end2end models, disabling end2end branch.")
             if engine and self.args.int8:
-                # TensorRT <=10.3 has known end2end build issues
+                # TensorRT <=10.3 with int8 has known end2end build issues
                 # https://github.com/ultralytics/ultralytics/issues/23841
                 try:
                     import tensorrt as trt
@@ -429,7 +429,7 @@ class Exporter:
                     if check_version(trt.__version__, "<=10.3.0", hard=True):
                         model.end2end = False
                         LOGGER.warning(
-                            f"TensorRT {trt.__version__} detected. TensorRT<=10.3.0 has known end2end build issues, "
+                            f"TensorRT {trt.__version__} detected. TensorRT<=10.3.0 with int8 has known end2end build issues, "
                             "disabling end2end branch."
                         )
                 except ImportError:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -421,7 +421,7 @@ class Exporter:
                 model.end2end = False
                 LOGGER.warning(f"{fmt.upper()} export does not support end2end models, disabling end2end branch.")
             if engine and self.args.int8:
-                # TensorRT <=10.3 with int8 has known end2end build issues
+                # TensorRT<=10.3.0 with int8 has known end2end build issues
                 # https://github.com/ultralytics/ultralytics/issues/23841
                 try:
                     import tensorrt as trt


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves TensorRT INT8 export reliability by automatically disabling the `end2end` branch for incompatible TensorRT versions.

### 📊 Key Changes
- Added a new safeguard in `ultralytics/engine/exporter.py` for TensorRT engine exports with `int8=True`.
- When exporting with TensorRT and INT8 enabled, the code now checks the installed TensorRT version.
- If TensorRT is `10.3.0` or older, `model.end2end` is automatically turned off.
- A warning message is logged to clearly explain why the `end2end` branch was disabled.
- The change is wrapped in a safe `try/except`, so export behavior is unaffected if TensorRT is not installed.

### 🎯 Purpose & Impact
- 🚦 Prevents known TensorRT build failures for INT8 exports on older TensorRT versions.
- 🔒 Makes the export process more robust by handling a version-specific compatibility issue automatically.
- 🧩 Reduces user confusion by providing a clear warning instead of letting exports fail unexpectedly.
- ⚡ Improves the experience for users deploying YOLO models with TensorRT, especially in INT8 optimization workflows.
- 📉 Lowers the chance of broken export pipelines for affected environments while preserving existing behavior for supported versions.