### PR TITLE
fix build_docs.py portability for local development

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -26,6 +26,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -582,6 +583,9 @@ def restore_docs_sources(backup_root: Path, backups: list[tuple[Path, Path]]):
 
 def main():
     """Build docs, update titles and edit links, minify HTML, and print local server command."""
+    if not shutil.which("zensical"):
+        raise SystemExit("zensical is not installed. Install it with: pip install -e '.[dev]'")
+
     start_time = time.perf_counter()
     backup_root: Path | None = None
     docs_backups: list[tuple[Path, Path]] = []
@@ -671,7 +675,7 @@ def main():
             LOGGER.info(f"Opening browser at {url}")
             webbrowser.open(url)
             try:
-                subprocess.run(["python", "-m", "http.server", "--directory", str(SITE), "8000"], check=True)
+                subprocess.run([sys.executable, "-m", "http.server", "--directory", str(SITE), "8000"], check=True)
             except KeyboardInterrupt:
                 LOGGER.info(f"\n✅ Server stopped. Restart at {url}")
             except Exception as e:


### PR DESCRIPTION
## Summary
- use `sys.executable` instead of hardcoded `"python"` for the local preview server
- add startup check for `zensical` to fail fast with a clear install message

## Problem

**`"python"` not found on macOS (line 674):**
On macOS (both Homebrew and python.org installs), only `python3` exists — there is no `python` symlink. The local preview server launched after a successful build fails with `FileNotFoundError: [Errno 2] No such file or directory: 'python'`. The existing `except Exception` block catches it but shows a confusing error message with no fix suggestion.

This only affects local development — CI uses `actions/setup-python` which creates a `python` symlink.

**Missing `zensical` detected too late (line 609):**
If `zensical` is not installed, the script runs ~15s of work (cloning repos, generating reference docs, rendering macros) before crashing with `FileNotFoundError` at the build step. All other dependencies (`minijinja`, `yaml`, `bs4`) are imported at module level and fail immediately.

## Fix

- replace `"python"` with `sys.executable` on line 674 — uses the same interpreter that is running the script
- add `shutil.which("zensical")` check at the top of `main()` with a clear install instruction

## Test plan
- [x] `sys.executable` correctly resolves to python3 and http.server works
- [x] zensical check passes when installed
- [x] zensical check prints clear error and exits when missing
- [x] `build_docs.py` imports and runs without errors
- [x] only `build_docs.py` modified, no unrelated changes

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves `docs/build_docs.py` portability for local development by validating a required tool upfront and using the active Python interpreter when launching the local docs server. 🛠️

### 📊 Key Changes
- Added `import sys` to access the currently running Python executable.
- Added an early dependency check for `zensical` using `shutil.which("zensical")`.
- Exits with a clear install message if `zensical` is unavailable: `pip install -e '.[dev]'`.
- Replaced hardcoded `python` in the local HTTP server command with `sys.executable`.
- Keeps the docs build flow unchanged apart from better environment handling and clearer local setup behavior. 📚

### 🎯 Purpose & Impact
- Prevents confusing build failures by surfacing a missing `zensical` dependency immediately. ✅
- Improves portability across virtual environments, Conda setups, and systems where `python` may not point to the intended interpreter. 🔄
- Makes local docs development more reliable and predictable for contributors. 👩‍💻
- Reduces setup friction without changing user-facing package functionality. 🚀