### PR TITLE
Add `dota128` dataset

### DIFF
--- a/docs/en/datasets/index.md
+++ b/docs/en/datasets/index.md
@@ -89,7 +89,7 @@ Oriented Bounding Boxes (OBB) is a method in computer vision for detecting angle
 
 - [DOTA-v2](obb/dota-v2.md): A popular OBB aerial imagery dataset with 1.7 million instances and 11,268 images.
 - [DOTA8](obb/dota8.md): A smaller subset of the first 8 images from the DOTAv1 split set, 4 for training and 4 for validation, suitable for quick tests.
-- [DOTA128](dota128.md): A 128-image subset of the DOTA dataset with 128 images for training and validation, providing a good balance between size and diversity for testing OBB models.
+- [DOTA128](obb/dota128.md): A 128-image subset of the DOTA dataset with 128 images for training and validation, providing a good balance between size and diversity for testing OBB models.
 
 ## [Multi-Object Tracking](track/index.md)
 

--- a/docs/en/datasets/index.md
+++ b/docs/en/datasets/index.md
@@ -89,6 +89,7 @@ Oriented Bounding Boxes (OBB) is a method in computer vision for detecting angle
 
 - [DOTA-v2](obb/dota-v2.md): A popular OBB aerial imagery dataset with 1.7 million instances and 11,268 images.
 - [DOTA8](obb/dota8.md): A smaller subset of the first 8 images from the DOTAv1 split set, 4 for training and 4 for validation, suitable for quick tests.
+- [DOTA128](dota128.md): A 128-image subset of the DOTA dataset with 128 images for training and validation, providing a good balance between size and diversity for testing OBB models.
 
 ## [Multi-Object Tracking](track/index.md)
 

--- a/docs/en/datasets/obb/dota128.md
+++ b/docs/en/datasets/obb/dota128.md
@@ -12,7 +12,7 @@ keywords: DOTA128 dataset, Ultralytics, YOLO26, object detection, debugging, tra
 
 ## Dataset Structure
 
-- **Images**: 128 aerial tiles (64 train, 64 val) sourced from DOTAv1.
+- **Images**: 128 aerial tiles (all in train folder, used for both train and val) sourced from DOTAv1.
 - **Classes**: Inherits the 15 DOTAv1 categories such as plane, ship, and large vehicle.
 - **Labels**: YOLO-format oriented bounding boxes saved as `.txt` files beside each image.
 - **Recommended layout**:
@@ -101,7 +101,7 @@ A special note of gratitude to the team behind the DOTA datasets for their comme
 
 ### What is the DOTA128 dataset and how can it be used?
 
-The DOTA128 dataset is a versatile oriented object detection dataset made up of 128 images from the DOTAv1 set, with 64 images designated for training and 64 for validation. It's ideal for testing and debugging OBB models like Ultralytics YOLO26. Due to its manageable size and diversity, it helps in identifying pipeline errors and running sanity checks before deploying larger datasets. Learn more about OBB detection with [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics).
+The DOTA128 dataset is a versatile oriented object detection dataset made up of 128 images from the DOTAv1 set, all stored in the train folder. Both training and validation use the same set of images, making it ideal for quick testing and debugging workflows. It's ideal for testing and debugging OBB models like Ultralytics YOLO26. Due to its manageable size and diversity, it helps in identifying pipeline errors and running sanity checks before deploying larger datasets. Learn more about OBB detection with [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics).
 
 ### How do I train a YOLO26 model using the DOTA128 dataset?
 
@@ -137,7 +137,7 @@ The DOTA dataset is known for its large-scale benchmark and the challenges it pr
 DOTA128 (128 images) sits between [DOTA8](dota8.md) (8 images) and the full [DOTA-v1](dota-v2.md) dataset (1,869 images) in terms of size:
 
 - **DOTA8**: Contains just 8 images (4 train, 4 val) - ideal for quick tests and debugging
-- **DOTA128**: Contains 128 images (64 train, 64 val) - balanced between size and diversity
+- **DOTA128**: Contains 128 images (all in train folder, used for both train and val) - balanced between size and diversity
 - **Full DOTA-v1**: Contains 1,869 images - comprehensive but resource-intensive
 
 DOTA128 provides a good middle ground, offering more diversity than DOTA8 while remaining much more manageable than the full DOTA dataset for experimentation and initial model development.

--- a/docs/en/datasets/obb/dota128.md
+++ b/docs/en/datasets/obb/dota128.md
@@ -8,24 +8,13 @@ keywords: DOTA128 dataset, Ultralytics, YOLO26, object detection, debugging, tra
 
 ## Introduction
 
-[Ultralytics](https://www.ultralytics.com/) DOTA128 is a small but versatile oriented [object detection](https://www.ultralytics.com/glossary/object-detection) dataset composed of 128 images from the DOTAv1 set, 64 for training and 64 for validation. This dataset is ideal for testing and debugging oriented bounding box (OBB) models, or for experimenting with new detection approaches. With 128 images, it is small enough to be easily manageable, yet diverse enough to test training pipelines for errors and act as a sanity check before training larger datasets.
+[Ultralytics](https://www.ultralytics.com/) DOTA128 is a small but versatile oriented [object detection](https://www.ultralytics.com/glossary/object-detection) dataset composed of 128 images from the DOTAv1 set, 128 for training and validation. This dataset is ideal for testing and debugging oriented bounding box (OBB) models, or for experimenting with new detection approaches. With 128 images, it is small enough to be easily manageable, yet diverse enough to test training pipelines for errors and act as a sanity check before training larger datasets.
 
 ## Dataset Structure
 
 - **Images**: 128 aerial tiles (all in train folder, used for both train and val) sourced from DOTAv1.
 - **Classes**: Inherits the 15 DOTAv1 categories such as plane, ship, and large vehicle.
 - **Labels**: YOLO-format oriented bounding boxes saved as `.txt` files beside each image.
-- **Recommended layout**:
-
-    ```
-    datasets/dota128/
-    ├── images/
-    │   ├── train/
-    │   └── val/
-    └── labels/
-        ├── train/
-        └── val/
-    ```
 
 This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
 

--- a/docs/en/datasets/obb/dota128.md
+++ b/docs/en/datasets/obb/dota128.md
@@ -1,0 +1,151 @@
+---
+comments: true
+description: Explore the DOTA128 dataset - a versatile oriented object detection dataset ideal for testing and debugging OBB models using Ultralytics YOLO26.
+keywords: DOTA128 dataset, Ultralytics, YOLO26, object detection, debugging, training models, oriented object detection, dataset YAML
+---
+
+# DOTA128 Dataset
+
+## Introduction
+
+[Ultralytics](https://www.ultralytics.com/) DOTA128 is a small but versatile oriented [object detection](https://www.ultralytics.com/glossary/object-detection) dataset composed of 128 images from the DOTAv1 set, 64 for training and 64 for validation. This dataset is ideal for testing and debugging oriented bounding box (OBB) models, or for experimenting with new detection approaches. With 128 images, it is small enough to be easily manageable, yet diverse enough to test training pipelines for errors and act as a sanity check before training larger datasets.
+
+## Dataset Structure
+
+- **Images**: 128 aerial tiles (64 train, 64 val) sourced from DOTAv1.
+- **Classes**: Inherits the 15 DOTAv1 categories such as plane, ship, and large vehicle.
+- **Labels**: YOLO-format oriented bounding boxes saved as `.txt` files beside each image.
+- **Recommended layout**:
+
+    ```
+    datasets/dota128/
+    ├── images/
+    │   ├── train/
+    │   └── val/
+    └── labels/
+        ├── train/
+        └── val/
+    ```
+
+This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+
+## Dataset YAML
+
+A YAML (Yet Another Markup Language) file is used to define the dataset configuration. It contains information about the dataset's paths, classes, and other relevant information. In the case of the DOTA128 dataset, the `dota128.yaml` file is maintained at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/dota128.yaml](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/dota128.yaml).
+
+!!! example "ultralytics/cfg/datasets/dota128.yaml"
+
+    ```yaml
+    --8<-- "ultralytics/cfg/datasets/dota128.yaml"
+    ```
+
+## Usage
+
+To train a YOLO26n-obb model on the DOTA128 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page.
+
+!!! example "Train Example"
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        # Load a model
+        model = YOLO("yolo26n-obb.pt")  # load a pretrained model (recommended for training)
+
+        # Train the model
+        results = model.train(data="dota128.yaml", epochs=100, imgsz=640)
+        ```
+
+    === "CLI"
+
+        ```bash
+        # Start training from a pretrained *.pt model
+        yolo obb train data=dota128.yaml model=yolo26n-obb.pt epochs=100 imgsz=640
+        ```
+
+## Sample Images and Annotations
+
+Here are some examples of images from the DOTA128 dataset, along with their corresponding annotations:
+
+<img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/mosaiced-training-batch.avif" alt="DOTA128 oriented bounding box dataset training mosaic" width="800">
+
+- **Mosaiced Image**: This image demonstrates a training batch composed of mosaiced dataset images. Mosaicing is a technique used during training that combines multiple images into a single image to increase the variety of objects and scenes within each training batch. This helps improve the model's ability to generalize to different object sizes, aspect ratios, and contexts.
+
+The example showcases the variety and complexity of the images in the DOTA128 dataset and the benefits of using mosaicing during the training process.
+
+## Citations and Acknowledgments
+
+If you use the DOTA dataset in your research or development work, please cite the following paper:
+
+!!! quote ""
+
+    === "BibTeX"
+
+        ```bibtex
+        @article{9560031,
+          author={Ding, Jian and Xue, Nan and Xia, Gui-Song and Bai, Xiang and Yang, Wen and Yang, Michael and Belongie, Serge and Luo, Jiebo and Datcu, Mihai and Pelillo, Marcello and Zhang, Liangpei},
+          journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
+          title={Object Detection in Aerial Images: A Large-Scale Benchmark and Challenges},
+          year={2021},
+          volume={},
+          number={},
+          pages={1-1},
+          doi={10.1109/TPAMI.2021.3117983}
+        }
+        ```
+
+A special note of gratitude to the team behind the DOTA datasets for their commendable effort in curating this dataset. For an exhaustive understanding of the dataset and its nuances, please visit the [official DOTA website](https://captain-whu.github.io/DOTA/index.html).
+
+## FAQ
+
+### What is the DOTA128 dataset and how can it be used?
+
+The DOTA128 dataset is a versatile oriented object detection dataset made up of 128 images from the DOTAv1 set, with 64 images designated for training and 64 for validation. It's ideal for testing and debugging OBB models like Ultralytics YOLO26. Due to its manageable size and diversity, it helps in identifying pipeline errors and running sanity checks before deploying larger datasets. Learn more about OBB detection with [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics).
+
+### How do I train a YOLO26 model using the DOTA128 dataset?
+
+To train a YOLO26n-obb model on the DOTA128 dataset for 100 epochs with an image size of 640, you can use the following code snippets. For comprehensive argument options, refer to the model [Training](../../modes/train.md) page.
+
+!!! example "Train Example"
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        # Load a model
+        model = YOLO("yolo26n-obb.pt")  # load a pretrained model (recommended for training)
+
+        # Train the model
+        results = model.train(data="dota128.yaml", epochs=100, imgsz=640)
+        ```
+
+    === "CLI"
+
+        ```bash
+        # Start training from a pretrained *.pt model
+        yolo obb train data=dota128.yaml model=yolo26n-obb.pt epochs=100 imgsz=640
+        ```
+
+### What are the key features of the DOTA dataset and where can I access the YAML file?
+
+The DOTA dataset is known for its large-scale benchmark and the challenges it presents for object detection in aerial images. The DOTA128 subset provides more diversity than DOTA8 while remaining manageable for initial tests. You can access the `dota128.yaml` file, which contains paths, classes, and configuration details, at this [GitHub link](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/dota128.yaml).
+
+### How does DOTA128 compare to other DOTA dataset variants?
+
+DOTA128 (128 images) sits between [DOTA8](dota8.md) (8 images) and the full [DOTA-v1](dota-v2.md) dataset (1,869 images) in terms of size:
+
+- **DOTA8**: Contains just 8 images (4 train, 4 val) - ideal for quick tests and debugging
+- **DOTA128**: Contains 128 images (64 train, 64 val) - balanced between size and diversity
+- **Full DOTA-v1**: Contains 1,869 images - comprehensive but resource-intensive
+
+DOTA128 provides a good middle ground, offering more diversity than DOTA8 while remaining much more manageable than the full DOTA dataset for experimentation and initial model development.
+
+### How does mosaicing enhance model training with the DOTA128 dataset?
+
+Mosaicing combines multiple images into one during training, increasing the variety of objects and contexts within each batch. This improves a model's ability to generalize to different object sizes, aspect ratios, and scenes. This technique can be visually demonstrated through a training batch composed of mosaiced DOTA128 dataset images, helping in robust model development. Explore more about mosaicing and training techniques on our [Training](../../modes/train.md) page.
+
+### Why should I use Ultralytics YOLO26 for oriented object detection tasks?
+
+Ultralytics YOLO26 provides state-of-the-art real-time object detection capabilities, including features like oriented bounding boxes (OBB), [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation), and a highly versatile training pipeline. It's suitable for various applications and offers pretrained models for efficient fine-tuning. Explore further about the advantages and usage in the [Ultralytics YOLO26 documentation](https://github.com/ultralytics/ultralytics).

--- a/docs/en/datasets/obb/index.md
+++ b/docs/en/datasets/obb/index.md
@@ -71,6 +71,7 @@ Currently, the following datasets with oriented bounding boxes are supported:
 - [DOTA-v1.5](dota-v2.md#dota-v15): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md#dota-v20): DOTA (A Large-scale Dataset for Object Detection in Aerial Images) version 2, emphasizes detection from aerial perspectives and contains oriented bounding boxes with 1.7 million instances and 11,268 images.
 - [DOTA8](dota8.md): A small, 8-image subset of the full DOTA dataset suitable for testing workflows and Continuous Integration (CI) checks of OBB training in the `ultralytics` repository.
+- [DOTA128](dota128.md): A 128-image subset of the DOTA dataset with 64 images for training and 64 for validation, providing a good balance between size and diversity for testing OBB models.
 
 ### Incorporating your own OBB dataset
 
@@ -149,6 +150,7 @@ Currently, Ultralytics supports the following datasets for OBB training:
 - [DOTA-v1.5](dota-v2.md): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md): This dataset includes 1.7 million instances with oriented bounding boxes and 11,268 images, primarily focusing on aerial object detection.
 - [DOTA8](dota8.md): A smaller, 8-image subset of the DOTA dataset used for testing and [continuous integration](../../help/CI.md) (CI) checks.
+- [DOTA128](dota128.md): A 128-image subset offering more diversity than DOTA8 while remaining manageable for initial OBB model development and experimentation.
 
 These datasets are tailored for scenarios where OBBs offer a significant advantage, such as aerial and satellite image analysis.
 

--- a/docs/en/datasets/obb/index.md
+++ b/docs/en/datasets/obb/index.md
@@ -71,7 +71,7 @@ Currently, the following datasets with oriented bounding boxes are supported:
 - [DOTA-v1.5](dota-v2.md#dota-v15): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md#dota-v20): DOTA (A Large-scale Dataset for Object Detection in Aerial Images) version 2, emphasizes detection from aerial perspectives and contains oriented bounding boxes with 1.7 million instances and 11,268 images.
 - [DOTA8](dota8.md): A small, 8-image subset of the full DOTA dataset suitable for testing workflows and Continuous Integration (CI) checks of OBB training in the `ultralytics` repository.
-- [DOTA128](dota128.md): A 128-image subset of the DOTA dataset with 64 images for training and 64 for validation, providing a good balance between size and diversity for testing OBB models.
+- [DOTA128](dota128.md): A 128-image subset of the DOTA dataset with all images in the train folder (used for both train and val), providing a good balance between size and diversity for testing OBB models.
 
 ### Incorporating your own OBB dataset
 
@@ -150,7 +150,7 @@ Currently, Ultralytics supports the following datasets for OBB training:
 - [DOTA-v1.5](dota-v2.md): An intermediate version of the DOTA dataset, offering additional annotations and improvements over DOTA-v1 for enhanced object detection tasks.
 - [DOTA-v2](dota-v2.md): This dataset includes 1.7 million instances with oriented bounding boxes and 11,268 images, primarily focusing on aerial object detection.
 - [DOTA8](dota8.md): A smaller, 8-image subset of the DOTA dataset used for testing and [continuous integration](../../help/CI.md) (CI) checks.
-- [DOTA128](dota128.md): A 128-image subset offering more diversity than DOTA8 while remaining manageable for initial OBB model development and experimentation.
+- [DOTA128](dota128.md): A 128-image subset with all images in the train folder (used for both train and val), offering more diversity than DOTA8 while remaining manageable for initial OBB model development and experimentation.
 
 These datasets are tailored for scenarios where OBBs offer a significant advantage, such as aerial and satellite image analysis.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -486,6 +486,7 @@ nav:
       - Oriented Bounding Boxes (OBB):
           - datasets/obb/index.md
           - DOTA8: datasets/obb/dota8.md
+          - DOTA128: datasets/obb/dota128.md
           - DOTAv2: datasets/obb/dota-v2.md
       - Multi-Object Tracking:
           - datasets/track/index.md

--- a/ultralytics/cfg/datasets/dota128.yaml
+++ b/ultralytics/cfg/datasets/dota128.yaml
@@ -1,0 +1,35 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# DOTA128 dataset (128 images from the DOTAv1 split) by Ultralytics
+# Documentation: https://docs.ultralytics.com/datasets/obb/dota128/
+# Example usage: yolo train model=yolo26n-obb.pt data=dota128.yaml
+# parent
+# ├── ultralytics
+# └── datasets
+#     └── dota128 ← downloads here (10 MB)
+
+# Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
+path: dota128 # dataset root dir
+train: images/train # train images (relative to 'path') 128 images
+val: images/train # val images (relative to 'path') 128 images
+
+# Classes for DOTA 1.0
+names:
+  0: plane
+  1: ship
+  2: storage tank
+  3: baseball diamond
+  4: tennis court
+  5: basketball court
+  6: ground track field
+  7: harbor
+  8: bridge
+  9: large vehicle
+  10: small vehicle
+  11: helicopter
+  12: roundabout
+  13: soccer ball field
+  14: swimming pool
+
+# Download script/URL (optional)
+download: https://github.com/ultralytics/assets/releases/download/v0.0.0/dota128.zip

--- a/ultralytics/cfg/datasets/dota128.yaml
+++ b/ultralytics/cfg/datasets/dota128.yaml
@@ -6,7 +6,7 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── dota128 ← downloads here (10 MB)
+#     └── dota128 ← downloads here (34 MB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: dota128 # dataset root dir


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📦 This PR adds **DOTA128**, a new lightweight OBB dataset option for Ultralytics docs and config files, giving users a practical middle ground between DOTA8 and the full DOTA dataset for testing and experimentation.

### 📊 Key Changes
- 🆕 Added a new dataset config file: `ultralytics/cfg/datasets/dota128.yaml`
- 📚 Created a full documentation page for **DOTA128** at `docs/en/datasets/obb/dota128.md`
- 🧭 Added DOTA128 to the dataset listings and navigation in:
  - `docs/en/datasets/index.md`
  - `docs/en/datasets/obb/index.md`
  - `mkdocs.yml`
- 🎯 Defined DOTA128 as a **128-image subset of DOTAv1** for oriented bounding box training
- 🔁 Configured the dataset so the same `images/train` split is used for both **train** and **val**, making it simple for quick tests
- 🤖 Included ready-to-use training examples for **YOLO26 OBB models** in both Python and CLI
- ⬇️ Added a download URL so the dataset can be fetched automatically

### 🎯 Purpose & Impact
- ⚡ Gives users a faster, more manageable dataset for **debugging, pipeline validation, and sanity checks** before running larger OBB training jobs
- balance_scale: Fills the gap between **DOTA8** (very small, minimal testing) and full **DOTA** datasets (larger, more resource-heavy)
- 🛠️ Makes it easier for developers and researchers to test **oriented bounding box workflows** without needing a full-scale aerial dataset
- 📖 Improves discoverability through docs and navigation, so users can find and start using DOTA128 more easily
- 🚀 Helps streamline experimentation with **YOLO26 OBB training**, especially for quick iteration and early-stage model development