### PR TITLE
Fix lowercase `callable` type hint to `Callable` in predictor

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -88,8 +88,8 @@ class BasePredictor:
         windows (list[str]): List of window names for visualization.
         batch (tuple): Current batch data.
         results (list[Any]): Current batch results.
-        transforms (callable): Image transforms for classification.
-        callbacks (dict[str, list[callable]]): Callback functions for different events.
+        transforms (Callable): Image transforms for classification.
+        callbacks (dict[str, list[Callable]]): Callback functions for different events.
         txt_path (Path): Path to save text results.
         _lock (threading.Lock): Lock for thread-safe inference.
 
@@ -112,7 +112,7 @@ class BasePredictor:
         self,
         cfg=DEFAULT_CFG,
         overrides: dict[str, Any] | None = None,
-        _callbacks: dict[str, list[callable]] | None = None,
+        _callbacks: dict[str, list[Callable]] | None = None,
     ):
         """Initialize the BasePredictor class.
 

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -39,7 +39,7 @@ import platform
 import re
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import cv2
 import numpy as np
@@ -508,6 +508,6 @@ class BasePredictor:
         for callback in self.callbacks.get(event, []):
             callback(self)
 
-    def add_callback(self, event: str, func: callable):
+    def add_callback(self, event: str, func: Callable):
         """Add a callback function for a specific event."""
         self.callbacks[event].append(func)


### PR DESCRIPTION
## Summary
- Fix incorrect lowercase `callable` type hint to proper `typing.Callable` in `BasePredictor.add_callback()` method
- Add `Callable` to the existing `typing` import in `ultralytics/engine/predictor.py`

## Details
Python's `callable` is a built-in function, not a type. Using it as a type hint (e.g., `func: callable`) is incorrect and may cause issues with static type checkers like `mypy`. The correct form is `typing.Callable`.

## Test plan
- [x] Verify `mypy` / type checkers no longer flag the annotation
- [ ] Existing tests pass without changes

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates type hints in `ultralytics/engine/predictor.py` by replacing lowercase `callable` with the correct `Callable` import from `typing` for improved type annotation accuracy 🛠️

### 📊 Key Changes
- Added `Callable` to the imports from `typing`.
- Updated the `transforms` attribute docstring type from `callable` to `Callable`.
- Updated the `callbacks` attribute docstring type from `dict[str, list[callable]]` to `dict[str, list[Callable]]`.
- Corrected the `_callbacks` constructor argument type hint to `dict[str, list[Callable]] | None`.
- Corrected the `add_callback()` method argument type hint from `callable` to `Callable`.

### 🎯 Purpose & Impact
- Improves Python typing correctness and consistency in the predictor module ✅
- Helps static analysis tools, editors, and contributors better understand callback-related APIs 🔍
- Has minimal runtime impact, since this is a type-hint-focused cleanup with low risk to users 🚀