### PR TITLE
fix docs CI: remove unused `black` dep and fix publish commit message

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@v7
       - name: Install Dependencies
-        run: uv pip install --system -e ".[dev]" ruff black --extra-index-url https://download.pytorch.org/whl/cpu
+        run: uv pip install --system -e ".[dev]" ruff --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Ruff fixes
         continue-on-error: true
         run: |
@@ -120,6 +120,7 @@ jobs:
           else
             git pull origin gh-pages
             LATEST_HASH=$(git rev-parse --short=7 HEAD)
-            git commit -m "Update Docs for 'ultralytics ${{ steps.check_pypi.outputs.version }} - $LATEST_HASH'"
+            VERSION=$(python -c "from ultralytics import __version__; print(__version__)")
+            git commit -m "Update Docs for 'ultralytics $VERSION - $LATEST_HASH'"
             git push https://${{ secrets._GITHUB_TOKEN }}@github.com/ultralytics/docs.git gh-pages
           fi


### PR DESCRIPTION
## Summary
- Remove unused `black` from install step — installed but never used since PR #15656 (Aug 2024)
- Fix broken `steps.check_pypi.outputs.version` reference in publish commit message — step doesn't exist in `docs.yml`, producing `'ultralytics  - abc1234'` (double space) in every docs publish commit. Replaced with actual package version via `python -c "from ultralytics import __version__; print(__version__)"`. Example [commit message](https://github.com/ultralytics/ultralytics/actions/runs/23038572790/job/66911852250#step:11:38) with the bug.

## Test plan
- [x] YAML validation passes
- [x] `black` fully removed from workflow
- [x] `check_pypi` reference replaced with working `__version__` import
- [x] Version import works from different working directory (simulating `cd docs-repo`)
- [x] Verified current broken commits: `Update Docs for 'ultralytics  - 919eecb'` (double space)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR streamlines the docs CI workflow by removing an unused `black` dependency and fixing the published docs commit message to use the installed Ultralytics version. 🚀

### 📊 Key Changes
- Removed `black` from the docs CI dependency installation step in `.github/workflows/docs.yml` since it is not used in the workflow.
- Updated the docs publish step to read `__version__` directly from the installed `ultralytics` package before creating the commit message.
- Replaced the previous commit message version source from `steps.check_pypi.outputs.version` with a runtime-derived package version for improved accuracy.

### 🎯 Purpose & Impact
- Reduces unnecessary dependency installation in docs CI, which can slightly improve workflow simplicity and reliability. ⚙️
- Ensures published docs commit messages reflect the actual installed Ultralytics version, avoiding mismatched or missing version references. 📝
- Improves maintainability of the docs deployment pipeline with a small, targeted CI fix. ✅