### PR TITLE
Remove unused tip from `export-table.md`

### DIFF
--- a/docs/macros/export-table.md
+++ b/docs/macros/export-table.md
@@ -1,6 +1,5 @@
 {%set tip1 = ':material-information-outline:{ title="conf, iou, agnostic_nms are also available when nms=True" }' %}
-{%set tip2 = ':material-information-outline:{ title="conf, iou are also available when nms=True" }' %}
-{%set tip3 = ':material-information-outline:{ title="IMX format is currently only supported for YOLOv8n, YOLO11n models" }' %}
+{%set tip2 = ':material-information-outline:{ title="IMX format is currently only supported for YOLOv8n, YOLO11n models" }' %}
 
 | Format                                             | `format` Argument | Model                                             | Metadata | Arguments                                                                                                           |
 | -------------------------------------------------- | ----------------- | ------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -18,7 +17,7 @@
 | [PaddlePaddle](../integrations/paddlepaddle.md)    | `paddle`          | `{{ model_name or "yolo26n" }}_paddle_model/`     | ✅       | `imgsz`, `batch`, `device`                                                                                          |
 | [MNN](../integrations/mnn.md)                      | `mnn`             | `{{ model_name or "yolo26n" }}.mnn`               | ✅       | `imgsz`, `batch`, `int8`, `half`, `device`                                                                          |
 | [NCNN](../integrations/ncnn.md)                    | `ncnn`            | `{{ model_name or "yolo26n" }}_ncnn_model/`       | ✅       | `imgsz`, `half`, `batch`, `device`                                                                                  |
-| [IMX500](../integrations/sony-imx500.md){{ tip3 }} | `imx`             | `{{ model_name or "yolo26n" }}_imx_model/`        | ✅       | `imgsz`, `int8`, `data`, `fraction`, `device`                                                                       |
+| [IMX500](../integrations/sony-imx500.md){{ tip2 }} | `imx`             | `{{ model_name or "yolo26n" }}_imx_model/`        | ✅       | `imgsz`, `int8`, `data`, `fraction`, `device`                                                                       |
 | [RKNN](../integrations/rockchip-rknn.md)           | `rknn`            | `{{ model_name or "yolo26n" }}_rknn_model/`       | ✅       | `imgsz`, `batch`, `name`, `device`                                                                                  |
 | [ExecuTorch](../integrations/executorch.md)        | `executorch`      | `{{ model_name or "yolo26n" }}_executorch_model/` | ✅       | `imgsz`, `device`                                                                                                   |
 | [Axelera](../integrations/axelera.md)              | `axelera`         | `{{ model_name or "yolo26n" }}_axelera_model/`    | ✅       | `imgsz`, `int8`, `data`, `fraction`, `device`                                                                       |


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes a small documentation cleanup in the export table by simplifying tooltip definitions and keeping the IMX500 support note clearly attached to the correct export format.

### 📊 Key Changes
- Removed an unused tooltip macro related to `conf` and `iou` arguments when `nms=True`.
- Renumbered the remaining tooltip macros to simplify the documentation template.
- Kept the IMX500 export note in place, clarifying that IMX format is currently supported only for `YOLOv8n` and `YOLO11n` models.
- Updated `docs/macros/export-table.md` only, with no code or runtime changes.

### 🎯 Purpose & Impact
- Improves documentation maintainability ✨ by reducing unnecessary macro definitions.
- Helps keep the export table cleaner and easier to understand for users browsing supported export formats.
- Prevents confusion around IMX500 export support 📌 by preserving the model limitation note in the right place.
- Has no effect on model training, inference, or export behavior; this is a documentation-only change ✅