### PR TITLE
Calibration dataset size < `batch` fix

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -610,7 +610,7 @@ def main():
 
         # Build the main documentation
         LOGGER.info(f"Building docs from {DOCS}")
-        subprocess.run(["zensical", "build", "-f", str(DOCS.parent / "mkdocs.yml")], check=True)
+        subprocess.run(["zensical", "build", "-f", str(DOCS.parent / "mkdocs.yml"), "--strict"], check=True)
         LOGGER.info(f"Site built at {SITE}")
 
         # Remove search index JSON files to disable search

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -677,7 +677,7 @@ class Exporter:
             LOGGER.warning(
                 f"{prefix} calibration dataset has only {n} images, reducing calibration batch size to {batch}."
             )
-        elif self.args.format == "axelera" and n < 100:
+        if self.args.format == "axelera" and n < 100:
             LOGGER.warning(f"{prefix} >100 images required for Axelera calibration, found {n} images.")
         elif self.args.format != "axelera" and n < 300:
             LOGGER.warning(f"{prefix} >300 images recommended for INT8 calibration, found {n} images.")

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -670,16 +670,18 @@ class Exporter:
             batch_size=self.args.batch,
         )
         n = len(dataset)
+        if n < 1:
+            raise ValueError(f"The calibration dataset must have at least 1 image, but found {n} images.")
+        batch = min(self.args.batch, n)
         if n < self.args.batch:
-            raise ValueError(
-                f"The calibration dataset ({n} images) must have at least as many images as the batch size "
-                f"('batch={self.args.batch}')."
+            LOGGER.warning(
+                f"{prefix} calibration dataset has only {n} images, reducing calibration batch size to {batch}."
             )
         elif self.args.format == "axelera" and n < 100:
             LOGGER.warning(f"{prefix} >100 images required for Axelera calibration, found {n} images.")
         elif self.args.format != "axelera" and n < 300:
             LOGGER.warning(f"{prefix} >300 images recommended for INT8 calibration, found {n} images.")
-        return build_dataloader(dataset, batch=self.args.batch, workers=0, drop_last=True)  # required for batch loading
+        return build_dataloader(dataset, batch=batch, workers=0, drop_last=True)  # required for batch loading
 
     @try_export
     def export_torchscript(self, prefix=colorstr("TorchScript:")):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes documentation builds stricter and improves INT8 export calibration by handling small datasets more gracefully instead of failing unnecessarily.

### 📊 Key Changes
- 📚 Updated the docs build command in `docs/build_docs.py` to use `--strict` with `zensical build`.
- ✅ This means documentation builds will now fail on warnings or issues that were previously easier to miss.
- 🤖 Improved INT8 calibration dataloader logic in `ultralytics/engine/exporter.py`.
- 🔍 Added a check to ensure the calibration dataset has at least 1 image.
- 📉 If the calibration dataset has fewer images than the requested batch size, the exporter now automatically reduces the batch size instead of raising an error.
- ⚠️ Existing warnings for small calibration datasets remain, including format-specific guidance for Axelera and general INT8 export recommendations.
- 🚚 The dataloader now uses the adjusted batch size when building the calibration loader.

### 🎯 Purpose & Impact
- 🧹 **Better documentation quality:** Strict doc builds help catch broken docs earlier, improving reliability for contributors and users reading the documentation.
- 💡 **More user-friendly exports:** Small calibration datasets no longer cause immediate export failure just because the batch size is too large.
- 🔄 **Improved robustness:** Export workflows can continue in more edge cases, especially for quick tests or limited datasets.
- ⚠️ **Clearer safeguards:** Users still get warnings when calibration datasets are smaller than recommended, helping maintain export quality expectations.
- 🚀 **Smoother developer experience:** This reduces friction in INT8 model export while also tightening standards for documentation maintenance.