### PR TITLE
Update format.yml to `cpu-latest`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   actions:
-    runs-on: ubuntu-latest
+    runs-on: cpu-latest
     steps:
       - name: Run Ultralytics Actions
         uses: ultralytics/actions@main


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the formatting GitHub Actions workflow to run on `cpu-latest` instead of `ubuntu-latest`.

### 📊 Key Changes
- Changed the runner in `.github/workflows/format.yml`:
  - from `ubuntu-latest`
  - to `cpu-latest`
- This affects the **formatting/CI workflow** that runs Ultralytics Actions during code formatting checks.

### 🎯 Purpose & Impact
- 🚀 Aligns the formatting workflow with Ultralytics’ preferred runner environment.
- 🛠️ May improve consistency across CI jobs by using a standardized `cpu-latest` runner.
- 📦 Helps ensure formatting checks run in the intended infrastructure, which can reduce environment-related issues.
- 👀 For most users, this has **no direct product impact**, but it can make development and pull request validation more reliable for contributors.