### PR TITLE
fix outdated INT8 batch doubling references in TensorRT docs

### DIFF
--- a/docs/en/integrations/tensorrt.md
+++ b/docs/en/integrations/tensorrt.md
@@ -159,7 +159,7 @@ The arguments provided when using [export](../modes/export.md) for an Ultralytic
 
 !!! note
 
-    During calibration, twice the `batch` size provided will be used. Using small batches can lead to inaccurate scaling during calibration. This is because the process adjusts based on the data it sees. Small batches might not capture the full range of values, leading to issues with the final calibration, so the `batch` size is doubled automatically. If no [batch size](https://www.ultralytics.com/glossary/batch-size) is specified `batch=1`, calibration will be run at `batch=1 * 2` to reduce calibration scaling errors.
+    Using small batches can lead to inaccurate scaling during INT8 calibration. This is because the process adjusts based on the data it sees. Small batches might not capture the full range of values, leading to issues with the final calibration. Using a larger [batch size](https://www.ultralytics.com/glossary/batch-size) helps ensure more representative calibration results.
 
 Experimentation by NVIDIA led them to recommend using at least 500 calibration images that are representative of the data for your model, with INT8 quantization calibration. This is a guideline and not a _hard_ requirement, and <u>**you will need to experiment with what is required to perform well for your dataset**.</u> Since the calibration data is required for INT8 calibration with TensorRT, make certain to use the `data` argument when `int8=True` for TensorRT and use `data="my_dataset.yaml"`, which will use the images from [validation](../modes/val.md) to calibrate with. When no value is passed for `data` with export to TensorRT with INT8 quantization, the default will be to use one of the ["small" example datasets based on the model task](../datasets/index.md) instead of throwing an error.
 
@@ -188,7 +188,7 @@ Experimentation by NVIDIA led them to recommend using at least 500 calibration i
         ```
 
         1. Exports with dynamic axes, this will be enabled by default when exporting with `int8=True` even when not explicitly set. See [export arguments](../modes/export.md#arguments) for additional information.
-        2. Sets max batch size of 8 for exported model, which calibrates with `batch = 2 * 8` to avoid scaling errors during calibration.
+        2. Sets max batch size of 8 for exported model and INT8 calibration.
         3. Allocates 4 GiB of memory instead of allocating the entire device for conversion process.
         4. Uses [COCO dataset](../datasets/detect/coco.md) for calibration, specifically the images used for [validation](../modes/val.md) (5,000 total).
 


### PR DESCRIPTION
## Summary
- Remove outdated references to automatic batch doubling during INT8 calibration in `docs/en/integrations/tensorrt.md`
- Batch doubling was removed in #20989 (Jun 2025) but the documentation was never updated
- Two locations fixed: the note block explaining doubled batch behavior, and the annotation comment claiming `batch = 2 * 8`

## Context
- Batch doubling was originally added in #10165, made conditional in #14872, and fully removed in #20989
- Current code in `exporter.py` (`get_int8_calibration_dataloader`) uses `batch = min(self.args.batch, n)` with no doubling
- `EngineCalibrator` in `export/engine.py` takes batch directly from the dataloader with no modification

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the TensorRT documentation to remove outdated INT8 calibration wording about automatic batch doubling and replace it with clearer, current guidance on using larger batches for more reliable calibration. ✨

### 📊 Key Changes
- Removed the outdated note claiming TensorRT INT8 calibration automatically uses twice the provided `batch` size.
- Reworded the INT8 calibration guidance to explain that small batches can reduce calibration quality and that larger batches are generally more representative. 📚
- Updated the export example explanation to state that `batch=8` sets the max batch size for the exported model and INT8 calibration, without referencing deprecated doubling behavior.
- Kept the rest of the TensorRT export and calibration recommendations intact, including dataset and memory guidance. 🔧

### 🎯 Purpose & Impact
- Improves accuracy and consistency of the TensorRT docs by aligning them with current behavior. ✅
- Helps users avoid confusion when exporting INT8 TensorRT models and selecting calibration settings.
- Reduces the chance of misunderstanding batch handling during calibration, leading to better-informed export workflows for YOLO models. 🚀