### PR TITLE
Infer NDJSON Pose keypoint length

### DIFF
--- a/docs/en/reference/data/converter.md
+++ b/docs/en/reference/data/converter.md
@@ -51,6 +51,10 @@ keywords: Ultralytics, data conversion, YOLO models, COCO, DOTA, YOLO bbox2segme
 
 <br><br><hr><br>
 
+## ::: ultralytics.data.converter._infer_ndjson_kpt_shape
+
+<br><br><hr><br>
+
 ## ::: ultralytics.data.converter.convert_ndjson_to_yolo
 
 <br><br>

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -748,6 +748,44 @@ def convert_to_multispectral(path: str | Path, n_channels: int = 10, replace: bo
         LOGGER.info(f"Converted {output_path}")
 
 
+def _infer_ndjson_kpt_shape(image_records: list) -> list:
+    """Infer kpt_shape [num_keypoints, dims] from NDJSON pose annotations.
+
+    Scans up to 50 pose annotations across image records. Annotation format is
+    [classId, cx, cy, w, h, kp1_x, kp1_y, kp1_vis, ...] so keypoint values start at index 5.
+
+    Tries dims=3 first (x, y, visibility) with visibility validation ({0, 1, 2}), then falls
+    back to dims=2 (x, y only) when values are unambiguously not divisible by 3.
+    """
+    kpt_lengths = []
+    samples = []  # raw keypoint value slices for visibility checking
+    for record in image_records:
+        for ann in record.get("annotations", {}).get("pose", []):
+            kpt_len = len(ann) - 5  # subtract classId + bbox (4 values)
+            if kpt_len > 0:
+                kpt_lengths.append(kpt_len)
+                samples.append(ann[5:])
+            if len(kpt_lengths) >= 50:
+                break
+        if len(kpt_lengths) >= 50:
+            break
+
+    if not kpt_lengths or len(set(kpt_lengths)) != 1:
+        raise ValueError("Pose dataset missing required 'kpt_shape'. See https://docs.ultralytics.com/datasets/pose/")
+
+    n = kpt_lengths[0]
+
+    # Try dims=3: requires divisible by 3 and every 3rd value (visibility) in {0, 1, 2}
+    if n % 3 == 0 and all(v in (0, 1, 2) for s in samples for v in s[2::3]):
+        return [n // 3, 3]
+
+    # Try dims=2: only when NOT divisible by 3 (avoids misclassifying dims=3 data)
+    if n % 2 == 0 and n % 3 != 0:
+        return [n // 2, 2]
+
+    raise ValueError("Pose dataset missing required 'kpt_shape'. See https://docs.ultralytics.com/datasets/pose/")
+
+
 async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Path | None = None) -> Path:
     """Convert NDJSON dataset format to Ultralytics YOLO dataset structure.
 
@@ -822,7 +860,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         if "val" not in splits and "test" not in splits:
             raise ValueError(f"Dataset missing required 'val' split. Found splits: {sorted(splits)}")
     if task == "pose" and "kpt_shape" not in dataset_record:
-        raise ValueError("Pose dataset missing required 'kpt_shape'. See https://docs.ultralytics.com/datasets/pose/")
+        dataset_record["kpt_shape"] = _infer_ndjson_kpt_shape(image_records)
 
     # Check if dataset already exists (enables image reuse across split changes)
     _reuse = dataset_dir.exists()

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -751,11 +751,11 @@ def convert_to_multispectral(path: str | Path, n_channels: int = 10, replace: bo
 def _infer_ndjson_kpt_shape(image_records: list) -> list:
     """Infer kpt_shape [num_keypoints, dims] from NDJSON pose annotations.
 
-    Scans up to 50 pose annotations across image records. Annotation format is
-    [classId, cx, cy, w, h, kp1_x, kp1_y, kp1_vis, ...] so keypoint values start at index 5.
+    Scans up to 50 pose annotations across image records. Annotation format is [classId, cx, cy, w, h, kp1_x, kp1_y,
+    kp1_vis, ...] so keypoint values start at index 5.
 
-    Tries dims=3 first (x, y, visibility) with visibility validation ({0, 1, 2}), then falls
-    back to dims=2 (x, y only) when values are unambiguously not divisible by 3.
+    Tries dims=3 first (x, y, visibility) with visibility validation ({0, 1, 2}), then falls back to dims=2 (x, y only)
+    when values are unambiguously not divisible by 3.
     """
     kpt_lengths = []
     samples = []  # raw keypoint value slices for visibility checking


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR improves NDJSON-to-YOLO pose dataset conversion by automatically inferring missing `kpt_shape` metadata instead of failing immediately.

### 📊 Key Changes
- Added a new internal helper: `ultralytics.data.converter._infer_ndjson_kpt_shape`.
- Updated `convert_ndjson_to_yolo()` so pose datasets without an explicit `kpt_shape` can still be converted automatically.
- The new logic scans up to 50 pose annotations and determines keypoint format by:
  - checking consistent keypoint lengths across samples
  - detecting whether annotations use 3 values per keypoint (`x, y, visibility`)
  - falling back to 2 values per keypoint (`x, y`) when appropriate
- Preserved strict validation:
  - conversion still raises an error if keypoint data is inconsistent or ambiguous
  - visibility values must match expected pose conventions
- Added documentation for the new helper in the converter reference docs.

### 🎯 Purpose & Impact
- ✅ Makes pose dataset conversion more user-friendly by reducing required manual metadata.
- 🚀 Helps users convert NDJSON pose datasets that are missing `kpt_shape`, avoiding unnecessary failures.
- 🛡️ Maintains reliability by rejecting malformed or unclear annotation formats instead of guessing incorrectly.
- 📦 Improves the developer and user experience for dataset migration into Ultralytics YOLO workflows.
- 📚 Better documentation makes the new behavior easier to discover and understand.