### PR TITLE
Fix TensorRT export OOM on Jetson shared-memory devices

### DIFF
--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -100,6 +100,8 @@ def onnx2engine(
     builder = trt.Builder(logger)
     config = builder.create_builder_config()
     workspace_bytes = int((workspace or 0) * (1 << 30))
+    if IS_JETSON and workspace is None:
+        workspace_bytes = 1 << 30  # 1 GiB default for Jetson shared-memory devices
     is_trt10 = int(trt.__version__.split(".", 1)[0]) >= 10  # is TensorRT >= 10
     if is_trt10 and workspace_bytes > 0:
         config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
@@ -139,7 +141,10 @@ def onnx2engine(
     if dynamic:
         profile = builder.create_optimization_profile()
         min_shape = (1, shape[1], 32, 32)  # minimum input shape
-        max_shape = (*shape[:2], *(int(max(2, workspace or 2) * d) for d in shape[2:]))  # max input shape
+        if IS_JETSON and workspace is None:
+            max_shape = shape  # cap at input shape on Jetson to conserve shared GPU memory
+        else:
+            max_shape = (*shape[:2], *(int(max(2, workspace or 2) * d) for d in shape[2:]))  # max input shape
         for inp in inputs:
             profile.set_shape(inp.name, min=min_shape, opt=shape, max=max_shape)
         config.add_optimization_profile(profile)
@@ -224,6 +229,10 @@ def onnx2engine(
 
     elif half:
         config.set_flag(trt.BuilderFlag.FP16)
+
+    # Free cached GPU memory before building on shared-memory Jetson devices
+    if IS_JETSON:
+        torch.cuda.empty_cache()
 
     # Write file
     if is_trt10:


### PR DESCRIPTION
## Summary

TensorRT export fails on Jetson JetPack 6 containers when `workspace` is not explicitly set (#23845). The builder runs out of device memory because:

1. No workspace limit is set, so TRT tries memory-hungry tactics that exceed available GPU memory
2. Dynamic `max_shape` doubles spatial dimensions (e.g. 640→1280), requiring ~4x more memory during build
3. Cached CUDA allocations from the preceding ONNX export aren't released

This patch adds Jetson-aware defaults in `onnx2engine()`:

- Default 1 GiB workspace limit when none is specified (matches NVIDIA's recommendation for Jetson Orin)
- Cap dynamic `max_shape` at the input shape instead of 2x on Jetson (dynamic batch/spatial range from min to input size still works)
- Call `torch.cuda.empty_cache()` before the TRT build step on Jetson

Users can still override with an explicit `workspace=N` value.

Fixes #23845

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes TensorRT export out-of-memory issues on Jetson shared-memory devices by applying safer default workspace and dynamic shape limits during engine export. 🚀

### 📊 Key Changes
- Adds a Jetson-specific default TensorRT workspace limit of `1 GiB` when `workspace=None` to avoid excessive shared memory usage.
- Caps dynamic export `max_shape` to the provided input `shape` on Jetson when no workspace is explicitly set, instead of scaling shapes aggressively.
- Calls `torch.cuda.empty_cache()` before TensorRT engine building on Jetson devices to free cached GPU memory.
- Keeps existing behavior unchanged for non-Jetson environments and for cases where `workspace` is explicitly provided.

### 🎯 Purpose & Impact
- Reduces TensorRT export failures caused by memory pressure on Jetson devices with shared CPU/GPU memory. 📉
- Makes exports more reliable out of the box for embedded deployments without requiring manual workspace tuning. 🤖
- Preserves flexibility for advanced users who explicitly set `workspace`, while improving default behavior for edge-device users.
- Especially beneficial for embedded and TensorRT export workflows in the official Ultralytics package. ⚡