### PR TITLE
Fix `References` docstring sections rendering incorrectly in API docs

### DIFF
--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -86,6 +86,7 @@ class ParsedDocstring:
     raises: list[ParameterDoc] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
     examples: list[str] = field(default_factory=list)
+    references: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -405,6 +406,8 @@ SECTION_ALIASES = {
     "example": "examples",
     "notes": "notes",
     "note": "notes",
+    "references": "references",
+    "reference": "references",
     "methods": "methods",
 }
 
@@ -471,6 +474,7 @@ def parse_google_docstring(docstring: str | None) -> ParsedDocstring:
         raises=_parse_named_entries(sections.get("raises", [])),
         notes=[textwrap.dedent("\n".join(sections.get("notes", []))).strip()] if sections.get("notes") else [],
         examples=[textwrap.dedent("\n".join(sections.get("examples", []))).strip()] if sections.get("examples") else [],
+        references=[line.strip() for line in sections.get("references", []) if line.strip()],
     )
 
 
@@ -494,6 +498,7 @@ def merge_docstrings(base: ParsedDocstring, extra: ParsedDocstring, ignore_summa
     _merge_unique(base.raises, extra.raises, lambda r: (r.name, r.type, r.description, r.default))
     _merge_unique(base.notes, extra.notes, lambda n: n.strip())
     _merge_unique(base.examples, extra.examples, lambda e: e.strip())
+    _merge_unique(base.references, extra.references, lambda r: r.strip())
     return base
 
 
@@ -705,7 +710,7 @@ def _merge_params(doc_params: list[ParameterDoc], signature_params: list[Paramet
     return merged
 
 
-DEFAULT_SECTION_ORDER = ["args", "returns", "examples", "notes", "attributes", "yields", "raises"]
+DEFAULT_SECTION_ORDER = ["args", "returns", "examples", "notes", "references", "attributes", "yields", "raises"]
 SUMMARY_BADGE_MAP = {"Classes": "class", "Properties": "property", "Methods": "method", "Functions": "function"}
 _missing_type_warnings: list[str] = []
 
@@ -817,6 +822,10 @@ def render_docstring(
             rows.append([f"`{type_cell}`" if type_cell else "", e.description or ""])
         table = _render_table(["Type", "Description"], rows, level, title=None)
         sections["raises"] = f"**Raises**\n\n{table}"
+
+    if doc.references:
+        links = "\n".join(f"- {ref}" for ref in doc.references)
+        sections["references"] = f"**References**\n\n{links}\n\n"
 
     if extra_sections:
         sections.update({k: v for k, v in extra_sections.items() if v})

--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -824,7 +824,7 @@ def render_docstring(
         sections["raises"] = f"**Raises**\n\n{table}"
 
     if doc.references:
-        links = "\n".join(f"- {ref}" for ref in doc.references)
+        links = "\n".join(ref if ref.startswith("- ") else f"- {ref}" for ref in doc.references)
         sections["references"] = f"**References**\n\n{links}\n\n"
 
     if extra_sections:


### PR DESCRIPTION
## Summary

Fixes #23920

`References:` sections in Google-style docstrings were not recognized by the custom docstring parser in `docs/build_reference.py`. This caused reference URLs to leak into the previous section — typically rendering as garbage rows in `Returns` tables or as raw text inside `Notes` admonitions.

**Affected pages** (24 docstrings across the codebase):
- https://docs.ultralytics.com/reference/utils/metrics — `box_iou`, `batch_probiou`, `probiou`, `smooth_bce`, `OBBMetrics`
- https://docs.ultralytics.com/reference/utils/tal — `TaskAlignedAssigner.forward`
- Plus `nn/modules/activation.py`, `nn/modules/transformer.py`, `nn/modules/block.py`, `nn/modules/conv.py`, `utils/loss.py`, and others

**Root cause**: `"references"` was missing from `SECTION_ALIASES`, so the parser never started a new section when encountering `References:` — the content stayed in whatever section was active before it (e.g. `returns`, `notes`, `description`).

**Before** (smooth_bce Returns table):
```
| Type | Description |
| --- | --- |
| `pos (float)` | Positive label smoothing BCE target. |
| `neg (float)` | Negative label smoothing BCE target. |
| `References` |  |
| `https` | //github.com/ultralytics/yolov3/issues/238#issuecomment-598028441 |
```

**After**:
```
| Type | Description |
| --- | --- |
| `pos (float)` | Positive label smoothing BCE target. |
| `neg (float)` | Negative label smoothing BCE target. |

**References**

- https://github.com/ultralytics/yolov3/issues/238#issuecomment-598028441
```

## Changes

All in `docs/build_reference.py`:
- Add `"references"` / `"reference"` to `SECTION_ALIASES`
- Add `references: list[str]` field to `ParsedDocstring` dataclass
- Parse references in `parse_google_docstring()`
- Merge references in `merge_docstrings()`
- Render as `**References**` bullet list in `render_docstring()`
- Add `"references"` to `DEFAULT_SECTION_ORDER` (after notes, before attributes)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes API docs rendering for Google-style `References` docstring sections by parsing, merging, ordering, and rendering them correctly. 📚✨

### 📊 Key Changes
- Added a new `references` field to `ParsedDocstring` to store parsed reference entries.
- Updated section alias mapping to recognize both `References` and `Reference` docstring headers.
- Extended `parse_google_docstring()` to collect non-empty reference lines into the parsed docstring output.
- Included `references` in docstring merge logic to prevent duplicate entries during inheritance/combination.
- Inserted `references` into `DEFAULT_SECTION_ORDER` so it appears consistently in rendered API docs.
- Added rendering support in `render_docstring()` to output a formatted **References** bullet list.

### 🎯 Purpose & Impact
- Fixes incorrect or missing rendering of `References` sections in generated API documentation. ✅
- Improves docstring support parity for Google-style sections used across the codebase.
- Helps contributors document sources and related materials more clearly in API docs.
- Low-risk documentation tooling change with localized impact to `docs/build_reference.py`. 🛠️