### PR TITLE
fix(nms): apply NMS for end2end models during validation

### DIFF
--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -64,9 +64,18 @@ def non_max_suppression(
         classes = torch.tensor(classes, device=prediction.device)
 
     if prediction.shape[-1] == 6 or end2end:  # end-to-end model (BNC, i.e. 1,300,6)
-        output = [pred[pred[:, 4] > conf_thres][:max_det] for pred in prediction]
+        output = [pred[pred[:, 4] > conf_thres] for pred in prediction]
         if classes is not None:
             output = [pred[(pred[:, 5:6] == classes).any(1)] for pred in output]
+        # Apply NMS to remove overlapping boxes even for end2end models during validation
+        for bi, pred in enumerate(output):
+            if pred.shape[0] == 0:
+                continue
+            # Apply class-aware NMS to filter overlapping detections
+            c = pred[:, 5:6] * (0 if agnostic else max_wh)
+            boxes, scores = pred[:, :4] + c, pred[:, 4]
+            keep_idx = TorchNMS.nms(boxes, scores, iou_thres)[:max_det]
+            output[bi] = pred[keep_idx]
         return output
 
     bs = prediction.shape[0]  # batch size (BCN, i.e. 1,84,6300)


### PR DESCRIPTION
YOLOv26 end2end models were bypassing NMS entirely during validation, causing overlapping boxes to remain in results.

The root cause: \`non_max_suppression()\` returned early for end2end models with only confidence filtering, skipping IoU-based suppression entirely.

This fix applies NMS to filter overlapping detections even when \`end2end=True\`, matching the expected validation behavior where duplicate predictions should be suppressed.

Fixes #23850

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes validation behavior for end-to-end detection models by applying NMS to their predictions, ensuring overlapping boxes are filtered correctly during evaluation. 🚀

### 📊 Key Changes
- Updates `non_max_suppression()` in `ultralytics/utils/nms.py` for the end-to-end prediction path.
- Removes the early `[:max_det]` truncation before overlap filtering so detections are filtered first, then limited afterward.
- Adds class-aware NMS for end-to-end model outputs during validation.
- Preserves optional class filtering before NMS is applied.
- Limits final kept detections to `max_det` after NMS.

### 🎯 Purpose & Impact
- Fixes inconsistent validation results for end-to-end models where overlapping detections were previously not suppressed. ✅
- Improves evaluation quality by reducing duplicate boxes in validation outputs. 📉
- Aligns end-to-end validation behavior more closely with expected detection postprocessing. 🎯
- May slightly change validation metrics for affected models, likely making them more reliable and representative. 📊