### PR TITLE
fix(platform): improve error message for platform dataset export failures

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -108,6 +108,8 @@ def resolve_platform_uri(uri, hard=True):
             return None
         if r.status_code == 409:
             raise RuntimeError(f"Resource not ready: {uri}. Dataset may still be processing.")
+        if r.status_code >= 500:
+            raise RuntimeError(f"Platform server error ({r.status_code}) for '{uri}'. Please try again later.")
 
         # Unexpected response
         r.raise_for_status()


### PR DESCRIPTION
Platform dataset export was returning misleading "Dataset may still be processing" errors when the API returned 500 Internal Server Error. This confused users into thinking they just needed to wait, when the server had actually failed permanently.

Added explicit handling for 5xx server errors to provide a clear message indicating a platform server issue. 409 errors (conflict) still indicate the dataset is being processed, but now 500/502/503 errors have distinct messaging.

Fixes #23817

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Ultralytics Platform dataset export error handling by surfacing clearer messages when server-side failures occur. 🚀

### 📊 Key Changes
- Adds explicit handling for HTTP `5xx` responses in `resolve_platform_uri()` within `ultralytics/utils/callbacks/platform.py`.
- Raises a `RuntimeError` with a clearer message when the Platform returns a server error during dataset export resolution.
- Preserves existing handling for `409` responses, which indicate the dataset may still be processing.
- Falls back to standard `raise_for_status()` behavior for other unexpected responses.

### 🎯 Purpose & Impact
- Improves debugging by distinguishing temporary Platform server failures from dataset processing delays. 🔍
- Gives users a more actionable message by suggesting they try again later instead of seeing a generic HTTP failure. 💡
- Enhances the overall Platform integration experience with clearer, more user-friendly error reporting. ✅