### PR TITLE
Fix TensorRT export memory error on Jetson JetPack6

### DIFF
--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -99,8 +99,12 @@ def onnx2engine(
     # Engine builder
     builder = trt.Builder(logger)
     config = builder.create_builder_config()
-    workspace_bytes = int((workspace or 0) * (1 << 30))
     is_trt10 = int(trt.__version__.split(".", 1)[0]) >= 10  # is TensorRT >= 10
+    # Default to 1 GB workspace for Jetson devices if not specified, as TensorRT 10+
+    # can request excessive memory on memory-constrained Jetson devices
+    if workspace is None and IS_JETSON:
+        workspace = 1
+    workspace_bytes = int((workspace or 0) * (1 << 30))
     if is_trt10 and workspace_bytes > 0:
         config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     elif workspace_bytes > 0:  # TensorRT versions 7, 8


### PR DESCRIPTION
## Issue
TensorRT export fails in `ultralytics/ultralytics:latest-jetson-jetpack6` container with memory errors:
- `Tactic Device request: 800MB Available: 526MB. Device memory is insufficient to use tactic.`

## Root Cause
TensorRT 10+ (included in JetPack 6) can request excessive memory during engine building when no workspace limit is specified. On memory-constrained Jetson devices, this causes export failures.

## Fix
Default to 1GB workspace for TensorRT export on Jetson devices when workspace is not explicitly specified. This prevents TensorRT from over-allocating memory while still allowing users to override if needed.

## Changes
- `ultralytics/utils/export/engine.py`: Add default workspace=1GB for IS_JETSON when workspace is None

Fixes #23845

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Fixes a TensorRT export memory issue on Jetson JetPack 6 by applying a safer default workspace size during engine export.

### 📊 Key Changes
- Adds Jetson-specific handling in `ultralytics/utils/export/engine.py` for TensorRT engine export.
- Sets the default `workspace` to `1` GB when `workspace` is not provided and the device is detected as Jetson.
- Applies this default before calculating `workspace_bytes` for TensorRT builder configuration.
- Preserves existing behavior for non-Jetson devices and for cases where users explicitly set `workspace`.

### 🎯 Purpose & Impact
- Prevents excessive TensorRT memory requests on memory-constrained Jetson devices running JetPack 6. 📉
- Improves export reliability for edge deployments using TensorRT on embedded hardware. 🤖
- Reduces the chance of export failures while keeping the change minimal and targeted. ✅