### PR TITLE
Vectorize keypoint batching loop for Pose loss calculation

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -713,11 +713,13 @@ class v8PoseLoss(v8DetectionLoss):
             (batch_size, max_kpts, keypoints.shape[1], keypoints.shape[2]), device=keypoints.device
         )
 
-        # TODO: any idea how to vectorize this?
-        # Fill batched_keypoints with keypoints based on batch_idx
-        for i in range(batch_size):
-            keypoints_i = keypoints[batch_idx == i]
-            batched_keypoints[i, : keypoints_i.shape[0]] = keypoints_i
+        # Vectorized fill: compute within-batch position for each keypoint using cumulative offsets
+        batch_idx_long = batch_idx.long()
+        offsets = torch.zeros(batch_size + 1, dtype=torch.long, device=keypoints.device)
+        offsets.scatter_add_(0, batch_idx_long + 1, torch.ones_like(batch_idx_long))
+        offsets = offsets.cumsum(0)
+        within_idx = torch.arange(len(batch_idx), device=keypoints.device) - offsets[batch_idx_long]
+        batched_keypoints[batch_idx_long, within_idx] = keypoints
 
         # Expand dimensions of target_gt_idx to match the shape of batched_keypoints
         target_gt_idx_expanded = target_gt_idx.unsqueeze(-1).unsqueeze(-1)


### PR DESCRIPTION
## Summary
- Replace the sequential `for` loop in `_keypoint_select` with fully vectorized tensor operations using `scatter_add_` and advanced indexing
- Resolves the TODO comment at loss.py:716

## Details
The previous implementation iterated over each batch index to fill `batched_keypoints`:

```python
for i in range(batch_size):
    keypoints_i = keypoints[batch_idx == i]
    batched_keypoints[i, : keypoints_i.shape[0]] = keypoints_i

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚡ This PR vectorizes keypoint batching in `ultralytics/utils/loss.py`, replacing a per-batch Python loop with indexed tensor operations for a cleaner and potentially faster pose loss path.

### 📊 Key Changes
- Replaces the loop that iterated over each batch element to populate `batched_keypoints`.
- Introduces a vectorized indexing approach using `batch_idx`, `scatter_add_`, cumulative offsets, and `within_idx`.
- Preserves the existing output structure and downstream target keypoint selection flow.
- Updates logic specifically in `_select_target_keypoints()`, which is part of the pose/keypoint loss pipeline.

### 🎯 Purpose & Impact
- Improves efficiency by reducing Python-side looping in a performance-sensitive loss computation path. 🚀
- Makes batching of pose keypoints more scalable for larger batch sizes or denser annotations. 📈
- Keeps functionality focused and minimal, lowering integration risk while improving implementation quality. ✅
- Most relevant to YOLO pose training workloads, where repeated loss computations can benefit from vectorization. 🧠