### PR TITLE
sync Ray Tune search space and docs with native tuner ranges

### DIFF
--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -128,7 +128,7 @@ Here's how to define a search space and use the `model.tune()` method to utilize
 
         # Define search space
         search_space = {
-            "lr0": (1e-5, 1e-1),
+            "lr0": (1e-5, 1e-2),
             "degrees": (0.0, 45.0),
         }
 
@@ -159,7 +159,7 @@ You can resume an interrupted hyperparameter tuning session by passing `resume=T
 
     # Define search space
     search_space = {
-        "lr0": (1e-5, 1e-1),
+        "lr0": (1e-5, 1e-2),
         "degrees": (0.0, 45.0),
     }
 

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -82,21 +82,21 @@ The following table lists the default search space parameters for hyperparameter
 
 | Parameter         | Type    | Value Range    | Description                                                                                                                |
 | ----------------- | ------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `lr0`             | `float` | `(1e-5, 1e-1)` | Initial learning rate at the start of training. Lower values provide more stable training but slower convergence           |
+| `lr0`             | `float` | `(1e-5, 1e-2)` | Initial learning rate at the start of training. Lower values provide more stable training but slower convergence           |
 | `lrf`             | `float` | `(0.01, 1.0)`  | Final learning rate factor as a fraction of lr0. Controls how much the learning rate decreases during training             |
-| `momentum`        | `float` | `(0.6, 0.98)`  | SGD momentum factor. Higher values help maintain consistent gradient direction and can speed up convergence                |
+| `momentum`        | `float` | `(0.7, 0.98)`  | SGD momentum factor. Higher values help maintain consistent gradient direction and can speed up convergence                |
 | `weight_decay`    | `float` | `(0.0, 0.001)` | L2 regularization factor to prevent overfitting. Larger values enforce stronger regularization                             |
 | `warmup_epochs`   | `float` | `(0.0, 5.0)`   | Number of epochs for linear learning rate warmup. Helps prevent early training instability                                 |
 | `warmup_momentum` | `float` | `(0.0, 0.95)`  | Initial momentum during warmup phase. Gradually increases to the final momentum value                                      |
-| `box`             | `float` | `(0.02, 0.2)`  | Bounding box loss weight in the total loss function. Balances box regression vs classification                             |
-| `cls`             | `float` | `(0.2, 4.0)`   | Classification loss weight in the total loss function. Higher values emphasize correct class prediction                    |
-| `dfl`             | `float` | `(0.4, 6.0)`   | DFL (Distribution Focal Loss) weight in the total loss function. Higher values emphasize precise bounding box localization |
+| `box`             | `float` | `(1.0, 20.0)`  | Bounding box loss weight in the total loss function. Balances box regression vs classification                             |
+| `cls`             | `float` | `(0.1, 4.0)`   | Classification loss weight in the total loss function. Higher values emphasize correct class prediction                    |
+| `dfl`             | `float` | `(0.4, 12.0)`  | DFL (Distribution Focal Loss) weight in the total loss function. Higher values emphasize precise bounding box localization |
 | `hsv_h`           | `float` | `(0.0, 0.1)`   | Random hue augmentation range in HSV color space. Helps model generalize across color variations                           |
 | `hsv_s`           | `float` | `(0.0, 0.9)`   | Random saturation augmentation range in HSV space. Simulates different lighting conditions                                 |
 | `hsv_v`           | `float` | `(0.0, 0.9)`   | Random value (brightness) augmentation range. Helps model handle different exposure levels                                 |
 | `degrees`         | `float` | `(0.0, 45.0)`  | Maximum rotation augmentation in degrees. Helps model become invariant to object orientation                               |
 | `translate`       | `float` | `(0.0, 0.9)`   | Maximum translation augmentation as fraction of image size. Improves robustness to object position                         |
-| `scale`           | `float` | `(0.0, 0.9)`   | Random scaling augmentation range. Helps model detect objects at different sizes                                           |
+| `scale`           | `float` | `(0.0, 0.95)`  | Random scaling augmentation range. Helps model detect objects at different sizes                                           |
 | `shear`           | `float` | `(0.0, 10.0)`  | Maximum shear augmentation in degrees. Adds perspective-like distortions to training images                                |
 | `perspective`     | `float` | `(0.0, 0.001)` | Random perspective augmentation range. Simulates different viewing angles                                                  |
 | `flipud`          | `float` | `(0.0, 1.0)`   | Probability of vertical image flip during training. Useful for overhead/aerial imagery                                     |
@@ -104,8 +104,9 @@ The following table lists the default search space parameters for hyperparameter
 | `bgr`             | `float` | `(0.0, 1.0)`   | Probability of using BGR augmentation, which swaps color channels. Can help with color invariance                          |
 | `mosaic`          | `float` | `(0.0, 1.0)`   | Probability of using mosaic augmentation, which combines 4 images. Especially useful for small object detection            |
 | `mixup`           | `float` | `(0.0, 1.0)`   | Probability of using mixup augmentation, which blends two images. Can improve model robustness                             |
+| `cutmix`          | `float` | `(0.0, 1.0)`   | Probability of using cutmix augmentation. Combines image regions while maintaining local features                          |
 | `copy_paste`      | `float` | `(0.0, 1.0)`   | Probability of using copy-paste augmentation. Helps improve instance segmentation performance                              |
-| `close_mosaic`    | `int`   | `(0, 10)`      | Disables mosaic in the last N epochs to stabilize training before completion.                                              |
+| `close_mosaic`    | `float` | `(0.0, 10.0)`  | Disables mosaic in the last N epochs to stabilize training before completion                                               |
 
 ## Custom Search Space Example
 

--- a/docs/en/integrations/ray-tune.md
+++ b/docs/en/integrations/ray-tune.md
@@ -120,13 +120,13 @@ In this example, we demonstrate how to use a custom search space for hyperparame
     # Run Ray Tune on the model
     result_grid = model.tune(
         data="coco8.yaml",
-        space={"lr0": tune.uniform(1e-5, 1e-1)},
+        space={"lr0": tune.uniform(1e-5, 1e-2)},
         epochs=50,
         use_ray=True,
     )
     ```
 
-In the code snippet above, we create a YOLO model with the "yolo26n.pt" pretrained weights. Then, we call the `tune()` method, specifying the dataset configuration with "coco8.yaml". We provide a custom search space for the initial learning rate `lr0` using a dictionary with the key "lr0" and the value `tune.uniform(1e-5, 1e-1)`. Finally, we pass additional training arguments, such as the number of epochs directly to the tune method as `epochs=50`.
+In the code snippet above, we create a YOLO model with the "yolo26n.pt" pretrained weights. Then, we call the `tune()` method, specifying the dataset configuration with "coco8.yaml". We provide a custom search space for the initial learning rate `lr0` using a dictionary with the key "lr0" and the value `tune.uniform(1e-5, 1e-2)`. Finally, we pass additional training arguments, such as the number of epochs directly to the tune method as `epochs=50`.
 
 ## Resuming An Interrupted Hyperparameter Tuning Session With Ray Tune
 
@@ -303,7 +303,7 @@ from ray import tune
 from ultralytics import YOLO
 
 model = YOLO("yolo26n.pt")
-search_space = {"lr0": tune.uniform(1e-5, 1e-1), "momentum": tune.uniform(0.6, 0.98)}
+search_space = {"lr0": tune.uniform(1e-5, 1e-2), "momentum": tune.uniform(0.7, 0.98)}
 result_grid = model.tune(data="coco8.yaml", space=search_space, use_ray=True)
 ```
 

--- a/docs/en/integrations/ray-tune.md
+++ b/docs/en/integrations/ray-tune.md
@@ -77,28 +77,31 @@ The following table lists the default search space parameters for hyperparameter
 
 | Parameter         | Range                      | Description                                                                                                                                      |
 | ----------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `lr0`             | `tune.uniform(1e-5, 1e-1)` | Initial learning rate that controls the step size during optimization. Higher values speed up training but may cause instability.                |
-| `lrf`             | `tune.uniform(0.01, 1.0)`  | Final learning rate factor that determines how much the learning rate decreases by the end of training.                                          |
-| `momentum`        | `tune.uniform(0.6, 0.98)`  | Momentum factor for the optimizer that helps accelerate training and overcome local minima.                                                      |
-| `weight_decay`    | `tune.uniform(0.0, 0.001)` | Regularization parameter that prevents overfitting by penalizing large weight values.                                                            |
-| `warmup_epochs`   | `tune.uniform(0.0, 5.0)`   | Number of epochs with gradually increasing learning rate to stabilize early training.                                                            |
-| `warmup_momentum` | `tune.uniform(0.0, 0.95)`  | Initial momentum value that gradually increases during the warmup period.                                                                        |
-| `box`             | `tune.uniform(0.02, 0.2)`  | Weight for the bounding box loss component, balancing localization accuracy in the model.                                                        |
-| `cls`             | `tune.uniform(0.2, 4.0)`   | Weight for the classification loss component, balancing class prediction accuracy in the model.                                                  |
-| `hsv_h`           | `tune.uniform(0.0, 0.1)`   | Hue augmentation range that introduces color variability to help the model generalize.                                                           |
-| `hsv_s`           | `tune.uniform(0.0, 0.9)`   | Saturation augmentation range that varies color intensity to improve robustness.                                                                 |
-| `hsv_v`           | `tune.uniform(0.0, 0.9)`   | Value (brightness) augmentation range that helps the model perform under various lighting conditions.                                            |
-| `degrees`         | `tune.uniform(0.0, 45.0)`  | Rotation augmentation range in degrees, improving recognition of rotated objects.                                                                |
-| `translate`       | `tune.uniform(0.0, 0.9)`   | Translation augmentation range that shifts images horizontally and vertically.                                                                   |
-| `scale`           | `tune.uniform(0.0, 0.9)`   | Scaling augmentation range that simulates objects at different distances.                                                                        |
-| `shear`           | `tune.uniform(0.0, 10.0)`  | Shear augmentation range in degrees, simulating perspective shifts.                                                                              |
-| `perspective`     | `tune.uniform(0.0, 0.001)` | Perspective augmentation range that simulates 3D viewpoint changes.                                                                              |
-| `flipud`          | `tune.uniform(0.0, 1.0)`   | Vertical flip augmentation probability, increasing dataset diversity.                                                                            |
-| `fliplr`          | `tune.uniform(0.0, 1.0)`   | Horizontal flip augmentation probability, useful for symmetrical objects.                                                                        |
-| `mosaic`          | `tune.uniform(0.0, 1.0)`   | Mosaic augmentation probability that combines four images into one training sample.                                                              |
-| `mixup`           | `tune.uniform(0.0, 1.0)`   | Mixup augmentation probability that blends two images and their labels together.                                                                 |
-| `cutmix`          | `tune.uniform(0.0, 1.0)`   | Cutmix augmentation probability that combines image regions while maintaining local features, improving detection of partially occluded objects. |
-| `copy_paste`      | `tune.uniform(0.0, 1.0)`   | Copy-paste augmentation probability that transfers objects between images to increase instance diversity.                                        |
+| `lr0`             | `tune.uniform(1e-5, 1e-2)`  | Initial learning rate that controls the step size during optimization. Higher values speed up training but may cause instability.                |
+| `lrf`             | `tune.uniform(0.01, 1.0)`   | Final learning rate factor that determines how much the learning rate decreases by the end of training.                                         |
+| `momentum`        | `tune.uniform(0.7, 0.98)`   | Momentum factor for the optimizer that helps accelerate training and overcome local minima.                                                     |
+| `weight_decay`    | `tune.uniform(0.0, 0.001)`  | Regularization parameter that prevents overfitting by penalizing large weight values.                                                           |
+| `warmup_epochs`   | `tune.uniform(0.0, 5.0)`    | Number of epochs with gradually increasing learning rate to stabilize early training.                                                           |
+| `warmup_momentum` | `tune.uniform(0.0, 0.95)`   | Initial momentum value that gradually increases during the warmup period.                                                                       |
+| `box`             | `tune.uniform(1.0, 20.0)`   | Weight for the bounding box loss component, balancing localization accuracy in the model.                                                       |
+| `cls`             | `tune.uniform(0.1, 4.0)`    | Weight for the classification loss component, balancing class prediction accuracy in the model.                                                 |
+| `dfl`             | `tune.uniform(0.4, 12.0)`   | Weight for the Distribution Focal Loss component, emphasizing precise bounding box localization.                                                |
+| `hsv_h`           | `tune.uniform(0.0, 0.1)`    | Hue augmentation range that introduces color variability to help the model generalize.                                                          |
+| `hsv_s`           | `tune.uniform(0.0, 0.9)`    | Saturation augmentation range that varies color intensity to improve robustness.                                                                |
+| `hsv_v`           | `tune.uniform(0.0, 0.9)`    | Value (brightness) augmentation range that helps the model perform under various lighting conditions.                                           |
+| `degrees`         | `tune.uniform(0.0, 45.0)`   | Rotation augmentation range in degrees, improving recognition of rotated objects.                                                               |
+| `translate`       | `tune.uniform(0.0, 0.9)`    | Translation augmentation range that shifts images horizontally and vertically.                                                                  |
+| `scale`           | `tune.uniform(0.0, 0.95)`   | Scaling augmentation range that simulates objects at different distances.                                                                       |
+| `shear`           | `tune.uniform(0.0, 10.0)`   | Shear augmentation range in degrees, simulating perspective shifts.                                                                             |
+| `perspective`     | `tune.uniform(0.0, 0.001)`  | Perspective augmentation range that simulates 3D viewpoint changes.                                                                             |
+| `flipud`          | `tune.uniform(0.0, 1.0)`    | Vertical flip augmentation probability, increasing dataset diversity.                                                                           |
+| `fliplr`          | `tune.uniform(0.0, 1.0)`    | Horizontal flip augmentation probability, useful for symmetrical objects.                                                                       |
+| `bgr`             | `tune.uniform(0.0, 1.0)`    | BGR channel swap augmentation probability, helping with color invariance.                                                                       |
+| `mosaic`          | `tune.uniform(0.0, 1.0)`    | Mosaic augmentation probability that combines four images into one training sample.                                                             |
+| `mixup`           | `tune.uniform(0.0, 1.0)`    | Mixup augmentation probability that blends two images and their labels together.                                                                |
+| `cutmix`          | `tune.uniform(0.0, 1.0)`    | Cutmix augmentation probability that combines image regions while maintaining local features.                                                   |
+| `copy_paste`      | `tune.uniform(0.0, 1.0)`    | Copy-paste augmentation probability that transfers objects between images to increase instance diversity.                                       |
+| `close_mosaic`    | `tune.uniform(0.0, 10.0)`   | Disables mosaic in the last N epochs to stabilize training before completion.                                                                   |
 
 ## Custom Search Space Example
 
@@ -239,13 +242,14 @@ Ultralytics YOLO26 uses the following default hyperparameters for tuning with Ra
 
 | Parameter       | Value Range                | Description                    |
 | --------------- | -------------------------- | ------------------------------ |
-| `lr0`           | `tune.uniform(1e-5, 1e-1)` | Initial learning rate          |
+| `lr0`           | `tune.uniform(1e-5, 1e-2)` | Initial learning rate          |
 | `lrf`           | `tune.uniform(0.01, 1.0)`  | Final learning rate factor     |
-| `momentum`      | `tune.uniform(0.6, 0.98)`  | Momentum                       |
+| `momentum`      | `tune.uniform(0.7, 0.98)`  | Momentum                       |
 | `weight_decay`  | `tune.uniform(0.0, 0.001)` | Weight decay                   |
 | `warmup_epochs` | `tune.uniform(0.0, 5.0)`   | Warmup epochs                  |
-| `box`           | `tune.uniform(0.02, 0.2)`  | Box loss weight                |
-| `cls`           | `tune.uniform(0.2, 4.0)`   | Class loss weight              |
+| `box`           | `tune.uniform(1.0, 20.0)`  | Box loss weight                |
+| `cls`           | `tune.uniform(0.1, 4.0)`   | Class loss weight              |
+| `dfl`           | `tune.uniform(0.4, 12.0)`  | DFL loss weight                |
 | `hsv_h`         | `tune.uniform(0.0, 0.1)`   | Hue augmentation range         |
 | `translate`     | `tune.uniform(0.0, 0.9)`   | Translation augmentation range |
 

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -78,7 +78,7 @@ class Tuner:
         >>> )
 
         Tune with custom search space:
-        >>> model.tune(space={"lr0": (1e-5, 1e-1), "momentum": (0.6, 0.98)})
+        >>> model.tune(space={"lr0": (1e-5, 1e-2), "momentum": (0.7, 0.98)})
     """
 
     def __init__(self, args=DEFAULT_CFG, _callbacks: dict | None = None):

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -55,20 +55,21 @@ def run_ray_tune(
     checks.check_version(ray.__version__, ">=2.0.0", "ray")
     default_space = {
         # 'optimizer': tune.choice(['SGD', 'Adam', 'AdamW', 'NAdam', 'RAdam', 'RMSProp']),
-        "lr0": tune.uniform(1e-5, 1e-1),
+        "lr0": tune.uniform(1e-5, 1e-2),  # initial learning rate (i.e. SGD=1E-2, Adam=1E-3)
         "lrf": tune.uniform(0.01, 1.0),  # final OneCycleLR learning rate (lr0 * lrf)
-        "momentum": tune.uniform(0.6, 0.98),  # SGD momentum/Adam beta1
+        "momentum": tune.uniform(0.7, 0.98),  # SGD momentum/Adam beta1
         "weight_decay": tune.uniform(0.0, 0.001),  # optimizer weight decay
         "warmup_epochs": tune.uniform(0.0, 5.0),  # warmup epochs (fractions ok)
         "warmup_momentum": tune.uniform(0.0, 0.95),  # warmup initial momentum
-        "box": tune.uniform(0.02, 0.2),  # box loss gain
-        "cls": tune.uniform(0.2, 4.0),  # cls loss gain (scale with pixels)
+        "box": tune.uniform(1.0, 20.0),  # box loss gain
+        "cls": tune.uniform(0.1, 4.0),  # cls loss gain (scale with pixels)
+        "dfl": tune.uniform(0.4, 12.0),  # dfl loss gain
         "hsv_h": tune.uniform(0.0, 0.1),  # image HSV-Hue augmentation (fraction)
         "hsv_s": tune.uniform(0.0, 0.9),  # image HSV-Saturation augmentation (fraction)
         "hsv_v": tune.uniform(0.0, 0.9),  # image HSV-Value augmentation (fraction)
         "degrees": tune.uniform(0.0, 45.0),  # image rotation (+/- deg)
         "translate": tune.uniform(0.0, 0.9),  # image translation (+/- fraction)
-        "scale": tune.uniform(0.0, 0.9),  # image scale (+/- gain)
+        "scale": tune.uniform(0.0, 0.95),  # image scale (+/- gain)
         "shear": tune.uniform(0.0, 10.0),  # image shear (+/- deg)
         "perspective": tune.uniform(0.0, 0.001),  # image perspective (+/- fraction), range 0-0.001
         "flipud": tune.uniform(0.0, 1.0),  # image flip up-down (probability)
@@ -78,6 +79,7 @@ def run_ray_tune(
         "mixup": tune.uniform(0.0, 1.0),  # image mixup (probability)
         "cutmix": tune.uniform(0.0, 1.0),  # image cutmix (probability)
         "copy_paste": tune.uniform(0.0, 1.0),  # segment copy-paste (probability)
+        "close_mosaic": tune.uniform(0.0, 10.0),  # close dataloader mosaic (epochs)
     }
 
     # Put the model in ray store


### PR DESCRIPTION
## Summary

Fixes #23926

The Ray Tune default search space (`utils/tuner.py`) and both hyperparameter tuning docs pages had outdated ranges from the YOLOv8 era that were never synced when the native tuner was updated for YOLO26 in PR #23176 (commit 06c41e675, Dec 2025).

Most critically, `box` loss range was `(0.02, 0.2)` while the default value is `7.5` and the correct native range is `(1.0, 20.0)` — as reported by the user, tuning with the old range produced 20-30% lower accuracy than values around `5-8` that the native tuner finds.

### Changes

**Code** (`ultralytics/utils/tuner.py`):
- Synced all 7 divergent ranges with native tuner: `lr0`, `momentum`, `box`, `cls`, `scale`
- Added 2 missing params: `dfl` and `close_mosaic`

**Docs** (`docs/en/guides/hyperparameter-tuning.md`):
- Updated table with correct ranges for `lr0`, `momentum`, `box`, `cls`, `dfl`, `scale`
- Added missing `cutmix` param
- Fixed `close_mosaic` type from `int` to `float`
- Updated code examples

**Docs** (`docs/en/integrations/ray-tune.md`):
- Updated both tables (main + FAQ) with correct ranges
- Added missing params: `dfl`, `bgr`, `close_mosaic`
- Updated code examples and descriptions

**Docstring** (`ultralytics/engine/tuner.py`):
- Updated example in class docstring

### Full diff (old → new)

| Param | Old (RayTune/Docs) | New (Native) | Default |
|---|---|---|---|
| `lr0` | `(1e-5, 1e-1)` | `(1e-5, 1e-2)` | `0.01` |
| `momentum` | `(0.6, 0.98)` | `(0.7, 0.98)` | `0.937` |
| `box` | `(0.02, 0.2)` | `(1.0, 20.0)` | `7.5` |
| `cls` | `(0.2, 4.0)` | `(0.1, 4.0)` | `0.5` |
| `dfl` | missing | `(0.4, 12.0)` | `1.5` |
| `scale` | `(0.0, 0.9)` | `(0.0, 0.95)` | `0.5` |
| `close_mosaic` | missing in RayTune | `(0.0, 10.0)` | `10` |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR aligns Ray Tune hyperparameter search spaces and related documentation with the native Ultralytics tuner defaults for more accurate, consistent tuning guidance. 🚀

### 📊 Key Changes
- Updated Ray Tune default search ranges in `ultralytics/utils/tuner.py` to match native tuner values, including changes to `lr0`, `momentum`, `box`, `cls`, `dfl`, `scale`, and `close_mosaic`.
- Added missing parameters to Ray Tune coverage and docs, including `dfl`, `bgr`, and `close_mosaic`, while keeping `cutmix` documented consistently.
- Synced documentation in `docs/en/guides/hyperparameter-tuning.md` and `docs/en/integrations/ray-tune.md` with the current tuner ranges and parameter types.
- Updated code examples and inline docstrings in `ultralytics/engine/tuner.py` and docs to use the corrected ranges, especially `lr0` and `momentum`.
- Adjusted `close_mosaic` documentation from `int` to `float` to reflect the actual tuning space representation.

### 🎯 Purpose & Impact
- Reduces confusion for users by ensuring docs, examples, and Ray Tune defaults all reflect the same tuning behavior. ✅
- Improves reliability of hyperparameter tuning workflows by exposing the intended native search ranges in Ray Tune. 🎯
- Helps users avoid overly broad or outdated search intervals that could waste tuning trials or produce inconsistent results. ⚡
- Strengthens maintainability by keeping implementation and documentation synchronized across tuning entry points. 📚