### PR TITLE
docs: remove duplicate Dataset Tabs heading

### DIFF
--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -85,8 +85,6 @@ This allows training on the platform's datasets from any machine with your [API 
     model.train(data="ul://username/datasets/my-dataset", epochs=100)
     ```
 
-### Dataset Tabs
-
 ### Dataset Versioning
 
 Create immutable NDJSON snapshots of your dataset for reproducible training. Each version captures image counts, class counts, and annotation counts at the time of creation. See [Versions Tab](datasets.md#versions-tab) for details.


### PR DESCRIPTION
## Summary
- Removed a duplicate `### Dataset Tabs` heading in `docs/en/platform/data/index.md`
- The first occurrence (line 88) was empty with no content before the next heading
- The second occurrence (line 94) contains the actual tab description table and is preserved

## Motivation
The empty duplicate heading creates a confusing document structure and a visible empty section in the rendered docs.

## Implementation
Deleted the empty first `### Dataset Tabs` heading (2 lines removed). No other changes.

## Testing
- Verified the remaining `### Dataset Tabs` section retains all content (the six-tab table)
- Verified `### Dataset Versioning` section above it is unaffected
- No code changes — docs-only fix

## Risks / Side Effects
None — this is a cosmetic documentation fix with no impact on code or builds.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes a duplicate `Dataset Tabs` heading from the Ultralytics Platform dataset documentation to improve page structure and readability. ✨

### 📊 Key Changes
- Deleted the redundant `### Dataset Tabs` heading in `docs/en/platform/data/index.md`.
- Kept the surrounding content, including `Dataset Versioning`, unchanged.
- Simplified the documentation flow for the Platform dataset page. 📝

### 🎯 Purpose & Impact
- Improves documentation clarity by eliminating repeated section headings.
- Makes the page easier to scan and navigate for users reading Platform dataset docs.
- Provides a small but meaningful docs cleanup with no functional code impact. ✅