### PR TITLE
Fix TensorRT export OOM on Jetson shared-memory devices

### DIFF
--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -92,6 +92,11 @@ def onnx2engine(
 
     engine_file = engine_file or Path(onnx_file).with_suffix(".engine")
 
+    # Default workspace to 1 GiB on Jetson to avoid OOM with shared memory
+    if workspace is None and IS_JETSON:
+        workspace = 1
+        LOGGER.info(f"{prefix} Jetson device detected: defaulting workspace to 1 GiB")
+
     logger = trt.Logger(trt.Logger.INFO)
     if verbose:
         logger.min_severity = trt.Logger.Severity.VERBOSE
@@ -139,7 +144,11 @@ def onnx2engine(
     if dynamic:
         profile = builder.create_optimization_profile()
         min_shape = (1, shape[1], 32, 32)  # minimum input shape
-        max_shape = (*shape[:2], *(int(max(2, workspace or 2) * d) for d in shape[2:]))  # max input shape
+        # Cap max_shape at input shape on Jetson to avoid OOM during engine build
+        if IS_JETSON:
+            max_shape = shape  # use exact input shape as max on Jetson
+        else:
+            max_shape = (*shape[:2], *(int(max(2, workspace or 2) * d) for d in shape[2:]))  # max input shape
         for inp in inputs:
             profile.set_shape(inp.name, min=min_shape, opt=shape, max=max_shape)
         config.add_optimization_profile(profile)
@@ -147,6 +156,11 @@ def onnx2engine(
             config.set_calibration_profile(profile)
 
     LOGGER.info(f"{prefix} building {'INT8' if int8 else 'FP' + ('16' if half else '32')} engine as {engine_file}")
+
+    # Clear CUDA cache before building to free up memory on Jetson devices
+    if IS_JETSON:
+        torch.cuda.empty_cache()
+
     if int8:
         config.set_flag(trt.BuilderFlag.INT8)
         config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED


### PR DESCRIPTION
## Problem

On Jetson devices with shared GPU/CPU memory, TensorRT engine builds fail with OOM when workspace is not explicitly set. The issue #23845 shows:

- Tactic Device request: 800MB Available: 526MB. Device memory is insufficient to use tactic.
- TensorRT engine build failed due to insufficient memory

## Solution

This PR implements three changes to fix OOM on Jetson devices:

1. **Default workspace to 1 GiB on Jetson** - When workspace is not explicitly set and the device is a Jetson, default to 1 GiB workspace size to avoid excessive memory allocation.

2. **Cap dynamic max_shape at input shape** - On Jetson devices, the max_shape for dynamic inputs is capped at the input shape instead of being scaled by workspace size, which could cause very large memory requirements.

3. **Clear CUDA cache before building** - Explicitly clear PyTorch's CUDA cache before TensorRT engine building to free up shared memory.

## Changes

- Modified "ultralytics/utils/export/engine.py"

## Testing

- Import and syntax validation passed
- The fix is targeted specifically at Jetson devices (IS_JETSON check) and does not affect other platforms

Fixes #23845

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves TensorRT export reliability on Jetson devices by reducing memory pressure during engine building to prevent out-of-memory failures. 🚀

### 📊 Key Changes
- Adds a Jetson-specific default TensorRT workspace of `1 GiB` when no workspace is provided. 📦
- Limits dynamic export `max_shape` to the exact input shape on Jetson instead of expanding it, reducing build-time memory usage. 🧠
- Clears the CUDA cache before engine building on Jetson to free memory proactively. 🧹
- Adds informative logging when Jetson-specific workspace defaults are applied. 📝

### 🎯 Purpose & Impact
- Fixes TensorRT export OOM issues on Jetson devices that use shared memory. ✅
- Makes exports more stable and predictable on embedded edge hardware. 🔧
- Reduces the chance of failed engine builds for dynamic models on memory-constrained systems. 📉
- Improves the embedded deployment experience for users exporting models to TensorRT. 🤖