### PR TITLE
Migrate model prefixes from `YOLO11` → `YOLO26`

### DIFF
--- a/ultralytics/solutions/streamlit_inference.py
+++ b/ultralytics/solutions/streamlit_inference.py
@@ -150,7 +150,7 @@ class Inference:
     def configure(self) -> None:
         """Configure the model and load selected classes for inference."""
         # Add dropdown menu for model selection
-        M_ORD, T_ORD = ["yolo11n", "yolo11s", "yolo11m", "yolo11l", "yolo11x"], ["", "-seg", "-pose", "-obb", "-cls"]
+        M_ORD, T_ORD = ["yolo26n", "yolo26s", "yolo26m", "yolo26l", "yolo26x"], ["", "-seg", "-pose", "-obb", "-cls"]
         available_models = sorted(
             [
                 x.replace("yolo", "YOLO")

--- a/ultralytics/solutions/streamlit_inference.py
+++ b/ultralytics/solutions/streamlit_inference.py
@@ -169,7 +169,7 @@ class Inference:
             ):
                 model_path = selected_model
             else:
-                model_path = f"{selected_model.lower()}.pt"  # Default to .pt if no model provided during function call.
+                model_path = f"{selected_model.lower()}"  # Default to .pt if no model provided during function call.
             self.model = YOLO(model_path)  # Load the YOLO model
             class_names = list(self.model.names.values())  # Convert dictionary to list of class names
         self.st.success("Model loaded successfully!")

--- a/ultralytics/solutions/streamlit_inference.py
+++ b/ultralytics/solutions/streamlit_inference.py
@@ -169,7 +169,7 @@ class Inference:
             ):
                 model_path = selected_model
             else:
-                model_path = f"{selected_model.lower()}"  # Default to .pt if no model provided during function call.
+                model_path = f"{selected_model.lower()}.pt"  # Default to .pt if no model provided during function call.
             self.model = YOLO(model_path)  # Load the YOLO model
             class_names = list(self.model.names.values())  # Convert dictionary to list of class names
         self.st.success("Model loaded successfully!")


### PR DESCRIPTION
@glenn-jocher @Laughing-q FYI. Thanks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Streamlit inference model selector to use `YOLO26` model prefixes instead of `YOLO11` for available model options. 🚀

### 📊 Key Changes
- Replaced the base model order list in `ultralytics/solutions/streamlit_inference.py` from `yolo11n/s/m/l/x` to `yolo26n/s/m/l/x`.
- Kept the task suffix options unchanged: standard, segmentation, pose, OBB, and classification.
- Preserves the existing UI logic while aligning model naming with the latest Ultralytics model family. 🔄

### 🎯 Purpose & Impact
- Aligns the Streamlit Solutions interface with current Ultralytics branding and recommended model defaults using `YOLO26`.
- Ensures users selecting models from the app see the latest supported model prefixes. ✅
- Reduces confusion caused by outdated model names and improves consistency across the repository and user experience.