### PR TITLE
Scope class badges to reference section

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -275,8 +275,9 @@ def update_docs_soup(content: str, html_file: Path | None = None, max_title_leng
                 span.insert_after(tail)
             modified = True
 
-    highlight_labels(soup.select("main h1, main h2, main h3, main h4, main h5"))
-    highlight_labels(soup.select("nav.md-nav--secondary .md-ellipsis, nav.md-nav__list .md-ellipsis"))
+    if "reference" in rel_path:
+        highlight_labels(soup.select("main h1, main h2, main h3, main h4, main h5"))
+        highlight_labels(soup.select("nav.md-nav--secondary .md-ellipsis, nav.md-nav__list .md-ellipsis"))
 
     if "reference" in rel_path:
         for ellipsis in soup.select("nav.md-nav--secondary .md-ellipsis"):

--- a/docs/en/integrations/ray-tune.md
+++ b/docs/en/integrations/ray-tune.md
@@ -75,33 +75,33 @@ By customizing these parameters, you can fine-tune the hyperparameter optimizati
 
 The following table lists the default search space parameters for hyperparameter tuning in YOLO26 with Ray Tune. Each parameter has a specific value range defined by `tune.uniform()`.
 
-| Parameter         | Range                      | Description                                                                                                                                      |
-| ----------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `lr0`             | `tune.uniform(1e-5, 1e-2)`  | Initial learning rate that controls the step size during optimization. Higher values speed up training but may cause instability.                |
-| `lrf`             | `tune.uniform(0.01, 1.0)`   | Final learning rate factor that determines how much the learning rate decreases by the end of training.                                         |
-| `momentum`        | `tune.uniform(0.7, 0.98)`   | Momentum factor for the optimizer that helps accelerate training and overcome local minima.                                                     |
-| `weight_decay`    | `tune.uniform(0.0, 0.001)`  | Regularization parameter that prevents overfitting by penalizing large weight values.                                                           |
-| `warmup_epochs`   | `tune.uniform(0.0, 5.0)`    | Number of epochs with gradually increasing learning rate to stabilize early training.                                                           |
-| `warmup_momentum` | `tune.uniform(0.0, 0.95)`   | Initial momentum value that gradually increases during the warmup period.                                                                       |
-| `box`             | `tune.uniform(1.0, 20.0)`   | Weight for the bounding box loss component, balancing localization accuracy in the model.                                                       |
-| `cls`             | `tune.uniform(0.1, 4.0)`    | Weight for the classification loss component, balancing class prediction accuracy in the model.                                                 |
-| `dfl`             | `tune.uniform(0.4, 12.0)`   | Weight for the Distribution Focal Loss component, emphasizing precise bounding box localization.                                                |
-| `hsv_h`           | `tune.uniform(0.0, 0.1)`    | Hue augmentation range that introduces color variability to help the model generalize.                                                          |
-| `hsv_s`           | `tune.uniform(0.0, 0.9)`    | Saturation augmentation range that varies color intensity to improve robustness.                                                                |
-| `hsv_v`           | `tune.uniform(0.0, 0.9)`    | Value (brightness) augmentation range that helps the model perform under various lighting conditions.                                           |
-| `degrees`         | `tune.uniform(0.0, 45.0)`   | Rotation augmentation range in degrees, improving recognition of rotated objects.                                                               |
-| `translate`       | `tune.uniform(0.0, 0.9)`    | Translation augmentation range that shifts images horizontally and vertically.                                                                  |
-| `scale`           | `tune.uniform(0.0, 0.95)`   | Scaling augmentation range that simulates objects at different distances.                                                                       |
-| `shear`           | `tune.uniform(0.0, 10.0)`   | Shear augmentation range in degrees, simulating perspective shifts.                                                                             |
-| `perspective`     | `tune.uniform(0.0, 0.001)`  | Perspective augmentation range that simulates 3D viewpoint changes.                                                                             |
-| `flipud`          | `tune.uniform(0.0, 1.0)`    | Vertical flip augmentation probability, increasing dataset diversity.                                                                           |
-| `fliplr`          | `tune.uniform(0.0, 1.0)`    | Horizontal flip augmentation probability, useful for symmetrical objects.                                                                       |
-| `bgr`             | `tune.uniform(0.0, 1.0)`    | BGR channel swap augmentation probability, helping with color invariance.                                                                       |
-| `mosaic`          | `tune.uniform(0.0, 1.0)`    | Mosaic augmentation probability that combines four images into one training sample.                                                             |
-| `mixup`           | `tune.uniform(0.0, 1.0)`    | Mixup augmentation probability that blends two images and their labels together.                                                                |
-| `cutmix`          | `tune.uniform(0.0, 1.0)`    | Cutmix augmentation probability that combines image regions while maintaining local features.                                                   |
-| `copy_paste`      | `tune.uniform(0.0, 1.0)`    | Copy-paste augmentation probability that transfers objects between images to increase instance diversity.                                       |
-| `close_mosaic`    | `tune.uniform(0.0, 10.0)`   | Disables mosaic in the last N epochs to stabilize training before completion.                                                                   |
+| Parameter         | Range                      | Description                                                                                                                       |
+| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `lr0`             | `tune.uniform(1e-5, 1e-2)` | Initial learning rate that controls the step size during optimization. Higher values speed up training but may cause instability. |
+| `lrf`             | `tune.uniform(0.01, 1.0)`  | Final learning rate factor that determines how much the learning rate decreases by the end of training.                           |
+| `momentum`        | `tune.uniform(0.7, 0.98)`  | Momentum factor for the optimizer that helps accelerate training and overcome local minima.                                       |
+| `weight_decay`    | `tune.uniform(0.0, 0.001)` | Regularization parameter that prevents overfitting by penalizing large weight values.                                             |
+| `warmup_epochs`   | `tune.uniform(0.0, 5.0)`   | Number of epochs with gradually increasing learning rate to stabilize early training.                                             |
+| `warmup_momentum` | `tune.uniform(0.0, 0.95)`  | Initial momentum value that gradually increases during the warmup period.                                                         |
+| `box`             | `tune.uniform(1.0, 20.0)`  | Weight for the bounding box loss component, balancing localization accuracy in the model.                                         |
+| `cls`             | `tune.uniform(0.1, 4.0)`   | Weight for the classification loss component, balancing class prediction accuracy in the model.                                   |
+| `dfl`             | `tune.uniform(0.4, 12.0)`  | Weight for the Distribution Focal Loss component, emphasizing precise bounding box localization.                                  |
+| `hsv_h`           | `tune.uniform(0.0, 0.1)`   | Hue augmentation range that introduces color variability to help the model generalize.                                            |
+| `hsv_s`           | `tune.uniform(0.0, 0.9)`   | Saturation augmentation range that varies color intensity to improve robustness.                                                  |
+| `hsv_v`           | `tune.uniform(0.0, 0.9)`   | Value (brightness) augmentation range that helps the model perform under various lighting conditions.                             |
+| `degrees`         | `tune.uniform(0.0, 45.0)`  | Rotation augmentation range in degrees, improving recognition of rotated objects.                                                 |
+| `translate`       | `tune.uniform(0.0, 0.9)`   | Translation augmentation range that shifts images horizontally and vertically.                                                    |
+| `scale`           | `tune.uniform(0.0, 0.95)`  | Scaling augmentation range that simulates objects at different distances.                                                         |
+| `shear`           | `tune.uniform(0.0, 10.0)`  | Shear augmentation range in degrees, simulating perspective shifts.                                                               |
+| `perspective`     | `tune.uniform(0.0, 0.001)` | Perspective augmentation range that simulates 3D viewpoint changes.                                                               |
+| `flipud`          | `tune.uniform(0.0, 1.0)`   | Vertical flip augmentation probability, increasing dataset diversity.                                                             |
+| `fliplr`          | `tune.uniform(0.0, 1.0)`   | Horizontal flip augmentation probability, useful for symmetrical objects.                                                         |
+| `bgr`             | `tune.uniform(0.0, 1.0)`   | BGR channel swap augmentation probability, helping with color invariance.                                                         |
+| `mosaic`          | `tune.uniform(0.0, 1.0)`   | Mosaic augmentation probability that combines four images into one training sample.                                               |
+| `mixup`           | `tune.uniform(0.0, 1.0)`   | Mixup augmentation probability that blends two images and their labels together.                                                  |
+| `cutmix`          | `tune.uniform(0.0, 1.0)`   | Cutmix augmentation probability that combines image regions while maintaining local features.                                     |
+| `copy_paste`      | `tune.uniform(0.0, 1.0)`   | Copy-paste augmentation probability that transfers objects between images to increase instance diversity.                         |
+| `close_mosaic`    | `tune.uniform(0.0, 10.0)`  | Disables mosaic in the last N epochs to stabilize training before completion.                                                     |
 
 ## Custom Search Space Example
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR tightens documentation rendering so label highlighting only applies to reference pages, while also cleaning up the Ray Tune integration docs for better table formatting and readability.

### 📊 Key Changes
- 🔒 Updated `docs/build_docs.py` so heading and navigation label highlighting now runs only on pages whose path includes `"reference"`.
- 🧭 This prevents the label-highlighting logic from affecting non-reference documentation pages.
- 📄 Reformatted the hyperparameter search space table in `docs/en/integrations/ray-tune.md`.
- ✨ The Ray Tune docs change is purely presentational: spacing and column alignment were cleaned up without changing the documented parameter ranges or meanings.

### 🎯 Purpose & Impact
- ✅ Improves documentation consistency by limiting special label styling to the pages it was intended for.
- 🎨 Reduces the chance of unwanted formatting or visual noise in general docs outside the reference section.
- 📚 Makes the Ray Tune integration page easier to read and maintain, especially for users reviewing YOLO26 tuning options.
- 🚀 No model, training, or inference behavior changes are introduced; impact is limited to docs build output and documentation quality.