### PR TITLE
Update Dockerfile-runner to v2.333.0

### DIFF
--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -7,7 +7,7 @@
 FROM ultralytics/ultralytics:latest
 
 # Set additional environment variables for runner (no "v" on the version)
-ARG RUNNER_VERSION=2.332.0
+ARG RUNNER_VERSION=2.333.0
 ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive
 

--- a/docker/Dockerfile-runner-cpu
+++ b/docker/Dockerfile-runner-cpu
@@ -7,7 +7,7 @@
 FROM ultralytics/ultralytics:latest-cpu
 
 # Set additional environment variables for runner (no "v" on the version)
-ARG RUNNER_VERSION=2.332.0
+ARG RUNNER_VERSION=2.333.0
 ENV RUNNER_ALLOW_RUNASROOT=1 \
     DEBIAN_FRONTEND=noninteractive
 

--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -26,19 +26,19 @@ For a deeper look at the motivation behind this architectural shift, see the [Ul
 
 YOLO26 uses a **dual-head architecture** during [training](../modes/train.md). Both heads share the same backbone and neck, but produce outputs in different ways:
 
-| Head | Purpose | Detection Output | Post-Processing |
-| --- | --- | --- | --- |
-| **One-to-One** (default) | End-to-end inference | `(N, 300, 6)` | Confidence threshold only |
-| **One-to-Many** | Traditional YOLO output | `(N, nc + 4, 8400)` | Requires NMS |
+| Head                     | Purpose                 | Detection Output    | Post-Processing           |
+| ------------------------ | ----------------------- | ------------------- | ------------------------- |
+| **One-to-One** (default) | End-to-end inference    | `(N, 300, 6)`       | Confidence threshold only |
+| **One-to-Many**          | Traditional YOLO output | `(N, nc + 4, 8400)` | Requires NMS              |
 
 The shapes above are for [detection](../tasks/detect.md). Other tasks extend the one-to-one output with additional data per detection:
 
-| Task | End-to-End Output | Extra Data |
-| --- | --- | --- |
-| [Detection](../tasks/detect.md) | `(N, 300, 6)` | — |
+| Task                                | End-to-End Output                          | Extra Data                          |
+| ----------------------------------- | ------------------------------------------ | ----------------------------------- |
+| [Detection](../tasks/detect.md)     | `(N, 300, 6)`                              | —                                   |
 | [Segmentation](../tasks/segment.md) | `(N, 300, 6 + nm)` + proto `(N, nm, H, W)` | `nm` mask coefficients (default 32) |
-| [Pose](../tasks/pose.md) | `(N, 300, 57)` | 17 keypoints × 3 (x, y, visibility) |
-| [OBB](../tasks/obb.md) | `(N, 300, 7)` | Rotation angle |
+| [Pose](../tasks/pose.md)            | `(N, 300, 57)`                             | 17 keypoints × 3 (x, y, visibility) |
+| [OBB](../tasks/obb.md)              | `(N, 300, 7)`                              | Rotation angle                      |
 
 During training, both heads run simultaneously — the one-to-many head provides a richer learning signal, while the one-to-one head learns to produce clean, non-overlapping predictions. During [inference](../modes/predict.md) and [export](../modes/export.md), only the **one-to-one head** is active by default, producing up to 300 detections per image in the format `[x1, y1, x2, y2, confidence, class_id]`.
 
@@ -74,13 +74,13 @@ When you call `model.fuse()`, it folds Conv + BatchNorm layers for faster infere
 
 **Yes, the output format is different.** If you wrote custom post-processing logic for [YOLOv8](../models/yolov8.md) or [YOLO11](../models/yolo11.md) (for example, when running inference with [ONNX Runtime](../integrations/onnx.md) or [TensorRT](../integrations/tensorrt.md)), you'll need to update it to handle the new output shape:
 
-| | YOLOv8 / YOLO11 | YOLO26 (end-to-end) |
-| --- | --- | --- |
-| **Detection output** | `(N, nc + 4, 8400)` | `(N, 300, 6)` |
-| **Box format** | `xywh` (center x, center y, width, height) | `xyxy` (top-left x, top-left y, bottom-right x, bottom-right y) |
-| **Layout** | Box coords + class scores per anchor | `[x1, y1, x2, y2, conf, class_id]` |
-| **NMS required** | Yes | No |
-| **Post-processing** | NMS + confidence filter | Confidence filter only |
+|                      | YOLOv8 / YOLO11                            | YOLO26 (end-to-end)                                             |
+| -------------------- | ------------------------------------------ | --------------------------------------------------------------- |
+| **Detection output** | `(N, nc + 4, 8400)`                        | `(N, 300, 6)`                                                   |
+| **Box format**       | `xywh` (center x, center y, width, height) | `xyxy` (top-left x, top-left y, bottom-right x, bottom-right y) |
+| **Layout**           | Box coords + class scores per anchor       | `[x1, y1, x2, y2, conf, class_id]`                              |
+| **NMS required**     | Yes                                        | No                                                              |
+| **Post-processing**  | NMS + confidence filter                    | Confidence filter only                                          |
 
 For [segmentation](../tasks/segment.md), [pose](../tasks/pose.md), and [OBB](../tasks/obb.md) tasks, YOLO26 appends task-specific data to each detection — see the [output shapes table](#how-end-to-end-detection-works) above.
 
@@ -149,12 +149,12 @@ The following formats **do not** support end-to-end and automatically fall back 
 
 End-to-end detection provides significant deployment benefits with minimal impact on [accuracy](https://www.ultralytics.com/glossary/accuracy):
 
-| Metric | End-to-End (default) | One-to-Many + NMS (`end2end=False`) |
-| --- | --- | --- |
-| **CPU Inference Speed** | Up to **43% faster** | Baseline |
-| **mAP Impact** | ~0.5 mAP lower | Matches or exceeds YOLO11 |
-| **Post-Processing** | Confidence filter only | Full NMS pipeline |
-| **Deployment Complexity** | Minimal | Requires NMS implementation |
+| Metric                    | End-to-End (default)   | One-to-Many + NMS (`end2end=False`) |
+| ------------------------- | ---------------------- | ----------------------------------- |
+| **CPU Inference Speed**   | Up to **43% faster**   | Baseline                            |
+| **mAP Impact**            | ~0.5 mAP lower         | Matches or exceeds YOLO11           |
+| **Post-Processing**       | Confidence filter only | Full NMS pipeline                   |
+| **Deployment Complexity** | Minimal                | Requires NMS implementation         |
 
 For most real-world applications, the ~0.5 [mAP](https://www.ultralytics.com/glossary/mean-average-precision-map) difference is negligible, especially when considering the speed and simplicity gains. If maximum accuracy is your top priority, you can always fall back to the one-to-many head using `end2end=False`.
 
@@ -197,12 +197,12 @@ Yes, that's the expected end-to-end output format for detection: [batch size](ht
 
 For other tasks, the output shape differs:
 
-| Task | Output Shape | Description |
-| --- | --- | --- |
-| Detection | `(1, 300, 6)` | `[x1, y1, x2, y2, conf, class_id]` |
+| Task         | Output Shape                         | Description                                                       |
+| ------------ | ------------------------------------ | ----------------------------------------------------------------- |
+| Detection    | `(1, 300, 6)`                        | `[x1, y1, x2, y2, conf, class_id]`                                |
 | Segmentation | `(1, 300, 38)` + `(1, 32, 160, 160)` | 6 box values + 32 mask coefficients, plus a prototype mask tensor |
-| Pose | `(1, 300, 57)` | 6 box values + 17 keypoints × 3 (x, y, visibility) |
-| OBB | `(1, 300, 7)` | 6 box values + 1 rotation angle |
+| Pose         | `(1, 300, 57)`                       | 6 box values + 17 keypoints × 3 (x, y, visibility)                |
+| OBB          | `(1, 300, 7)`                        | 6 box values + 1 rotation angle                                   |
 
 ### How do I check if my exported model is end-to-end?
 
@@ -238,9 +238,9 @@ Yes. All YOLO26 task variants — [detection](../tasks/detect.md), [segmentation
 
 Each task extends the base detection output with task-specific data:
 
-| Task | Model | End-to-End Output |
-| --- | --- | --- |
-| Detection | `yolo26n.pt` | `(N, 300, 6)` |
-| Segmentation | `yolo26n-seg.pt` | `(N, 300, 38)` + proto `(N, 32, 160, 160)` |
-| Pose | `yolo26n-pose.pt` | `(N, 300, 57)` |
-| OBB | `yolo26n-obb.pt` | `(N, 300, 7)` |
+| Task         | Model             | End-to-End Output                          |
+| ------------ | ----------------- | ------------------------------------------ |
+| Detection    | `yolo26n.pt`      | `(N, 300, 6)`                              |
+| Segmentation | `yolo26n-seg.pt`  | `(N, 300, 38)` + proto `(N, 32, 160, 160)` |
+| Pose         | `yolo26n-pose.pt` | `(N, 300, 57)`                             |
+| OBB          | `yolo26n-obb.pt`  | `(N, 300, 7)`                              |


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the GitHub Actions runner Docker images to version `2.333.0` and improves the YOLO26 end-to-end detection guide with cleaner, more readable tables and formatting.

### 📊 Key Changes
- ⬆️ Bumped the GitHub Actions runner version from `2.332.0` to `2.333.0` in:
  - `docker/Dockerfile-runner`
  - `docker/Dockerfile-runner-cpu`
- 📚 Refined the documentation in `docs/en/guides/end2end-detection.md` by:
  - Reformatting multiple tables for better readability
  - Improving alignment and presentation of output shapes across detection, segmentation, pose, and OBB tasks
  - Clarifying comparisons between YOLOv8 / YOLO11 outputs and YOLO26 end-to-end outputs
  - Making deployment and performance tradeoff tables easier to scan

### 🎯 Purpose & Impact
- ✅ Keeps CI and runner container environments up to date with the latest GitHub Actions runner release
- 👀 Makes the YOLO26 end-to-end detection documentation easier for users to understand, especially around output formats and post-processing differences
- 🚀 Helps developers integrating exported YOLO26 models more quickly identify how outputs differ from older models like YOLO11
- 🔒 Low-risk change overall: this PR appears to be maintenance and documentation polish, with no core model logic changes