### PR TITLE
Remove TF pins

### DIFF
--- a/docker/Dockerfile-export
+++ b/docker/Dockerfile-export
@@ -7,9 +7,8 @@
 FROM ultralytics/ultralytics:latest
 
 # Install export dependencies and run exports to AutoInstall packages
-# Numpy 1.26.4 required for TensorFlow export compatibility
 # Note tensorrt installed on-demand as depends on runtime environment CUDA version
-RUN uv pip install --system -e ".[export]" "onnxruntime-gpu" paddlepaddle x2paddle numpy==1.26.4 && \
+RUN uv pip install --system -e ".[export]" "onnxruntime-gpu" paddlepaddle x2paddle && \
     # Run exports to AutoInstall packages \
     yolo export model=tmp/yolo26n.pt format=edgetpu imgsz=32 && \
     yolo export model=tmp/yolo26n.pt format=ncnn imgsz=32 && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,7 @@ export = [
     "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
-    "tensorflow>=2.0.0", # TF export
-    "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
+    "tensorflow>=2.0.0", # TF export (tensorflowjs installed --no-deps at export time to avoid decision-forests conflicts)
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ export = [
     "openvino>=2024.0.0",  # OpenVINO export
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
+    "protobuf>=6.31.1,<7", # tensorflow-decision-forests gencode compiled with 6.31.1, needs matching runtime
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,16 +88,14 @@ dev = [
     "minijinja>=2.0.0", # render docs macros without mkdocs-macros-plugin
 ]
 export = [
-    "numpy<2.0.0", # TF 2.20 compatibility
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS (tested up to onnx==1.20.0)
     "onnxslim>=0.1.82",
     "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
     "openvino>=2024.0.0",  # OpenVINO export
-    "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
+    "tensorflow>=2.0.0", # TF export
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
-    "protobuf>=6.31.1,<7", # tensorflow-decision-forests gencode compiled with 6.31.1, needs matching runtime
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dev = [
     "minijinja>=2.0.0", # render docs macros without mkdocs-macros-plugin
 ]
 export = [
+    "numpy<=2.3.5", # coremltools 9.0 incompatible with numpy 2.4+
     "onnx>=1.12.0; platform_system != 'Darwin'", # ONNX export
     "onnx>=1.12.0,<1.18.0; platform_system == 'Darwin'",  # TF inference hanging on MacOS (tested up to onnx==1.20.0)
     "onnxslim>=0.1.82",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1074,11 +1074,11 @@ class Exporter:
         try:
             import tensorflow as tf
         except ImportError:
-            check_requirements("tensorflow>=2.0.0,<=2.19.0")
+            check_requirements("tensorflow>=2.0.0")
             import tensorflow as tf
         check_requirements(
             (
-                "tf_keras<=2.19.0",  # required by 'onnx2tf' package
+                "tf_keras",  # required by 'onnx2tf' package
                 "sng4onnx>=1.0.1",  # required by 'onnx2tf' package
                 "onnx_graphsurgeon>=0.3.26",  # required by 'onnx2tf' package
                 "ai-edge-litert>=1.2.0" + (",<1.4.0" if MACOS else ""),  # required by 'onnx2tf' package

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1259,7 +1259,9 @@ class Exporter:
     @try_export
     def export_tfjs(self, prefix=colorstr("TensorFlow.js:")):
         """Export YOLO model to TensorFlow.js format."""
-        check_requirements("tensorflowjs")
+        # Install tensorflowjs without deps to avoid tensorflow-decision-forests pulling in
+        # conflicting protobuf/tensorflow versions. TF is already installed from [export] extras.
+        check_requirements("tensorflowjs", cmds="--no-deps")
 
         f = str(self.file).replace(self.file.suffix, "_web_model")  # js dir
         f_pb = str(self.file.with_suffix(".pb"))  # *.pb path

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -121,6 +121,11 @@ def benchmark(
             # Checks
             if format == "pb":
                 assert model.task != "obb", "TensorFlow GraphDef not supported for OBB task"
+            elif format == "tfjs":
+                # tensorflowjs 4.22.0 requires tensorflow-decision-forests which pins tensorflow==2.19.0,
+                # but tensorflow<=2.19.0 requires protobuf<6 while decision-forests gencode needs protobuf>=6.
+                # Older tensorflowjs (3.18.0) uses np.object removed in numpy 1.24+. No valid resolution exists.
+                assert False, "TF.js export disabled due to irreconcilable dependency conflicts in tensorflowjs"
             elif format == "edgetpu":
                 assert LINUX and not ARM64, "Edge TPU export only supported on non-aarch64 Linux"
             elif format in {"coreml", "tfjs"}:

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -121,11 +121,6 @@ def benchmark(
             # Checks
             if format == "pb":
                 assert model.task != "obb", "TensorFlow GraphDef not supported for OBB task"
-            elif format == "tfjs":
-                # tensorflowjs 4.22.0 requires tensorflow-decision-forests which pins tensorflow==2.19.0,
-                # but tensorflow<=2.19.0 requires protobuf<6 while decision-forests gencode needs protobuf>=6.
-                # Older tensorflowjs (3.18.0) uses np.object removed in numpy 1.24+. No valid resolution exists.
-                assert False, "TF.js export disabled due to irreconcilable dependency conflicts in tensorflowjs"
             elif format == "edgetpu":
                 assert LINUX and not ARM64, "Edge TPU export only supported on non-aarch64 Linux"
             elif format in {"coreml", "tfjs"}:

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -121,10 +121,6 @@ def benchmark(
             # Checks
             if format == "pb":
                 assert model.task != "obb", "TensorFlow GraphDef not supported for OBB task"
-            elif format == "tfjs":
-                # tensorflowjs pulls in tensorflow-decision-forests which requires protobuf>=6,
-                # but tensorflow<=2.19 requires protobuf<6, causing an irreconcilable import error
-                assert False, "TF.js export disabled due to protobuf version conflict in tensorflowjs"
             elif format == "edgetpu":
                 assert LINUX and not ARM64, "Edge TPU export only supported on non-aarch64 Linux"
             elif format in {"coreml", "tfjs"}:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates TensorFlow and export dependencies to make YOLO export workflows more flexible, restore TF.js export support, and reduce version conflicts across export formats.

### 📊 Key Changes
- Removed the strict `numpy==1.26.4` pin from `Dockerfile-export` and relaxed the export dependency to `numpy<=2.3.5` ✅
- Broadened TensorFlow support from `tensorflow<=2.19.0` to `tensorflow>=2.0.0` in both package dependencies and exporter checks 📦
- Removed the `tensorflowjs` package from default export extras, so it is no longer installed automatically with all export dependencies ⚙️
- Updated TF.js export to install `tensorflowjs` with `--no-deps` at export time, avoiding dependency clashes with TensorFlow Decision Forests and protobuf 🔄
- Relaxed the `tf_keras` requirement by removing the old `<=2.19.0` cap 🧩
- Re-enabled TF.js benchmarking/export flow by removing the hardcoded block that previously disabled TF.js export 🚀
- Updated dependency comments to reflect current compatibility constraints, including CoreML tools and NumPy notes 📝

### 🎯 Purpose & Impact
- Makes export environments easier to maintain by reducing overly strict version pinning and improving compatibility across packages 👍
- Restores TensorFlow.js export support, which is useful for deploying YOLO models in web and browser-based applications 🌐
- Lowers the chance of installation failures caused by conflicting TensorFlow, protobuf, and Decision Forests dependencies 🛠️
- Improves Docker export setup by avoiding unnecessary NumPy pinning while keeping compatibility with supported export tools 🐳
- Gives users more flexibility with newer TensorFlow and NumPy versions, while still protecting known unsupported combinations 🔒
- Overall, this should make model export workflows in `ultralytics` more reliable and smoother for both developers and end users ✨