### PR TITLE
`ultralytics 8.4.25` TensorFlow.js fix pin `ydf<0.13.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ export = [
     "openvino>=2024.0.0",  # OpenVINO export
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
-    "ydf<0.13.0", # ydf>=0.13 has protobuf gencode 6.x but tensorflow<=2.19 requires protobuf<6
+    "ydf<0.13.0; platform_machine != 'aarch64'", # ydf>=0.13 has protobuf gencode 6.x but tensorflow<=2.19 requires protobuf<6
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ export = [
     "openvino>=2024.0.0",  # OpenVINO export
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
+    "ydf<0.13.0", # ydf>=0.13 has protobuf gencode 6.x but tensorflow<=2.19 requires protobuf<6
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.24"
+__version__ = "8.4.25"
 
 import importlib
 import os

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -123,10 +123,10 @@ def benchmark(
                 assert model.task != "obb", "TensorFlow GraphDef not supported for OBB task"
             elif format == "edgetpu":
                 assert LINUX and not ARM64, "Edge TPU export only supported on non-aarch64 Linux"
-            elif format in {"coreml", "tfjs"}:
-                assert MACOS or (LINUX and not ARM64), (
-                    "CoreML and TF.js export only supported on macOS and non-aarch64 Linux"
-                )
+            elif format == "tfjs":
+                assert not (LINUX and ARM64), "TF.js export not supported on ARM64 Linux"
+            elif format == "coreml":
+                assert MACOS or (LINUX and not ARM64), "CoreML export only supported on macOS and non-aarch64 Linux"
             if format == "coreml":
                 assert not IS_PYTHON_3_13, "CoreML not supported on Python 3.13"
             if format in {"saved_model", "pb", "tflite", "edgetpu", "tfjs"}:

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -121,10 +121,6 @@ def benchmark(
             # Checks
             if format == "pb":
                 assert model.task != "obb", "TensorFlow GraphDef not supported for OBB task"
-            elif format == "tfjs":
-                # tensorflowjs pulls in tensorflow-decision-forests which requires protobuf>=6,
-                # but tensorflow<=2.19 requires protobuf<6, causing an irreconcilable import error
-                assert False, "TF.js export disabled due to protobuf version conflict in tensorflowjs"
             elif format == "edgetpu":
                 assert LINUX and not ARM64, "Edge TPU export only supported on non-aarch64 Linux"
             elif format in {"coreml", "tfjs"}:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR re-enables TensorFlow.js export in supported environments by fixing a dependency conflict and refining platform checks 🔧✅

### 📊 Key Changes
- Added a version pin for `ydf<0.13.0` in export dependencies on non-`aarch64` platforms.
- This avoids a `protobuf` compatibility issue between newer `ydf` releases and `tensorflow<=2.19`.
- Removed the hard block that previously disabled TF.js export in `ultralytics/utils/benchmarks.py`.
- Updated TF.js export validation so it is now allowed again, except on ARM64 Linux where it remains unsupported.
- Split platform checks more clearly:
  - **TF.js**: blocked only on ARM64 Linux
  - **CoreML**: still limited to macOS and non-ARM64 Linux
- Bumped the package version from `8.4.24` to `8.4.25` 📦

### 🎯 Purpose & Impact
- Restores **TensorFlow.js export** for most supported users, making browser and JavaScript deployment possible again 🌐
- Reduces installation and runtime failures caused by incompatible dependency versions.
- Improves clarity in export support rules, so users get more accurate feedback about what works on their system.
- Keeps ARM64 Linux restrictions in place where TF.js is still not reliably supported, helping avoid broken export workflows ⚠️
- Overall, this makes Ultralytics export tooling more reliable and practical for users deploying models beyond Python 🚀