### PR TITLE
Add Platform videos to docs

### DIFF
--- a/docs/en/platform/account/index.md
+++ b/docs/en/platform/account/index.md
@@ -16,7 +16,7 @@ keywords: Ultralytics Platform, account, settings, API keys, billing, security, 
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Get Started with Ultralytics Platform - Account</strong> 
+  <strong>Watch: </strong> Get Started with Ultralytics Platform - Account
 </p>
 
 ## Overview

--- a/docs/en/platform/account/index.md
+++ b/docs/en/platform/account/index.md
@@ -8,6 +8,17 @@ keywords: Ultralytics Platform, account, settings, API keys, billing, security, 
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive account management for API keys, billing, teams, and user settings. Manage your account securely with GDPR-compliant data handling.
 
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/u_s1R5ZXcSE"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Get Started with Ultralytics Platform - Account</strong> 
+</p>
+
 ## Overview
 
 The Account section helps you:

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -16,7 +16,7 @@ Data preparation is the foundation of successful [computer vision](https://www.u
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Get Started with Ultralytics Platform - Data</strong> 
+  <strong>Watch:</strong> Get Started with Ultralytics Platform - Data
 </p>
 
 ## Overview

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -8,6 +8,17 @@ keywords: Ultralytics Platform, data management, datasets, annotation, YOLO, com
 
 Data preparation is the foundation of successful [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models. [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive tools for managing your training data, from upload through annotation to analysis.
 
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/kA09zsjZGdA"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Get Started with Ultralytics Platform - Data</strong> 
+</p>
+
 ## Overview
 
 The Data section of Ultralytics Platform helps you:

--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -8,6 +8,18 @@ keywords: Ultralytics Platform, deployment, inference, endpoints, monitoring, YO
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive deployment options for putting your YOLO models into production. Test models with browser-based inference, deploy to dedicated endpoints across 43 global regions, and monitor performance in real-time.
 
+
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/JjgQYPetX8w"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Get Started with Ultralytics Platform - Deploy</strong> 
+</p>
+
 ## Overview
 
 The Deployment section helps you:

--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -17,7 +17,7 @@ keywords: Ultralytics Platform, deployment, inference, endpoints, monitoring, YO
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Get Started with Ultralytics Platform - Deploy</strong> 
+  <strong>Watch:</strong> Get Started with Ultralytics Platform - Deploy
 </p>
 
 ## Overview

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -8,6 +8,17 @@ keywords: Ultralytics Platform, Quickstart, YOLO models, dataset upload, model t
 
 [Ultralytics Platform](https://platform.ultralytics.com) is designed to be user-friendly and intuitive, allowing users to quickly upload their datasets and train new YOLO models. It offers a range of pretrained models to choose from, making it easy for users to get started. Once a model is trained, it can be tested directly in the browser and deployed to production with a single click.
 
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/VGa3HMUWQSM"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Watch:</strong>Get Started with Ultralytics Platform - QuickStart
+</p>
+
 ```mermaid
 journey
     title Your First Model in 5 Minutes
@@ -24,17 +35,6 @@ journey
       Test model: 5: User
       Deploy endpoint: 5: User
 ```
-
-<p align="center">
-  <br>
-  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/VGa3HMUWQSM"
-    title="YouTube video player" frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    allowfullscreen>
-  </iframe>
-  <br>
-  <strong>Get Started with Ultralytics Platform - QuickStart</strong> 
-</p>
 
 ## Get Started
 

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -16,7 +16,7 @@ keywords: Ultralytics Platform, Quickstart, YOLO models, dataset upload, model t
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong>Get Started with Ultralytics Platform - QuickStart
+  <strong>Watch:</strong> Get Started with Ultralytics Platform - QuickStart
 </p>
 
 ```mermaid

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -25,6 +25,17 @@ journey
       Deploy endpoint: 5: User
 ```
 
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/VGa3HMUWQSM"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Get Started with Ultralytics Platform - QuickStart</strong> 
+</p>
+
 ## Get Started
 
 [Ultralytics Platform](https://platform.ultralytics.com) offers a variety of easy signup options. You can register and log in using your Google or GitHub accounts, or with your email address.

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -16,7 +16,7 @@ keywords: Ultralytics Platform, model training, cloud training, YOLO, GPU traini
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Get Started with Ultralytics Platform - Train</strong> 
+  <strong>Watch:</strong> Get Started with Ultralytics Platform - Train
 </p>
 
 ## Overview

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -8,6 +8,17 @@ keywords: Ultralytics Platform, model training, cloud training, YOLO, GPU traini
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive tools for training YOLO models, from organizing experiments to running cloud training jobs with real-time metrics streaming.
 
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/bajkq0NrSN8"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Get Started with Ultralytics Platform - Train</strong> 
+</p>
+
 ## Overview
 
 The Training section helps you:


### PR DESCRIPTION
@glenn-jocher

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds embedded Ultralytics Platform onboarding videos to key Platform documentation pages for quicker, more visual product walkthroughs. 🎥

### 📊 Key Changes
- Added centered embedded YouTube videos to `docs/en/platform/quickstart.md`.
- Added embedded walkthrough videos to Platform section pages:
  - `docs/en/platform/account/index.md`
  - `docs/en/platform/data/index.md`
  - `docs/en/platform/train/index.md`
  - `docs/en/platform/deploy/index.md`
- Each page now includes a section-specific “Get Started with Ultralytics Platform” video near the top of the content.
- Uses lazy-loaded `iframe` embeds to help reduce unnecessary page-load overhead. ⚡

### 🎯 Purpose & Impact
- Improves documentation usability by pairing written guides with visual tutorials. 📚
- Helps new users onboard faster across core Ultralytics Platform workflows like account setup, data prep, training, and deployment.
- Increases discoverability of Platform education content directly inside the docs.
- Enhances the docs experience without changing product behavior or code paths. ✅