### PR TITLE
fix pad rounding in `scale_coords` and `scale_masks` to match LetterBox

### DIFF
--- a/ultralytics/models/yolo/yoloe/predict.py
+++ b/ultralytics/models/yolo/yoloe/predict.py
@@ -112,8 +112,8 @@ class YOLOEVPDetectPredictor(DetectionPredictor):
             # Calculate scaling factor and adjust bounding boxes
             gain = min(dst_shape[0] / src_shape[0], dst_shape[1] / src_shape[1])  # gain = old / new
             bboxes *= gain
-            bboxes[..., 0::2] += round((dst_shape[1] - src_shape[1] * gain) / 2 - 0.1)
-            bboxes[..., 1::2] += round((dst_shape[0] - src_shape[0] * gain) / 2 - 0.1)
+            bboxes[..., 0::2] += round((dst_shape[1] - round(src_shape[1] * gain)) / 2 - 0.1)
+            bboxes[..., 1::2] += round((dst_shape[0] - round(src_shape[0] * gain)) / 2 - 0.1)
         elif masks is not None:
             # Resize and process masks
             resized_masks = super().pre_transform(masks)

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -547,7 +547,7 @@ def scale_masks(
 
     if ratio_pad is None:  # calculate from im0_shape
         gain = min(im1_h / im0_h, im1_w / im0_w)  # gain  = old / new
-        pad_w, pad_h = (im1_w - im0_w * gain), (im1_h - im0_h * gain)  # wh padding
+        pad_w, pad_h = (im1_w - round(im0_w * gain)), (im1_h - round(im0_h * gain))  # wh padding
         if padding:
             pad_w /= 2
             pad_h /= 2
@@ -577,7 +577,7 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None, normalize: bool
     if ratio_pad is None:  # calculate from img0_shape
         img1_h, img1_w = img1_shape[:2]  # supports both HWC or HW shapes
         gain = min(img1_h / img0_h, img1_w / img0_w)  # gain  = old / new
-        pad = (img1_w - img0_w * gain) / 2, (img1_h - img0_h * gain) / 2  # wh padding
+        pad = (img1_w - round(img0_w * gain)) / 2, (img1_h - round(img0_h * gain)) / 2  # wh padding
     else:
         gain = ratio_pad[0][0]
         pad = ratio_pad[1]


### PR DESCRIPTION
## summary

follow-up to #23967 - apply the same `round()` fix to `scale_coords()` and `scale_masks()` in `ultralytics/utils/ops.py`. both functions used unrounded `shape * gain` when calculating padding, causing a 1px shift on ~15% of image size combinations for keypoints and masks relative to bounding boxes.

## verification

- 0 padding mismatches across 3.6M image size combinations (was 541k before fix)
- pose and segmentation models tested on affected sizes
- all python tests pass

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes pad rounding in `scale_coords()` and `scale_masks()` so postprocessing matches `LetterBox` behavior more consistently. 🎯

### 📊 Key Changes
- Updated `scale_masks()` padding calculation to use `round(im0_w * gain)` and `round(im0_h * gain)` before deriving width and height padding.
- Updated `scale_coords()` padding calculation to use the same rounded resized dimensions before dividing padding across both sides.
- Aligns internal coordinate and mask rescaling logic with `LetterBox` preprocessing behavior.

### 🎯 Purpose & Impact
- Reduces off-by-one padding mismatches during coordinate and mask scaling. ✅
- Improves consistency between preprocessing and postprocessing for detection and segmentation outputs. 🧩
- Helps avoid subtle localization or mask alignment errors, especially near image borders. 📏