### PR TITLE
Pin `paddlepaddle<3.3.0`

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -853,11 +853,11 @@ class Exporter:
         assert not IS_JETSON, "Jetson Paddle exports not supported yet"
         check_requirements(
             (
-                "paddlepaddle-gpu>=3.0.0,!=3.3.0"  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
+                "paddlepaddle-gpu>=3.0.0,<3.3.0"  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
                 if torch.cuda.is_available()
                 else "paddlepaddle==3.0.0"  # pin 3.0.0 for ARM64
                 if ARM64
-                else "paddlepaddle>=3.0.0,!=3.3.0",  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
+                else "paddlepaddle>=3.0.0,<3.3.0",  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
                 "x2paddle",
             )
         )

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -853,11 +853,11 @@ class Exporter:
         assert not IS_JETSON, "Jetson Paddle exports not supported yet"
         check_requirements(
             (
-                "paddlepaddle-gpu>=3.0.0,<3.3.0"  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
+                "paddlepaddle-gpu>=3.0.0,<3.3.0"  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
                 if torch.cuda.is_available()
                 else "paddlepaddle==3.0.0"  # pin 3.0.0 for ARM64
                 if ARM64
-                else "paddlepaddle>=3.0.0,<3.3.0",  # exclude 3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
+                else "paddlepaddle>=3.0.0,<3.3.0",  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
                 "x2paddle",
             )
         )

--- a/ultralytics/nn/backends/paddle.py
+++ b/ultralytics/nn/backends/paddle.py
@@ -29,11 +29,11 @@ class PaddleBackend(BaseBackend):
         cuda = isinstance(self.device, torch.device) and torch.cuda.is_available() and self.device.type != "cpu"
         LOGGER.info(f"Loading {weight} for PaddlePaddle inference...")
         if cuda:
-            check_requirements("paddlepaddle-gpu>=3.0.0,!=3.3.0")
+            check_requirements("paddlepaddle-gpu>=3.0.0,<3.3.0")
         elif ARM64:
             check_requirements("paddlepaddle==3.0.0")
         else:
-            check_requirements("paddlepaddle>=3.0.0,!=3.3.0")
+            check_requirements("paddlepaddle>=3.0.0,<3.3.0")
 
         import paddle.inference as pdi
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔒 This PR tightens PaddlePaddle version requirements to block all `3.3.x` releases, helping prevent known compatibility issues during export and inference.

### 📊 Key Changes
- Updated PaddlePaddle dependency checks in `exporter.py` for Paddle export:
  - Changed GPU requirement from `paddlepaddle-gpu>=3.0.0,!=3.3.0` to `paddlepaddle-gpu>=3.0.0,<3.3.0`
  - Changed CPU requirement from `paddlepaddle>=3.0.0,!=3.3.0` to `paddlepaddle>=3.0.0,<3.3.0`
- Updated the same version checks in `ultralytics/nn/backends/paddle.py` for Paddle inference loading.
- Kept existing ARM64 behavior unchanged, still pinning `paddlepaddle==3.0.0`.
- Clarified comments to show this is now a stricter version pin due to a known PaddlePaddle issue ⚠️

### 🎯 Purpose & Impact
- Prevents users from installing unsupported PaddlePaddle `3.3.x` versions that may break Ultralytics Paddle export or inference.
- Improves reliability and consistency across environments by limiting Paddle installs to known compatible versions ✅
- Reduces confusing runtime errors for users working with Paddle backends, especially on CPU and GPU setups.
- Makes dependency handling more proactive: instead of excluding only `3.3.0`, it now avoids the full `3.3.x` range until upstream issues are resolved 🛠️