### PR TITLE
fix IndexError in convert_coco with missing keypoints or segmentation

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -308,23 +308,25 @@ def convert_coco(
                 cls = coco80[ann["category_id"] - 1] if cls91to80 else ann["category_id"] - 1  # class
                 box = [cls, *box.tolist()]
                 if box not in bboxes:
-                    bboxes.append(box)
-                    if use_segments and ann.get("segmentation") is not None:
-                        if len(ann["segmentation"]) == 0:
-                            segments.append([])
+                    if use_keypoints:
+                        if ann.get("keypoints") is None:
                             continue
-                        elif len(ann["segmentation"]) > 1:
-                            s = merge_multi_segment(ann["segmentation"])
-                            s = (np.concatenate(s, axis=0) / np.array([w, h])).reshape(-1).tolist()
-                        else:
-                            s = [j for i in ann["segmentation"] for j in i]  # all segments concatenated
-                            s = (np.array(s).reshape(-1, 2) / np.array([w, h])).reshape(-1).tolist()
-                        s = [cls, *s]
-                        segments.append(s)
-                    if use_keypoints and ann.get("keypoints") is not None:
                         keypoints.append(
                             box + (np.array(ann["keypoints"]).reshape(-1, 3) / np.array([w, h, 1])).reshape(-1).tolist()
                         )
+                    bboxes.append(box)
+                    if use_segments:
+                        seg = ann.get("segmentation")
+                        if seg is None or len(seg) == 0:
+                            segments.append([])
+                        elif len(seg) > 1:
+                            s = merge_multi_segment(seg)
+                            s = (np.concatenate(s, axis=0) / np.array([w, h])).reshape(-1).tolist()
+                            segments.append([cls, *s])
+                        else:
+                            s = [j for i in seg for j in i]  # all segments concatenated
+                            s = (np.array(s).reshape(-1, 2) / np.array([w, h])).reshape(-1).tolist()
+                            segments.append([cls, *s])
 
             # Write
             with open((fn / f).with_suffix(".txt"), "a", encoding="utf-8") as file:


### PR DESCRIPTION
## summary

`convert_coco()` crashes with `IndexError: list index out of range` when annotations are missing `keypoints` or `segmentation` fields, or when segmentation is an empty list. the root cause is that `bboxes`, `segments`, and `keypoints` lists go out of sync because appends are conditional.

## crashes fixed

tested 13 annotation combinations, 4 of which crashed before this fix:

- `use_segments=True, use_keypoints=True` with empty `segmentation: []` - the `continue` on empty segmentation skipped keypoints append
- `use_segments=True, use_keypoints=True` with missing `keypoints` field - bbox appended but keypoints not
- `use_keypoints=True` with missing `keypoints` field - same desync
- `use_segments=True` with missing `segmentation` field - bbox appended but segments not

## fix

- move keypoints processing before segments so `continue` on empty segmentation can't skip it
- skip the entire annotation (including bbox) when `use_keypoints=True` but no keypoints field
- always append to segments when `use_segments=True`, using empty `[]` as fallback for missing or empty segmentation
- remove the `continue` that broke list synchronization

## verification

all 13 test combinations pass after fix, all python tests pass

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes an `IndexError` in `convert_coco()` by safely handling COCO annotations that are missing keypoints or segmentation data, improving conversion robustness for pose and segmentation datasets. 🛠️

### 📊 Key Changes
- Adds an early guard for `use_keypoints` to skip annotations when `ann["keypoints"]` is missing.
- Refactors segmentation handling to first store `ann.get("segmentation")` in a local variable and safely handle `None` or empty values.
- Prevents invalid indexing and reshaping paths when segmentation data is absent or incomplete.
- Preserves existing behavior for multi-segment merging and single-segment normalization while making append logic clearer.
- Reorders annotation processing so keypoints are validated before downstream conversion steps that depend on annotation completeness.

### 🎯 Purpose & Impact
- Prevents crashes when converting COCO-format datasets containing incomplete annotations. ✅
- Improves reliability for pose and segmentation dataset conversion workflows. 🎯
- Makes `convert_coco()` more tolerant of real-world dataset inconsistencies without changing expected output for valid annotations. 📦
- Reduces manual dataset cleanup for users working with mixed-quality annotation exports. 🚀