### PR TITLE
Split slow CI tests into daily and workflow dispatch jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,10 @@ jobs:
             python: "3.10"
             torch: "1.13.0"
             torchvision: "0.14.0"
+          - os: ubuntu-latest # Axelera exports
+            python: "3.10"
+            torch: "2.8.0"
+            torchvision: "0.23.0"
           - os: ubuntu-latest
             python: "3.11"
             torch: "2.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
     if: github.event_name == 'schedule'
     timeout-minutes: 360
     runs-on: ${{ matrix.os }}
+    env:
+      RUN_AXELERA_EXPORT: "true"
     strategy: &slow_tests_strategy
       fail-fast: false
       matrix:
@@ -281,6 +283,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.tests == 'true'
     timeout-minutes: 360
     runs-on: ${{ matrix.os }}
+    env:
+      RUN_AXELERA_EXPORT: "false"
     strategy: *slow_tests_strategy
     steps: *slow_tests_steps
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,12 @@ jobs:
       - name: Prune uv Cache
         run: uv cache prune --ci
 
-  SlowTests:
-    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.tests == 'true') || github.event_name == 'schedule'
+  SlowTestsDaily:
+    name: Slow Tests (Daily CI)
+    if: github.event_name == 'schedule'
     timeout-minutes: 360
     runs-on: ${{ matrix.os }}
-    strategy:
+    strategy: &slow_tests_strategy
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-26, windows-latest, ubuntu-24.04-arm]
@@ -195,10 +196,6 @@ jobs:
             python: "3.10"
             torch: "1.13.0"
             torchvision: "0.14.0"
-          - os: ubuntu-latest # Axelera exports
-            python: "3.10"
-            torch: "2.8.0"
-            torchvision: "0.23.0"
           - os: ubuntu-latest
             python: "3.11"
             torch: "2.0.0"
@@ -243,7 +240,7 @@ jobs:
             python: "3.12"
             torch: "2.10.0"
             torchvision: "0.25.0"
-    steps:
+    steps: &slow_tests_steps
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         if: matrix.os != 'cpu-latest'
@@ -274,6 +271,14 @@ jobs:
           retry_delay_seconds: 60
       - name: Prune uv Cache
         run: uv cache prune --ci
+
+  SlowTestsDispatch:
+    name: Slow Tests (Workflow Dispatch)
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.tests == 'true'
+    timeout-minutes: 360
+    runs-on: ${{ matrix.os }}
+    strategy: *slow_tests_strategy
+    steps: *slow_tests_steps
 
   GPU:
     if: github.repository == 'ultralytics/ultralytics' && (github.event_name != 'workflow_dispatch' || github.event.inputs.gpu == 'true')
@@ -481,11 +486,11 @@ jobs:
 
   Summary:
     runs-on: ubuntu-latest
-    needs: [Benchmarks, Tests, SlowTests, GPU, RaspberryPi, NVIDIA_Jetson, Conda]
+    needs: [Benchmarks, Tests, SlowTestsDaily, SlowTestsDispatch, GPU, RaspberryPi, NVIDIA_Jetson, Conda]
     if: always()
     steps:
       - name: Check for failure and notify
-        if: (needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.SlowTests.result == 'failure' || needs.GPU.result == 'failure' || needs.RaspberryPi.result == 'failure' || needs.NVIDIA_Jetson.result == 'failure' || needs.Conda.result == 'failure' ) && github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
+        if: (needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.SlowTestsDaily.result == 'failure' || needs.SlowTestsDispatch.result == 'failure' || needs.GPU.result == 'failure' || needs.RaspberryPi.result == 'failure' || needs.NVIDIA_Jetson.result == 'failure' || needs.Conda.result == 'failure' ) && github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
         uses: slackapi/slack-github-action@v3.0.1
         with:
           webhook-type: incoming-webhook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         run: uv cache prune --ci
 
   SlowTestsDaily:
-    name: Slow Tests (Daily CI)
+    name: SlowTestsDaily
     if: github.event_name == 'schedule'
     timeout-minutes: 360
     runs-on: ${{ matrix.os }}
@@ -273,7 +273,7 @@ jobs:
         run: uv cache prune --ci
 
   SlowTestsDispatch:
-    name: Slow Tests (Workflow Dispatch)
+    name: SlowTestsDispatch
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.tests == 'true'
     timeout-minutes: 360
     runs-on: ${{ matrix.os }}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,6 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import io
+import os
 import shutil
 import uuid
 from contextlib import redirect_stderr, redirect_stdout
@@ -299,6 +300,7 @@ def test_export_imx():
 @pytest.mark.skipif(not TORCH_2_8, reason="Axelera export requires torch>=2.8.0")
 @pytest.mark.skipif(not LINUX, reason="Axelera export only supported on Linux")
 @pytest.mark.skipif(not checks.IS_PYTHON_3_10, reason="Axelera export requires Python 3.10")
+@pytest.mark.skipif(os.getenv("RUN_AXELERA_EXPORT", "false").lower() != "true", reason="Axelera export disabled")
 def test_export_axelera():
     """Test YOLO export to Axelera format."""
     # For faster testing, use a smaller calibration dataset (32 image size crashes axelera export, so 64 is used)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refactors slow CI coverage by splitting the existing slow test job into separate daily and manual-dispatch workflows, improving clarity and control over when long-running test suites execute. 🚦

### 📊 Key Changes
- Renames the original `SlowTests` job into two dedicated jobs:
  - `SlowTestsDaily` for scheduled runs only 📅
  - `SlowTestsDispatch` for manual `workflow_dispatch` runs when `tests == 'true'` 🖱️
- Reuses the same matrix strategy and step definitions across both jobs using YAML anchors, reducing duplication and simplifying maintenance ♻️
- Removes the dedicated Ubuntu Axelera exports slow-test matrix entry from this workflow configuration 🧹
- Updates the `Summary` job dependencies to include both new slow test jobs instead of the previous single job 🧾
- Updates failure notification logic so Slack alerts check `SlowTestsDaily` and `SlowTestsDispatch` independently 🔔

### 🎯 Purpose & Impact
- Makes CI behavior easier to understand by separating scheduled slow tests from manually triggered ones ✨
- Improves workflow maintainability by centralizing shared slow-test configuration in reusable anchors 🛠️
- Preserves existing slow-test coverage while giving contributors more explicit control during manual runs 🎛️
- Helps reduce ambiguity in CI reporting and summary status checks by exposing daily and dispatch slow jobs as distinct units 📈