### PR TITLE
Update Platform docs: remove model Activity tab, expand onboarding tours

### DIFF
--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -139,9 +139,26 @@ Press `Cmd+K` (Mac) or `Ctrl+K` (Windows/Linux) to open the search bar. Search a
 
 A floating chat widget is available on every page. Click it to ask questions about YOLO training, annotation, deployment, or any Platform feature. The assistant provides context-aware help based on the current page.
 
-### Onboarding Tour
+### Onboarding Tours
 
-New users see a guided tour highlighting key Platform features. To restart the tour at any time, navigate to `platform.ultralytics.com/home?tour=nav`.
+The Platform includes guided tours that introduce key features as you explore different sections:
+
+| Tour            | Trigger                              | What It Covers                                                  |
+| --------------- | ------------------------------------ | --------------------------------------------------------------- |
+| **Nav Tour**    | First visit to Home after onboarding | Home, Explore, Annotate, Train, Deploy, Settings, Account       |
+| **Project Tour**| First visit to a project page        | Models sidebar, Training Charts, Train button                   |
+| **Dataset Tour**| First visit to a dataset page        | Images gallery, Split tabs, Classes, Charts, Train, Upload, Download |
+
+!!! tip "Enterprise Users"
+
+    Enterprise plan users see an enhanced Nav Tour with enterprise-specific guidance on the Train step.
+
+#### Restart Tours
+
+To replay any tour:
+
+- **Redo Tour button** — Click your profile avatar (bottom-left of the sidebar) to open the user menu, then select **Redo Tour**. This resets all tours so they replay on your next visit to each section.
+- **URL parameter** — Navigate to `platform.ultralytics.com/home?tour=nav` to restart the Nav Tour directly.
 
 ## Upload Your First Dataset
 

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -143,11 +143,11 @@ A floating chat widget is available on every page. Click it to ask questions abo
 
 The Platform includes guided tours that introduce key features as you explore different sections:
 
-| Tour            | Trigger                              | What It Covers                                                  |
-| --------------- | ------------------------------------ | --------------------------------------------------------------- |
-| **Nav Tour**    | First visit to Home after onboarding | Home, Explore, Annotate, Train, Deploy, Settings, Account       |
-| **Project Tour**| First visit to a project page        | Models sidebar, Training Charts, Train button                   |
-| **Dataset Tour**| First visit to a dataset page        | Images gallery, Split tabs, Classes, Charts, Train, Upload, Download |
+| Tour             | Trigger                              | What It Covers                                                       |
+| ---------------- | ------------------------------------ | -------------------------------------------------------------------- |
+| **Nav Tour**     | First visit to Home after onboarding | Home, Explore, Annotate, Train, Deploy, Settings, Account            |
+| **Project Tour** | First visit to a project page        | Models sidebar, Training Charts, Train button                        |
+| **Dataset Tour** | First visit to a dataset page        | Images gallery, Split tabs, Classes, Charts, Train, Upload, Download |
 
 !!! tip "Enterprise Users"
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -78,7 +78,6 @@ Each model page has the following tabs:
 | **Predict**  | Interactive browser inference                 |
 | **Export**   | Format conversion with GPU selection          |
 | **Deploy**   | Endpoint creation and management              |
-| **Activity** | Audit log of all actions on this model        |
 
 ### Overview Tab
 
@@ -156,10 +155,6 @@ Export your model to 17+ deployment formats. See [Export Model](#export-model) b
 ### Deploy Tab
 
 Create and manage dedicated inference endpoints. See [Deployments](../deploy/index.md) for details.
-
-### Activity Tab
-
-The Activity tab shows an audit log of all actions performed on this model, including creation, training start/completion, exports, deployments, and settings changes. Each entry includes the action type, timestamp, and user who performed it.
 
 ## Validation Plots
 


### PR DESCRIPTION
## Summary
- Remove non-existent Activity tab from `models.md` — the model page has 5 tabs (Overview, Train, Predict, Export, Deploy), not 6
- Expand onboarding tour section in `quickstart.md` to document all 4 guided tours (Nav, Enterprise Nav, Project, Dataset), the "Redo Tour" button, and tour triggers

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates Ultralytics Platform documentation to reflect the current UI by removing the outdated model **Activity** tab and expanding onboarding guidance into section-specific tours. ✨

### 📊 Key Changes
- Renamed **Onboarding Tour** to **Onboarding Tours** in `docs/en/platform/quickstart.md`.
- Added a tour overview table covering **Nav Tour**, **Project Tour**, and **Dataset Tour**, including triggers and what each tour explains.
- Documented two ways to restart tours: the **Redo Tour** user menu option and the `?tour=nav` URL parameter.
- Added a note for **Enterprise** users about enhanced navigation tour guidance.
- Removed the **Activity** tab from the model tabs table in `docs/en/platform/train/models.md`.
- Deleted the dedicated **Activity Tab** section to align docs with the current Platform model page. 🧹

### 🎯 Purpose & Impact
- Improves doc accuracy by removing references to UI elements that are no longer available.
- Makes Platform onboarding clearer by describing tours users encounter across different sections.
- Helps new and existing users rediscover guided tours more easily, reducing confusion during navigation and setup.
- Better supports Enterprise users with explicit documentation of plan-specific onboarding behavior. 🚀