### PR TITLE
fix: 🐞 resume functionality in detection and segmentation tests

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -57,8 +57,8 @@ def test_detect():
 
     # Test resume functionality
     overrides["resume"] = trainer.last
-    trainer = detect.DetectionTrainer(overrides=overrides)
     try:
+        trainer = detect.DetectionTrainer(overrides=overrides)
         trainer.train()
     except Exception as e:
         print(f"Expected exception caught: {e}")
@@ -103,8 +103,8 @@ def test_segment():
 
     # Test resume functionality
     overrides["resume"] = trainer.last
-    trainer = segment.SegmentationTrainer(overrides=overrides)
     try:
+        trainer = segment.SegmentationTrainer(overrides=overrides)
         trainer.train()
     except Exception as e:
         print(f"Expected exception caught: {e}")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -55,16 +55,16 @@ def test_detect():
         result = pred(source=ASSETS, model=MODEL)
         assert len(result), "predictor test failed"
 
-    # Test resume functionality
+    # Test resume functionality, completed training (epochs=1, save=False) should not be resumable
     overrides["resume"] = trainer.last
     try:
         trainer = detect.DetectionTrainer(overrides=overrides)
         trainer.train()
-    except Exception as e:
-        print(f"Expected exception caught: {e}")
+    except ValueError as e:
+        assert "is not a resumable training checkpoint" in str(e), f"Unexpected ValueError: {e}"
         return
 
-    raise Exception("Resume test failed!")
+    raise Exception("Resume test failed. Expected ValueError for non-resumable checkpoint")
 
 
 def test_segment():
@@ -101,16 +101,16 @@ def test_segment():
     result = pred(source=ASSETS, model=WEIGHTS_DIR / "yolo26n-seg.pt")
     assert len(result), "predictor test failed"
 
-    # Test resume functionality
+    # Test resume functionality - completed training (epochs=1, save=False) should not be resumable
     overrides["resume"] = trainer.last
     try:
         trainer = segment.SegmentationTrainer(overrides=overrides)
         trainer.train()
-    except Exception as e:
-        print(f"Expected exception caught: {e}")
+    except ValueError as e:
+        assert "is not a resumable training checkpoint" in str(e), f"Unexpected ValueError: {e}"
         return
 
-    raise Exception("Resume test failed!")
+    raise Exception("Resume test failed - expected ValueError for non-resumable checkpoint")
 
 
 def test_classify():


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR tightens training resume tests to ensure completed, non-resumable checkpoints correctly raise a clear `ValueError` instead of passing with any generic exception.

### 📊 Key Changes
- Updated resume-related tests in `tests/test_engine.py` for:
  - detection training
  - segmentation training
- Clarified test comments to explicitly state that a fully completed training run with `epochs=1` and `save=False` should **not** be resumable.
- Changed exception handling from catching any `Exception` to specifically catching `ValueError`.
- Added assertions to verify the error message includes `"is not a resumable training checkpoint"`.
- Improved failure messages so tests now clearly report when the expected non-resumable checkpoint error does not occur.

### 🎯 Purpose & Impact
- ✅ Makes tests more precise by checking for the **expected error type and message**, not just any failure.
- 🔒 Helps prevent regressions in resume logic for detection and segmentation trainers.
- 🧪 Improves reliability of the training engine by confirming that invalid resume attempts are handled properly.
- 👩‍💻 Gives developers clearer signals during testing, making debugging easier when checkpoint resume behavior changes.
- 📣 For users, this supports more predictable training behavior and clearer errors when trying to resume from checkpoints that cannot be resumed.