### PR TITLE
`ultralytics 8.4.30` Fix training resume

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.29"
+__version__ = "8.4.30"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -841,52 +841,46 @@ class BaseTrainer:
             try:
                 exists = isinstance(resume, (str, Path)) and Path(resume).exists()
                 last = Path(check_file(resume) if exists else get_latest_run())
+                ckpt_args = load_checkpoint(last)[0].args
+                if not isinstance(ckpt_args["data"], dict) and not Path(ckpt_args["data"]).exists():
+                    ckpt_args["data"] = self.args.data
+
+                resume = True
+                self.args = get_cfg(ckpt_args)
+                self.args.model = self.args.resume = str(last)  # reinstate model
+                for k in (
+                    "imgsz",
+                    "batch",
+                    "device",
+                    "close_mosaic",
+                    "augmentations",
+                    "save_period",
+                    "workers",
+                    "cache",
+                    "patience",
+                    "time",
+                    "freeze",
+                    "val",
+                    "plots",
+                ):  # allow arg updates to reduce memory or update device on resume
+                    if k in overrides:
+                        setattr(self.args, k, overrides[k])
+
+                # Handle augmentations parameter for resume: check if user provided custom augmentations
+                if ckpt_args.get("augmentations") is not None:
+                    # Augmentations were saved in checkpoint as reprs but can't be restored automatically
+                    LOGGER.warning(
+                        "Custom Albumentations transforms were used in the original training run but are not "
+                        "being restored. To preserve custom augmentations when resuming, you need to pass the "
+                        "'augmentations' parameter again to get expected results. Example: \n"
+                        f"model.train(resume=True, augmentations={ckpt_args['augmentations']})"
+                    )
+
             except Exception as e:
                 raise FileNotFoundError(
                     "Resume checkpoint not found. Please pass a valid checkpoint to resume from, "
                     "i.e. 'yolo train resume model=path/to/last.pt'"
                 ) from e
-            model, ckpt = load_checkpoint(last)
-            if ckpt.get("epoch", -1) < 0 or ckpt.get("optimizer") is None:
-                raise ValueError(
-                    f"checkpoint '{last}' is not a resumable training checkpoint "
-                    f"(missing epoch/optimizer state). Use 'resume' only to continue incomplete training runs."
-                )
-
-            ckpt_args = model.args
-            if not isinstance(ckpt_args["data"], dict) and not Path(ckpt_args["data"]).exists():
-                ckpt_args["data"] = self.args.data
-
-            resume = True
-            self.args = get_cfg(ckpt_args)
-            self.args.model = self.args.resume = str(last)  # reinstate model
-            for k in (
-                "imgsz",
-                "batch",
-                "device",
-                "close_mosaic",
-                "augmentations",
-                "save_period",
-                "workers",
-                "cache",
-                "patience",
-                "time",
-                "freeze",
-                "val",
-                "plots",
-            ):  # allow arg updates to reduce memory or update device on resume
-                if k in overrides:
-                    setattr(self.args, k, overrides[k])
-
-            # Handle augmentations parameter for resume: check if user provided custom augmentations
-            if ckpt_args.get("augmentations") is not None:
-                # Augmentations were saved in checkpoint as reprs but can't be restored automatically
-                LOGGER.warning(
-                    "Custom Albumentations transforms were used in the original training run but are not "
-                    "being restored. To preserve custom augmentations when resuming, you need to pass the "
-                    "'augmentations' parameter again to get expected results. Example: \n"
-                    f"model.train(resume=True, augmentations={ckpt_args['augmentations']})"
-                )
         self.resume = resume
 
     def _load_checkpoint_state(self, ckpt):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR simplifies YOLO training resume logic, improves checkpoint argument recovery, and bumps Ultralytics to version `8.4.30`.

### 📊 Key Changes
- Refactored `check_resume()` in `ultralytics/engine/trainer.py` to load training arguments directly from the saved checkpoint earlier in the resume flow.
- Kept the fallback behavior that replaces an invalid or missing saved `data` path with the current `data` argument, helping resume training in moved or changed environments. 📁
- Preserved support for updating selected settings when resuming, such as `imgsz`, `batch`, `device`, `workers`, `cache`, `patience`, `freeze`, `val`, and `plots`. ⚙️
- Retained the warning for custom Albumentations transforms, reminding users to pass `augmentations` again when resuming because they cannot be automatically restored. ⚠️
- Removed the earlier explicit resumability check for missing epoch or optimizer state from this part of the resume setup.
- Updated the package version from `8.4.29` to `8.4.30`. 🚀

### 🎯 Purpose & Impact
- Makes resume handling cleaner and more streamlined, which should improve maintainability for developers. 🧹
- Helps users resume training more reliably when dataset paths have changed since the original run. ✅
- Continues to allow practical runtime overrides like changing device or batch size during resume, which is useful for adapting to new hardware or memory limits. 💻
- Gives clearer guidance for users relying on custom augmentations so resumed training behaves as expected. 📣
- The relaxed checkpoint handling may broaden compatibility, but users should still ensure they resume from a proper training checkpoint for best results. 🔍