### PR TITLE
Inference video support documentation

### DIFF
--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -346,11 +346,15 @@ Dedicated endpoints are **not subject to the Platform API rate limits**. Request
 
 | Parameter   | Type   | Default | Description                   |
 | ----------- | ------ | ------- | ----------------------------- |
-| `file`      | file   | -       | Image file (required)         |
+| `file`      | file   | -       | Image or video file (required) |
 | `conf`      | float  | 0.25    | Minimum confidence threshold  |
 | `iou`       | float  | 0.7     | NMS IoU threshold             |
 | `imgsz`     | int    | 640     | Input image size              |
 | `normalize` | string | -       | Return normalized coordinates |
+
+!!! tip "Video Inference"
+
+    Dedicated endpoints accept video files in addition to images. Supported video formats (up to 100MB): ASF, AVI, GIF, M4V, MKV, MOV, MP4, MPEG, MPG, TS, WEBM, WMV. Each frame is processed individually and results are returned per frame. Supported image formats (up to 50MB): AVIF, BMP, DNG, HEIC, JP2, JPEG, JPG, MPO, PNG, TIF, TIFF, WEBP.
 
 ### Response Format
 

--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -344,13 +344,13 @@ Dedicated endpoints are **not subject to the Platform API rate limits**. Request
 
 ### Request Parameters
 
-| Parameter   | Type   | Default | Description                   |
-| ----------- | ------ | ------- | ----------------------------- |
+| Parameter   | Type   | Default | Description                    |
+| ----------- | ------ | ------- | ------------------------------ |
 | `file`      | file   | -       | Image or video file (required) |
-| `conf`      | float  | 0.25    | Minimum confidence threshold  |
-| `iou`       | float  | 0.7     | NMS IoU threshold             |
-| `imgsz`     | int    | 640     | Input image size              |
-| `normalize` | string | -       | Return normalized coordinates |
+| `conf`      | float  | 0.25    | Minimum confidence threshold   |
+| `iou`       | float  | 0.7     | NMS IoU threshold              |
+| `imgsz`     | int    | 640     | Input image size               |
+| `normalize` | string | -       | Return normalized coordinates  |
 
 !!! tip "Video Inference"
 

--- a/docs/en/platform/deploy/inference.md
+++ b/docs/en/platform/deploy/inference.md
@@ -359,13 +359,10 @@ Common error responses:
 
 ### Can I run inference on video?
 
-The API accepts individual frames. For video:
+It depends on the inference method:
 
-1. Extract frames locally
-2. Send each frame to the API
-3. Aggregate results
-
-For real-time video, consider deploying a [dedicated endpoint](endpoints.md).
+- **Dedicated endpoints** accept video files directly. Supported formats (up to 100MB): ASF, AVI, GIF, M4V, MKV, MOV, MP4, MPEG, MPG, TS, WEBM, WMV. Each frame is processed individually and results are returned per frame. See [dedicated endpoints](endpoints.md#request-parameters) for details.
+- **Shared inference** (`/api/models/{id}/predict`) accepts images only. For video, extract frames locally, send each frame as a separate request, and aggregate results.
 
 ### How do I get the annotated image?
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📘 This PR updates Ultralytics Platform deployment docs to clearly explain that **dedicated inference endpoints support direct video inference**, while **shared inference only supports images**.

### 📊 Key Changes
- Added documentation in `docs/en/platform/deploy/endpoints.md` stating that the `file` request parameter for dedicated endpoints accepts **image or video files**, not just images.
- Introduced a new **Video Inference** tip section with:
  - supported video formats
  - file size limits for videos and images
  - clarification that videos are processed **frame by frame** with results returned per frame
- Updated the FAQ in `docs/en/platform/deploy/inference.md` to distinguish between:
  - **Dedicated endpoints**: support direct video uploads 🎥
  - **Shared inference** (`/api/models/{id}/predict`): image-only, requiring local frame extraction for video workflows
- Replaced older, more generic video guidance with clearer method-specific instructions for users.

### 🎯 Purpose & Impact
- Makes the docs more accurate and easier to understand for users deploying models on the **Ultralytics Platform** ✅
- Helps prevent confusion about which inference path supports video uploads, reducing setup mistakes and failed requests.
- Improves discoverability of **video inference support** for dedicated endpoints, which may encourage more production-oriented usage 🚀
- Gives users clear expectations around supported formats, upload limits, and per-frame processing behavior.
- Simplifies onboarding for both technical and non-technical users by clarifying when they need to preprocess video themselves and when the platform handles it automatically.