### PR TITLE
Improve val availability in NDJSON to YAML

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -859,7 +859,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     if not is_classification:
         if "train" not in splits:
             raise ValueError(f"Dataset missing required 'train' split. Found splits: {sorted(splits)}")
-        if "val" not in splits and "test" not in splits:
+        if "val" not in splits:
             train_records = [r for r in image_records if r.get("split") == "train"]
             if len(train_records) < 2:
                 raise ValueError(


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚠️ This PR makes YOLO dataset conversion stricter by requiring a `val` split for non-classification datasets instead of allowing only `train` + `test`.

### 📊 Key Changes
- Updated `convert_ndjson_to_yolo()` in `ultralytics/data/converter.py`.
- Changed validation logic for non-classification datasets:
  - **Before:** conversion accepted datasets with `train` and either `val` or `test`.
  - **Now:** conversion requires a `train` split **and specifically a `val` split**.
- If `val` is missing, the converter now falls back to checking whether it can create one from the `train` data, rather than accepting `test` as a substitute.

### 🎯 Purpose & Impact
- ✅ Aligns dataset structure with standard YOLO training expectations, where `val` is typically needed for evaluation during training.
- 🔍 Helps prevent ambiguous dataset setups where a `test` split was previously treated as sufficient.
- 🛠️ May improve consistency and reliability in dataset conversion workflows.
- ⚠️ Users with NDJSON datasets containing only `train` and `test` may now need to add or generate a `val` split before conversion.