### PR TITLE
Add `--no-tty` flag for `edgetpu_compiler` installation

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1243,7 +1243,7 @@ class Exporter:
             sudo = "sudo " if is_sudo_available() else ""
             for c in (
                 f"{sudo}mkdir -p /etc/apt/keyrings",
-                f"curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | {sudo}gpg --dearmor -o /etc/apt/keyrings/google.gpg",
+                f"curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | {sudo}gpg --no-tty --dearmor -o /etc/apt/keyrings/google.gpg",
                 f'echo "deb [signed-by=/etc/apt/keyrings/google.gpg] https://packages.cloud.google.com/apt coral-edgetpu-stable main" | {sudo}tee /etc/apt/sources.list.d/coral-edgetpu.list',
             ):
                 subprocess.run(c, shell=True, check=True)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves Edge TPU export setup on Linux by making the Google APT key installation command work more reliably in non-interactive environments.

### 📊 Key Changes
- Updated the Edge TPU export dependency setup in `ultralytics/engine/exporter.py`.
- Added the `--no-tty` flag to the `gpg --dearmor` command used when installing the Google package signing key.
- The change affects the automatic system command sequence that prepares Coral Edge TPU package sources during export.

### 🎯 Purpose & Impact
- ✅ Prevents failures when running Edge TPU export in environments without an interactive terminal, such as servers, Docker containers, and CI pipelines.
- 🔒 Makes the APT key setup process more robust and compatible across different Linux execution contexts.
- 🚀 Improves the reliability of the Edge TPU export workflow for users deploying YOLO models to Coral Edge TPU devices.