### PR TITLE
Feature: Add remaining patience display to training progress bar when Patience is Set

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -481,7 +481,7 @@ class BaseTrainer:
                     patience_str = ""
                     if self.args.patience:
                         best_epoch = getattr(self.stopper, "best_epoch", 0)
-                        patience_left = max(0, self.args.patience - (epoch - best_epoch)) # How many epochs of patience are left since last best epoch
+                        patience_left = max(0, self.args.patience - max(0, epoch - best_epoch - 1))
                         patience_str = f"   Patience: {patience_left}/{self.args.patience}"
 
                     pbar.set_description(

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -478,6 +478,12 @@ class BaseTrainer:
                 # Log
                 if RANK in {-1, 0}:
                     loss_length = self.tloss.shape[0] if len(self.tloss.shape) else 1
+                    patience_str = ""
+                    if self.args.patience:
+                        best_epoch = getattr(self.stopper, "best_epoch", 0)
+                        patience_left = max(0, self.args.patience - (epoch - best_epoch)) # How many epochs of patience are left since last best epoch
+                        patience_str = f"   Patience: {patience_left}/{self.args.patience}"
+
                     pbar.set_description(
                         ("%11s" * 2 + "%11.4g" * (2 + loss_length))
                         % (
@@ -487,6 +493,7 @@ class BaseTrainer:
                             batch["cls"].shape[0],  # batch size, i.e. 8
                             batch["img"].shape[-1],  # imgsz, i.e 640
                         )
+                        + patience_str
                     )
                     self.run_callbacks("on_batch_end")
                     if self.args.plots and ni in self.plot_idx:


### PR DESCRIPTION
### Summary
Adds a real-time patience countdown to the training progress bar.

While early stopping tracks patience internally, users currently have no visual indicator of how many epochs are left before training halts. This PR adds a `Patience: X/Y` indicator to the TQDM description to clarify the current state of early stopping.

No behavior change.

***

#

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a training progress bar enhancement to display remaining early-stopping patience when `patience` is configured. ⏳🚀

### 📊 Key Changes
- Updates `ultralytics/engine/trainer.py` to compute remaining patience during training.
- Reads `best_epoch` from the early stopper and calculates how many epochs remain before patience is exhausted.
- Appends a `Patience: remaining/total` indicator to the progress bar description when `self.args.patience` is set.
- Keeps the display disabled when patience is not configured, preserving current behavior.

### 🎯 Purpose & Impact
- Improves training visibility by showing early-stopping status directly in the live progress bar. 👀
- Helps users better understand how close training is to stopping without checking logs or internal state.
- Provides a small but useful UX enhancement with minimal code changes and low risk to existing training flows. ✅