### PR TITLE
fix warmup_bias_lr default for MuSGD optimizer

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -979,8 +979,11 @@ class BaseTrainer:
             )
             nc = self.data.get("nc", 10)  # number of classes
             lr_fit = round(0.002 * 5 / (4 + nc), 6)  # lr0 fit equation to 6 decimal places
-            name, lr, momentum = ("MuSGD", 0.01, 0.9) if iterations > 10000 else ("AdamW", lr_fit, 0.9)
-            self.args.warmup_bias_lr = 0.0  # no higher than 0.01 for Adam
+            if iterations > 10000:
+                name, lr, momentum = "MuSGD", 0.01, 0.9
+            else:
+                name, lr, momentum = "AdamW", lr_fit, 0.9
+                self.args.warmup_bias_lr = 0.0  # no higher than 0.01 for Adam
 
         use_muon = name == "MuSGD"
         for module_name, module in unwrap_model(model).named_modules():


### PR DESCRIPTION
fixes the issue where `optimizer=auto` unconditionally sets `warmup_bias_lr=0.0`, even when MuSGD is selected. this moves the assignment into the AdamW-only branch so MuSGD keeps its default `0.1`, matching the behavior of explicitly setting `optimizer=MuSGD`.

closes #23637

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `warmup_bias_lr` auto-configuration so it is only overridden for `AdamW`, not for `MuSGD` ⚙️

### 📊 Key Changes
- Updates `build_optimizer()` in `ultralytics/engine/trainer.py` to split the optimizer auto-selection into explicit `if/else` branches.
- Keeps `MuSGD` auto-selection unchanged for large training runs with `lr=0.01` and `momentum=0.9`.
- Restricts `self.args.warmup_bias_lr = 0.0` to the `AdamW` path only, instead of applying it to both optimizers.
- Preserves the existing Adam-specific safeguard comment indicating the bias warmup LR should remain low 🛠️

### 🎯 Purpose & Impact
- Prevents unintended mutation of `warmup_bias_lr` when `auto` selects `MuSGD` ✅
- Aligns optimizer-specific warmup behavior with the intended logic, reducing the chance of incorrect training hyperparameters.
- Improves training consistency and makes the auto-optimizer path easier to understand and maintain for contributors and users.