### PR TITLE
Add multi-task annotation storage documentation

### DIFF
--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -34,6 +34,10 @@ The annotation editor supports all 5 YOLO task types:
 | **[OBB](../../datasets/obb/index.md)**           | Oriented Box   | Rotated bounding boxes (4 corners)                        |
 | **[Classify](../../datasets/classify/index.md)** | Class Selector | Image-level labels                                        |
 
+!!! tip "Multi-Task Annotations"
+
+    All 5 annotation types are stored together on each image. You can switch the dataset's active task type without losing existing annotations — they are preserved and reappear when you switch back.
+
 ### Task Details
 
 ??? info "Object Detection"

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -536,9 +536,9 @@ Dataset metadata is edited inline directly on the dataset page — no dialog nee
 - **Task type**: Click the task badge to select a different task type.
 - **License**: Click the license selector to change the dataset license.
 
-!!! warning "Changing Task Type"
+!!! info "Changing Task Type"
 
-    Changing the task type may affect how existing annotations are visualized. Incompatible annotations won't be displayed.
+    Each image stores annotations for all task types together. Changing the dataset task type controls which annotations are visible in the editor and included in exports and training. Annotations for other task types are preserved in the database and reappear when you switch back.
 
 ## Clone Dataset
 
@@ -637,3 +637,7 @@ Ultralytics Platform supports two annotation formats for upload:
 === "COCO Format"
 
     JSON files with `images`, `annotations`, and `categories` arrays. Supports detection (`bbox`), segmentation (polygon), and pose (`keypoints`) tasks. COCO uses absolute pixel coordinates which are automatically converted to normalized format during upload.
+
+### Can I annotate the same dataset for multiple task types?
+
+Yes. Each image stores annotations for all 5 task types (detect, segment, pose, OBB, classify) together. You can switch the dataset's active task type at any time without losing existing annotations. Only annotations matching the active task type are shown in the editor and included in exports and training — annotations for other tasks are preserved and reappear when you switch back.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves Ultralytics Platform documentation to clarify that a single dataset can safely hold annotations for all 5 YOLO task types, even when switching the active task view.

### 📊 Key Changes
- Added a new **“Multi-Task Annotations”** tip in the annotation docs explaining that all 5 annotation types are stored together per image.
- Clarified that switching a dataset’s **active task type** does **not delete existing annotations**.
- Updated the **Changing Task Type** note in dataset docs from a warning to an informational message, reflecting the actual behavior more accurately.
- Expanded the explanation that the selected task type only controls:
  - which annotations are visible in the editor 👀
  - which annotations are used in exports 📦
  - which annotations are used for training 🧠
- Added a new FAQ-style section answering whether the same dataset can be annotated for multiple task types ✅

### 🎯 Purpose & Impact
- Reduces user confusion when changing between detect, segment, pose, OBB, and classify tasks.
- Reassures users that their work is preserved, which helps prevent fear of accidental data loss 🔒
- Makes the Ultralytics Platform workflow easier to understand for both new and experienced users.
- Encourages more flexible multi-task dataset management by clearly documenting that one dataset can support multiple annotation types.
- Improves documentation accuracy, which can reduce support questions and setup mistakes.