### PR TITLE
Migrate CI to `ubuntu-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         # Temporarily disable windows-latest due to https://github.com/ultralytics/ultralytics/actions/runs/13020330819/job/36319338854?pr=18921
-        os: [cpu-latest, macos-26, ubuntu-24.04-arm]
+        os: [ubuntu-latest, macos-26, ubuntu-24.04-arm]
         python: ["3.12"]
         model: [yolo26n]
     steps:
@@ -116,11 +116,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [cpu-latest, macos-26, windows-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest, macos-26, windows-latest, ubuntu-24.04-arm]
         python: ["3.12"]
         torch: [latest]
         include:
-          - os: cpu-latest
+          - os: ubuntu-latest
             python: "3.8" # torch 1.8.0 requires python >=3.6, <=3.9
             torch: "1.8.0"
             torchvision: "0.9.0"
@@ -151,7 +151,7 @@ jobs:
         shell: bash # for Windows compatibility
         run: pytest --cov=ultralytics/ --cov-report=xml tests/
       - name: Upload Coverage Reports to CodeCov
-        if: github.repository == 'ultralytics/ultralytics' # && matrix.os == 'cpu-latest' && matrix.python == '3.12'
+        if: github.repository == 'ultralytics/ultralytics' # && matrix.os == 'ubuntu-latest' && matrix.python == '3.12'
         uses: codecov/codecov-action@v6
         with:
           flags: Tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   Docs:
     if: github.repository == 'ultralytics/ultralytics'
-    runs-on: cpu-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_REF: ${{ github.head_ref || github.ref }}
     steps:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   actions:
-    runs-on: cpu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Run Ultralytics Actions
         uses: ultralytics/actions@main


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates GitHub Actions workflows to replace the custom `cpu-latest` runner with the standard `ubuntu-latest` runner across CI, docs, and formatting jobs.

### 📊 Key Changes
- 🖥️ Replaced `cpu-latest` with `ubuntu-latest` in the main CI workflow matrix.
- 🧪 Updated the test matrix `include` section so the Python 3.8 / Torch 1.8.0 job also runs on `ubuntu-latest`.
- 📈 Adjusted the Codecov workflow comment to reflect the new runner name.
- 📚 Changed the documentation build workflow to run on `ubuntu-latest`.
- 🎨 Changed the formatting/actions workflow to run on `ubuntu-latest`.
- 🌍 Other platforms remain covered, including `macos-26`, `windows-latest`, and `ubuntu-24.04-arm`.

### 🎯 Purpose & Impact
- ✅ Simplifies CI configuration by using GitHub’s standard Ubuntu runner instead of a custom alias.
- 🛠️ Reduces maintenance overhead and makes workflows easier for contributors to understand.
- 🚀 Likely improves reliability and consistency of testing, docs, and formatting jobs across the repository.
- 👥 Makes the setup more transparent for external contributors, since `ubuntu-latest` is a familiar GitHub Actions environment.
- ⚠️ Functional code behavior is unchanged; this is mainly an infrastructure and developer-experience improvement.