### PR TITLE
Include `multi_scale` in auto-batch computation

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -570,9 +570,10 @@ class BaseTrainer:
 
     def auto_batch(self, max_num_obj=0, dataset_size=0):
         """Calculate optimal batch size based on model and device memory constraints."""
+        max_imgsz = int(self.args.imgsz * (1 + self.args.multi_scale))  # need not be stride-aligned
         return check_train_batch_size(
             model=self.model,
-            imgsz=int(self.args.imgsz * (1 + self.args.multi_scale)),
+            imgsz=max_imgsz,
             amp=self.amp,
             batch=self.batch_size,
             max_num_obj=max_num_obj,

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -572,7 +572,7 @@ class BaseTrainer:
         """Calculate optimal batch size based on model and device memory constraints."""
         return check_train_batch_size(
             model=self.model,
-            imgsz=self.args.imgsz,
+            imgsz=int(self.args.imgsz * (1 + self.args.multi_scale)),
             amp=self.amp,
             batch=self.batch_size,
             max_num_obj=max_num_obj,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves automatic batch size estimation during training by accounting for larger image sizes when multi-scale augmentation is enabled 📦🖼️

### 📊 Key Changes
- Updated `auto_batch()` in `ultralytics/engine/trainer.py` to use a larger effective image size when `multi_scale` training is active.
- Added a new `max_imgsz` calculation based on `self.args.imgsz * (1 + self.args.multi_scale)`.
- Changed the batch size check to use `max_imgsz` instead of the base `imgsz`.

### 🎯 Purpose & Impact
- Helps batch size auto-tuning better reflect real training conditions when multi-scale augmentation increases input image size 📏
- Reduces the risk of selecting a batch size that is too large for available GPU memory, which can cause out-of-memory errors 💥
- Makes training more reliable and predictable, especially for users relying on automatic settings rather than manual batch tuning ⚙️
- Small internal change, but valuable for smoother training workflows and fewer memory-related surprises 🚀