### PR TITLE
Fix overlapping text with inline code in docs

### DIFF
--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -24,6 +24,10 @@ td {
 .md-typeset__table tr:nth-child(2n) {
   background-color: #f6f8fa;
 }
+/* fix inline code overlap */
+.md-typeset code {
+  padding: unset;
+}
 /* dark mode alternating table bg colors */
 [data-md-color-scheme="slate"] .md-typeset__table tr:nth-child(2n) {
   background-color: #161b22;

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -25,7 +25,7 @@ td {
   background-color: #f6f8fa;
 }
 /* fix inline code overlap */
-.md-typeset code {
+.md-typeset__table table:not([class]) code {
   padding: unset;
 }
 /* dark mode alternating table bg colors */


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes a small docs styling fix to prevent inline code snippets from overlapping inside documentation tables.

### 📊 Key Changes
- Added a targeted CSS rule in `docs/overrides/stylesheets/style.css`.
- Updated table styling so inline `code` elements inside standard Markdown tables no longer use conflicting padding.
- Kept the change narrowly scoped to table content, avoiding broader style changes elsewhere in the docs.

### 🎯 Purpose & Impact
- ✅ Improves documentation readability by making inline code display correctly inside tables.
- 📚 Helps prevent visual glitches or cramped formatting in docs pages with command names, arguments, or code snippets in tabular format.
- 🎨 Provides a cleaner, more polished docs experience with minimal risk, since the change only affects inline code styling within tables.