### PR TITLE
Prevent DDP resource cleanup issues when generate_ddp_command(self) r…

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -231,14 +231,16 @@ class BaseTrainer:
                 )
 
             # Command
-            cmd, file = generate_ddp_command(self)
+            cmd, file = None, None
             try:
+                cmd, file = generate_ddp_command(self)
                 LOGGER.info(f"{colorstr('DDP:')} debug command {' '.join(cmd)}")
                 subprocess.run(cmd, check=True)
             except Exception as e:
                 raise e
             finally:
-                ddp_cleanup(self, str(file))
+                if file is not None:
+                    ddp_cleanup(self, str(file))
 
         else:
             self._do_train()


### PR DESCRIPTION
…aises an exception

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves DDP training cleanup safety by only calling distributed cleanup after `generate_ddp_command(self)` successfully returns a valid temp file. 🛠️

### 📊 Key Changes
- Initializes `cmd` and `file` to `None` before entering the DDP execution flow.
- Moves `generate_ddp_command(self)` inside the `try` block so failures are handled before cleanup runs.
- Guards `ddp_cleanup(self, str(file))` in `finally` with `if file is not None:`.
- Preserves the existing DDP subprocess execution path and logging behavior.

### 🎯 Purpose & Impact
- Prevents cleanup from running on an uninitialized or invalid DDP file reference. ✅
- Reduces the chance of secondary exceptions masking the original DDP command generation failure. 🔍
- Makes distributed training error handling more robust and easier to debug for users and maintainers. 🚀