### PR TITLE
20GB and 50GB Pro and Enterprise docs updates

### DIFF
--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -23,6 +23,7 @@ Choose the plan that fits your needs. Compare plans in `Settings > Plans`:
 | **Models**                 | 100        | 500             | Unlimited  |
 | **Concurrent Trainings**   | 3          | 10              | Unlimited  |
 | **Storage**                | 100 GB     | 500 GB          | Unlimited  |
+| **Dataset Upload Size**    | 10 GB      | 20 GB           | 50 GB      |
 | **Deployments**            | 3          | 10              | Unlimited  |
 | **Cloud GPU Types**        | 20         | 23              | 23         |
 | **Best GPUs (H200, B200)** | -          | Yes             | Yes        |
@@ -42,7 +43,7 @@ Get started at no cost:
 - 100 models
 - 3 concurrent cloud trainings
 - 3 deployments
-- 100 GB storage
+- 100 GB storage · 10 GB dataset upload limit
 - Model export to all 17+ formats
 - Manual, SAM 3 & YOLO Smart annotation
 - 20 cloud GPU types including 5090 & H100 ($0.24–$3.07/hr)
@@ -59,7 +60,7 @@ For professionals and small teams ($29/month or $290/year):
 - $30/seat/month in credits (recurring)
 - 500 models
 - 10 concurrent cloud trainings
-- 500 GB storage
+- 500 GB storage · 20 GB dataset upload limit
 - 10 cloud deployments
 - [Team collaboration](teams.md) (up to 5 members)
 - Access to the best GPUs (H200, B200)
@@ -74,7 +75,7 @@ For professionals and small teams ($29/month or $290/year):
 For organizations with advanced needs:
 
 - Custom credit allocation
-- Unlimited models, storage, trainings, and deployments
+- Unlimited models, storage, trainings, and deployments · 50 GB dataset upload limit
 - Enterprise License (commercial use, non-AGPL)
 - SSO / SAML authentication
 - RBAC with 4 roles (Owner, Admin, Editor, Viewer)
@@ -224,7 +225,7 @@ Upgrade for more features and monthly credits:
 After upgrading:
 
 - $30/seat/month credit added immediately and each month
-- Storage increased to 500 GB
+- Storage increased to 500 GB · 20 GB dataset upload limit
 - 500 models
 - 10 concurrent cloud trainings
 - 10 cloud deployments
@@ -255,6 +256,7 @@ When your Pro subscription ends (cancelled or expired), your account reverts to 
 | **Models**               | All models preserved. Cannot create new models beyond 100-model limit            |
 | **Deployments**          | All deployments preserved. Cannot create new beyond 3-deployment limit           |
 | **Storage**              | All data preserved. Cannot upload new data beyond 100 GB limit                   |
+| **Dataset Upload Size**  | Upload limit reduced from 20 GB to 10 GB per file                                |
 | **Credit Balance**       | Existing credits preserved and usable                                            |
 | **Monthly Credits**      | $30/seat/month grants stop immediately                                           |
 | **Team Members**         | Members notified and lose access to team resources                               |

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -23,7 +23,7 @@ Choose the plan that fits your needs. Compare plans in `Settings > Plans`:
 | **Models**                 | 100        | 500             | Unlimited  |
 | **Concurrent Trainings**   | 3          | 10              | Unlimited  |
 | **Storage**                | 100 GB     | 500 GB          | Unlimited  |
-| **Dataset Upload Size**    | 10 GB      | 20 GB           | 50 GB      |
+| **Dataset Upload (ZIP/TAR/NDJSON)**    | 10 GB      | 20 GB           | 50 GB      |
 | **Deployments**            | 3          | 10              | Unlimited  |
 | **Cloud GPU Types**        | 20         | 23              | 23         |
 | **Best GPUs (H200, B200)** | -          | Yes             | Yes        |
@@ -256,7 +256,7 @@ When your Pro subscription ends (cancelled or expired), your account reverts to 
 | **Models**               | All models preserved. Cannot create new models beyond 100-model limit            |
 | **Deployments**          | All deployments preserved. Cannot create new beyond 3-deployment limit           |
 | **Storage**              | All data preserved. Cannot upload new data beyond 100 GB limit                   |
-| **Dataset Upload Size**  | Upload limit reduced from 20 GB to 10 GB per file                                |
+| **Dataset Upload (ZIP/TAR/NDJSON)**  | Upload limit reduced from 20 GB to 10 GB per file                                |
 | **Credit Balance**       | Existing credits preserved and usable                                            |
 | **Monthly Credits**      | $30/seat/month grants stop immediately                                           |
 | **Team Members**         | Members notified and lose access to team resources                               |

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -16,21 +16,21 @@ Choose the plan that fits your needs. Compare plans in `Settings > Plans`:
 
 ![Ultralytics Platform Settings Plans Tab Free Pro Enterprise Comparison](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-plans-tab-free-pro-enterprise-comparison.avif)
 
-| Feature                    | Free       | Pro ($29/mo)    | Enterprise |
-| -------------------------- | ---------- | --------------- | ---------- |
-| **Signup Credit**          | $5 / $25\* | -               | Custom     |
-| **Monthly Credit**         | -          | $30/seat/month  | Custom     |
-| **Models**                 | 100        | 500             | Unlimited  |
-| **Concurrent Trainings**   | 3          | 10              | Unlimited  |
-| **Storage**                | 100 GB     | 500 GB          | Unlimited  |
-| **Dataset Upload (ZIP/TAR/NDJSON)**    | 10 GB      | 20 GB           | 50 GB      |
-| **Deployments**            | 3          | 10              | Unlimited  |
-| **Cloud GPU Types**        | 20         | 23              | 23         |
-| **Best GPUs (H200, B200)** | -          | Yes             | Yes        |
-| **Teams**                  | -          | Up to 5 members | Up to 50   |
-| **SSO / SAML**             | -          | -               | Yes        |
-| **Enterprise License**     | -          | -               | Yes        |
-| **License**                | AGPL-3.0   | AGPL-3.0        | Enterprise |
+| Feature                             | Free       | Pro ($29/mo)    | Enterprise |
+| ----------------------------------- | ---------- | --------------- | ---------- |
+| **Signup Credit**                   | $5 / $25\* | -               | Custom     |
+| **Monthly Credit**                  | -          | $30/seat/month  | Custom     |
+| **Models**                          | 100        | 500             | Unlimited  |
+| **Concurrent Trainings**            | 3          | 10              | Unlimited  |
+| **Storage**                         | 100 GB     | 500 GB          | Unlimited  |
+| **Dataset Upload (ZIP/TAR/NDJSON)** | 10 GB      | 20 GB           | 50 GB      |
+| **Deployments**                     | 3          | 10              | Unlimited  |
+| **Cloud GPU Types**                 | 20         | 23              | 23         |
+| **Best GPUs (H200, B200)**          | -          | Yes             | Yes        |
+| **Teams**                           | -          | Up to 5 members | Up to 50   |
+| **SSO / SAML**                      | -          | -               | Yes        |
+| **Enterprise License**              | -          | -               | Yes        |
+| **License**                         | AGPL-3.0   | AGPL-3.0        | Enterprise |
 
 \*Free plan: $5 at signup, or $25 if you verify a company/work email address.
 
@@ -251,17 +251,17 @@ Cancel anytime from the billing portal:
 
 When your Pro subscription ends (cancelled or expired), your account reverts to the Free plan. Here's what happens to your existing resources:
 
-| Resource                 | What Happens                                                                     |
-| ------------------------ | -------------------------------------------------------------------------------- |
-| **Models**               | All models preserved. Cannot create new models beyond 100-model limit            |
-| **Deployments**          | All deployments preserved. Cannot create new beyond 3-deployment limit           |
-| **Storage**              | All data preserved. Cannot upload new data beyond 100 GB limit                   |
-| **Dataset Upload (ZIP/TAR/NDJSON)**  | Upload limit reduced from 20 GB to 10 GB per file                                |
-| **Credit Balance**       | Existing credits preserved and usable                                            |
-| **Monthly Credits**      | $30/seat/month grants stop immediately                                           |
-| **Team Members**         | Members notified and lose access to team resources                               |
-| **GPU Access**           | Standard GPUs remain available. Best GPUs (H200, B200) require Pro or Enterprise |
-| **Concurrent Trainings** | Limit reduced from 10 to 3                                                       |
+| Resource                            | What Happens                                                                     |
+| ----------------------------------- | -------------------------------------------------------------------------------- |
+| **Models**                          | All models preserved. Cannot create new models beyond 100-model limit            |
+| **Deployments**                     | All deployments preserved. Cannot create new beyond 3-deployment limit           |
+| **Storage**                         | All data preserved. Cannot upload new data beyond 100 GB limit                   |
+| **Dataset Upload (ZIP/TAR/NDJSON)** | Upload limit reduced from 20 GB to 10 GB per file                                |
+| **Credit Balance**                  | Existing credits preserved and usable                                            |
+| **Monthly Credits**                 | $30/seat/month grants stop immediately                                           |
+| **Team Members**                    | Members notified and lose access to team resources                               |
+| **GPU Access**                      | Standard GPUs remain available. Best GPUs (H200, B200) require Pro or Enterprise |
+| **Concurrent Trainings**            | Limit reduced from 10 to 3                                                       |
 
 !!! tip "No Data Loss"
 

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -151,7 +151,7 @@ The storage card shows:
 | **Image**       | 50 MB  | 50 MB  | 50 MB      |
 | **Video**       | 1 GB   | 1 GB   | 1 GB       |
 | **Model (.pt)** | 1 GB   | 1 GB   | 1 GB       |
-| **ZIP Archive** | 10 GB  | 20 GB  | 50 GB      |
+| **Dataset (ZIP/TAR/NDJSON)** | 10 GB  | 20 GB  | 50 GB      |
 
 #### Trash and Storage
 

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -146,12 +146,12 @@ The storage card shows:
 
 #### Upload Size Limits
 
-| File Type       | Max Size |
-| --------------- | -------- |
-| **Image**       | 50 MB    |
-| **Video**       | 1 GB     |
-| **Model (.pt)** | 1 GB     |
-| **ZIP Archive** | 10 GB    |
+| File Type       | Free   | Pro    | Enterprise |
+| --------------- | ------ | ------ | ---------- |
+| **Image**       | 50 MB  | 50 MB  | 50 MB      |
+| **Video**       | 1 GB   | 1 GB   | 1 GB       |
+| **Model (.pt)** | 1 GB   | 1 GB   | 1 GB       |
+| **ZIP Archive** | 10 GB  | 20 GB  | 50 GB      |
 
 #### Trash and Storage
 

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -146,12 +146,12 @@ The storage card shows:
 
 #### Upload Size Limits
 
-| File Type       | Free   | Pro    | Enterprise |
-| --------------- | ------ | ------ | ---------- |
-| **Image**       | 50 MB  | 50 MB  | 50 MB      |
-| **Video**       | 1 GB   | 1 GB   | 1 GB       |
-| **Model (.pt)** | 1 GB   | 1 GB   | 1 GB       |
-| **Dataset (ZIP/TAR/NDJSON)** | 10 GB  | 20 GB  | 50 GB      |
+| File Type                    | Free  | Pro   | Enterprise |
+| ---------------------------- | ----- | ----- | ---------- |
+| **Image**                    | 50 MB | 50 MB | 50 MB      |
+| **Video**                    | 1 GB  | 1 GB  | 1 GB       |
+| **Model (.pt)**              | 1 GB  | 1 GB  | 1 GB       |
+| **Dataset (ZIP/TAR/NDJSON)** | 10 GB | 20 GB | 50 GB      |
 
 #### Trash and Storage
 

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -146,12 +146,12 @@ The storage card shows:
 
 #### Upload Size Limits
 
-| File Type       | Free   | Pro    | Enterprise |
-| --------------- | ------ | ------ | ---------- |
-| **Image**       | 50 MB  | 50 MB  | 50 MB      |
-| **Video**       | 1 GB   | 1 GB   | 1 GB       |
-| **Model (.pt)** | 1 GB   | 1 GB   | 1 GB       |
-| **ZIP Archive** | 10 GB  | 20 GB  | 50 GB      |
+| File Type       | Free  | Pro   | Enterprise |
+| --------------- | ----- | ----- | ---------- |
+| **Image**       | 50 MB | 50 MB | 50 MB      |
+| **Video**       | 1 GB  | 1 GB  | 1 GB       |
+| **Model (.pt)** | 1 GB  | 1 GB  | 1 GB       |
+| **ZIP Archive** | 10 GB | 20 GB | 50 GB      |
 
 #### Trash and Storage
 

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -516,12 +516,12 @@ Run YOLO inference on dataset images to auto-generate annotations. Uses a select
 POST /api/datasets/ingest
 ```
 
-Create a dataset ingest job to process uploaded ZIP files containing images and labels.
+Create a dataset ingest job to process uploaded ZIP or TAR files containing images and labels.
 
 ```mermaid
 graph LR
-    A[Upload ZIP] --> B[POST /api/datasets/ingest]
-    B --> C[Process ZIP]
+    A[Upload Archive] --> B[POST /api/datasets/ingest]
+    B --> C[Process Archive]
     C --> D[Extract images]
     C --> E[Parse labels]
     C --> F[Generate thumbnails]

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -50,12 +50,12 @@ Ultralytics Platform accepts multiple upload formats for flexibility.
 
     Archives are extracted and processed automatically.
 
-    | Format | Extensions        | Notes                | Max Size |
-    | ------ | ----------------- | -------------------- | -------- |
-    | ZIP    | `.zip`            | Most common          | 10 GB    |
-    | TAR    | `.tar`            | Uncompressed archive | 10 GB    |
-    | TAR.GZ | `.tar.gz`, `.tgz` | Compressed archive   | 10 GB    |
-    | GZ     | `.gz`             | Gzip compressed      | 10 GB    |
+    | Format | Extensions        | Notes                | Free   | Pro    | Enterprise |
+    | ------ | ----------------- | -------------------- | ------ | ------ | ---------- |
+    | ZIP    | `.zip`            | Most common          | 10 GB  | 20 GB  | 50 GB      |
+    | TAR    | `.tar`            | Uncompressed archive | 10 GB  | 20 GB  | 50 GB      |
+    | TAR.GZ | `.tar.gz`, `.tgz` | Compressed archive   | 10 GB  | 20 GB  | 50 GB      |
+    | GZ     | `.gz`             | Gzip compressed      | 10 GB  | 20 GB  | 50 GB      |
 
 ### Preparing Your Dataset
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -50,12 +50,11 @@ Ultralytics Platform accepts multiple upload formats for flexibility.
 
     Archives are extracted and processed automatically.
 
-    | Format | Extensions        | Notes                | Free   | Pro    | Enterprise |
-    | ------ | ----------------- | -------------------- | ------ | ------ | ---------- |
-    | ZIP    | `.zip`            | Most common          | 10 GB  | 20 GB  | 50 GB      |
-    | TAR    | `.tar`            | Uncompressed archive | 10 GB  | 20 GB  | 50 GB      |
-    | TAR.GZ | `.tar.gz`, `.tgz` | Compressed archive   | 10 GB  | 20 GB  | 50 GB      |
-    | GZ     | `.gz`             | Gzip compressed      | 10 GB  | 20 GB  | 50 GB      |
+    | Format | Extensions | Notes                | Free   | Pro    | Enterprise |
+    | ------ | ---------- | -------------------- | ------ | ------ | ---------- |
+    | ZIP    | `.zip`     | Most common          | 10 GB  | 20 GB  | 50 GB      |
+    | TAR    | `.tar`     | Uncompressed archive | 10 GB  | 20 GB  | 50 GB      |
+    | NDJSON | `.ndjson`  | Dataset export       | 10 GB  | 20 GB  | 50 GB      |
 
 ### Preparing Your Dataset
 

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -23,7 +23,7 @@ Data preparation is the foundation of successful [computer vision](https://www.u
 
 The Data section of Ultralytics Platform helps you:
 
-- **Upload** images, videos, and archives (ZIP, TAR, GZ)
+- **Upload** images, videos, and dataset files (ZIP, TAR, NDJSON)
 - **Annotate** with manual drawing tools and SAM-powered smart labeling — choose from [SAM 2.1](../../models/sam-2.md) or the new [SAM 3](../../models/sam-3.md)
 - **Analyze** your data with statistics and visualizations
 - **Export** in [NDJSON format](../../datasets/detect/index.md#ultralytics-ndjson-format) for local training
@@ -142,7 +142,7 @@ Ultralytics Platform supports:
 
 **Videos:** MP4, WebM, MOV, AVI, MKV, M4V (max 1GB, frames extracted at 1 FPS, max 100 frames)
 
-**Archives:** ZIP, TAR, TAR.GZ, TGZ, GZ (max 10GB) containing images with optional [YOLO-format labels](../../datasets/detect/index.md#ultralytics-yolo-format)
+**Dataset files:** ZIP or TAR archives (max 10GB on Free, 20GB on Pro, 50GB on Enterprise) containing images with optional [YOLO-format labels](../../datasets/detect/index.md#ultralytics-yolo-format), plus NDJSON exports
 
 ### What is the maximum dataset size?
 
@@ -154,7 +154,7 @@ Storage limits depend on your plan:
 | Pro        | 500 GB        |
 | Enterprise | Unlimited     |
 
-Individual file limits: Images 50MB, Videos 1GB, Archives 10GB
+Individual file limits: Images 50MB, Videos 1GB, datasets 10GB on Free / 20GB on Pro / 50GB on Enterprise
 
 ### Can I use my Platform datasets for local training?
 

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -64,7 +64,7 @@ graph LR
 
 | Stage        | Features                                                                                                                                       |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Upload**   | Images (50MB), videos (1GB), and dataset files (ZIP, TAR, NDJSON) with automatic processing                                                       |
+| **Upload**   | Images (50MB), videos (1GB), and dataset files (ZIP, TAR, NDJSON) with automatic processing                                                    |
 | **Annotate** | Manual tools, SAM smart annotation, YOLO auto-labeling for all 5 task types (see [supported tasks](data/index.md#supported-tasks))             |
 | **Train**    | Cloud GPUs (20 free + 3 Pro-exclusive), real-time metrics, project organization                                                                |
 | **Export**   | [17 deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, TFLite, etc.; see [supported formats](train/models.md#supported-formats)) |
@@ -415,7 +415,7 @@ See [Models Export](train/models.md#export-model), the [Export mode guide](../mo
 
 | Problem                | Solution                                                                                                                                                  |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Dataset won't process  | Check file format is supported (JPEG, PNG, WebP, etc.). Max file size: images 50MB, videos 1GB, datasets 10GB on Free / 20GB on Pro / 50GB on Enterprise |
+| Dataset won't process  | Check file format is supported (JPEG, PNG, WebP, etc.). Max file size: images 50MB, videos 1GB, datasets 10GB on Free / 20GB on Pro / 50GB on Enterprise  |
 | Missing annotations    | Verify labels are in [YOLO format](../datasets/detect/index.md#ultralytics-yolo-format) with `.txt` files matching image filenames                        |
 | "Train split required" | Add `train/` folder to your dataset structure, or create splits in [dataset settings](data/datasets.md#filter-by-split)                                   |
 | Class names undefined  | Add a `data.yaml` file with `names:` list (see [YOLO format](../datasets/detect/index.md#ultralytics-yolo-format)), or define classes in dataset settings |

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -64,7 +64,7 @@ graph LR
 
 | Stage        | Features                                                                                                                                       |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Upload**   | Images (50MB), videos (1GB), ZIP archives (10GB) with automatic processing                                                                     |
+| **Upload**   | Images (50MB), videos (1GB), and dataset files (ZIP, TAR, NDJSON) with automatic processing                                                       |
 | **Annotate** | Manual tools, SAM smart annotation, YOLO auto-labeling for all 5 task types (see [supported tasks](data/index.md#supported-tasks))             |
 | **Train**    | Cloud GPUs (20 free + 3 Pro-exclusive), real-time metrics, project organization                                                                |
 | **Export**   | [17 deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, TFLite, etc.; see [supported formats](train/models.md#supported-formats)) |
@@ -72,7 +72,7 @@ graph LR
 
 **What you can do:**
 
-- **Upload** images, videos, and ZIP archives to create training datasets
+- **Upload** images, videos, and dataset files to create training datasets
 - **Visualize** annotations with interactive overlays for all 5 YOLO task types (see [supported tasks](data/index.md#supported-tasks))
 - **Train** models on cloud GPUs (20 free, 23 with Pro) with real-time metrics
 - **Export** to [17 deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, TFLite, etc.)
@@ -100,7 +100,7 @@ You select your region during onboarding, and all your data, models, and deploym
 
 ### Data Preparation
 
-- **Dataset Management**: Upload images, videos, or ZIP archives with automatic processing
+- **Dataset Management**: Upload images, videos, or dataset files with automatic processing
 - **Annotation Editor**: Manual annotation for all 5 YOLO task types (detect, segment, pose, OBB, classify; see [supported tasks](data/index.md#supported-tasks))
 - **Skeleton Templates**: Built-in (Person, Hand, Face, Dog, Box) and custom skeleton templates for one-click pose annotation
 - **SAM Smart Annotation**: Click-based intelligent annotation with 5 models — [SAM 2.1](../models/sam-2.md) (Tiny, Small, Base, Large) and the new [SAM 3](../models/sam-3.md) for highest accuracy. Switch models per-image from the annotation toolbar.
@@ -110,7 +110,7 @@ You select your region during onboarding, and all your data, models, and deploym
 
 ```mermaid
 graph LR
-    A[Upload ZIP/Images/Video] --> B[Auto-Process]
+    A[Upload Dataset/Images/Video] --> B[Auto-Process]
     B --> C[Browse & Filter]
     C --> D{Annotate}
     D --> E[Manual Tools]
@@ -415,7 +415,7 @@ See [Models Export](train/models.md#export-model), the [Export mode guide](../mo
 
 | Problem                | Solution                                                                                                                                                  |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Dataset won't process  | Check file format is supported (JPEG, PNG, WebP, etc.). Max file size: images 50MB, videos 1GB, ZIP 10GB                                                  |
+| Dataset won't process  | Check file format is supported (JPEG, PNG, WebP, etc.). Max file size: images 50MB, videos 1GB, datasets 10GB on Free / 20GB on Pro / 50GB on Enterprise |
 | Missing annotations    | Verify labels are in [YOLO format](../datasets/detect/index.md#ultralytics-yolo-format) with `.txt` files matching image filenames                        |
 | "Train split required" | Add `train/` folder to your dataset structure, or create splits in [dataset settings](data/datasets.md#filter-by-split)                                   |
 | Class names undefined  | Add a `data.yaml` file with `names:` list (see [YOLO format](../datasets/detect/index.md#ultralytics-yolo-format)), or define classes in dataset settings |
@@ -466,7 +466,7 @@ See [Models Export](train/models.md#export-model), the [Export mode guide](../mo
 
 ??? question "What are the file size limits?"
 
-    Images: 50MB, Videos: 1GB, ZIP archives: 10GB. For larger files, split into multiple uploads.
+    Images: 50MB, Videos: 1GB, datasets: 10GB on Free, 20GB on Pro, 50GB on Enterprise. For larger files, split into multiple uploads.
 
 ??? question "How long are deleted items kept in Trash?"
 

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -125,7 +125,7 @@ The welcome card shows your profile, plan badge, and workspace statistics at a g
 
 Below the welcome card, the dashboard shows three cards:
 
-- **Datasets**: Create a new dataset or drop images, videos, or ZIP files to upload. Shows your recent datasets.
+- **Datasets**: Create a new dataset or drop images, videos, or dataset files to upload. Shows your recent datasets.
 - **Projects**: Create a new project or drop `.pt` model files to upload. Shows your recent projects.
 - **Storage**: Overview of your storage usage (datasets, models, exports) with plan limits.
 
@@ -168,12 +168,12 @@ Navigate to `Annotate` in the sidebar and click `New Dataset` to add your traini
 
 Ultralytics Platform supports multiple upload formats (full details in [Datasets](data/datasets.md)):
 
-| Format                                                                 | Max Size | Description                                                                 |
-| ---------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
-| **Images**                                                             | 50 MB    | JPG, PNG, WebP, TIFF, and other common formats                              |
-| **ZIP Archive**                                                        | 10 GB    | Compressed folder with images and labels                                    |
-| **Video**                                                              | 1 GB     | MP4, WebM, MOV, AVI, MKV, M4V - frames extracted at ~1 fps (max 100 frames) |
-| **[YOLO Format](../datasets/detect/index.md#ultralytics-yolo-format)** | 10 GB    | Standard YOLO dataset structure with labels                                 |
+| Format                                                                 | Max Size (Free / Pro / Enterprise) | Description                                                                 |
+| ---------------------------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------- |
+| **Images**                                                             | 50 MB                              | JPG, PNG, WebP, TIFF, and other common formats                              |
+| **Dataset Archive**                                                    | 10 / 20 / 50 GB                    | ZIP or TAR archive with images and labels                                   |
+| **Video**                                                              | 1 GB                               | MP4, WebM, MOV, AVI, MKV, M4V - frames extracted at ~1 fps (max 100 frames) |
+| **NDJSON**                                                             | 10 / 20 / 50 GB                    | Ultralytics dataset export format for portable metadata                     |
 
 ```mermaid
 graph LR
@@ -195,7 +195,7 @@ After upload, the platform automatically processes your data:
 
 !!! tip "YOLO Dataset Structure"
 
-    For best results, upload a ZIP with the standard YOLO structure:
+    For best results, upload a ZIP or TAR archive with the standard YOLO structure:
 
     ```
     my-dataset.zip

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -168,12 +168,12 @@ Navigate to `Annotate` in the sidebar and click `New Dataset` to add your traini
 
 Ultralytics Platform supports multiple upload formats (full details in [Datasets](data/datasets.md)):
 
-| Format                                                                 | Max Size (Free / Pro / Enterprise) | Description                                                                 |
-| ---------------------------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------- |
-| **Images**                                                             | 50 MB                              | JPG, PNG, WebP, TIFF, and other common formats                              |
-| **Dataset Archive**                                                    | 10 / 20 / 50 GB                    | ZIP or TAR archive with images and labels                                   |
-| **Video**                                                              | 1 GB                               | MP4, WebM, MOV, AVI, MKV, M4V - frames extracted at ~1 fps (max 100 frames) |
-| **NDJSON**                                                             | 10 / 20 / 50 GB                    | Ultralytics dataset export format for portable metadata                     |
+| Format              | Max Size (Free / Pro / Enterprise) | Description                                                                 |
+| ------------------- | ---------------------------------- | --------------------------------------------------------------------------- |
+| **Images**          | 50 MB                              | JPG, PNG, WebP, TIFF, and other common formats                              |
+| **Dataset Archive** | 10 / 20 / 50 GB                    | ZIP or TAR archive with images and labels                                   |
+| **Video**           | 1 GB                               | MP4, WebM, MOV, AVI, MKV, M4V - frames extracted at ~1 fps (max 100 frames) |
+| **NDJSON**          | 10 / 20 / 50 GB                    | Ultralytics dataset export format for portable metadata                     |
 
 ```mermaid
 graph LR


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates Ultralytics Platform documentation to clarify dataset upload support and plan-based upload limits, adding clearer guidance for ZIP, TAR, and NDJSON files across Free, Pro, and Enterprise plans 📦📘

### 📊 Key Changes
- Added **plan-specific dataset upload limits** throughout the docs:
  - **Free:** 10 GB
  - **Pro:** 20 GB
  - **Enterprise:** 50 GB
- Updated the **billing page** to include a new row for **Dataset Upload (ZIP/TAR/NDJSON)** in the plan comparison table 💳
- Revised plan descriptions to show dataset upload limits alongside storage limits for **Free, Pro, and Enterprise**
- Documented what happens to **dataset upload limits after downgrading** from Pro to Free
- Updated **account settings** docs to show upload size limits by plan, instead of a single fixed archive limit
- Clarified supported dataset formats across the platform docs:
  - **ZIP**
  - **TAR**
  - **NDJSON**
- Removed older references to broader archive types like **TAR.GZ, TGZ, and GZ** in several docs pages
- Updated the **API documentation** for dataset ingest to say it processes **ZIP or TAR** files, not just ZIP
- Refreshed quickstart, platform overview, dataset, and FAQ content to consistently use the broader term **“dataset files”** instead of only “ZIP archives” 🛠️

### 🎯 Purpose & Impact
- Makes upload limits and supported formats much **clearer for users choosing a plan** or preparing datasets
- Reduces confusion by aligning documentation across billing, settings, API, quickstart, and dataset guides ✅
- Helps users avoid failed uploads by clearly stating which file types and sizes are supported
- Better reflects current Ultralytics Platform capabilities, especially for **TAR and NDJSON dataset workflows**
- Improves transparency for teams that may **upgrade, downgrade, or work with larger datasets** 📈