### PR TITLE
Update NVIDIA Jetson AGX Orin benchmarks with YOLO26

### DIFF
--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -519,7 +519,7 @@ The below table represents the benchmark results for five different models (YOLO
         |-----------------|--------|-------------------|-------------|------------------------|
         | PyTorch         | ✅      | 5.3               | 0.4790      | 11.58                  |
         | TorchScript     | ✅      | 9.8               | 0.4770      | 4.60                   |
-        | ONNX            | ✅      | 9.5               | 0.4760      | 38.44                  |
+        | ONNX            | ✅      | 9.5               | 0.4770      | 9.87                   |
         | OpenVINO        | ✅      | 9.6               | 0.4820      | 28.80                  |
         | TensorRT (FP32) | ✅      | 11.5              | 0.0450      | 4.18                   |
         | TensorRT (FP16) | ✅      | 7.9               | 0.0450      | 2.62                   |
@@ -537,7 +537,7 @@ The below table represents the benchmark results for five different models (YOLO
         |-----------------|--------|-------------------|-------------|------------------------|
         | PyTorch         | ✅      | 20.0              | 0.5730      | 13.18                  |
         | TorchScript     | ✅      | 36.8              | 0.5670      | 11.48                  |
-        | ONNX            | ✅      | 36.5              | 0.5660      | 96.92                  |
+        | ONNX            | ✅      | 36.5              | 0.5660      | 13.47                  |
         | OpenVINO        | ✅      | 36.7              | 0.5650      | 58.30                  |
         | TensorRT (FP32) | ✅      | 38.5              | 0.5660      | 6.82                   |
         | TensorRT (FP16) | ✅      | 21.9              | 0.5660      | 3.76                   |
@@ -554,7 +554,7 @@ The below table represents the benchmark results for five different models (YOLO
         |-----------------|--------|-------------------|-------------|------------------------|
         | PyTorch         | ✅      | 43.0              | 0.6220      | 19.36                  |
         | TorchScript     | ✅      | 78.5              | 0.6230      | 20.02                  |
-        | ONNX            | ✅      | 78.2              | 0.6230      | 257.16                 |
+        | ONNX            | ✅      | 78.2              | 0.6230      | 25.40                  |
         | OpenVINO        | ✅      | 78.3              | 0.6190      | 130.76                 |
         | TensorRT (FP32) | ✅      | 80.2              | 0.6220      | 12.60                  |
         | TensorRT (FP16) | ✅      | 42.5              | 0.6220      | 6.24                   |
@@ -571,7 +571,7 @@ The below table represents the benchmark results for five different models (YOLO
         |-----------------|--------|-------------------|-------------|------------------------|
         | PyTorch         | ✅      | 51.0              | 0.6230      | 23.53                   |
         | TorchScript     | ✅      | 95.5              | 0.6250      | 24.23                  |
-        | ONNX            | ✅      | 95.0              | 0.6250      | 328.00                 |
+        | ONNX            | ✅      | 95.0              | 0.6250      | 31.73                  |
         | OpenVINO        | ✅      | 95.3              | 0.6240      | 162.80                 |
         | TensorRT (FP32) | ✅      | 97.3              | 0.6250      | 15.90                  |
         | TensorRT (FP16) | ✅      | 51.4              | 0.6240      | 7.93                   |
@@ -588,7 +588,7 @@ The below table represents the benchmark results for five different models (YOLO
         |-----------------|--------|-------------------|-------------|------------------------|
         | PyTorch         | ✅      | 114               | 0.6610      | 38.37                  |
         | TorchScript     | ✅      | 213.5             | 0.6590      | 41.23                  |
-        | ONNX            | ✅      | 212.9             | 0.6590      | 658.87                 |
+        | ONNX            | ✅      | 212.9             | 0.6590      | 52.03                  |
         | OpenVINO        | ✅      | 213.2             | 0.6590      | 300.40                 |
         | TensorRT (FP32) | ✅      | 215.2             | 0.6590      | 28.43                  |
         | TensorRT (FP16) | ✅      | 110.3             | 0.6570      | 13.50                  |

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -398,7 +398,7 @@ Even though all model exports work on NVIDIA Jetson, we have only included **PyT
 
 <figure style="text-align: center;">
     <img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/jetson-agx-orin-benchmarks-coco128.avif" alt="Jetson AGX Orin Benchmarks">
-    <figcaption style="font-style: italic; color: gray;">Benchmarked with Ultralytics 8.3.157</figcaption>
+    <figcaption style="font-style: italic; color: gray;">Benchmarked with Ultralytics 8.4.32</figcaption>
 </figure>
 
 #### NVIDIA Jetson Orin Nano Super Developer Kit
@@ -513,92 +513,87 @@ The below table represents the benchmark results for five different models (YOLO
 
 !!! tip "Performance"
 
-    === "YOLO11n"
+    === "YOLO26n"
 
         | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
         |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 5.4               | 0.5101      | 9.40                   |
-        | TorchScript     | ✅      | 10.5              | 0.5083      | 11.00                  |
-        | ONNX            | ✅      | 10.2              | 0.5077      | 48.32                  |
-        | OpenVINO        | ✅      | 10.4              | 0.5058      | 27.24                  |
-        | TensorRT (FP32) | ✅      | 12.1              | 0.5085      | 3.93                   |
-        | TensorRT (FP16) | ✅      | 8.3               | 0.5063      | 2.55                   |
-        | TensorRT (INT8) | ✅      | 5.4               | 0.4719      | 2.18                   |
-        | TF SavedModel   | ✅      | 25.9              | 0.5077      | 66.87                  |
-        | TF GraphDef     | ✅      | 10.3              | 0.5077      | 65.68                  |
-        | TF Lite         | ✅      | 10.3              | 0.5077      | 272.92                 |
-        | MNN             | ✅      | 10.1              | 0.5059      | 36.33                  |
-        | NCNN            | ✅      | 10.2              | 0.5031      | 28.51                  |
+        | PyTorch         | ✅      | 5.3               | 0.4790      | 11.58                  |
+        | TorchScript     | ✅      | 9.8               | 0.4770      | 4.60                   |
+        | ONNX            | ✅      | 9.5               | 0.4760      | 38.44                  |
+        | OpenVINO        | ✅      | 9.6               | 0.4820      | 28.80                  |
+        | TensorRT (FP32) | ✅      | 11.5              | 0.0450      | 4.18                   |
+        | TensorRT (FP16) | ✅      | 7.9               | 0.0450      | 2.62                   |
+        | TensorRT (INT8) | ✅      | 5.4               | 0.4640      | 2.30                   |
+        | TF SavedModel   | ✅      | 24.6              | 0.4760      | 71.10                  |
+        | TF GraphDef     | ✅      | 9.5               | 0.4760      | 70.02                  |
+        | TF Lite         | ✅      | 9.9               | 0.4760      | 227.94                 |
+        | MNN             | ✅      | 9.4               | 0.4760      | 32.46                  |
 
-    === "YOLO11s"
-
-        | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
-        |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 18.4              | 0.5783      | 12.10                  |
-        | TorchScript     | ✅      | 36.5              | 0.5782      | 11.01                  |
-        | ONNX            | ✅      | 36.3              | 0.5782      | 107.54                 |
-        | OpenVINO        | ✅      | 36.4              | 0.5810      | 55.03                  |
-        | TensorRT (FP32) | ✅      | 38.1              | 0.5781      | 6.52                   |
-        | TensorRT (FP16) | ✅      | 21.4              | 0.5803      | 3.65                   |
-        | TensorRT (INT8) | ✅      | 12.1              | 0.5735      | 2.81                   |
-        | TF SavedModel   | ✅      | 91.0              | 0.5782      | 132.73                 |
-        | TF GraphDef     | ✅      | 36.4              | 0.5782      | 134.96                 |
-        | TF Lite         | ✅      | 36.3              | 0.5782      | 798.21                 |
-        | MNN             | ✅      | 36.2              | 0.5777      | 82.35                  |
-        | NCNN            | ✅      | 36.2              | 0.5784      | 56.07                  |
-
-    === "YOLO11m"
+    === "YOLO26s"
 
         | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
         |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 38.8              | 0.6265      | 22.20                  |
-        | TorchScript     | ✅      | 77.3              | 0.6307      | 21.47                  |
-        | ONNX            | ✅      | 76.9              | 0.6307      | 270.89                 |
-        | OpenVINO        | ✅      | 77.1              | 0.6284      | 129.10                 |
-        | TensorRT (FP32) | ✅      | 78.8              | 0.6306      | 12.53                  |
-        | TensorRT (FP16) | ✅      | 41.9              | 0.6305      | 6.25                   |
-        | TensorRT (INT8) | ✅      | 23.2              | 0.6291      | 4.69                   |
-        | TF SavedModel   | ✅      | 192.7             | 0.6307      | 299.95                 |
-        | TF GraphDef     | ✅      | 77.1              | 0.6307      | 310.58                 |
-        | TF Lite         | ✅      | 77.0              | 0.6307      | 2400.54                |
-        | MNN             | ✅      | 76.8              | 0.6308      | 213.56                 |
-        | NCNN            | ✅      | 76.8              | 0.6284      | 141.18                 |
+        | PyTorch         | ✅      | 20.0              | 0.5730      | 13.18                  |
+        | TorchScript     | ✅      | 36.8              | 0.5670      | 11.48                  |
+        | ONNX            | ✅      | 36.5              | 0.5660      | 96.92                  |
+        | OpenVINO        | ✅      | 36.7              | 0.5650      | 58.30                  |
+        | TensorRT (FP32) | ✅      | 38.5              | 0.5660      | 6.82                   |
+        | TensorRT (FP16) | ✅      | 21.9              | 0.5660      | 3.76                   |
+        | TensorRT (INT8) | ✅      | 12.5              | 0.5480      | 2.98                   |
+        | TF SavedModel   | ✅      | 92.2              | 0.5660      | 145.62                 |
+        | TF GraphDef     | ✅      | 36.5              | 0.5660      | 146.26                 |
+        | TF Lite         | ✅      | 36.9              | 0.5660      | 753.52                 |
+        | MNN             | ✅      | 36.4              | 0.5650      | 79.50                  |
 
-    === "YOLO11l"
-
-        | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
-        |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 49.0              | 0.6364      | 27.70                   |
-        | TorchScript     | ✅      | 97.6              | 0.6399      | 27.94                  |
-        | ONNX            | ✅      | 97.0              | 0.6409      | 345.47                 |
-        | OpenVINO        | ✅      | 97.3              | 0.6378      | 161.93                 |
-        | TensorRT (FP32) | ✅      | 99.1              | 0.6406      | 16.11                  |
-        | TensorRT (FP16) | ✅      | 52.6              | 0.6376      | 8.08                   |
-        | TensorRT (INT8) | ✅      | 30.8              | 0.6208      | 6.12                   |
-        | TF SavedModel   | ✅      | 243.1             | 0.6409      | 390.78                 |
-        | TF GraphDef     | ✅      | 97.2              | 0.6409      | 398.76                 |
-        | TF Lite         | ✅      | 97.1              | 0.6409      | 3037.05                |
-        | MNN             | ✅      | 96.9              | 0.6372      | 265.46                 |
-        | NCNN            | ✅      | 96.9              | 0.6364      | 179.68                 |
-
-    === "YOLO11x"
+    === "YOLO26m"
 
         | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
         |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 109.3             | 0.7005      | 44.40                  |
-        | TorchScript     | ✅      | 218.1             | 0.6898      | 47.49                  |
-        | ONNX            | ✅      | 217.5             | 0.6900      | 682.98                 |
-        | OpenVINO        | ✅      | 217.8             | 0.6876      | 298.15                 |
-        | TensorRT (FP32) | ✅      | 219.6             | 0.6904      | 28.50                  |
-        | TensorRT (FP16) | ✅      | 112.2             | 0.6887      | 13.55                  |
-        | TensorRT (INT8) | ✅      | 60.0              | 0.6574      | 9.40                   |
-        | TF SavedModel   | ✅      | 544.3             | 0.6900      | 749.85                 |
-        | TF GraphDef     | ✅      | 217.7             | 0.6900      | 753.86                 |
-        | TF Lite         | ✅      | 217.6             | 0.6900      | 6603.27                |
-        | MNN             | ✅      | 217.3             | 0.6868      | 519.77                 |
-        | NCNN            | ✅      | 217.3             | 0.6849      | 298.58                 |
+        | PyTorch         | ✅      | 43.0              | 0.6220      | 19.36                  |
+        | TorchScript     | ✅      | 78.5              | 0.6230      | 20.02                  |
+        | ONNX            | ✅      | 78.2              | 0.6230      | 257.16                 |
+        | OpenVINO        | ✅      | 78.3              | 0.6190      | 130.76                 |
+        | TensorRT (FP32) | ✅      | 80.2              | 0.6220      | 12.60                  |
+        | TensorRT (FP16) | ✅      | 42.5              | 0.6220      | 6.24                   |
+        | TensorRT (INT8) | ✅      | 23.4              | 0.5820      | 4.72                   |
+        | TF SavedModel   | ✅      | 196.3             | 0.6230      | 306.76                 |
+        | TF GraphDef     | ✅      | 78.2              | 0.6230      | 314.23                 |
+        | TF Lite         | ✅      | 78.5              | 0.6230      | 2331.63                |
+        | MNN             | ✅      | 78.0              | 0.6220      | 206.93                 |
 
-    Benchmarked with Ultralytics 8.3.157
+    === "YOLO26l"
+
+        | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
+        |-----------------|--------|-------------------|-------------|------------------------|
+        | PyTorch         | ✅      | 51.0              | 0.6230      | 23.53                   |
+        | TorchScript     | ✅      | 95.5              | 0.6250      | 24.23                  |
+        | ONNX            | ✅      | 95.0              | 0.6250      | 328.00                 |
+        | OpenVINO        | ✅      | 95.3              | 0.6240      | 162.80                 |
+        | TensorRT (FP32) | ✅      | 97.3              | 0.6250      | 15.90                  |
+        | TensorRT (FP16) | ✅      | 51.4              | 0.6240      | 7.93                   |
+        | TensorRT (INT8) | ✅      | 29.9              | 0.5920      | 5.97                   |
+        | TF SavedModel   | ✅      | 238.4             | 0.6250      | 394.30                 |
+        | TF GraphDef     | ✅      | 95.0              | 0.6250      | 398.63                 |
+        | TF Lite         | ✅      | 95.4              | 0.6250      | 2925.27                |
+        | MNN             | ✅      | 94.8              | 0.6250      | 255.87                 |
+
+    === "YOLO26x"
+
+        | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
+        |-----------------|--------|-------------------|-------------|------------------------|
+        | PyTorch         | ✅      | 114               | 0.6610      | 38.37                  |
+        | TorchScript     | ✅      | 213.5             | 0.6590      | 41.23                  |
+        | ONNX            | ✅      | 212.9             | 0.6590      | 658.87                 |
+        | OpenVINO        | ✅      | 213.2             | 0.6590      | 300.40                 |
+        | TensorRT (FP32) | ✅      | 215.2             | 0.6590      | 28.43                  |
+        | TensorRT (FP16) | ✅      | 110.3             | 0.6570      | 13.50                  |
+        | TensorRT (INT8) | ✅      | 59.9              | 0.6080      | 9.33                   |
+        | TF SavedModel   | ✅      | 533.3             | 0.6590      | 738.60                 |
+        | TF GraphDef     | ✅      | 212.9             | 0.6590      | 785.70                 |
+        | TF Lite         | ✅      | 217.6             | 0.6900      | 6476.80                |
+        | MNN             | ✅      | 213.3             | 0.6590      | 519.77                 |
+
+    Benchmarked with Ultralytics 8.4.32
 
     !!! note
 

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -528,6 +528,8 @@ The below table represents the benchmark results for five different models (YOLO
         | TF GraphDef     | ✅      | 9.5               | 0.4760      | 70.02                  |
         | TF Lite         | ✅      | 9.9               | 0.4760      | 227.94                 |
         | MNN             | ✅      | 9.4               | 0.4760      | 32.46                  |
+        | NCNN            | ✅      | 9.3               | 0.4810      | 29.93                  |
+
 
     === "YOLO26s"
 
@@ -544,6 +546,7 @@ The below table represents the benchmark results for five different models (YOLO
         | TF GraphDef     | ✅      | 36.5              | 0.5660      | 146.26                 |
         | TF Lite         | ✅      | 36.9              | 0.5660      | 753.52                 |
         | MNN             | ✅      | 36.4              | 0.5650      | 79.50                  |
+        | NCNN            | ✅      | 36.4              | 0.5700      | 58.73                  |
 
     === "YOLO26m"
 
@@ -560,6 +563,7 @@ The below table represents the benchmark results for five different models (YOLO
         | TF GraphDef     | ✅      | 78.2              | 0.6230      | 314.23                 |
         | TF Lite         | ✅      | 78.5              | 0.6230      | 2331.63                |
         | MNN             | ✅      | 78.0              | 0.6220      | 206.93                 |
+        | NCNN            | ✅      | 78.0              | 0.6220      | 143.03                 |
 
     === "YOLO26l"
 
@@ -576,6 +580,7 @@ The below table represents the benchmark results for five different models (YOLO
         | TF GraphDef     | ✅      | 95.0              | 0.6250      | 398.63                 |
         | TF Lite         | ✅      | 95.4              | 0.6250      | 2925.27                |
         | MNN             | ✅      | 94.8              | 0.6250      | 255.87                 |
+        | NCNN            | ✅      | 94.8              | 0.6320      | 177.70                 |
 
     === "YOLO26x"
 
@@ -592,6 +597,7 @@ The below table represents the benchmark results for five different models (YOLO
         | TF GraphDef     | ✅      | 212.9             | 0.6590      | 785.70                 |
         | TF Lite         | ✅      | 217.6             | 0.6900      | 6476.80                |
         | MNN             | ✅      | 213.3             | 0.6590      | 519.77                 |
+        | NCNN            | ✅      | 212.8             | 0.6670      | 300.00                 |
 
     Benchmarked with Ultralytics 8.4.32
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the NVIDIA Jetson AGX Orin benchmark documentation to replace YOLO11 results with YOLO26 benchmarks and refresh the reported Ultralytics version to 8.4.32. 🚀

### 📊 Key Changes
- Replaces Jetson AGX Orin benchmark tables from `YOLO11n/s/m/l/x` to `YOLO26n/s/m/l/x`.
- Updates performance metrics across export formats, including PyTorch, TorchScript, ONNX, OpenVINO, TensorRT, TensorFlow, and MNN. 📈
- Refreshes the figure caption and benchmark note from Ultralytics `8.3.157` to `8.4.32`.
- Removes NCNN rows from the shown benchmark tables where they are no longer included in the updated results.
- Keeps the documentation aligned with the latest recommended Ultralytics model family for edge benchmarking on Jetson devices. 🧠

### 🎯 Purpose & Impact
- Provides users with more current Jetson AGX Orin performance data based on YOLO26, improving documentation relevance.
- Helps edge and embedded developers compare export/runtime tradeoffs using newer benchmark numbers before deployment on Jetson hardware. ⚡
- Aligns the Jetson guide with current Ultralytics model naming and recommendation standards, reducing confusion for new users.
- May influence deployment choices by showing updated latency, size, and accuracy characteristics across supported export targets.