### PR TITLE
update SAM-2 docs with YOLO26 references and fresh benchmarks

### DIFF
--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -316,21 +316,22 @@ It offers three significant enhancements:
 
 ## SAM 2 Comparison vs YOLO
 
-Here we compare Meta's SAM 2 models, including the smallest SAM2-t variant, with Ultralytics smallest segmentation model, [YOLO11n-seg](../tasks/segment.md):
+Here we compare Meta's SAM 2 models, including the smallest SAM2-t variant, with Ultralytics segmentation models including [YOLO26n-seg](yolo26.md):
 
 | Model                                                                                          | Size<br><sup>(MB)</sup> | Parameters<br><sup>(M)</sup> | Speed (CPU)<br><sup>(ms/im)</sup> |
 | ---------------------------------------------------------------------------------------------- | ----------------------- | ---------------------------- | --------------------------------- |
-| [Meta SAM-b](sam.md)                                                                           | 375                     | 93.7                         | 49401                             |
-| Meta SAM2-b                                                                                    | 162                     | 80.8                         | 31901                             |
-| Meta SAM2-t                                                                                    | 78.1                    | 38.9                         | 25997                             |
-| [MobileSAM](mobile-sam.md)                                                                     | 40.7                    | 10.1                         | 25381                             |
-| [FastSAM-s](fast-sam.md) with YOLOv8 [backbone](https://www.ultralytics.com/glossary/backbone) | 23.7                    | 11.8                         | 55.9                              |
-| Ultralytics [YOLOv8n-seg](yolov8.md)                                                           | **6.7** (11.7x smaller) | **3.4** (11.4x less)         | **24.5** (1061x faster)           |
-| Ultralytics [YOLO11n-seg](yolo11.md)                                                           | **5.9** (13.2x smaller) | **2.9** (13.4x less)         | **30.1** (864x faster)            |
+| [Meta SAM-b](sam.md)                                                                           | 375                     | 93.7                         | 41703                             |
+| Meta SAM2-b                                                                                    | 162                     | 80.8                         | 28867                             |
+| Meta SAM2-t                                                                                    | 78.1                    | 38.9                         | 23430                             |
+| [MobileSAM](mobile-sam.md)                                                                     | 40.7                    | 10.1                         | 23802                             |
+| [FastSAM-s](fast-sam.md) with YOLOv8 [backbone](https://www.ultralytics.com/glossary/backbone) | 23.9                    | 11.8                         | 58.0                              |
+| Ultralytics [YOLOv8n-seg](yolov8.md)                                                           | **7.1** (11.0x smaller) | **3.4** (11.4x less)         | **28.0** (837x faster)            |
+| Ultralytics [YOLO11n-seg](yolo11.md)                                                           | **6.2** (12.6x smaller) | **2.9** (13.4x less)         | **27.0** (868x faster)            |
+| Ultralytics [YOLO26n-seg](yolo26.md)                                                           | **6.7** (11.7x smaller) | **2.7** (14.4x less)         | **29.7** (789x faster)            |
 
-This comparison demonstrates the substantial differences in model sizes and speeds between SAM variants and YOLO segmentation models. While SAM provides unique automatic segmentation capabilities, YOLO models, particularly YOLOv8n-seg and YOLO11n-seg, are significantly smaller, faster, and more computationally efficient.
+This comparison demonstrates the substantial differences in model sizes and speeds between SAM variants and YOLO segmentation models. While SAM provides unique automatic segmentation capabilities, YOLO models, particularly YOLOv8n-seg, YOLO11n-seg and YOLO26n-seg, are significantly smaller, faster, and more computationally efficient.
 
-Tests run on a 2025 Apple M4 Pro with 24GB of RAM using `torch==2.6.0` and `ultralytics==8.3.90`. To reproduce this test:
+Tests run on a 2025 Apple M4 Air with 16GB of RAM using `torch==2.10.0` and `ultralytics==8.4.31`. To reproduce this test:
 
 !!! example
 
@@ -351,7 +352,7 @@ Tests run on a 2025 Apple M4 Pro with 24GB of RAM using `torch==2.6.0` and `ultr
         model(ASSETS)
 
         # Profile YOLO models
-        for file_name in ["yolov8n-seg.pt", "yolo11n-seg.pt"]:
+        for file_name in ["yolov8n-seg.pt", "yolo11n-seg.pt", "yolo26n-seg.pt"]:
             model = YOLO(file_name)
             model.info()
             model(ASSETS)

--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -479,6 +479,6 @@ SAM 2 includes a sophisticated memory mechanism to manage temporal dependencies 
 
 This mechanism ensures continuity even when objects are temporarily obscured or exit and re-enter the scene. For more details, refer to the [Memory Mechanism and Occlusion Handling](#memory-mechanism-and-occlusion-handling) section.
 
-### How does SAM 2 compare to other segmentation models like YOLO11?
+### How does SAM 2 compare to other segmentation models like YOLO26?
 
-SAM 2 models, such as Meta's SAM2-t and SAM2-b, offer powerful zero-shot segmentation capabilities but are significantly larger and slower compared to YOLO11 models. For instance, YOLO11n-seg is approximately **13 times smaller** and over **860 times faster** than SAM2-b. While SAM 2 excels in versatile, prompt-based, and zero-shot segmentation scenarios, YOLO11 is optimized for speed, efficiency, and real-time applications, making it better suited for deployment in resource-constrained environments.
+SAM 2 models, such as Meta's SAM2-t and SAM2-b, offer powerful zero-shot segmentation capabilities but are significantly larger and slower compared to YOLO models. For instance, [YOLO26n-seg](yolo26.md) is approximately **24 times smaller** and over **970 times faster** than SAM2-b on CPU. While SAM 2 excels in versatile, prompt-based, and zero-shot segmentation scenarios, YOLO26 is optimized for speed, efficiency, and real-time applications with NMS-free end-to-end inference, making it better suited for deployment in resource-constrained environments.

--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -382,7 +382,7 @@ To auto-annotate your dataset using SAM 2, follow this example:
     ```python
     from ultralytics.data.annotator import auto_annotate
 
-    auto_annotate(data="path/to/images", det_model="yolo11x.pt", sam_model="sam2_b.pt")
+    auto_annotate(data="path/to/images", det_model="yolo26x.pt", sam_model="sam2_b.pt")
     ```
 
 {% include "macros/sam-auto-annotate.md" %}

--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 description: Discover SAM 2, the next generation of Meta's Segment Anything Model, supporting real-time promptable segmentation in both images and videos with state-of-the-art performance. Learn about its key features, datasets, and how to use it.
-keywords: SAM 2, SAM 2.1, Segment Anything, video segmentation, image segmentation, promptable segmentation, zero-shot performance, SA-V dataset, Ultralytics, real-time segmentation, AI, machine learning
+keywords: SAM 2, SAM 2.1, SAM-2, Segment Anything, video segmentation, image segmentation, promptable segmentation, zero-shot segmentation, instance segmentation, interactive segmentation, real-time segmentation, SAM 2 vs YOLO, SAM 2 vs SAM 3, SA-V dataset, Meta, Ultralytics
 ---
 
 # SAM 2: Segment Anything Model 2

--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -331,7 +331,7 @@ Here we compare Meta's SAM 2 models, including the smallest SAM2-t variant, with
 
 This comparison demonstrates the substantial differences in model sizes and speeds between SAM variants and YOLO segmentation models. While SAM provides unique automatic segmentation capabilities, YOLO models, particularly YOLOv8n-seg, YOLO11n-seg and YOLO26n-seg, are significantly smaller, faster, and more computationally efficient.
 
-SAM speeds measured with PyTorch, YOLO speeds measured with ONNX Runtime. Tests run on a 2025 Apple M4 Air with 16GB of RAM using `torch==2.10.0` and `ultralytics==8.4.31`. To reproduce this test:
+SAM speeds measured with PyTorch, YOLO speeds measured with ONNX Runtime. Tests run on a 2025 Apple M4 Air with 16GB of RAM using `torch==2.10.0`, `ultralytics==8.4.31`, and `onnxruntime==1.24.4`. To reproduce this test:
 
 !!! example
 

--- a/docs/en/models/sam-2.md
+++ b/docs/en/models/sam-2.md
@@ -325,13 +325,13 @@ Here we compare Meta's SAM 2 models, including the smallest SAM2-t variant, with
 | Meta SAM2-t                                                                                    | 78.1                    | 38.9                         | 23430                             |
 | [MobileSAM](mobile-sam.md)                                                                     | 40.7                    | 10.1                         | 23802                             |
 | [FastSAM-s](fast-sam.md) with YOLOv8 [backbone](https://www.ultralytics.com/glossary/backbone) | 23.9                    | 11.8                         | 58.0                              |
-| Ultralytics [YOLOv8n-seg](yolov8.md)                                                           | **7.1** (11.0x smaller) | **3.4** (11.4x less)         | **28.0** (837x faster)            |
-| Ultralytics [YOLO11n-seg](yolo11.md)                                                           | **6.2** (12.6x smaller) | **2.9** (13.4x less)         | **27.0** (868x faster)            |
-| Ultralytics [YOLO26n-seg](yolo26.md)                                                           | **6.7** (11.7x smaller) | **2.7** (14.4x less)         | **29.7** (789x faster)            |
+| Ultralytics [YOLOv8n-seg](yolov8.md)                                                           | **7.1** (11.0x smaller) | **3.4** (11.4x less)         | **24.8** (945x faster)            |
+| Ultralytics [YOLO11n-seg](yolo11.md)                                                           | **6.2** (12.6x smaller) | **2.9** (13.4x less)         | **24.3** (964x faster)            |
+| Ultralytics [YOLO26n-seg](yolo26.md)                                                           | **6.7** (11.7x smaller) | **2.7** (14.4x less)         | **25.2** (930x faster)            |
 
 This comparison demonstrates the substantial differences in model sizes and speeds between SAM variants and YOLO segmentation models. While SAM provides unique automatic segmentation capabilities, YOLO models, particularly YOLOv8n-seg, YOLO11n-seg and YOLO26n-seg, are significantly smaller, faster, and more computationally efficient.
 
-Tests run on a 2025 Apple M4 Air with 16GB of RAM using `torch==2.10.0` and `ultralytics==8.4.31`. To reproduce this test:
+SAM speeds measured with PyTorch, YOLO speeds measured with ONNX Runtime. Tests run on a 2025 Apple M4 Air with 16GB of RAM using `torch==2.10.0` and `ultralytics==8.4.31`. To reproduce this test:
 
 !!! example
 
@@ -351,10 +351,12 @@ Tests run on a 2025 Apple M4 Air with 16GB of RAM using `torch==2.10.0` and `ult
         model.info()
         model(ASSETS)
 
-        # Profile YOLO models
+        # Profile YOLO models (ONNX)
         for file_name in ["yolov8n-seg.pt", "yolo11n-seg.pt", "yolo26n-seg.pt"]:
             model = YOLO(file_name)
             model.info()
+            onnx_path = model.export(format="onnx", dynamic=True)
+            model = YOLO(onnx_path)
             model(ASSETS)
         ```
 
@@ -481,4 +483,4 @@ This mechanism ensures continuity even when objects are temporarily obscured or 
 
 ### How does SAM 2 compare to other segmentation models like YOLO26?
 
-SAM 2 models, such as Meta's SAM2-t and SAM2-b, offer powerful zero-shot segmentation capabilities but are significantly larger and slower compared to YOLO models. For instance, [YOLO26n-seg](yolo26.md) is approximately **24 times smaller** and over **970 times faster** than SAM2-b on CPU. While SAM 2 excels in versatile, prompt-based, and zero-shot segmentation scenarios, YOLO26 is optimized for speed, efficiency, and real-time applications with NMS-free end-to-end inference, making it better suited for deployment in resource-constrained environments.
+SAM 2 models, such as Meta's SAM2-t and SAM2-b, offer powerful zero-shot segmentation capabilities but are significantly larger and slower compared to YOLO models. For instance, [YOLO26n-seg](yolo26.md) is approximately **24 times smaller** and over **1145 times faster** than SAM2-b on CPU. While SAM 2 excels in versatile, prompt-based, and zero-shot segmentation scenarios, YOLO26 is optimized for speed, efficiency, and real-time applications with NMS-free end-to-end inference, making it better suited for deployment in resource-constrained environments.

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -16,21 +16,21 @@ Choose the plan that fits your needs. Compare plans in `Settings > Plans`:
 
 ![Ultralytics Platform Settings Plans Tab Free Pro Enterprise Comparison](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-plans-tab-free-pro-enterprise-comparison.avif)
 
-| Feature                             | Free       | Pro ($29/mo)    | Enterprise |
-| ----------------------------------- | ---------- | --------------- | ---------- |
-| **Signup Credit**                   | $5 / $25\* | -               | Custom     |
-| **Monthly Credit**                  | -          | $30/seat/month  | Custom     |
-| **Models**                          | 100        | 500             | Unlimited  |
-| **Concurrent Trainings**            | 3          | 10              | Unlimited  |
-| **Storage**                         | 100 GB     | 500 GB          | Unlimited  |
+| Feature                                                    | Free       | Pro ($29/mo)    | Enterprise |
+| ---------------------------------------------------------- | ---------- | --------------- | ---------- |
+| **Signup Credit**                                          | $5 / $25\* | -               | Custom     |
+| **Monthly Credit**                                         | -          | $30/seat/month  | Custom     |
+| **Models**                                                 | 100        | 500             | Unlimited  |
+| **Concurrent Trainings**                                   | 3          | 10              | Unlimited  |
+| **Storage**                                                | 100 GB     | 500 GB          | Unlimited  |
 | **Dataset Upload (ZIP/TAR incl. `.tar.gz`/`.tgz`/NDJSON)** | 10 GB      | 20 GB           | 50 GB      |
-| **Deployments**                     | 3          | 10              | Unlimited  |
-| **Cloud GPU Types**                 | 20         | 23              | 23         |
-| **Best GPUs (H200, B200)**          | -          | Yes             | Yes        |
-| **Teams**                           | -          | Up to 5 members | Up to 50   |
-| **SSO / SAML**                      | -          | -               | Yes        |
-| **Enterprise License**              | -          | -               | Yes        |
-| **License**                         | AGPL-3.0   | AGPL-3.0        | Enterprise |
+| **Deployments**                                            | 3          | 10              | Unlimited  |
+| **Cloud GPU Types**                                        | 20         | 23              | 23         |
+| **Best GPUs (H200, B200)**                                 | -          | Yes             | Yes        |
+| **Teams**                                                  | -          | Up to 5 members | Up to 50   |
+| **SSO / SAML**                                             | -          | -               | Yes        |
+| **Enterprise License**                                     | -          | -               | Yes        |
+| **License**                                                | AGPL-3.0   | AGPL-3.0        | Enterprise |
 
 \*Free plan: $5 at signup, or $25 if you verify a company/work email address.
 
@@ -251,17 +251,17 @@ Cancel anytime from the billing portal:
 
 When your Pro subscription ends (cancelled or expired), your account reverts to the Free plan. Here's what happens to your existing resources:
 
-| Resource                            | What Happens                                                                     |
-| ----------------------------------- | -------------------------------------------------------------------------------- |
-| **Models**                          | All models preserved. Cannot create new models beyond 100-model limit            |
-| **Deployments**                     | All deployments preserved. Cannot create new beyond 3-deployment limit           |
-| **Storage**                         | All data preserved. Cannot upload new data beyond 100 GB limit                   |
+| Resource                                                   | What Happens                                                                     |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **Models**                                                 | All models preserved. Cannot create new models beyond 100-model limit            |
+| **Deployments**                                            | All deployments preserved. Cannot create new beyond 3-deployment limit           |
+| **Storage**                                                | All data preserved. Cannot upload new data beyond 100 GB limit                   |
 | **Dataset Upload (ZIP/TAR incl. `.tar.gz`/`.tgz`/NDJSON)** | Upload limit reduced from 20 GB to 10 GB per file                                |
-| **Credit Balance**                  | Existing credits preserved and usable                                            |
-| **Monthly Credits**                 | $30/seat/month grants stop immediately                                           |
-| **Team Members**                    | Members notified and lose access to team resources                               |
-| **GPU Access**                      | Standard GPUs remain available. Best GPUs (H200, B200) require Pro or Enterprise |
-| **Concurrent Trainings**            | Limit reduced from 10 to 3                                                       |
+| **Credit Balance**                                         | Existing credits preserved and usable                                            |
+| **Monthly Credits**                                        | $30/seat/month grants stop immediately                                           |
+| **Team Members**                                           | Members notified and lose access to team resources                               |
+| **GPU Access**                                             | Standard GPUs remain available. Best GPUs (H200, B200) require Pro or Enterprise |
+| **Concurrent Trainings**                                   | Limit reduced from 10 to 3                                                       |
 
 !!! tip "No Data Loss"
 

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -146,11 +146,11 @@ The storage card shows:
 
 #### Upload Size Limits
 
-| File Type                    | Free  | Pro   | Enterprise |
-| ---------------------------- | ----- | ----- | ---------- |
-| **Image**                    | 50 MB | 50 MB | 50 MB      |
-| **Video**                    | 1 GB  | 1 GB  | 1 GB       |
-| **Model (.pt)**              | 1 GB  | 1 GB  | 1 GB       |
+| File Type                                           | Free  | Pro   | Enterprise |
+| --------------------------------------------------- | ----- | ----- | ---------- |
+| **Image**                                           | 50 MB | 50 MB | 50 MB      |
+| **Video**                                           | 1 GB  | 1 GB  | 1 GB       |
+| **Model (.pt)**                                     | 1 GB  | 1 GB  | 1 GB       |
 | **Dataset (ZIP/TAR incl. `.tar.gz`/`.tgz`/NDJSON)** | 10 GB | 20 GB | 50 GB      |
 
 #### Trash and Storage


### PR DESCRIPTION
## Summary

Updates SAM-2 documentation with YOLO26 references and fresh ONNX benchmarks.

## Changes

- added YOLO26n-seg row to benchmark table
- re-ran benchmark on Apple M4 Air 16GB (torch 2.10.0, ultralytics 8.4.31)
- YOLO speeds now use ONNX Runtime with dynamic=True for consistency with other docs pages
- updated FAQ comparison from YOLO11 to YOLO26
- updated auto-annotate example from yolo11x.pt to yolo26x.pt
- updated frontmatter keywords

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refreshes the SAM 2 documentation with YOLO26 references, updated segmentation benchmark figures, and revised usage examples for current Ultralytics recommendations. 📝

### 📊 Key Changes
- Updated SAM 2 page metadata keywords to improve discoverability for segmentation, comparison, and YOLO-related searches.
- Reworked the **SAM 2 Comparison vs YOLO** section to include [YOLO26n-seg](yolo26.md) alongside YOLOv8n-seg and YOLO11n-seg.
- Replaced benchmark values across SAM, MobileSAM, FastSAM, and YOLO models with fresh CPU timing and model size figures.
- Clarified benchmarking methodology by noting that SAM speeds were measured with PyTorch and YOLO speeds with ONNX Runtime.
- Updated the reproducibility example to export YOLO segmentation models to ONNX before profiling, and added `yolo26n-seg.pt` to the test loop.
- Updated the auto-annotation example from `yolo11x.pt` to `yolo26x.pt` to reflect the latest recommended Ultralytics model family.
- Revised the FAQ comparison from YOLO11 to YOLO26 and updated the accompanying efficiency claims and positioning.

### 🎯 Purpose & Impact
- Improves documentation accuracy by aligning SAM 2 comparisons with current Ultralytics model recommendations, especially YOLO26. 🚀
- Gives users more up-to-date benchmark context when choosing between promptable SAM segmentation and real-time YOLO segmentation.
- Makes reproduction steps clearer by documenting the runtime differences and export flow used for YOLO benchmarks.
- Strengthens discoverability and relevance of the SAM 2 docs for users evaluating segmentation tradeoffs across Ultralytics and Meta models.