### PR TITLE
`ultralytics 8.4.33` Progressive loss train resume fix

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.32"
+__version__ = "8.4.33"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -944,6 +944,11 @@ class BaseTrainer:
             )
             self.epochs += ckpt["epoch"]  # finetune additional epochs
         self._load_checkpoint_state(ckpt)
+        if unwrap_model(self.model).end2end:
+            # initialize loss and resume o2o and o2m args
+            unwrap_model(self.model).criterion = unwrap_model(self.model).init_criterion()
+            unwrap_model(self.model).criterion.updates = start_epoch - 1
+            unwrap_model(self.model).criterion.update()
         self.start_epoch = start_epoch
         if start_epoch > (self.epochs - self.args.close_mosaic):
             self._close_dataloader_mosaic()


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR fixes resume-training behavior for end-to-end YOLO models by properly restoring loss-related training state when continuing from a checkpoint.

### 📊 Key Changes
- Bumped the package version from `8.4.32` to `8.4.33` 📦
- Updated `resume_training()` in `ultralytics/engine/trainer.py` to better handle **end-to-end models**
- When resuming training, the trainer now:
  - reinitializes the model’s loss criterion
  - restores its internal update counter based on the saved training progress
  - applies an update so one-to-one and one-to-many training settings are resumed correctly ⚙️

### 🎯 Purpose & Impact
- Fixes a resume-training edge case for **end-to-end training workflows** 🛠️
- Helps ensure training continues with the correct loss behavior after loading a checkpoint, instead of restarting with partially reset internal state
- Improves consistency and reliability for users resuming long YOLO training jobs, especially on interrupted runs or multi-stage experiments ⏯️
- Reduces the risk of unexpected training behavior or degraded results when fine-tuning from saved checkpoints 📈