### PR TITLE
Fix loss explosion on resume when training on small dataset

### DIFF
--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -405,17 +405,17 @@ SAM 3 provides accurate counting by segmenting all instances, a common requireme
 
 Here we compare SAM 3's capabilities with [SAM 2](./sam-2.md) and [YOLO26](./yolo26.md) models:
 
-| Capability                   | SAM 3                                 | SAM 2                | YOLO26n-seg        |
-| ---------------------------- | ------------------------------------- | -------------------- | ------------------ |
-| **Concept Segmentation**     | ✅ All instances from text/exemplars  | ❌ Not supported     | ❌ Not supported   |
-| **Visual Segmentation**      | ✅ Single instance (SAM 2 compatible) | ✅ Single instance   | ✅ All instances   |
-| **Zero-shot Capability**     | ✅ Open vocabulary                    | ✅ Geometric prompts | ❌ Closed set      |
-| **Interactive Refinement**   | ✅ Exemplars + clicks                 | ✅ Clicks only       | ❌ Not supported   |
-| **Video Tracking**           | ✅ Multi-object with identities       | ✅ Multi-object      | ✅ Multi-object    |
-| **LVIS Mask AP (zero-shot)** | **47.0**                              | N/A                  | N/A                |
-| **MOSEv2 J&F**               | **60.1**                              | 47.9                 | N/A                |
-| **Speed (GPU, ms/im)**       | 2921                                  | 857                  | **8.4**            |
-| **Model Size**               | 3.45 GB                               | 162 MB (base)        | **6.4 MB**         |
+| Capability                   | SAM 3                                 | SAM 2                | YOLO26n-seg      |
+| ---------------------------- | ------------------------------------- | -------------------- | ---------------- |
+| **Concept Segmentation**     | ✅ All instances from text/exemplars  | ❌ Not supported     | ❌ Not supported |
+| **Visual Segmentation**      | ✅ Single instance (SAM 2 compatible) | ✅ Single instance   | ✅ All instances |
+| **Zero-shot Capability**     | ✅ Open vocabulary                    | ✅ Geometric prompts | ❌ Closed set    |
+| **Interactive Refinement**   | ✅ Exemplars + clicks                 | ✅ Clicks only       | ❌ Not supported |
+| **Video Tracking**           | ✅ Multi-object with identities       | ✅ Multi-object      | ✅ Multi-object  |
+| **LVIS Mask AP (zero-shot)** | **47.0**                              | N/A                  | N/A              |
+| **MOSEv2 J&F**               | **60.1**                              | 47.9                 | N/A              |
+| **Speed (GPU, ms/im)**       | 2921                                  | 857                  | **8.4**          |
+| **Model Size**               | 3.45 GB                               | 162 MB (base)        | **6.4 MB**       |
 
 Speed benchmarked on NVIDIA RTX PRO 6000 with `torch==2.9.1` and `ultralytics==8.4.19`.
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -770,7 +770,7 @@ def convert_optimizer_state_dict_to_fp16(state_dict):
     """
     for state in state_dict["state"].values():
         for k, v in state.items():
-            if k != "step" and isinstance(v, torch.Tensor) and v.dtype is torch.float32:
+            if k not in {"step", "exp_avg_sq"} and isinstance(v, torch.Tensor) and v.dtype is torch.float32:
                 state[k] = v.half()
 
     return state_dict


### PR DESCRIPTION
Closes #24079 

## Claude summary

In 8.4.8, the optimizer selection changed from always using MuSGD to using AdamW for small datasets (<10k iterations). Unlike SGD, AdamW maintains exp_avg_sq (second moment estimates) which contain very small values near zero. When convert_optimizer_state_dict_to_fp16 converts these to FP16 during checkpoint saving, values below ~6e-5 are rounded to zero. On resume,Adam's update rule divides by sqrt(exp_avg_sq) + eps, and the zeroed values cause divide-by-epsilon explosions, spiking cls_loss by 1000-5000x.  

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR refines optimizer state conversion to FP16 by keeping the `exp_avg_sq` tensor in FP32, improving numerical stability during training.

### 📊 Key Changes
- Updated `convert_optimizer_state_dict_to_fp16()` in `ultralytics/utils/torch_utils.py`.
- Changed the FP16 conversion rule so that optimizer state entries named `exp_avg_sq` are **no longer converted** from `float32` to `float16`.
- The function still skips converting `step`, and now also skips `exp_avg_sq`.

### 🎯 Purpose & Impact
- ✅ **Improves training stability** by preserving a sensitive optimizer statistic in higher precision.
- ⚙️ **Reduces risk of precision-related issues** when resuming training or working with mixed-precision workflows.
- 🚀 **Helps maintain reliable optimizer behavior** without broadly changing the FP16 conversion logic.
- 👥 **Benefits users training YOLO models at scale**, especially in setups where checkpoint efficiency and stable optimization both matter.