### PR TITLE
Docs: Redistribute Splits

### DIFF
--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -405,17 +405,17 @@ SAM 3 provides accurate counting by segmenting all instances, a common requireme
 
 Here we compare SAM 3's capabilities with [SAM 2](./sam-2.md) and [YOLO26](./yolo26.md) models:
 
-| Capability                   | SAM 3                                 | SAM 2                | YOLO26n-seg        |
-| ---------------------------- | ------------------------------------- | -------------------- | ------------------ |
-| **Concept Segmentation**     | ✅ All instances from text/exemplars  | ❌ Not supported     | ❌ Not supported   |
-| **Visual Segmentation**      | ✅ Single instance (SAM 2 compatible) | ✅ Single instance   | ✅ All instances   |
-| **Zero-shot Capability**     | ✅ Open vocabulary                    | ✅ Geometric prompts | ❌ Closed set      |
-| **Interactive Refinement**   | ✅ Exemplars + clicks                 | ✅ Clicks only       | ❌ Not supported   |
-| **Video Tracking**           | ✅ Multi-object with identities       | ✅ Multi-object      | ✅ Multi-object    |
-| **LVIS Mask AP (zero-shot)** | **47.0**                              | N/A                  | N/A                |
-| **MOSEv2 J&F**               | **60.1**                              | 47.9                 | N/A                |
-| **Speed (GPU, ms/im)**       | 2921                                  | 857                  | **8.4**            |
-| **Model Size**               | 3.45 GB                               | 162 MB (base)        | **6.4 MB**         |
+| Capability                   | SAM 3                                 | SAM 2                | YOLO26n-seg      |
+| ---------------------------- | ------------------------------------- | -------------------- | ---------------- |
+| **Concept Segmentation**     | ✅ All instances from text/exemplars  | ❌ Not supported     | ❌ Not supported |
+| **Visual Segmentation**      | ✅ Single instance (SAM 2 compatible) | ✅ Single instance   | ✅ All instances |
+| **Zero-shot Capability**     | ✅ Open vocabulary                    | ✅ Geometric prompts | ❌ Closed set    |
+| **Interactive Refinement**   | ✅ Exemplars + clicks                 | ✅ Clicks only       | ❌ Not supported |
+| **Video Tracking**           | ✅ Multi-object with identities       | ✅ Multi-object      | ✅ Multi-object  |
+| **LVIS Mask AP (zero-shot)** | **47.0**                              | N/A                  | N/A              |
+| **MOSEv2 J&F**               | **60.1**                              | 47.9                 | N/A              |
+| **Speed (GPU, ms/im)**       | 2921                                  | 857                  | **8.4**          |
+| **Model Size**               | 3.45 GB                               | 162 MB (base)        | **6.4 MB**       |
 
 Speed benchmarked on NVIDIA RTX PRO 6000 with `torch==2.9.1` and `ultralytics==8.4.19`.
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -455,7 +455,7 @@ The dialog provides three ways to set your target split ratios:
 | -------- | -------------------------------------------------------------------------------------------- |
 | **Drag** | Drag the handles between the colored segments to visually adjust split boundaries            |
 | **Type** | Edit the percentage input for any split (the other two splits auto-rebalance proportionally) |
-| **Auto** | One-click to instantly set the recommended 80/20 train/validation split                      |
+| **Auto** | One-click to instantly set an 80/20 train/validation split with the test split set to 0%        |
 
 A live preview shows exactly how many images will land in each split before you apply.
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -438,14 +438,30 @@ You can also drag and drop images onto the split filter tabs in grid view.
 
     Upload all images to one dataset, then use bulk move-to-split to organize subsets into train, validation, and test splits.
 
-### Auto Split Redistribution
+### Split Redistribution
 
-Automatically distribute images across train, validation, and test splits:
+Redistribute all images across train, validation, and test splits using custom ratios:
 
-1. Click the split redistribution button in the dataset toolbar
-2. The Platform automatically assigns images to splits based on standard ratios
+1. Click the **split bar** in the dataset toolbar to open the **Redistribute Splits** dialog
+2. Adjust split percentages using any of the methods below
+3. Review the live image count preview to confirm the distribution
+4. Click **Apply** to randomly reassign all images according to your percentages
 
-This is useful when you upload images without split folders and want to quickly organize them for training.
+![Ultralytics Platform Datasets Split Redistribution Dialog](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-datasets-split-redistribution-dialog.avif)
+
+The dialog provides three ways to set your target split ratios:
+
+| Method   | Description                                                                                  |
+| -------- | -------------------------------------------------------------------------------------------- |
+| **Drag** | Drag the handles between the colored segments to visually adjust split boundaries            |
+| **Type** | Edit the percentage input for any split (the other two splits auto-rebalance proportionally) |
+| **Auto** | One-click to instantly set the recommended 80/20 train/validation split                      |
+
+A live preview shows exactly how many images will land in each split before you apply.
+
+!!! tip "Quick 80/20 Split"
+
+    Click the **Auto** button to instantly set the recommended 80/20 train/validation split. This is the most common ratio for training.
 
 ### Bulk Delete
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves the Ultralytics Platform dataset docs by expanding and clarifying how users can redistribute train, validation, and test splits with custom ratios.

### 📊 Key Changes
- Renamed the documentation section from **Auto Split Redistribution** to **Split Redistribution** for clearer wording.
- Updated the workflow to explain the new **Redistribute Splits** dialog opened from the **split bar** in the dataset toolbar.
- Added step-by-step instructions for:
  - opening the dialog
  - adjusting split percentages
  - previewing image counts live
  - applying the redistribution
- Documented **three ways** to set split ratios:
  - **Drag** split boundaries visually
  - **Type** exact percentage values
  - **Auto** for a one-click 80/20 train/validation split
- Added a new screenshot showing the split redistribution dialog. 🖼️
- Included a **tip callout** highlighting the recommended quick **80/20 split** setup.

### 🎯 Purpose & Impact
- Makes dataset split management easier to understand for both new and experienced users. ✅
- Better reflects the actual Ultralytics Platform UI and available controls, reducing confusion.
- Helps users organize uploaded images more accurately before training YOLO models.
- The live preview and clearer instructions can prevent mistakes when redistributing data across splits. 📊
- Highlighting the one-click **Auto** option encourages a fast, common training setup for many projects. 🚀