### PR TITLE
Remove redundant ray tune test

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -644,6 +644,7 @@ def test_model_tune():
     YOLO("yolo26n-pose.pt").tune(data="coco8-pose.yaml", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
     YOLO("yolo26n-cls.pt").tune(data="imagenet10", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
 
+
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE or not checks.IS_PYTHON_MINIMUM_3_10, reason="environment is offline")
 def test_model_tune_ray():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -643,17 +643,6 @@ def test_model_tune():
     """Tune YOLO model for performance improvement."""
     YOLO("yolo26n-pose.pt").tune(data="coco8-pose.yaml", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
     YOLO("yolo26n-cls.pt").tune(data="imagenet10", plots=False, imgsz=32, epochs=1, iterations=2, device="cpu")
-    YOLO("yolo26n-cls.pt").tune(
-        data="imagenet10",
-        use_ray=True,
-        plots=False,
-        imgsz=32,
-        epochs=1,
-        iterations=2,
-        search_alg="random",
-        device="cpu",
-    )
-
 
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE or not checks.IS_PYTHON_MINIMUM_3_10, reason="environment is offline")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR simplifies the Python test suite by removing a `use_ray=True` hyperparameter tuning test for YOLO26 classification models.

### 📊 Key Changes
- Removed a test case in `tests/test_python.py` that called `YOLO("yolo26n-cls.pt").tune(...)` with `use_ray=True`.
- Kept the standard tuning tests for:
  - YOLO26 pose models
  - YOLO26 classification models without Ray-based tuning
- Eliminated the extra test parameters related to Ray integration, including `search_alg="random"`.

### 🎯 Purpose & Impact
- Reduces test suite complexity and maintenance burden 🛠️
- Avoids relying on Ray-specific tuning behavior in core Python tests, which can be harder to maintain or more brittle ⚠️
- Keeps coverage focused on the main built-in tuning functionality that most users depend on ✅
- Likely improves test reliability and consistency across environments, especially where Ray is not installed or configured 🚀