### PR TITLE
Docs: Fix Banner Link

### DIFF
--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -455,7 +455,7 @@ The dialog provides three ways to set your target split ratios:
 | -------- | -------------------------------------------------------------------------------------------- |
 | **Drag** | Drag the handles between the colored segments to visually adjust split boundaries            |
 | **Type** | Edit the percentage input for any split (the other two splits auto-rebalance proportionally) |
-| **Auto** | One-click to instantly set an 80/20 train/validation split with the test split set to 0%        |
+| **Auto** | One-click to instantly set an 80/20 train/validation split with the test split set to 0%     |
 
 A live preview shows exactly how many images will land in each split before you apply.
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -19,21 +19,27 @@
   });
 </script>
 {{ super() }} {% endblock %} {% block announce %}
-<div class="banner-wrapper">
-  <a href="https://platform.ultralytics.com" target="_blank" class="banner-content-wrapper">
+<a
+  href="https://platform.ultralytics.com"
+  target="_blank"
+  class="banner-wrapper"
+>
+  <div class="banner-content-wrapper">
     <img
       src="https://cdn.prod.website-files.com/680a070c3b99253410dd3dcf/680a070c3b99253410dd3e84_Ultralytics_full_white.svg"
       alt="Ultralytics"
       class="banner-logo"
     />
-    <p>Introducing Ultralytics Platform: Annotate, train, and deploy YOLO models</p>
-  </a>
+    <p>
+      Introducing Ultralytics Platform: Annotate, train, and deploy YOLO models
+    </p>
+  </div>
   <img
     src="https://cdn.prod.website-files.com/680a070c3b99253410dd3dcf/69ba5bb596507e4235390de5_banner-arrow-right.png"
     alt="Arrow"
     class="banner-arrow"
   />
-</div>
+</a>
 {% endblock %} {% block scripts %}
 <noscript
   ><iframe
@@ -46,11 +52,13 @@
 
 {{ super() }}
 <script defer src="/_vercel/insights/script.js"></script>
-{% endblock %} {% block htmltitle %} {% if page and page.toc is defined and page.toc.items is defined and page.toc.items
-%} {% set page_specific_title = page.toc.items[0].title %} {% elif page %} {% set page_specific_title = page.title |
-striptags %} {% else %} {% set page_specific_title = "" %} {% endif %}
+{% endblock %} {% block htmltitle %} {% if page and page.toc is defined and
+page.toc.items is defined and page.toc.items %} {% set page_specific_title =
+page.toc.items[0].title %} {% elif page %} {% set page_specific_title =
+page.title | striptags %} {% else %} {% set page_specific_title = "" %} {% endif
+%}
 <title>
-  {%- if page_specific_title -%} {{ page_specific_title }} - {{ config.site_name }} {%- else -%} {{ config.site_name }}
-  {%- endif -%}
+  {%- if page_specific_title -%} {{ page_specific_title }} - {{ config.site_name
+  }} {%- else -%} {{ config.site_name }} {%- endif -%}
 </title>
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -19,20 +19,14 @@
   });
 </script>
 {{ super() }} {% endblock %} {% block announce %}
-<a
-  href="https://platform.ultralytics.com"
-  target="_blank"
-  class="banner-wrapper"
->
+<a href="https://platform.ultralytics.com" target="_blank" class="banner-wrapper">
   <div class="banner-content-wrapper">
     <img
       src="https://cdn.prod.website-files.com/680a070c3b99253410dd3dcf/680a070c3b99253410dd3e84_Ultralytics_full_white.svg"
       alt="Ultralytics"
       class="banner-logo"
     />
-    <p>
-      Introducing Ultralytics Platform: Annotate, train, and deploy YOLO models
-    </p>
+    <p>Introducing Ultralytics Platform: Annotate, train, and deploy YOLO models</p>
   </div>
   <img
     src="https://cdn.prod.website-files.com/680a070c3b99253410dd3dcf/69ba5bb596507e4235390de5_banner-arrow-right.png"
@@ -52,13 +46,11 @@
 
 {{ super() }}
 <script defer src="/_vercel/insights/script.js"></script>
-{% endblock %} {% block htmltitle %} {% if page and page.toc is defined and
-page.toc.items is defined and page.toc.items %} {% set page_specific_title =
-page.toc.items[0].title %} {% elif page %} {% set page_specific_title =
-page.title | striptags %} {% else %} {% set page_specific_title = "" %} {% endif
-%}
+{% endblock %} {% block htmltitle %} {% if page and page.toc is defined and page.toc.items is defined and page.toc.items
+%} {% set page_specific_title = page.toc.items[0].title %} {% elif page %} {% set page_specific_title = page.title |
+striptags %} {% else %} {% set page_specific_title = "" %} {% endif %}
 <title>
-  {%- if page_specific_title -%} {{ page_specific_title }} - {{ config.site_name
-  }} {%- else -%} {{ config.site_name }} {%- endif -%}
+  {%- if page_specific_title -%} {{ page_specific_title }} - {{ config.site_name }} {%- else -%} {{ config.site_name }}
+  {%- endif -%}
 </title>
 {% endblock %}


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR makes a small documentation cleanup and improves the docs site banner markup so the Ultralytics Platform announcement link works more cleanly and consistently.

### 📊 Key Changes
- 🧹 Fixed a minor spacing/formatting issue in the [Ultralytics Platform datasets documentation](https://docs.ultralytics.com/platform/data/datasets/).
- 🔗 Updated the docs site banner HTML in `docs/overrides/main.html`:
  - Changed the outer wrapper from a `<div>` to an `<a>` tag.
  - Moved the banner content inside that anchor.
  - Kept the arrow image inside the clickable banner structure.
- 🏗️ This effectively turns the full announcement banner into a single linked element pointing to the [Ultralytics Platform](https://platform.ultralytics.com).

### 🎯 Purpose & Impact
- ✅ Improves HTML structure and likely fixes a usability issue where only part of the banner was clickable.
- 🎯 Makes it easier for users to access the Ultralytics Platform from the docs with a more intuitive click target.
- 📚 Keeps documentation polished by correcting a small formatting inconsistency.
- 🔍 Low-risk change overall, with impact focused on better docs-site UX rather than model training or inference behavior.