### PR TITLE
Fix Sentry bugs 2026-04-01

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -58,10 +58,7 @@ def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
         except Exception as error:  # pragma: no cover - assertion handled below
             errors.append(error)
 
-    threads = [
-        threading.Thread(target=export_model, args=(i,))
-        for i in range(4)
-    ]
+    threads = [threading.Thread(target=export_model, args=(i,)) for i in range(4)]
     for thread in threads:
         thread.start()
     for thread in threads:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -2,17 +2,21 @@
 
 import io
 import shutil
+import threading
+import time
 import uuid
 from contextlib import redirect_stderr, redirect_stdout
 from itertools import product
 from pathlib import Path
 
 import pytest
+import torch
 
 from tests import MODEL, SOURCE
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.utils import ARM64, IS_DOCKER, IS_RASPBERRYPI, LINUX, MACOS, MACOS_VERSION, WINDOWS, checks
+from ultralytics.utils.export.engine import torch2onnx
 from ultralytics.utils.torch_utils import TORCH_1_10, TORCH_1_11, TORCH_1_13, TORCH_2_0, TORCH_2_1, TORCH_2_8, TORCH_2_9
 
 
@@ -28,6 +32,43 @@ def test_export_onnx(end2end):
     """Test YOLO model export to ONNX format with dynamic axes."""
     file = YOLO(MODEL).export(format="onnx", dynamic=True, imgsz=32, end2end=end2end)
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
+
+
+def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
+    """Ensure ONNX exports do not overlap across worker threads."""
+    active = 0
+    max_active = 0
+    errors = []
+    state_lock = threading.Lock()
+
+    def fake_export(*args, **kwargs):
+        nonlocal active, max_active
+        with state_lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.05)
+        with state_lock:
+            active -= 1
+
+    monkeypatch.setattr(torch.onnx, "export", fake_export)
+
+    def export_model(index: int):
+        try:
+            torch2onnx(torch.nn.Identity(), torch.zeros(1, 3, 8, 8), str(tmp_path / f"export-{index}.onnx"))
+        except Exception as error:  # pragma: no cover - assertion handled below
+            errors.append(error)
+
+    threads = [
+        threading.Thread(target=export_model, args=(i,))
+        for i in range(4)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert max_active == 1
 
 
 @pytest.mark.skipif(not TORCH_2_1, reason="OpenVINO requires torch>=2.1")

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import torch
 
-from ultralytics.utils import IS_JETSON, LOGGER, TORCH_VERSION
+from ultralytics.utils import IS_JETSON, LOGGER, TORCH_VERSION, ThreadingLocked
 from ultralytics.utils.torch_utils import TORCH_2_4, TORCH_2_9
 
 
@@ -42,6 +42,7 @@ def best_onnx_opset(onnx: types.ModuleType, cuda: bool = False) -> int:
     return min(opset, onnx.defs.onnx_opset_version())
 
 
+@ThreadingLocked()
 def torch2onnx(
     torch_model: torch.nn.Module,
     im: torch.Tensor,


### PR DESCRIPTION
## Summary
- Fix ALPHA-D1: https://ultralytics.sentry.io/issues/7222365471/
- Replace the shared ONNX export helper with a thread-safe wrapper so concurrent worker threads cannot enter PyTorch's global ONNX exporter state at the same time.
- Change type: replacement

## Root Cause
PyTorch's legacy ONNX exporter uses process-global mutable state (`GLOBALS.in_onnx_export`). Our alpha workers process export jobs in parallel threads, so overlapping ONNX-based exports could enter `torch.onnx.export()` concurrently and trip `GLOBALS.in_onnx_export must be False` at the start of the next export.

## Minimal Fix
- Serialize `torch2onnx()` with the existing `ThreadingLocked` utility in [`ultralytics/utils/export/engine.py`](../ultralytics/utils/export/engine.py).
- Add a focused regression test in [`tests/test_exports.py`](../ultralytics/tests/test_exports.py) that starts concurrent threads and asserts the ONNX export helper never overlaps.

## Verification
- `python -m py_compile ultralytics/utils/export/engine.py tests/test_exports.py`
- `pytest tests/test_exports.py -k torch2onnx_serializes_concurrent_exports`
- `pytest tests/test_exports.py -k 'test_export_onnx and not matrix'`

## Sentry
- Resolved in next release: ALPHA-D1

## Related
- Portal PR: https://github.com/ultralytics/portal/pull/1583

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔒 This PR makes ONNX export thread-safe by preventing multiple `torch2onnx()` exports from running at the same time, and adds a test to verify concurrent exports are properly serialized.

### 📊 Key Changes
- Added a `@ThreadingLocked()` decorator to `torch2onnx()` in `ultralytics/utils/export/engine.py`.
- This change ensures ONNX export calls are executed one at a time, even when triggered from multiple threads.
- Added a new test in `tests/test_exports.py` that:
  - launches several export threads in parallel,
  - mocks `torch.onnx.export`,
  - verifies exports do not overlap,
  - confirms no thread raises an error.
- Introduced supporting test imports for threading, timing, and PyTorch to simulate and validate concurrent behavior.

### 🎯 Purpose & Impact
- 🛡️ Improves reliability of ONNX exports in multi-threaded environments.
- 🧵 Prevents race conditions or conflicts when several export jobs start at once.
- ✅ Adds automated coverage to catch future regressions in export concurrency behavior.
- 🚀 Especially helpful for users running batch exports, backend services, or apps that may export models in parallel.
- 🔧 Low-risk internal improvement: it does not change the export API, but makes the process safer and more predictable.