### PR TITLE
Update NVIDIA Jetson Orin Nano Super benchmarks with YOLO26

### DIFF
--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -415,7 +415,7 @@ Even though all model exports work on NVIDIA Jetson, we have only included **PyT
 
 <figure style="text-align: center;">
     <img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/jetson-orin-nano-super-benchmarks-coco128.avif" alt="Jetson Orin Nano Super Benchmarks">
-    <figcaption style="font-style: italic; color: gray;">Benchmarked with Ultralytics 8.3.157</figcaption>
+    <figcaption style="font-style: italic; color: gray;">Benchmarked with Ultralytics 8.4.33</figcaption>
 </figure>
 
 #### NVIDIA Jetson Orin NX 16GB
@@ -619,92 +619,92 @@ The below table represents the benchmark results for five different models (YOLO
 
 !!! tip "Performance"
 
-    === "YOLO11n"
+    === "YOLO26n"
 
         | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
         |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 5.4               | 0.5101      | 13.70                  |
-        | TorchScript     | ✅      | 10.5              | 0.5082      | 13.69                  |
-        | ONNX            | ✅      | 10.2              | 0.5081      | 14.47                  |
-        | OpenVINO        | ✅      | 10.4              | 0.5058      | 56.66                  |
-        | TensorRT (FP32) | ✅      | 12.0              | 0.5081      | 7.44                   |
-        | TensorRT (FP16) | ✅      | 8.2               | 0.5061      | 4.53                   |
-        | TensorRT (INT8) | ✅      | 5.4               | 0.4825      | 3.70                   |
-        | TF SavedModel   | ✅      | 25.9              | 0.5077      | 116.23                 |
-        | TF GraphDef     | ✅      | 10.3              | 0.5077      | 114.92                 |
-        | TF Lite         | ✅      | 10.3              | 0.5077      | 340.75                 |
-        | MNN             | ✅      | 10.1              | 0.5059      | 76.26                  |
-        | NCNN            | ✅      | 10.2              | 0.5031      | 45.03                  |
+        | PyTorch         | ✅      | 5.3               | 0.4790      | 15.60                  |
+        | TorchScript     | ✅      | 9.8               | 0.4770      | 12.60                  |
+        | ONNX            | ✅      | 9.5               | 0.4760      | 15.76                  |
+        | OpenVINO        | ✅      | 9.6               | 0.4820      | 56.23                  |
+        | TensorRT (FP32) | ✅      | 11.3              | 0.4770      | 7.53                   |
+        | TensorRT (FP16) | ✅      | 8.1               | 0.4800      | 4.57                   |
+        | TensorRT (INT8) | ✅      | 5.3               | 0.4490      | 3.80                   |
+        | TF SavedModel   | ✅      | 24.6              | 0.4760      | 118.33                 |
+        | TF GraphDef     | ✅      | 9.5               | 0.4760      | 116.30                 |
+        | TF Lite         | ✅      | 9.9               | 0.4760      | 286.00                 |
+        | MNN             | ✅      | 9.4               | 0.4760      | 68.77                  |
+        | NCNN            | ✅      | 9.3               | 0.4810      | 47.50                  |
 
-    === "YOLO11s"
-
-        | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
-        |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 18.4              | 0.5790      | 20.90                  |
-        | TorchScript     | ✅      | 36.5              | 0.5781      | 21.22                  |
-        | ONNX            | ✅      | 36.3              | 0.5781      | 25.07                  |
-        | OpenVINO        | ✅      | 36.4              | 0.5810      | 122.98                 |
-        | TensorRT (FP32) | ✅      | 37.9              | 0.5783      | 13.02                  |
-        | TensorRT (FP16) | ✅      | 21.8              | 0.5779      | 6.93                   |
-        | TensorRT (INT8) | ✅      | 12.2              | 0.5735      | 5.08                   |
-        | TF SavedModel   | ✅      | 91.0              | 0.5782      | 250.65                 |
-        | TF GraphDef     | ✅      | 36.4              | 0.5782      | 252.69                 |
-        | TF Lite         | ✅      | 36.3              | 0.5782      | 998.68                 |
-        | MNN             | ✅      | 36.2              | 0.5781      | 188.01                 |
-        | NCNN            | ✅      | 36.2              | 0.5784      | 101.37                 |
-
-    === "YOLO11m"
+    === "YOLO26s"
 
         | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
         |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 38.8              | 0.6266      | 46.50                  |
-        | TorchScript     | ✅      | 77.3              | 0.6307      | 47.95                  |
-        | ONNX            | ✅      | 76.9              | 0.6307      | 53.06                  |
-        | OpenVINO        | ✅      | 77.1              | 0.6284      | 301.63                 |
-        | TensorRT (FP32) | ✅      | 78.8              | 0.6305      | 27.86                  |
-        | TensorRT (FP16) | ✅      | 41.7              | 0.6309      | 13.50                  |
-        | TensorRT (INT8) | ✅      | 23.2              | 0.6291      | 9.12                   |
-        | TF SavedModel   | ✅      | 192.7             | 0.6307      | 622.24                 |
-        | TF GraphDef     | ✅      | 77.1              | 0.6307      | 628.74                 |
-        | TF Lite         | ✅      | 77.0              | 0.6307      | 2997.93                |
-        | MNN             | ✅      | 76.8              | 0.6299      | 509.96                 |
-        | NCNN            | ✅      | 76.8              | 0.6284      | 292.99                 |
+        | PyTorch         | ✅      | 20.0              | 0.5730      | 22.83                  |
+        | TorchScript     | ✅      | 36.8              | 0.5670      | 21.83                  |
+        | ONNX            | ✅      | 36.5              | 0.5664      | 26.29                  |
+        | OpenVINO        | ✅      | 36.7              | 0.5653      | 127.09                 |
+        | TensorRT (FP32) | ✅      | 38.2              | 0.5664      | 13.60                  |
+        | TensorRT (FP16) | ✅      | 21.3              | 0.5649      | 7.17                   |
+        | TensorRT (INT8) | ✅      | 12.7              | 0.5468      | 5.25                   |
+        | TF SavedModel   | ✅      | 92.2              | 0.5665      | 263.69                 |
+        | TF GraphDef     | ✅      | 36.5              | 0.5665      | 268.21                 |
+        | TF Lite         | ✅      | 36.9              | 0.5665      | 949.63                 |
+        | MNN             | ✅      | 36.4              | 0.5644      | 184.68                 |
+        | NCNN            | ✅      | 36.4              | 0.5697      | 107.48                 |
 
-    === "YOLO11l"
-
-        | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
-        |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 49.0              | 0.6364      | 56.50                  |
-        | TorchScript     | ✅      | 97.6              | 0.6409      | 62.51                  |
-        | ONNX            | ✅      | 97.0              | 0.6399      | 68.35                  |
-        | OpenVINO        | ✅      | 97.3              | 0.6378      | 376.03                 |
-        | TensorRT (FP32) | ✅      | 99.2              | 0.6396      | 35.59                  |
-        | TensorRT (FP16) | ✅      | 52.1              | 0.6361      | 17.48                  |
-        | TensorRT (INT8) | ✅      | 30.9              | 0.6207      | 11.87                  |
-        | TF SavedModel   | ✅      | 243.1             | 0.6409      | 807.47                 |
-        | TF GraphDef     | ✅      | 97.2              | 0.6409      | 822.88                 |
-        | TF Lite         | ✅      | 97.1              | 0.6409      | 3792.23                |
-        | MNN             | ✅      | 96.9              | 0.6372      | 631.16                 |
-        | NCNN            | ✅      | 96.9              | 0.6364      | 350.46                 |
-
-    === "YOLO11x"
+    === "YOLO26m"
 
         | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
         |-----------------|--------|-------------------|-------------|------------------------|
-        | PyTorch         | ✅      | 109.3             | 0.7005      | 90.00                  |
-        | TorchScript     | ✅      | 218.1             | 0.6901      | 113.40                 |
-        | ONNX            | ✅      | 217.5             | 0.6901      | 122.94                 |
-        | OpenVINO        | ✅      | 217.8             | 0.6876      | 713.1                  |
-        | TensorRT (FP32) | ✅      | 219.5             | 0.6904      | 66.93                  |
-        | TensorRT (FP16) | ✅      | 112.2             | 0.6892      | 32.58                  |
-        | TensorRT (INT8) | ✅      | 61.5              | 0.6612      | 19.90                  |
-        | TF SavedModel   | ✅      | 544.3             | 0.6900      | 1605.4                 |
-        | TF GraphDef     | ✅      | 217.8             | 0.6900      | 2961.8                 |
-        | TF Lite         | ✅      | 217.6             | 0.6900      | 8234.86                |
-        | MNN             | ✅      | 217.3             | 0.6893      | 1254.18                |
-        | NCNN            | ✅      | 217.3             | 0.6849      | 725.50                 |
+        | PyTorch         | ✅      | 43.0              | 0.6220      | 44.43                  |
+        | TorchScript     | ✅      | 78.5              | 0.6230      | 44.00                  |
+        | ONNX            | ✅      | 78.2              | 0.6225      | 53.44                  |
+        | OpenVINO        | ✅      | 78.3              | 0.6186      | 303.26                 |
+        | TensorRT (FP32) | ✅      | 80.0              | 0.6217      | 28.19                  |
+        | TensorRT (FP16) | ✅      | 42.6              | 0.6225      | 13.59                  |
+        | TensorRT (INT8) | ✅      | 23.4              | 0.5817      | 9.30                   |
+        | TF SavedModel   | ✅      | 196.3             | 0.6229      | 636.03                 |
+        | TF GraphDef     | ✅      | 78.2              | 0.6229      | 659.57                 |
+        | TF Lite         | ✅      | 78.5              | 0.6229      | 2905.17                |
+        | MNN             | ✅      | 78.0              | 0.6168      | 500.09                 |
+        | NCNN            | ✅      | 78.0              | 0.6224      | 332.39                 |
 
-    Benchmarked with Ultralytics 8.3.157
+    === "YOLO26l"
+
+        | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
+        |-----------------|--------|-------------------|-------------|------------------------|
+        | PyTorch         | ✅      | 51.0              | 0.6230      | 60.97                  |
+        | TorchScript     | ✅      | 95.5              | 0.6250      | 56.20                  |
+        | ONNX            | ✅      | 95.0              | 0.6247      | 68.12                  |
+        | OpenVINO        | ✅      | 95.3              | 0.6238      | 397.84                 |
+        | TensorRT (FP32) | ✅      | 97.1              | 0.6250      | 35.88                  |
+        | TensorRT (FP16) | ✅      | 51.4              | 0.6225      | 17.42                  |
+        | TensorRT (INT8) | ✅      | 30.0              | 0.5923      | 11.83                  |
+        | TF SavedModel   | ✅      | 238.4             | 0.6245      | 835.83                 |
+        | TF GraphDef     | ✅      | 95.0              | 0.6245      | 852.16                 |
+        | TF Lite         | ✅      | 95.4              | 0.6245      | 3650.85                |
+        | MNN             | ✅      | 94.8              | 0.6257      | 612.37                 |
+        | NCNN            | ✅      | 94.8              | 0.6323      | 405.45                 |
+
+    === "YOLO26x"
+
+        | Format          | Status | Size on disk (MB) | mAP50-95(B) | Inference time (ms/im) |
+        |-----------------|--------|-------------------|-------------|------------------------|
+        | PyTorch         | ✅      | 113.2             | 0.6561      | 98.44                  |
+        | TorchScript     | ✅      | 214.0             | 0.6593      | 98.0                   |
+        | ONNX            | ✅      | 212.9             | 0.6595      | 122.43                 |
+        | OpenVINO        | ✅      | 213.2             | 0.6592      | 760.72                 |
+        | TensorRT (FP32) | ✅      | 215.1             | 0.6593      | 67.17                  |
+        | TensorRT (FP16) | ✅      | 110.2             | 0.6637      | 32.60                  |
+        | TensorRT (INT8) | ✅      | 59.9              | 0.6170      | 19.99                  |
+        | TF SavedModel   | ✅      | 533.3             | 0.6593      | 1647.06                |
+        | TF GraphDef     | ✅      | 212.9             | 0.6593      | 1670.30                |
+        | TF Lite         | ✅      | 213.3             | 0.6590      | 8066.30                |
+        | MNN             | ✅      | 212.8             | 0.6600      | 1227.90                |
+        | NCNN            | ✅      | 212.8             | 0.6666      | 782.24                 |
+
+    Benchmarked with Ultralytics 8.4.33
 
     !!! note
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📘 This PR refreshes the NVIDIA Jetson guide by replacing older YOLO11 benchmark tables with updated YOLO26 benchmark results and noting they were generated with a newer Ultralytics release.

### 📊 Key Changes
- 🔄 Updated the Jetson benchmark documentation from **YOLO11** model entries to **YOLO26** entries:
  - `YOLO26n`
  - `YOLO26s`
  - `YOLO26m`
  - `YOLO26l`
  - `YOLO26x`
- 📈 Replaced the benchmark values across multiple export formats, including:
  - PyTorch
  - TorchScript
  - ONNX
  - OpenVINO
  - TensorRT FP32 / FP16 / INT8
  - TensorFlow SavedModel / GraphDef / Lite
  - MNN
  - NCNN
- 🏷️ Updated benchmark version labels from **Ultralytics 8.3.157** to **Ultralytics 8.4.33** in both the figure caption and benchmark section.
- 🧾 Refreshed reported model sizes, accuracy, and inference times to match the newer benchmark runs on NVIDIA Jetson devices.

### 🎯 Purpose & Impact
- 🎯 Keeps the Jetson documentation aligned with **YOLO26**, the latest recommended Ultralytics model family.
- 🤝 Gives users more current performance expectations when choosing a model and export format for Jetson deployment.
- 🚀 Helps developers and edge AI users make better tradeoffs between **speed, accuracy, and model size** on NVIDIA hardware.
- 📚 Improves documentation accuracy, reducing confusion for users comparing older YOLO11 results with current Ultralytics releases.
- ⚠️ Since this is a documentation and benchmark refresh, it likely does **not change runtime code behavior**, but it may influence deployment decisions based on the new published results.