### PR TITLE
Add https://youtu.be/Y7cfNkqSdMg to docs

### DIFF
--- a/docs/en/datasets/classify/caltech256.md
+++ b/docs/en/datasets/classify/caltech256.md
@@ -10,13 +10,13 @@ The [Caltech-256](https://data.caltech.edu/records/nyy15-4j048) dataset is an ex
 
 <p align="center">
   <br>
-  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/isc06_9qnM0"
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/Y7cfNkqSdMg"
     title="YouTube video player" frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> How to Train <a href="https://www.ultralytics.com/glossary/image-classification">Image Classification</a> Model using Caltech-256 Dataset with Ultralytics Platform
+  <strong>Watch:</strong> How to Train <a href="https://www.ultralytics.com/glossary/image-classification">Image Classification</a> Model using Caltech-256 Dataset with Ultralytics YOLO26
 </p>
 
 !!! note "Automatic Data Splitting"


### PR DESCRIPTION
@glenn-jocher @Laughing-q

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Caltech-256 classification dataset documentation to embed the correct YouTube tutorial and refresh the caption text to reference Ultralytics YOLO26 🎥📚

### 📊 Key Changes
- Replaced the embedded YouTube video in `docs/en/datasets/classify/caltech256.md` with the new video ID `Y7cfNkqSdMg`
- Updated the watch caption from "Ultralytics Platform" to "Ultralytics YOLO26"
- Kept the change scoped only to the Caltech-256 classification docs page

### 🎯 Purpose & Impact
- Improves documentation accuracy by pointing users to the intended tutorial content
- Aligns dataset documentation messaging with current Ultralytics model branding, including YOLO26
- Helps classification users find more relevant training guidance directly from the dataset page 🚀