### PR TITLE
fix: 🐞 `draw_specific_kpts` to respect user-specified indices order

### DIFF
--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -466,7 +466,8 @@ class SolutionAnnotator(Annotator):
 
         Args:
             keypoints (list[list[float]]): Keypoints data to be plotted, each in format [x, y, confidence].
-            indices (list[int], optional): Keypoint indices to be plotted.
+            indices (list[int], optional): Keypoint indices to be plotted. The drawing order follows the order of
+                this list.
             radius (int): Keypoint radius.
             conf_thresh (float): Confidence threshold for keypoints.
 
@@ -478,7 +479,12 @@ class SolutionAnnotator(Annotator):
             Modifies self.im in-place.
         """
         indices = indices or [2, 5, 7]
-        points = [(int(k[0]), int(k[1])) for i, k in enumerate(keypoints) if i in indices and k[2] >= conf_thresh]
+        n = len(keypoints)
+        points = [
+            (int(keypoints[j][0]), int(keypoints[j][1]))
+            for j in indices
+            if 0 <= j < n and (float(keypoints[j][2]) if len(keypoints[j]) > 2 else 1.0) >= conf_thresh
+        ]
 
         # Draw lines between consecutive points
         for start, end in zip(points[:-1], points[1:]):

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -466,8 +466,8 @@ class SolutionAnnotator(Annotator):
 
         Args:
             keypoints (list[list[float]]): Keypoints data to be plotted, each in format [x, y, confidence].
-            indices (list[int], optional): Keypoint indices to be plotted. The drawing order follows the order of
-                this list.
+            indices (list[int], optional): Keypoint indices to be plotted. The drawing order follows the order of this
+                list.
             radius (int): Keypoint radius.
             conf_thresh (float): Confidence threshold for keypoints.
 


### PR DESCRIPTION
Fixes https://github.com/ultralytics/ultralytics/issues/23652


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves keypoint drawing in `solutions.py` so selected keypoints are rendered in the exact user-specified order, with safer handling of missing confidence values and invalid indices 🎯

### 📊 Key Changes
- Updated `draw_specific_kpts()` in `ultralytics/solutions/solutions.py` to preserve the order of the provided `indices` list when drawing keypoints and connecting lines 🔄
- Replaced the previous filtering logic with direct iteration over `indices`, ensuring points are collected in the intended sequence ✅
- Added bounds checking so out-of-range keypoint indices are safely ignored instead of causing issues 🛡️
- Improved confidence handling:
  - Uses the keypoint confidence value when available
  - Falls back to full confidence if a keypoint does not include a confidence field 🤝
- Clarified the docstring to explicitly state that drawing order follows the order of the `indices` list 📝

### 🎯 Purpose & Impact
- Makes keypoint visualization more predictable, especially when users want to draw custom point sequences or skeleton segments 🎨
- Prevents accidental mis-ordering of lines between keypoints, which could previously produce incorrect visual connections 📍
- Improves robustness for varied keypoint input formats, including data without explicit confidence scores 🔧
- Reduces the chance of errors from invalid indices, making the solution code safer and easier to use for real-world applications 🚀