### PR TITLE
Resume WandB run when training resumes

### DIFF
--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -129,13 +129,17 @@ def on_pretrain_routine_start(trainer):
     """Initialize and start wandb project if module is present."""
     if not wb.run:
         from datetime import datetime
+        from pathlib import Path
 
         name = str(trainer.args.name).replace("/", "-").replace(" ", "_")
+        latest_run = Path(trainer.save_dir) / "wandb" / "latest-run"
+        resuming = trainer.args.resume and latest_run.exists()
         wb.init(
             project=str(trainer.args.project).replace("/", "-") if trainer.args.project else "Ultralytics",
             name=name,
             config=vars(trainer.args),
-            id=f"{name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",  # add unique id
+            id=latest_run.resolve().name.split("-", 2)[2] if resuming else f"{name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
+            resume="allow" if resuming else None,
             dir=str(trainer.save_dir),
         )
 

--- a/ultralytics/utils/callbacks/wb.py
+++ b/ultralytics/utils/callbacks/wb.py
@@ -138,7 +138,9 @@ def on_pretrain_routine_start(trainer):
             project=str(trainer.args.project).replace("/", "-") if trainer.args.project else "Ultralytics",
             name=name,
             config=vars(trainer.args),
-            id=latest_run.resolve().name.split("-", 2)[2] if resuming else f"{name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
+            id=latest_run.resolve().name.split("-", 2)[2]
+            if resuming
+            else f"{name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
             resume="allow" if resuming else None,
             dir=str(trainer.save_dir),
         )


### PR DESCRIPTION
When `resume=True` is passed to the trainer, WandB would previously start a 
fresh disconnected run even though training continued from a checkpoint. 
This change detects the `wandb/latest-run` symlink in the save directory and 
passes the original run ID back to `wb.init` with `resume="allow"`, so metrics 
continue appending to the existing dashboard run instead of creating a new one.

```python
# Initial training
model = YOLO("yolo26n.pt")
model.train(data="coco8.yaml", epochs=60, name="deneme_debug")

# Resume — model points to last checkpoint, not the original weights
model = YOLO("runs/detect/deneme_debug/weights/last.pt")
model.train(resume=True)  # WandB run continues from where it left off
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR improves Weights & Biases (W&B) run handling so resumed Ultralytics training sessions can continue logging to the same W&B run instead of creating a new one.

### 📊 Key Changes
- Added logic in `ultralytics/utils/callbacks/wb.py` to detect whether training is being resumed.
- Checks for an existing W&B run folder at `wandb/latest-run` inside the training save directory.
- If resuming, reuses the existing W&B run ID from the previous run folder instead of generating a new timestamp-based ID.
- Sets `resume="allow"` in `wb.init()` when a resumable W&B run is found.
- Keeps the existing behavior of creating a new unique W&B run ID for fresh training runs.

### 🎯 Purpose & Impact
- 📈 Ensures resumed training sessions stay connected to the original W&B experiment, keeping logs and metrics in one place.
- 🧹 Reduces duplicate or fragmented W&B runs that can make experiment tracking harder to follow.
- 🔍 Makes training history clearer for users monitoring long-running or interrupted jobs.
- ⚙️ Improves the reliability of experiment tracking with minimal behavior change for new runs.
- 🙌 Benefits anyone using W&B with Ultralytics training, especially when resuming interrupted jobs or continuing previous experiments.