### PR TITLE
Fix AAttn: resolve shape mismatches and crashes when dim is not divisible by `num_heads`

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1691,7 +1691,7 @@ class AAttn(nn.Module):
         Returns:
             (torch.Tensor): Output tensor after area-attention.
         """
-        B, C, H, W = x.shape
+        B, _, H, W = x.shape
         N = H * W
 
         qkv = self.qkv(x).flatten(2).transpose(1, 2)
@@ -1713,7 +1713,7 @@ class AAttn(nn.Module):
             x = x.reshape(B // self.area, N * self.area, self.all_head_dim)
             v = v.reshape(B // self.area, N * self.area, self.all_head_dim)
             B, N, _ = x.shape
-        
+
         x = x.reshape(B, H, W, self.all_head_dim).permute(0, 3, 1, 2).contiguous()
         v = v.reshape(B, H, W, self.all_head_dim).permute(0, 3, 1, 2).contiguous()
 

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1676,11 +1676,11 @@ class AAttn(nn.Module):
 
         self.num_heads = num_heads
         self.head_dim = head_dim = dim // num_heads
-        all_head_dim = head_dim * self.num_heads
+        self.all_head_dim = all_head_dim = head_dim * self.num_heads
 
         self.qkv = Conv(dim, all_head_dim * 3, 1, act=False)
         self.proj = Conv(all_head_dim, dim, 1, act=False)
-        self.pe = Conv(all_head_dim, dim, 7, 1, 3, g=dim, act=False)
+        self.pe = Conv(all_head_dim, all_head_dim, 7, 1, 3, g=all_head_dim, act=False)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Process the input tensor through the area-attention.
@@ -1696,7 +1696,7 @@ class AAttn(nn.Module):
 
         qkv = self.qkv(x).flatten(2).transpose(1, 2)
         if self.area > 1:
-            qkv = qkv.reshape(B * self.area, N // self.area, C * 3)
+            qkv = qkv.reshape(B * self.area, N // self.area, self.all_head_dim * 3)
             B, N, _ = qkv.shape
         q, k, v = (
             qkv.view(B, N, self.num_heads, self.head_dim * 3)
@@ -1710,12 +1710,12 @@ class AAttn(nn.Module):
         v = v.permute(0, 3, 1, 2)
 
         if self.area > 1:
-            x = x.reshape(B // self.area, N * self.area, C)
-            v = v.reshape(B // self.area, N * self.area, C)
+            x = x.reshape(B // self.area, N * self.area, self.all_head_dim)
+            v = v.reshape(B // self.area, N * self.area, self.all_head_dim)
             B, N, _ = x.shape
-
-        x = x.reshape(B, H, W, C).permute(0, 3, 1, 2).contiguous()
-        v = v.reshape(B, H, W, C).permute(0, 3, 1, 2).contiguous()
+        
+        x = x.reshape(B, H, W, self.all_head_dim).permute(0, 3, 1, 2).contiguous()
+        v = v.reshape(B, H, W, self.all_head_dim).permute(0, 3, 1, 2).contiguous()
 
         x = x + self.pe(v)
         return self.proj(x)


### PR DESCRIPTION
### Description

I noticed that the `AAttn` class attempts to handle cases where `dim` is not divisible by `num_heads` by defining the `all_head_dim` variable. However, the current implementation doesn't use it consistently, which leads to crashes in both initialization and forward passes.

Specifically, when `dim % num_heads != 0`, the original code encounters 3 critical issues:
1. **Initialization Crash (`ValueError`):** In `self.pe`, the module is initialized with `in_channels=all_head_dim` but `groups=dim`. This triggers `ValueError: in_channels must be divisible by groups`.
<img width="691" height="343" alt="2026-04-02 221235" src="https://github.com/user-attachments/assets/a0c5ed68-5236-4ce1-89d8-7ff03a33a8cb" />

2. **Reshape Crash (`RuntimeError`):** In the forward pass, `x` cannot be properly reshaped because it forces the use of the original `C` (`dim`) instead of the internally processed channel size.
<img width="735" height="193" alt="image" src="https://github.com/user-attachments/assets/763bd34c-7183-4145-b02e-4f524923dbcd" />

3. **Addition Mismatch:** `x + self.pe(v)` results in adding two tensors of different shapes, and passing this broken state to `self.proj(x)` would fail.

### How this PR fixes it

This PR corrects the internal channel logic to consistently use the calculated `all_head_dim` (which resolves to `head_dim * num_heads`) for intermediate operations. 

- **No structural changes:** It does not change the final input/output shapes.
- **Logic preserved:** All underlying operations (group convolutions, dimensional transformations) are kept exactly as intended.
- **Robustness:** The code now successfully handles ANY `dim` input, fulfilling the original intent of defining `all_head_dim` and significantly improving the module's robustness for custom/lightweight model designs.

### Minimum Reproducible Example (Before this PR)
```python
from ultralytics.nn.modules.block import AAttn
import torch

# This will crash immediately before this PR
model = AAttn(dim=18, num_heads=4, area=2)
input_tensor = torch.randn(1, 18, 8, 8)
output = model(input_tensor)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `AAttn` tensor shape handling so attention blocks no longer crash when `dim` is not evenly divisible by `num_heads`. 🛠️

### 📊 Key Changes
- Stores `self.all_head_dim` explicitly and uses it consistently throughout the module.
- Updates `pe` to operate on `all_head_dim` channels instead of mismatched `dim` channels, including matching grouped convolution settings.
- Fixes `qkv` reshaping in area-attention mode to use `self.all_head_dim * 3` rather than the original input channel count.
- Corrects `x` and `v` reshape paths after area merging to use `self.all_head_dim` instead of `C`.
- Aligns final spatial reshapes before positional encoding with the actual projected attention width.

### 🎯 Purpose & Impact
- Prevents runtime shape mismatches and crashes in `AAttn` for configurations where `dim % num_heads != 0`. ✅
- Makes channel flow through attention, positional encoding, and projection internally consistent.
- Improves robustness for custom model definitions and edge-case architectures using this block.
- Keeps the fix narrowly scoped to Python module logic, reducing regression risk. 🚀