### PR TITLE
Clamp coordinates in `crop_mask` before cropping

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -464,7 +464,7 @@ def crop_mask(masks: torch.Tensor, boxes: torch.Tensor) -> torch.Tensor:
         boxes = boxes.to(masks.device)
     n, h, w = masks.shape
     if n < 50 and not masks.is_cuda:  # faster for fewer masks (predict)
-        for i, (x1, y1, x2, y2) in enumerate(boxes.round().int()):
+        for i, (x1, y1, x2, y2) in enumerate(boxes.clamp(min=0).round().int()):
             masks[i, :y1] = 0
             masks[i, y2:] = 0
             masks[i, :, :x1] = 0


### PR DESCRIPTION
Closes #24100 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes mask cropping in `ops.py` by clamping box coordinates to valid non-negative values before applying crops, improving segmentation robustness.

### 📊 Key Changes
- Updated `crop_mask()` in `ultralytics/utils/ops.py`.
- Changed bounding box handling from `boxes.round().int()` to `boxes.clamp(min=0).round().int()`.
- This ensures negative box coordinates are corrected to `0` before cropping masks on CPU for smaller batches.

### 🎯 Purpose & Impact
- ✅ Prevents invalid negative crop indices from affecting mask cropping behavior.
- 🎯 Makes segmentation post-processing more reliable when predicted boxes extend outside the image boundary.
- 🚀 Reduces the chance of incorrect mask outputs in edge cases, especially during CPU-based prediction with fewer masks.
- 🔒 Improves overall stability with a very small, low-risk code change.