### PR TITLE
Add dataset training readiness documentation

### DIFF
--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -131,7 +131,7 @@ The Platform supports two annotation formats plus raw uploads: [Ultralytics YOLO
 
 !!! tip "Flat Directory Structure"
 
-    You can also upload images without the train/val folder structure. When no split folder is detected, images are treated as `train`. For most non-classify datasets, if no `val` images exist after ingest, the worker automatically reassigns about 20% of `train` images to `val`.
+    You can also upload images without the train/val folder structure. When no split folder is detected, images are treated as `train`. For most non-classify datasets, if no `val` images exist after ingest, the worker automatically reassigns about 20% of `train` images to `val`. You can reassign them later using the bulk move-to-split feature.
 
 !!! tip "Format Auto-Detection"
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -131,7 +131,7 @@ The Platform supports two annotation formats plus raw uploads: [Ultralytics YOLO
 
 !!! tip "Flat Directory Structure"
 
-    You can also upload images without the train/val folder structure. Images uploaded without split folders are assigned to the `train` split by default. You can reassign them later using the bulk move-to-split feature.
+    You can also upload images without the train/val folder structure. When no split folder is detected, images are treated as `train`. For most non-classify datasets, if no `val` images exist after ingest, the worker automatically reassigns about 20% of `train` images to `val`.
 
 !!! tip "Format Auto-Detection"
 
@@ -256,6 +256,34 @@ Filter images by their dataset split:
 | **Train** | Used for model training             |
 | **Val**   | Used for validation during training |
 | **Test**  | Used for final evaluation           |
+
+### Training Readiness
+
+Each dataset shows a training readiness badge:
+
+- **Ready**: The dataset meets the minimum requirements for training.
+- **Not Ready**: One or more training requirements are missing.
+
+To train on a dataset, processing must be complete and the dataset status must be `ready`.
+
+After that, the dataset must also:
+
+1. Have at least 1 image in the `train` split
+2. Have at least 1 image in the `val` or `test` split
+3. Have at least 1 labeled image
+
+If your dataset shows **Not Ready**, open the **Images** tab and use the message in the badge popover to identify what is missing.
+
+Common fixes:
+
+- **Dataset is still processing**: Wait for ingest to finish until the dataset status changes to `ready`.
+- **No training images**: Move at least one image to the `train` split using [Bulk Move to Split](#bulk-move-to-split).
+- **No validation images**: Move at least one image to the `val` or `test` split using [Bulk Move to Split](#bulk-move-to-split), or use [Split Redistribution](#split-redistribution) to rebalance the entire dataset.
+- **No labeled images**: Add annotations in the [annotation editor](annotation.md) or upload labeled data.
+
+!!! tip "Why this happens often after upload"
+
+    If your upload does not include split folders, the worker treats images as `train` first. For most non-classify datasets it then auto-creates a `val` split if none exists, but you can still rebalance splits manually later with [Split Redistribution](#split-redistribution).
 
 ## Dataset Tabs
 

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -52,7 +52,7 @@ Choose a dataset to train on (see [Datasets](../data/datasets.md)):
 
 !!! note "Dataset Requirements"
 
-    Datasets must be in `ready` status with at least 1 image in the train split, 1 image in the validation or test split, and at least 1 labeled image.
+    Datasets must be in `ready` status with at least 1 image in the train split, 1 image in the validation or test split, and at least 1 labeled image. If your dataset shows **Not Ready** or a message such as `No validation images`, see [Training Readiness](../data/datasets.md#training-readiness) for the required conditions and resolution steps.
 
 !!! warning "Task Mismatch"
 


### PR DESCRIPTION
  - Add a new **Training Readiness** section to the datasets docs explaining the ready/not-ready badge, minimum training requirements (train split, val/test split, labeled images), and common fixes
  - Update the flat directory upload tip to clarify the automatic val-split behavior for non-classify datasets
  - Add a cross-reference from the cloud training page to the new training readiness section so users can quickly resolve "Not Ready" issues

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds clearer Ultralytics Platform documentation for dataset training readiness, including readiness criteria, common fixes, and improved guidance for datasets uploaded without split folders. 

### 📊 Key Changes
- Updates dataset upload documentation to explain that images without detected split folders are initially treated as `train`.
- Documents automatic `val` split creation for most non-classify datasets when no validation images exist after ingest.
- Adds a new **Training Readiness** section to `docs/en/platform/data/datasets.md`.
- Lists the minimum requirements for training: processed dataset in `ready` status, at least one `train` image, at least one `val` or `test` image, and at least one labeled image.
- Adds troubleshooting guidance for common **Not Ready** states such as missing training images, validation images, or labels.
- Updates cloud training docs to link directly to the new **Training Readiness** section when users encounter readiness errors.

### 🎯 Purpose & Impact
- Improves clarity for Platform users preparing datasets for training. 📘
- Reduces confusion around automatic split handling after upload. 🗂️
- Helps users diagnose and fix **Not Ready** datasets faster through actionable documentation. ✅
- Creates better cross-linking between dataset management and cloud training docs for a smoother workflow. 🔗