### PR TITLE
Add missing type hints to `segment2box` and `scale_boxes` in `utils/ops.py`

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -100,9 +100,9 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
 
 
 def scale_boxes(
-    img1_shape: tuple,
+    img1_shape: tuple[int, int],
     boxes: torch.Tensor | np.ndarray,
-    img0_shape: tuple,
+    img0_shape: tuple[int, int],
     ratio_pad: tuple | None = None,
     padding: bool = True,
     xywh: bool = False,
@@ -113,9 +113,9 @@ def scale_boxes(
     both xyxy and xywh box formats.
 
     Args:
-        img1_shape (tuple): Shape of the source image (height, width).
+        img1_shape (tuple[int, int]): Shape of the source image (height, width).
         boxes (torch.Tensor | np.ndarray): Bounding boxes to rescale in format (N, 4).
-        img0_shape (tuple): Shape of the target image (height, width).
+        img0_shape (tuple[int, int]): Shape of the target image (height, width).
         ratio_pad (tuple, optional): Tuple of (ratio, pad) for scaling. If None, calculated from image shapes.
         padding (bool): Whether boxes are based on YOLO-style augmented images with padding.
         xywh (bool): Whether box format is xywh (True) or xyxy (False).

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -114,14 +114,14 @@ def scale_boxes(
 
     Args:
         img1_shape (tuple): Shape of the source image (height, width).
-        boxes (torch.Tensor): Bounding boxes to rescale in format (N, 4).
+        boxes (torch.Tensor | np.ndarray): Bounding boxes to rescale in format (N, 4).
         img0_shape (tuple): Shape of the target image (height, width).
         ratio_pad (tuple, optional): Tuple of (ratio, pad) for scaling. If None, calculated from image shapes.
         padding (bool): Whether boxes are based on YOLO-style augmented images with padding.
         xywh (bool): Whether box format is xywh (True) or xyxy (False).
 
     Returns:
-        (torch.Tensor): Rescaled bounding boxes in the same format as input.
+        (torch.Tensor | np.ndarray): Rescaled bounding boxes in the same format as input.
     """
     if ratio_pad is None:  # calculate from img0_shape
         gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -70,7 +70,7 @@ class Profile(contextlib.ContextDecorator):
         return time.perf_counter()
 
 
-def segment2box(segment, width: int = 640, height: int = 640):
+def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.ndarray:
     """Convert segment coordinates to bounding box coordinates.
 
     Converts a single segment label to a box label by finding the minimum and maximum x and y coordinates. Applies
@@ -99,7 +99,9 @@ def segment2box(segment, width: int = 640, height: int = 640):
     )  # xyxy
 
 
-def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, padding: bool = True, xywh: bool = False):
+def scale_boxes(
+    img1_shape: tuple, boxes: torch.Tensor, img0_shape: tuple, ratio_pad: tuple | None = None, padding: bool = True, xywh: bool = False
+) -> torch.Tensor:
     """Rescale bounding boxes from one image shape to another.
 
     Rescales bounding boxes from img1_shape to img0_shape, accounting for padding and aspect ratio changes. Supports

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -100,8 +100,13 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
 
 
 def scale_boxes(
-    img1_shape: tuple, boxes: torch.Tensor, img0_shape: tuple, ratio_pad: tuple | None = None, padding: bool = True, xywh: bool = False
-) -> torch.Tensor:
+    img1_shape: tuple,
+    boxes: torch.Tensor | np.ndarray,
+    img0_shape: tuple,
+    ratio_pad: tuple | None = None,
+    padding: bool = True,
+    xywh: bool = False,
+) -> torch.Tensor | np.ndarray:
     """Rescale bounding boxes from one image shape to another.
 
     Rescales bounding boxes from img1_shape to img0_shape, accounting for padding and aspect ratio changes. Supports


### PR DESCRIPTION
## Summary
- Add parameter and return type hints to `segment2box()` (`segment: np.ndarray`, `-> np.ndarray`)
- Add parameter and return type hints to `scale_boxes()` (`img1_shape: tuple`, `boxes: torch.Tensor`, `img0_shape: tuple`, `ratio_pad: tuple | None`, `-> torch.Tensor`)

These type hints are consistent with the existing docstrings and improve IDE support and static analysis.

## Test plan
- No functional changes; only type annotations added
- Existing tests should pass without modification

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds missing type hints to `segment2box` and `scale_boxes` in `ultralytics/utils/ops.py` to improve code clarity, editor support, and static analysis 🧩

### 📊 Key Changes
- Added `np.ndarray` input and return type annotations to `segment2box`.
- Added explicit type annotations to `scale_boxes` parameters, including `tuple`, `torch.Tensor`, and `tuple | None` for `ratio_pad`.
- Added a `torch.Tensor` return type annotation to `scale_boxes`.
- Kept implementation behavior unchanged, making this a non-functional Python typing improvement.

### 🎯 Purpose & Impact
- Improves readability and maintainability of utility functions in `utils/ops.py`.
- Enhances IDE autocomplete, linting, and static type checking for contributors and users.
- Reduces ambiguity around expected inputs and outputs for detection and segmentation box utilities.
- Low-risk change with minimal impact on runtime behavior since it only strengthens type metadata ✅