### PR TITLE
Update YOLO26 `sahi` tiled inference code

### DIFF
--- a/docs/en/guides/sahi-tiled-inference.md
+++ b/docs/en/guides/sahi-tiled-inference.md
@@ -70,7 +70,7 @@ pip install -U ultralytics sahi
 
 ### Import Modules and Download Resources
 
-Here's how to import some test images:
+Here's how to download some test images:
 
 ```python
 from sahi.utils.file import download_from_url
@@ -105,7 +105,7 @@ detection_model = AutoDetectionModel.from_pretrained(
 
 ### Perform Standard Prediction
 
-Perform standard inference using an image path or a numpy image.
+Perform standard inference using an image path.
 
 ```python
 from sahi.predict import get_prediction

--- a/docs/en/guides/sahi-tiled-inference.md
+++ b/docs/en/guides/sahi-tiled-inference.md
@@ -123,7 +123,7 @@ Export and visualize the predicted bounding boxes and masks:
 from PIL import Image
 
 # Open the predicted image
-processed_image = Image.open('demo_data/prediction_visual.png')
+processed_image = Image.open("demo_data/prediction_visual.png")
 
 # Display the predicted image
 processed_image.show()
@@ -146,11 +146,11 @@ result = get_sliced_prediction(
     overlap_width_ratio=0.2,
 )
 
-# export results
-result.export_visuals(export_dir="demo_data/", hide_conf=True)  
+# Export results
+result.export_visuals(export_dir="demo_data/", hide_conf=True)
 
 # Open the predicted image
-processed_image = Image.open('demo_data/prediction_visual.png')
+processed_image = Image.open("demo_data/prediction_visual.png")
 
 # Display the predicted image
 processed_image.show()
@@ -261,7 +261,7 @@ from PIL import Image
 
 result.export_visuals(export_dir="demo_data/", hide_conf=True)
 
-processed_image = Image.open('demo_data/prediction_visual.png')
+processed_image = Image.open("demo_data/prediction_visual.png")
 
 processed_image.show()
 ```

--- a/docs/en/guides/sahi-tiled-inference.md
+++ b/docs/en/guides/sahi-tiled-inference.md
@@ -70,15 +70,10 @@ pip install -U ultralytics sahi
 
 ### Import Modules and Download Resources
 
-Here's how to import the necessary modules and download a YOLO26 model and some test images:
+Here's how to import some test images:
 
 ```python
 from sahi.utils.file import download_from_url
-from sahi.utils.ultralytics import download_yolo26n_model
-
-# Download YOLO26 model
-model_path = "models/yolo26n.pt"
-download_yolo26n_model(model_path)
 
 # Download test images
 download_from_url(
@@ -102,7 +97,7 @@ from sahi import AutoDetectionModel
 
 detection_model = AutoDetectionModel.from_pretrained(
     model_type="ultralytics",
-    model_path=model_path,
+    model_path="yolo26n.pt",
     confidence_threshold=0.3,
     device="cpu",  # or 'cuda:0'
 )
@@ -114,13 +109,10 @@ Perform standard inference using an image path or a numpy image.
 
 ```python
 from sahi.predict import get_prediction
-from sahi.utils.cv import read_image
 
-# With an image path
 result = get_prediction("demo_data/small-vehicles1.jpeg", detection_model)
 
-# With a numpy image
-result_with_np_image = get_prediction(read_image("demo_data/small-vehicles1.jpeg"), detection_model)
+result.export_visuals(export_dir="demo_data/", hide_conf=True)
 ```
 
 ### Visualize Results
@@ -128,10 +120,13 @@ result_with_np_image = get_prediction(read_image("demo_data/small-vehicles1.jpeg
 Export and visualize the predicted bounding boxes and masks:
 
 ```python
-from IPython.display import Image
+from PIL import Image
 
-result.export_visuals(export_dir="demo_data/")
-Image("demo_data/prediction_visual.png")
+# Open the predicted image
+processed_image = Image.open('demo_data/prediction_visual.png')
+
+# Display the predicted image
+processed_image.show()
 ```
 
 ## Sliced Inference with YOLO26
@@ -139,6 +134,7 @@ Image("demo_data/prediction_visual.png")
 Perform sliced inference by specifying the slice dimensions and overlap ratios:
 
 ```python
+from PIL import Image
 from sahi.predict import get_sliced_prediction
 
 result = get_sliced_prediction(
@@ -149,6 +145,15 @@ result = get_sliced_prediction(
     overlap_height_ratio=0.2,
     overlap_width_ratio=0.2,
 )
+
+# export results
+result.export_visuals(export_dir="demo_data/", hide_conf=True)  
+
+# Open the predicted image
+processed_image = Image.open('demo_data/prediction_visual.png')
+
+# Display the predicted image
+processed_image.show()
 ```
 
 ## Handling Prediction Results
@@ -175,7 +180,7 @@ from sahi.predict import predict
 
 predict(
     model_type="ultralytics",
-    model_path="path/to/yolo26n.pt",
+    model_path="yolo26n.pt",
     model_device="cpu",  # or 'cuda:0'
     model_confidence_threshold=0.4,
     source="path/to/dir",
@@ -219,20 +224,19 @@ Integrating Ultralytics YOLO26 with SAHI (Slicing Aided Hyper Inference) for sli
 pip install -U ultralytics sahi
 ```
 
-Then, download a YOLO26 model and test images:
+Then, download test images:
 
 ```python
 from sahi.utils.file import download_from_url
-from sahi.utils.ultralytics import download_yolo26n_model
-
-# Download YOLO26 model
-model_path = "models/yolo26n.pt"
-download_yolo26n_model(model_path)
 
 # Download test images
 download_from_url(
     "https://raw.githubusercontent.com/obss/sahi/main/demo/demo_data/small-vehicles1.jpeg",
     "demo_data/small-vehicles1.jpeg",
+)
+download_from_url(
+    "https://raw.githubusercontent.com/obss/sahi/main/demo/demo_data/terrain2.png",
+    "demo_data/terrain2.png",
 )
 ```
 
@@ -253,10 +257,13 @@ Learn more about the [benefits of sliced inference](#benefits-of-sliced-inferenc
 Yes, you can visualize prediction results when using YOLO26 with SAHI. Here's how you can export and visualize the results:
 
 ```python
-from IPython.display import Image
+from PIL import Image
 
-result.export_visuals(export_dir="demo_data/")
-Image("demo_data/prediction_visual.png")
+result.export_visuals(export_dir="demo_data/", hide_conf=True)
+
+processed_image = Image.open('demo_data/prediction_visual.png')
+
+processed_image.show()
 ```
 
 This command will save the visualized predictions to the specified directory, and you can then load the image to view it in your notebook or application. For a detailed guide, check out the [Standard Inference section](#visualize-results).


### PR DESCRIPTION
@glenn-jocher @Laughing-q @fcakyon

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the YOLO26 SAHI tiled inference guide to simplify setup, use direct model loading, and improve result visualization examples. 🚀

### 📊 Key Changes
- Removes `download_yolo26n_model` usage and replaces it with direct `model_path="yolo26n.pt"` examples.
- Simplifies the setup sections to only download test images, reducing unnecessary model download steps.
- Updates standard inference examples by removing the NumPy image variant and adding `export_visuals(..., hide_conf=True)` for clearer outputs.
- Replaces notebook-specific `IPython.display.Image` usage with `PIL.Image` and `processed_image.show()` for broader compatibility.
- Enhances sliced inference examples with result export and visualization steps included inline.
- Adds an extra demo image download (`terrain2.png`) in the FAQ-style usage example.
- Aligns CLI-style `predict()` examples to use `model_path="yolo26n.pt"` consistently.

### 🎯 Purpose & Impact
- Makes the documentation easier to follow for users running YOLO26 with SAHI locally or outside notebooks. ✅
- Reduces friction by relying on standard Ultralytics model loading behavior instead of helper download utilities.
- Improves consistency across examples, especially for visualization and model path usage.
- Helps users quickly verify inference outputs with clearer, more practical end-to-end examples. 🖼️