### PR TITLE
update outdated model references to YOLO26

### DIFF
--- a/docs/en/models/yolov4.md
+++ b/docs/en/models/yolov4.md
@@ -50,7 +50,7 @@ We regret any inconvenience this may cause and will strive to update this docume
 
 YOLOv4 is a powerful and efficient object detection model that strikes a balance between speed and accuracy. Its use of unique features and bag of freebies techniques during training allows it to perform excellently in real-time object detection tasks. YOLOv4 can be trained and used by anyone with a conventional GPU, making it accessible and practical for a wide range of applications including [surveillance systems](https://www.ultralytics.com/blog/shattering-the-surveillance-status-quo-with-vision-ai), [autonomous vehicles](https://www.ultralytics.com/solutions/ai-in-automotive), and [industrial automation](https://www.ultralytics.com/blog/improving-manufacturing-with-computer-vision).
 
-For those looking to implement object detection in their projects, YOLOv4 remains a strong contender, especially when real-time performance is a priority. While Ultralytics currently focuses on supporting newer YOLO versions like [YOLO26](yolo26.md), the architectural innovations introduced in YOLOv4 have influenced the development of these later models.
+For those looking to implement object detection in their projects, YOLOv4 remains a strong contender, especially when real-time performance is a priority. While Ultralytics currently focuses on supporting newer YOLO versions like [YOLO11](yolo11.md) and [YOLO26](yolo26.md), the architectural innovations introduced in YOLOv4 have influenced the development of these later models.
 
 ## Citations and Acknowledgments
 

--- a/docs/en/models/yolov4.md
+++ b/docs/en/models/yolov4.md
@@ -50,7 +50,7 @@ We regret any inconvenience this may cause and will strive to update this docume
 
 YOLOv4 is a powerful and efficient object detection model that strikes a balance between speed and accuracy. Its use of unique features and bag of freebies techniques during training allows it to perform excellently in real-time object detection tasks. YOLOv4 can be trained and used by anyone with a conventional GPU, making it accessible and practical for a wide range of applications including [surveillance systems](https://www.ultralytics.com/blog/shattering-the-surveillance-status-quo-with-vision-ai), [autonomous vehicles](https://www.ultralytics.com/solutions/ai-in-automotive), and [industrial automation](https://www.ultralytics.com/blog/improving-manufacturing-with-computer-vision).
 
-For those looking to implement object detection in their projects, YOLOv4 remains a strong contender, especially when real-time performance is a priority. While Ultralytics currently focuses on supporting newer YOLO versions like [YOLOv8](https://docs.ultralytics.com/models/yolov8/) and [YOLO11](https://docs.ultralytics.com/models/yolo11/), the architectural innovations introduced in YOLOv4 have influenced the development of these later models.
+For those looking to implement object detection in their projects, YOLOv4 remains a strong contender, especially when real-time performance is a priority. While Ultralytics currently focuses on supporting newer YOLO versions like [YOLO26](yolo26.md), the architectural innovations introduced in YOLOv4 have influenced the development of these later models.
 
 ## Citations and Acknowledgments
 

--- a/docs/en/yolov5/index.md
+++ b/docs/en/yolov5/index.md
@@ -23,7 +23,7 @@ keywords: YOLOv5, Ultralytics, object detection, computer vision, deep learning,
 
 # Comprehensive Guide to Ultralytics YOLOv5
 
-Welcome to the Ultralytics [YOLOv5](https://github.com/ultralytics/yolov5)🚀 Documentation! Ultralytics YOLOv5, the fifth iteration of the revolutionary "You Only Look Once" [object detection](https://www.ultralytics.com/glossary/object-detection) model, is designed to deliver high-speed, high-accuracy results in real-time. While YOLOv5 remains a powerful tool, consider exploring [Ultralytics YOLO26](../models/yolo26.md) for the latest advancements.
+Welcome to the Ultralytics [YOLOv5](https://github.com/ultralytics/yolov5)🚀 Documentation! Ultralytics YOLOv5, the fifth iteration of the revolutionary "You Only Look Once" [object detection](https://www.ultralytics.com/glossary/object-detection) model, is designed to deliver high-speed, high-accuracy results in real-time. While YOLOv5 remains a powerful tool, consider exploring its successors, [Ultralytics YOLOv8](../models/yolov8.md), [YOLO11](../models/yolo11.md), and [YOLO26](../models/yolo26.md), for the latest advancements.
 
 Built on [PyTorch](https://pytorch.org/), this powerful [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) framework has garnered immense popularity for its versatility, ease of use, and high performance. Our documentation guides you through the installation process, explains the architectural nuances of the model, showcases various use cases, and provides a series of detailed tutorials. These resources will help you harness the full potential of YOLOv5 for your [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) projects. Let's get started!
 

--- a/docs/en/yolov5/index.md
+++ b/docs/en/yolov5/index.md
@@ -23,7 +23,7 @@ keywords: YOLOv5, Ultralytics, object detection, computer vision, deep learning,
 
 # Comprehensive Guide to Ultralytics YOLOv5
 
-Welcome to the Ultralytics [YOLOv5](https://github.com/ultralytics/yolov5)🚀 Documentation! Ultralytics YOLOv5, the fifth iteration of the revolutionary "You Only Look Once" [object detection](https://www.ultralytics.com/glossary/object-detection) model, is designed to deliver high-speed, high-accuracy results in real-time. While YOLOv5 remains a powerful tool, consider exploring its successor, [Ultralytics YOLOv8](../models/yolov8.md), for the latest advancements.
+Welcome to the Ultralytics [YOLOv5](https://github.com/ultralytics/yolov5)🚀 Documentation! Ultralytics YOLOv5, the fifth iteration of the revolutionary "You Only Look Once" [object detection](https://www.ultralytics.com/glossary/object-detection) model, is designed to deliver high-speed, high-accuracy results in real-time. While YOLOv5 remains a powerful tool, consider exploring [Ultralytics YOLO26](../models/yolo26.md) for the latest advancements.
 
 Built on [PyTorch](https://pytorch.org/), this powerful [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) framework has garnered immense popularity for its versatility, ease of use, and high performance. Our documentation guides you through the installation process, explains the architectural nuances of the model, showcases various use cases, and provides a series of detailed tutorials. These resources will help you harness the full potential of YOLOv5 for your [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) projects. Let's get started!
 


### PR DESCRIPTION
- yolov4.md: conclusion referenced YOLOv8 and YOLO11 as latest, updated to YOLO26
- yolov5/index.md: recommended YOLOv8 as successor, updated to YOLO26

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR refreshes legacy model docs to better point users from YOLOv4 and YOLOv5 toward newer Ultralytics models, especially YOLO11 and YOLO26.

### 📊 Key Changes
- Updated the **YOLOv4 documentation** to replace references to older “newer versions” guidance:
  - Removed mention of YOLOv8 in that section
  - Added **YOLO11** and **YOLO26** as the current Ultralytics focus
  - Switched links to local doc references for these models
- Updated the **YOLOv5 landing page** intro text:
  - Changed “successor” to **“successors”**
  - Expanded recommended newer options from just **YOLOv8** to **YOLOv8, YOLO11, and YOLO26**
- These are **documentation-only changes** with no model code, training logic, or API behavior modified 🛠️

### 🎯 Purpose & Impact
- Helps users discover the **latest recommended Ultralytics models** more easily 🚀
- Improves documentation consistency by aligning older pages with current model positioning
- Gives readers of legacy docs clearer upgrade paths from **YOLOv4/YOLOv5** to modern alternatives
- Supports broader awareness that **YOLO26** is part of the current recommended model lineup
- No breaking changes for developers or users, since this PR only updates docs ✅