### PR TITLE
docs: update DeepStream 7.1 documentation link for JetPack 6.1

### DIFF
--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -38,7 +38,7 @@ Before you start to follow this guide:
 - Install [DeepStream SDK](https://developer.nvidia.com/deepstream-getting-started) according to the JetPack version
     - For JetPack 4.6.4, install [DeepStream 6.0.1](https://docs.nvidia.com/metropolis/deepstream/6.0.1/dev-guide/text/DS_Quickstart.html)
     - For JetPack 5.1.3, install [DeepStream 6.3](https://docs.nvidia.com/metropolis/deepstream/6.3/dev-guide/text/DS_Quickstart.html)
-    - For JetPack 6.1, install [DeepStream 7.1](https://docs.nvidia.com/metropolis/deepstream/7.0/dev-guide/text/DS_Overview.html)
+    - For JetPack 6.1, install [DeepStream 7.1](https://docs.nvidia.com/metropolis/deepstream/7.1/text/DS_Overview.html)
 
 !!! tip
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR fixes an incorrect DeepStream documentation link in the Jetson guide, updating the JetPack 6.1 reference to the correct DeepStream 7.1 page.

### 📊 Key Changes
- Updated the **DeepStream 7.1** link in `docs/en/guides/deepstream-nvidia-jetson.md`.
- Replaced a URL that incorrectly pointed to the **DeepStream 7.0** documentation path with the correct **DeepStream 7.1** path.
- No code, model, or runtime behavior changes were made — this is a documentation-only fix 📝.

### 🎯 Purpose & Impact
- Helps users following the Jetson + DeepStream setup guide reach the **correct NVIDIA documentation** more reliably.
- Reduces confusion during installation for **JetPack 6.1** users 🚀.
- Improves the overall accuracy and usability of Ultralytics docs, especially for deployment workflows on NVIDIA Jetson devices.