### PR TITLE
Add missing `isatty()` to `_ConsoleCapture` stream wrapper

### DIFF
--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -270,6 +270,10 @@ class ConsoleLogger:
             """Flush the wrapped stream to propagate buffered output promptly during console capture."""
             self.original.flush()
 
+        def isatty(self):
+            """Delegate isatty check to the original stream."""
+            return self.original.isatty()
+
     class _LogHandler(logging.Handler):
         """Lightweight logging handler."""
 


### PR DESCRIPTION
`ConsoleLogger._ConsoleCapture` (introduced in #21761) replaces `sys.stdout`/`sys.stderr` but only implements `write()` and `flush()`. Any library calling `sys.stdout.isatty()` while console capture is active crashes with `AttributeError`. This affects HuggingFace `transformers` model loading (`loading_report` calls `isatty()`) and potentially other libraries.

Fix delegates `isatty()` to the wrapped original stream.

References:
- wandb/wandb#10832 — same root cause pattern (missing `isatty` on stream wrapper), wandb maintainer confirmed "this class is not maintained by W&B"
- https://docs.python.org/3/library/io.html#io.IOBase.isatty — `isatty()` is part of the standard stream interface

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds `isatty()` support to Ultralytics’ wrapped logger stream so terminal behavior is preserved during console output capture 🖥️✨

### 📊 Key Changes
- Added an `isatty()` method to the internal wrapped stream class in `ultralytics/utils/logger.py`.
- The new method simply forwards the `isatty()` check to the original underlying stream.
- No broader logging logic was changed; this is a small, targeted compatibility improvement.

### 🎯 Purpose & Impact
- Helps wrapped console streams behave more like normal terminal streams ✅
- Improves compatibility with tools or libraries that check `isatty()` to detect whether output is going to a real terminal.
- Can prevent issues with terminal-dependent features such as colored output, formatting, or interactive behavior 🎨
- Low-risk change: it does not alter core logging flow, only restores expected stream capabilities.