### PR TITLE
Fix cache miss handling for coordinate retrieval

### DIFF
--- a/ultralytics/models/sam/sam3/decoder.py
+++ b/ultralytics/models/sam/sam3/decoder.py
@@ -330,7 +330,7 @@ class TransformerDecoder(nn.Module):
             # cache miss, will create compilation issue
             # In case we're not compiling, we'll still rely on the dict-based cache
             if feat_size not in self.coord_cache:
-                self.coord_cache[feat_size] = self._get_coords(H, W, reference_boxes.device)
+                self.coord_cache[feat_size] = self._get_coords(H, W, reference_boxes.device, reference_boxes.dtype)
             coords_h, coords_w = self.coord_cache[feat_size]
 
             assert coords_h.shape == (H,)


### PR DESCRIPTION
TypeError: TransformerDecoder._get_coords() missing 1 required positional argument: 'dtype'

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a SAM3 decoder cache-miss path by storing generated coordinates with the same dtype as `reference_boxes`, improving consistency during coordinate retrieval. 🛠️

### 📊 Key Changes
- Updates `ultralytics/models/sam/sam3/decoder.py` in `_get_rpb_matrix()`.
- On coordinate cache miss, changes `_get_coords(H, W, reference_boxes.device)` to `_get_coords(H, W, reference_boxes.device, reference_boxes.dtype)`.
- Ensures cached coordinate tensors are created with both the correct device and dtype.
- Preserves the existing dict-based cache behavior while addressing the cache-miss edge case.

### 🎯 Purpose & Impact
- Fixes a bug where cache-miss coordinate generation could use an inconsistent dtype.
- Reduces the risk of dtype-related runtime or compilation issues in SAM3 decoder flows.
- Improves reliability and stability for users working with cached coordinate retrieval in Python inference and development workflows.