### PR TITLE
Fix YOLO12 forward pass with old checkpoints

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1681,6 +1681,12 @@ class AAttn(nn.Module):
         self.qkv = Conv(dim, all_head_dim * 3, 1, act=False)
         self.proj = Conv(all_head_dim, dim, 1, act=False)
         self.pe = Conv(all_head_dim, all_head_dim, 7, 1, 3, g=all_head_dim, act=False)
+    
+    def __setstate__(self, state):
+        """Add missing all_head_dim attribute to old checkpoints."""
+        super().__setstate__(state)
+        if not hasattr(self, 'all_head_dim'):
+            self.all_head_dim = self.head_dim * self.num_heads
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Process the input tensor through the area-attention.

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1681,11 +1681,11 @@ class AAttn(nn.Module):
         self.qkv = Conv(dim, all_head_dim * 3, 1, act=False)
         self.proj = Conv(all_head_dim, dim, 1, act=False)
         self.pe = Conv(all_head_dim, all_head_dim, 7, 1, 3, g=all_head_dim, act=False)
-    
+
     def __setstate__(self, state):
         """Add missing all_head_dim attribute to old checkpoints."""
         super().__setstate__(state)
-        if not hasattr(self, 'all_head_dim'):
+        if not hasattr(self, "all_head_dim"):
             self.all_head_dim = self.head_dim * self.num_heads
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Fixes #24151 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR adds backward-compatibility handling for older Area Attention checkpoints so they continue to load correctly after internal model changes.

### 📊 Key Changes
- Added a `__setstate__()` method to the Area Attention module in `ultralytics/nn/modules/block.py`.
- The new method checks whether the `all_head_dim` attribute is missing when loading older saved checkpoints.
- If the attribute is absent, it is automatically reconstructed from existing values: `head_dim * num_heads`.
- This change only affects checkpoint deserialization/loading behavior, not normal training or inference logic.

### 🎯 Purpose & Impact
- ✅ Prevents errors when loading older model checkpoints created before `all_head_dim` was stored explicitly.
- 🔄 Improves backward compatibility across Ultralytics versions, making upgrades smoother.
- 💾 Helps users keep using previously trained models without needing to retrain or manually patch checkpoints.
- 🚀 Reduces friction for developers and practitioners working with long-lived projects or archived model weights.