### PR TITLE
Exclude OpenVINO 2026.1.0 on ARM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,8 @@ export = [
     "onnxslim>=0.1.82",
     "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
-    "openvino>=2024.0.0",  # OpenVINO export
+    "openvino>=2024.0.0,!=2026.1.0; platform_machine == 'aarch64'",  # OpenVINO compilation error on ARM with 2026.1.0
+    "openvino>=2024.0.0; platform_machine != 'aarch64'",  # OpenVINO export
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "ydf<0.13.0; platform_machine != 'aarch64'", # ydf>=0.13 has protobuf gencode 6.x but tensorflow<=2.19 requires protobuf<6

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -695,7 +695,7 @@ class Exporter:
         from ultralytics.utils.export import torch2openvino
 
         # OpenVINO <= 2025.1.0 error on macOS 15.4+: https://github.com/openvinotoolkit/openvino/issues/30023"
-        check_requirements("openvino>=2025.2.0" if MACOS and MACOS_VERSION >= "15.4" else "openvino>=2024.0.0")
+        check_requirements("openvino>=2025.2.0" if MACOS and MACOS_VERSION >= "15.4" else "openvino>=2024.0.0,!=2026.1.0" if ARM64 else "openvino>=2024.0.0")
         import openvino as ov
 
         assert TORCH_2_1, f"OpenVINO export requires torch>=2.1 but torch=={TORCH_VERSION} is installed"

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -695,7 +695,13 @@ class Exporter:
         from ultralytics.utils.export import torch2openvino
 
         # OpenVINO <= 2025.1.0 error on macOS 15.4+: https://github.com/openvinotoolkit/openvino/issues/30023"
-        check_requirements("openvino>=2025.2.0" if MACOS and MACOS_VERSION >= "15.4" else "openvino>=2024.0.0,!=2026.1.0" if ARM64 else "openvino>=2024.0.0")
+        check_requirements(
+            "openvino>=2025.2.0"
+            if MACOS and MACOS_VERSION >= "15.4"
+            else "openvino>=2024.0.0,!=2026.1.0"
+            if ARM64
+            else "openvino>=2024.0.0"
+        )
         import openvino as ov
 
         assert TORCH_2_1, f"OpenVINO export requires torch>=2.1 but torch=={TORCH_VERSION} is installed"


### PR DESCRIPTION
OpenVINO CI fix

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves OpenVINO export reliability by blocking a known broken OpenVINO version on ARM64 devices while keeping existing macOS compatibility checks in place.

### 📊 Key Changes
- Added a platform-specific dependency rule in `pyproject.toml` to **exclude `openvino==2026.1.0` on `aarch64`/ARM64** due to a known compilation error.
- Kept the normal OpenVINO requirement for non-ARM platforms as `openvino>=2024.0.0`.
- Updated `export_openvino()` in `ultralytics/engine/exporter.py` so runtime dependency checks now:
  - require `openvino>=2025.2.0` on **macOS 15.4+** because of an existing OpenVINO issue there,
  - require `openvino>=2024.0.0,!=2026.1.0` on **ARM64**,
  - and use `openvino>=2024.0.0` elsewhere.
- Preserved the existing export flow and logic, changing only the version handling for safer installation and export behavior. ✅

### 🎯 Purpose & Impact
- Prevents users on **ARM-based systems** from installing an OpenVINO version known to fail during export. 🚫
- Makes **YOLO model export to OpenVINO more dependable** across different hardware and operating systems.
- Reduces avoidable installation and compilation errors, especially for users on **ARM Linux devices and similar platforms**. 📉
- Improves the overall user experience by ensuring Ultralytics selects **safer OpenVINO versions automatically** instead of letting users hit known upstream issues. 👍