### PR TITLE
Force OpenVINO ARM inference to FP32

### DIFF
--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from ultralytics.utils import LOGGER
+from ultralytics.utils import ARM64, LINUX, LOGGER
 from ultralytics.utils.checks import check_requirements
 
 from .base import BaseBackend
@@ -58,11 +58,15 @@ class OpenVINOBackend(BaseBackend):
 
         # Set inference mode
         self.inference_mode = "CUMULATIVE_THROUGHPUT" if self.dynamic and self.batch > 1 else "LATENCY"
+        config = {"PERFORMANCE_HINT": self.inference_mode}
+        if LINUX and ARM64 and device_name == "CPU":
+            config["EXECUTION_MODE_HINT"] = ov.properties.hint.ExecutionMode.ACCURACY
+            config["INFERENCE_PRECISION_HINT"] = ov.Type.f32
 
         self.ov_compiled_model = core.compile_model(
             ov_model,
             device_name=device_name,
-            config={"PERFORMANCE_HINT": self.inference_mode},
+            config=config,
         )
         LOGGER.info(
             f"Using OpenVINO {self.inference_mode} mode for batch={self.batch} inference on "

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -31,16 +31,15 @@ class OpenVINOBackend(BaseBackend):
         import openvino as ov
 
         core = ov.Core()
-        available_devices = core.available_devices
-        device_name = "CPU" if available_devices == ["CPU"] else "AUTO"
+        fallback_device = "CPU" if core.available_devices == ["CPU"] else "AUTO"
+        device_name = fallback_device
 
         if isinstance(self.device, str) and self.device.startswith("intel"):
-            requested_device = self.device
-            device_name = requested_device.split(":")[1].upper()
+            device_name = self.device.split(":")[1].upper()
             self.device = torch.device("cpu")
-            if device_name not in available_devices:
-                device_name = "CPU" if available_devices == ["CPU"] else "AUTO"
-                LOGGER.warning(f"OpenVINO device '{requested_device}' not available. Using '{device_name}' instead.")
+            if device_name not in core.available_devices:
+                LOGGER.warning(f"OpenVINO device '{device_name}' not available. Using '{fallback_device}' instead.")
+                device_name = fallback_device
 
         w = Path(weight)
         if not w.is_file():

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -31,14 +31,16 @@ class OpenVINOBackend(BaseBackend):
         import openvino as ov
 
         core = ov.Core()
-        device_name = "AUTO"
+        available_devices = core.available_devices
+        device_name = "CPU" if available_devices == ["CPU"] else "AUTO"
 
         if isinstance(self.device, str) and self.device.startswith("intel"):
-            device_name = self.device.split(":")[1].upper()
+            requested_device = self.device
+            device_name = requested_device.split(":")[1].upper()
             self.device = torch.device("cpu")
-            if device_name not in core.available_devices:
-                LOGGER.warning(f"OpenVINO device '{device_name}' not available. Using 'AUTO' instead.")
-                device_name = "AUTO"
+            if device_name not in available_devices:
+                device_name = "CPU" if available_devices == ["CPU"] else "AUTO"
+                LOGGER.warning(f"OpenVINO device '{requested_device}' not available. Using '{device_name}' instead.")
 
         w = Path(weight)
         if not w.is_file():


### PR DESCRIPTION
Update device selection logic for OpenVINO backend to prioritize available devices.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the OpenVINO backend to choose safer default devices and add Linux ARM64 CPU-specific settings for more reliable inference 🚀

### 📊 Key Changes
- Updated OpenVINO device selection to use `CPU` as the fallback when only a CPU is available, instead of always defaulting to `AUTO`.
- Improved warning behavior when a requested Intel device is unavailable, now clearly falling back to the best available option 🔄
- Added Linux ARM64 CPU-specific OpenVINO configuration:
  - sets execution mode to prioritize accuracy
  - forces FP32 inference precision for compatibility and stability
- Refactored compile configuration into a reusable `config` dictionary before passing it to `core.compile_model()`.

### 🎯 Purpose & Impact
- Makes OpenVINO inference more robust on systems with limited hardware options, especially CPU-only environments 💻
- Improves behavior on Linux ARM64 devices, where default settings may be less reliable or optimal.
- Helps avoid unexpected device-selection issues when users request unavailable Intel accelerators.
- Likely increases inference stability and correctness on ARM-based Linux platforms, though FP32 may trade some speed for better accuracy ⚖️