### PR TITLE
Add Patience left since last best epoch LOG via tqdm bar [Previously opened]

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -480,6 +480,12 @@ class BaseTrainer:
                 # Log
                 if RANK in {-1, 0}:
                     loss_length = self.tloss.shape[0] if len(self.tloss.shape) else 1
+                    patience_str = ""
+                    if self.args.patience:
+                        best_epoch = getattr(self.stopper, "best_epoch", 0)
+                        patience_left = max(0, self.args.patience - (epoch - best_epoch))
+                        patience_str = f"  Patience: {patience_left}/{self.args.patience}"
+
                     pbar.set_description(
                         ("%11s" * 2 + "%11.4g" * (2 + loss_length))
                         % (
@@ -489,6 +495,7 @@ class BaseTrainer:
                             batch["cls"].shape[0],  # batch size, i.e. 8
                             batch["img"].shape[-1],  # imgsz, i.e 640
                         )
+                        + patience_str
                     )
                     self.run_callbacks("on_batch_end")
                     if self.args.plots and ni in self.plot_idx:


### PR DESCRIPTION

### Summary
Adds a real-time patience countdown to the training progress bar.

While early stopping tracks patience internally, users currently have no visual indicator of how many epochs are left before training halts. This PR adds a `Patience: X/Y` indicator to the TQDM description to clarify the current state of early stopping.

No behavior change.

---

### 🎥 Visual Demo

<img width="1429" height="579" alt="Screenshot from 2026-04-08 14-42-23" src="https://github.com/user-attachments/assets/81d42abb-87ce-4374-8541-3f830ff56fc9" />

---

#

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a live `patience` countdown to the training `tqdm` progress bar, showing how many epochs remain since the last best epoch before early stopping may trigger. 🚀

### 📊 Key Changes
- Adds a `patience_str` segment to the training progress bar description in `ultralytics/engine/trainer.py`.
- Reads `best_epoch` from `self.stopper` and computes remaining patience based on the current epoch.
- Displays the value as `Patience: X/Y` when `self.args.patience` is enabled.
- Uses safe defaults with `getattr(..., 0)` and clamps the displayed value to avoid negative counts.

### 🎯 Purpose & Impact
- Improves training visibility by showing early-stopping status directly in the live progress bar. 👀
- Helps users better understand how close training is to stopping without needing to inspect logs separately.
- Provides a small but useful UX enhancement for monitoring long training runs, with minimal code changes. ✅