### PR TITLE
Use archived DeepStream 6.0.1 and 6.3 links

### DIFF
--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -36,8 +36,8 @@ Before you start to follow this guide:
 
 - Visit our documentation, [Quick Start Guide: NVIDIA Jetson with Ultralytics YOLO26](nvidia-jetson.md) to set up your NVIDIA Jetson device with Ultralytics YOLO26
 - Install [DeepStream SDK](https://developer.nvidia.com/deepstream-getting-started) according to the JetPack version
-    - For JetPack 4.6.4, install [DeepStream 6.0.1](https://docs.nvidia.com/metropolis/deepstream/6.0.1/dev-guide/text/DS_Quickstart.html)
-    - For JetPack 5.1.3, install [DeepStream 6.3](https://docs.nvidia.com/metropolis/deepstream/6.3/dev-guide/text/DS_Quickstart.html)
+    - For JetPack 4.6.4, install [DeepStream 6.0.1](https://archive.docs.nvidia.com/metropolis/deepstream/6.0.1/dev-guide/text/DS_Quickstart.html)
+    - For JetPack 5.1.3, install [DeepStream 6.3](https://archive.docs.nvidia.com/metropolis/deepstream/6.3/dev-guide/text/DS_Quickstart.html)
     - For JetPack 6.1, install [DeepStream 7.1](https://docs.nvidia.com/metropolis/deepstream/7.1/text/DS_Overview.html)
     - For JetPack 7.1, install [DeepStream 9.0](https://docs.nvidia.com/metropolis/deepstream/9.0/text/DS_Overview.html)
 


### PR DESCRIPTION
Docs archived by NVIDIA

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR updates NVIDIA DeepStream documentation links in the Jetson guide so older JetPack users are directed to the correct archived NVIDIA docs.

### 📊 Key Changes
- Updated the DeepStream installation links in `docs/en/guides/deepstream-nvidia-jetson.md`.
- Changed the **JetPack 4.6.4 → DeepStream 6.0.1** link to use NVIDIA’s **archived documentation**.
- Changed the **JetPack 5.1.3 → DeepStream 6.3** link to use NVIDIA’s **archived documentation**.
- Left newer version links unchanged, including:
  - **JetPack 6.1 → DeepStream 7.1**
  - **JetPack 7.1 → DeepStream 9.0**

### 🎯 Purpose & Impact
- Helps users find the correct DeepStream setup instructions for older JetPack versions without hitting outdated or broken pages 🛠️
- Improves reliability of the Jetson + Ultralytics YOLO26 setup guide for developers working on legacy NVIDIA devices 📘
- Reduces confusion during installation by pointing to version-matched NVIDIA resources ✅
- Small documentation-only change, with no impact on model code, training, or inference behavior 🚀