### PR TITLE
Fix setup_model crash with ul:// model URIs after #23640

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -35,6 +35,7 @@ from ultralytics.utils import (
     LOCAL_RANK,
     LOGGER,
     RANK,
+    SETTINGS,
     TQDM,
     YAML,
     callbacks,
@@ -720,8 +721,11 @@ class BaseTrainer:
 
         cfg, weights = self.model, None
         ckpt = None
-        if str(self.model).endswith(".pt"):
-            weights, ckpt = load_checkpoint(self.model)
+        # Resolve remote URIs (ul://, https://, etc.) to local .pt files before suffix check
+        if isinstance(cfg, str) and "://" in cfg:
+            cfg = check_file(cfg, download_dir=SETTINGS["weights_dir"])
+        if str(cfg).endswith(".pt"):
+            weights, ckpt = load_checkpoint(cfg)
             cfg = weights.yaml
         elif isinstance(self.args.pretrained, (str, Path)):
             weights, _ = load_checkpoint(self.args.pretrained)


### PR DESCRIPTION
Summary

Fix setup_model() crash when training with ul:// platform model URIs (regression from #23640).
   > Shell cwd was reset to /Users/user/git/ultra/mega/dev8/portal
After #23640 removed model pre-initialization from Model.train(), setup_model() receives the raw ul:// URI string as self.model. The string doesn't end in .pt, so it's passed directly as cfg to yaml_model_load() → check_yaml() → check_suffix(), which crashes because the URI has no .yaml/.yml extension.

Root Cause

#23640 deleted these lines from Model.train() to fix duplicate weight loading for YAML models:

# Removed in v8.4.35

```
if not args.get("resume"):
    self.trainer.model = self.trainer.get_model(weights=self.model if self.ckpt else None, cfg=self.model.yaml)
    self.model = self.trainer.model
```

Previously, this pre-loaded the model as an nn.Module before train(), so setup_model() hit the early return at isinstance(self.model, torch.nn.Module) and never had to resolve URIs. Now setup_model() must handle remote URIs itself, but it only handled local .pt paths.

Error

```
File "ultralytics/nn/tasks.py", line 1750, in yaml_model_load
    yaml_file = check_yaml(unified_path, hard=False) or check_yaml(path)
File "ultralytics/utils/checks.py", line 641, in check_file
    check_suffix(file, suffix)
File "ultralytics/utils/checks.py", line 583, in check_suffix
    assert f".{s}" in suffix, f"{msg}{f} acceptable suffix is {suffix}, not .{s}"
AssertionError: ul://user/project/model acceptable suffix is ('.yaml', '.yml'), not .ul://user/project/model
```

Fix

Add URI resolution in setup_model() before the .pt suffix check, using check_file() (same function Model._load() already uses) with SETTINGS["weights_dir"] to reuse any file already downloaded during YOLO.__init__():

```
# Resolve remote URIs (ul://, https://, etc.) to local .pt files before suffix check
if isinstance(cfg, str) and "://" in cfg:
    cfg = check_file(cfg, download_dir=SETTINGS["weights_dir"])
```

How to Reproduce

pip install ultralytics==8.4.35
export ULTRALYTICS_API_KEY="your-key"

# Fails — any ul:// user model reference
yolo train model=ul://username/project/model data=coco8.yaml epochs=1

# Works — official models (stem is in GITHUB_ASSETS_STEMS, gets .pt suffix added)
yolo train model=yolo26n.pt data=coco8.yaml epochs=1

Test Results

- yolo train model=ul://user/project/model data=ul://user/datasets/dataset epochs=1 — training starts successfully
- yolo train model=yolo26n.pt data=coco8.yaml epochs=1 — no regression
- Official model ul:// URIs — no regression  


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves model loading in training by properly resolving remote model URLs before checking for `.pt` checkpoint files.

### 📊 Key Changes
- Added `SETTINGS` import in `ultralytics/engine/trainer.py`.
- Updated `setup_model()` to detect remote model paths such as `ul://` and `https://`.
- Remote URIs are now resolved to a local file using `check_file(..., download_dir=SETTINGS["weights_dir"])` before the `.pt` suffix check.
- Once downloaded locally, `.pt` checkpoint files are loaded as expected with `load_checkpoint()`.

### 🎯 Purpose & Impact
- 🌐 Enables smoother use of remote model weights during training, not just local `.pt` files.
- ✅ Prevents cases where remote checkpoint paths might be skipped or mishandled because they were checked before being downloaded.
- 📦 Ensures downloaded weights are stored in the configured weights directory for more consistent file management.
- 🚀 Makes training workflows more reliable and user-friendly, especially for users loading models from hosted sources or custom URI schemes like `ul://`.