### PR TITLE
`ultralytics 8.4.36` Fix platform training checkpoint regression

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import sys
+from types import SimpleNamespace
 from unittest import mock
 
 import torch
@@ -155,3 +156,44 @@ def test_nan_recovery():
     trainer.add_callback("on_train_batch_end", inject_nan)
     trainer.train()
     assert nan_injected[0], "NaN injection failed"
+
+
+def test_train_reuses_loaded_checkpoint_model(monkeypatch):
+    """Test training reuses an already-loaded checkpoint model instead of re-parsing the model source."""
+    model = YOLO("yolo26n.yaml")
+    model.ckpt = {"checkpoint": True}
+    model.ckpt_path = "/tmp/fake.pt"
+    model.overrides["model"] = "ul://glenn-jocher/m2/exp-14"
+    original_model = model.model
+    captured = {}
+
+    class FakeTrainer:
+        def __init__(self, overrides=None, _callbacks=None):
+            self.overrides = overrides
+            self.callbacks = _callbacks
+            self.model = None
+            self.validator = SimpleNamespace(metrics=None)
+            self.best = MODEL.parent / "nonexistent-best.pt"
+            self.last = MODEL
+            captured["trainer"] = self
+
+        def get_model(self, cfg=None, weights=None, verbose=True):
+            captured["cfg"] = cfg
+            captured["weights"] = weights
+            return original_model
+
+        def train(self):
+            return None
+
+    monkeypatch.setattr("ultralytics.engine.model.checks.check_pip_update_available", lambda: None)
+    monkeypatch.setattr(model, "_smart_load", lambda key: FakeTrainer)
+    monkeypatch.setattr(
+        "ultralytics.engine.model.load_checkpoint",
+        lambda path: (original_model, {"checkpoint": True}),
+    )
+
+    model.train(data="coco8.yaml", epochs=1)
+
+    assert captured["trainer"].model is original_model
+    assert captured["cfg"] == original_model.yaml
+    assert captured["weights"] is original_model

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -64,6 +64,7 @@ def test_model_methods():
     _ = model.transforms
     _ = model.task_map
 
+
 def test_model_profile():
     """Test profiling of the YOLO model with `profile=True` to assess performance and resource usage."""
     from ultralytics.nn.tasks import DetectionModel

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -64,7 +64,6 @@ def test_model_methods():
     _ = model.transforms
     _ = model.task_map
 
-
 def test_model_profile():
     """Test profiling of the YOLO model with `profile=True` to assess performance and resource usage."""
     from ultralytics.nn.tasks import DetectionModel

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.35"
+__version__ = "8.4.36"
 
 import importlib
 import os

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -779,6 +779,10 @@ class Model(torch.nn.Module):
                     args["resume"] = False
 
         self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
+        if not args.get("resume") and self.ckpt:
+            # Reuse the already-loaded checkpoint model to avoid re-resolving remote weight sources during trainer setup.
+            self.trainer.model = self.trainer.get_model(weights=self.model, cfg=self.model.yaml)
+            self.model = self.trainer.model
 
         self.trainer.train()
         # Update model and cfg after training


### PR DESCRIPTION
## Summary
- restore checkpoint-backed trainer seeding in `Model.train()` so already-loaded `.pt` models do not get re-parsed from the trainer args during training
- keep the fix scoped to the regression introduced by `#23640`, without changing trainer file resolution or suffix handling
- add a focused regression test for the checkpoint-backed training path

## Verification
- `pytest -q tests/test_engine.py -k 'test_train_reuses_loaded_checkpoint_model or test_detect or test_segment or test_classify'`
- `pytest -q tests/test_python.py -k test_model_methods`

## Root Cause
`#23640` removed the checkpoint-backed model seeding from `Model.train()`. That left training dependent on `trainer.args.model` even when the model had already been loaded from a checkpoint, which broke Platform/HUB flows where the trainer args can carry a non-file model identifier.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR improves training reliability by reusing an already-loaded checkpoint model instead of reloading or re-resolving it, especially for models sourced from remote locations.

### 📊 Key Changes
- Added logic in `ultralytics/engine/model.py` to reuse the currently loaded checkpoint model during training when not resuming.
- Prevents the trainer from re-parsing or re-resolving the model source if a checkpoint is already available.
- Updates the model reference so both the trainer and the main `YOLO` object use the same loaded model instance.
- Added a new test in `tests/test_engine.py` to verify that training correctly reuses the loaded checkpoint model.
- Bumped the package version from `8.4.35` to `8.4.36` 📦

### 🎯 Purpose & Impact
- Reduces unnecessary model reloading, which can help avoid failures with remote model sources like Ultralytics HUB or other external paths 🌐
- Makes training more efficient by reusing an in-memory model instead of rebuilding it again ⚡
- Improves consistency by ensuring the trainer works with the exact model that was already loaded 🧠
- Adds test coverage to guard against regressions, making this behavior more stable over time ✅
- Benefits users who train from checkpoint-based or remotely referenced models by making the workflow smoother and more dependable 🙌