### PR TITLE
Attempt to unify the model input

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -139,9 +139,8 @@ class Model(torch.nn.Module):
         # Load or create new YOLO model
         __import__("os").environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # to avoid deterministic warnings
 
-        if model.lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://", "ul://")):
+        if str(model).lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://", "ul://")):
             model = checks.check_file(model, download_dir=SETTINGS["weights_dir"])  # download and return local file
-        model = checks.check_model_file_from_stem(model)  # add suffix, i.e. yolo26 -> yolo26n.pt
         if str(model).endswith((".yaml", ".yml")):
             self._new(model, task=task, verbose=verbose)
         else:
@@ -279,6 +278,7 @@ class Model(torch.nn.Module):
             >>> model._load("yolo26n.pt")
             >>> model._load("path/to/weights.pth", task="detect")
         """
+        weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolo26 -> yolo26n.pt
         if str(weights).rpartition(".")[-1] == "pt":
             self.model, self.ckpt = load_checkpoint(weights)
             self.task = self.model.task

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -138,6 +138,10 @@ class Model(torch.nn.Module):
 
         # Load or create new YOLO model
         __import__("os").environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # to avoid deterministic warnings
+
+        if model.lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://", "ul://")):
+            model = checks.check_file(model, download_dir=SETTINGS["weights_dir"])  # download and return local file
+        model = checks.check_model_file_from_stem(model)  # add suffix, i.e. yolo26 -> yolo26n.pt
         if str(model).endswith((".yaml", ".yml")):
             self._new(model, task=task, verbose=verbose)
         else:
@@ -275,10 +279,6 @@ class Model(torch.nn.Module):
             >>> model._load("yolo26n.pt")
             >>> model._load("path/to/weights.pth", task="detect")
         """
-        if weights.lower().startswith(("https://", "http://", "rtsp://", "rtmp://", "tcp://", "ul://")):
-            weights = checks.check_file(weights, download_dir=SETTINGS["weights_dir"])  # download and return local file
-        weights = checks.check_model_file_from_stem(weights)  # add suffix, i.e. yolo26 -> yolo26n.pt
-
         if str(weights).rpartition(".")[-1] == "pt":
             self.model, self.ckpt = load_checkpoint(weights)
             self.task = self.model.task
@@ -779,10 +779,6 @@ class Model(torch.nn.Module):
                     args["resume"] = False
 
         self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
-        if not args.get("resume") and self.ckpt:
-            # Reuse the already-loaded checkpoint model to avoid re-resolving remote weight sources during trainer setup.
-            self.trainer.model = self.trainer.get_model(weights=self.model, cfg=self.model.yaml)
-            self.model = self.trainer.model
 
         self.trainer.train()
         # Update model and cfg after training


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR simplifies how Ultralytics models handle remote weight files by resolving URLs earlier during model initialization and removing redundant training-time model reuse logic.

### 📊 Key Changes
- 🌐 Moved remote path handling into `Model.__init__()`, so URLs like `https://`, `rtsp://`, `rtmp://`, `tcp://`, and `ul://` are downloaded or resolved immediately.
- 🧹 Removed duplicate remote-file resolution from `_load()`, centralizing this behavior in one place.
- 🏋️ Deleted the special training setup that reused an already-loaded checkpoint model when not resuming training.
- 📁 Remote model files are still stored locally in the configured weights directory after being resolved.

### 🎯 Purpose & Impact
- ✅ Makes model loading more consistent by handling remote sources at the very start, regardless of how the model is later processed.
- 🛠️ Reduces duplicate logic, which makes the code easier to maintain and less error-prone.
- 🚀 Helps avoid issues tied to resolving remote weights multiple times during training setup.
- 👥 For users, this should mean smoother loading of models from URLs and more predictable behavior when training from remote checkpoints.