### PR TITLE
Fix duplicate model info print for DDP training

### DIFF
--- a/ultralytics/models/rtdetr/train.py
+++ b/ultralytics/models/rtdetr/train.py
@@ -52,9 +52,7 @@ class RTDETRTrainer(DetectionTrainer):
         Returns:
             (RTDETRDetectionModel): Initialized model.
         """
-        model = RTDETRDetectionModel(
-            cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK in {-1, 0}
-        )
+        model = RTDETRDetectionModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
         if weights:
             model.load(weights)
         return model

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -79,9 +79,7 @@ class ClassificationTrainer(BaseTrainer):
         Returns:
             (ClassificationModel): Configured PyTorch model for classification.
         """
-        model = ClassificationModel(
-            cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1
-        )
+        model = ClassificationModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
         if weights:
             model.load(weights)
 

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -80,7 +80,7 @@ class ClassificationTrainer(BaseTrainer):
             (ClassificationModel): Configured PyTorch model for classification.
         """
         model = ClassificationModel(
-            cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK in {-1, 0}
+            cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1
         )
         if weights:
             model.load(weights)

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -178,7 +178,7 @@ class DetectionTrainer(BaseTrainer):
         Returns:
             (DetectionModel): YOLO detection model.
         """
-        model = DetectionModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK in {-1, 0})
+        model = DetectionModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
         if weights:
             model.load(weights)
         return model

--- a/ultralytics/models/yolo/obb/train.py
+++ b/ultralytics/models/yolo/obb/train.py
@@ -64,7 +64,7 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
             >>> trainer = OBBTrainer()
             >>> model = trainer.get_model(cfg="yolo26n-obb.yaml", weights="yolo26n-obb.pt")
         """
-        model = OBBModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK in {-1, 0})
+        model = OBBModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
         if weights:
             model.load(weights)
 

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import PoseModel
-from ultralytics.utils import DEFAULT_CFG
+from ultralytics.utils import DEFAULT_CFG, RANK
 from ultralytics.utils.torch_utils import unwrap_model
 
 
@@ -72,7 +72,11 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
             (PoseModel): Initialized pose estimation model.
         """
         model = PoseModel(
-            cfg, nc=self.data["nc"], ch=self.data["channels"], data_kpt_shape=self.data["kpt_shape"], verbose=verbose
+            cfg,
+            nc=self.data["nc"],
+            ch=self.data["channels"],
+            data_kpt_shape=self.data["kpt_shape"],
+            verbose=verbose and RANK == -1,
         )
         if weights:
             model.load(weights)

--- a/ultralytics/models/yolo/segment/train.py
+++ b/ultralytics/models/yolo/segment/train.py
@@ -55,9 +55,7 @@ class SegmentationTrainer(yolo.detect.DetectionTrainer):
             >>> model = trainer.get_model(cfg="yolo26n-seg.yaml")
             >>> model = trainer.get_model(weights="yolo26n-seg.pt", verbose=False)
         """
-        model = SegmentationModel(
-            cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK in {-1, 0}
-        )
+        model = SegmentationModel(cfg, nc=self.data["nc"], ch=self.data["channels"], verbose=verbose and RANK == -1)
         if weights:
             model.load(weights)
 

--- a/ultralytics/models/yolo/world/train.py
+++ b/ultralytics/models/yolo/world/train.py
@@ -83,7 +83,7 @@ class WorldTrainer(DetectionTrainer):
             cfg["yaml_file"] if isinstance(cfg, dict) else cfg,
             ch=self.data["channels"],
             nc=min(self.data["nc"], 80),
-            verbose=verbose and RANK in {-1, 0},
+            verbose=verbose and RANK == -1,
         )
         if weights:
             model.load(weights)

--- a/ultralytics/models/yolo/yoloe/train.py
+++ b/ultralytics/models/yolo/yoloe/train.py
@@ -70,7 +70,7 @@ class YOLOETrainer(DetectionTrainer):
             cfg["yaml_file"] if isinstance(cfg, dict) else cfg,
             ch=self.data["channels"],
             nc=min(self.data["nc"], 80),
-            verbose=verbose and RANK in {-1, 0},
+            verbose=verbose and RANK == -1,
         )
         if weights:
             model.load(weights)
@@ -128,7 +128,7 @@ class YOLOEPETrainer(DetectionTrainer):
             cfg["yaml_file"] if isinstance(cfg, dict) else cfg,
             ch=self.data["channels"],
             nc=self.data["nc"],
-            verbose=verbose and RANK in {-1, 0},
+            verbose=verbose and RANK == -1,
         )
 
         del model.model[-1].savpe

--- a/ultralytics/models/yolo/yoloe/train_seg.py
+++ b/ultralytics/models/yolo/yoloe/train_seg.py
@@ -39,7 +39,7 @@ class YOLOESegTrainer(YOLOETrainer, SegmentationTrainer):
             cfg["yaml_file"] if isinstance(cfg, dict) else cfg,
             ch=self.data["channels"],
             nc=min(self.data["nc"], 80),
-            verbose=verbose and RANK in {-1, 0},
+            verbose=verbose and RANK == -1,
         )
         if weights:
             model.load(weights)
@@ -85,7 +85,7 @@ class YOLOEPESegTrainer(SegmentationTrainer):
             cfg["yaml_file"] if isinstance(cfg, dict) else cfg,
             ch=self.data["channels"],
             nc=self.data["nc"],
-            verbose=verbose and RANK in {-1, 0},
+            verbose=verbose and RANK == -1,
         )
 
         del model.model[-1].savpe


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR standardizes model initialization logging so training runs are only verbose in single-process mode, reducing duplicate console output during distributed training 🧹🚀

### 📊 Key Changes
- Updated `verbose` handling across multiple training modules to use `RANK == -1` instead of `RANK in {-1, 0}`.
- Applied this change consistently to many model trainers, including:
  - RT-DETR
  - YOLO detection
  - classification
  - segmentation
  - pose
  - OBB
  - YOLO-World
  - YOLOE and YOLOE segmentation
- In the pose trainer, added the missing `RANK` import so it follows the same verbosity logic as the other trainers.
- No model architecture, training logic, or weight-loading behavior was changed—only when startup/model details are printed to the console.

### 🎯 Purpose & Impact
- Prevents repeated or noisy logs in distributed training setups 🖥️🖥️🖥️
- Makes training output cleaner and easier to read, especially for multi-GPU users.
- Improves consistency across Ultralytics training code by using the same verbosity rule everywhere.
- Low risk change: it should not affect model accuracy, training results, or saved weights—just the user experience around logging ✅