### PR TITLE
`ultralytics 8.4.37` NDJSON-based multidataset hyperparameter tuning

### DIFF
--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -70,7 +70,7 @@ Use metrics like AP50, F1-score, or custom metrics to evaluate the model's perfo
 
 ### Log Results
 
-It's crucial to log both the performance metrics and the corresponding hyperparameters for future reference. Ultralytics YOLO automatically saves these results in CSV format.
+It's crucial to log both the performance metrics and the corresponding hyperparameters for future reference. Ultralytics YOLO automatically saves these results in NDJSON format.
 
 ### Repeat
 
@@ -187,8 +187,8 @@ runs/
     ├── ...
     └── tune/
         ├── best_hyperparameters.yaml
-        ├── best_fitness.png
-        ├── tune_results.csv
+        ├── tune_fitness.png
+        ├── tune_results.ndjson
         ├── tune_scatter_plots.png
         └── weights/
             ├── last.pt
@@ -237,7 +237,7 @@ This YAML file contains the best-performing hyperparameters found during the tun
     copy_paste: 0.0
     ```
 
-#### best_fitness.png
+#### tune_fitness.png
 
 This is a plot displaying fitness (typically a performance metric like AP50) against the number of iterations. It helps you visualize how well the genetic algorithm performed over time.
 
@@ -248,23 +248,56 @@ This is a plot displaying fitness (typically a performance metric like AP50) aga
   <img width="640" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/best-fitness.avif" alt="Hyperparameter Tuning Fitness vs Iteration">
 </p>
 
-#### tune_results.csv
+#### tune_results.ndjson
 
-A CSV file containing detailed results of each iteration during the tuning. Each row in the file represents one iteration, and it includes metrics like fitness score, [precision](https://www.ultralytics.com/glossary/precision), [recall](https://www.ultralytics.com/glossary/recall), as well as the hyperparameters used.
+An NDJSON file containing detailed results of each tuning iteration. Each line is one JSON object with the aggregate fitness, tuned hyperparameters, and per-dataset metrics. Single-dataset and multi-dataset tuning use the same file format.
 
-- **Format**: CSV
+- **Format**: NDJSON
 - **Usage**: Per-iteration results tracking.
 - **Example**:
-    ```csv
-      fitness,lr0,lrf,momentum,weight_decay,warmup_epochs,warmup_momentum,box,cls,dfl,hsv_h,hsv_s,hsv_v,degrees,translate,scale,shear,perspective,flipud,fliplr,mosaic,mixup,copy_paste
-      0.05021,0.01,0.01,0.937,0.0005,3.0,0.8,7.5,0.5,1.5,0.015,0.7,0.4,0.0,0.1,0.5,0.0,0.0,0.0,0.5,1.0,0.0,0.0
-      0.07217,0.01003,0.00967,0.93897,0.00049,2.79757,0.81075,7.5,0.50746,1.44826,0.01503,0.72948,0.40658,0.0,0.0987,0.4922,0.0,0.0,0.0,0.49729,1.0,0.0,0.0
-      0.06584,0.01003,0.00855,0.91009,0.00073,3.42176,0.95,8.64301,0.54594,1.72261,0.01503,0.59179,0.40658,0.0,0.0987,0.46955,0.0,0.0,0.0,0.49729,0.80187,0.0,0.0
-    ```
+```json
+{
+  "iteration": 1,
+  "fitness": 0.23345,
+  "hyperparameters": {
+    "lr0": 0.01,
+    "lrf": 0.01,
+    "momentum": 0.937,
+    "weight_decay": 0.0005
+  },
+  "datasets": {
+    "coco8": {
+      "fitness": 0.28992
+    },
+    "coco8-grayscale": {
+      "fitness": 0.17697
+    }
+  }
+}
+
+{
+  "iteration": 2,
+  "fitness": 0.23661,
+  "hyperparameters": {
+    "lr0": 0.0062,
+    "lrf": 0.01,
+    "momentum": 0.90058,
+    "weight_decay": 0.0
+  },
+  "datasets": {
+    "coco8": {
+      "fitness": 0.29561
+    },
+    "coco8-grayscale": {
+      "fitness": 0.1776
+    }
+  }
+}
+```
 
 #### tune_scatter_plots.png
 
-This file contains scatter plots generated from `tune_results.csv`, helping you visualize relationships between different hyperparameters and performance metrics. Note that hyperparameters initialized to 0 will not be tuned, such as `degrees` and `shear` below.
+This file contains scatter plots generated from `tune_results.ndjson`, helping you visualize relationships between different hyperparameters and performance metrics. Note that hyperparameters initialized to 0 will not be tuned, such as `degrees` and `shear` below.
 
 - **Format**: PNG
 - **Usage**: Exploratory data analysis

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -255,6 +255,7 @@ An NDJSON file containing detailed results of each tuning iteration. Each line i
 - **Format**: NDJSON
 - **Usage**: Per-iteration results tracking.
 - **Example**:
+
 ```json
 {
   "iteration": 1,

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -255,6 +255,9 @@ An NDJSON file containing detailed results of each tuning iteration. Each line i
 - **Format**: NDJSON
 - **Usage**: Per-iteration results tracking.
 - **Example**:
+
+A pretty-printed example is shown below for readability. In the actual `.ndjson` file, each object is stored on a single line.
+
 ```json
 {
   "iteration": 1,

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -316,7 +316,7 @@ class Tuner:
             if len(csv_data) > 0:
                 fitness = csv_data[:, 0]  # first column
                 order = np.argsort(-fitness)
-                x = csv_data[order][:n, :len(self.space) + 1]  # top-n sorted by fitness DESC
+                x = csv_data[order][:n, : len(self.space) + 1]  # top-n sorted by fitness DESC
 
         # Mutate if we have data, otherwise use defaults
         if x is not None:

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -364,7 +364,7 @@ class Tuner:
             cleanup (bool): Whether to delete iteration weights to reduce storage space during tuning.
         """
         t0 = time.time()
-        best_save_dir, best_metrics = None, None
+        best_save_dir, best_metrics = [], None
         (self.tune_dir / "weights").mkdir(parents=True, exist_ok=True)
 
         # Sync MongoDB to CSV at startup for proper resume logic
@@ -456,8 +456,9 @@ class Tuner:
                     best_weights_dir.mkdir(parents=True, exist_ok=True)
                     for ckpt in weights_dir[j].glob("*.pt"):
                         shutil.copy2(ckpt, best_weights_dir)
-            elif cleanup and best_save_dir:
-                shutil.rmtree(best_save_dir, ignore_errors=True)  # remove iteration dirs to reduce storage space
+            elif cleanup and len(best_save_dir):
+                for s in best_save_dir:
+                    shutil.rmtree(s, ignore_errors=True)  # remove iteration dirs to reduce storage space
 
             # Plot tune results
             plot_tune_results(str(self.tune_csv))

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -306,7 +306,8 @@ class Tuner:
             return None
         x = np.array(
             [
-                [r.get("fitness", 0.0)] + [r.get("hyperparameters", {}).get(k, getattr(self.args, k)) for k in self.space]
+                [r.get("fitness", 0.0)]
+                + [r.get("hyperparameters", {}).get(k, getattr(self.args, k)) for k in self.space]
                 for r in results
             ],
             dtype=float,
@@ -452,9 +453,11 @@ class Tuner:
             data = train_args.pop("data")
             if not isinstance(data, (list, tuple)):
                 data = [data]
-            save_dir = [get_save_dir(get_cfg(train_args))] if len(data) == 1 else [
-                get_save_dir(get_cfg(train_args), name=Path(str(d)).stem) for d in data
-            ]
+            save_dir = (
+                [get_save_dir(get_cfg(train_args))]
+                if len(data) == 1
+                else [get_save_dir(get_cfg(train_args), name=Path(str(d)).stem) for d in data]
+            )
             weights_dir = [s / "weights" for s in save_dir]
             metrics = {}
             all_fitness = []

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -316,7 +316,8 @@ class Tuner:
             return None
         x = np.array(
             [
-                [r.get("fitness", 0.0)] + [r.get("hyperparameters", {}).get(k, getattr(self.args, k)) for k in self.space]
+                [r.get("fitness", 0.0)]
+                + [r.get("hyperparameters", {}).get(k, getattr(self.args, k)) for k in self.space]
                 for r in results
             ],
             dtype=float,
@@ -475,9 +476,11 @@ class Tuner:
             if not isinstance(data, (list, tuple)):
                 data = [data]
             dataset_names = self._dataset_names(data)
-            save_dir = [get_save_dir(get_cfg(train_args))] if len(data) == 1 else [
-                get_save_dir(get_cfg(train_args), name=name) for name in dataset_names
-            ]
+            save_dir = (
+                [get_save_dir(get_cfg(train_args))]
+                if len(data) == 1
+                else [get_save_dir(get_cfg(train_args), name=name) for name in dataset_names]
+            )
             weights_dir = [s / "weights" for s in save_dir]
             metrics = {}
             all_fitness = []
@@ -513,7 +516,11 @@ class Tuner:
                 all_fitness.append(dataset_metrics[dataset].get("fitness") or 0.0)
             fitness = sum(all_fitness) / len(all_fitness)
             result = self._result_record(
-                i + 1, fitness, mutated_hyp, dataset_metrics, {dataset: str(s) for dataset, s in zip(dataset_names, save_dir)}
+                i + 1,
+                fitness,
+                mutated_hyp,
+                dataset_metrics,
+                {dataset: str(s) for dataset, s in zip(dataset_names, save_dir)},
             )
             stop_after_iteration = False
             if self.mongodb:

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -391,7 +391,7 @@ class Tuner:
             all_fitness = []
             if not isinstance(data, (list, tuple)):
                 data = [data]
-            save_dir = [get_save_dir(get_cfg(train_args)) / Path(d).stem for d in data]
+            save_dir = [get_save_dir(get_cfg(train_args), name=Path(d).stem) for d in data]
             weights_dir = [s / "weights" for s in save_dir]
             for j, d in enumerate(data):
                 try:

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -388,7 +388,7 @@ class Tuner:
             metrics = {}
             train_args = {**vars(self.args), **mutated_hyp}
             data = train_args.pop("data")
-            fitness = []
+            all_fitness = []
             if not isinstance(data, (list, tuple)):
                 data = [data]
             save_dir = [get_save_dir(get_cfg(train_args)) for _ in range(len(data))]
@@ -418,8 +418,8 @@ class Tuner:
                     LOGGER.error(f"training failure for hyperparameter tuning iteration {i + 1}\n{e}")
 
                 # Save results - MongoDB takes precedence
-                fitness.append(metrics.get("fitness") or 0.0)
-            fitness = sum(fitness) / len(fitness)
+                all_fitness.append(metrics.get("fitness") or 0.0)
+            fitness = sum(all_fitness) / len(all_fitness)
             if self.mongodb:
                 self._save_to_mongodb(fitness, mutated_hyp, metrics, i + 1)
                 self._sync_mongodb_to_csv()
@@ -431,8 +431,15 @@ class Tuner:
                     break
             else:
                 # Save to CSV only if no MongoDB
-                log_row = [round(fitness, 5)] + [mutated_hyp[k] for k in self.space.keys()]
-                headers = "" if self.tune_csv.exists() else (",".join(["fitness", *list(self.space.keys())]) + "\n")
+                log_row = [round(fitness, 5)] + all_fitness + [mutated_hyp[k] for k in self.space.keys()]
+                headers = (
+                    ""
+                    if self.tune_csv.exists()
+                    else (
+                        ",".join(["fitness", *[f"fitness-{Path(d).stem}" for d in data], *list(self.space.keys())])
+                        + "\n"
+                    )
+                )
                 with open(self.tune_csv, "a", encoding="utf-8") as f:
                     f.write(headers + ",".join(map(str, log_row)) + "\n")
 
@@ -453,7 +460,7 @@ class Tuner:
                 shutil.rmtree(best_save_dir, ignore_errors=True)  # remove iteration dirs to reduce storage space
 
             # Plot tune results
-            plot_tune_results(str(self.tune_csv))
+            plot_tune_results(str(self.tune_csv), num_metrics_columns=len(data) + 1)
 
             # Save and print tune results
             header = (

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -449,9 +449,9 @@ class Tuner:
             best_idx = fitness.argmax()
             best_is_current = best_idx == i
             if best_is_current:
+                best_save_dir = save_dir
+                best_metrics = {k: round(v, 5) for k, v in metrics.items()}
                 for j in range(len(data)):
-                    best_save_dir = str(save_dir[j])
-                    best_metrics = {k: round(v, 5) for k, v in metrics.items()}
                     best_weights_dir = self.tune_dir / "weights" / Path(data[j]).stem
                     best_weights_dir.mkdir(parents=True, exist_ok=True)
                     for ckpt in weights_dir[j].glob("*.pt"):

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -392,7 +392,7 @@ class Tuner:
                 data = [data]
             for d in data:
                 try:
-                    save_dir = get_save_dir(get_cfg(train_args))
+                    save_dir = get_save_dir(get_cfg({k: v for k, v in train_args.items() if k != "save_dir"}))
                     train_args["save_dir"] = str(save_dir)  # pass save_dir to subprocess to ensure same path is used
                     weights_dir = save_dir / "weights"
                     train_args["data"] = d

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -386,15 +386,15 @@ class Tuner:
 
             metrics = {}
             train_args = {**vars(self.args), **mutated_hyp}
-            save_dir = get_save_dir(get_cfg(train_args))
-            train_args["save_dir"] = str(save_dir)  # pass save_dir to subprocess to ensure same path is used
-            weights_dir = save_dir / "weights"
             data = train_args.pop("data")
             fitness = []
             if not isinstance(data, (list, tuple)):
                 data = [data]
             for d in data:
                 try:
+                    save_dir = get_save_dir(get_cfg(train_args))
+                    train_args["save_dir"] = str(save_dir)  # pass save_dir to subprocess to ensure same path is used
+                    weights_dir = save_dir / "weights"
                     train_args["data"] = d
                     # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
                     launch = [

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -445,7 +445,7 @@ class Tuner:
                 for j in range(len(data)):
                     best_save_dir = str(save_dir[j])
                     best_metrics = {k: round(v, 5) for k, v in metrics.items()}
-                    best_weights_dir = self.tune_dir / f"{Path(data[j]).stem}-weights"
+                    best_weights_dir = self.tune_dir / "weights" / Path(data[j]).stem
                     best_weights_dir.mkdir(parents=True, exist_ok=True)
                     for ckpt in weights_dir[j].glob("*.pt"):
                         shutil.copy2(ckpt, best_weights_dir)

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -17,6 +17,7 @@ Examples:
 from __future__ import annotations
 
 import gc
+import json
 import random
 import shutil
 import subprocess
@@ -38,13 +39,13 @@ class Tuner:
     """A class for hyperparameter tuning of YOLO models.
 
     The class evolves YOLO model hyperparameters over a given number of iterations by mutating them according to the
-    search space and retraining the model to evaluate their performance. Supports both local CSV storage and distributed
-    MongoDB Atlas coordination for multi-machine hyperparameter optimization.
+    search space and retraining the model to evaluate their performance. Supports both local NDJSON storage and
+    distributed MongoDB Atlas coordination for multi-machine hyperparameter optimization.
 
     Attributes:
         space (dict[str, tuple]): Hyperparameter search space containing bounds and scaling factors for mutation.
         tune_dir (Path): Directory where evolution logs and results will be saved.
-        tune_csv (Path): Path to the CSV file where evolution logs are saved.
+        tune_file (Path): Path to the NDJSON file where evolution logs are saved.
         args (SimpleNamespace): Configuration arguments for the tuning process.
         callbacks (dict): Callback functions to be executed during tuning.
         prefix (str): Prefix string for logging messages.
@@ -126,7 +127,7 @@ class Tuner:
         self.args.exist_ok = self.args.resume  # resume w/ same tune_dir
         self.tune_dir = get_save_dir(self.args, name=self.args.name or "tune")
         self.args.name, self.args.exist_ok, self.args.resume = (None, False, False)  # reset to not affect training
-        self.tune_csv = self.tune_dir / "tune_results.csv"
+        self.tune_file = self.tune_dir / "tune_results.ndjson"
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
         self.prefix = colorstr("Tuner: ")
         callbacks.add_integration_callbacks(self)
@@ -194,7 +195,7 @@ class Tuner:
 
         Notes:
             - Creates a fitness index for fast queries of top results
-            - Falls back to CSV-only mode if connection fails
+            - Falls back to local NDJSON mode if connection fails
             - Uses connection pooling and retry logic for production reliability
         """
         self.mongodb = self._connect(mongodb_uri)
@@ -216,13 +217,37 @@ class Tuner:
         except Exception:
             return []
 
-    def _save_to_mongodb(self, fitness: float, hyperparameters: dict[str, float], metrics: dict, iteration: int):
+    @staticmethod
+    def _json_default(x):
+        """Convert tensor-like values for JSON serialization."""
+        return x.item() if hasattr(x, "item") else str(x)
+
+    def _result_record(
+        self, iteration: int, fitness: float, hyperparameters: dict[str, float], datasets: dict[str, dict]
+    ) -> dict:
+        """Build one local tuning result record."""
+        return {
+            "iteration": iteration,
+            "fitness": round(fitness, 5),
+            "hyperparameters": hyperparameters,
+            "datasets": datasets,
+        }
+
+    def _save_to_mongodb(
+        self,
+        fitness: float,
+        hyperparameters: dict[str, float],
+        metrics: dict,
+        datasets: dict[str, dict],
+        iteration: int,
+    ):
         """Save results to MongoDB with proper type conversion.
 
         Args:
             fitness (float): Fitness score achieved with these hyperparameters.
             hyperparameters (dict[str, float]): Dictionary of hyperparameter values.
             metrics (dict): Complete training metrics dictionary (mAP, precision, recall, losses, etc.).
+            datasets (dict[str, dict]): Per-dataset metrics for the iteration.
             iteration (int): Current iteration number.
         """
         try:
@@ -231,6 +256,7 @@ class Tuner:
                     "fitness": fitness,
                     "hyperparameters": {k: (v.item() if hasattr(v, "item") else v) for k, v in hyperparameters.items()},
                     "metrics": metrics,
+                    "datasets": datasets,
                     "timestamp": datetime.now(),
                     "iteration": iteration,
                 }
@@ -238,30 +264,72 @@ class Tuner:
         except Exception as e:
             LOGGER.warning(f"{self.prefix}MongoDB save failed: {e}")
 
-    def _sync_mongodb_to_csv(self):
-        """Sync MongoDB results to CSV for plotting compatibility.
+    def _sync_mongodb_to_file(self):
+        """Sync MongoDB results to the local NDJSON tuning log.
 
-        Downloads all results from MongoDB and writes them to the local CSV file in chronological order. This enables
-        the existing plotting functions to work seamlessly with distributed MongoDB data.
+        Downloads all results from MongoDB and writes them to the local NDJSON file in chronological order. This keeps
+        resume, mutation, and plotting on the same local source of truth when using distributed tuning.
         """
         try:
-            # Get all results from MongoDB
             all_results = list(self.collection.find().sort("iteration", 1))
             if not all_results:
                 return
 
-            # Write to CSV
-            headers = ",".join(["fitness", *list(self.space.keys())]) + "\n"
-            with open(self.tune_csv, "w", encoding="utf-8") as f:
-                f.write(headers)
+            with open(self.tune_file, "w", encoding="utf-8") as f:
                 for result in all_results:
-                    fitness = result["fitness"] or 0.0
-                    hyp_values = [result["hyperparameters"].get(k, self.args.get(k)) for k in self.space.keys()]
-                    log_row = [round(fitness, 5), *hyp_values]
-                    f.write(",".join(map(str, log_row)) + "\n")
+                    f.write(
+                        json.dumps(
+                            self._result_record(
+                                result["iteration"],
+                                result["fitness"] or 0.0,
+                                result.get("hyperparameters", {}),
+                                result.get("datasets", {}),
+                            ),
+                            default=self._json_default,
+                        )
+                        + "\n"
+                    )
 
         except Exception as e:
-            LOGGER.warning(f"{self.prefix}MongoDB to CSV sync failed: {e}")
+            LOGGER.warning(f"{self.prefix}MongoDB to NDJSON sync failed: {e}")
+
+    def _load_local_results(self) -> list[dict]:
+        """Load local tuning results from the NDJSON log."""
+        if not self.tune_file.exists():
+            return []
+        with open(self.tune_file, encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def _local_results_to_array(self, results: list[dict], n: int | None = None) -> np.ndarray | None:
+        """Convert local NDJSON records to a fitness-plus-hyperparameters numpy array."""
+        if not results:
+            return None
+        x = np.array(
+            [
+                [r.get("fitness", 0.0)] + [r.get("hyperparameters", {}).get(k, getattr(self.args, k)) for k in self.space]
+                for r in results
+            ],
+            dtype=float,
+        )
+        if n is None:
+            return x
+        order = np.argsort(-x[:, 0])
+        return x[order][:n]
+
+    def _save_local_result(self, result: dict):
+        """Append one tuning result to the local NDJSON log."""
+        with open(self.tune_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(result, default=self._json_default) + "\n")
+
+    @staticmethod
+    def _best_metrics(result: dict) -> dict | None:
+        """Summarize best-result metrics for logging."""
+        datasets = result.get("datasets", {})
+        if len(datasets) == 1:
+            return next(iter(datasets.values()))
+        if len(datasets) > 1:
+            return {k: round(v.get("fitness") or 0.0, 5) for k, v in datasets.items()}
+        return None
 
     @staticmethod
     def _crossover(x: np.ndarray, alpha: float = 0.2, k: int = 9) -> np.ndarray:
@@ -310,13 +378,9 @@ class Tuner:
             elif self.collection.name in self.collection.database.list_collection_names():  # Tuner started elsewhere
                 x = np.array([[0.0] + [getattr(self.args, k) for k in self.space.keys()]])
 
-        # Fall back to CSV if MongoDB unavailable or empty
-        if x is None and self.tune_csv.exists():
-            csv_data = np.loadtxt(self.tune_csv, ndmin=2, delimiter=",", skiprows=1)
-            if len(csv_data) > 0:
-                fitness = csv_data[:, 0]  # first column
-                order = np.argsort(-fitness)
-                x = csv_data[order][:n, : len(self.space) + 1]  # top-n sorted by fitness DESC
+        # Fall back to local NDJSON if MongoDB unavailable or empty
+        if x is None:
+            x = self._local_results_to_array(self._load_local_results(), n=n)
 
         # Mutate if we have data, otherwise use defaults
         if x is not None:
@@ -353,10 +417,10 @@ class Tuner:
         """Execute the hyperparameter evolution process when the Tuner instance is called.
 
         This method iterates through the specified number of iterations, performing the following steps:
-        1. Sync MongoDB results to CSV (if using distributed mode)
+        1. Sync MongoDB results to local NDJSON (if using distributed mode)
         2. Mutate hyperparameters using the best previous results or defaults
         3. Train a YOLO model with the mutated hyperparameters
-        4. Log fitness scores and hyperparameters to MongoDB and/or CSV
+        4. Log fitness scores and hyperparameters to MongoDB and/or NDJSON
         5. Track the best performing configuration across all iterations
 
         Args:
@@ -364,17 +428,16 @@ class Tuner:
             cleanup (bool): Whether to delete iteration weights to reduce storage space during tuning.
         """
         t0 = time.time()
-        best_save_dir, best_metrics = [], None
+        self.tune_dir.mkdir(parents=True, exist_ok=True)
         (self.tune_dir / "weights").mkdir(parents=True, exist_ok=True)
 
-        # Sync MongoDB to CSV at startup for proper resume logic
+        # Sync MongoDB to local NDJSON at startup for proper resume logic
         if self.mongodb:
-            self._sync_mongodb_to_csv()
+            self._sync_mongodb_to_file()
 
         start = 0
-        if self.tune_csv.exists():
-            x = np.loadtxt(self.tune_csv, ndmin=2, delimiter=",", skiprows=1)
-            start = x.shape[0]
+        if self.tune_file.exists():
+            start = len(self._load_local_results())
             LOGGER.info(f"{self.prefix}Resuming tuning run {self.tune_dir} from iteration {start + 1}...")
         for i in range(start, iterations):
             # Linearly decay sigma from 0.2 → 0.1 over first 300 iterations
@@ -385,15 +448,20 @@ class Tuner:
             mutated_hyp = self._mutate(sigma=sigma_i)
             LOGGER.info(f"{self.prefix}Starting iteration {i + 1}/{iterations} with hyperparameters: {mutated_hyp}")
 
-            metrics = {}
             train_args = {**vars(self.args), **mutated_hyp}
             data = train_args.pop("data")
-            all_fitness = []
             if not isinstance(data, (list, tuple)):
                 data = [data]
-            save_dir = [get_save_dir(get_cfg(train_args), name=Path(d).stem) for d in data]
+            save_dir = [get_save_dir(get_cfg(train_args))] if len(data) == 1 else [
+                get_save_dir(get_cfg(train_args), name=Path(str(d)).stem) for d in data
+            ]
             weights_dir = [s / "weights" for s in save_dir]
+            metrics = {}
+            all_fitness = []
+            dataset_metrics = {}
             for j, d in enumerate(data):
+                dataset = Path(str(d)).stem
+                metrics_i = {}
                 try:
                     train_args["data"] = d
                     train_args["save_dir"] = str(save_dir[j])  # pass save_dir to subprocess to ensure same path is used
@@ -406,7 +474,8 @@ class Tuner:
                     cmd = [*launch, "train", *(f"{k}={v}" for k, v in train_args.items())]
                     return_code = subprocess.run(cmd, check=True).returncode
                     ckpt_file = weights_dir[j] / ("best.pt" if (weights_dir[j] / "best.pt").exists() else "last.pt")
-                    metrics = torch_load(ckpt_file)["train_metrics"]
+                    metrics_i = torch_load(ckpt_file)["train_metrics"]
+                    metrics = metrics_i
                     assert return_code == 0, "training failed"
 
                     # Cleanup
@@ -418,11 +487,13 @@ class Tuner:
                     LOGGER.error(f"training failure for hyperparameter tuning iteration {i + 1}\n{e}")
 
                 # Save results - MongoDB takes precedence
-                all_fitness.append(metrics.get("fitness") or 0.0)
+                dataset_metrics[dataset] = metrics_i or {"fitness": 0.0}
+                all_fitness.append(dataset_metrics[dataset].get("fitness") or 0.0)
             fitness = sum(all_fitness) / len(all_fitness)
+            result = self._result_record(i + 1, fitness, mutated_hyp, dataset_metrics)
             if self.mongodb:
-                self._save_to_mongodb(fitness, mutated_hyp, metrics, i + 1)
-                self._sync_mongodb_to_csv()
+                self._save_to_mongodb(fitness, mutated_hyp, metrics, dataset_metrics, i + 1)
+                self._sync_mongodb_to_file()
                 total_mongo_iterations = self.collection.count_documents({})
                 if total_mongo_iterations >= iterations:
                     LOGGER.info(
@@ -430,46 +501,39 @@ class Tuner:
                     )
                     break
             else:
-                # Save to CSV only if no MongoDB
-                log_row = [round(fitness, 5)] + [mutated_hyp[k] for k in self.space.keys()] + all_fitness
-                headers = (
-                    ""
-                    if self.tune_csv.exists()
-                    else (
-                        ",".join(["fitness", *list(self.space.keys()), *[f"fitness-{Path(d).stem}" for d in data]])
-                        + "\n"
-                    )
-                )
-                with open(self.tune_csv, "a", encoding="utf-8") as f:
-                    f.write(headers + ",".join(map(str, log_row)) + "\n")
+                self._save_local_result(result)
 
             # Get best results
-            x = np.loadtxt(self.tune_csv, ndmin=2, delimiter=",", skiprows=1)
+            results = self._load_local_results()
+            x = self._local_results_to_array(results)
             fitness = x[:, 0]  # first column
             best_idx = fitness.argmax()
+            best_result = results[best_idx]
             best_is_current = best_idx == i
             if best_is_current:
-                best_save_dir = save_dir
-                best_metrics = {k: round(v, 5) for k, v in metrics.items()}
-                for j in range(len(data)):
-                    best_weights_dir = self.tune_dir / "weights" / Path(data[j]).stem
-                    best_weights_dir.mkdir(parents=True, exist_ok=True)
-                    for ckpt in weights_dir[j].glob("*.pt"):
-                        shutil.copy2(ckpt, best_weights_dir)
-            elif cleanup and len(best_save_dir):
-                for s in best_save_dir:
+                if len(data) == 1:
+                    for ckpt in weights_dir[0].glob("*.pt"):
+                        shutil.copy2(ckpt, self.tune_dir / "weights")
+                else:
+                    for j in range(len(data)):
+                        best_weights_dir = self.tune_dir / "weights" / Path(str(data[j])).stem
+                        best_weights_dir.mkdir(parents=True, exist_ok=True)
+                        for ckpt in weights_dir[j].glob("*.pt"):
+                            shutil.copy2(ckpt, best_weights_dir)
+            elif cleanup:
+                for s in save_dir:
                     shutil.rmtree(s, ignore_errors=True)  # remove iteration dirs to reduce storage space
 
             # Plot tune results
-            plot_tune_results(str(self.tune_csv))
+            plot_tune_results(str(self.tune_file))
 
             # Save and print tune results
             header = (
                 f"{self.prefix}{i + 1}/{iterations} iterations complete ✅ ({time.time() - t0:.2f}s)\n"
                 f"{self.prefix}Results saved to {colorstr('bold', self.tune_dir)}\n"
                 f"{self.prefix}Best fitness={fitness[best_idx]} observed at iteration {best_idx + 1}\n"
-                f"{self.prefix}Best fitness metrics are {best_metrics}\n"
-                f"{self.prefix}Best fitness model is {best_save_dir}"
+                f"{self.prefix}Best fitness metrics are {self._best_metrics(best_result)}\n"
+                f"{self.prefix}Best fitness model is {self.tune_dir / 'weights'}"
             )
             LOGGER.info("\n" + header)
             data = {k: int(v) if k in CFG_INT_KEYS else float(v) for k, v in zip(self.space.keys(), x[best_idx, 1:])}

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -22,6 +22,7 @@ import random
 import shutil
 import subprocess
 import time
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
@@ -223,15 +224,23 @@ class Tuner:
         return x.item() if hasattr(x, "item") else str(x)
 
     def _result_record(
-        self, iteration: int, fitness: float, hyperparameters: dict[str, float], datasets: dict[str, dict]
+        self,
+        iteration: int,
+        fitness: float,
+        hyperparameters: dict[str, float],
+        datasets: dict[str, dict],
+        save_dirs: dict[str, str] | None = None,
     ) -> dict:
         """Build one local tuning result record."""
-        return {
+        result = {
             "iteration": iteration,
             "fitness": round(fitness, 5),
             "hyperparameters": hyperparameters,
             "datasets": datasets,
         }
+        if save_dirs:
+            result["save_dirs"] = save_dirs
+        return result
 
     def _save_to_mongodb(
         self,
@@ -284,6 +293,7 @@ class Tuner:
                                 result["fitness"] or 0.0,
                                 result.get("hyperparameters", {}),
                                 result.get("datasets", {}),
+                                result.get("save_dirs"),
                             ),
                             default=self._json_default,
                         )
@@ -330,6 +340,17 @@ class Tuner:
         if len(datasets) > 1:
             return {k: round(v.get("fitness") or 0.0, 5) for k, v in datasets.items()}
         return None
+
+    @staticmethod
+    def _dataset_names(data: list) -> list[str]:
+        """Create stable unique dataset names for logging and per-run directories."""
+        stems = [Path(str(d)).stem for d in data]
+        totals, seen = Counter(stems), Counter()
+        names = []
+        for stem in stems:
+            seen[stem] += 1
+            names.append(f"{stem}-{seen[stem]}" if totals[stem] > 1 else stem)
+        return names
 
     @staticmethod
     def _crossover(x: np.ndarray, alpha: float = 0.2, k: int = 9) -> np.ndarray:
@@ -430,6 +451,7 @@ class Tuner:
         t0 = time.time()
         self.tune_dir.mkdir(parents=True, exist_ok=True)
         (self.tune_dir / "weights").mkdir(parents=True, exist_ok=True)
+        best_save_dirs = {}
 
         # Sync MongoDB to local NDJSON at startup for proper resume logic
         if self.mongodb:
@@ -452,15 +474,15 @@ class Tuner:
             data = train_args.pop("data")
             if not isinstance(data, (list, tuple)):
                 data = [data]
+            dataset_names = self._dataset_names(data)
             save_dir = [get_save_dir(get_cfg(train_args))] if len(data) == 1 else [
-                get_save_dir(get_cfg(train_args), name=Path(str(d)).stem) for d in data
+                get_save_dir(get_cfg(train_args), name=name) for name in dataset_names
             ]
             weights_dir = [s / "weights" for s in save_dir]
             metrics = {}
             all_fitness = []
             dataset_metrics = {}
-            for j, d in enumerate(data):
-                dataset = Path(str(d)).stem
+            for j, (d, dataset) in enumerate(zip(data, dataset_names)):
                 metrics_i = {}
                 try:
                     train_args["data"] = d
@@ -490,16 +512,16 @@ class Tuner:
                 dataset_metrics[dataset] = metrics_i or {"fitness": 0.0}
                 all_fitness.append(dataset_metrics[dataset].get("fitness") or 0.0)
             fitness = sum(all_fitness) / len(all_fitness)
-            result = self._result_record(i + 1, fitness, mutated_hyp, dataset_metrics)
+            result = self._result_record(
+                i + 1, fitness, mutated_hyp, dataset_metrics, {dataset: str(s) for dataset, s in zip(dataset_names, save_dir)}
+            )
+            stop_after_iteration = False
             if self.mongodb:
                 self._save_to_mongodb(fitness, mutated_hyp, metrics, dataset_metrics, i + 1)
                 self._sync_mongodb_to_file()
                 total_mongo_iterations = self.collection.count_documents({})
                 if total_mongo_iterations >= iterations:
-                    LOGGER.info(
-                        f"{self.prefix}Target iterations ({iterations}) reached in MongoDB ({total_mongo_iterations}). Stopping."
-                    )
-                    break
+                    stop_after_iteration = True
             else:
                 self._save_local_result(result)
 
@@ -509,20 +531,21 @@ class Tuner:
             fitness = x[:, 0]  # first column
             best_idx = fitness.argmax()
             best_result = results[best_idx]
+            current_best_save_dirs = best_result.get("save_dirs", {})
             best_is_current = best_idx == i
             if best_is_current:
+                if cleanup:
+                    for s in best_save_dirs.values():
+                        if s not in current_best_save_dirs.values():
+                            shutil.rmtree(s, ignore_errors=True)
                 if len(data) == 1:
                     for ckpt in weights_dir[0].glob("*.pt"):
                         shutil.copy2(ckpt, self.tune_dir / "weights")
-                else:
-                    for j in range(len(data)):
-                        best_weights_dir = self.tune_dir / "weights" / Path(str(data[j])).stem
-                        best_weights_dir.mkdir(parents=True, exist_ok=True)
-                        for ckpt in weights_dir[j].glob("*.pt"):
-                            shutil.copy2(ckpt, best_weights_dir)
+                best_save_dirs = current_best_save_dirs
             elif cleanup:
                 for s in save_dir:
                     shutil.rmtree(s, ignore_errors=True)  # remove iteration dirs to reduce storage space
+                best_save_dirs = current_best_save_dirs
 
             # Plot tune results
             plot_tune_results(str(self.tune_file))
@@ -533,7 +556,8 @@ class Tuner:
                 f"{self.prefix}Results saved to {colorstr('bold', self.tune_dir)}\n"
                 f"{self.prefix}Best fitness={fitness[best_idx]} observed at iteration {best_idx + 1}\n"
                 f"{self.prefix}Best fitness metrics are {self._best_metrics(best_result)}\n"
-                f"{self.prefix}Best fitness model is {self.tune_dir / 'weights'}"
+                f"{self.prefix}Best fitness model is "
+                f"{self.tune_dir / 'weights' if len(best_result.get('datasets', {})) == 1 else 'not saved for multi-dataset tuning'}"
             )
             LOGGER.info("\n" + header)
             data = {k: int(v) if k in CFG_INT_KEYS else float(v) for k, v in zip(self.space.keys(), x[best_idx, 1:])}
@@ -543,3 +567,8 @@ class Tuner:
                 header=remove_colorstr(header.replace(self.prefix, "# ")) + "\n",
             )
             YAML.print(self.tune_dir / "best_hyperparameters.yaml")
+            if stop_after_iteration:
+                LOGGER.info(
+                    f"{self.prefix}Target iterations ({iterations}) reached in MongoDB ({total_mongo_iterations}). Stopping."
+                )
+                break

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -316,7 +316,7 @@ class Tuner:
             if len(csv_data) > 0:
                 fitness = csv_data[:, 0]  # first column
                 order = np.argsort(-fitness)
-                x = csv_data[order][:n]  # top-n sorted by fitness DESC
+                x = csv_data[order][:n, :len(self.space) + 1]  # top-n sorted by fitness DESC
 
         # Mutate if we have data, otherwise use defaults
         if x is not None:
@@ -391,7 +391,7 @@ class Tuner:
             all_fitness = []
             if not isinstance(data, (list, tuple)):
                 data = [data]
-            save_dir = [get_save_dir(get_cfg(train_args)) for _ in range(len(data))]
+            save_dir = [get_save_dir(get_cfg(train_args)) / Path(d).stem for d in data]
             weights_dir = [s / "weights" for s in save_dir]
             for j, d in enumerate(data):
                 try:
@@ -431,12 +431,12 @@ class Tuner:
                     break
             else:
                 # Save to CSV only if no MongoDB
-                log_row = [round(fitness, 5)] + all_fitness + [mutated_hyp[k] for k in self.space.keys()]
+                log_row = [round(fitness, 5)] + [mutated_hyp[k] for k in self.space.keys()] + all_fitness
                 headers = (
                     ""
                     if self.tune_csv.exists()
                     else (
-                        ",".join(["fitness", *[f"fitness-{Path(d).stem}" for d in data], *list(self.space.keys())])
+                        ",".join(["fitness", *list(self.space.keys()), *[f"fitness-{Path(d).stem}" for d in data]])
                         + "\n"
                     )
                 )
@@ -460,7 +460,7 @@ class Tuner:
                 shutil.rmtree(best_save_dir, ignore_errors=True)  # remove iteration dirs to reduce storage space
 
             # Plot tune results
-            plot_tune_results(str(self.tune_csv), num_metrics_columns=len(data) + 1)
+            plot_tune_results(str(self.tune_csv))
 
             # Save and print tune results
             header = (

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import time
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -390,12 +391,12 @@ class Tuner:
             fitness = []
             if not isinstance(data, (list, tuple)):
                 data = [data]
-            for d in data:
+            save_dir = [get_save_dir(get_cfg(train_args)) for _ in range(len(data))]
+            weights_dir = [s / "weights" for s in save_dir]
+            for j, d in enumerate(data):
                 try:
-                    save_dir = get_save_dir(get_cfg({k: v for k, v in train_args.items() if k != "save_dir"}))
-                    train_args["save_dir"] = str(save_dir)  # pass save_dir to subprocess to ensure same path is used
-                    weights_dir = save_dir / "weights"
                     train_args["data"] = d
+                    train_args["save_dir"] = str(save_dir[j])  # pass save_dir to subprocess to ensure same path is used
                     # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
                     launch = [
                         __import__("sys").executable,
@@ -404,7 +405,7 @@ class Tuner:
                     ]  # workaround yolo not found
                     cmd = [*launch, "train", *(f"{k}={v}" for k, v in train_args.items())]
                     return_code = subprocess.run(cmd, check=True).returncode
-                    ckpt_file = weights_dir / ("best.pt" if (weights_dir / "best.pt").exists() else "last.pt")
+                    ckpt_file = weights_dir[j] / ("best.pt" if (weights_dir[j] / "best.pt").exists() else "last.pt")
                     metrics = torch_load(ckpt_file)["train_metrics"]
                     assert return_code == 0, "training failed"
 
@@ -441,10 +442,13 @@ class Tuner:
             best_idx = fitness.argmax()
             best_is_current = best_idx == i
             if best_is_current:
-                best_save_dir = str(save_dir)
-                best_metrics = {k: round(v, 5) for k, v in metrics.items()}
-                for ckpt in weights_dir.glob("*.pt"):
-                    shutil.copy2(ckpt, self.tune_dir / "weights")
+                for j in range(len(data)):
+                    best_save_dir = str(save_dir[j])
+                    best_metrics = {k: round(v, 5) for k, v in metrics.items()}
+                    best_weights_dir = self.tune_dir / f"{Path(data[j]).stem}-weights"
+                    best_weights_dir.mkdir(parents=True, exist_ok=True)
+                    for ckpt in weights_dir[j].glob("*.pt"):
+                        shutil.copy2(ckpt, best_weights_dir)
             elif cleanup and best_save_dir:
                 shutil.rmtree(best_save_dir, ignore_errors=True)  # remove iteration dirs to reduce storage space
 

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -940,14 +940,17 @@ def plt_color_scatter(v, f, bins: int = 20, cmap: str = "viridis", alpha: float 
 
 
 @plt_settings()
-def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_points: bool = True):
-    """Plot the evolution results stored in a 'tune_results.csv' file. The function generates a scatter plot for each
-    key in the CSV, color-coded based on fitness scores. The best-performing configurations are highlighted on
-    the plots.
+def plot_tune_results(
+    csv_file: str = "tune_results.csv", exclude_zero_fitness_points: bool = True, num_metrics_columns: int = 1
+):
+    """
+    Plot the evolution results stored in a 'tune_results.csv' file. The function generates a scatter plot for each key
+    in the CSV, color-coded based on fitness scores. The best-performing configurations are highlighted on the plots.
 
     Args:
         csv_file (str, optional): Path to the CSV file containing the tuning results.
         exclude_zero_fitness_points (bool, optional): Don't include points with zero fitness in tuning plots.
+        num_metrics_columns (int, optional): Number of initial columns in the CSV that are metrics (e.g., fitness) rather than hyperparameters.
 
     Examples:
         >>> plot_tune_results("path/to/tune_results.csv")
@@ -965,16 +968,14 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
     # Scatter plots for each hyperparameter
     csv_file = Path(csv_file)
     data = pl.read_csv(csv_file, infer_schema_length=None)
-    num_metrics_columns = 1
-    keys = [x.strip() for x in data.columns][num_metrics_columns:]
+    keys = [x.strip() for x in data.columns]
+    fitness_keys = keys[:num_metrics_columns]  # metric keys (e.g., fitness)
+    keys = keys[num_metrics_columns:]  # hyperparameter keys
     x = data.to_numpy()
     fitness = x[:, 0]  # fitness
     if exclude_zero_fitness_points:
         mask = fitness > 0  # exclude zero-fitness points
         x, fitness = x[mask], fitness[mask]
-    if len(fitness) == 0:
-        LOGGER.warning("No valid fitness values to plot (all iterations may have failed)")
-        return
     # Iterative sigma rejection on lower bound only
     for _ in range(3):  # max 3 iterations
         mean, std = fitness.mean(), fitness.std()
@@ -999,16 +1000,18 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
     _save_one_file(csv_file.with_name("tune_scatter_plots.png"))
 
     # Fitness vs iteration
-    x = range(1, len(fitness) + 1)
-    plt.figure(figsize=(10, 6), tight_layout=True)
-    plt.plot(x, fitness, marker="o", linestyle="none", label="fitness")
-    plt.plot(x, gaussian_filter1d(fitness, sigma=3), ":", label="smoothed", linewidth=2)  # smoothing line
-    plt.title("Fitness vs Iteration")
-    plt.xlabel("Iteration")
-    plt.ylabel("Fitness")
-    plt.grid(True)
-    plt.legend()
-    _save_one_file(csv_file.with_name("tune_fitness.png"))
+    for i, k in enumerate(fitness_keys):
+        fitness = x[:, i]
+        xx = range(1, len(fitness) + 1)
+        plt.figure(figsize=(10, 6), tight_layout=True)
+        plt.plot(xx, fitness, marker="o", linestyle="none", label=k)
+        plt.plot(xx, gaussian_filter1d(fitness, sigma=3), ":", label="smoothed", linewidth=2)  # smoothing line
+        plt.title("Fitness vs Iteration")
+        plt.xlabel("Iteration")
+        plt.ylabel("Fitness")
+        plt.grid(True)
+        plt.legend()
+        _save_one_file(csv_file.with_name(f"tune_{k}.png"))
 
 
 @plt_settings()

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -940,20 +940,18 @@ def plt_color_scatter(v, f, bins: int = 20, cmap: str = "viridis", alpha: float 
 
 
 @plt_settings()
-def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_points: bool = True):
-    """Plot the evolution results stored in a 'tune_results.csv' file. The function generates a scatter plot for each
-    key in the CSV, color-coded based on fitness scores. The best-performing configurations are highlighted on
-    the plots.
+def plot_tune_results(results_file: str = "tune_results.ndjson", exclude_zero_fitness_points: bool = True):
+    """Plot the evolution results stored in a tuning NDJSON file.
 
     Args:
-        csv_file (str, optional): Path to the CSV file containing the tuning results.
+        results_file (str, optional): Path to the NDJSON file containing the tuning results.
         exclude_zero_fitness_points (bool, optional): Don't include points with zero fitness in tuning plots.
 
     Examples:
-        >>> plot_tune_results("path/to/tune_results.csv")
+        >>> plot_tune_results("path/to/tune_results.ndjson")
     """
+    import json
     import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
-    import polars as pl
     from scipy.ndimage import gaussian_filter1d
 
     def _save_one_file(file):
@@ -962,19 +960,27 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
         plt.close()
         LOGGER.info(f"Saved {file}")
 
-    # Scatter plots for each hyperparameter
-    csv_file = Path(csv_file)
-    data = pl.read_csv(csv_file, infer_schema_length=None)
-    keys = [x.strip() for x in data.columns]
-    fitness_keys = {i: k for i, k in enumerate(keys) if "fitness" in k}  # metric keys (e.g., fitness)
-    hyp_keys = {i: k for i, k in enumerate(keys) if "fitness" not in k}  # hyperparameter keys
-    x = data.to_numpy()
-    fitness = x[:, 0]  # fitness
-    if exclude_zero_fitness_points:
-        mask = fitness > 0  # exclude zero-fitness points
-        x, fitness = x[mask], fitness[mask]
-    if len(x) == 0:
+    results_file = Path(results_file)
+    with open(results_file, encoding="utf-8") as f:
+        records = [json.loads(line) for line in f if line.strip()]
+    if not records:
         return
+
+    keys = list(records[0].get("hyperparameters", {}))
+    x = np.array(
+        [[r.get("fitness", 0.0)] + [r.get("hyperparameters", {}).get(k, np.nan) for k in keys] for r in records],
+        dtype=float,
+    )
+    total_iterations = len(x)
+    all_fitness = x[:, 0]  # fitness
+    zero_mask = slice(None)
+    if exclude_zero_fitness_points:
+        zero_mask = all_fitness > 0  # exclude zero-fitness points
+        x, all_fitness = x[zero_mask], all_fitness[zero_mask]
+    if len(all_fitness) == 0:
+        LOGGER.warning("No valid fitness values to plot (all iterations may have failed)")
+        return
+    fitness = all_fitness.copy()
     # Iterative sigma rejection on lower bound only
     for _ in range(3):  # max 3 iterations
         mean, std = fitness.mean(), fitness.std()
@@ -984,33 +990,36 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
             break
         x, fitness = x[mask], fitness[mask]
     j = np.argmax(fitness)  # max fitness index
-    n = math.ceil(len(hyp_keys) ** 0.5)  # columns and rows in plot
+    n = math.ceil(len(keys) ** 0.5)  # columns and rows in plot
     plt.figure(figsize=(10, 10), tight_layout=True)
-    for idx, (i, k) in enumerate(hyp_keys.items()):
-        v = x[:, i]
+    for i, k in enumerate(keys):
+        v = x[:, i + 1]
         mu = v[j]  # best single result
-        plt.subplot(n, n, idx + 1)
+        plt.subplot(n, n, i + 1)
         plt_color_scatter(v, fitness, cmap="viridis", alpha=0.8, edgecolors="none")
         plt.plot(mu, fitness.max(), "k+", markersize=15)
         plt.title(f"{k} = {mu:.3g}", fontdict={"size": 9})  # limit to 40 characters
         plt.tick_params(axis="both", labelsize=8)  # Set axis label size to 8
-        if idx % n != 0:
+        if i % n != 0:
             plt.yticks([])
-    _save_one_file(csv_file.with_name("tune_scatter_plots.png"))
+    _save_one_file(results_file.with_name("tune_scatter_plots.png"))
 
     # Fitness vs iteration
-    for i, k in fitness_keys.items():
-        fitness = x[:, i]
-        xx = range(1, len(fitness) + 1)
-        plt.figure(figsize=(10, 6), tight_layout=True)
-        plt.plot(xx, fitness, marker="o", linestyle="none", label=k)
-        plt.plot(xx, gaussian_filter1d(fitness, sigma=3), ":", label="smoothed", linewidth=2)  # smoothing line
-        plt.title("Fitness vs Iteration")
-        plt.xlabel("Iteration")
-        plt.ylabel("Fitness")
-        plt.grid(True)
-        plt.legend()
-        _save_one_file(csv_file.with_name(f"tune_{k}.png"))
+    x = range(1, len(all_fitness) + 1)
+    plt.figure(figsize=(10, 6), tight_layout=True)
+    for dataset in sorted({k for r in records for k in r.get("datasets", {})}):
+        y = np.array([r.get("datasets", {}).get(dataset, {}).get("fitness", np.nan) for r in records], dtype=float)
+        if exclude_zero_fitness_points and not isinstance(zero_mask, slice):
+            y = y[zero_mask]
+        plt.plot(x, y, "o", markersize=5, alpha=0.8, label=dataset)
+    plt.plot(x, all_fitness, marker="o", linewidth=2, label="mean fitness")
+    plt.plot(x, gaussian_filter1d(all_fitness, sigma=3), ":", label="smoothed mean", linewidth=2)
+    plt.title("Fitness vs Iteration")
+    plt.xlabel("Iteration")
+    plt.ylabel("Fitness")
+    plt.grid(True)
+    plt.legend()
+    _save_one_file(results_file.with_name("tune_fitness.png"))
 
 
 @plt_settings()

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -940,9 +940,7 @@ def plt_color_scatter(v, f, bins: int = 20, cmap: str = "viridis", alpha: float 
 
 
 @plt_settings()
-def plot_tune_results(
-    csv_file: str = "tune_results.csv", exclude_zero_fitness_points: bool = True, num_metrics_columns: int = 1
-):
+def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_points: bool = True):
     """Plot the evolution results stored in a 'tune_results.csv' file. The function generates a scatter plot for each
     key in the CSV, color-coded based on fitness scores. The best-performing configurations are highlighted on
     the plots.
@@ -950,8 +948,6 @@ def plot_tune_results(
     Args:
         csv_file (str, optional): Path to the CSV file containing the tuning results.
         exclude_zero_fitness_points (bool, optional): Don't include points with zero fitness in tuning plots.
-        num_metrics_columns (int, optional): Number of initial columns in the CSV that are metrics (e.g., fitness)
-            rather than hyperparameters.
 
     Examples:
         >>> plot_tune_results("path/to/tune_results.csv")
@@ -970,8 +966,9 @@ def plot_tune_results(
     csv_file = Path(csv_file)
     data = pl.read_csv(csv_file, infer_schema_length=None)
     keys = [x.strip() for x in data.columns]
-    fitness_keys = keys[:num_metrics_columns]  # metric keys (e.g., fitness)
-    keys = keys[num_metrics_columns:]  # hyperparameter keys
+    num_metrics_columns = 1
+    fitness_keys = {i: k for i, k in enumerate(keys) if "fitness" in k}  # metric keys (e.g., fitness)
+    keys = {i: k for i, k in enumerate(keys) if "fitness" not in k}  # hyperparameter keys
     x = data.to_numpy()
     fitness = x[:, 0]  # fitness
     if exclude_zero_fitness_points:
@@ -988,20 +985,20 @@ def plot_tune_results(
     j = np.argmax(fitness)  # max fitness index
     n = math.ceil(len(keys) ** 0.5)  # columns and rows in plot
     plt.figure(figsize=(10, 10), tight_layout=True)
-    for i, k in enumerate(keys):
+    for idx, (i, k) in enumerate(keys.items()):
         v = x[:, i + num_metrics_columns]
         mu = v[j]  # best single result
-        plt.subplot(n, n, i + 1)
+        plt.subplot(n, n, idx + 1)
         plt_color_scatter(v, fitness, cmap="viridis", alpha=0.8, edgecolors="none")
         plt.plot(mu, fitness.max(), "k+", markersize=15)
         plt.title(f"{k} = {mu:.3g}", fontdict={"size": 9})  # limit to 40 characters
         plt.tick_params(axis="both", labelsize=8)  # Set axis label size to 8
-        if i % n != 0:
+        if idx % n != 0:
             plt.yticks([])
     _save_one_file(csv_file.with_name("tune_scatter_plots.png"))
 
     # Fitness vs iteration
-    for i, k in enumerate(fitness_keys):
+    for i, k in fitness_keys.items():
         fitness = x[:, i]
         xx = range(1, len(fitness) + 1)
         plt.figure(figsize=(10, 6), tight_layout=True)

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -951,6 +951,7 @@ def plot_tune_results(results_file: str = "tune_results.ndjson", exclude_zero_fi
         >>> plot_tune_results("path/to/tune_results.ndjson")
     """
     import json
+
     import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
     from scipy.ndimage import gaussian_filter1d
 
@@ -971,7 +972,7 @@ def plot_tune_results(results_file: str = "tune_results.ndjson", exclude_zero_fi
         [[r.get("fitness", 0.0)] + [r.get("hyperparameters", {}).get(k, np.nan) for k in keys] for r in records],
         dtype=float,
     )
-    total_iterations = len(x)
+    len(x)
     all_fitness = x[:, 0]  # fitness
     zero_mask = slice(None)
     if exclude_zero_fitness_points:

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -943,14 +943,15 @@ def plt_color_scatter(v, f, bins: int = 20, cmap: str = "viridis", alpha: float 
 def plot_tune_results(
     csv_file: str = "tune_results.csv", exclude_zero_fitness_points: bool = True, num_metrics_columns: int = 1
 ):
-    """
-    Plot the evolution results stored in a 'tune_results.csv' file. The function generates a scatter plot for each key
-    in the CSV, color-coded based on fitness scores. The best-performing configurations are highlighted on the plots.
+    """Plot the evolution results stored in a 'tune_results.csv' file. The function generates a scatter plot for each
+    key in the CSV, color-coded based on fitness scores. The best-performing configurations are highlighted on
+    the plots.
 
     Args:
         csv_file (str, optional): Path to the CSV file containing the tuning results.
         exclude_zero_fitness_points (bool, optional): Don't include points with zero fitness in tuning plots.
-        num_metrics_columns (int, optional): Number of initial columns in the CSV that are metrics (e.g., fitness) rather than hyperparameters.
+        num_metrics_columns (int, optional): Number of initial columns in the CSV that are metrics (e.g., fitness)
+            rather than hyperparameters.
 
     Examples:
         >>> plot_tune_results("path/to/tune_results.csv")

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -966,14 +966,15 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
     csv_file = Path(csv_file)
     data = pl.read_csv(csv_file, infer_schema_length=None)
     keys = [x.strip() for x in data.columns]
-    num_metrics_columns = 1
     fitness_keys = {i: k for i, k in enumerate(keys) if "fitness" in k}  # metric keys (e.g., fitness)
-    keys = {i: k for i, k in enumerate(keys) if "fitness" not in k}  # hyperparameter keys
+    hyp_keys = {i: k for i, k in enumerate(keys) if "fitness" not in k}  # hyperparameter keys
     x = data.to_numpy()
     fitness = x[:, 0]  # fitness
     if exclude_zero_fitness_points:
         mask = fitness > 0  # exclude zero-fitness points
         x, fitness = x[mask], fitness[mask]
+    if len(x) == 0:
+        return
     # Iterative sigma rejection on lower bound only
     for _ in range(3):  # max 3 iterations
         mean, std = fitness.mean(), fitness.std()
@@ -983,10 +984,10 @@ def plot_tune_results(csv_file: str = "tune_results.csv", exclude_zero_fitness_p
             break
         x, fitness = x[mask], fitness[mask]
     j = np.argmax(fitness)  # max fitness index
-    n = math.ceil(len(keys) ** 0.5)  # columns and rows in plot
+    n = math.ceil(len(hyp_keys) ** 0.5)  # columns and rows in plot
     plt.figure(figsize=(10, 10), tight_layout=True)
-    for idx, (i, k) in enumerate(keys.items()):
-        v = x[:, i + num_metrics_columns]
+    for idx, (i, k) in enumerate(hyp_keys.items()):
+        v = x[:, i]
         mu = v[j]  # best single result
         plt.subplot(n, n, idx + 1)
         plt_color_scatter(v, fitness, cmap="viridis", alpha=0.8, edgecolors="none")

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -1013,8 +1013,7 @@ def plot_tune_results(results_file: str = "tune_results.ndjson", exclude_zero_fi
         if exclude_zero_fitness_points and not isinstance(zero_mask, slice):
             y = y[zero_mask]
         plt.plot(x, y, "o", markersize=5, alpha=0.8, label=dataset)
-    plt.plot(x, all_fitness, marker="o", linewidth=2, label="mean fitness")
-    plt.plot(x, gaussian_filter1d(all_fitness, sigma=3), ":", label="smoothed mean", linewidth=2)
+    plt.plot(x, gaussian_filter1d(all_fitness, sigma=3), ":", color="0.35", label="smoothed mean", linewidth=2)
     plt.title("Fitness vs Iteration")
     plt.xlabel("Iteration")
     plt.ylabel("Fitness")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR upgrades YOLO hyperparameter tuning logs from CSV to NDJSON, adding richer multi-dataset result tracking, better MongoDB sync, and updated plotting/output behavior 📈🧠

### 📊 Key Changes
- Switched tuning result storage from `tune_results.csv` to `tune_results.ndjson` for local logs and docs 📝
- Renamed the fitness plot output from `best_fitness.png` to `tune_fitness.png` to better match its purpose 🖼️
- Updated the tuner to save structured records per iteration, including:
  - overall fitness
  - hyperparameters
  - per-dataset metrics
  - save directories for runs
- Added support for cleaner multi-dataset tuning logs, using stable dataset names when multiple datasets are tuned together 🗂️
- Improved MongoDB integration so distributed tuning now syncs back into the same local NDJSON format, keeping resume, mutation, and plotting workflows consistent 🔄
- Reworked local result loading/parsing logic to use NDJSON instead of CSV, including resume and best-result selection
- Updated plotting to read NDJSON directly and show:
  - hyperparameter scatter plots
  - fitness-over-iteration plots
  - per-dataset fitness lines for multi-dataset tuning 📊
- Refreshed documentation examples and output file references to match the new format and filenames 📚

### 🎯 Purpose & Impact
- NDJSON makes tuning results more flexible and easier to extend than CSV, especially for nested data like multi-dataset metrics ⚙️
- Users running tuning across multiple datasets get clearer, more complete records of how each dataset performed 🎯
- Distributed tuning with MongoDB becomes more reliable and easier to resume because local and remote logs now use the same structure 🌐
- Plotting and analysis become more informative, especially when comparing dataset-specific fitness trends over time 📉
- Existing users may need to update any custom scripts that expected `tune_results.csv` or `best_fitness.png` to use the new `tune_results.ndjson` and `tune_fitness.png` filenames 🔧
- Overall, this change makes YOLO tuning more scalable, more transparent, and better suited for advanced workflows 🚀