### PR TITLE
docs: fix wrong weights in segment and obb .load() examples

### DIFF
--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -66,7 +66,7 @@ Train YOLO26n-obb on the DOTA8 dataset for 100 [epochs](https://www.ultralytics.
         # Load a model
         model = YOLO("yolo26n-obb.yaml")  # build a new model from YAML
         model = YOLO("yolo26n-obb.pt")  # load a pretrained model (recommended for training)
-        model = YOLO("yolo26n-obb.yaml").load("yolo26n.pt")  # build from YAML and transfer weights
+        model = YOLO("yolo26n-obb.yaml").load("yolo26n-obb.pt")  # build from YAML and transfer weights
 
         # Train the model
         results = model.train(data="dota8.yaml", epochs=100, imgsz=640)

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -54,7 +54,7 @@ Train YOLO26n-seg on the COCO8-seg dataset for 100 [epochs](https://www.ultralyt
         # Load a model
         model = YOLO("yolo26n-seg.yaml")  # build a new model from YAML
         model = YOLO("yolo26n-seg.pt")  # load a pretrained model (recommended for training)
-        model = YOLO("yolo26n-seg.yaml").load("yolo26n.pt")  # build from YAML and transfer weights
+        model = YOLO("yolo26n-seg.yaml").load("yolo26n-seg.pt")  # build from YAML and transfer weights
 
         # Train the model
         results = model.train(data="coco8-seg.yaml", epochs=100, imgsz=640)


### PR DESCRIPTION
## Summary

Fixed incorrect pretrained weights in `.load()` calls in `docs/en/tasks/segment.md` and `docs/en/tasks/obb.md`.

- `segment.md:57` was loading `yolo26n.pt` (detection weights) into a segmentation YAML
- `obb.md:69` was loading `yolo26n.pt` (detection weights) into an OBB YAML

## Motivation

Loading detection weights into a task-specific YAML is a silent failure — no error is raised, but the transferred weights are mismatched, resulting in a poorly initialized model. Users following the docs would get bad training results with no indication of why.

## Implementation

- `segment.md:57`: `yolo26n.pt` → `yolo26n-seg.pt`
- `obb.md:69`: `yolo26n.pt` → `yolo26n-obb.pt`

`pose.md` and `classify.md` already use the correct task-specific weights (`yolo26n-pose.pt`, `yolo26n-cls.pt`) — this brings segment and OBB in line with that pattern.

## Testing

No automated tests exist for docs. Verified all five task docs now consistently use task-specific weights in `.load()` calls. Docs-only fix.

## Risks / Side Effects

None — documentation fix only, no impact on code or builds.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes incorrect pretrained weight filenames in the segmentation and OBB `.load()` documentation examples so they match the correct task-specific YOLO26 model variants. 🛠️📚

### 📊 Key Changes
- Updated `docs/en/tasks/segment.md` to change `.load("yolo26n.pt")` to `.load("yolo26n-seg.pt")` in the segmentation training example.
- Updated `docs/en/tasks/obb.md` to change `.load("yolo26n.pt")` to `.load("yolo26n-obb.pt")` in the OBB training example.
- Corrected task-specific transfer learning examples for YAML-built models in both docs pages.

### 🎯 Purpose & Impact
- Prevents confusion for users following segmentation and OBB training docs. ✅
- Ensures examples use the correct pretrained weights for each task, improving documentation accuracy. 🎯
- Reduces the chance of misconfigured training workflows when users copy and run the provided examples. 🚀