### PR TITLE
docs: update OpenVINO notebook links to YOLO26 optimization

### DIFF
--- a/docs/en/integrations/openvino.md
+++ b/docs/en/integrations/openvino.md
@@ -99,7 +99,7 @@ For more details about the export process, visit the [Ultralytics documentation 
 1. **Performance**: OpenVINO delivers high-performance inference by utilizing the power of Intel CPUs, integrated and discrete GPUs, and FPGAs.
 2. **Support for Heterogeneous Execution**: OpenVINO provides an API to write once and deploy on any supported Intel hardware (CPU, GPU, FPGA, VPU, etc.).
 3. **Model Optimizer**: OpenVINO provides a Model Optimizer that imports, converts, and optimizes models from popular [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) frameworks such as PyTorch, [TensorFlow](https://www.ultralytics.com/glossary/tensorflow), TensorFlow Lite, Keras, ONNX, PaddlePaddle, and Caffe.
-4. **Ease of Use**: The toolkit comes with more than [80 tutorial notebooks](https://github.com/openvinotoolkit/openvino_notebooks) (including [YOLOv8 optimization](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/yolov8-optimization)) teaching different aspects of the toolkit.
+4. **Ease of Use**: The toolkit comes with more than [80 tutorial notebooks](https://github.com/openvinotoolkit/openvino_notebooks) (including [YOLO26 optimization](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/yolov26-optimization)) teaching different aspects of the toolkit.
 
 ## OpenVINO Export Structure
 
@@ -136,7 +136,7 @@ This approach is ideal for fast prototyping or deployment when you don't need fu
 
 ### Inference with OpenVINO Runtime
 
-The OpenVINO Runtime provides a unified API for inference across all supported Intel hardware. It also provides advanced capabilities like load balancing across Intel hardware and asynchronous execution. For more information on running inference, refer to the [YOLO26 notebooks](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/yolov11-optimization).
+The OpenVINO Runtime provides a unified API for inference across all supported Intel hardware. It also provides advanced capabilities like load balancing across Intel hardware and asynchronous execution. For more information on running inference, refer to the [YOLO26 notebooks](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/yolov26-optimization).
 
 Remember, you'll need the XML and BIN files as well as any application-specific settings like input size, scale factor for normalization, etc., to correctly set up and use the model with the Runtime.
 


### PR DESCRIPTION
## Summary

Updated outdated OpenVINO notebook links in `docs/en/integrations/openvino.md` to point to the YOLO26 optimization notebook.

## Changes

- **Line 102**: Changed `YOLOv8 optimization` link (`notebooks/yolov8-optimization`) → `YOLO26 optimization` link (`notebooks/yolov26-optimization`)
- **Line 139**: Changed `YOLO26 notebooks` link from `notebooks/yolov11-optimization` → `notebooks/yolov26-optimization`

## Motivation

The OpenVINO integration page header and all code examples already reference YOLO26, but the notebook links still pointed to the outdated YOLOv8 and YOLO11 optimization notebooks. The `yolov26-optimization` notebook now exists in the [OpenVINO notebooks repo](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/yolov26-optimization), so the links should point there for consistency.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates OpenVINO documentation links to consistently reference YOLO26 optimization notebooks instead of outdated YOLOv8 and incorrect YOLO11 notebook paths. 🚀

### 📊 Key Changes
- Replaced the OpenVINO tutorial notebook reference in `docs/en/integrations/openvino.md` from **YOLOv8 optimization** to **YOLO26 optimization**.
- Corrected the inference section notebook link from the mismatched `yolov11-optimization` path to the correct `yolov26-optimization` path.
- Improved naming consistency in the OpenVINO integration docs to align with current Ultralytics model branding.

### 🎯 Purpose & Impact
- Keeps documentation aligned with the latest recommended Ultralytics model, **YOLO26**. 📘
- Reduces user confusion caused by outdated or inconsistent notebook references.
- Improves the documentation experience for users following OpenVINO export and inference workflows. ✅