### PR TITLE
Fix tune dataset name collisions

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -345,12 +345,15 @@ class Tuner:
     @staticmethod
     def _dataset_names(data: list) -> list[str]:
         """Create stable unique dataset names for logging and per-run directories."""
-        stems = [Path(str(d)).stem for d in data]
-        totals, seen = Counter(stems), Counter()
-        names = []
-        for stem in stems:
-            seen[stem] += 1
-            names.append(f"{stem}-{seen[stem]}" if totals[stem] > 1 else stem)
+        paths = [Path(str(d)) for d in data]
+        generic_stems = {"config", "configs", "data", "dataset", "datasets", "default", "defaults"}
+        names = [path.parent.name if path.stem in generic_stems else path.stem for path in paths]
+
+        counts, seen = Counter(names), Counter()
+        for i, name in enumerate(names):
+            if counts[name] > 1:
+                seen[name] += 1
+                names[i] = f"{name}-{seen[name]}"
         return names
 
     @staticmethod


### PR DESCRIPTION
## Summary
- avoid NDJSON and plot key collisions when multiple datasets use generic YAML filenames
- use parent directory names for generic stems like `data`, `dataset`, `config`, and `default` and their plural forms
- keep the existing stem-based naming for normal dataset files like `coco8.yaml`

## Validation
- `python -m py_compile ultralytics/engine/tuner.py`
- verified helper output for `data.yaml`, `dataset.yaml`, `config.yaml`, `default.yaml`, and plural variants
- reran a 1-iteration multi-dataset tune with two different `data.yaml` paths and confirmed distinct dataset keys: `coco8` and `coco8-grayscale`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves how dataset names are generated in the tuner, making experiment logs and run folders clearer and more consistent when dataset files use generic filenames.

### 📊 Key Changes
- Updated `ultralytics/engine/tuner.py` in the `_dataset_names()` helper.
- Changed dataset naming logic to look at the full path first, not just the file stem.
- Added special handling for common generic dataset filenames like `data`, `dataset`, `config`, `default`, and similar names.
- When a dataset file has one of these generic names, the tuner now uses the parent folder name instead, which is usually more descriptive.
- Kept duplicate-name protection: if multiple datasets still resolve to the same name, they are automatically suffixed with `-1`, `-2`, and so on.

### 🎯 Purpose & Impact
- Makes tuning runs easier to understand 📁 by producing more meaningful dataset names in logs and output directories.
- Reduces confusion when different datasets are stored in files with generic names like `data.yaml` or `config.yaml`.
- Helps users compare experiments more reliably 🔍, especially in multi-dataset or repeated tuning workflows.
- Improves organization without changing model training behavior, so the impact is low-risk and mostly quality-of-life ✨