### PR TITLE
Fix `torch` and `torchvision` versions on JetPack 5 Docker

### DIFF
--- a/docker/Dockerfile-jetson-jetpack5
+++ b/docker/Dockerfile-jetson-jetpack5
@@ -41,8 +41,8 @@ RUN sed -i 's/^\( *"tensorflowjs\)>=.*\(".*\)/\1>=3.9.0\2/' pyproject.toml && \
 # Pip install onnxruntime-gpu, torch, torchvision and ultralytics, then remove build files
 RUN uv pip install --system \
     https://github.com/ultralytics/assets/releases/download/v0.0.0/onnxruntime_gpu-1.18.0-cp38-cp38-linux_aarch64.whl \
-    https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.2.0-cp38-cp38-linux_aarch64.whl \
-    https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl && \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.1.0a0+41361538.nv23.06-cp38-cp38-linux_aarch64.whl \
+    https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.16.2+c6f3977-cp38-cp38-linux_aarch64.whl && \
     # Need lower version of 'numpy' for TensorRT export
     uv pip install --system numpy==1.23.5 && \
     uv pip install --system -e ".[export]" && \

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -270,11 +270,11 @@ The above ultralytics installation will install Torch and Torchvision. However, 
     pip uninstall torch torchvision
     ```
 
-2. Install `torch 2.2.0` and `torchvision 0.17.2` according to JP5.1.2
+2. Install `torch 2.1.0` and `torchvision 0.16.2` according to JP5.1.2
 
     ```bash
-    pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.2.0-cp38-cp38-linux_aarch64.whl
-    pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.17.2+c1d70fe-cp38-cp38-linux_aarch64.whl
+    pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torch-2.1.0a0+41361538.nv23.06-cp38-cp38-linux_aarch64.whl
+    pip install https://github.com/ultralytics/assets/releases/download/v0.0.0/torchvision-0.16.2+c6f3977-cp38-cp38-linux_aarch64.whl
     ```
 
 !!! note

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -631,10 +631,7 @@ class BaseTrainer:
         import io
 
         ema = deepcopy(unwrap_model(self.ema.ema)).half()
-        if (
-            not all(torch.isfinite(v).all() for v in ema.state_dict().values() if isinstance(v, torch.Tensor))
-            and self.epoch > self.start_epoch  # at least save checkpoint for the first epoch
-        ):
+        if not all(torch.isfinite(v).all() for v in ema.state_dict().values() if isinstance(v, torch.Tensor)):
             LOGGER.warning(f"Skipping checkpoint save at epoch {self.epoch}: EMA contains NaN/Inf")
             return False
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves NVIDIA Jetson compatibility by aligning JetPack 5 installs with supported PyTorch packages and makes training checkpoint saving safer by blocking any model save when EMA weights contain invalid values. 🚀

### 📊 Key Changes
- Updated the Jetson JetPack 5 Docker image to use:
  - `torch 2.1.0a0+41361538.nv23.06`
  - `torchvision 0.16.2+c6f3977`
  instead of newer `torch 2.2.0` and `torchvision 0.17.2`.
- Updated the [NVIDIA Jetson guide](https://docs.ultralytics.com/guides/nvidia-jetson/) documentation to match these revised package versions for JP5.1.2. 🛠️
- Tightened checkpoint-saving logic in `trainer.py`:
  - If EMA model weights contain `NaN` or `Inf`, checkpoint saving is now always skipped.
  - Removed the previous exception that still allowed saving after the first epoch even with invalid EMA values. ⚠️

### 🎯 Purpose & Impact
- Improves reliability on Jetson devices by using PyTorch and Torchvision builds that better match the JetPack 5 environment. 🤖
- Reduces installation and runtime issues for edge AI users deploying Ultralytics models on NVIDIA Jetson hardware.
- Keeps documentation consistent with the actual Docker setup, making Jetson installation steps clearer and easier to follow. 📘
- Prevents corrupt or unstable checkpoints from being saved during training, which can help users avoid hard-to-debug recovery and resume issues. ✅
- Overall, this PR makes Jetson workflows more dependable and training outputs safer for users running long jobs or production experiments.