### PR TITLE
Fix solutions-args colormap default drift (JET vs DEEPGREEN)

### DIFF
--- a/docs/macros/solutions-args.md
+++ b/docs/macros/solutions-args.md
@@ -7,7 +7,7 @@
     "show_in": ["bool", "True", "Flag to control whether to display the in counts on the video stream."],
     "show_out": ["bool", "True", "Flag to control whether to display the out counts on the video stream."],
     "analytics_type": ["str", "'line'", "Type of graph, i.e., `line`, `bar`, `area`, or `pie`."],
-    "colormap": ["int", "cv2.COLORMAP_JET", "Colormap to use for the heatmap."],
+    "colormap": ["int", "cv2.COLORMAP_DEEPGREEN", "Colormap to use for the heatmap."],
     "json_file": ["str", "None", "Path to the JSON file that contains all parking coordinates data."],
     "up_angle": ["float", "145.0", "Angle threshold for the 'up' pose."],
     "kpts": ["list[int]", "'[6, 8, 10]'", "List of three keypoint indices used for monitoring workouts. These keypoints correspond to body joints or parts, such as shoulders, elbows, and wrists, for exercises like push-ups, pull-ups, squats, and ab-workouts."],

--- a/ultralytics/solutions/config.py
+++ b/ultralytics/solutions/config.py
@@ -23,7 +23,7 @@ class SolutionConfig:
         show_conf (bool): Whether to show confidence scores on the visual output.
         show_labels (bool): Whether to display class labels on visual output.
         region (list[tuple[int, int]], optional): Polygonal region or line for object counting.
-        colormap (int, optional): OpenCV colormap constant for visual overlays (e.g., cv2.COLORMAP_JET).
+        colormap (int, optional): OpenCV colormap constant for visual overlays (e.g., cv2.COLORMAP_DEEPGREEN).
         show_in (bool): Whether to display count number for objects entering the region.
         show_out (bool): Whether to display count number for objects leaving the region.
         up_angle (float): Upper angle threshold used in pose-based workouts monitoring.


### PR DESCRIPTION
## Summary

`docs/macros/solutions-args.md` showed the `colormap` default as `cv2.COLORMAP_JET` (2), but `SolutionConfig` defaults to `cv2.COLORMAP_DEEPGREEN` (21). Users reading the docs saw one default and got another at runtime. This PR aligns the macro to the code and updates the docstring example in `ultralytics/solutions/config.py` for consistency.

Drift introduced in #20455 when `SolutionConfig` dataclass was created with `DEEPGREEN` while the macro and docstring still referenced `JET`.

Verified empirically: `SolutionConfig().colormap == cv2.COLORMAP_DEEPGREEN == 21`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🟢 This PR updates the default heatmap colormap in Ultralytics Solutions docs and config references from `cv2.COLORMAP_JET` to `cv2.COLORMAP_DEEPGREEN` for a more consistent visual default.

### 📊 Key Changes
- Changed the documented default `colormap` value in `docs/macros/solutions-args.md`:
  - from `cv2.COLORMAP_JET`
  - to `cv2.COLORMAP_DEEPGREEN`
- Updated the `SolutionConfig` parameter description in `ultralytics/solutions/config.py` to match the new colormap example.
- No logic or API behavior changes were introduced; this is a documentation/config reference update only. 🛠️

### 🎯 Purpose & Impact
- Improves consistency between Ultralytics Solutions configuration docs and the intended default visualization style. ✅
- Helps users see `DEEPGREEN` as the recommended/default heatmap colormap when configuring visual overlays. 🎨
- Reduces confusion for developers and users reading docs or config comments, especially when customizing heatmap outputs. 📘
- Since this does not change core functionality, impact on existing workflows should be minimal to none. 🔒