### PR TITLE
Clarify YOLO12 pretrained weights are detect-only in model docs

### DIFF
--- a/docs/en/models/yolo12.md
+++ b/docs/en/models/yolo12.md
@@ -48,13 +48,19 @@ YOLO12, released in early 2025, introduces an attention-centric architecture tha
 
 YOLO12 supports a variety of computer vision tasks. The table below shows task support and the operational modes (Inference, Validation, Training, and Export) enabled for each:
 
+!!! warning "Pretrained weights availability"
+
+    Only detection weights (`yolo12n.pt`, `yolo12s.pt`, `yolo12m.pt`, `yolo12l.pt`, `yolo12x.pt`) are released on [ultralytics/assets](https://github.com/ultralytics/assets/releases). Segmentation, classification, pose, and OBB architectures are defined in [ultralytics/cfg/models/12/](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models/12), so those variants support training from scratch from the `.yaml` config, but no pretrained `.pt` files are currently available for them. For pretrained segmentation, pose, classification, or OBB checkpoints, Ultralytics recommends [YOLO11](yolo11.md) or [YOLO26](yolo26.md).
+
 | Model Type                                                                                                     | Task                                   | Inference | Validation | Training | Export |
 | -------------------------------------------------------------------------------------------------------------- | -------------------------------------- | --------- | ---------- | -------- | ------ |
 | [YOLO12](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12.yaml)           | [Detection](../tasks/detect.md)        | ✅        | ✅         | ✅       | ✅     |
-| [YOLO12-seg](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-seg.yaml)   | [Segmentation](../tasks/segment.md)    | ✅        | ✅         | ✅       | ✅     |
-| [YOLO12-pose](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-pose.yaml) | [Pose](../tasks/pose.md)               | ✅        | ✅         | ✅       | ✅     |
-| [YOLO12-cls](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-cls.yaml)   | [Classification](../tasks/classify.md) | ✅        | ✅         | ✅       | ✅     |
-| [YOLO12-obb](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-obb.yaml)   | [OBB](../tasks/obb.md)                 | ✅        | ✅         | ✅       | ✅     |
+| [YOLO12-seg](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-seg.yaml)   | [Segmentation](../tasks/segment.md)    | ❌        | ❌         | ✅       | ❌     |
+| [YOLO12-pose](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-pose.yaml) | [Pose](../tasks/pose.md)               | ❌        | ❌         | ✅       | ❌     |
+| [YOLO12-cls](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-cls.yaml)   | [Classification](../tasks/classify.md) | ❌        | ❌         | ✅       | ❌     |
+| [YOLO12-obb](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-obb.yaml)   | [OBB](../tasks/obb.md)                 | ❌        | ❌         | ✅       | ❌     |
+
+The ❌ marks above indicate that those modes require pretrained `.pt` weights, which are not published for YOLO12 segmentation, pose, classification, or OBB. Once you complete training from scratch using the corresponding `.yaml`, all modes become available for your custom checkpoint.
 
 ## Performance Metrics
 
@@ -173,7 +179,7 @@ YOLO12 incorporates several key innovations to balance speed and accuracy. The A
 
 ### What [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks does YOLO12 support?
 
-YOLO12 is a versatile model that supports a wide range of core computer vision tasks. It excels in object [detection](../tasks/detect.md), instance [segmentation](../tasks/segment.md), image [classification](../tasks/classify.md), [pose estimation](../tasks/pose.md), and oriented object detection (OBB) ([see details](../tasks/obb.md)). This comprehensive task support makes YOLO12 a powerful tool for diverse applications, from [robotics](https://www.ultralytics.com/glossary/robotics) and autonomous driving to medical imaging and industrial inspection. Each of these tasks can be performed in Inference, Validation, Training, and Export modes.
+YOLO12 is a versatile model that supports a wide range of core computer vision tasks. It excels in object [detection](../tasks/detect.md), instance [segmentation](../tasks/segment.md), image [classification](../tasks/classify.md), [pose estimation](../tasks/pose.md), and oriented object detection (OBB) ([see details](../tasks/obb.md)). This comprehensive task support makes YOLO12 a powerful tool for diverse applications, from [robotics](https://www.ultralytics.com/glossary/robotics) and autonomous driving to medical imaging and industrial inspection. Note that pretrained `.pt` weights are currently published for detection only; the segmentation, pose, classification, and OBB architectures are provided as `.yaml` configs for training from scratch.
 
 ### How does YOLO12 compare to other YOLO models and competitors like RT-DETR?
 

--- a/docs/en/models/yolo12.md
+++ b/docs/en/models/yolo12.md
@@ -52,15 +52,15 @@ YOLO12 supports a variety of computer vision tasks. The table below shows task s
 
     Only detection weights (`yolo12n.pt`, `yolo12s.pt`, `yolo12m.pt`, `yolo12l.pt`, `yolo12x.pt`) are released on [ultralytics/assets](https://github.com/ultralytics/assets/releases). Segmentation, classification, pose, and OBB architectures are defined in [ultralytics/cfg/models/12/](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/models/12), so those variants support training from scratch from the `.yaml` config, but no pretrained `.pt` files are currently available for them. For pretrained segmentation, pose, classification, or OBB checkpoints, Ultralytics recommends [YOLO11](yolo11.md) or [YOLO26](yolo26.md).
 
-| Model Type                                                                                                     | Task                                   | Inference | Validation | Training | Export |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------- | --------- | ---------- | -------- | ------ |
-| [YOLO12](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12.yaml)           | [Detection](../tasks/detect.md)        | ✅        | ✅         | ✅       | ✅     |
-| [YOLO12-seg](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-seg.yaml)   | [Segmentation](../tasks/segment.md)    | ❌        | ❌         | ✅       | ❌     |
-| [YOLO12-pose](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-pose.yaml) | [Pose](../tasks/pose.md)               | ❌        | ❌         | ✅       | ❌     |
-| [YOLO12-cls](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-cls.yaml)   | [Classification](../tasks/classify.md) | ❌        | ❌         | ✅       | ❌     |
-| [YOLO12-obb](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-obb.yaml)   | [OBB](../tasks/obb.md)                 | ❌        | ❌         | ✅       | ❌     |
+| Model Type                                                                                                     | Task                                   | Pretrained Weights | Inference | Validation | Training | Export |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------ | --------- | ---------- | -------- | ------ |
+| [YOLO12](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12.yaml)           | [Detection](../tasks/detect.md)        | ✅                 | ✅        | ✅         | ✅       | ✅     |
+| [YOLO12-seg](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-seg.yaml)   | [Segmentation](../tasks/segment.md)    | ❌                 | ✅        | ✅         | ✅       | ✅     |
+| [YOLO12-pose](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-pose.yaml) | [Pose](../tasks/pose.md)               | ❌                 | ✅        | ✅         | ✅       | ✅     |
+| [YOLO12-cls](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-cls.yaml)   | [Classification](../tasks/classify.md) | ❌                 | ✅        | ✅         | ✅       | ✅     |
+| [YOLO12-obb](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/12/yolo12-obb.yaml)   | [OBB](../tasks/obb.md)                 | ❌                 | ✅        | ✅         | ✅       | ✅     |
 
-The ❌ marks above indicate that those modes require pretrained `.pt` weights, which are not published for YOLO12 segmentation, pose, classification, or OBB. Once you complete training from scratch using the corresponding `.yaml`, all modes become available for your custom checkpoint.
+All YOLO12 architectures support every mode once a trained checkpoint is available. The `Pretrained Weights` column indicates only whether Ultralytics publishes an official pretrained `.pt` on [ultralytics/assets](https://github.com/ultralytics/assets/releases): for segmentation, pose, classification, and OBB, you must train your own checkpoint from the corresponding `.yaml` before running inference, validation, or export.
 
 ## Performance Metrics
 


### PR DESCRIPTION
## Summary

The YOLO12 model page showed ✅ for inference/validation/training/export across detect, seg, pose, cls, and obb, but only detect `.pt` weights are published on `ultralytics/assets` — the other task variants are architecture-only (`.yaml` configs in `ultralytics/cfg/models/12/` that support training from scratch). This updates the supported tasks table and FAQ to reflect reality so users stop hitting `FileNotFoundError` when calling `YOLO("yolo12n-seg.pt")` and similar.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the YOLO12 docs to clearly show that official pretrained weights are currently available only for detection, while other YOLO12 task variants are config-only and must be trained from scratch.

### 📊 Key Changes
- ➕ Added a prominent warning in the YOLO12 documentation about **pretrained weights availability**.
- 📋 Expanded the task support table with a new **“Pretrained Weights”** column.
- ✅ Clarified that **YOLO12 detection** has official pretrained `.pt` weights available.
- ❌ Marked **YOLO12 segmentation, pose, classification, and OBB** as having **no official pretrained `.pt` weights** at this time.
- 🛠️ Explained that these non-detection variants are still supported via their `.yaml` model configs and can be **trained from scratch**.
- 🔁 Added guidance recommending **YOLO11** or **YOLO26** for users who need pretrained checkpoints for segmentation, pose, classification, or OBB.
- ✏️ Updated the FAQ/task-support text to reflect this limitation and avoid implying that all YOLO12 variants have ready-to-use pretrained models.

### 🎯 Purpose & Impact
- 🎯 Prevents confusion for users who may expect downloadable pretrained YOLO12 weights for every task.
- 📚 Makes the documentation more accurate and transparent about what is officially released versus what is only architecturally supported.
- 🚀 Helps users choose the right model faster: use **YOLO12** for pretrained detection, or **YOLO11/YOLO26** when pretrained non-detection models are needed.
- 🧩 Sets clearer expectations for developers and researchers who want to use YOLO12 segmentation, pose, classification, or OBB—they will need to **train their own checkpoints first**.
- 💬 Reduces setup friction and support issues caused by missing weight files or incorrect assumptions about model availability.