### PR TITLE
Document cfg arg in configuration reference

### DIFF
--- a/docs/en/usage/cfg.md
+++ b/docs/en/usage/cfg.md
@@ -177,8 +177,8 @@ Effective management of these aspects helps track progress and makes debugging a
 
 Load a saved YAML to reuse a full set of arguments without passing them inline. The `cfg` argument overrides values from `default.yaml`, while additional arguments passed alongside still take precedence.
 
-| Argument | Default | Description                                                                                                                                                              |
-| -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Argument | Default | Description                                                                                                                                                            |
+| -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cfg`    | `None`  | Path to a YAML file whose values replace `default.yaml` entries. See [Overriding Default Config File](cli.md#overriding-default-config-file) for a worked CLI example. |
 
 ## FAQ

--- a/docs/en/usage/cfg.md
+++ b/docs/en/usage/cfg.md
@@ -173,6 +173,14 @@ Effective management of these aspects helps track progress and makes debugging a
 | `plots`    | `True`   | Controls the generation and saving of training and validation plots. Set to `True` to create plots like loss curves, [precision](https://www.ultralytics.com/glossary/precision)-[recall](https://www.ultralytics.com/glossary/recall) curves, and sample predictions for visual tracking of performance. |
 | `save`     | `True`   | Enables saving training checkpoints and final model weights. Set to `True` to save model states periodically, allowing training resumption or model deployment.                                                                                                                                           |
 
+## Custom Configuration File
+
+Load a saved YAML to reuse a full set of arguments without passing them inline. The `cfg` argument overrides values from `default.yaml`, while additional arguments passed alongside still take precedence.
+
+| Argument | Default | Description                                                                                                                                                              |
+| -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cfg`    | `None`  | Path to a YAML file whose values replace `default.yaml` entries. See [Overriding Default Config File](cli.md#overriding-default-config-file) for a worked CLI example. |
+
 ## FAQ
 
 ### How do I improve my YOLO model's performance during training?


### PR DESCRIPTION
## Summary

`ultralytics/cfg/default.yaml:131` defines a `cfg` argument that loads a user YAML to override all default values (as used in the CLI via `yolo cfg=my_config.yaml`), but the Configuration reference page did not mention it. Adds a short `Custom Configuration File` section to `docs/en/usage/cfg.md` with a one-row table and a cross-link to the existing worked CLI example in `cli.md`, so every argument in `default.yaml` now has a corresponding row on the configuration reference page.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR adds documentation for a new `cfg` option, making it easier to load a custom YAML configuration file and reuse full experiment settings across YOLO workflows.

### 📊 Key Changes
- Added a new **“Custom Configuration File”** section to `docs/en/usage/cfg.md`.
- Documented the `cfg` argument, which lets users provide a **path to a YAML config file**.
- Clarified how configuration priority works:
  - values in `cfg` override `default.yaml`
  - any extra arguments passed directly still take highest priority
- Included a link to the CLI documentation for a worked example of overriding the default config file.

### 🎯 Purpose & Impact
- ✅ Makes configuration behavior clearer for users working with training and inference settings.
- 🔁 Simplifies **reusing the same setup** across runs without repeatedly passing many inline arguments.
- 🧩 Helps improve **experiment consistency and reproducibility** by storing settings in a single YAML file.
- 📚 Reduces confusion around which settings win when multiple config sources are used.
- 🚀 Especially useful for teams and advanced users managing multiple YOLO projects or standardized pipelines.