### PR TITLE
Fix SAM3 presence logits clamp being a no-op

### DIFF
--- a/ultralytics/models/sam/sam3/decoder.py
+++ b/ultralytics/models/sam/sam3/decoder.py
@@ -522,7 +522,7 @@ class TransformerDecoder(nn.Module):
 
                 # clamp to mitigate numerical issues
                 if self.clamp_presence_logits:
-                    intermediate_layer_presence_logits.clamp(
+                    intermediate_layer_presence_logits.clamp_(
                         min=-self.clamp_presence_logit_max_val,
                         max=self.clamp_presence_logit_max_val,
                     )


### PR DESCRIPTION
`.clamp()` returns a new tensor; result was discarded. Use `.clamp_()` in-place so clamp actually applies.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR fixes a small but important issue in the SAM3 decoder by making presence-logit clamping happen in-place, ensuring the numerical-stability safeguard actually takes effect.

### 📊 Key Changes
- Updated `ultralytics/models/sam/sam3/decoder.py` in the `forward()` path.
- Replaced `intermediate_layer_presence_logits.clamp(...)` with `intermediate_layer_presence_logits.clamp_(...)`.
- This change makes the clamping operation modify the tensor directly instead of creating a clamped result that was not being used.
- The fix applies specifically when `self.clamp_presence_logits` is enabled to limit extreme logit values.

### 🎯 Purpose & Impact
- 🛡️ Improves numerical stability by correctly constraining presence logits to the intended range.
- 🐛 Fixes a subtle bug where the previous clamp call likely had no effect because its output was not assigned.
- ⚙️ Helps make SAM3 decoder behavior more reliable during inference or training in edge cases with large logit values.
- 📉 May reduce risks of unstable outputs, overflow-related issues, or harder-to-debug prediction behavior in segmentation workflows.