### PR TITLE
Update annotation viewer zoom shortcut docs

### DIFF
--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -447,7 +447,7 @@ Efficient annotation with keyboard shortcuts:
     | `Cmd/Ctrl++` or `Cmd/Ctrl+=` | Zoom in                  |
     | `Cmd/Ctrl+-`           | Zoom out                     |
     | `Cmd/Ctrl+0`           | Reset to fit                 |
-    | `Space+Drag`            | Pan canvas                   |
+    | `Space+Drag`           | Pan canvas when zoomed      |
     | `Shift+Click`          | Multi-select annotations   |
     | `Cmd/Ctrl+A`           | Select all annotations     |
 

--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -444,6 +444,10 @@ Efficient annotation with keyboard shortcuts:
     | `Delete` / `Backspace` | Delete selected annotation |
     | `1-9`                  | Select class 1-9           |
     | `Cmd/Ctrl+Scroll`      | Zoom in/out                |
+    | `Cmd/Ctrl++` or `Cmd/Ctrl+=` | Zoom in                  |
+    | `Cmd/Ctrl+-`           | Zoom out                     |
+    | `Cmd/Ctrl+0`           | Reset to fit                 |
+    | `Space+Drag`            | Pan canvas                   |
     | `Shift+Click`          | Multi-select annotations   |
     | `Cmd/Ctrl+A`           | Select all annotations     |
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -268,7 +268,9 @@ Click any image to open the fullscreen viewer with:
 - **Edit**: Enter annotation mode to add or modify labels
 - **Download**: Download the original image file
 - **Delete**: Delete the image from the dataset
-- **Zoom**: `Cmd/Ctrl+Scroll` to zoom in/out
+- **Zoom**: `Cmd/Ctrl+Scroll`, `Cmd/Ctrl + +/=`, and `Cmd/Ctrl + -` to zoom in/out
+- **Reset view**: `Cmd/Ctrl + 0` or the reset button to fit the image to the viewer
+- **Pan**: Hold `Space` and drag to pan the canvas when zoomed
 - **Pixel view**: Toggle pixelated rendering for close inspection
 
 ![Ultralytics Platform Datasets Fullscreen Viewer With Metadata Panel](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-datasets-fullscreen-viewer-with-metadata-panel.avif)

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -268,7 +268,7 @@ Click any image to open the fullscreen viewer with:
 - **Edit**: Enter annotation mode to add or modify labels
 - **Download**: Download the original image file
 - **Delete**: Delete the image from the dataset
-- **Zoom**: `Cmd/Ctrl+Scroll`, `Cmd/Ctrl + +/=`, and `Cmd/Ctrl + -` to zoom in/out
+- **Zoom**: `Cmd/Ctrl+Scroll`, `Cmd/Ctrl++`, or `Cmd/Ctrl+=` to zoom in, and `Cmd/Ctrl+-` to zoom out
 - **Reset view**: `Cmd/Ctrl + 0` or the reset button to fit the image to the viewer
 - **Pan**: Hold `Space` and drag to pan the canvas when zoomed
 - **Pixel view**: Toggle pixelated rendering for close inspection


### PR DESCRIPTION
## Summary
- document the fullscreen viewer zoom, reset, and pan controls
- add the new annotation editor keyboard shortcuts for zooming and reset

Related feature PR https://github.com/ultralytics/portal/pull/1711

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates Ultralytics Platform documentation to better explain image viewer and annotation zoom, reset, and pan keyboard shortcuts.

### 📊 Key Changes
- Added new annotation shortcut docs in the [Ultralytics Platform annotation guide](https://docs.ultralytics.com/platform/data/annotation/) for:
  - `Cmd/Ctrl++` or `Cmd/Ctrl+=` to zoom in
  - `Cmd/Ctrl+-` to zoom out
  - `Cmd/Ctrl+0` to reset the view
  - `Space+Drag` to pan the canvas when zoomed
- Expanded the [Ultralytics Platform datasets guide](https://docs.ultralytics.com/platform/data/datasets/) fullscreen viewer instructions with:
  - More complete zoom shortcut options
  - A documented reset-to-fit shortcut and reset button behavior
  - Panning controls for navigating zoomed images
- Improves consistency between dataset viewing and annotation documentation 📚

### 🎯 Purpose & Impact
- Helps users discover useful navigation controls faster, especially when reviewing or annotating detailed images 🔍
- Makes zoomed-in inspection easier and more intuitive, which can improve labeling efficiency and accuracy ✨
- Reduces confusion by documenting multiple common shortcut variations across platforms and keyboards ⌨️
- Low-risk change: this is a documentation-only update, so it improves usability guidance without changing product behavior ✅