### PR TITLE
Fix Sentry bugs 2026-04-14

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -380,6 +380,7 @@ class Exporter:
             assert fmt != "ncnn", "optimize=True not compatible with format='ncnn', i.e. use optimize=False"
             assert self.device.type == "cpu", "optimize=True not compatible with cuda devices, i.e. use device='cpu'"
         if fmt == "rknn":
+            rknn_export_chips = RKNN_CHIPS - {"rv1126b"}
             if not self.args.name:
                 LOGGER.warning(
                     "Rockchip RKNN export requires a missing 'name' arg for processor type. "
@@ -387,8 +388,9 @@ class Exporter:
                 )
                 self.args.name = "rk3588"
             self.args.name = self.args.name.lower()
-            assert self.args.name in RKNN_CHIPS, (
-                f"Invalid processor name '{self.args.name}' for Rockchip RKNN export. Valid names are {RKNN_CHIPS}."
+            assert self.args.name in rknn_export_chips, (
+                f"Invalid processor name '{self.args.name}' for Rockchip RKNN export. "
+                f"Valid names are {rknn_export_chips}."
             )
         if self.args.nms:
             assert not isinstance(model, ClassificationModel), "'nms=True' is not valid for classification models."

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -380,7 +380,6 @@ class Exporter:
             assert fmt != "ncnn", "optimize=True not compatible with format='ncnn', i.e. use optimize=False"
             assert self.device.type == "cpu", "optimize=True not compatible with cuda devices, i.e. use device='cpu'"
         if fmt == "rknn":
-            rknn_export_chips = RKNN_CHIPS - {"rv1126b"}
             if not self.args.name:
                 LOGGER.warning(
                     "Rockchip RKNN export requires a missing 'name' arg for processor type. "
@@ -388,10 +387,20 @@ class Exporter:
                 )
                 self.args.name = "rk3588"
             self.args.name = self.args.name.lower()
-            assert self.args.name in rknn_export_chips, (
-                f"Invalid processor name '{self.args.name}' for Rockchip RKNN export. "
-                f"Valid names are {rknn_export_chips}."
+            assert self.args.name in RKNN_CHIPS, (
+                f"Invalid processor name '{self.args.name}' for Rockchip RKNN export. Valid names are {RKNN_CHIPS}."
             )
+            if self.args.name == "rv1126b":
+                from importlib import metadata
+
+                try:
+                    rknn_version = metadata.version("rknn-toolkit2")
+                except metadata.PackageNotFoundError:
+                    rknn_version = None
+                if rknn_version and check_version(rknn_version, "<2.3.2"):
+                    raise AssertionError(
+                        f"Processor name 'rv1126b' requires rknn-toolkit2>=2.3.2, but found {rknn_version}."
+                    )
         if self.args.nms:
             assert not isinstance(model, ClassificationModel), "'nms=True' is not valid for classification models."
             assert fmt != "tflite" or not ARM64 or not LINUX, "TFLite export with NMS unsupported on ARM64 Linux"

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -390,17 +390,6 @@ class Exporter:
             assert self.args.name in RKNN_CHIPS, (
                 f"Invalid processor name '{self.args.name}' for Rockchip RKNN export. Valid names are {RKNN_CHIPS}."
             )
-            if self.args.name == "rv1126b":
-                from importlib import metadata
-
-                try:
-                    rknn_version = metadata.version("rknn-toolkit2")
-                except metadata.PackageNotFoundError:
-                    rknn_version = None
-                if rknn_version and check_version(rknn_version, "<2.3.2"):
-                    raise AssertionError(
-                        f"Processor name 'rv1126b' requires rknn-toolkit2>=2.3.2, but found {rknn_version}."
-                    )
         if self.args.nms:
             assert not isinstance(model, ClassificationModel), "'nms=True' is not valid for classification models."
             assert fmt != "tflite" or not ARM64 or not LINUX, "TFLite export with NMS unsupported on ARM64 Linux"

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -478,7 +478,10 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
                 text=True,
             )
         return subprocess.check_output(
-            f"pip install --no-cache-dir {packages} {commands}", shell=True, stderr=subprocess.STDOUT, text=True
+            f'"{sys.executable}" -m pip install --no-cache-dir {packages} {commands}',
+            shell=True,
+            stderr=subprocess.STDOUT,
+            text=True,
         )
 
     s = " ".join(f'"{x}"' for x in pkgs)  # console string

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -27,7 +27,7 @@ def onnx2rknn(
     from ultralytics.utils.checks import check_requirements
 
     LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
-    check_requirements("rknn-toolkit2")
+    check_requirements("rknn-toolkit2>=2.3.2")
     check_requirements("onnx<1.19.0")  # fix AttributeError: module 'onnx' has no attribute 'mapping'
 
     if IS_COLAB:


### PR DESCRIPTION
## Sentry issues fixed
- [ALPHA-19H](https://ultralytics.sentry.io/issues/7392142563/): `check_requirements()` fell back to a bare `pip install ...`, but the worker runtime did not have a `pip` binary on `PATH`, so ONNX auto-install failed and export crashed with `ModuleNotFoundError: No module named 'onnx'`.
- [ALPHA-RE](https://ultralytics.sentry.io/issues/7287166152/): the worker RKNN toolchain was too old for current RKNN export support.

## What changed
- Replacement: switched the `check_requirements()` fallback install path from `pip install ...` to `"{sys.executable}" -m pip install ...` so the fallback targets the active interpreter instead of depending on a shell binary.
- Replacement: made RKNN export broadly require `rknn-toolkit2>=2.3.2` via `check_requirements()` instead of per-chip gating in the exporter.

## Verification
- `python -m py_compile ultralytics/utils/checks.py ultralytics/engine/exporter.py ultralytics/utils/export/rknn.py`

## Sentry resolution
- Marked [ALPHA-19H](https://ultralytics.sentry.io/issues/7392142563/) resolved in Sentry after review.
- Marked [ALPHA-RE](https://ultralytics.sentry.io/issues/7287166152/) resolved in Sentry after review.

## Related
- Portal/UI companion PR: https://github.com/ultralytics/portal/pull/1727

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves package installation reliability by using the active Python interpreter for `pip` commands and updates RKNN export requirements to a newer, safer `rknn-toolkit2` version 🔧📦

### 📊 Key Changes
- Updated internal package installation logic in `ultralytics/utils/checks.py` to run `pip` as `"{sys.executable}" -m pip` instead of calling `pip` directly.
- This change ensures installs happen in the same Python environment that is running Ultralytics, reducing environment mismatch issues.
- Updated RKNN export dependency checks in `ultralytics/utils/export/rknn.py`:
  - `rknn-toolkit2` now requires version `>=2.3.2`
  - Existing `onnx<1.19.0` compatibility check remains in place

### 🎯 Purpose & Impact
- Helps prevent failed installs caused by `pip` pointing to a different Python environment than the one running the code ✅
- Makes dependency setup more consistent across virtual environments, Conda, system Python, and similar setups 🐍
- Improves RKNN export stability by requiring a newer supported `rknn-toolkit2` version 📤
- Reduces confusion for users troubleshooting export or installation problems, especially on multi-Python systems 💡