### PR TITLE
fix: OpenVINO 2026 segfault on conda CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,7 @@ jobs:
           channel-priority: true
           activate-environment: anaconda-client-env
       - name: Install Ultralytics package from conda-forge
-        run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino
+        run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics "openvino<2026"
       - name: Install pip packages
         run: uv pip install pytest
       - name: Check environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,7 @@ jobs:
           channel-priority: true
           activate-environment: anaconda-client-env
       - name: Install Ultralytics package from conda-forge
-        run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics "openvino!=2026.0.0"
+        run: conda install -c pytorch -c conda-forge pytorch-cpu torchvision ultralytics openvino
       - name: Install pip packages
         run: uv pip install pytest
       - name: Check environment

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -30,7 +30,7 @@ class OpenVINOBackend(BaseBackend):
         check_requirements("openvino>=2024.0.0")
         import openvino as ov
 
-        core = OpenVINOBackend._core = getattr(OpenVINOBackend, "_core", None) or ov.Core()
+        core = ov.Core()
         fallback_device = "CPU" if core.available_devices == ["CPU"] else "AUTO"
         device_name = fallback_device
 

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -20,7 +20,6 @@ class OpenVINOBackend(BaseBackend):
     selection, Intel-specific device targeting, and async inference for throughput optimization.
     """
 
-    core = None  # cached ov.Core singleton (avoids segfault on repeated instantiation in OpenVINO 2026+)
 
     def load_model(self, weight: str | Path) -> None:
         """Load an Intel OpenVINO IR model from a .xml/.bin file pair or model directory.
@@ -32,7 +31,7 @@ class OpenVINOBackend(BaseBackend):
         check_requirements("openvino>=2024.0.0")
         import openvino as ov
 
-        core = OpenVINOBackend.core = OpenVINOBackend.core or ov.Core()
+        core = OpenVINOBackend._core = getattr(OpenVINOBackend, "_core", None) or ov.Core()
         fallback_device = "CPU" if core.available_devices == ["CPU"] else "AUTO"
         device_name = fallback_device
 

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -20,6 +20,8 @@ class OpenVINOBackend(BaseBackend):
     selection, Intel-specific device targeting, and async inference for throughput optimization.
     """
 
+    _core = None  # cached ov.Core singleton (avoids segfault on repeated instantiation in OpenVINO 2026+)
+
     def load_model(self, weight: str | Path) -> None:
         """Load an Intel OpenVINO IR model from a .xml/.bin file pair or model directory.
 
@@ -30,7 +32,9 @@ class OpenVINOBackend(BaseBackend):
         check_requirements("openvino>=2024.0.0")
         import openvino as ov
 
-        core = ov.Core()
+        if OpenVINOBackend._core is None:
+            OpenVINOBackend._core = ov.Core()
+        core = OpenVINOBackend._core
         fallback_device = "CPU" if core.available_devices == ["CPU"] else "AUTO"
         device_name = fallback_device
 

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -20,7 +20,7 @@ class OpenVINOBackend(BaseBackend):
     selection, Intel-specific device targeting, and async inference for throughput optimization.
     """
 
-    _core = None  # cached ov.Core singleton (avoids segfault on repeated instantiation in OpenVINO 2026+)
+    core = None  # cached ov.Core singleton (avoids segfault on repeated instantiation in OpenVINO 2026+)
 
     def load_model(self, weight: str | Path) -> None:
         """Load an Intel OpenVINO IR model from a .xml/.bin file pair or model directory.
@@ -32,9 +32,7 @@ class OpenVINOBackend(BaseBackend):
         check_requirements("openvino>=2024.0.0")
         import openvino as ov
 
-        if OpenVINOBackend._core is None:
-            OpenVINOBackend._core = ov.Core()
-        core = OpenVINOBackend._core
+        core = OpenVINOBackend.core = OpenVINOBackend.core or ov.Core()
         fallback_device = "CPU" if core.available_devices == ["CPU"] else "AUTO"
         device_name = fallback_device
 

--- a/ultralytics/nn/backends/openvino.py
+++ b/ultralytics/nn/backends/openvino.py
@@ -20,7 +20,6 @@ class OpenVINOBackend(BaseBackend):
     selection, Intel-specific device targeting, and async inference for throughput optimization.
     """
 
-
     def load_model(self, weight: str | Path) -> None:
         """Load an Intel OpenVINO IR model from a .xml/.bin file pair or model directory.
 


### PR DESCRIPTION
Cache ov.Core() as a class-level singleton in OpenVINOBackend to avoid a segfault in the OpenVINO 2026.0.0 conda-forge build when Core is created more than once in the same process. This crashed benchmarks, tests, and any workflow that loads an OpenVINO model multiple times. 

Also removing the `openvino!=2026.0.0` exclusion from the Conda CI job since the fix makes it safe to use.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates CI dependency installation to block all `openvino` 2026 releases, improving build stability for Ultralytics tests and package validation.

### 📊 Key Changes
- Changed the CI workflow’s Conda install command in `.github/workflows/ci.yml`.
- Replaced the `openvino!=2026.0.0` version constraint with `openvino<2026`.
- This means CI will no longer install any `openvino` version from the 2026 release line, instead of excluding only one specific version.

### 🎯 Purpose & Impact
- 🛡️ **Improves CI reliability** by preventing incompatible future `openvino` 2026 packages from being pulled into test environments.
- 📦 **Makes dependency pinning safer** by blocking an entire major version family rather than a single known-bad release.
- ⚙️ **Reduces risk of sudden breakages** in automated testing as new `openvino` 2026.x versions become available.
- 👥 **Benefits contributors and maintainers** with more predictable CI results and fewer dependency-related failures.
- 🚀 **Helps keep Ultralytics package validation stable** until `openvino` 2026 compatibility is confirmed.