### PR TITLE
Clarify architecture-only yamls and historical framing on model pages

### DIFF
--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -90,7 +90,7 @@ This table presents the model types, the specific pretrained weights, the tasks 
 
 !!! note "Architecture-only variants"
 
-    [`rtdetr-resnet50.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet50.yaml) and [`rtdetr-resnet101.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet101.yaml) are shipped as YAML architectures only. Ultralytics releases pretrained weights only for `rtdetr-l` and `rtdetr-x`. Load the ResNet backbones via the YAML (e.g. `RTDETR("rtdetr-resnet50.yaml")`) and train from scratch.
+    [`rtdetr-resnet50.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet50.yaml) and [`rtdetr-resnet101.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet101.yaml) are shipped as YAML architectures only. Ultralytics releases pretrained weights only for `rtdetr-l` and `rtdetr-x`. Instantiate the ResNet variants from YAML (for example, `RTDETR("rtdetr-resnet50.yaml")`) and train or fine-tune them as needed.
 
 ## Ideal Use Cases
 

--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -88,6 +88,10 @@ This table presents the model types, the specific pretrained weights, the tasks 
 | RT-DETR Large       | [rtdetr-l.pt](https://github.com/ultralytics/assets/releases/download/v8.4.0/rtdetr-l.pt) | [Object Detection](../tasks/detect.md) | ✅        | ✅         | ✅       | ✅     |
 | RT-DETR Extra-Large | [rtdetr-x.pt](https://github.com/ultralytics/assets/releases/download/v8.4.0/rtdetr-x.pt) | [Object Detection](../tasks/detect.md) | ✅        | ✅         | ✅       | ✅     |
 
+!!! note "Architecture-only variants"
+
+    [`rtdetr-resnet50.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet50.yaml) and [`rtdetr-resnet101.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet101.yaml) are shipped as YAML architectures only — Ultralytics releases pretrained weights only for `rtdetr-l` and `rtdetr-x`. Load the ResNet backbones via the YAML (e.g. `RTDETR("rtdetr-resnet50.yaml")`) and train from scratch.
+
 ## Ideal Use Cases
 
 RT-DETR is particularly well-suited for applications requiring both high accuracy and real-time performance:

--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -90,7 +90,7 @@ This table presents the model types, the specific pretrained weights, the tasks 
 
 !!! note "Architecture-only variants"
 
-    [`rtdetr-resnet50.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet50.yaml) and [`rtdetr-resnet101.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet101.yaml) are shipped as YAML architectures only — Ultralytics releases pretrained weights only for `rtdetr-l` and `rtdetr-x`. Load the ResNet backbones via the YAML (e.g. `RTDETR("rtdetr-resnet50.yaml")`) and train from scratch.
+    [`rtdetr-resnet50.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet50.yaml) and [`rtdetr-resnet101.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/rt-detr/rtdetr-resnet101.yaml) are shipped as YAML architectures only. Ultralytics releases pretrained weights only for `rtdetr-l` and `rtdetr-x`. Load the ResNet backbones via the YAML (e.g. `RTDETR("rtdetr-resnet50.yaml")`) and train from scratch.
 
 ## Ideal Use Cases
 

--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -71,7 +71,7 @@ This unified framework ensures YOLO26 is applicable across real-time detection, 
 
 !!! note "Architecture-only variants"
 
-    [`yolo26-p2.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p2.yaml) and [`yolo26-p6.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p6.yaml) add a P2 (small-object) or P6 (large-input) detection head and are shipped as YAML architectures only. No scale-specific `yolo26*-p2.pt` or `yolo26*-p6.pt` weights are released. Load a scaled config via its YAML (e.g. `YOLO("yolo26n-p6.yaml")`) and train from scratch.
+    [`yolo26-p2.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p2.yaml) and [`yolo26-p6.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p6.yaml) add a P2 (small-object) or P6 (large-input) detection head and are shipped as YAML architectures only. No scale-specific `yolo26*-p2.pt` or `yolo26*-p6.pt` weights are released. Instantiate a scaled config from YAML (for example, `YOLO("yolo26n-p6.yaml")`) and train or fine-tune it as needed.
 
 ---
 

--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -69,6 +69,10 @@ YOLO26 builds upon the versatile model range established by earlier Ultralytics 
 
 This unified framework ensures YOLO26 is applicable across real-time detection, segmentation, classification, pose estimation, and oriented object detection — all with training, validation, inference, and export support.
 
+!!! note "Architecture-only variants"
+
+    [`yolo26-p2.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p2.yaml) and [`yolo26-p6.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p6.yaml) add a P2 (small-object) or P6 (large-input) detection head and are shipped as YAML architectures only — no `yolo26n-p2.pt` or `yolo26n-p6.pt` weights are released. Load them via the YAML (e.g. `YOLO("yolo26-p6.yaml")`) and train from scratch.
+
 ---
 
 ## Performance Metrics

--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -71,7 +71,7 @@ This unified framework ensures YOLO26 is applicable across real-time detection, 
 
 !!! note "Architecture-only variants"
 
-    [`yolo26-p2.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p2.yaml) and [`yolo26-p6.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p6.yaml) add a P2 (small-object) or P6 (large-input) detection head and are shipped as YAML architectures only. No `yolo26n-p2.pt` or `yolo26n-p6.pt` weights are released. Load them via the YAML (e.g. `YOLO("yolo26-p6.yaml")`) and train from scratch.
+    [`yolo26-p2.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p2.yaml) and [`yolo26-p6.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p6.yaml) add a P2 (small-object) or P6 (large-input) detection head and are shipped as YAML architectures only. No scale-specific `yolo26*-p2.pt` or `yolo26*-p6.pt` weights are released. Load a scaled config via its YAML (e.g. `YOLO("yolo26n-p6.yaml")`) and train from scratch.
 
 ---
 

--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -71,7 +71,7 @@ This unified framework ensures YOLO26 is applicable across real-time detection, 
 
 !!! note "Architecture-only variants"
 
-    [`yolo26-p2.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p2.yaml) and [`yolo26-p6.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p6.yaml) add a P2 (small-object) or P6 (large-input) detection head and are shipped as YAML architectures only — no `yolo26n-p2.pt` or `yolo26n-p6.pt` weights are released. Load them via the YAML (e.g. `YOLO("yolo26-p6.yaml")`) and train from scratch.
+    [`yolo26-p2.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p2.yaml) and [`yolo26-p6.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/models/26/yolo26-p6.yaml) add a P2 (small-object) or P6 (large-input) detection head and are shipped as YAML architectures only. No `yolo26n-p2.pt` or `yolo26n-p6.pt` weights are released. Load them via the YAML (e.g. `YOLO("yolo26-p6.yaml")`) and train from scratch.
 
 ---
 

--- a/docs/en/models/yolov4.md
+++ b/docs/en/models/yolov4.md
@@ -32,7 +32,7 @@ When compared to other models in the YOLO family, such as [YOLOv5](https://docs.
 
 ## Usage Examples
 
-As of the time of writing, Ultralytics does not currently support YOLOv4 models. Therefore, any users interested in using YOLOv4 will need to refer directly to the YOLOv4 GitHub repository for installation and usage instructions.
+YOLOv4 is a Darknet-based model and is **not natively supported** by the Ultralytics Python package: there are no `yolov4.pt` pretrained weights published on [ultralytics/assets](https://github.com/ultralytics/assets/releases) and no `ultralytics/cfg/models/v4/` YAMLs. This page is kept as an architectural reference. Users interested in running YOLOv4 should refer directly to the YOLOv4 GitHub repository for installation and usage instructions.
 
 Here is a brief overview of the typical steps you might take to use YOLOv4:
 
@@ -44,7 +44,7 @@ Here is a brief overview of the typical steps you might take to use YOLOv4:
 
 Please note that the specific steps may vary depending on your specific use case and the current state of the YOLOv4 repository. Therefore, it is strongly recommended to refer directly to the instructions provided in the YOLOv4 GitHub repository.
 
-We regret any inconvenience this may cause and will strive to update this document with usage examples for Ultralytics once support for YOLOv4 is implemented.
+For training and inference within the Ultralytics framework, see [YOLO11](yolo11.md) or [YOLO26](yolo26.md).
 
 ## Conclusion
 

--- a/docs/en/models/yolov7.md
+++ b/docs/en/models/yolov7.md
@@ -91,7 +91,7 @@ YOLOv7 introduces several key features:
 
 ## Usage Examples
 
-As of the time of writing, Ultralytics only supports ONNX and TensorRT inference for YOLOv7.
+Ultralytics does not publish `yolov7.pt` pretrained weights or `ultralytics/cfg/models/v7/` YAMLs — native PyTorch training and inference for YOLOv7 are **not supported** by the Ultralytics Python package. However, you can bring a YOLOv7 checkpoint trained in the [upstream YOLOv7 repository](https://github.com/WongKinYiu/yolov7) into Ultralytics by exporting it to ONNX or TensorRT, as shown below.
 
 ### ONNX Export
 

--- a/docs/en/models/yolov7.md
+++ b/docs/en/models/yolov7.md
@@ -91,7 +91,7 @@ YOLOv7 introduces several key features:
 
 ## Usage Examples
 
-Ultralytics does not publish `yolov7.pt` pretrained weights or `ultralytics/cfg/models/v7/` YAMLs — native PyTorch training and inference for YOLOv7 are **not supported** by the Ultralytics Python package. However, you can bring a YOLOv7 checkpoint trained in the [upstream YOLOv7 repository](https://github.com/WongKinYiu/yolov7) into Ultralytics by exporting it to ONNX or TensorRT, as shown below.
+Ultralytics does not publish `yolov7.pt` pretrained weights or `ultralytics/cfg/models/v7/` YAMLs, and native PyTorch training and inference for YOLOv7 are **not supported** by the Ultralytics Python package. However, you can bring a YOLOv7 checkpoint trained in the [upstream YOLOv7 repository](https://github.com/WongKinYiu/yolov7) into Ultralytics by exporting it to ONNX or TensorRT, as shown below.
 
 ### ONNX Export
 


### PR DESCRIPTION
## Summary

Small framing fixes on a few `docs/en/models/` pages. Users could reasonably expect pretrained weights that don't exist.

- **yolo26.md**: `ultralytics/cfg/models/26/` ships `yolo26-p2.yaml` and `yolo26-p6.yaml`, but no `yolo26n-p2.pt` or `yolo26n-p6.pt` are released (`ultralytics/utils/downloads.py:21` lists only `n/s/m/l/x`). Added a short `!!! note` under the Supported Tasks table clarifying these are YAML-only architectures that must be trained from scratch.
- **rtdetr.md**: `ultralytics/cfg/models/rt-detr/` ships `rtdetr-resnet50.yaml` and `rtdetr-resnet101.yaml`, but `ultralytics/utils/downloads.py:36` releases only `rtdetr-l` and `rtdetr-x`. Added the same style of note under the Supported Tasks table.
- **yolov4.md** and **yolov7.md**: no `ultralytics/cfg/models/v4/` or `v7/` directories, no `.pt` weights. Reframed the `## Usage Examples` intro paragraph on each page to make it clear these are architectural / historical reference pages. Removed the stale line promising to update yolov4.md once support is implemented (YOLOv4 is Darknet-based and not on the native-support roadmap). YOLOv7's ONNX / TensorRT import workflow is preserved as-is since that path does work.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves model documentation by clearly distinguishing which model variants have released pretrained weights versus YAML-only architectures, and by clarifying support limitations for YOLOv4 and YOLOv7 in Ultralytics.

### 📊 Key Changes
- Added **architecture-only notes** to the [RT-DETR model docs](https://docs.ultralytics.com/models/rtdetr/) clarifying that:
  - `rtdetr-resnet50.yaml` and `rtdetr-resnet101.yaml` are available as **YAML configs only**
  - pretrained weights are released only for `rtdetr-l` and `rtdetr-x`
  - users should instantiate these variants from YAML and then train or fine-tune them
- Added a similar **architecture-only note** to the [YOLO26 model docs](https://docs.ultralytics.com/models/yolo26/) explaining that:
  - `yolo26-p2.yaml` and `yolo26-p6.yaml` are **architecture definitions only**
  - no pretrained `yolo26*-p2.pt` or `yolo26*-p6.pt` weights are provided
  - users can create scaled variants from YAML and train them as needed
- Updated the [YOLOv4 docs](https://docs.ultralytics.com/models/yolov4/) to explicitly state that:
  - YOLOv4 is **not natively supported** in the Ultralytics Python package
  - there are no official Ultralytics weights or model YAMLs for YOLOv4
  - the page is kept mainly as an architectural reference
  - users looking for supported alternatives should use YOLO11 or YOLO26
- Updated the [YOLOv7 docs](https://docs.ultralytics.com/models/yolov7/) to clarify that:
  - native PyTorch training and inference for YOLOv7 are **not supported**
  - Ultralytics does not publish `yolov7.pt` weights or v7 YAML configs
  - YOLOv7 models can still be used through **ONNX or TensorRT export** from the upstream repository

### 🎯 Purpose & Impact
- ✅ Reduces confusion for users who may expect pretrained weights for every documented model variant
- 🚫 Prevents failed setup attempts by making unsupported models and unsupported workflows much more explicit
- 📚 Improves documentation accuracy, especially for users comparing available architectures with actually supported checkpoints
- 🛠️ Helps advanced users understand when they need to start from a YAML architecture and train or fine-tune it themselves
- 🎯 Guides users toward supported Ultralytics options like YOLO26 for a smoother training and deployment experience