### PR TITLE
Clarify tt100k uses 221 annotation categories with 45 trainable classes

### DIFF
--- a/docs/en/datasets/detect/tt100k.md
+++ b/docs/en/datasets/detect/tt100k.md
@@ -8,7 +8,7 @@ keywords: TT100K, Tsinghua-Tencent 100K, traffic sign detection, YOLO26, dataset
 
 The [Tsinghua-Tencent 100K (TT100K)](https://cg.cs.tsinghua.edu.cn/traffic-sign/) is a large-scale traffic sign benchmark dataset created from 100,000 Tencent Street View panoramas. This dataset is specifically designed for traffic sign detection and classification in real-world conditions, providing researchers and developers with a comprehensive resource for building robust traffic sign recognition systems.
 
-The dataset contains **100,000 images** with over **30,000 traffic sign instances** across **221 different categories**. These images capture large variations in illuminance, weather conditions, viewing angles, and distances, making it ideal for training models that need to perform reliably in diverse real-world scenarios.
+The dataset contains **100,000 images** with over **30,000 traffic sign instances** across **221 annotation categories**. The original paper applies a 100-instance threshold per class for supervised training, which leaves **45 classes** with sufficient samples to learn from; the remaining categories are present in the annotations but appear too rarely for reliable training. These images capture large variations in illuminance, weather conditions, viewing angles, and distances, making it ideal for training models that need to perform reliably in diverse real-world scenarios.
 
 This dataset is particularly valuable for:
 

--- a/docs/en/datasets/detect/tt100k.md
+++ b/docs/en/datasets/detect/tt100k.md
@@ -8,7 +8,7 @@ keywords: TT100K, Tsinghua-Tencent 100K, traffic sign detection, YOLO26, dataset
 
 The [Tsinghua-Tencent 100K (TT100K)](https://cg.cs.tsinghua.edu.cn/traffic-sign/) is a large-scale traffic sign benchmark dataset created from 100,000 Tencent Street View panoramas. This dataset is specifically designed for traffic sign detection and classification in real-world conditions, providing researchers and developers with a comprehensive resource for building robust traffic sign recognition systems.
 
-The dataset contains **100,000 images** with over **30,000 traffic sign instances** across **221 annotation categories**. The original paper applies a 100-instance threshold per class for supervised training, which leaves **45 classes** with sufficient samples to learn from; the remaining categories are present in the annotations but appear too rarely for reliable training. These images capture large variations in illuminance, weather conditions, viewing angles, and distances, making it ideal for training models that need to perform reliably in diverse real-world scenarios.
+The dataset contains **100,000 images** with over **30,000 traffic sign instances** across **221 annotation categories**. The original paper applies a 100-instance threshold per class for supervised training, yielding a commonly used **45-class** subset; however, the provided Ultralytics dataset configuration retains all **221 annotated categories**, many of which are very sparse. These images capture large variations in illuminance, weather conditions, viewing angles, and distances, making it ideal for training models that need to perform reliably in diverse real-world scenarios.
 
 This dataset is particularly valuable for:
 


### PR DESCRIPTION
## Summary

Small wording fix on `docs/en/datasets/detect/tt100k.md`. The page previously said "221 different categories", which is technically the count of annotation labels but does not reflect that only a subset of them have enough samples to actually be trainable.

The original [TT100K paper](https://openaccess.thecvf.com/content_cvpr_2016/papers/Zhu_Traffic-Sign_Detection_and_CVPR_2016_paper.pdf) (Zhu et al., CVPR 2016, section 4.2) explicitly states:

> "We simply ignored classes with fewer than 100 instances. This left 45 classes to classify."

`ultralytics/cfg/datasets/TT100K.yaml:19` already encodes this in a code comment (`# Classes (221 traffic sign categories, 45 with sufficient training instances)`); this PR just brings the docs in line with that.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the TT100K dataset documentation to clarify that Ultralytics uses all 221 annotated traffic sign categories, while noting that the original paper commonly trains on a reduced 45-class subset.

### 📊 Key Changes
- Updated the TT100K dataset description in the docs for better accuracy.
- Changed wording from **221 different categories** to **221 annotation categories**.
- Added clarification that:
  - the original TT100K paper uses a **100-instance-per-class threshold** for supervised training,
  - this creates a commonly used **45-class subset**,
  - the Ultralytics dataset configuration still keeps all **221 annotated categories**.
- Noted that many of the 221 categories are **very sparse** in the dataset.

### 🎯 Purpose & Impact
- 📚 Helps users better understand the difference between the **full annotated dataset** and the **commonly used training subset**.
- 🎯 Sets clearer expectations for training, since sparse classes can affect model performance and class balance.
- ✅ Improves documentation accuracy, reducing confusion for researchers and developers working with TT100K in Ultralytics.
- 🚗 Makes it easier to choose the right dataset setup for traffic sign detection tasks with YOLO models.