### PR TITLE
Check for `lrpc` attribute before attempting fuse during YOLOE model export

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -476,7 +476,7 @@ class Exporter:
                 m.agnostic_nms = self.args.agnostic_nms
                 m.xyxy = self.args.nms and fmt != "coreml"
                 m.shape = None  # reset cached shape for new export input size
-                if hasattr(model, "pe") and hasattr(m, "fuse"):  # for YOLOE models
+                if hasattr(model, "pe") and hasattr(m, "fuse") and not hasattr(m, "lrpc") :  # for YOLOE models
                     m.fuse(model.pe.to(self.device))
             elif isinstance(m, C2f) and not is_tf_format:
                 # EdgeTPU does not support FlexSplitV while split provides cleaner ONNX graph

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -476,7 +476,7 @@ class Exporter:
                 m.agnostic_nms = self.args.agnostic_nms
                 m.xyxy = self.args.nms and fmt != "coreml"
                 m.shape = None  # reset cached shape for new export input size
-                if hasattr(model, "pe") and hasattr(m, "fuse") and not hasattr(m, "lrpc") :  # for YOLOE models
+                if hasattr(model, "pe") and hasattr(m, "fuse") and not hasattr(m, "lrpc"):  # for YOLOE models
                     m.fuse(model.pe.to(self.device))
             elif isinstance(m, C2f) and not is_tf_format:
                 # EdgeTPU does not support FlexSplitV while split provides cleaner ONNX graph


### PR DESCRIPTION
Fixes https://github.com/orgs/ultralytics/discussions/24047

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes a YOLO export edge case by preventing an incompatible fusion step for modules that use `lrpc`, improving export reliability for certain YOLOE model variants.

### 📊 Key Changes
- Updated `ultralytics/engine/exporter.py` in the export path for YOLOE models.
- Refined the condition that calls `m.fuse(model.pe.to(self.device))`.
- Added a new safeguard: fusion now only runs when the module has `fuse` **and does not have** `lrpc`.
- Kept existing export behavior unchanged for other supported modules and formats.

### 🎯 Purpose & Impact
- ✅ Prevents incorrect or unsupported fusion during model export for modules with `lrpc`.
- 🚀 Improves export stability and reduces the chance of failures for affected YOLOE models.
- 🔒 Makes the exporter more robust by applying fusion only where it is appropriate.
- 👥 Benefits users exporting specialized model architectures, while having little to no impact on standard export workflows.