### PR TITLE
SAM3: Skip geometry token when using text prompts

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2273,8 +2273,9 @@ class SAM3SemanticPredictor(SAM3Predictor):
         """Run inference on the extracted features with optional bounding boxes and labels."""
         # NOTE: priority: bboxes > text > pre-set classes
         nc = 1 if bboxes is not None else len(text) if text is not None else len(self.model.names)
-        geometric_prompt = self._get_dummy_prompt(nc)
+        geometric_prompt = None
         if bboxes is not None:
+            geometric_prompt = self._get_dummy_prompt(nc)
             for i in range(len(bboxes)):
                 geometric_prompt.append_boxes(bboxes[[i]], labels[[i]])
             if text is None:

--- a/ultralytics/models/sam/sam3/sam3_image.py
+++ b/ultralytics/models/sam/sam3/sam3_image.py
@@ -296,9 +296,7 @@ class SAM3SemanticModel(torch.nn.Module):
         txt_masks = backbone_out["language_mask"][text_ids]
         if geometric_prompt is not None:
             with torch.profiler.record_function("SAM3Image._encode_prompt"):
-                geo_prompt, geo_mask = self._encode_prompt(
-                    img_feats, img_pos_embeds, vis_feat_sizes, geometric_prompt
-                )
+                geo_prompt, geo_mask = self._encode_prompt(img_feats, img_pos_embeds, vis_feat_sizes, geometric_prompt)
             prompt = torch.cat([txt_feats, geo_prompt], dim=0)
             prompt_mask = torch.cat([txt_masks, geo_mask], dim=1)
         else:

--- a/ultralytics/models/sam/sam3/sam3_image.py
+++ b/ultralytics/models/sam/sam3/sam3_image.py
@@ -290,15 +290,20 @@ class SAM3SemanticModel(torch.nn.Module):
             self, backbone_out, batch=len(text_ids)
         )
         backbone_out.update({k: v for k, v in self.text_embeddings.items()})
-        with torch.profiler.record_function("SAM3Image._encode_prompt"):
-            prompt, prompt_mask = self._encode_prompt(img_feats, img_pos_embeds, vis_feat_sizes, geometric_prompt)
         # index text features (note that regardless of early or late fusion, the batch size of
         # `txt_feats` is always the number of *prompts* in the encoder)
         txt_feats = backbone_out["language_features"][:, text_ids]
         txt_masks = backbone_out["language_mask"][text_ids]
-        # encode text
-        prompt = torch.cat([txt_feats, prompt], dim=0)
-        prompt_mask = torch.cat([txt_masks, prompt_mask], dim=1)
+        if geometric_prompt is not None:
+            with torch.profiler.record_function("SAM3Image._encode_prompt"):
+                geo_prompt, geo_mask = self._encode_prompt(
+                    img_feats, img_pos_embeds, vis_feat_sizes, geometric_prompt
+                )
+            prompt = torch.cat([txt_feats, geo_prompt], dim=0)
+            prompt_mask = torch.cat([txt_masks, geo_mask], dim=1)
+        else:
+            prompt = txt_feats
+            prompt_mask = txt_masks
 
         # Run the encoder
         with torch.profiler.record_function("SAM3Image._run_encoder"):


### PR DESCRIPTION
Closes #24159

 ## Summary

  - Fix SAM3 text-only grounding producing lower confidence scores than expected
  - Skip dummy geometry prompt encoding when no bounding boxes are provided, matching the reference implementation behavior

  ## Details

 `SAM3SemanticPredictor._inference_features()` always created a dummy geometry prompt via `_get_dummy_prompt()`, even for text-only grounding. The geometry encoder produces a non-zero learned token from this empty prompt, which gets concatenated with text tokens and fed into the DETR encoder. This extra token alters encoder cross-attention, cascading through the decoder to produce lower `pred_logits` and `presence_logit_dec` scores.

The reference HF Transformers implementation skips geometry encoding entirely when no boxes are provided.

  ### Before fix
  | Metric | HF Transformers | Ultralytics |
  |---|---|---|
  | `presence_sigmoid` | 0.020 | 0.006 |
  | `pred_logits` top | -0.16 | -0.47 |

  ### After fix
  | Metric | HF Transformers | Ultralytics |
  |---|---|---|
  | `presence_sigmoid` | 0.020 | 0.021 |
  | `pred_logits` top | -0.16 | -0.17 |

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes SAM/SAM3 grounding inference so text-only prompts work correctly by avoiding creation and encoding of unnecessary geometric prompts.

### 📊 Key Changes
- Updated `ultralytics/models/sam/predict.py` to set `geometric_prompt` to `None` by default instead of always creating a dummy prompt.
- Changed logic so dummy geometric prompts are created only when bounding boxes are actually provided.
- Updated `ultralytics/models/sam/sam3/sam3_image.py` to handle two cases cleanly:
  - **With boxes**: combine text features with encoded geometric prompts.
  - **Text-only**: use text features directly without trying to encode geometric prompts.
- Preserved existing priority behavior for prompts: **bounding boxes > text > pre-set classes**.

### 🎯 Purpose & Impact
- ✅ Fixes a likely bug or edge case where SAM3 grounding could incorrectly process text-only prompts.
- 🚀 Improves robustness by preventing unnecessary prompt encoding when no geometric input exists.
- ⚡ May slightly reduce overhead for text-only inference by skipping extra prompt-building work.
- 🎯 Makes SAM/SAM3 prompt handling more consistent and predictable for users working with text prompts, box prompts, or both.