### PR TITLE
Fix: corrected undocumented scaling of track_buffer in trackers

### DIFF
--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -241,7 +241,7 @@ class BYTETracker:
         removed_stracks (list[STrack]): List of removed tracks.
         frame_id (int): The current frame ID.
         args (Namespace): Command-line arguments.
-        max_time_lost (int): The maximum frames for a track to be considered as 'lost'.
+        max_frames_lost (int): The maximum frames for a track to be considered as 'lost'.
         kalman_filter (KalmanFilterXYAH): Kalman Filter object.
 
     Methods:
@@ -276,7 +276,7 @@ class BYTETracker:
 
         self.frame_id = 0
         self.args = args
-        self.max_time_lost = int(frame_rate / 30.0 * args.track_buffer)
+        self.max_frames_lost = args.track_buffer
         self.kalman_filter = self.get_kalmanfilter()
         self.reset_id()
 
@@ -377,7 +377,7 @@ class BYTETracker:
             activated_stracks.append(track)
         # Step 5: Update state
         for track in self.lost_stracks:
-            if self.frame_id - track.end_frame > self.max_time_lost:
+            if self.frame_id - track.end_frame > self.max_frames_lost:
                 track.mark_removed()
                 removed_stracks.append(track)
 


### PR DESCRIPTION
This patch makes `track_buffer` consistently behave as a frame count in bytetracker and botsort.

Previously, the lost-track threshold was computed as `int(frame_rate / 30 * track_buffer)`, which meant the effective buffer no longer matched the configured `track_buffer` value whenever `frame_rate` is not equal to this hard-coded value of 30. That was inconsistent with the `config.yaml` descriptions and the docs, which explicitly describe `track_buffer` as a number of frames, and it also made `max_time_lost` a misleading name because the threshold is frame-based, not time-based.

Please note that problem has been raised already in #4284 but was not fixed. For people using custom frame rates, this can cause unexpected behavior. For example, setting `frame_rate` to 10 and `track_buffer` to 30 resulted in an actual buffer of `10/30 * 30 = 10` frames after which tracks are deleted, which significantly deviates from the expected 30.

This change removes that FPS scaling and uses the configured buffer directly as the maximum number of lost frames. `frame_rate` is intentionally still kept for compatibility, to avoid hard breakage for users who already instantiate these trackers with a `frame_rate` argument today, even though it is no longer used for the lost-track buffer calculation. Perhaps this can be depreciated in future?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes ByteTrack buffer handling by removing undocumented frame-rate scaling from `track_buffer` and aligning the implementation with the configured value directly.

### 📊 Key Changes
- Renames the internal tracker attribute from `max_time_lost` to `max_frames_lost` for clearer semantics.
- Changes tracker initialization in `ultralytics/trackers/byte_tracker.py` to use `args.track_buffer` directly instead of scaling it by `frame_rate / 30.0`.
- Updates the lost-track removal logic to reference the renamed `max_frames_lost` attribute.
- Corrects the related class docstring to reflect frame-based behavior more accurately.

### 🎯 Purpose & Impact
- Fixes inconsistent and undocumented behavior where `track_buffer` changed effectively based on video frame rate.
- Makes tracker configuration more predictable for users across different inputs and deployments.
- Improves code clarity by using a name that matches the actual unit being tracked: frames, not time.
- Reduces confusion for users tuning tracking persistence in detection workflows.