### PR TITLE
Fix integrations docs drift for neptune and mlflow

### DIFF
--- a/docs/en/integrations/mlflow.md
+++ b/docs/en/integrations/mlflow.md
@@ -86,7 +86,11 @@ Make sure that MLflow logging is enabled in Ultralytics settings. Usually, this 
     mlflow server --backend-store-uri runs/mlflow
     ```
 
-    This will start a local server at `http://127.0.0.1:5000` by default and save all mlflow logs to the 'runs/mlflow' directory. To specify a different URI, set the `MLFLOW_TRACKING_URI` environment variable.
+    This will start a local server at `http://127.0.0.1:5000` by default and save all mlflow logs to the 'runs/mlflow' directory. To point your training runs at a different tracking server, export `MLFLOW_TRACKING_URI` before training:
+
+    ```bash
+    export MLFLOW_TRACKING_URI=http://127.0.0.1:5000
+    ```
 
 4. **Kill MLflow Server Instances**: To stop all running MLflow instances, run:
 

--- a/docs/en/integrations/neptune.md
+++ b/docs/en/integrations/neptune.md
@@ -74,7 +74,6 @@ The securest way to handle credentials is via environment variables. Note that t
     import os
 
     os.environ["NEPTUNE_API_TOKEN"] = "your_long_api_token_here"
-    os.environ["NEPTUNE_PROJECT"] = "your_workspace/your_project"
     ```
 
 ## Usage


### PR DESCRIPTION
## summary

align `docs/en/integrations/neptune.md` and `docs/en/integrations/mlflow.md` with the actual callback behavior. in `neptune.md`, the python env-var example set `NEPTUNE_PROJECT`, but the ultralytics callback always passes `project=trainer.args.project or "Ultralytics"` to `neptune.init_run`, so the SDK never falls back to the env var (the fallback only fires when `project=None`). in `mlflow.md`, the tracking-uri section only mentioned `MLFLOW_TRACKING_URI` in prose; added the concrete `export` command so users can copy it directly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small but helpful documentation updates to the MLflow and Neptune integrations, mainly clarifying setup steps and removing potentially confusing credential guidance.

### 📊 Key Changes
- 🔧 Updated the [MLflow integration docs](https://docs.ultralytics.com/integrations/mlflow/) to clearly show how to set `MLFLOW_TRACKING_URI` before training runs.
- 💡 Added an explicit shell example for exporting `MLFLOW_TRACKING_URI`, making it easier to connect training to a chosen MLflow tracking server.
- 🧹 Simplified the [Neptune integration docs](https://docs.ultralytics.com/integrations/neptune/) by removing the `NEPTUNE_PROJECT` environment variable from the credential example.
- 📚 Improved setup instructions without changing any core Ultralytics code or model behavior.

### 🎯 Purpose & Impact
- ✅ Reduces confusion for users configuring MLflow tracking, especially when working with a local or custom tracking server.
- 🔐 Encourages cleaner handling of Neptune credentials by avoiding unnecessary project configuration in the authentication example.
- 🚀 Makes onboarding smoother for users integrating experiment tracking with Ultralytics training workflows.
- ⚠️ No functional changes to YOLO training or inference are introduced; this is a documentation-only improvement.