### PR TITLE
Fix in-place obb `gt_bboxes` modification in `RotatedTaskAlignedAssigner`

### DIFF
--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -373,15 +373,16 @@ class RotatedTaskAlignedAssigner(TaskAlignedAssigner):
         Returns:
             (torch.Tensor): Boolean mask of positive anchors with shape (b, n_boxes, h*w).
         """
-        wh_mask = gt_bboxes[..., 2:4] < self.stride[0]
-        gt_bboxes[..., 2:4] = torch.where(
+        gt_bboxes_clone = gt_bboxes.clone()
+        wh_mask = gt_bboxes_clone[..., 2:4] < self.stride[0]
+        gt_bboxes_clone[..., 2:4] = torch.where(
             (wh_mask * mask_gt).bool(),
-            torch.tensor(self.stride_val, dtype=gt_bboxes.dtype, device=gt_bboxes.device),
-            gt_bboxes[..., 2:4],
+            torch.tensor(self.stride_val, dtype=gt_bboxes_clone.dtype, device=gt_bboxes_clone.device),
+            gt_bboxes_clone[..., 2:4],
         )
 
         # (b, n_boxes, 5) --> (b, n_boxes, 4, 2)
-        corners = xywhr2xyxyxyxy(gt_bboxes)
+        corners = xywhr2xyxyxyxy(gt_bboxes_clone)
         # (b, n_boxes, 1, 2)
         a, b, _, d = corners.split(1, dim=-2)
         ab = b - a


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes an in-place modification issue in rotated box target assignment by cloning ground-truth boxes before adjusting very small boxes.

### 📊 Key Changes
- Added `gt_bboxes_clone = gt_bboxes.clone()` in `ultralytics/utils/tal.py` to avoid modifying the original ground-truth tensor directly.
- Updated the small-width/height box handling logic to operate on the cloned tensor instead of `gt_bboxes`.
- Switched the downstream corner conversion call from `gt_bboxes` to `gt_bboxes_clone` when computing rotated box corners.

### 🎯 Purpose & Impact
- Prevents unintended side effects from in-place edits to `gt_bboxes`, which can cause hard-to-track bugs during training ⚠️
- Makes the task-aligned assigner logic safer and more predictable, especially for rotated bounding box workflows 🔄
- Improves code reliability for small-object handling without changing the intended behavior of the model ✅
- Reduces the risk of training instability or incorrect label processing in oriented detection tasks 📦