### PR TITLE
Harden retry behavior in docker and links workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,7 +124,7 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         with:
           retries: 3
-          run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          run: printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Login to GHCR
         uses: docker/login-action@v4
@@ -139,7 +139,7 @@ jobs:
           NVIDIA_NGC_API_KEY: ${{ secrets.NVIDIA_NGC_API_KEY }}
         with:
           retries: 3
-          run: echo "$NVIDIA_NGC_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
+          run: printf '%s' "$NVIDIA_NGC_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
 
       - name: Retrieve Ultralytics version
         id: get_version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,23 +123,37 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         with:
-          retries: 3
-          run: printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          run: |
+            if ! out=$(printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin 2>&1); then
+              printf '%s\n' "$out" >&2
+              exit 1
+            fi
+            echo "Logged in to docker.io"
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: ultralytics/actions/retry@main
+        env:
+          GHCR_USERNAME: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets._GITHUB_TOKEN }}
+          run: |
+            if ! out=$(printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin 2>&1); then
+              printf '%s\n' "$out" >&2
+              exit 1
+            fi
+            echo "Logged in to ghcr.io"
 
       - name: Login to NVIDIA NGC
         uses: ultralytics/actions/retry@main
         env:
           NVIDIA_NGC_API_KEY: ${{ secrets.NVIDIA_NGC_API_KEY }}
         with:
-          retries: 3
-          run: printf '%s' "$NVIDIA_NGC_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
+          run: |
+            if ! out=$(printf '%s' "$NVIDIA_NGC_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1); then
+              printf '%s\n' "$out" >&2
+              exit 1
+            fi
+            echo "Logged in to nvcr.io"
 
       - name: Retrieve Ultralytics version
         id: get_version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,10 +118,14 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: ultralytics/actions/retry@main
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          retry_delay_seconds: 30
+          retries: 3
+          run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Login to GHCR
         uses: docker/login-action@v4
@@ -131,11 +135,13 @@ jobs:
           password: ${{ secrets._GITHUB_TOKEN }}
 
       - name: Login to NVIDIA NGC
-        uses: docker/login-action@v4
+        uses: ultralytics/actions/retry@main
+        env:
+          NVIDIA_NGC_API_KEY: ${{ secrets.NVIDIA_NGC_API_KEY }}
         with:
-          registry: nvcr.io
-          username: $oauthtoken
-          password: ${{ secrets.NVIDIA_NGC_API_KEY }}
+          retry_delay_seconds: 30
+          retries: 3
+          run: echo "$NVIDIA_NGC_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
 
       - name: Retrieve Ultralytics version
         id: get_version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,7 +123,6 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         with:
-          retry_delay_seconds: 30
           retries: 3
           run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 
@@ -139,7 +138,6 @@ jobs:
         env:
           NVIDIA_NGC_API_KEY: ${{ secrets.NVIDIA_NGC_API_KEY }}
         with:
-          retry_delay_seconds: 30
           retries: 3
           run: echo "$NVIDIA_NGC_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -35,6 +35,7 @@ jobs:
           timeout_minutes: 60
           retry_delay_seconds: 1800
           retries: 2
+          backoff: fixed
           run: |
             lychee \
             --scheme https \
@@ -70,6 +71,7 @@ jobs:
           timeout_minutes: 60
           retry_delay_seconds: 1800
           retries: 2
+          backoff: fixed
           run: |
             lychee \
             --scheme https \


### PR DESCRIPTION
## Summary
Improves retry handling in the Docker and links workflows.

## Changes
- wrap Docker Hub and NVIDIA NGC logins in ultralytics/actions/retry
- preserve fixed 30-minute retry spacing for the two 60-minute links checks by setting backoff: fixed

## Why
The retry action now defaults to exponential backoff with jitter. That is a good default overall, but the links checks using 1800-second delays need explicit fixed backoff so retries stay within the existing 60-minute timeout budget.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR improves GitHub Actions reliability by replacing Docker registry login steps with retry-enabled commands and making link-check retries more predictable.

### 📊 Key Changes
- 🔐 Replaced `docker/login-action@v4` in the Docker workflow with `ultralytics/actions/retry@main` for:
  - Docker Hub login
  - GitHub Container Registry (GHCR) login
  - NVIDIA NGC login
- ♻️ Converted each registry login into explicit `docker login` shell commands using environment variables and `--password-stdin`.
- 🛡️ Added retry handling around these login steps, so temporary network or registry issues are less likely to fail the workflow.
- 🔗 Updated the link-check workflow to use `backoff: fixed` for Lychee retries in both retry blocks.
- ⏱️ This keeps retry timing consistent instead of changing delay behavior between attempts.

### 🎯 Purpose & Impact
- 🚀 Improves CI/CD stability by making container publishing workflows more resilient to intermittent login failures.
- 📦 Helps reduce failed Docker image builds and releases caused by temporary external service issues.
- 🔍 Makes link validation runs more predictable and easier to troubleshoot with fixed retry intervals.
- 👨‍💻 Benefits maintainers most directly, but end users may also see fewer delays in container image availability and more reliable release automation.