### PR TITLE
Clarify 4-role rbac availability on pro plan

### DIFF
--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -62,7 +62,7 @@ For professionals and small teams ($29/month or $290/year):
 - 10 concurrent cloud trainings
 - 500 GB storage · 20 GB dataset upload limit
 - 10 cloud deployments
-- [Team collaboration](teams.md) (up to 5 members)
+- [Team collaboration](teams.md) with 4-role RBAC (up to 5 members)
 - Access to the best GPUs (H200, B200)
 - Priority support
 
@@ -78,7 +78,6 @@ For organizations with advanced needs:
 - Unlimited models, storage, trainings, and deployments · 50 GB dataset upload limit
 - Enterprise License (commercial use, non-AGPL)
 - SSO / SAML authentication
-- RBAC with 4 roles (Owner, Admin, Editor, Viewer)
 - On-premise deployment (coming soon)
 - ISO/SOC compliance (coming soon)
 - SLA guarantees (coming soon)

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -237,7 +237,7 @@ From this tab you can:
 
 - **Compare features** across Free, Pro, and Enterprise tiers
 - **Upgrade to Pro** to unlock more storage, models, team collaboration, and priority GPU access
-- **Review Enterprise** capabilities including SSO/SAML, RBAC, and commercial licensing — see [Ultralytics Licensing](https://www.ultralytics.com/license)
+- **Review Enterprise** capabilities including SSO/SAML and commercial licensing — see [Ultralytics Licensing](https://www.ultralytics.com/license)
 
 See [Billing](billing.md) for detailed plan information, pricing, and upgrade instructions.
 


### PR DESCRIPTION
## summary

the enterprise plan block in `docs/en/platform/account/billing.md` listed "rbac with 4 roles (owner, admin, editor, viewer)" as an enterprise benefit, and `docs/en/platform/account/settings.md` named rbac alongside sso/saml as an enterprise-exclusive capability. the 4-role hierarchy is actually shared with pro plan, which supports team collaboration with the same owner/admin/editor/viewer roles. the current wording implies pro lacks role-based access control.

this moves the 4-role rbac mention into the pro bullet in billing.md and removes rbac from the enterprise-capabilities line in settings.md.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Ultralytics Platform docs were updated to clarify that 4-role RBAC is included with **Pro team collaboration**, not listed as a separate Enterprise-only feature 📝

### 📊 Key Changes
- Updated the **Billing** docs to describe Pro plan team collaboration as:
  - **“Team collaboration with 4-role RBAC”** for up to 5 members
- Removed the separate Enterprise billing bullet that previously listed:
  - **“RBAC with 4 roles (Owner, Admin, Editor, Viewer)”**
- Updated the **Settings** docs so Enterprise features now mention:
  - **SSO/SAML** and **commercial licensing**
  - and no longer mention **RBAC** as an Enterprise-specific capability

### 🎯 Purpose & Impact
- Clarifies **plan feature availability** so users can better understand what is included in **Pro vs. Enterprise** ✅
- Makes it clear that **role-based access control** is available for smaller teams on the **Pro plan**, which may reduce confusion and upgrade friction 👥
- Helps teams evaluating the [Ultralytics Platform](https://platform.ultralytics.com) choose the right subscription with more accurate documentation 💡
- Reduces the chance of users assuming they need **Enterprise** just to get multi-role team permissions 🚀