### PR TITLE
Correct AP data region label from Hong Kong to Taiwan

### DIFF
--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -73,7 +73,7 @@ graph TB
     API --> Router{Region Router}
     Router -->|US users| US["US Predict Service<br/>Iowa"]
     Router -->|EU users| EU["EU Predict Service<br/>Belgium"]
-    Router -->|AP users| AP["AP Predict Service<br/>Hong Kong"]
+    Router -->|AP users| AP["AP Predict Service<br/>Taiwan"]
 
     style User fill:#f5f5f5,color:#333
     style API fill:#2196F3,color:#fff
@@ -87,7 +87,7 @@ graph TB
 | ------ | ----------------------- |
 | US     | Iowa, USA               |
 | EU     | Belgium, Europe         |
-| AP     | Hong Kong, Asia-Pacific |
+| AP     | Taiwan, Asia-Pacific    |
 
 ### Dedicated Endpoints
 

--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -83,11 +83,11 @@ graph TB
     style AP fill:#4CAF50,color:#fff
 ```
 
-| Region | Location                |
-| ------ | ----------------------- |
-| US     | Iowa, USA               |
-| EU     | Belgium, Europe         |
-| AP     | Taiwan, Asia-Pacific    |
+| Region | Location             |
+| ------ | -------------------- |
+| US     | Iowa, USA            |
+| EU     | Belgium, Europe      |
+| AP     | Taiwan, Asia-Pacific |
 
 ### Dedicated Endpoints
 

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -84,11 +84,11 @@ graph LR
 
 Your data stays in your region. Ultralytics Platform operates infrastructure in three global regions:
 
-| Region | Label                        | Location                | Best For                                |
-| ------ | ---------------------------- | ----------------------- | --------------------------------------- |
-| **US** | Americas                     | Iowa, USA               | Americas users, fastest for Americas    |
-| **EU** | Europe, Middle East & Africa | Belgium, Europe         | European users, GDPR compliance         |
-| **AP** | Asia Pacific                 | Taiwan, Asia-Pacific    | Asia-Pacific users, lowest APAC latency |
+| Region | Label                        | Location             | Best For                                |
+| ------ | ---------------------------- | -------------------- | --------------------------------------- |
+| **US** | Americas                     | Iowa, USA            | Americas users, fastest for Americas    |
+| **EU** | Europe, Middle East & Africa | Belgium, Europe      | European users, GDPR compliance         |
+| **AP** | Asia Pacific                 | Taiwan, Asia-Pacific | Asia-Pacific users, lowest APAC latency |
 
 You select your region during onboarding, and all your data, models, and deployments remain in that region.
 

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -88,7 +88,7 @@ Your data stays in your region. Ultralytics Platform operates infrastructure in 
 | ------ | ---------------------------- | ----------------------- | --------------------------------------- |
 | **US** | Americas                     | Iowa, USA               | Americas users, fastest for Americas    |
 | **EU** | Europe, Middle East & Africa | Belgium, Europe         | European users, GDPR compliance         |
-| **AP** | Asia Pacific                 | Hong Kong, Asia-Pacific | Asia-Pacific users, lowest APAC latency |
+| **AP** | Asia Pacific                 | Taiwan, Asia-Pacific    | Asia-Pacific users, lowest APAC latency |
 
 You select your region during onboarding, and all your data, models, and deployments remain in that region.
 

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -47,11 +47,11 @@ During onboarding, you'll be asked to select your data region. The Platform auto
 
 ![Ultralytics Platform Onboarding Region Map With Latency](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-onboarding-region-map-with-latency.avif)
 
-| Region | Label                        | Location                | Best For                                |
-| ------ | ---------------------------- | ----------------------- | --------------------------------------- |
-| **US** | Americas                     | Iowa, USA               | Americas users, fastest for Americas    |
-| **EU** | Europe, Middle East & Africa | Belgium, Europe         | European users, GDPR compliance         |
-| **AP** | Asia Pacific                 | Taiwan, Asia-Pacific    | Asia-Pacific users, lowest APAC latency |
+| Region | Label                        | Location             | Best For                                |
+| ------ | ---------------------------- | -------------------- | --------------------------------------- |
+| **US** | Americas                     | Iowa, USA            | Americas users, fastest for Americas    |
+| **EU** | Europe, Middle East & Africa | Belgium, Europe      | European users, GDPR compliance         |
+| **AP** | Asia Pacific                 | Taiwan, Asia-Pacific | Asia-Pacific users, lowest APAC latency |
 
 !!! warning "Region is Permanent"
 

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -51,7 +51,7 @@ During onboarding, you'll be asked to select your data region. The Platform auto
 | ------ | ---------------------------- | ----------------------- | --------------------------------------- |
 | **US** | Americas                     | Iowa, USA               | Americas users, fastest for Americas    |
 | **EU** | Europe, Middle East & Africa | Belgium, Europe         | European users, GDPR compliance         |
-| **AP** | Asia Pacific                 | Hong Kong, Asia-Pacific | Asia-Pacific users, lowest APAC latency |
+| **AP** | Asia Pacific                 | Taiwan, Asia-Pacific    | Asia-Pacific users, lowest APAC latency |
 
 !!! warning "Region is Permanent"
 


### PR DESCRIPTION
## summary

The AP shared region is served from Google Cloud's `asia-east1` region, which is located in Changhua, Taiwan (see [Google Cloud locations](https://cloud.google.com/about/locations)) — not Hong Kong. Updating the three docs tables and the deploy Mermaid diagram to match the actual infrastructure location.

The label was inadvertently changed to "Hong Kong" in #23706; this PR restores the correct Taiwan label to match `asia-east1`. `docs/en/platform/deploy/endpoints.md` already correctly distinguishes `asia-east1` (Changhua, Taiwan) from `asia-east2` (Kowloon, Hong Kong) in the dedicated endpoints region list.

Files updated:
- `docs/en/platform/index.md` — region table
- `docs/en/platform/quickstart.md` — region table
- `docs/en/platform/deploy/index.md` — region router Mermaid diagram + region table

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🌍 This PR updates Ultralytics Platform documentation to reflect that the Asia-Pacific deployment region is now hosted in **Taiwan** instead of **Hong Kong**.

### 📊 Key Changes
- Updated the **AP region location** from **Hong Kong** to **Taiwan** in platform documentation.
- Revised the **deployment architecture diagram** in `docs/en/platform/deploy/index.md` to show the AP Predict Service in Taiwan.
- Updated **regional location tables** in:
  - `docs/en/platform/deploy/index.md`
  - `docs/en/platform/index.md`
  - `docs/en/platform/quickstart.md`
- Kept the US and EU region details unchanged:
  - **US:** Iowa, USA
  - **EU:** Belgium, Europe

### 🎯 Purpose & Impact
- 📍 Ensures the docs accurately match the current Ultralytics Platform infrastructure.
- 🚀 Gives Asia-Pacific users clearer expectations about where their data and deployed models are hosted.
- 🔒 Helps users make better decisions around **latency, regional data residency, and compliance**.
- 🧭 Reduces confusion during onboarding and deployment setup by keeping region information consistent across the docs.
- 📝 This is a **documentation-only change**, so it should not affect model behavior or API functionality directly.