### PR TITLE
Update Axelera SDK to 1.6.0 with YOLO classifier fix

### DIFF
--- a/docs/en/integrations/axelera.md
+++ b/docs/en/integrations/axelera.md
@@ -106,8 +106,15 @@ For detailed instructions, see our [Ultralytics Installation guide](../quickstar
 
 2. Add the repository to apt:
 
+    Choose the appropriate snippet from below to match the OS being used.
+
     ```bash
-    sudo sh -c "echo 'deb [signed-by=/etc/apt/keyrings/axelera.gpg] https://software.axelera.ai/artifactory/axelera-apt-source/ ubuntu22 main' > /etc/apt/sources.list.d/axelera.list"
+    # Ubuntu 22.04
+    sudo sh -c "echo 'deb [signed-by=/etc/apt/keyrings/axelera.gpg] https://software.axelera.ai/artifactory/axelera-apt-source ubuntu22 main' > /etc/apt/sources.list.d/axelera.list"
+    ```
+    ```bash
+    # Ubuntu 24.04
+    sudo sh -c "echo 'deb [signed-by=/etc/apt/keyrings/axelera.gpg] https://software.axelera.ai/artifactory/axelera-apt-source ubuntu24 main' > /etc/apt/sources.list.d/axelera.list"
     ```
 
 3. Install the SDK and load the driver:
@@ -116,6 +123,15 @@ For detailed instructions, see our [Ultralytics Installation guide](../quickstar
     sudo apt update
     sudo apt install -y metis-dkms=1.4.16
     sudo modprobe metis
+    ```
+
+!!! tip "First run downloads the SDK automatically"
+
+    The first `yolo export format=axelera` or `yolo predict` with an Axelera model will automatically download and install the Axelera SDK packages. This may take several minutes depending on your connection speed, and no progress is shown during the download. To install manually beforehand:
+
+    ```bash
+    pip install axelera-devkit==1.6.0 --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
+    pip install axelera-rt==1.6.0 --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
     ```
 
 ## Exporting YOLO Models to Axelera

--- a/examples/YOLO-Axelera-Python/README.md
+++ b/examples/YOLO-Axelera-Python/README.md
@@ -39,7 +39,7 @@ Two examples are provided below. It should be straightforward to apply them to o
 If you followed the [Axelera integration guide](../../docs/en/integrations/axelera.md), `axelera-rt` is already installed — running `yolo predict` or `yolo val` with an Axelera model auto-installs the runtime dependencies. If you need to install manually:
 
 ```bash
-pip install axelera-rt==1.6.0rc3 --no-cache-dir --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
+pip install axelera-rt==1.6.0 --no-cache-dir --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
 ```
 
 You will also need `opencv-python` and `numpy` (likely already present).

--- a/ultralytics/nn/backends/axelera.py
+++ b/ultralytics/nn/backends/axelera.py
@@ -27,8 +27,8 @@ class AxeleraBackend(BaseBackend):
             from axelera.runtime import op
         except ImportError:
             check_requirements(
-                "axelera-rt==1.6.0rc3",
-                cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple --pre",
+                "axelera-rt==1.6.0",
+                cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
             )
 
         from axelera.runtime import op

--- a/ultralytics/utils/export/axelera.py
+++ b/ultralytics/utils/export/axelera.py
@@ -43,8 +43,8 @@ def torch2axelera(
         from axelera import compiler
     except ImportError:
         check_requirements(
-            "axelera-devkit==1.6.0rc3",
-            cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple --pre",
+            "axelera-devkit==1.6.0",
+            cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
         )
         from axelera import compiler
 


### PR DESCRIPTION
Bump axelera-devkit and axelera-rt from 1.6.0rc3 to 1.6.0 which fixes YOLO classifier export and inference.
Add Ubuntu 24.04 apt repository option alongside Ubuntu 22.04 in the driver installation docs and correct the repository URL.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Axelera integration to SDK 1.6.0, fixes classifier-related runtime/export dependency versions, and improves installation guidance for Ubuntu 22.04 and 24.04. 🚀

### 📊 Key Changes
- Bumped Axelera Python package requirements from `1.6.0rc3` to stable `1.6.0` in both export and runtime backend code.
- Updated `ultralytics/nn/backends/axelera.py` to install `axelera-rt==1.6.0` when missing.
- Updated `ultralytics/utils/export/axelera.py` to install `axelera-devkit==1.6.0` when missing.
- Refreshed Axelera integration docs with separate apt repository commands for Ubuntu 22.04 and Ubuntu 24.04. 📘
- Added a docs tip explaining that the first `yolo export format=axelera` or `yolo predict` run auto-downloads SDK packages, plus manual install commands.
- Updated the Axelera Python example README to use stable `axelera-rt==1.6.0` instead of the release candidate.

### 🎯 Purpose & Impact
- Fixes compatibility issues caused by referencing outdated pre-release Axelera packages, especially for classifier workflows. ✅
- Aligns code, examples, and documentation around the same stable SDK version, reducing user confusion.
- Improves onboarding for Axelera users on newer Ubuntu versions by documenting the correct apt source configuration.
- Makes Axelera export and inference setup more reliable and easier to troubleshoot for edge and embedded deployments. 🧩