### PR TITLE
Correct activity feed access paths on platform

### DIFF
--- a/docs/en/platform/account/activity.md
+++ b/docs/en/platform/account/activity.md
@@ -24,10 +24,11 @@ The Activity Feed serves as your central hub for:
 
 ## Accessing Activity
 
-Navigate to the Activity Feed:
+Navigate to the Activity Feed in any of the following ways:
 
-1. Click **Activity** in the sidebar
-2. Or navigate directly to `/activity`
+1. Click the activity indicator in the top navigation bar
+2. Open the profile menu at the bottom of the sidebar and select **Activity**
+3. Navigate directly to `/activity`
 
 ![Ultralytics Platform Activity Page Inbox With Search And Date Filter](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/activity-page-inbox-with-search-and-date-filter.avif)
 


### PR DESCRIPTION
## summary

Rewrite the `Accessing Activity` section in `docs/en/platform/account/activity.md` to match the actual UX. The prior wording told users to click an `Activity` item in the sidebar, but the platform surfaces the activity feed via the top-nav activity indicator, the sidebar profile menu, or the direct `/activity` URL — there is no dedicated top-level sidebar entry.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the Ultralytics Platform documentation to clarify how users can access the Activity Feed.

### 📊 Key Changes
- Added more complete instructions for opening the **Activity Feed** in the [Ultralytics Platform](https://platform.ultralytics.com).
- Expanded the documentation from 2 access methods to 3:
  - Click the **activity indicator** in the top navigation bar
  - Open the **profile menu** at the bottom of the sidebar and select **Activity**
  - Go directly to `/activity`
- Improved wording to make it clear that there are multiple ways to reach the same page.

### 🎯 Purpose & Impact
- ✅ Makes the documentation easier to follow for new and existing users.
- 🔍 Helps users find the Activity Feed faster, especially if they use different navigation habits.
- 📚 Reduces confusion caused by incomplete navigation instructions.
- 💡 Improves overall usability of the [Ultralytics Platform](https://platform.ultralytics.com) docs with a small but practical clarification.