### PR TITLE
Correct platform onboarding step order and final step

### DIFF
--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -74,9 +74,9 @@ Every new account receives free credits for cloud GPU training:
 
 The onboarding flow guides you through three steps:
 
-1. **Username** — Choose a unique username (permanent, cannot be changed later)
-2. **Data Region** — Select US, EU, or AP with a visual world map showing latency
-3. **Profile** — Set your display name, company, and primary use case
+1. **Profile** - Enter your display name, unique username (permanent, cannot be changed later), organization (optional), and primary use case
+2. **Data Region** - Select US, EU, or AP with a visual world map showing latency
+3. **Complete** - Review your selections, optionally apply a promo code, and finish signup to claim your welcome credits
 
 ![Ultralytics Platform Onboarding Profile With Use Case](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-onboarding-profile-with-use-case.avif)
 


### PR DESCRIPTION
## summary

Rewrite the three-step onboarding list in `docs/en/platform/quickstart.md`. The prior order was "Username / Data Region / Profile", but the live wizard's steps are "Profile / Data Region / Complete". Step 1 (Profile) already collects the username, display name, organization, and primary use case; step 3 (Complete) is a confirmation screen with optional promo code, not a second profile page.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the Ultralytics Platform quickstart docs to reflect the latest onboarding flow and signup steps more accurately.

### 📊 Key Changes
- 🔄 Reordered the onboarding steps in `docs/en/platform/quickstart.md`
- 👤 Expanded the first step from just choosing a username to a fuller **Profile** setup:
  - display name
  - unique username
  - optional organization
  - primary use case
- 🌍 Kept the **Data Region** step, clarifying users can choose US, EU, or AP based on latency
- ✅ Replaced the old **Profile** step with a new **Complete** step:
  - review selections
  - optionally enter a promo code
  - finish signup and claim welcome credits

### 🎯 Purpose & Impact
- 📚 Keeps the documentation aligned with the current Ultralytics Platform onboarding experience
- 🙌 Reduces confusion for new users by showing the actual signup sequence they will see
- 🎁 Makes welcome-credit claiming and promo code usage more visible during setup
- 🔧 Improves the quickstart guide’s accuracy, which can help users get started faster on the [Ultralytics Platform](https://platform.ultralytics.com)