### PR TITLE
`ultralytics 8.4.41` Avoid mutable NDJSON dataset cache collisions

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -865,7 +865,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
     # Validate required fields before downloading images
     task = dataset_record.get("task", "detect")
-    if not is_classification and not class_names:
+    if not is_classification:
         class_ids = {
             int(label[0])
             for record in image_records
@@ -873,8 +873,13 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
             for label in labels
             if label
         }
-        if class_ids:
-            inferred_nc = max(class_ids) + 1
+        if class_ids or class_names:
+            max_class_id = max(class_ids | set(class_names))
+            if class_names:
+                for i in range(max_class_id + 1):
+                    class_names.setdefault(i, f"class{i}")
+            else:
+                inferred_nc = max_class_id + 1
     if not is_classification:
         if "train" not in splits:
             raise ValueError(f"Dataset missing required 'train' split. Found splits: {sorted(splits)}")

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -15,7 +15,7 @@ import cv2
 import numpy as np
 from PIL import Image
 
-from ultralytics.utils import ASSETS_URL, DATASETS_DIR, LOGGER, NUM_THREADS, TQDM, YAML
+from ultralytics.utils import ASSETS_URL, DATASETS_DIR, LOGGER, NUM_THREADS, TQDM, YAML, clean_url
 from ultralytics.utils.checks import check_file
 from ultralytics.utils.downloads import download, zip_directory
 from ultralytics.utils.files import increment_path
@@ -832,14 +832,18 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         lines = [json.loads(line.strip()) for line in f if line.strip()]
     dataset_record, image_records = lines[0], lines[1:]
 
-    # Hash semantic content only (excludes signed URLs which change on every export)
+    # Hash stable content plus source identity. Query strings are excluded because signed URLs change on every export.
     _h = hashlib.sha256()
     for r in lines:
-        _h.update(json.dumps({k: v for k, v in r.items() if k != "url"}, sort_keys=True).encode())
-    _hash = _h.hexdigest()[:16]
+        hash_record = {k: v for k, v in r.items() if k != "url"}
+        if r.get("file"):
+            hash_record["_source"] = clean_url(r["url"]) if r.get("url") else str(ndjson_path.parent.resolve())
+        _h.update(json.dumps(hash_record, sort_keys=True).encode())
+    _hash = _h.hexdigest()[:8]
 
-    # Early exit if dataset content unchanged (hash stored in data.yaml)
-    dataset_dir = output_path / ndjson_path.stem
+    # Hash-qualified dirs allow identical datasets to reuse downloads while preventing changed datasets from mutating
+    # files that another training job may still be reading.
+    dataset_dir = output_path / f"{ndjson_path.stem}-{_hash}"
     yaml_path = dataset_dir / "data.yaml"
     if yaml_path.is_file():
         try:
@@ -857,10 +861,20 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     # Check if this is a classification dataset
     is_classification = dataset_record.get("task") == "classify"
     class_names = {int(k): v for k, v in dataset_record.get("class_names", {}).items()}
-    len(class_names)
+    inferred_nc = None
 
     # Validate required fields before downloading images
     task = dataset_record.get("task", "detect")
+    if not is_classification and not class_names:
+        class_ids = {
+            int(label[0])
+            for record in image_records
+            for labels in record.get("annotations", {}).values()
+            for label in labels
+            if label
+        }
+        if class_ids:
+            inferred_nc = max(class_ids) + 1
     if not is_classification:
         if "train" not in splits:
             raise ValueError(f"Dataset missing required 'train' split. Found splits: {sorted(splits)}")
@@ -896,7 +910,10 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     if not is_classification:
         # Detection/segmentation/pose/obb: prepare YAML and create base structure
         data_yaml = dict(dataset_record)
-        data_yaml["names"] = class_names
+        if class_names:
+            data_yaml["names"] = class_names
+        elif inferred_nc is not None:
+            data_yaml["nc"] = inferred_nc
         data_yaml.pop("class_names", None)
         data_yaml.pop("type", None)  # Remove NDJSON-specific fields
         for split in sorted(splits):


### PR DESCRIPTION
## Summary
- writes converted NDJSON datasets to hash-qualified directories based on stable record content and image source identity, so identical datasets reuse downloads while changed or different-source datasets do not mutate files used by concurrent jobs
- strips signed URL query strings from the hash input so refreshed signatures do not force redownloads
- when NDJSON metadata omits `class_names`, infers only `nc` from label class IDs and lets the existing dataset checker assign default class names

## Validation
- `python -m ruff check ultralytics/data/converter.py tests/test_python.py`
- `python -m py_compile ultralytics/data/converter.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes NDJSON-to-YOLO dataset conversion safer and smarter by improving dataset versioning, avoiding unnecessary reprocessing, and handling missing class names more robustly.

### 📊 Key Changes
- 🔒 **Improved dataset hashing logic**
  - The converter now builds a hash from stable dataset content plus source identity.
  - It ignores changing signed URL query strings, which prevents false dataset changes between exports.
- 📁 **Hash-based output directories**
  - Converted datasets are now saved to folders like `datasetname-<hash>` instead of just `datasetname`.
  - This allows unchanged datasets to reuse prior outputs while keeping changed datasets isolated.
- 🧹 **Added source cleanup with `clean_url`**
  - Source URLs are normalized before hashing so temporary URL parameters do not affect dataset identity.
- 🏷️ **Better class metadata handling**
  - If class names exist but are incomplete, missing class IDs are automatically filled with placeholders like `class0`, `class1`, etc.
  - If no class names are provided, the converter now infers the number of classes and writes `nc` to `data.yaml`.
- ✅ **Refined YAML generation for detection-style tasks**
  - The generated `data.yaml` now includes either `names` or inferred `nc`, depending on what information is available.

### 🎯 Purpose & Impact
- 🚫 **Prevents dataset collisions**
  - Different dataset versions no longer overwrite the same output folder, which reduces risk during concurrent training or repeated exports.
- ⚡ **Improves cache reuse**
  - Identical datasets can be recognized more reliably, avoiding redundant downloads and conversions.
- 🧠 **Makes imports more resilient**
  - Datasets with incomplete or missing class-name metadata are now handled more gracefully, reducing conversion failures.
- 👥 **Safer for teams and automation**
  - This is especially useful in shared environments, pipelines, or cloud workflows where multiple jobs may access dataset files at once.
- 📦 **Better user experience**
  - Users get more predictable dataset conversion behavior with less manual cleanup or metadata fixing.