### PR TITLE
Document Platform segment label payloads

### DIFF
--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -579,13 +579,18 @@ PUT /api/datasets/{datasetId}/images/{hash}/labels
 
 ```json
 {
-    "labels": [{ "classId": 0, "bbox": [0.5, 0.5, 0.2, 0.3] }]
+    "labels": [
+        { "classId": 0, "bbox": [0.5, 0.5, 0.2, 0.3] },
+        { "classId": 1, "segments": [0.1, 0.2, 0.3, 0.2, 0.2, 0.4] }
+    ]
 }
 ```
 
 !!! info "Coordinate Format"
 
-    Bounding boxes use YOLO normalized format: `[x_center, y_center, width, height]` where all values are between 0 and 1.
+    Label coordinates use YOLO normalized values between 0 and 1. Bounding boxes use `[x_center, y_center, width, height]`.
+    Segmentation labels use `segments`, a flattened list of polygon vertices `[x1, y1, x2, y2, ...]`.
+    Use `segments` in API payloads, not `polygon`.
 
 #### Bulk Image Operations
 

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -590,7 +590,6 @@ PUT /api/datasets/{datasetId}/images/{hash}/labels
 
     Label coordinates use YOLO normalized values between 0 and 1. Bounding boxes use `[x_center, y_center, width, height]`.
     Segmentation labels use `segments`, a flattened list of polygon vertices `[x1, y1, x2, y2, ...]`.
-    Use `segments` in API payloads, not `polygon`.
 
 #### Bulk Image Operations
 


### PR DESCRIPTION
## Summary
- document the Platform image labels API with a segmentation label example using `segments`
- clarify that API payloads should use `segments`, not `polygon`

## Validation
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the Ultralytics Platform API docs to clarify that image label updates support both bounding boxes and segmentation polygons.

### 📊 Key Changes
- Added an API example showing `labels` can now include:
  - object detection labels with `bbox`
  - segmentation labels with `segments`
- Expanded the coordinate format documentation to explain that:
  - all label coordinates use normalized YOLO values between 0 and 1
  - `bbox` uses `[x_center, y_center, width, height]`
  - `segments` uses a flattened polygon point list like `[x1, y1, x2, y2, ...]`
- Improved the `PUT /api/datasets/{datasetId}/images/{hash}/labels` documentation to better reflect supported annotation formats 📚

### 🎯 Purpose & Impact
- Makes the API easier to understand for developers working with both detection and segmentation tasks ✅
- Reduces confusion around label formatting, especially for polygon-based annotations 🎯
- Helps users integrate with the Ultralytics Platform API more reliably, with fewer formatting mistakes and smoother dataset annotation workflows 🚀