### PR TITLE
feat: (deepx) enhance export/inference pipeline and add dxtron auto-install

### DIFF
--- a/docs/en/integrations/deepx.md
+++ b/docs/en/integrations/deepx.md
@@ -51,10 +51,6 @@ The `dx_com` compiler package will be automatically installed from the DeepX SDK
 
 ### Usage
 
-!!! note
-
-    Export is currently supported for **detection models** only. Support for additional tasks may be added in future releases.
-
 !!! example "Usage"
 
     === "Python"
@@ -108,13 +104,34 @@ yolo26n_deepx_model/
 
 The `.dxnn` file is the compiled model binary that the `dx_engine` runtime loads directly on the NPU. The `metadata.yaml` contains class names, image size, and other information used by the Ultralytics inference pipeline.
 
+### Visualizing with dxtron
+
+During export, the [dxtron](https://sdk.deepx.ai/) visualizer is automatically installed on x86-64 Linux if not already present. You can use it to inspect your exported model:
+
+```bash
+dxtron yolo26n_deepx_model/yolo26n.dxnn
+```
+
 ## Deploying Exported YOLO DeepX Models
 
 Once you've successfully exported your Ultralytics YOLO model to DeepX format, the next step is deploying these models on DeepX NPU hardware.
 
 ### Installation
 
-The `dx_engine` runtime package is required for inference and will be installed automatically on first use.
+The `dx_engine` runtime package is required for inference on DeepX NPU hardware. The backend will attempt to install it automatically on first use:
+
+1. **Debian Trixie (ARM64)**: Installs automatically via the [Sixfab APT repository](https://github.com/sixfab/sixfab_dx/).
+2. **Other platforms**: The backend automatically downloads and installs the NPU driver and runtime from GitHub, then installs the `dx_engine` wheel from `/usr/share/libdxrt/src/python_package/`.
+
+!!! tip "Controlling install verbosity"
+
+    Set `YOLO_VERBOSE=false` to suppress detailed installation output (dpkg, pip):
+
+    ```bash
+    YOLO_VERBOSE=false python predict_dxnn_deepx.py
+    ```
+
+If automatic installation fails, install the runtime manually:
 
 !!! tip "Installation"
 
@@ -123,6 +140,37 @@ The `dx_engine` runtime package is required for inference and will be installed 
         ```bash
         # Install the required package for YOLO
         pip install ultralytics
+        ```
+
+!!! warning "Manual Runtime Installation (non-Trixie platforms)"
+
+    If the DeepX runtime is not available on your system, install it manually:
+
+    1. **Install the NPU driver:**
+        ```bash
+        # Download from https://github.com/DEEPX-AI/dx_rt_npu_linux_driver/blob/main/release/2.4.0/
+        sudo dpkg -i dxrt-driver-dkms_2.4.0-2_all.deb
+        ```
+
+    2. **Install the runtime library:**
+        ```bash
+        # Download from https://github.com/DEEPX-AI/dx_rt/blob/main/release/3.3.0/
+        sudo dpkg -i libdxrt_3.3.0_all.deb
+        ```
+
+    3. **Install the `dx_engine` Python package:**
+        ```bash
+        pip install /usr/share/libdxrt/src/python_package/dx_engine-*.whl
+        ```
+
+    !!! note "PEP 668 (Python 3.12+)"
+
+        On systems with Python 3.12+, `pip install` outside a virtual environment may fail due to [PEP 668](https://peps.python.org/pep-0668/). Create and activate a virtual environment first:
+
+        ```bash
+        python3 -m venv /path/to/venv
+        source /path/to/venv/bin/activate
+        pip install /usr/share/libdxrt/src/python_package/dx_engine-*.whl
         ```
 
 ### Usage
@@ -206,7 +254,7 @@ DeepX NPUs are designed to execute INT8 computations at maximum efficiency. The 
 
 ### What platforms are supported for DeepX export?
 
-DeepX model export (compilation) requires an **x86-64 Linux** host. The export step is not supported on ARM64/aarch64 machines. Inference using the exported `.dxnn` model can be run on any platform supported by the `dx_engine` runtime.
+DeepX model export (compilation) requires an **x86-64 Linux** host. The export step is not supported on ARM64/aarch64 or Windows machines. Inference using the exported `.dxnn` model can be run on any Linux platform supported by the `dx_engine` runtime (x86-64 and ARM64).
 
 ### What is the output of a DeepX export?
 
@@ -218,8 +266,12 @@ The export creates a directory (e.g., `yolo26n_deepx_model/`) containing:
 
 ### Can I deploy custom-trained models on DeepX hardware?
 
-Yes. Any model trained using [Ultralytics Train Mode](../modes/train.md) and exported with `format="deepx"` can be deployed on DeepX NPU hardware, provided it uses supported layer operations. Export is currently limited to **detection models**.
+Yes. Any model trained using [Ultralytics Train Mode](../modes/train.md) and exported with `format="deepx"` can be deployed on DeepX NPU hardware, provided it uses supported layer operations. Export supports detection, segmentation, pose estimation, oriented bounding box (OBB), and classification tasks.
 
 ### How many calibration images should I use for DeepX export?
 
 The DeepX export pipeline defaults to 100 calibration images using the EMA calibration method. This is generally sufficient for good quantization accuracy. You can adjust the calibration dataset using the `data` and `fraction` arguments, but using more than a few hundred images rarely improves results significantly.
+
+### How do I install the DeepX runtime on non-Trixie platforms?
+
+On platforms other than Debian Trixie (ARM64), the runtime is not auto-installed via APT. You need to manually install the NPU driver (`dxrt-driver-dkms`), runtime library (`libdxrt`), and the `dx_engine` Python wheel. The backend will attempt to find and install the wheel from `/usr/share/libdxrt/src/python_package/` automatically, but if that fails, see the [Manual Runtime Installation](#installation_1) section above for step-by-step instructions. If you encounter PEP 668 errors on Python 3.12+, use a virtual environment.

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -565,12 +565,20 @@ class Exporter:
             )
             imgsz = self.imgsz[0] if square else str(self.imgsz)[1:-1].replace(" ", "")
             q = "int8" if self.args.int8 else "half" if self.args.half else ""  # quantization
+            is_deepx = fmt == "deepx"
+            if is_deepx:
+                dxnn_file = next(Path(f).rglob("*.dxnn"), Path(f))
+                results_path = colorstr("bold", dxnn_file)
+                visualize_line = f"\nVisualize:       dxtron {dxnn_file}"
+            else:
+                results_path = colorstr("bold", file.parent.resolve())
+                visualize_line = f"\nVisualize:       https://netron.app"
             LOGGER.info(
                 f"\nExport complete ({time.time() - t:.1f}s)"
-                f"\nResults saved to {colorstr('bold', file.parent.resolve())}"
+                f"\nResults saved to {results_path}"
                 f"\nPredict:         yolo predict task={model.task} model={f} imgsz={imgsz} {q}"
                 f"\nValidate:        yolo val task={model.task} model={f} imgsz={imgsz} data={data} {q} {s}"
-                f"\nVisualize:       https://netron.app"
+                f"{visualize_line}"
             )
 
         self.run_callbacks("on_export_end")

--- a/ultralytics/nn/backends/deepx.py
+++ b/ultralytics/nn/backends/deepx.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from ultralytics.utils import ARM64, IS_DEBIAN_TRIXIE, LOGGER
+from ultralytics.utils import ARM64, IS_DEBIAN_TRIXIE, LOGGER, VERBOSE
 from ultralytics.utils.checks import check_apt_requirements, is_sudo_available
 
 from .base import BaseBackend
@@ -31,42 +31,150 @@ class DeepXBackend(BaseBackend):
             FileNotFoundError: If no .dxnn file is found in the given directory.
         """
         cmd = ["dxrt-cli", "--version"]
-        help_url = "https://github.com/sixfab/sixfab_dx/"
+        help_url_sixfab = "https://github.com/sixfab/sixfab_dx/"
+        download_url_driver = "https://github.com/DEEPX-AI/dx_rt_npu_linux_driver/raw/main/release/2.4.0/dxrt-driver-dkms_2.4.0-2_all.deb"
+        download_url_runtime = "https://github.com/DEEPX-AI/dx_rt/raw/main/release/3.3.0/libdxrt_3.3.0_all.deb"
+        whl_dir = Path("/usr/share/libdxrt/src/python_package")
+        dxrt_available = False
+        _devnull = {} if VERBOSE else {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
         try:
             subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+            dxrt_available = True
         except (FileNotFoundError, subprocess.CalledProcessError):
-            LOGGER.info(f"\nDeepX inference requires the DeepX runtime. Attempting install from {help_url}")
-            if not (IS_DEBIAN_TRIXIE and ARM64):
-                raise OSError("DeepX runtime auto-install is only supported on Debian Trixie (arm64).")
-            sudo = "sudo " if is_sudo_available() else ""
-            for c in (
-                f"wget -qO - https://sixfab.github.io/sixfab_dx/public.gpg | {sudo}gpg --dearmor -o /usr/share/keyrings/sixfab-dx.gpg",
-                f'echo "deb [signed-by=/usr/share/keyrings/sixfab-dx.gpg] https://sixfab.github.io/sixfab_dx trixie main" | {sudo}tee /etc/apt/sources.list.d/sixfab-dx.list',
-            ):
-                subprocess.run(c, shell=True, check=True, stdout=subprocess.DEVNULL)
-            check_apt_requirements(["sixfab-dx"])
+            if IS_DEBIAN_TRIXIE and ARM64:
+                LOGGER.info(f"\nDeepX inference requires the DeepX runtime. Attempting install from {help_url_sixfab}")
+                sudo = "sudo " if is_sudo_available() else ""
+                for c in (
+                    f"wget -qO - https://sixfab.github.io/sixfab_dx/public.gpg | {sudo}gpg --dearmor -o /usr/share/keyrings/sixfab-dx.gpg",
+                    f'echo "deb [signed-by=/usr/share/keyrings/sixfab-dx.gpg] https://sixfab.github.io/sixfab_dx trixie main" | {sudo}tee /etc/apt/sources.list.d/sixfab-dx.list',
+                ):
+                    subprocess.run(c, shell=True, check=True, stdout=subprocess.DEVNULL)
+                check_apt_requirements(["sixfab-dx"])
+                dxrt_available = True
+            else:
+                LOGGER.warning(
+                    "DeepX runtime (dxrt-cli) not found. "
+                    "Will attempt to install automatically if needed."
+                )
 
         try:
             from dx_engine import InferenceEngine
         except ImportError:
+            import sys
+
+            installed = False
+            pip_cmd = [sys.executable, "-m", "pip", "install"]
+
             if IS_DEBIAN_TRIXIE and ARM64:
                 wheels = sorted(Path("/opt/sixfab-dx/wheels").glob("dx_engine-*.whl"))
-                if not wheels:
-                    raise FileNotFoundError(
-                        "No dx_engine wheel found in /opt/sixfab-dx/wheels/. Ensure sixfab-dx is installed."
+                if wheels:
+                    LOGGER.info(f"Attempting to install dx_engine from {wheels[-1]}")
+                    subprocess.run([*pip_cmd, str(wheels[-1])], check=True)
+                    installed = True
+
+            if not installed:
+                # Try pre-built wheel from libdxrt package
+                wheels = sorted(whl_dir.glob("dx_engine-*.whl")) if whl_dir.exists() else []
+                if not wheels and not (IS_DEBIAN_TRIXIE and ARM64):
+                    # Wheel not found — attempt to download and install libdxrt to get it
+                    LOGGER.info("dx_engine wheel not found. Attempting to install libdxrt package...")
+                    import tempfile
+
+                    sudo = "sudo " if is_sudo_available() else ""
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        # Install driver if not already present
+                        if not dxrt_available:
+                            try:
+                                driver_deb = Path(tmpdir) / "dxrt-driver-dkms_2.4.0-2_all.deb"
+                                LOGGER.info(f"Downloading NPU driver from {download_url_driver}...")
+                                subprocess.run(
+                                    ["wget", "-q", "-O", str(driver_deb), download_url_driver],
+                                    check=True,
+                                    timeout=120,
+                                    **_devnull,
+                                )
+                                LOGGER.info("Installing NPU driver...")
+                                subprocess.run(f"{sudo}dpkg -i {driver_deb}".split(), check=True, **_devnull)
+                            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+                                LOGGER.warning(f"NPU driver installation failed (non-fatal): {e}")
+
+                        # Install runtime (libdxrt)
+                        try:
+                            runtime_deb = Path(tmpdir) / "libdxrt_3.3.0_all.deb"
+                            LOGGER.info(f"Downloading runtime from {download_url_runtime}...")
+                            subprocess.run(
+                                ["wget", "-q", "-O", str(runtime_deb), download_url_runtime],
+                                check=True,
+                                timeout=120,
+                                **_devnull,
+                            )
+                            LOGGER.info("Installing runtime (libdxrt)...")
+                            # postinst may fail due to PEP 668, but files are still extracted
+                            subprocess.run(f"{sudo}dpkg -i {runtime_deb}".split(), **_devnull)
+                        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+                            LOGGER.warning(f"Runtime installation failed: {e}")
+
+                    # Re-check for wheels after installation
+                    wheels = sorted(whl_dir.glob("dx_engine-*.whl")) if whl_dir.exists() else []
+
+                if wheels:
+                    LOGGER.info(f"Attempting to install dx_engine from {wheels[-1]}")
+                    try:
+                        subprocess.run([*pip_cmd, str(wheels[-1])], check=True, **_devnull)
+                        installed = True
+                    except subprocess.CalledProcessError as e:
+                        LOGGER.warning(f"Failed to install dx_engine wheel: {e}")
+                else:
+                    LOGGER.warning(
+                        f"No dx_engine wheel found in {whl_dir}. "
+                        "The libdxrt package may not be installed."
                     )
-                subprocess.run(["pip", "install", str(wheels[-1])], check=True)
-            else:
-                raise OSError(
-                    "dx_engine is not installed. Auto-install is only supported on Debian Trixie (arm64). "
-                    "Please install dx_engine manually and try again."
+
+            if not installed:
+                libdxrt_installed = whl_dir.exists()
+                msg = "dx_engine is not installed and automatic installation failed.\n"
+                if not dxrt_available or not libdxrt_installed:
+                    msg += (
+                        "\nThe DeepX runtime is not properly installed.\n"
+                        "For manual installation, follow these steps:\n"
+                        "  1. Download and install the NPU driver:\n"
+                        f"     wget {download_url_driver}\n"
+                        "     sudo dpkg -i dxrt-driver-dkms_2.4.0-2_all.deb\n"
+                        "  2. Download and install the runtime:\n"
+                        f"     wget {download_url_runtime}\n"
+                        "     sudo dpkg -i libdxrt_3.3.0_all.deb\n"
+                        "  3. Install the dx_engine Python package:\n"
+                        "     pip install /usr/share/libdxrt/src/python_package/dx_engine-*.whl\n"
+                    )
+                else:
+                    msg += (
+                        "\nThe DeepX runtime is installed but the dx_engine Python package is missing.\n"
+                        "Install it with:\n"
+                        "  pip install /usr/share/libdxrt/src/python_package/dx_engine-*.whl\n"
+                    )
+                msg += (
+                    "\nIf you are using Python 3.12+ and encountering PEP 668 errors,\n"
+                    "please create a virtual environment and try again:\n"
+                    f"  python3 -m venv /path/to/venv\n"
+                    f"  source /path/to/venv/bin/activate\n"
+                    f"  pip install /usr/share/libdxrt/src/python_package/dx_engine-*.whl\n"
+                    f"\n"
+                    f"Current Python: {sys.executable} (v{sys.version.split()[0]})"
                 )
+                raise OSError(msg)
             from dx_engine import InferenceEngine
 
-        ver = (
-            subprocess.run(cmd, capture_output=True, check=True).stdout.decode().splitlines()[0].split()[-1].lstrip("v")
-        )
-        LOGGER.info(f"Loading {weight} for DeepX inference... (runtime v{ver})")
+        if dxrt_available:
+            ver = (
+                subprocess.run(cmd, capture_output=True, check=True)
+                .stdout.decode()
+                .splitlines()[0]
+                .split()[-1]
+                .lstrip("v")
+            )
+            LOGGER.info(f"Loading {weight} for DeepX inference... (runtime v{ver})")
+        else:
+            LOGGER.info(f"Loading {weight} for DeepX inference...")
 
         w = Path(weight)
         found = next(w.rglob("*.dxnn"), None)

--- a/ultralytics/utils/export/deepx.py
+++ b/ultralytics/utils/export/deepx.py
@@ -3,10 +3,34 @@
 from __future__ import annotations
 
 import json
+import platform
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
-from ultralytics.utils import LOGGER, YAML
+from ultralytics.utils import LINUX, LOGGER, VERBOSE, YAML
 from ultralytics.utils.checks import check_requirements
+
+
+def _ensure_dxtron(prefix: str = "") -> None:
+    """Install dxtron visualizer if not already present (amd64 Linux only)."""
+    if shutil.which("dxtron"):
+        return
+    if not (LINUX and platform.machine() in ("x86_64", "AMD64")):
+        return
+
+    download_url = "https://sdk.deepx.ai/release/dxtron/v2.0.1/dxtron_2.0.1_amd64.deb"
+    _devnull = {} if VERBOSE else {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
+    try:
+        LOGGER.info(f"{prefix} Installing dxtron visualizer from {download_url}...")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            deb_path = Path(tmpdir) / "dxtron_2.0.1_amd64.deb"
+            subprocess.run(["wget", "-q", "-O", str(deb_path), download_url], check=True, timeout=120, **_devnull)
+            subprocess.run(["sudo", "dpkg", "-i", str(deb_path)], check=True, **_devnull)
+        LOGGER.info(f"{prefix} dxtron installed successfully ✅")
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+        LOGGER.warning(f"{prefix} dxtron installation failed (non-fatal): {e}")
 
 
 def onnx2deepx(
@@ -36,6 +60,8 @@ def onnx2deepx(
     except ImportError:
         check_requirements("dx_com", cmds="-f https://sdk.deepx.ai/release/dxcom/v2.3.0/index.html")
         import dx_com
+
+    _ensure_dxtron(prefix=prefix)
 
     LOGGER.info(f"\n{prefix} starting export with DeepX...")
 


### PR DESCRIPTION
## Summary

Improve the DeepX export and inference pipeline with automatic tool installation, better logging control, and updated documentation.

## Changes

### Export (`utils/export/deepx.py`)
- **Auto-install dxtron visualizer**: On x86-64 Linux, `dxtron` is automatically downloaded and installed via `sudo dpkg -i` during the first DeepX export if not already present.

### Export logging (`engine/exporter.py`)
- **Results path**: Show the `.dxnn` file path (e.g., `yolo26n_deepx_model/yolo26n.dxnn`) instead of the parent directory.
- **Visualize command**: Show `dxtron <model>.dxnn` instead of `https://netron.app` for DeepX exports.

### Inference backend (`nn/backends/deepx.py`)
- **Auto-download from GitHub**: On non-Trixie platforms, automatically download and install the NPU driver (`dxrt-driver-dkms`) and runtime (`libdxrt`) deb packages from GitHub when `dx_engine` is not found.
- **YOLO_VERBOSE support**: All subprocess calls (wget, dpkg, pip) respect the `YOLO_VERBOSE` flag. Set `YOLO_VERBOSE=false` to suppress detailed installation output.

### Documentation (`docs/en/integrations/deepx.md`, `docs/ko/integrations/deepx.md`)
- Remove "detection models only" limitation — now supports detect, segment, pose, OBB, and classify tasks.
- Add dxtron visualization section with usage example.
- Add `YOLO_VERBOSE` tip for controlling install log verbosity.
- Update auto-install description to reflect GitHub download flow.
- Add Windows unsupported mention in platform FAQ.
- Update custom model FAQ to list all supported tasks.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enhances the DeepX export and inference pipeline with improved auto-install behavior, better export UX, dxtron visualizer support, and expanded documentation for runtime setup and supported tasks. 🚀

### 📊 Key Changes
- Added automatic `dxtron` visualizer installation during DeepX export on x86-64 Linux and documented how to inspect exported `.dxnn` models. 👀
- Updated export completion logs to show DeepX-specific output paths and a `dxtron` visualization command instead of the generic Netron link for DeepX exports. 🧭
- Expanded DeepX backend runtime setup to support more Linux environments beyond Debian Trixie ARM64, including attempts to install the NPU driver, `libdxrt`, and `dx_engine` wheel automatically when needed. 🔧
- Added verbosity-aware installation behavior using `YOLO_VERBOSE=false` to suppress detailed install output. 🤫
- Improved DeepX inference error handling with clearer fallback messages and manual installation guidance, including Python 3.12+ virtual environment notes. 📦
- Updated DeepX docs to reflect broader export task support, including detection, segmentation, pose, OBB, and classification. 📚
- Clarified platform support for export and inference, including Linux-only inference support and no Windows export support. 🖥️

### 🎯 Purpose & Impact
- Makes DeepX workflows easier to use by reducing manual setup for export visualization and runtime inference dependencies. ✅
- Improves developer and user experience with more actionable logs, clearer install behavior, and better troubleshooting guidance. 🛠️
- Expands documented DeepX capabilities, helping users understand that export is no longer limited to detection-only models. 📈
- Increases accessibility for edge and embedded Linux deployments by supporting more runtime installation paths on non-Trixie systems. 🤖