### PR TITLE
Remove drifting GPU heuristic table from platform quickstart

### DIFF
--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -237,21 +237,9 @@ From your project, click `Train Model` to start cloud training.
 ### Training Configuration
 
 1. **Select Dataset**: Choose from your uploaded datasets (only datasets with a [`train` split](data/datasets.md#filter-by-split) are shown)
-2. **Choose Model**: Select a base model — official Ultralytics models or your own trained models
+2. **Choose Model**: Select a base model - official Ultralytics models or your own trained models
 3. **Set Epochs**: Number of training iterations (default: 100)
-4. **Select GPU**: Choose compute resources based on your budget and model size
-
-| Model   | Size        | Speed    | Accuracy | Recommended GPU                                                         |
-| ------- | ----------- | -------- | -------- | ----------------------------------------------------------------------- |
-| YOLO26n | Nano        | Fastest  | Good     | RTX PRO 6000 (96 GB) or RTX 4090 (24 GB)                                |
-| YOLO26s | Small       | Fast     | Better   | RTX PRO 6000 (96 GB)                                                    |
-| YOLO26m | Medium      | Moderate | High     | RTX PRO 6000 (96 GB)                                                    |
-| YOLO26l | Large       | Slower   | Higher   | RTX PRO 6000 (96 GB) or A100 SXM (80 GB)                                |
-| YOLO26x | Extra Large | Slowest  | Best     | H100 SXM (80 GB); H200 (141 GB) or B200 (180 GB) with Pro or Enterprise |
-
-!!! info "GPU Selection"
-
-    GPUs range from $0.24/hr (RTX 2000 Ada, 16 GB) to $4.99/hr (B200, 180 GB). The default GPU is **RTX PRO 6000** (96 GB Blackwell, $1.69/hr) — a great balance of memory and performance. 20 GPUs are available on all plans; H200 and B200 require [Pro or Enterprise](account/billing.md#plans). See the full [GPU pricing table](index.md#what-gpu-options-are-available-for-cloud-training).
+4. **Select GPU**: Choose compute resources based on your budget and model size. The default is **RTX PRO 6000** (96 GB Blackwell, $1.69/hr), which handles every YOLO26 variant. See the full [GPU pricing table](index.md#what-gpu-options-are-available-for-cloud-training) or the [Cloud Training GPU step](train/cloud-training.md#step-5-select-gpu-cloud-tab) for the complete list and tier gating.
 
 !!! warning "Credit Balance Required"
 


### PR DESCRIPTION
## Summary

The Training Configuration section in `docs/en/platform/quickstart.md` had a hardcoded "Model → Recommended GPU" heuristic table that duplicated the canonical GPU pricing table and risked silent drift. Replaced the table and its accompanying info block with a single sentence noting the default GPU and linking to the authoritative GPU pricing table in the FAQ and the Cloud Training GPU step, which remain the single source of truth.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR simplifies the Ultralytics Platform quickstart docs by replacing a large model-to-GPU recommendation table with a shorter, easier-to-maintain GPU selection note.

### 📊 Key Changes
- Removed the detailed GPU recommendation table from the cloud training quickstart guide.
- Replaced the long pricing and hardware note with a concise summary:
  - default GPU is **RTX PRO 6000**
  - it can handle all **YOLO26** model variants
- Added clearer links to:
  - the full **GPU pricing table**
  - the **Cloud Training GPU selection step** for complete hardware options and plan restrictions
- Minor formatting cleanup in the “Choose Model” step for consistency.

### 🎯 Purpose & Impact
- ✅ Makes the quickstart page easier to scan for new users by reducing clutter.
- 🔧 Improves maintainability by moving detailed GPU guidance to dedicated documentation pages instead of duplicating it in the quickstart.
- 💡 Gives users a clear default recommendation without overwhelming them with hardware comparisons.
- 🔗 Helps users find up-to-date GPU options, pricing, and tier requirements in the correct source pages.
- 🚀 Overall, this should create a smoother onboarding experience for anyone starting cloud training on the Ultralytics Platform.