### PR TITLE
Add `__call__` wrapper for `BaseBackend.forward` method

### DIFF
--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -274,7 +274,7 @@ with torch.no_grad():
     pytorch_output = model(im).numpy()
 
 onnx_model = ONNXBackend("resnet18.onnx", device=torch.device("cpu"))
-onnx_output = onnx_model.forward(im)[0]
+onnx_output = onnx_model(im)[0]
 
 diff = np.abs(pytorch_output - onnx_output).max()
 print(f"Max difference: {diff:.6f}")  # should be < 1e-5

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -274,6 +274,9 @@ lukasbuligonantunes@gmail.com:
 makei05@outlook.de:
   avatar: https://avatars.githubusercontent.com/u/78843978?v=4
   username: Skillnoob
+matt@ultralytics.com:
+  avatar: null
+  username: null
 matthewnoyce@icloud.com:
   avatar: https://avatars.githubusercontent.com/u/131261051?v=4
   username: MatthewNoyce

--- a/ultralytics/nn/backends/base.py
+++ b/ultralytics/nn/backends/base.py
@@ -75,15 +75,7 @@ class BaseBackend(ABC):
         raise NotImplementedError
 
     def __call__(self, *args, **kwargs) -> Any:
-        """Invoke the backend's forward pass.
-
-        Args:
-            *args: Positional arguments forwarded to `forward`.
-            **kwargs: Keyword arguments forwarded to `forward`.
-
-        Returns:
-            (Any): The output from the `forward` method.
-        """
+        """Allow the backend instance to be called directly to perform inference, forwarding arguments to the `forward` method."""
         return self.forward(*args, **kwargs)
 
     def apply_metadata(self, metadata: dict | None) -> None:

--- a/ultralytics/nn/backends/base.py
+++ b/ultralytics/nn/backends/base.py
@@ -75,8 +75,7 @@ class BaseBackend(ABC):
         raise NotImplementedError
 
     def __call__(self, *args, **kwargs) -> Any:
-        """
-        Invoke the backend's forward pass.
+        """Invoke the backend's forward pass.
 
         Args:
             *args: Positional arguments forwarded to `forward`.

--- a/ultralytics/nn/backends/base.py
+++ b/ultralytics/nn/backends/base.py
@@ -73,6 +73,17 @@ class BaseBackend(ABC):
         """
         raise NotImplementedError
 
+    def __call__(self, im: torch.Tensor) -> torch.Tensor | list[torch.Tensor]:
+        """Alias for the forward method to allow direct calling of the backend instance.
+
+        Args:
+            im (torch.Tensor): Input image tensor in BCHW format, normalized to [0, 1].
+
+        Returns:
+            (torch.Tensor | list[torch.Tensor]): Model output as a single tensor or list of tensors.
+        """
+        return self.forward(im)
+
     def apply_metadata(self, metadata: dict | None) -> None:
         """Process and apply model metadata to backend attributes.
 

--- a/ultralytics/nn/backends/base.py
+++ b/ultralytics/nn/backends/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 from abc import ABC, abstractmethod
+from typing import Any
 
 import torch
 
@@ -62,27 +63,29 @@ class BaseBackend(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def forward(self, im: torch.Tensor) -> torch.Tensor | list[torch.Tensor]:
+    def forward(self, im: torch.Tensor) -> Any:
         """Run inference on the input image tensor.
 
         Args:
             im (torch.Tensor): Input image tensor in BCHW format, normalized to [0, 1].
 
         Returns:
-            (torch.Tensor | list[torch.Tensor]): Model output as a single tensor or list of tensors.
+            (Any): The raw output from the model's forward pass, which may require post-processing.
         """
         raise NotImplementedError
 
-    def __call__(self, im: torch.Tensor) -> torch.Tensor | list[torch.Tensor]:
-        """Alias for the forward method to allow direct calling of the backend instance.
+    def __call__(self, *args, **kwargs) -> Any:
+        """
+        Invoke the backend's forward pass.
 
         Args:
-            im (torch.Tensor): Input image tensor in BCHW format, normalized to [0, 1].
+            *args: Positional arguments forwarded to `forward`.
+            **kwargs: Keyword arguments forwarded to `forward`.
 
         Returns:
-            (torch.Tensor | list[torch.Tensor]): Model output as a single tensor or list of tensors.
+            (Any): The output from the `forward` method.
         """
-        return self.forward(im)
+        return self.forward(*args, **kwargs)
 
     def apply_metadata(self, metadata: dict | None) -> None:
         """Process and apply model metadata to backend attributes.

--- a/ultralytics/nn/backends/base.py
+++ b/ultralytics/nn/backends/base.py
@@ -75,7 +75,9 @@ class BaseBackend(ABC):
         raise NotImplementedError
 
     def __call__(self, *args, **kwargs) -> Any:
-        """Allow the backend instance to be called directly to perform inference, forwarding arguments to the `forward` method."""
+        """Allow the backend instance to be called directly to perform inference, forwarding arguments to the `forward`
+        method.
+        """
         return self.forward(*args, **kwargs)
 
     def apply_metadata(self, metadata: dict | None) -> None:


### PR DESCRIPTION
allow usage:
```python
from ultralytics.nn.backends import ONNXBackend
import torch

im = torch.randn(1, 3, 224, 224)
model = ONNXBackend("model.onnx")
model(im)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR makes Ultralytics backend inference easier to use by letting backend objects be called like regular models, while also updating docs and author metadata 🛠️📘

### 📊 Key Changes
- Added a `__call__()` method to `BaseBackend`, so backend instances can now be used like `model(input)` instead of requiring `model.forward(input)` ✅
- Updated the `forward()` method return type from a narrow tensor/list type to `Any`, reflecting that different backends may return different raw output formats 🔄
- Clarified the `forward()` docstring to note that backend outputs may need post-processing before use 🧾
- Updated the non-YOLO export guide example to use the new callable backend style:
  - changed `onnx_model.forward(im)[0]` to `onnx_model(im)[0]` 📚
- Added a docs author entry for `matt@ultralytics.com` in the GitHub authors config file 👤

### 🎯 Purpose & Impact
- Makes backend inference feel more natural and consistent with standard PyTorch usage, which improves developer experience 🤝
- Reduces boilerplate in inference code and documentation, making examples easier for users to read and adopt quickly ✨
- Better supports the reality that backend outputs can vary across formats like ONNX and others, improving type flexibility and maintainability 🔧
- Helps keep docs aligned with actual API behavior, reducing confusion for users exporting and testing non-YOLO models 📖
- The changes are small and low-risk, but they improve usability across the backend interface for both contributors and end users 🚀