### PR TITLE
fix(coreml): skip proxy load during export

### DIFF
--- a/ultralytics/utils/export/coreml.py
+++ b/ultralytics/utils/export/coreml.py
@@ -88,7 +88,7 @@ def pipeline_coreml(
     if len(names) != nc:  # Hack fix for MLProgram NMS bug https://github.com/ultralytics/ultralytics/issues/22309
         names = {**names, **{i: str(i) for i in range(len(names), nc)}}
 
-    model = ct.models.MLModel(spec, weights_dir=weights_dir)
+    model = ct.models.MLModel(spec, weights_dir=weights_dir, skip_model_load=True)
 
     # Create NMS protobuf
     nms_spec = ct.proto.Model_pb2.Model()
@@ -125,7 +125,7 @@ def pipeline_coreml(
     nms.confidenceThreshold = conf
     nms.pickTop.perClass = not agnostic_nms
     nms.stringClassLabels.vector.extend(names.values())
-    nms_model = ct.models.MLModel(nms_spec)
+    nms_model = ct.models.MLModel(nms_spec, skip_model_load=True)
 
     # Pipeline models together
     pipeline = ct.models.pipeline.Pipeline(
@@ -151,7 +151,7 @@ def pipeline_coreml(
     )
 
     # Save the model
-    model = ct.models.MLModel(pipeline.spec, weights_dir=weights_dir)
+    model = ct.models.MLModel(pipeline.spec, weights_dir=weights_dir, skip_model_load=True)
     model.input_description["image"] = "Input image"
     model.input_description["iouThreshold"] = f"(optional) IoU threshold override (default: {nms.iouThreshold})"
     model.input_description["confidenceThreshold"] = (
@@ -206,6 +206,7 @@ def torch2coreml(
         inputs=inputs,
         classifier_config=ct.ClassifierConfig(classifier_names) if classifier_names else None,
         convert_to="neuralnetwork" if mlmodel else "mlprogram",
+        skip_model_load=True,
     )
     bits, mode = (8, "kmeans") if int8 else (16, "linear") if half else (32, None)
     if bits < 32:


### PR DESCRIPTION
Fixes #24306

## Summary
Avoid CoreML proxy initialization during export by passing `skip_model_load=True`
through the CoreML export path.

This updates all CoreML model construction points used during export:
- `ct.convert(...)`
- `ct.models.MLModel(spec, ...)`
- `ct.models.MLModel(nms_spec, ...)`
- `ct.models.MLModel(pipeline.spec, ...)`

## Motivation
CoreML export can abort on Apple Silicon during CoreML proxy initialization in
`coremltools`, even though Ultralytics export path only needs model spec access,
metadata updates, and `save()`.

Export does not use in-memory `predict()` on these CoreML objects, so loading
the proxy during export is unnecessary and can crash valid exports.

## Implementation
Updated `ultralytics/utils/export/coreml.py` to pass `skip_model_load=True` at
all CoreML construction sites in export flow:
- decoder model wrapper in `pipeline_coreml()`
- NMS model wrapper in `pipeline_coreml()`
- final pipeline wrapper in `pipeline_coreml()`
- `ct.convert(...)` in `torch2coreml()`

This keeps export behavior focused on spec manipulation and file generation,
while avoiding proxy/model load during export-time construction.

## Testing
Ran:
```bash
pytest tests/test_exports.py -k coreml -q -rs
ruff check ultralytics/utils/export/coreml.py tests/test_exports.py
python -m build --sdist --wheel --outdir /tmp/ultralytics-build-coreml-skip-load
python -m compileall ultralytics/utils/export/coreml.py
```

Result:
- `pytest` passed: `1 passed, 12 deselected`
- `ruff` passed
- package build succeeded (`sdist` and `wheel`)
- `compileall` passed

Build emitted existing setuptools license deprecation warnings unrelated to this
change.

## Risks / Side Effects
Returned in-memory CoreML objects from export path will not support `predict()`
before reload, because proxy load is skipped.

This should not affect Ultralytics export flow:
- export path uses spec/metadata/save only
- test coverage confirms CoreML export still succeeds
- saved CoreML artifact can still be loaded afterward in supported environments

## Sanity Check
- Input: CoreML export on Apple Silicon
- Expected: export completes without proxy-init crash
- Actual: CoreML export test passes with `skip_model_load=True`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates the CoreML export path to skip proxy model loading during export, improving reliability and reducing unnecessary model initialization steps. 🚀

### 📊 Key Changes
- Adds `skip_model_load=True` to `ct.models.MLModel(...)` when creating the intermediate CoreML model from `spec`.
- Adds `skip_model_load=True` when creating the NMS CoreML model from `nms_spec`.
- Adds `skip_model_load=True` when rebuilding the final pipeline CoreML model before saving.
- Adds `skip_model_load=True` to `ct.convert(...)` in `torch2coreml()`.
- Applies the change consistently across the CoreML export pipeline in `ultralytics/utils/export/coreml.py`.

### 🎯 Purpose & Impact
- Prevents unnecessary proxy/model loading during CoreML export, which can help avoid export-time failures. ✅
- Improves robustness of the CoreML export workflow, especially for pipeline and ML Program generation. 📦
- Keeps the change minimal and targeted, reducing risk of side effects outside the export path. 🔧