### PR TITLE
Remove redundant .keys() call in dict membership test

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -2051,7 +2051,7 @@ class SAM2DynamicInteractivePredictor(SAM2Predictor):
                 consolidated_out["pred_masks"][obj_idx : obj_idx + 1] = obj_mask
                 consolidated_out["obj_ptr"][obj_idx : obj_idx + 1] = out["obj_ptr"]
 
-                if "object_score_logits" in out.keys():
+                if "object_score_logits" in out:
                     consolidated_out["object_score_logits"][obj_idx : obj_idx + 1] = out["object_score_logits"]
 
         high_res_masks = F.interpolate(


### PR DESCRIPTION
Minor cleanup in predict.py: in out.keys() → in out. Dict membership already checks keys, so .keys() is redundant (also flagged by Ruff rule SIM118). No behavior change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR makes a small Python cleanup in SAM memory update logic by removing a redundant `.keys()` call from a dictionary membership check. ✨

### 📊 Key Changes
- Replaced `if "object_score_logits" in out.keys():` with `if "object_score_logits" in out:` in `ultralytics/models/sam/predict.py`
- Keeps the existing behavior unchanged while using the more idiomatic Python pattern 🐍
- Touches the `update_memory()` path for handling optional `object_score_logits` values

### 🎯 Purpose & Impact
- Improves code readability and aligns with Python best practices ✅
- Avoids an unnecessary `.keys()` call, resulting in a minor efficiency and cleanliness improvement
- Low-risk change with no expected functional impact for users or model outputs 🎯