### PR TITLE
Remove credential-like MongoDB examples

### DIFF
--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -71,11 +71,12 @@ class Tuner:
         >>> )
 
         Tune with distributed MongoDB Atlas coordination across multiple machines:
+        >>> import os
         >>> model.tune(
         >>>     data="coco8.yaml",
         >>>     epochs=10,
         >>>     iterations=300,
-        >>>     mongodb_uri="mongodb+srv://user:pass@cluster.mongodb.net/",
+        >>>     mongodb_uri=os.environ["ULTRALYTICS_MONGODB_URI"],
         >>>     mongodb_db="ultralytics",
         >>>     mongodb_collection="tune_results"
         >>> )
@@ -143,7 +144,7 @@ class Tuner:
             f"{self.prefix}💡 Learn about tuning at https://docs.ultralytics.com/guides/hyperparameter-tuning"
         )
 
-    def _connect(self, uri: str = "mongodb+srv://username:password@cluster.mongodb.net/", max_retries: int = 3):
+    def _connect(self, uri: str = "", max_retries: int = 3):
         """Create MongoDB client with exponential backoff retry on connection failures.
 
         Args:
@@ -190,7 +191,7 @@ class Tuner:
         saves results to a shared collection and reads the latest best hyperparameters from all workers for evolution.
 
         Args:
-            mongodb_uri (str): MongoDB connection string, e.g. 'mongodb+srv://username:password@cluster.mongodb.net/'.
+            mongodb_uri (str): MongoDB connection string, e.g. from `os.environ["ULTRALYTICS_MONGODB_URI"]`.
             mongodb_db (str, optional): Database name.
             mongodb_collection (str, optional): Collection name.
 


### PR DESCRIPTION
## Summary\n- replace credential-shaped MongoDB URI examples with an environment-variable example\n- remove the credential-shaped default from Tuner._connect()\n\n## Security\nAddresses the source content that generated the MongoDB URI secret scanning alert in docs.\n\n## Validation\n- python -m compileall -q ultralytics/engine/tuner.py\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR improves MongoDB-based hyperparameter tuning examples and defaults by removing hardcoded placeholder credentials and encouraging safer environment-variable usage.

### 📊 Key Changes
- Updated the distributed tuning example in `ultralytics/engine/tuner.py` to import `os` and use `os.environ["ULTRALYTICS_MONGODB_URI"]` instead of an inline MongoDB connection string.
- Changed the internal `_connect()` method default `uri` from a placeholder MongoDB Atlas URL to an empty string.
- Revised the `_init_mongodb()` docstring to recommend passing the MongoDB URI from an environment variable rather than embedding credentials directly in code.
- Kept the overall tuning workflow unchanged; this PR focuses on safer configuration and clearer guidance. ✨

### 🎯 Purpose & Impact
- Helps users avoid accidentally exposing database credentials in scripts, examples, or shared codebases. 🔒
- Encourages a more secure and production-friendly setup for distributed tuning across multiple machines.
- Makes the API behavior cleaner by removing a misleading default placeholder URI that could imply a usable connection value.
- Improves documentation clarity for both new and experienced users setting up MongoDB-backed tuning. 📘