### PR TITLE
Fix lychee install workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install lychee
-        run: curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" | sudo tar xz -C /usr/local/bin
+        run: |
+          curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" |
+            sudo tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
 
       - name: Test Markdown and HTML links with retry
         uses: ultralytics/actions/retry@main


### PR DESCRIPTION

Extract the lychee binary from the nested release archive path
Match the working handbook install command pattern

## Tests
- action lint .github/workflows/links.yml
- git diff --check -- .github/workflows/links.yml
- Verified latest lychee archive contains lychee-x86_64-unknown-linux-gnu/lychee

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR fixes the GitHub Actions setup for the link-checking workflow by improving how the `lychee` tool is extracted and installed.

### 📊 Key Changes
- Updated `.github/workflows/links.yml` to change the `lychee` installation command.
- Replaced the previous direct archive extraction with a more precise extraction step using `--strip-components=1`.
- Explicitly extracts only the `lychee` binary from the downloaded tarball into `/usr/local/bin`.
- Kept the rest of the link-checking workflow unchanged, including the retry-based Markdown and HTML link tests.

### 🎯 Purpose & Impact
- ✅ Makes the CI setup more reliable by ensuring the `lychee` binary is installed in the expected location.
- 🛠️ Prevents issues caused by archive directory structure changes or incorrect extraction behavior.
- 🚀 Improves workflow stability for automated link validation in documentation and web content.
- 👥 Benefits both maintainers and contributors by reducing false CI failures related to tool installation rather than actual broken links.