### PR TITLE
Remove redundant `.keys()` calls in dict iteration

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -943,7 +943,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
                 image_path = dataset_dir / "images" / split / original_name
                 label_path = dataset_dir / "labels" / split / f"{Path(original_name).stem}.txt"
                 lines_to_write = []
-                for key in annotations.keys():
+                for key in annotations:
                     lines_to_write = [" ".join(map(str, item)) for item in annotations[key]]
                     break
                 label_path.write_text("\n".join(lines_to_write) + "\n" if lines_to_write else "")

--- a/ultralytics/models/sam/build.py
+++ b/ultralytics/models/sam/build.py
@@ -355,7 +355,7 @@ def build_sam(ckpt="sam_b.pt"):
     """
     model_builder = None
     ckpt = str(ckpt)  # to allow Path ckpt types
-    for k in sam_model_map.keys():
+    for k in sam_model_map:
         if ckpt.endswith(k):
             model_builder = sam_model_map.get(k)
 

--- a/ultralytics/models/utils/loss.py
+++ b/ultralytics/models/utils/loss.py
@@ -433,7 +433,7 @@ class RTDETRDetectionLoss(DETRLoss):
             total_loss.update(dn_loss)
         else:
             # If no denoising metadata is provided, set denoising loss to zero
-            total_loss.update({f"{k}_dn": torch.tensor(0.0, device=self.device) for k in total_loss.keys()})
+            total_loss.update({f"{k}_dn": torch.tensor(0.0, device=self.device) for k in total_loss})
 
         return total_loss
 

--- a/ultralytics/solutions/analytics.py
+++ b/ultralytics/solutions/analytics.py
@@ -176,20 +176,20 @@ class Analytics(BaseSolution):
                 color_cycle = cycle(["#DD00BA", "#042AFF", "#FF4447", "#7D24FF", "#BD00FF"])
                 # Multiple lines or area update
                 x_data = self.ax.lines[0].get_xdata() if self.ax.lines else np.array([])
-                y_data_dict = {key: np.array([]) for key in count_dict.keys()}
+                y_data_dict = {key: np.array([]) for key in count_dict}
                 if self.ax.lines:
                     for line, key in zip(self.ax.lines, count_dict.keys()):
                         y_data_dict[key] = line.get_ydata()
 
                 x_data = np.append(x_data, float(frame_number))
                 max_length = len(x_data)
-                for key in count_dict.keys():
+                for key in count_dict:
                     y_data_dict[key] = np.append(y_data_dict[key], float(count_dict[key]))
                     if len(y_data_dict[key]) < max_length:
                         y_data_dict[key] = np.pad(y_data_dict[key], (0, max_length - len(y_data_dict[key])))
                 if len(x_data) > self.max_points:
                     x_data = x_data[1:]
-                    for key in count_dict.keys():
+                    for key in count_dict:
                         y_data_dict[key] = y_data_dict[key][1:]
 
                 self.ax.clear()

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -481,7 +481,7 @@ class ConfusionMatrix(DataExportMixin):
             if "conf" not in mbatch:
                 mbatch["conf"] = torch.tensor([1.0] * len(mbatch["bboxes"]), device=img.device)
             mbatch["batch_idx"] = torch.ones(len(mbatch["bboxes"]), device=img.device) * i
-            for k in mbatch.keys():
+            for k in mbatch:
                 labels[k] += mbatch[k]
 
         labels = {k: torch.stack(v, 0) if len(v) else torch.empty(0) for k, v in labels.items()}


### PR DESCRIPTION
## Summary

Iterating a dict directly is equivalent to iterating `dict.keys()` but avoids a method call. Follows up on #24339, which removed the same redundancy from `in` membership tests — this PR cleans up the remaining `for ... in <dict>.keys():` iteration sites.

## Changes

7 single-token edits across 5 files:

- `ultralytics/utils/metrics.py` — `ConfusionMatrix.plot_matches` loop
- `ultralytics/solutions/analytics.py` — 3 sites in `Analytics.update_area`
- `ultralytics/models/sam/build.py` — `build_sam` model lookup loop
- `ultralytics/models/utils/loss.py` — `RTDETRDetectionLoss.forward` denoising-zero branch
- `ultralytics/data/converter.py` — `convert_ndjson_to_yolo` annotation iteration

## Notes

- `loss.py:436` site uses the iteration inside a dict comprehension passed to `total_loss.update(...)`. The comprehension is fully evaluated before `update()` runs, so the snapshot-then-mutate semantics are preserved.
- No behavior change, no tests affected.

## Test plan

- [x] `git diff` reviewed — pure `.keys()` removals
- [x] No remaining `for ... in <name>.keys():` patterns under `ultralytics/`
- [ ] CI passes

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR removes redundant `.keys()` calls in dictionary iteration across several Python modules, making the code a bit cleaner and more idiomatic without changing behavior. ✨

### 📊 Key Changes
- Replaces `for key in some_dict.keys():` with `for key in some_dict:` in multiple files.
- Updates affected areas in:
  - `ultralytics/data/converter.py`
  - `ultralytics/models/sam/build.py`
  - `ultralytics/models/utils/loss.py`
  - `ultralytics/solutions/analytics.py`
  - `ultralytics/utils/metrics.py`
- Keeps existing logic intact while simplifying dictionary traversal patterns. 🧹

### 🎯 Purpose & Impact
- Improves code readability by using standard Python dictionary iteration style.
- Removes minor redundancy and helps keep the codebase more consistent. ✅
- No expected functional impact for users, as this is a low-risk internal cleanup change.
- Useful as a small maintainability improvement for contributors working across the codebase. 🔧