### PR TITLE
Fix: `FileNotFoundError` when loading datasets from paths containing square brackets

### DIFF
--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -164,7 +164,7 @@ class BaseDataset(Dataset):
             for p in img_path if isinstance(img_path, list) else [img_path]:
                 p = Path(p)  # os-agnostic
                 if p.is_dir():  # dir
-                    f += glob.glob(str(p / "**" / "*.*"), recursive=True)
+                    f += glob.glob(str(Path(glob.escape(str(p))) / "**" / "*.*"), recursive=True)
                     # F = list(p.rglob('*.*'))  # pathlib
                 elif p.is_file():  # file
                     with open(p, encoding="utf-8") as t:

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -164,7 +164,7 @@ class BaseDataset(Dataset):
             for p in img_path if isinstance(img_path, list) else [img_path]:
                 p = Path(p)  # os-agnostic
                 if p.is_dir():  # dir
-                    f += glob.glob(str(Path(glob.escape(str(p))) / "**" / "*.*"), recursive=True)
+                    f += glob.glob(str(Path(glob.escape(p)) / "**" / "*.*"), recursive=True)
                     # F = list(p.rglob('*.*'))  # pathlib
                 elif p.is_file():  # file
                     with open(p, encoding="utf-8") as t:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -359,7 +359,7 @@ class LoadImagesAndVideos:
             if "*" in a:
                 files.extend(sorted(glob.glob(a, recursive=True)))  # glob
             elif os.path.isdir(a):
-                files.extend(sorted(glob.glob(os.path.join(a, "*.*"))))  # dir
+                files.extend(sorted(glob.glob(os.path.join(glob.escape(a), "*.*"))))  # dir
             elif os.path.isfile(a):
                 files.append(a)  # files (absolute or relative to CWD)
             elif parent and (parent / p).is_file():


### PR DESCRIPTION
## Bug Fix

### Description
This PR fixes [Issue #24257](https://github.com/ultralytics/ultralytics/issues/24257) where the `predict` and `train` modes fail to load media if the dataset or image path contains square brackets (e.g., `./[examples]/`).

The bug is caused by `glob.glob` interpreting `[examples]` as a regex-like character range rather than a literal string directory. 

### Solution
- Modified `ultralytics/data/loaders.py` and `ultralytics/data/base.py` to wrap the base directory paths in `glob.escape()` before appending wildcard glob patterns (`**/*.*`).
- This allows `glob` to correctly treat brackets as literal folder names while maintaining the wildcard capabilities of the recursive scan.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### CLA
I have read the CLA Document and I sign the CLA.

## PR Summary

### Summary
Fixes dataset path discovery when directories contain square brackets by escaping glob-special characters before file matching. 

### Key Changes
- Updated `ultralytics/data/base.py` to escape directory paths with `glob.escape()` before recursive image file discovery.
- Updated `ultralytics/data/loaders.py` to escape directory paths with `glob.escape()` before non-recursive file listing.
- Preserves existing loading behavior while preventing `glob` from misinterpreting square brackets in valid filesystem paths.

### Purpose & Impact
- Resolves `FileNotFoundError` for datasets stored in paths like `data/[sample]/images` where square brackets were previously treated as glob patterns.
- Improves robustness of dataset loading across supported platforms without changing the public API.
- Reduces friction for users organizing datasets in directories with special characters, making file loading more reliable. 