### PR TITLE
YOLOE: check `one2many` head exists while fusing prompt embeddings

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1040,7 +1040,8 @@ class YOLOEDetect(Detect):
 
         assert not self.training
         txt_feats = txt_feats.to(torch.float32).squeeze(0)
-        self._fuse_tp(txt_feats, self.cv3, self.cv4)
+        if self.cv3 and self.cv4:
+            self._fuse_tp(txt_feats, self.cv3, self.cv4)
         if self.end2end:
             self._fuse_tp(txt_feats, self.one2one_cv3, self.one2one_cv4)
         del self.reprta


### PR DESCRIPTION
Closes #24356 

`model.fuse()` removes the `one2many` head. So the later embedding fuse fails because `cv3` and `cv4` are `None`.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR adds a safety check in the model head fusion logic to avoid calling text-prompt fusion when required layers are missing.

### 📊 Key Changes
- Added a conditional check before running `_fuse_tp(txt_feats, self.cv3, self.cv4)` in `ultralytics/nn/modules/head.py`.
- The fusion step now only runs if both `self.cv3` and `self.cv4` exist.
- Existing end-to-end fusion behavior for `self.one2one_cv3` and `self.one2one_cv4` remains unchanged.

### 🎯 Purpose & Impact
- Prevents potential runtime errors or crashes during fusion when certain head layers are not initialized. ✅
- Improves robustness for models or configurations where `cv3` and `cv4` may be absent. 🔒
- Makes the fusion process safer and more flexible, especially for custom architectures or edge-case setups. 🚀
- Low-risk change: it does not alter normal behavior when both layers are present. 👍