### PR TITLE
`ultralytics 8.4.42` Free tensors before OOM batch retry

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.41"
+__version__ = "8.4.42"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -456,6 +456,8 @@ class BaseTrainer:
                         f"CUDA out of memory with batch={old_batch}. "
                         f"Reducing to batch={self.batch_size} and retrying ({self._oom_retries}/3)."
                     )
+                    batch = loss = preds = None
+                    self.loss = self.loss_items = self.tloss = None
                     self._clear_memory()
                     self._build_train_pipeline()  # rebuild dataloaders, optimizer, scheduler
                     self.scheduler.last_epoch = self.start_epoch - 1


### PR DESCRIPTION
Summary
- clear batch/loss/prediction references before CUDA memory cleanup on first-epoch OOM retries
- keep the existing auto-batch retry flow unchanged

Validation
- python -m ruff check ultralytics/engine/trainer.py
- python -m py_compile ultralytics/engine/trainer.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves training stability by cleaning up memory more aggressively after CUDA out-of-memory errors, while also bumping the package version to `8.4.42` 🚀

### 📊 Key Changes
- Added extra cleanup in `ultralytics/engine/trainer.py` when a CUDA out-of-memory error occurs during training.
- Explicitly resets temporary training variables like `batch`, `loss`, and `preds` to `None` before retrying.
- Clears stored loss-related attributes (`self.loss`, `self.loss_items`, `self.tloss`) before rebuilding the training pipeline.
- Keeps the existing automatic retry flow that reduces batch size and restarts training after an OOM event.
- Updated the Ultralytics package version from `8.4.41` to `8.4.42` 📦

### 🎯 Purpose & Impact
- Helps free GPU memory more completely after an out-of-memory failure, reducing the chance of repeated crashes 💡
- Makes automatic batch-size fallback more reliable when training large models or datasets on limited VRAM.
- Improves the user experience for training workflows by allowing recovery from memory errors with less manual intervention 🔄
- Especially useful for users training YOLO models on smaller GPUs, where memory pressure is more common 🎯