### PR TITLE
Add `data` argument to valid args for INT8 export formats

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -125,30 +125,16 @@ from ultralytics.utils.torch_utils import (
 def export_formats():
     """Return a dictionary of Ultralytics YOLO export formats."""
     x = [
-        ["PyTorch", "-", ".pt", True, True, ["data", "device"]],
-        [
-            "TorchScript",
-            "torchscript",
-            ".torchscript",
-            True,
-            True,
-            ["batch", "data", "device", "dynamic", "half", "nms", "optimize"],
-        ],
-        [
-            "ONNX",
-            "onnx",
-            ".onnx",
-            True,
-            True,
-            ["batch", "data", "device", "dynamic", "half", "opset", "simplify", "nms"],
-        ],
+        ["PyTorch", "-", ".pt", True, True, []],
+        ["TorchScript", "torchscript", ".torchscript", True, True, ["batch", "optimize", "half", "nms", "dynamic"]],
+        ["ONNX", "onnx", ".onnx", True, True, ["batch", "dynamic", "half", "opset", "simplify", "nms"]],
         [
             "OpenVINO",
             "openvino",
             "_openvino_model",
             True,
             False,
-            ["batch", "data", "device", "dynamic", "half", "int8", "nms", "fraction"],
+            ["batch", "data", "dynamic", "half", "int8", "nms", "fraction"],
         ],
         [
             "TensorRT",
@@ -156,35 +142,21 @@ def export_formats():
             ".engine",
             False,
             True,
-            ["batch", "data", "device", "dynamic", "half", "int8", "simplify", "nms", "fraction"],
+            ["batch", "data", "dynamic", "half", "int8", "simplify", "nms", "fraction"],
         ],
-        ["CoreML", "coreml", ".mlpackage", True, False, ["batch", "data", "device", "dynamic", "half", "int8", "nms"]],
-        [
-            "TensorFlow SavedModel",
-            "saved_model",
-            "_saved_model",
-            True,
-            True,
-            ["batch", "data", "device", "int8", "keras", "nms"],
-        ],
-        ["TensorFlow GraphDef", "pb", ".pb", True, True, ["batch", "data", "device"]],
-        [
-            "TensorFlow Lite",
-            "tflite",
-            ".tflite",
-            True,
-            False,
-            ["batch", "data", "device", "half", "int8", "nms", "fraction"],
-        ],
-        ["TensorFlow Edge TPU", "edgetpu", "_edgetpu.tflite", True, False, ["data", "device"]],
-        ["TensorFlow.js", "tfjs", "_web_model", True, False, ["batch", "data", "device", "half", "int8", "nms"]],
-        ["PaddlePaddle", "paddle", "_paddle_model", True, True, ["batch", "data", "device"]],
-        ["MNN", "mnn", ".mnn", True, True, ["batch", "data", "device", "half", "int8"]],
-        ["NCNN", "ncnn", "_ncnn_model", True, True, ["batch", "data", "device", "half"]],
-        ["IMX", "imx", "_imx_model", True, True, ["data", "device", "int8", "fraction", "nms"]],
-        ["RKNN", "rknn", "_rknn_model", False, False, ["batch", "data", "device", "name"]],
-        ["ExecuTorch", "executorch", "_executorch_model", True, False, ["batch", "data", "device"]],
-        ["Axelera AI", "axelera", "_axelera_model", False, False, ["batch", "data", "device", "int8", "fraction"]],
+        ["CoreML", "coreml", ".mlpackage", True, False, ["batch", "data", "dynamic", "half", "int8", "nms"]],
+        ["TensorFlow SavedModel", "saved_model", "_saved_model", True, True, ["batch", "data", "int8", "keras", "nms"]],
+        ["TensorFlow GraphDef", "pb", ".pb", True, True, ["batch"]],
+        ["TensorFlow Lite", "tflite", ".tflite", True, False, ["batch", "data", "half", "int8", "nms", "fraction"]],
+        ["TensorFlow Edge TPU", "edgetpu", "_edgetpu.tflite", True, False, []],
+        ["TensorFlow.js", "tfjs", "_web_model", True, False, ["batch", "data", "half", "int8", "nms"]],
+        ["PaddlePaddle", "paddle", "_paddle_model", True, True, ["batch"]],
+        ["MNN", "mnn", ".mnn", True, True, ["batch", "data", "half", "int8"]],
+        ["NCNN", "ncnn", "_ncnn_model", True, True, ["batch", "half"]],
+        ["IMX", "imx", "_imx_model", True, True, ["data", "int8", "fraction", "nms"]],
+        ["RKNN", "rknn", "_rknn_model", False, False, ["batch", "name"]],
+        ["ExecuTorch", "executorch", "_executorch_model", True, False, ["batch"]],
+        ["Axelera AI", "axelera", "_axelera_model", False, False, ["batch", "int8", "fraction", "data"]],
     ]
     return dict(zip(["Format", "Argument", "Suffix", "CPU", "GPU", "Arguments"], zip(*x)))
 
@@ -200,7 +172,7 @@ def validate_args(format, passed_args, valid_args):
     Raises:
         AssertionError: If an unsupported argument is used, or if the format lacks supported argument listings.
     """
-    export_args = ["half", "int8", "dynamic", "keras", "nms", "batch", "fraction", "data", "device"]
+    export_args = ["half", "int8", "dynamic", "keras", "nms", "batch", "fraction", "data"]
 
     assert valid_args is not None, f"ERROR ❌️ valid arguments for '{format}' not listed."
     custom = {"batch": 1, "data": None, "device": None}  # exporter defaults
@@ -529,7 +501,7 @@ class Exporter:
             "batch": self.args.batch,
             "imgsz": self.imgsz,
             "names": model.names,
-            "args": {k: str(v) if k == "device" else v for k, v in self.args if k in fmt_keys},
+            "args": {k: v for k, v in self.args if k in fmt_keys},
             "channels": model.yaml.get("channels", 3),
             "end2end": getattr(model, "end2end", False),
         }  # model metadata

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -134,7 +134,7 @@ def export_formats():
             "_openvino_model",
             True,
             False,
-            ["batch", "dynamic", "half", "int8", "nms", "fraction"],
+            ["batch", "data", "dynamic", "half", "int8", "nms", "fraction"],
         ],
         [
             "TensorRT",
@@ -142,18 +142,18 @@ def export_formats():
             ".engine",
             False,
             True,
-            ["batch", "dynamic", "half", "int8", "simplify", "nms", "fraction"],
+            ["batch", "data", "dynamic", "half", "int8", "simplify", "nms", "fraction"],
         ],
-        ["CoreML", "coreml", ".mlpackage", True, False, ["batch", "dynamic", "half", "int8", "nms"]],
-        ["TensorFlow SavedModel", "saved_model", "_saved_model", True, True, ["batch", "int8", "keras", "nms"]],
+        ["CoreML", "coreml", ".mlpackage", True, False, ["batch", "data", "dynamic", "half", "int8", "nms"]],
+        ["TensorFlow SavedModel", "saved_model", "_saved_model", True, True, ["batch", "data", "int8", "keras", "nms"]],
         ["TensorFlow GraphDef", "pb", ".pb", True, True, ["batch"]],
-        ["TensorFlow Lite", "tflite", ".tflite", True, False, ["batch", "half", "int8", "nms", "fraction"]],
+        ["TensorFlow Lite", "tflite", ".tflite", True, False, ["batch", "data", "half", "int8", "nms", "fraction"]],
         ["TensorFlow Edge TPU", "edgetpu", "_edgetpu.tflite", True, False, []],
-        ["TensorFlow.js", "tfjs", "_web_model", True, False, ["batch", "half", "int8", "nms"]],
+        ["TensorFlow.js", "tfjs", "_web_model", True, False, ["batch", "data", "half", "int8", "nms"]],
         ["PaddlePaddle", "paddle", "_paddle_model", True, True, ["batch"]],
-        ["MNN", "mnn", ".mnn", True, True, ["batch", "half", "int8"]],
+        ["MNN", "mnn", ".mnn", True, True, ["batch", "data", "half", "int8"]],
         ["NCNN", "ncnn", "_ncnn_model", True, True, ["batch", "half"]],
-        ["IMX", "imx", "_imx_model", True, True, ["int8", "fraction", "nms"]],
+        ["IMX", "imx", "_imx_model", True, True, ["data", "int8", "fraction", "nms"]],
         ["RKNN", "rknn", "_rknn_model", False, False, ["batch", "name"]],
         ["ExecuTorch", "executorch", "_executorch_model", True, False, ["batch"]],
         ["Axelera AI", "axelera", "_axelera_model", False, False, ["batch", "int8", "fraction", "data"]],
@@ -172,7 +172,7 @@ def validate_args(format, passed_args, valid_args):
     Raises:
         AssertionError: If an unsupported argument is used, or if the format lacks supported argument listings.
     """
-    export_args = ["half", "int8", "dynamic", "keras", "nms", "batch", "fraction"]
+    export_args = ["half", "int8", "dynamic", "keras", "nms", "batch", "fraction", "data"]
 
     assert valid_args is not None, f"ERROR ❌️ valid arguments for '{format}' not listed."
     custom = {"batch": 1, "data": None, "device": None}  # exporter defaults

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -125,16 +125,30 @@ from ultralytics.utils.torch_utils import (
 def export_formats():
     """Return a dictionary of Ultralytics YOLO export formats."""
     x = [
-        ["PyTorch", "-", ".pt", True, True, []],
-        ["TorchScript", "torchscript", ".torchscript", True, True, ["batch", "optimize", "half", "nms", "dynamic"]],
-        ["ONNX", "onnx", ".onnx", True, True, ["batch", "dynamic", "half", "opset", "simplify", "nms"]],
+        ["PyTorch", "-", ".pt", True, True, ["data", "device"]],
+        [
+            "TorchScript",
+            "torchscript",
+            ".torchscript",
+            True,
+            True,
+            ["batch", "data", "device", "dynamic", "half", "nms", "optimize"],
+        ],
+        [
+            "ONNX",
+            "onnx",
+            ".onnx",
+            True,
+            True,
+            ["batch", "data", "device", "dynamic", "half", "opset", "simplify", "nms"],
+        ],
         [
             "OpenVINO",
             "openvino",
             "_openvino_model",
             True,
             False,
-            ["batch", "data", "dynamic", "half", "int8", "nms", "fraction"],
+            ["batch", "data", "device", "dynamic", "half", "int8", "nms", "fraction"],
         ],
         [
             "TensorRT",
@@ -142,21 +156,35 @@ def export_formats():
             ".engine",
             False,
             True,
-            ["batch", "data", "dynamic", "half", "int8", "simplify", "nms", "fraction"],
+            ["batch", "data", "device", "dynamic", "half", "int8", "simplify", "nms", "fraction"],
         ],
-        ["CoreML", "coreml", ".mlpackage", True, False, ["batch", "data", "dynamic", "half", "int8", "nms"]],
-        ["TensorFlow SavedModel", "saved_model", "_saved_model", True, True, ["batch", "data", "int8", "keras", "nms"]],
-        ["TensorFlow GraphDef", "pb", ".pb", True, True, ["batch"]],
-        ["TensorFlow Lite", "tflite", ".tflite", True, False, ["batch", "data", "half", "int8", "nms", "fraction"]],
-        ["TensorFlow Edge TPU", "edgetpu", "_edgetpu.tflite", True, False, []],
-        ["TensorFlow.js", "tfjs", "_web_model", True, False, ["batch", "data", "half", "int8", "nms"]],
-        ["PaddlePaddle", "paddle", "_paddle_model", True, True, ["batch"]],
-        ["MNN", "mnn", ".mnn", True, True, ["batch", "data", "half", "int8"]],
-        ["NCNN", "ncnn", "_ncnn_model", True, True, ["batch", "half"]],
-        ["IMX", "imx", "_imx_model", True, True, ["data", "int8", "fraction", "nms"]],
-        ["RKNN", "rknn", "_rknn_model", False, False, ["batch", "name"]],
-        ["ExecuTorch", "executorch", "_executorch_model", True, False, ["batch"]],
-        ["Axelera AI", "axelera", "_axelera_model", False, False, ["batch", "int8", "fraction", "data"]],
+        ["CoreML", "coreml", ".mlpackage", True, False, ["batch", "data", "device", "dynamic", "half", "int8", "nms"]],
+        [
+            "TensorFlow SavedModel",
+            "saved_model",
+            "_saved_model",
+            True,
+            True,
+            ["batch", "data", "device", "int8", "keras", "nms"],
+        ],
+        ["TensorFlow GraphDef", "pb", ".pb", True, True, ["batch", "data", "device"]],
+        [
+            "TensorFlow Lite",
+            "tflite",
+            ".tflite",
+            True,
+            False,
+            ["batch", "data", "device", "half", "int8", "nms", "fraction"],
+        ],
+        ["TensorFlow Edge TPU", "edgetpu", "_edgetpu.tflite", True, False, ["data", "device"]],
+        ["TensorFlow.js", "tfjs", "_web_model", True, False, ["batch", "data", "device", "half", "int8", "nms"]],
+        ["PaddlePaddle", "paddle", "_paddle_model", True, True, ["batch", "data", "device"]],
+        ["MNN", "mnn", ".mnn", True, True, ["batch", "data", "device", "half", "int8"]],
+        ["NCNN", "ncnn", "_ncnn_model", True, True, ["batch", "data", "device", "half"]],
+        ["IMX", "imx", "_imx_model", True, True, ["data", "device", "int8", "fraction", "nms"]],
+        ["RKNN", "rknn", "_rknn_model", False, False, ["batch", "data", "device", "name"]],
+        ["ExecuTorch", "executorch", "_executorch_model", True, False, ["batch", "data", "device"]],
+        ["Axelera AI", "axelera", "_axelera_model", False, False, ["batch", "data", "device", "int8", "fraction"]],
     ]
     return dict(zip(["Format", "Argument", "Suffix", "CPU", "GPU", "Arguments"], zip(*x)))
 
@@ -172,7 +200,7 @@ def validate_args(format, passed_args, valid_args):
     Raises:
         AssertionError: If an unsupported argument is used, or if the format lacks supported argument listings.
     """
-    export_args = ["half", "int8", "dynamic", "keras", "nms", "batch", "fraction", "data"]
+    export_args = ["half", "int8", "dynamic", "keras", "nms", "batch", "fraction", "data", "device"]
 
     assert valid_args is not None, f"ERROR ❌️ valid arguments for '{format}' not listed."
     custom = {"batch": 1, "data": None, "device": None}  # exporter defaults

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -529,7 +529,7 @@ class Exporter:
             "batch": self.args.batch,
             "imgsz": self.imgsz,
             "names": model.names,
-            "args": {k: v for k, v in self.args if k in fmt_keys},
+            "args": {k: str(v) if k == "device" else v for k, v in self.args if k in fmt_keys},
             "channels": model.yaml.get("channels", 3),
             "end2end": getattr(model, "end2end", False),
         }  # model metadata


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds `data` as a supported export argument for several model export formats, improving dataset-aware export workflows and argument validation ✅

### 📊 Key Changes
- Added `data` to the list of globally recognized export arguments in `ultralytics/engine/exporter.py`.
- Updated supported argument lists for multiple export targets so they now explicitly accept `data`, including:
  - OpenVINO
  - TensorRT
  - CoreML
  - TensorFlow SavedModel
  - TensorFlow Lite
  - TensorFlow.js
  - MNN
  - IMX
- Kept existing validation logic intact, but extended it so `data` is no longer treated as an unsupported argument for these formats.
- Aligns export format capability definitions more consistently across backends 🛠️

### 🎯 Purpose & Impact
- Makes exports more flexible by allowing dataset-related configuration to be passed to more backends 📦
- Prevents unnecessary validation errors when users include `data` during export ✅
- Improves consistency across supported export formats, making the export interface easier to understand and use 🤝
- Especially helpful for workflows that depend on dataset metadata during quantization or backend-specific export preparation 🚀