### PR TITLE
`ultralytics 8.4.43` Fix NDJSON dataset validation

### DIFF
--- a/docs/en/reference/data/utils.md
+++ b/docs/en/reference/data/utils.md
@@ -59,6 +59,10 @@ keywords: Ultralytics, dataset utils, data handling, image verification, Python,
 
 <br><br><hr><br>
 
+## ::: ultralytics.data.utils.convert_ndjson_to_yolo_if_needed
+
+<br><br><hr><br>
+
 ## ::: ultralytics.data.utils.check_det_dataset
 
 <br><br><hr><br>

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.42"
+__version__ = "8.4.43"
 
 import importlib
 import os

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -398,6 +398,18 @@ def find_dataset_yaml(path: Path) -> Path:
     return files[0]
 
 
+def convert_ndjson_to_yolo_if_needed(data: str | Path) -> str | Path:
+    """Convert an NDJSON dataset or Platform dataset URI to YOLO format."""
+    data_str = str(data)
+    if data_str.endswith(".ndjson") or (data_str.startswith("ul://") and "/datasets/" in data_str):
+        import asyncio
+
+        from ultralytics.data.converter import convert_ndjson_to_yolo
+
+        return asyncio.run(convert_ndjson_to_yolo(check_file(data)))
+    return data
+
+
 def check_det_dataset(dataset: str, autodownload: bool = True) -> dict[str, Any]:
     """Download, verify, and/or unzip a dataset if not found locally.
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -26,7 +26,7 @@ from torch import nn, optim
 
 from ultralytics import __version__
 from ultralytics.cfg import get_cfg, get_save_dir
-from ultralytics.data.utils import check_cls_dataset, check_det_dataset
+from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.tasks import load_checkpoint
 from ultralytics.optim import MuSGD
 from ultralytics.utils import (
@@ -682,15 +682,7 @@ class BaseTrainer:
             (dict): A dictionary containing the training/validation/test dataset and category names.
         """
         try:
-            # Convert ul:// platform URIs and NDJSON files to local dataset format first
-            data_str = str(self.args.data)
-            if data_str.endswith(".ndjson") or (data_str.startswith("ul://") and "/datasets/" in data_str):
-                import asyncio
-
-                from ultralytics.data.converter import convert_ndjson_to_yolo
-                from ultralytics.utils.checks import check_file
-
-                self.args.data = str(asyncio.run(convert_ndjson_to_yolo(check_file(self.args.data))))
+            self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
 
             # Task-specific dataset checking
             if self.args.task == "classify":

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -165,7 +165,12 @@ class BaseValidator:
                     model.end2end = self.args.end2end
                 if model.end2end:
                     model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
-            self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
+            if RANK in {-1, 0}:
+                self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
+            if RANK != -1:
+                broadcast_list = [self.args.data if RANK == 0 else None]
+                dist.broadcast_object_list(broadcast_list, 0)
+                self.args.data = broadcast_list[0]
             model = AutoBackend(
                 model=model or self.args.model,
                 device=select_device(self.args.device) if RANK == -1 else torch.device("cuda", RANK),

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -36,7 +36,7 @@ import torch
 import torch.distributed as dist
 
 from ultralytics.cfg import get_cfg, get_save_dir
-from ultralytics.data.utils import check_cls_dataset, check_det_dataset
+from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.utils import LOGGER, RANK, TQDM, callbacks, colorstr, emojis
 from ultralytics.utils.checks import check_imgsz
@@ -165,6 +165,7 @@ class BaseValidator:
                     model.end2end = self.args.end2end
                 if model.end2end:
                     model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
+            self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
             model = AutoBackend(
                 model=model or self.args.model,
                 device=select_device(self.args.device) if RANK == -1 else torch.device("cuda", RANK),

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -38,10 +38,16 @@ import torch.distributed as dist
 from ultralytics.cfg import get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import LOGGER, RANK, TQDM, callbacks, colorstr, emojis
+from ultralytics.utils import LOCAL_RANK, LOGGER, RANK, TQDM, callbacks, colorstr, emojis
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
-from ultralytics.utils.torch_utils import attempt_compile, select_device, smart_inference_mode, unwrap_model
+from ultralytics.utils.torch_utils import (
+    attempt_compile,
+    select_device,
+    smart_inference_mode,
+    torch_distributed_zero_first,
+    unwrap_model,
+)
 
 
 class BaseValidator:
@@ -165,12 +171,8 @@ class BaseValidator:
                     model.end2end = self.args.end2end
                 if model.end2end:
                     model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
-            if RANK in {-1, 0}:
+            with torch_distributed_zero_first(LOCAL_RANK):
                 self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
-            if RANK != -1:
-                broadcast_list = [self.args.data if RANK == 0 else None]
-                dist.broadcast_object_list(broadcast_list, 0)
-                self.args.data = broadcast_list[0]
             model = AutoBackend(
                 model=model or self.args.model,
                 device=select_device(self.args.device) if RANK == -1 else torch.device("cuda", RANK),


### PR DESCRIPTION
## Summary
- add one shared NDJSON/Platform dataset resolver for train and val
- replace the train-only inline conversion with the shared resolver
- convert standalone val data before backend setup so NDJSON and ul:// datasets resolve to YOLO data
- bump patch version to 8.4.43

## Tests
- python inline NDJSON test-split validation script
- pytest tests/test_python.py -k train_ndjson -q
- ruff check ultralytics/data/utils.py ultralytics/engine/trainer.py ultralytics/engine/validator.py ultralytics/__init__.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refactors dataset handling by adding a shared NDJSON-to-YOLO conversion helper and enabling the same automatic conversion flow in both training and validation 🚀

### 📊 Key Changes
- Added a new utility function: `convert_ndjson_to_yolo_if_needed()` in `ultralytics.data.utils`.
- Moved existing NDJSON and Ultralytics Platform dataset URI conversion logic out of `trainer.py` into this reusable helper 🔧
- Updated the trainer to use the new shared conversion function instead of inline conversion code.
- Added the same automatic dataset conversion step to the validator, so validation now also supports `.ndjson` files and `ul://.../datasets/...` URIs ✅
- Wrapped validator-side conversion with `torch_distributed_zero_first(...)` to avoid duplicate work in distributed runs 🧠
- Added documentation for the new utility in the data utils reference docs 📘
- Bumped the package version from `8.4.42` to `8.4.43`

### 🎯 Purpose & Impact
- Makes dataset input handling more consistent across training and validation, reducing surprises for users.
- Improves code maintainability by centralizing conversion logic in one place instead of duplicating it ✨
- Expands support for Ultralytics Platform and NDJSON dataset formats during validation, not just training.
- Helps distributed validation run more safely and efficiently by ensuring conversion happens once before other processes proceed ⚡
- Makes it easier for users working with datasets from the [Ultralytics Platform](https://platform.ultralytics.com) or NDJSON exports to plug them into existing YOLO workflows with less manual setup.