### PR TITLE
Exclude `tensorrt==10.2.0` to fix `libnvinfer_builder_resource_win.so.10.2.0` error

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -606,6 +606,7 @@ class Exporter:
             requirements += ["onnxslim>=0.1.71", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
         import onnx
+
         from ultralytics.utils.export.engine import best_onnx_opset, torch2onnx
 
         opset = self.args.opset or best_onnx_opset(onnx, cuda="cuda" in self.device.type)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -896,7 +896,7 @@ class Exporter:
             check_tensorrt()
             import tensorrt as trt
         check_version(trt.__version__, ">=7.0.0", hard=True)
-        check_version(trt.__version__, "!=10.1.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
+        check_version(trt.__version__, "!=10.2.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
 
         from ultralytics.utils.export.engine import onnx2engine
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -874,19 +874,6 @@ class Exporter:
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
 
-        # Force re-install TensorRT on CUDA 13 ARM devices to 10.15.x versions for RT-DETR exports
-        # https://github.com/ultralytics/ultralytics/issues/22873
-        if is_jetson(jetpack=7) or is_dgx():
-            check_tensorrt("10.15")
-
-        try:
-            import tensorrt as trt
-        except ImportError:
-            check_tensorrt()
-            import tensorrt as trt
-        check_version(trt.__version__, ">=7.0.0", hard=True)
-        check_version(trt.__version__, "!=10.2.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
-
         from ultralytics.utils.export.engine import onnx2engine
 
         assert Path(f_onnx).exists(), f"failed to export ONNX file: {f_onnx}"

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -606,7 +606,6 @@ class Exporter:
             requirements += ["onnxslim>=0.1.71", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
         check_requirements(requirements)
         import onnx
-
         from ultralytics.utils.export.engine import best_onnx_opset, torch2onnx
 
         opset = self.args.opset or best_onnx_opset(onnx, cuda="cuda" in self.device.type)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -873,7 +873,6 @@ class Exporter:
         """Export YOLO model to TensorRT format https://developer.nvidia.com/tensorrt."""
         assert self.im.device.type != "cpu", "export running on CPU but must be on GPU, i.e. use 'device=0'"
         f_onnx = self.export_onnx()  # run before TRT import https://github.com/ultralytics/ultralytics/issues/7016
-
         from ultralytics.utils.export.engine import onnx2engine
 
         assert Path(f_onnx).exists(), f"failed to export ONNX file: {f_onnx}"

--- a/ultralytics/nn/backends/tensorrt.py
+++ b/ultralytics/nn/backends/tensorrt.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 
 from ultralytics.utils import IS_JETSON, LOGGER, PYTHON_VERSION
-from ultralytics.utils.checks import check_requirements, check_version
+from ultralytics.utils.checks import check_requirements, check_version, check_tensorrt
 
 from .base import BaseBackend
 

--- a/ultralytics/nn/backends/tensorrt.py
+++ b/ultralytics/nn/backends/tensorrt.py
@@ -36,12 +36,11 @@ class TensorRTBackend(BaseBackend):
         try:
             import tensorrt as trt
         except ImportError:
-            if LINUX:
-                check_requirements("tensorrt>7.0.0,!=10.1.0")
+            check_tensorrt()
             import tensorrt as trt
 
         check_version(trt.__version__, ">=7.0.0", hard=True)
-        check_version(trt.__version__, "!=10.1.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
+        check_version(trt.__version__, "!=10.2.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
 
         if self.device.type == "cpu":
             self.device = torch.device("cuda:0")

--- a/ultralytics/nn/backends/tensorrt.py
+++ b/ultralytics/nn/backends/tensorrt.py
@@ -40,7 +40,7 @@ class TensorRTBackend(BaseBackend):
             import tensorrt as trt
 
         check_version(trt.__version__, ">=7.0.0", hard=True)
-        check_version(trt.__version__, "!=10.2.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
+        check_version(trt.__version__, "!=10.2.0", msg="https://github.com/ultralytics/ultralytics/pull/24367")
 
         if self.device.type == "cpu":
             self.device = torch.device("cuda:0")

--- a/ultralytics/nn/backends/tensorrt.py
+++ b/ultralytics/nn/backends/tensorrt.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 
 from ultralytics.utils import IS_JETSON, LOGGER, PYTHON_VERSION
-from ultralytics.utils.checks import check_requirements, check_version, check_tensorrt
+from ultralytics.utils.checks import check_requirements, check_tensorrt, check_version
 
 from .base import BaseBackend
 

--- a/ultralytics/nn/backends/tensorrt.py
+++ b/ultralytics/nn/backends/tensorrt.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from ultralytics.utils import IS_JETSON, LINUX, LOGGER, PYTHON_VERSION
+from ultralytics.utils import IS_JETSON, LOGGER, PYTHON_VERSION
 from ultralytics.utils.checks import check_requirements, check_version
 
 from .base import BaseBackend

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -531,7 +531,7 @@ def check_tensorrt(min_version: str = "7.0.0"):
     """
     if LINUX:
         cuda_version = torch.version.cuda.split(".")[0]
-        check_requirements(f"tensorrt-cu{cuda_version}>={min_version},!=10.1.0")
+        check_requirements(f"tensorrt-cu{cuda_version}>={min_version},!=10.2.0")
 
 
 def check_torchvision():

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -143,7 +143,7 @@ def onnx2engine(
         check_tensorrt()
         import tensorrt as trt
     check_version(trt.__version__, ">=7.0.0", hard=True)
-    check_version(trt.__version__, "!=10.1.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
+    check_version(trt.__version__, "!=10.2.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
 
     LOGGER.info(f"\n{prefix} starting export with TensorRT {trt.__version__}...")
     output_file = output_file or Path(onnx_file).with_suffix(".engine")

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -143,7 +143,7 @@ def onnx2engine(
         check_tensorrt()
         import tensorrt as trt
     check_version(trt.__version__, ">=7.0.0", hard=True)
-    check_version(trt.__version__, "!=10.2.0", msg="https://github.com/ultralytics/ultralytics/pull/14239")
+    check_version(trt.__version__, "!=10.2.0", msg="https://github.com/ultralytics/ultralytics/pull/24367")
 
     LOGGER.info(f"\n{prefix} starting export with TensorRT {trt.__version__}...")
     output_file = output_file or Path(onnx_file).with_suffix(".engine")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves TensorRT compatibility checks by standardizing how TensorRT is installed and blocking the problematic TensorRT 10.2.0 version instead of 10.1.0.

### 📊 Key Changes
- Replaced direct Linux-only TensorRT installation handling in `tensorrt.py` with the shared `check_tensorrt()` utility.
- Updated TensorRT version validation to disallow `10.2.0` in both:
  - TensorRT backend loading
  - TensorRT engine export flow
- Updated the shared `check_tensorrt()` dependency check to avoid installing `tensorrt-cu*` version `10.2.0`.
- Removed the older exclusion for TensorRT `10.1.0` and linked the new warning to the related PR for `10.2.0`.

### 🎯 Purpose & Impact
- ✅ Prevents users from running into known issues with TensorRT `10.2.0`.
- 🔄 Makes TensorRT setup more consistent by using one centralized check instead of separate logic in different places.
- 🧩 Reduces maintenance overhead and lowers the chance of mismatched behavior between inference and export code paths.
- 🚀 Improves reliability for users exporting or running YOLO models with TensorRT, especially on Linux and CUDA-based systems.