### PR TITLE
Auto-update `tensorrt` from `10.3` to `10.7` on JetPack 6 systems to fix YOLO26 int8 build issues 

### DIFF
--- a/docker/Dockerfile-jetson-jetpack6
+++ b/docker/Dockerfile-jetson-jetpack6
@@ -26,7 +26,16 @@ RUN dpkg -i cudss-local-tegra-repo-ubuntu2204-0.7.1_0.7.1-1_arm64.deb && \
     apt-get install -y --no-install-recommends \
     git python3-pip libopenmpi-dev libopenblas-base libomp-dev cudss && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* 
+    rm -rf /var/lib/apt/lists/*
+
+# Upgrade TensorRT from 10.3.0 to 10.7.0 to fix INT8 + end2end build issues on JetPack 6
+# https://github.com/ultralytics/ultralytics/issues/23841
+ADD https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb .
+RUN dpkg -i cuda-keyring_1.1-1_all.deb && \
+    apt-get update && \
+    apt-get install -y tensorrt && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* cuda-keyring_1.1-1_all.deb
 
 # Create working directory
 WORKDIR /ultralytics

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -990,3 +990,18 @@ Available RAM is often the bottleneck on lower-memory Jetson devices. Three easy
 3. **Run inference without a display** by setting `show=False` in your YOLO `predict` call, which avoids allocating display pipeline memory (~200+ MB saved).
 
 Use `procrank` to profile per-process RAM usage and `sudo cat /sys/kernel/debug/nvmap/iovmm/clients` to inspect GPU allocations. See the [Memory Optimization Tips](#memory-optimization-tips-for-nvidia-jetson) section for full details.
+
+### Why does my TensorRT INT8 export disable end2end on JetPack 6?
+
+TensorRT 10.3.0 shipped with JetPack 6 has a known issue that prevents INT8 engine builds when `end2end=True` is enabled. When Ultralytics detects this combination, it automatically disables the end2end branch to ensure the export succeeds.
+
+To restore end2end INT8 exports, upgrade TensorRT to a newer version (e.g., 10.7.0+):
+
+```bash
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo apt-get update
+sudo apt-get install -y tensorrt
+```
+
+After upgrading, re-run your export. For more details, see [GitHub issue #23841](https://github.com/ultralytics/ultralytics/issues/23841).

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import time
 from copy import deepcopy
 from datetime import datetime
@@ -98,6 +99,7 @@ from ultralytics.utils import (
     callbacks,
     colorstr,
     get_default_args,
+    is_jetson,
 )
 from ultralytics.utils.checks import (
     IS_PYTHON_MINIMUM_3_9,
@@ -105,6 +107,7 @@ from ultralytics.utils.checks import (
     check_requirements,
     check_version,
     is_intel,
+    is_sudo_available,
 )
 from ultralytics.utils.files import file_size
 from ultralytics.utils.metrics import batch_probiou
@@ -344,16 +347,31 @@ class Exporter:
                 model.end2end = False
                 LOGGER.warning(f"{fmt.upper()} export does not support end2end models, disabling end2end branch.")
             if fmt == "engine" and self.args.int8:
-                # TensorRT<=10.3.0 with int8 has known end2end build issues
+                # TensorRT 10.3.0 on JetPack 6 with int8 has known end2end build issues
                 # https://github.com/ultralytics/ultralytics/issues/23841
                 try:
                     import tensorrt as trt
 
-                    if check_version(trt.__version__, "<=10.3.0", hard=True):
-                        model.end2end = False
-                        LOGGER.warning(
-                            "TensorRT<=10.3.0 with int8 has known end2end build issues, disabling end2end branch."
+                    if check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
+                        LOGGER.info(
+                            "\nTensorRT 10.3.0 on JetPack 6 has known INT8 + end2end build issues. "
+                            "Attempting auto-upgrade from https://developer.nvidia.com/cuda-downloads..."
                         )
+                        try:
+                            sudo = "sudo " if is_sudo_available() else ""
+                            keyring_url = (
+                                "https://developer.download.nvidia.com/compute/cuda/repos/"
+                                "ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb"
+                            )
+                            for c in (
+                                f"wget -q {keyring_url} -O /tmp/cuda-keyring.deb",
+                                f"{sudo}dpkg -i /tmp/cuda-keyring.deb",
+                                f"{sudo}apt-get update",
+                                f"{sudo}apt-get install -y tensorrt",
+                            ):
+                                subprocess.run(c, shell=True, check=True)
+                        except subprocess.CalledProcessError as e:
+                            LOGGER.warning(f"TensorRT auto-upgrade failed: {e}")
                 except ImportError:
                     pass
         if self.args.half and self.args.int8:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -66,6 +66,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import time
 from copy import deepcopy
 from datetime import datetime
@@ -355,7 +356,7 @@ class Exporter:
                     if check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
                         LOGGER.info(
                             "\nTensorRT 10.3.0 on JetPack 6 has known INT8 + end2end build issues. "
-                            "Attempting auto-upgrade from https://developer.nvidia.com/cuda-downloads..."
+                            "Upgrading TensorRT from https://developer.nvidia.com/cuda-downloads..."
                         )
                         try:
                             sudo = "sudo " if is_sudo_available() else ""
@@ -370,6 +371,11 @@ class Exporter:
                                 f"{sudo}apt-get install -y tensorrt",
                             ):
                                 subprocess.run(c, shell=True, check=True)
+                            LOGGER.info(
+                                "✅ TensorRT upgraded successfully. "
+                                "Please re-run your export to use the new TensorRT version."
+                            )
+                            sys.exit(0)
                         except subprocess.CalledProcessError as e:
                             LOGGER.warning(f"TensorRT auto-upgrade failed: {e}")
                 except ImportError:

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -351,35 +351,40 @@ class Exporter:
                 # TensorRT 10.3.0 on JetPack 6 with int8 has known end2end build issues
                 # https://github.com/ultralytics/ultralytics/issues/23841
                 try:
-                    import tensorrt as trt
+                    trt_version = subprocess.run(
+                        [sys.executable, "-c", "import tensorrt; print(tensorrt.__version__)"],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                    ).stdout.strip()
+                except Exception:
+                    trt_version = None
 
-                    if check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
-                        LOGGER.info(
-                            "\nTensorRT 10.3.0 on JetPack 6 has known INT8 + end2end build issues. "
-                            "Upgrading TensorRT from https://developer.nvidia.com/cuda-downloads..."
+                if trt_version and check_version(trt_version, "==10.3.0") and is_jetson(jetpack=6):
+                    LOGGER.info(
+                        "\nTensorRT 10.3.0 on JetPack 6 has known INT8 + end2end build issues. "
+                        "Upgrading TensorRT from https://developer.nvidia.com/cuda-downloads..."
+                    )
+                    try:
+                        sudo = "sudo " if is_sudo_available() else ""
+                        keyring_url = (
+                            "https://developer.download.nvidia.com/compute/cuda/repos/"
+                            "ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb"
                         )
-                        try:
-                            sudo = "sudo " if is_sudo_available() else ""
-                            keyring_url = (
-                                "https://developer.download.nvidia.com/compute/cuda/repos/"
-                                "ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb"
-                            )
-                            for c in (
-                                f"wget -q {keyring_url} -O /tmp/cuda-keyring.deb",
-                                f"{sudo}dpkg -i /tmp/cuda-keyring.deb",
-                                f"{sudo}apt-get update",
-                                f"{sudo}apt-get install -y tensorrt",
-                            ):
-                                subprocess.run(c, shell=True, check=True)
-                            LOGGER.info(
-                                "✅ TensorRT upgraded successfully. "
-                                "Please re-run your export to use the new TensorRT version."
-                            )
-                            sys.exit(0)
-                        except subprocess.CalledProcessError as e:
-                            LOGGER.warning(f"TensorRT auto-upgrade failed: {e}")
-                except ImportError:
-                    pass
+                        for c in (
+                            f"wget -q {keyring_url} -O /tmp/cuda-keyring.deb",
+                            f"{sudo}dpkg -i /tmp/cuda-keyring.deb",
+                            f"{sudo}apt-get update",
+                            f"{sudo}apt-get install -y tensorrt",
+                        ):
+                            subprocess.run(c, shell=True, check=True)
+                        LOGGER.info("✅ TensorRT upgraded successfully.")
+                    except subprocess.CalledProcessError as e:
+                        LOGGER.warning(f"TensorRT auto-upgrade failed: {e}")
+                        model.end2end = False
+                        LOGGER.warning(
+                            "TensorRT 10.3.0 with int8 has known end2end build issues, disabling end2end branch."
+                        )
         if self.args.half and self.args.int8:
             LOGGER.warning("half=True and int8=True are mutually exclusive, setting half=False.")
             self.args.half = False

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -65,8 +65,6 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import subprocess
-import sys
 import time
 from copy import deepcopy
 from datetime import datetime
@@ -102,14 +100,7 @@ from ultralytics.utils import (
     get_default_args,
     is_jetson,
 )
-from ultralytics.utils.checks import (
-    IS_PYTHON_MINIMUM_3_9,
-    check_imgsz,
-    check_requirements,
-    check_version,
-    is_intel,
-    is_sudo_available,
-)
+from ultralytics.utils.checks import IS_PYTHON_MINIMUM_3_9, check_imgsz, check_requirements, check_version, is_intel
 from ultralytics.utils.files import file_size
 from ultralytics.utils.metrics import batch_probiou
 from ultralytics.utils.nms import TorchNMS
@@ -351,40 +342,15 @@ class Exporter:
                 # TensorRT 10.3.0 on JetPack 6 with int8 has known end2end build issues
                 # https://github.com/ultralytics/ultralytics/issues/23841
                 try:
-                    trt_version = subprocess.run(
-                        [sys.executable, "-c", "import tensorrt; print(tensorrt.__version__)"],
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                    ).stdout.strip()
-                except Exception:
-                    trt_version = None
+                    import tensorrt as trt
 
-                if trt_version and check_version(trt_version, "==10.3.0") and is_jetson(jetpack=6):
-                    LOGGER.info(
-                        "\nTensorRT 10.3.0 on JetPack 6 has known INT8 + end2end build issues. "
-                        "Upgrading TensorRT from https://developer.nvidia.com/cuda-downloads..."
-                    )
-                    try:
-                        sudo = "sudo " if is_sudo_available() else ""
-                        keyring_url = (
-                            "https://developer.download.nvidia.com/compute/cuda/repos/"
-                            "ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb"
-                        )
-                        for c in (
-                            f"wget -q {keyring_url} -O /tmp/cuda-keyring.deb",
-                            f"{sudo}dpkg -i /tmp/cuda-keyring.deb",
-                            f"{sudo}apt-get update",
-                            f"{sudo}apt-get install -y tensorrt",
-                        ):
-                            subprocess.run(c, shell=True, check=True)
-                        LOGGER.info("✅ TensorRT upgraded successfully.")
-                    except subprocess.CalledProcessError as e:
-                        LOGGER.warning(f"TensorRT auto-upgrade failed: {e}")
+                    if check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
                         model.end2end = False
                         LOGGER.warning(
-                            "TensorRT 10.3.0 with int8 has known end2end build issues, disabling end2end branch."
+                            "TensorRT<=10.3.0 with int8 has known end2end build issues, disabling end2end branch."
                         )
+                except ImportError:
+                    pass
         if self.args.half and self.args.int8:
             LOGGER.warning("half=True and int8=True are mutually exclusive, setting half=False.")
             self.args.half = False

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -347,7 +347,9 @@ class Exporter:
                     if check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
                         model.end2end = False
                         LOGGER.warning(
-                            "TensorRT<=10.3.0 with int8 has known end2end build issues, disabling end2end branch."
+                            "TensorRT 10.3.0 on JetPack 6 with int8 has known end2end build issues, disabling end2end branch. "
+                            "For a fix, see https://docs.ultralytics.com/guides/nvidia-jetson/#why-does-my-tensorrt-int8-export-disable-end2end-on-jetpack-6"
+                            ""
                         )
                 except ImportError:
                     pass


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR improves JetPack 6 support by fixing TensorRT INT8 export issues on NVIDIA Jetson devices and documenting how users can restore full `end2end` export behavior.

### 📊 Key Changes
- 🐳 Updated the `Dockerfile-jetson-jetpack6` image to install a newer TensorRT version (`10.7.0`) instead of relying on the older JetPack 6 default (`10.3.0`).
- 🛡️ Refined export logic in `exporter.py` so the `end2end` branch is only automatically disabled for the specific problematic case: **TensorRT 10.3.0 + JetPack 6 + INT8 engine export**.
- 📍 Added a clearer warning message during export, including a link to the relevant Jetson documentation for the workaround.
- 📚 Expanded the NVIDIA Jetson guide with a new troubleshooting section explaining:
  - why `end2end` may be disabled during INT8 TensorRT export on JetPack 6
  - how to upgrade TensorRT manually to fix it
  - where to find more details in [GitHub issue #23841](https://github.com/ultralytics/ultralytics/issues/23841)

### 🎯 Purpose & Impact
- ✅ Fixes a real Jetson-specific export problem that could break or limit INT8 TensorRT engine builds.
- 🎯 Makes the workaround more precise by avoiding overly broad disabling of `end2end` on other systems or TensorRT versions.
- 🚀 Improves the out-of-the-box Jetson Docker experience by shipping with a TensorRT version that avoids the known issue.
- 📖 Helps users troubleshoot faster with better docs and direct guidance, reducing confusion during deployment on Jetson devices.
- 🤝 Overall, this should make YOLO deployment on JetPack 6 more reliable, especially for users targeting optimized INT8 TensorRT inference.