### PR TITLE
`ultralytics 8.4.45` Fix pretrained checkpoint training regression

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -173,6 +173,7 @@ def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights)
     model.ckpt = {"checkpoint": True}
     model.ckpt_path = "/tmp/fake.pt"
     model.overrides["model"] = "ul://glenn-jocher/m2/exp-14"
+    model.overrides["pretrained"] = False
     original_model = model.model
     captured = {}
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -163,9 +163,11 @@ def test_nan_recovery():
     assert nan_injected[0], "NaN injection failed"
 
 
-@pytest.mark.parametrize("pretrained", [True, False, MODEL])
-def test_train_reuses_loaded_checkpoint_config(monkeypatch, pretrained):
-    """Test training reuses an already-loaded checkpoint config without forcing pretrained weights."""
+@pytest.mark.parametrize(
+    "kwargs,expected_weights", [({}, "model"), ({"pretrained": False}, None), ({"pretrained": MODEL}, "model")]
+)
+def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, expected_weights):
+    """Test training reuses loaded checkpoint config while respecting the pretrained argument."""
     model = YOLO("yolo26n.yaml")
     model.ckpt = {"checkpoint": True}
     model.ckpt_path = "/tmp/fake.pt"
@@ -198,15 +200,15 @@ def test_train_reuses_loaded_checkpoint_config(monkeypatch, pretrained):
         lambda path: (original_model, {"checkpoint": True}),
     )
 
-    model.train(data="coco8.yaml", epochs=1, pretrained=pretrained)
+    model.train(data="coco8.yaml", epochs=1, **kwargs)
 
     assert captured["trainer"].model is original_model, "Trainer model does not match original"
     assert captured["cfg"] == original_model.yaml, f"Config mismatch: {captured['cfg']} != {original_model.yaml}"
-    assert captured["weights"] is (None if pretrained is False else original_model), "Unexpected weights loaded"
+    assert captured["weights"] is (original_model if expected_weights == "model" else None), "Unexpected weights loaded"
 
 
-@pytest.mark.parametrize("pretrained", [False, MODEL])
-def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrained):
+@pytest.mark.parametrize("pretrained,expected_weights", [(True, "model"), (False, None), (MODEL, "model")])
+def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrained, expected_weights):
     """Test .pt models use checkpoint config while respecting the pretrained argument."""
     captured = {}
     checkpoint_model = SimpleNamespace(yaml={"nc": 80})
@@ -228,4 +230,4 @@ def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrain
     trainer.setup_model()
 
     assert captured["cfg"] == checkpoint_model.yaml, "Checkpoint config was not used"
-    assert captured["weights"] is (None if pretrained is False else checkpoint_model), "Unexpected weights loaded"
+    assert captured["weights"] is (checkpoint_model if expected_weights == "model" else None), "Unexpected weights loaded"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -165,7 +165,7 @@ def test_nan_recovery():
 
 @pytest.mark.parametrize(
     "kwargs,uses_weights",
-    [({}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)],
+    [({}, True), ({"pretrained": True}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)],
 )
 def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights):
     """Test training reuses loaded checkpoint config while respecting the pretrained argument."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -164,9 +164,9 @@ def test_nan_recovery():
 
 
 @pytest.mark.parametrize(
-    "kwargs,expected_weights", [({}, "model"), ({"pretrained": False}, None), ({"pretrained": MODEL}, "model")]
+    "kwargs,uses_weights", [({}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)]
 )
-def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, expected_weights):
+def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights):
     """Test training reuses loaded checkpoint config while respecting the pretrained argument."""
     model = YOLO("yolo26n.yaml")
     model.ckpt = {"checkpoint": True}
@@ -204,11 +204,11 @@ def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, expected_weig
 
     assert captured["trainer"].model is original_model, "Trainer model does not match original"
     assert captured["cfg"] == original_model.yaml, f"Config mismatch: {captured['cfg']} != {original_model.yaml}"
-    assert captured["weights"] is (original_model if expected_weights == "model" else None), "Unexpected weights loaded"
+    assert captured["weights"] is (original_model if uses_weights else None), "Unexpected weights loaded"
 
 
-@pytest.mark.parametrize("pretrained,expected_weights", [(True, "model"), (False, None), (MODEL, "model")])
-def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrained, expected_weights):
+@pytest.mark.parametrize("pretrained,uses_weights", [(True, True), (False, False), (MODEL, True)])
+def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrained, uses_weights):
     """Test .pt models use checkpoint config while respecting the pretrained argument."""
     captured = {}
     checkpoint_model = SimpleNamespace(yaml={"nc": 80})
@@ -230,4 +230,4 @@ def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrain
     trainer.setup_model()
 
     assert captured["cfg"] == checkpoint_model.yaml, "Checkpoint config was not used"
-    assert captured["weights"] is (checkpoint_model if expected_weights == "model" else None), "Unexpected weights loaded"
+    assert captured["weights"] is (checkpoint_model if uses_weights else None), "Unexpected weights loaded"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -230,4 +230,6 @@ def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrain
     trainer.setup_model()
 
     assert captured["cfg"] == checkpoint_model.yaml, "Checkpoint config was not used"
-    assert captured["weights"] is (checkpoint_model if expected_weights == "model" else None), "Unexpected weights loaded"
+    assert captured["weights"] is (checkpoint_model if expected_weights == "model" else None), (
+        "Unexpected weights loaded"
+    )

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.44"
+__version__ = "8.4.45"
 
 import importlib
 import os

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -767,6 +767,7 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train", "session": self.session}  # prioritizes rightmost args
+        pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
         if args.get("resume"):
             if args["resume"] is True:  # resume=True (boolean) uses current model as checkpoint
                 if self.ckpt and self.ckpt.get("epoch", -1) >= 0 and self.ckpt.get("optimizer") is not None:
@@ -782,7 +783,6 @@ class Model(torch.nn.Module):
         self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
         if not args.get("resume") and self.ckpt:
             # Reuse the already-loaded checkpoint model to avoid re-resolving remote weight sources during trainer setup.
-            pretrained = args.get("pretrained", True)
             weights = None if pretrained is False else self.model
             if isinstance(pretrained, (str, Path)):
                 weights, _ = load_checkpoint(pretrained)

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -781,10 +781,11 @@ class Model(torch.nn.Module):
 
         self.trainer = (trainer or self._smart_load("trainer"))(overrides=args, _callbacks=self.callbacks)
         if not args.get("resume") and self.ckpt:
-            # Reuse the already-loaded checkpoint config to avoid re-resolving remote sources during trainer setup.
-            weights = self.model if args.get("pretrained") else None
-            if isinstance(args.get("pretrained"), (str, Path)):
-                weights, _ = load_checkpoint(args["pretrained"])
+            # Reuse the already-loaded checkpoint model to avoid re-resolving remote weight sources during trainer setup.
+            pretrained = args.get("pretrained", True)
+            weights = None if pretrained is False else self.model
+            if isinstance(pretrained, (str, Path)):
+                weights, _ = load_checkpoint(pretrained)
             self.trainer.model = self.trainer.get_model(weights=weights, cfg=self.model.yaml)
             self.model = self.trainer.model
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -718,12 +718,10 @@ class BaseTrainer:
         if str(self.model).endswith(".pt"):
             weights, ckpt = load_checkpoint(self.model)
             cfg = weights.yaml
-            if isinstance(self.args.pretrained, (str, Path)):
-                weights, _ = load_checkpoint(self.args.pretrained)
-            elif self.args.pretrained is False and not self.resume:
-                weights = None
-        elif isinstance(self.args.pretrained, (str, Path)):
+        if isinstance(self.args.pretrained, (str, Path)):
             weights, _ = load_checkpoint(self.args.pretrained)
+        elif self.args.pretrained is False and not self.resume:
+            weights = None
         self.model = self.get_model(cfg=cfg, weights=weights, verbose=RANK in {-1, 0})  # calls Model(cfg, weights)
         return ckpt
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -720,7 +720,7 @@ class BaseTrainer:
             cfg = weights.yaml
             if isinstance(self.args.pretrained, (str, Path)):
                 weights, _ = load_checkpoint(self.args.pretrained)
-            elif not self.args.pretrained and not self.resume:
+            elif self.args.pretrained is False and not self.resume:
                 weights = None
         elif isinstance(self.args.pretrained, (str, Path)):
             weights, _ = load_checkpoint(self.args.pretrained)

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -84,7 +84,7 @@ class ClassificationTrainer(BaseTrainer):
             model.load(weights)
 
         for m in model.modules():
-            if not self.args.pretrained and hasattr(m, "reset_parameters"):
+            if self.args.pretrained is False and hasattr(m, "reset_parameters"):
                 m.reset_parameters()
             if isinstance(m, torch.nn.Dropout) and self.args.dropout:
                 m.p = self.args.dropout  # set dropout

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -84,6 +84,8 @@ class ClassificationTrainer(BaseTrainer):
             model.load(weights)
 
         for m in model.modules():
+            if not self.args.pretrained and hasattr(m, "reset_parameters"):
+                m.reset_parameters()
             if isinstance(m, torch.nn.Dropout) and self.args.dropout:
                 m.p = self.args.dropout  # set dropout
         for p in model.parameters():


### PR DESCRIPTION
## Summary
- restore default pretrained checkpoint loading for YOLO('*.pt').train() and CLI training
- only disable checkpoint weights when pretrained=False is explicitly provided
- preserve custom pretrained weight paths and restore classify scratch reset behavior
- bump version to 8.4.45 for hotfix release

## Root cause
PR #24374 used args.get('pretrained') in Model.train(), but that args dict omits pretrained when the user relies on the default. The missing key was treated as false, so YOLO('yolo26n.pt').train() built from checkpoint YAML without loading checkpoint weights.

## Tests
- pytest tests/test_engine.py -k 'train_reuses_loaded_checkpoint_model or setup_model_respects_pretrained_arg_for_pt_models'
- ruff check ultralytics/engine/model.py ultralytics/engine/trainer.py ultralytics/models/yolo/classify/train.py tests/test_engine.py
- git diff --check
- python - <<'PY'
from ultralytics import YOLO
YOLO('yolo26n.pt').train(data='coco8.yaml', epochs=1, imgsz=64, batch=2, workers=0, plots=False, save=False, val=False, device='cpu', verbose=True)
PY
- python -m ultralytics.cfg.__init__ train model=yolo26n.pt data=coco8.yaml epochs=1 imgsz=64 batch=2 workers=0 plots=False save=False val=False device=cpu verbose=True

Both real training smoke tests printed: Transferred 708/708 items from pretrained weights.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes how training handles `pretrained` models and checkpoints, ensuring Ultralytics reuses already-loaded models correctly while still honoring user choices about loading weights.

### 📊 Key Changes
- Updated training logic in `engine/model.py` to better handle the `pretrained` argument when a checkpoint is already loaded.
- Changed checkpoint reuse behavior to reuse the already-loaded **model weights** directly, instead of only reusing config data.
- Fixed `trainer.py` so `.pt` models now consistently respect `pretrained=True`, `pretrained=False`, or a custom weight path.
- Improved classification training so when `pretrained=False`, layers with `reset_parameters()` are explicitly reset to avoid accidental carryover of old weights.
- Expanded and refined tests in `tests/test_engine.py` to cover more `pretrained` cases, including:
  - default behavior
  - `pretrained=True`
  - `pretrained=False`
  - custom pretrained model paths
- Bumped the package version from `8.4.44` to `8.4.45` 📦

### 🎯 Purpose & Impact
- ✅ Makes training behavior more predictable when starting from YAML configs, `.pt` checkpoints, or remotely loaded models.
- 🚀 Avoids unnecessary reloading or re-resolving of checkpoint sources, which can improve reliability and reduce overhead.
- 🎛️ Gives users clearer control over whether training should use existing weights or start fresh.
- 🧠 Prevents unintended pretrained initialization in classification models when `pretrained=False` is requested.
- 🧪 Stronger tests reduce the chance of regressions in future training and checkpoint-loading changes.