### PR TITLE
Improve RKNN exports to highlight non-int8 supported chips

### DIFF
--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -94,13 +94,13 @@ For detailed instructions and best practices related to the installation process
 
 ### Export Arguments
 
-| Argument | Type             | Default    | Description                                                                                                                             |
-| -------- | ---------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `format` | `str`            | `'rknn'`   | Target format for the exported model, defining compatibility with various deployment environments.                                      |
-| `imgsz`  | `int` or `tuple` | `640`      | Desired image size for the model input. Can be an integer for square images or a tuple `(height, width)` for specific dimensions.       |
-| `batch`  | `int`            | `1`        | Specifies export model batch inference size or the max number of images the exported model will process concurrently in `predict` mode. |
+| Argument | Type             | Default    | Description                                                                                                                                                                         |
+| -------- | ---------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `format` | `str`            | `'rknn'`   | Target format for the exported model, defining compatibility with various deployment environments.                                                                                  |
+| `imgsz`  | `int` or `tuple` | `640`      | Desired image size for the model input. Can be an integer for square images or a tuple `(height, width)` for specific dimensions.                                                   |
+| `batch`  | `int`            | `1`        | Specifies export model batch inference size or the max number of images the exported model will process concurrently in `predict` mode.                                             |
 | `name`   | `str`            | `'rk3588'` | Specifies the Rockchip target. FP16-supported: rk3588, rk3576, rk3566, rk3568, rk3562, rk2118, rv1126b. INT8-only targets (rv1103, rv1106, rv1103b, rv1106b) are not yet supported. |
-| `device` | `str`            | `None`     | Specifies the device for exporting: GPU (`device=0`), CPU (`device=cpu`).                                                               |
+| `device` | `str`            | `None`     | Specifies the device for exporting: GPU (`device=0`), CPU (`device=cpu`).                                                                                                           |
 
 !!! tip
 

--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -14,7 +14,7 @@ When deploying computer vision models on embedded devices, especially those powe
 
 !!! note
 
-    This guide has been tested with [Radxa Rock 5B](https://radxa.com/products/rock5/5b/) which is based on Rockchip RK3588 and [Radxa Zero 3W](https://radxa.com/products/zeros/zero3w/) which is based on Rockchip RK3566. It is expected to work across other Rockchip-based devices that support [rknn-toolkit2](https://github.com/airockchip/rknn-toolkit2) such as RK3576, RK3568, RK3562, RV1103, RV1106, RV1103B, RV1106B, RK2118 and RV1126B.
+    This guide has been tested with [Radxa Rock 5B](https://radxa.com/products/rock5/5b/) which is based on Rockchip RK3588 and [Radxa Zero 3W](https://radxa.com/products/zeros/zero3w/) which is based on Rockchip RK3566. It is expected to work across other Rockchip-based devices that support [rknn-toolkit2](https://github.com/airockchip/rknn-toolkit2) such as RK3576, RK3568, RK3562, RK2118 and RV1126B. Targets that only support INT8 inference (RV1103, RV1106, RV1103B, RV1106B) are not yet supported because Ultralytics RKNN export currently produces FP16 models only.
 
 ## What is Rockchip?
 
@@ -80,7 +80,7 @@ For detailed instructions and best practices related to the installation process
         model = YOLO("yolo26n.pt")
 
         # Export the model to RKNN format
-        # 'name' can be one of rk3588, rk3576, rk3566, rk3568, rk3562, rv1103, rv1106, rv1103b, rv1106b, rk2118, rv1126b
+        # 'name' can be one of rk3588, rk3576, rk3566, rk3568, rk3562, rk2118, rv1126b (FP16). INT8-only targets rv1103, rv1106, rv1103b, rv1106b are not yet supported.
         model.export(format="rknn", name="rk3588")  # creates '/yolo26n_rknn_model'
         ```
 
@@ -88,7 +88,7 @@ For detailed instructions and best practices related to the installation process
 
         ```bash
         # Export a YOLO26n PyTorch model to RKNN format
-        # 'name' can be one of rk3588, rk3576, rk3566, rk3568, rk3562, rv1103, rv1106, rv1103b, rv1106b, rk2118, rv1126b
+        # 'name' can be one of rk3588, rk3576, rk3566, rk3568, rk3562, rk2118, rv1126b (FP16). INT8-only targets rv1103, rv1106, rv1103b, rv1106b are not yet supported.
         yolo export model=yolo26n.pt format=rknn name=rk3588 # creates '/yolo26n_rknn_model'
         ```
 
@@ -99,7 +99,7 @@ For detailed instructions and best practices related to the installation process
 | `format` | `str`            | `'rknn'`   | Target format for the exported model, defining compatibility with various deployment environments.                                      |
 | `imgsz`  | `int` or `tuple` | `640`      | Desired image size for the model input. Can be an integer for square images or a tuple `(height, width)` for specific dimensions.       |
 | `batch`  | `int`            | `1`        | Specifies export model batch inference size or the max number of images the exported model will process concurrently in `predict` mode. |
-| `name`   | `str`            | `'rk3588'` | Specifies the Rockchip model (rk3588, rk3576, rk3566, rk3568, rk3562, rv1103, rv1106, rv1103b, rv1106b, rk2118, rv1126b)                |
+| `name`   | `str`            | `'rk3588'` | Specifies the Rockchip target. FP16-supported: rk3588, rk3576, rk3566, rk3568, rk3562, rk2118, rv1126b. INT8-only targets (rv1103, rv1106, rv1103b, rv1106b) are not yet supported. |
 | `device` | `str`            | `None`     | Specifies the device for exporting: GPU (`device=0`), CPU (`device=cpu`).                                                               |
 
 !!! tip
@@ -230,7 +230,7 @@ RKNN models are specifically optimized for Rockchip platforms and their integrat
 
 ### What Rockchip platforms are supported for RKNN model deployment?
 
-The Ultralytics YOLO export to RKNN format supports a wide range of Rockchip platforms, including the popular RK3588, RK3576, RK3566, RK3568, RK3562, RV1103, RV1106, RV1103B, RV1106B, RK2118 and RV1126B. These platforms are commonly found in devices from manufacturers like Radxa, ASUS, Pine64, Orange Pi, Odroid, Khadas, and Banana Pi. This broad support ensures that you can deploy your optimized RKNN models on various Rockchip-powered devices, from single-board computers to industrial systems, taking full advantage of their AI acceleration capabilities for enhanced performance in your computer vision applications.
+The Ultralytics YOLO export to RKNN format currently supports Rockchip platforms with FP16 inference: RK3588, RK3576, RK3566, RK3568, RK3562, RK2118 and RV1126B. INT8-only targets (RV1103, RV1106, RV1103B, RV1106B) are not yet supported because their NPUs require quantization, which is on the roadmap. These platforms are commonly found in devices from manufacturers like Radxa, ASUS, Pine64, Orange Pi, Odroid, Khadas, and Banana Pi, allowing you to deploy your optimized RKNN models on a range of Rockchip-powered devices from single-board computers to industrial systems.
 
 ### How does the performance of RKNN models compare to other formats on Rockchip devices?
 

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -45,8 +45,8 @@ def onnx2rknn(
 
     if name in {"rv1103", "rv1106", "rv1103b", "rv1106b"}:
         raise RuntimeError(
-            f"Rockchip target '{name}' requires INT8 quantization, which is not yet supported by Ultralytics RKNN "
-            f"export (TODO). Use a target that supports FP build (e.g. rk3588, rk3576, rk3566, rk3568, rk3562)."
+            f"Rockchip target '{name}' requires INT8 quantization, which is not yet supported by Ultralytics RKNN. "
+            f"Use a target that supports FP16 builds (e.g. rk3588, rk3576, rk3566, rk3568, rk3562)."
         )
 
     rknn = RKNN(verbose=False)

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -43,6 +43,12 @@ def onnx2rknn(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    if name in {"rv1103", "rv1106", "rv1103b", "rv1106b"}:
+        raise RuntimeError(
+            f"Rockchip target '{name}' requires INT8 quantization, which is not yet supported by Ultralytics RKNN "
+            f"export (TODO). Use a target that supports FP build (e.g. rk3588, rk3576, rk3566, rk3568, rk3562)."
+        )
+
     rknn = RKNN(verbose=False)
     rknn.config(mean_values=[[0, 0, 0]], std_values=[[255, 255, 255]], target_platform=name)
     rknn.load_onnx(model=onnx_file)

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -26,7 +26,6 @@ def onnx2rknn(
     Returns:
         (str): Path to the exported ``_rknn_model`` directory.
     """
-
     if name in {"rv1103", "rv1106", "rv1103b", "rv1106b"}:
         raise ValueError(
             f"Rockchip target '{name}' requires INT8 quantization, which is not yet supported by Ultralytics RKNN. "

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -26,6 +26,13 @@ def onnx2rknn(
     Returns:
         (str): Path to the exported ``_rknn_model`` directory.
     """
+
+    if name in {"rv1103", "rv1106", "rv1103b", "rv1106b"}:
+        raise ValueError(
+            f"Rockchip target '{name}' requires INT8 quantization, which is not yet supported by Ultralytics RKNN. "
+            f"Use a target that supports FP16 builds (e.g. rk2118, rk3562, rk3566, rk3568, rk3576, rk3588, rv1126b)."
+        )
+
     from ultralytics.utils.checks import check_requirements
 
     LOGGER.info(f"\n{prefix} starting export with rknn-toolkit2...")
@@ -42,12 +49,6 @@ def onnx2rknn(
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-
-    if name in {"rv1103", "rv1106", "rv1103b", "rv1106b"}:
-        raise RuntimeError(
-            f"Rockchip target '{name}' requires INT8 quantization, which is not yet supported by Ultralytics RKNN. "
-            f"Use a target that supports FP16 builds (e.g. rk2118, rk3562, rk3566, rk3568, rk3576, rk3588, rv1126b)."
-        )
 
     rknn = RKNN(verbose=False)
     rknn.config(mean_values=[[0, 0, 0]], std_values=[[255, 255, 255]], target_platform=name)

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -46,7 +46,7 @@ def onnx2rknn(
     if name in {"rv1103", "rv1106", "rv1103b", "rv1106b"}:
         raise RuntimeError(
             f"Rockchip target '{name}' requires INT8 quantization, which is not yet supported by Ultralytics RKNN. "
-            f"Use a target that supports FP16 builds (e.g. rk3588, rk3576, rk3566, rk3568, rk3562)."
+            f"Use a target that supports FP16 builds (e.g. rk2118, rk3562, rk3566, rk3568, rk3576, rk3588, rv1126b)."
         )
 
     rknn = RKNN(verbose=False)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR clarifies and enforces current RKNN export support by blocking INT8-only Rockchip targets that Ultralytics does not yet support, while updating the documentation to match actual behavior.

### 📊 Key Changes
- 🛑 Added a runtime check in `ultralytics/utils/export/rknn.py` that raises a clear `ValueError` when users try to export for INT8-only Rockchip targets:
  - `rv1103`
  - `rv1106`
  - `rv1103b`
  - `rv1106b`
- 📝 Updated the [Rockchip RKNN integration docs](https://docs.ultralytics.com/integrations/rockchip-rknn/) to explicitly state that current Ultralytics RKNN export produces **FP16** models only.
- ✅ Narrowed the documented list of currently supported RKNN export targets to FP16-capable chips:
  - `rk3588`, `rk3576`, `rk3566`, `rk3568`, `rk3562`, `rk2118`, `rv1126b`
- 🔍 Revised code examples, argument tables, and FAQ text so documentation now matches the actual exporter limitations.
- 🗺️ Added roadmap context in the docs noting that INT8 quantization support is planned but not available yet.

### 🎯 Purpose & Impact
- 🎯 Prevents confusing export attempts that would fail or produce unsupported results on INT8-only Rockchip devices.
- 📚 Improves documentation accuracy, helping users choose compatible hardware and export targets more confidently.
- ⚠️ Gives clearer error messages, making troubleshooting easier for developers and embedded users.
- 🤝 Sets proper expectations for Rockchip deployment support today: FP16 targets work now, while INT8-only devices will need future quantization support.
- 🔧 Reduces support friction by aligning code behavior and docs, which should save users time during deployment on Rockchip platforms.