### PR TITLE
Fix docs strict validation warnings

### DIFF
--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -230,7 +230,7 @@ You can check using either the Ultralytics Python API or by inspecting the expor
         print(metadata.get("end2end"))  # 'True' if end-to-end is enabled
         ```
 
-Alternatively, check the output shape — end-to-end detection models output `(1, 300, 6)`, while traditional models output `(1, nc + 4, 8400)`. For other task shapes, see the [output shapes FAQ](#my-exported-onnx-model-outputs-1-300-6--is-that-correct).
+Alternatively, check the output shape — end-to-end detection models output `(1, 300, 6)`, while traditional models output `(1, nc + 4, 8400)`. For other task shapes, see the [output shapes FAQ](#my-exported-onnx-model-outputs-1-300-6-is-that-correct).
 
 ### Is end-to-end supported for segmentation, pose, and OBB tasks?
 

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -548,11 +548,9 @@ Explore more commands and usage examples in the full [CLI Guide](usage/cli.md).
 <!-- Article Links -->
 
 [Ultralytics Platform]: https://platform.ultralytics.com
-[API Key]: https://platform.ultralytics.com/settings
 [pip]: https://pypi.org/project/ultralytics/
 [DVC for experiment tracking]: https://dvc.org/doc/dvclive/ml-frameworks/yolo
 [Comet ML]: https://bit.ly/yolov8-readme-comet
-[Ultralytics Platform]: https://platform.ultralytics.com
 [ClearML]: ./integrations/clearml.md
 [MLFlow]: ./integrations/mlflow.md
 [Neptune]: https://neptune.ai/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,8 @@ validation:
     absolute_links: relative_to_docs
     anchors: warn
     unrecognized_links: warn
+    # Zensical treats bracketed examples like [0, 1] and [x1, y1, x2, y2] as shortcut references.
+    unresolved_references: false
 
 # Primary navigation ---------------------------------------------------------------------------------------------------
 not_in_nav: |


### PR DESCRIPTION
## Summary
- fix the end-to-end detection FAQ anchor link generated by Zensical
- remove duplicate/unused quickstart link definitions
- keep docs builds strict while disabling Zensical shortcut-reference validation for bracketed examples

## Validation
- `python docs/build_docs.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes small but important documentation and site-build fixes to improve link handling, reduce false warnings, and keep the docs cleaner and more reliable.

### 📊 Key Changes
- Fixed an internal FAQ anchor link in the end-to-end detection guide so it matches the actual section ID correctly 🔗
- Cleaned up duplicate and unused reference-style links in `docs/en/quickstart.md` 🧹
- Updated `mkdocs.yml` to disable unresolved reference warnings caused by bracketed examples like `[0, 1]` or `[x1, y1, x2, y2]` being misread as links ⚙️
- Added a clarifying comment in the MkDocs config explaining why unresolved references are turned off 💬

### 🎯 Purpose & Impact
- Improves documentation reliability by preventing broken in-page links in the rendered docs ✅
- Reduces noisy or misleading documentation build warnings, making maintenance easier for contributors 👨‍💻
- Helps avoid false link validation errors from common array or coordinate examples used in technical docs 📚
- Keeps the docs cleaner and easier to navigate for users, with no expected changes to model behavior or runtime functionality 🚀