### PR TITLE
`ultralytics 8.4.46` Fix `multiscale` minimum train size

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -163,19 +163,6 @@ def test_nan_recovery():
     assert nan_injected[0], "NaN injection failed"
 
 
-def test_multiscale_preprocess_clamps_min_size(monkeypatch):
-    """Test multi-scale preprocessing keeps resized images at least one stride."""
-    trainer = object.__new__(detect.DetectionTrainer)
-    trainer.args = SimpleNamespace(imgsz=320, multi_scale=0.9)
-    trainer.device = torch.device("cpu")
-    trainer.stride = 32
-    monkeypatch.setattr("ultralytics.models.yolo.detect.train.random.randrange", lambda start, end: start)
-
-    batch = trainer.preprocess_batch({"img": torch.zeros(1, 3, 320, 320)})
-
-    assert batch["img"].shape[-2:] == (32, 32)
-
-
 @pytest.mark.parametrize(
     "kwargs,uses_weights",
     [({}, True), ({"pretrained": True}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)],

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -163,6 +163,19 @@ def test_nan_recovery():
     assert nan_injected[0], "NaN injection failed"
 
 
+def test_multiscale_preprocess_clamps_min_size(monkeypatch):
+    """Test multi-scale preprocessing keeps resized images at least one stride."""
+    trainer = object.__new__(detect.DetectionTrainer)
+    trainer.args = SimpleNamespace(imgsz=320, multi_scale=0.9)
+    trainer.device = torch.device("cpu")
+    trainer.stride = 32
+    monkeypatch.setattr("ultralytics.models.yolo.detect.train.random.randrange", lambda start, end: start)
+
+    batch = trainer.preprocess_batch({"img": torch.zeros(1, 3, 320, 320)})
+
+    assert batch["img"].shape[-2:] == (32, 32)
+
+
 @pytest.mark.parametrize(
     "kwargs,uses_weights",
     [({}, True), ({"pretrained": True}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)],

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.45"
+__version__ = "8.4.46"
 
 import importlib
 import os

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -119,11 +119,10 @@ class DetectionTrainer(BaseTrainer):
         batch["img"] = batch["img"].float() / 255
         if self.args.multi_scale > 0.0:
             imgs = batch["img"]
-            min_imgsz = max(self.stride, int(self.args.imgsz * (1.0 - self.args.multi_scale)))
             sz = (
                 random.randrange(
-                    min_imgsz,
-                    int(self.args.imgsz * (1.0 + self.args.multi_scale) + self.stride),
+                    max(self.stride, int(self.args.imgsz * (1.0 - self.args.multi_scale))),  # min imgsz
+                    int(self.args.imgsz * (1.0 + self.args.multi_scale) + self.stride),  # max imgsz
                 )
                 // self.stride
                 * self.stride

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -119,9 +119,10 @@ class DetectionTrainer(BaseTrainer):
         batch["img"] = batch["img"].float() / 255
         if self.args.multi_scale > 0.0:
             imgs = batch["img"]
+            min_imgsz = max(self.stride, int(self.args.imgsz * (1.0 - self.args.multi_scale)))
             sz = (
                 random.randrange(
-                    int(self.args.imgsz * (1.0 - self.args.multi_scale)),
+                    min_imgsz,
                     int(self.args.imgsz * (1.0 + self.args.multi_scale) + self.stride),
                 )
                 // self.stride


### PR DESCRIPTION
## Summary
- clamp the multiscale random lower bound to at least one model stride
- add a regression test for aggressive multiscale shrinking on small image sizes

## Testing
- pytest tests/test_engine.py -k multiscale_preprocess_clamps_min_size
- ruff check ultralytics/models/yolo/detect/train.py tests/test_engine.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR fixes YOLO training multi-scale image resizing by enforcing a safe minimum image size, helping prevent invalid training dimensions.

### 📊 Key Changes
- Updated the package version from `8.4.45` to `8.4.46` 📦
- Adjusted multi-scale training logic in `ultralytics/models/yolo/detect/train.py` 🛠️
- Added a minimum bound for randomly selected training image sizes so they can never go below the model stride ⚠️
- Kept the existing upper bound behavior for multi-scale image resizing unchanged 📏

### 🎯 Purpose & Impact
- Prevents multi-scale training from choosing image sizes that are too small for the model to process reliably ✅
- Improves training stability, especially when using aggressive `multi_scale` settings 🚀
- Reduces the chance of stride-related resizing issues or unexpected behavior during detection training 🧩
- Delivers a small but useful robustness fix for users training YOLO models with variable image sizes 🎯