### PR TITLE
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: (needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.SlowTests.result == 'failure' || needs.GPU.result == 'failure' || needs.RaspberryPi.result == 'failure' || needs.NVIDIA_Jetson.result == 'failure' || needs.Conda.result == 'failure' ) && github.repository == 'ultralytics/ultralytics' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -303,7 +303,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: needs.docker.result == 'failure' && github.repository == 'ultralytics/ultralytics' && github.event_name == 'push' && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,7 +151,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -159,7 +159,7 @@ jobs:
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
       - name: Notify Failure
         if: needs.publish.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Slack notification action from `slackapi/slack-github-action@v3.0.2` to `v3.0.3` across Ultralytics CI, Docker, and publish workflows.

### 📊 Key Changes
- ⬆️ Upgraded the Slack GitHub Action in `.github/workflows/ci.yml` from `v3.0.2` to `v3.0.3`.
- ⬆️ Upgraded the same Slack action in `.github/workflows/docker.yml`.
- ⬆️ Updated both success and failure Slack notification steps in `.github/workflows/publish.yml`.
- 🛠️ No workflow logic, triggers, or notification content was changed—only the action version was bumped.

### 🎯 Purpose & Impact
- 🔐 Keeps Ultralytics GitHub Actions dependencies up to date with the latest patch release.
- 🚦 Helps improve the reliability and maintainability of Slack notifications for CI failures, Docker build failures, and package publishing events.
- 👥 Has little to no direct impact on end users, but benefits maintainers by reducing risk from outdated workflow dependencies.
- ✅ This is a low-risk maintenance update that supports smoother repository operations behind the scenes.