### PR TITLE
Return `None` in `imread` on read failure to match `cv2.imread`

### DIFF
--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -34,7 +34,7 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
     """
     try:
         file_bytes = np.fromfile(path, dtype=dtype)
-    except Exception as e:
+    except Exception:
         return None
     if filename.endswith((".tiff", ".tif")):
         success, frames = cv2.imdecodemulti(file_bytes, cv2.IMREAD_UNCHANGED)

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -32,7 +32,10 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
         >>> img = imread("path/to/image.jpg")
         >>> img = imread("path/to/image.jpg", cv2.IMREAD_GRAYSCALE)
     """
-    file_bytes = np.fromfile(filename, np.uint8)
+    try:
+        file_bytes = np.fromfile(path, dtype=dtype)
+    except Exception as e:
+        return None
     if filename.endswith((".tiff", ".tif")):
         success, frames = cv2.imdecodemulti(file_bytes, cv2.IMREAD_UNCHANGED)
         if success:

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -34,7 +34,7 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
     """
     try:
         file_bytes = np.fromfile(filename, np.uint8)
-    except Exception:
+    except (FileNotFoundError, OSError):
         return None
     if filename.endswith((".tiff", ".tif")):
         success, frames = cv2.imdecodemulti(file_bytes, cv2.IMREAD_UNCHANGED)

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -33,7 +33,7 @@ def imread(filename: str, flags: int = cv2.IMREAD_COLOR) -> np.ndarray | None:
         >>> img = imread("path/to/image.jpg", cv2.IMREAD_GRAYSCALE)
     """
     try:
-        file_bytes = np.fromfile(path, dtype=dtype)
+        file_bytes = np.fromfile(filename, np.uint8)
     except Exception:
         return None
     if filename.endswith((".tiff", ".tif")):


### PR DESCRIPTION
Closes #24405 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes image loading more robust by safely handling missing or inaccessible files in `imread()` and returning `None` instead of raising an error.

### 📊 Key Changes
- Added a `try/except` block around `np.fromfile()` in `ultralytics/utils/patches.py`.
- `imread()` now catches `FileNotFoundError` and `OSError` when reading image bytes.
- If a file cannot be found or opened, the function returns `None` gracefully.
- Existing TIFF and multi-frame decoding behavior remains unchanged. 📷

### 🎯 Purpose & Impact
- Improves stability when working with invalid, missing, or broken image paths. ✅
- Prevents unexpected crashes during data loading or inference pipelines. 🚦
- Makes `imread()` behavior more consistent with common image-loading patterns that return `None` on failure.
- Helps developers and users build more fault-tolerant applications on top of Ultralytics, especially in large-scale or automated workflows. 🤖