### PR TITLE
Run Python dependency updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
       time: "04:00"
     open-pull-requests-limit: 10
     labels:


### PR DESCRIPTION
## Summary
- change Dependabot `pip` updates from daily to monthly
- leave GitHub Actions dependency update cadence unchanged

## Validation
- `git diff --check -- .github/dependabot.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📅 This PR reduces Dependabot update frequency for Python packages in `ultralytics/ultralytics` from **daily** to **monthly**.

### 📊 Key Changes
- Updated `.github/dependabot.yml` for the `pip` ecosystem at the repository root.
- Changed Dependabot’s scheduled update interval from `daily` to `monthly`.
- Kept the existing update time, PR limit, and labels unchanged.

### 🎯 Purpose & Impact
- Reduces the number of automated dependency update PRs opened in the repository 📉
- Helps maintainers spend less time reviewing routine dependency bumps and more time on important code changes 🛠️
- May lower CI workload and notification noise for the team 🔕
- Dependency updates will arrive less often, which can simplify repo maintenance but may delay some package version bumps slightly ⏳