### PR TITLE
Fix benchmarks passing unsupported `data` arg to export formats

### DIFF
--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -126,7 +126,7 @@ def benchmark(
     if format_arg:
         formats = frozenset(export_formats()["Argument"])
         assert format in formats, f"Expected format to be one of {formats}, but got '{format_arg}'."
-    for name, format, suffix, cpu, gpu, _ in zip(*export_formats().values()):
+    for name, format, suffix, cpu, gpu, valid_args in zip(*export_formats().values()):
         emoji, filename = "❌", None  # export defaults
         try:
             if format_arg and format_arg != format:
@@ -185,8 +185,9 @@ def benchmark(
                 filename = model.pt_path or model.ckpt_path or model.model_name
                 exported_model = deepcopy(model)  # PyTorch format
             else:
+                export_data = data if "data" in valid_args else None
                 filename = deepcopy(model).export(
-                    imgsz=imgsz, format=format, half=half, int8=int8, data=data, device=device, verbose=False, **kwargs
+                    imgsz=imgsz, format=format, half=half, int8=int8, data=export_data, device=device, verbose=False, **kwargs
                 )
                 exported_model = YOLO(filename, task=model.task)
                 assert suffix in str(filename), "export failed"

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -187,7 +187,14 @@ def benchmark(
             else:
                 export_data = data if "data" in valid_args else None
                 filename = deepcopy(model).export(
-                    imgsz=imgsz, format=format, half=half, int8=int8, data=export_data, device=device, verbose=False, **kwargs
+                    imgsz=imgsz,
+                    format=format,
+                    half=half,
+                    int8=int8,
+                    data=export_data,
+                    device=device,
+                    verbose=False,
+                    **kwargs,
                 )
                 exported_model = YOLO(filename, task=model.task)
                 assert suffix in str(filename), "export failed"


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves benchmark export reliability by only passing the `data` argument to model export formats that actually support it.

### 📊 Key Changes
- Updated `ultralytics/utils/benchmarks.py` to read each export format’s supported arguments (`valid_args`) from `export_formats()`.
- Added a check so `data` is only included during export when the target format supports it.
- Kept existing benchmark behavior the same for PyTorch models, while making non-PyTorch export calls safer and more format-aware.
- Refactored the export call slightly for better clarity and maintainability.

### 🎯 Purpose & Impact
- ✅ Prevents benchmark/export failures caused by passing unsupported `data` arguments to certain formats.
- 🚀 Makes benchmarking more robust across different export targets, especially when testing multiple formats automatically.
- 🔍 Reduces format-specific errors and improves compatibility without changing the user-facing workflow.
- 🧹 Helps keep the export pipeline cleaner and easier to extend as new formats or arguments are added.