### PR TITLE
docs: Add SyncBatchNorm example to custom trainer guide

### DIFF
--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -1,20 +1,21 @@
 ---
 comments: true
-description: Learn how to customize the Ultralytics YOLO trainer with custom metrics, class-weighted loss, custom model saving, backbone freezing, and per-layer learning rates.
-keywords: Ultralytics, YOLO, Custom Trainer, DetectionTrainer, BaseTrainer, Custom Metrics, F1 Score, Class Weights, Backbone Freezing, Per-Layer Learning Rate, Fine-Tuning, Transfer Learning
+description: Learn how to customize the Ultralytics YOLO trainer with custom metrics, class-weighted loss, custom model saving, backbone freezing, per-layer learning rates, and SyncBatchNorm.
+keywords: Ultralytics, YOLO, Custom Trainer, DetectionTrainer, BaseTrainer, Custom Metrics, F1 Score, Class Weights, Backbone Freezing, Per-Layer Learning Rate, SyncBatchNorm, Multi-GPU Training, Fine-Tuning, Transfer Learning
 ---
 
 # Customizing Trainer
 
 The Ultralytics training pipeline is built around `BaseTrainer` and task-specific trainers like `DetectionTrainer`. These classes handle the training loop, validation, checkpointing, and logging out of the box. When you need more control — tracking custom metrics, adjusting loss weighting, or implementing learning rate schedules — you can subclass the trainer and override specific methods.
 
-This guide walks through five common customizations:
+This guide walks through six common customizations:
 
 1. [Logging custom metrics (F1 score)](#logging-custom-metrics) at the end of each [epoch](https://www.ultralytics.com/glossary/epoch)
 2. [Adding class weights](#adding-class-weights) to handle class imbalance
 3. [Saving the best model](#saving-the-best-model-by-custom-metric) based on a different metric
 4. [Freezing the backbone](#freezing-and-unfreezing-the-backbone) for the first N epochs, then unfreezing
 5. [Specifying per-layer learning rates](#per-layer-learning-rates)
+6. [Synchronizing BatchNorm across GPUs](#synchronized-batchnorm-for-multi-gpu-training) for multi-GPU training
 
 !!! tip "Prerequisites"
 
@@ -321,6 +322,43 @@ model.train(data="coco8.yaml", epochs=20, trainer=PerLayerLRTrainer)
 !!! tip "Combining Techniques"
 
     These customizations can be combined into a single trainer class by overriding multiple methods and adding callbacks as needed.
+
+## Synchronized BatchNorm for Multi-GPU Training
+
+When training on multiple GPUs with DistributedDataParallel, the default `BatchNorm2d` layers compute statistics independently on each GPU. For RT-DETR fine-tuning and other recipes that use small per-GPU batch sizes, per-GPU batch statistics can be noisy. PyTorch's `SyncBatchNorm` synchronizes mean and variance across all ranks for a single global batch statistic, which often improves convergence at the cost of a small inter-GPU communication overhead.
+
+The conversion has to happen after the model is on the GPU but before DDP wraps it. The cleanest hook for this is `set_model_attributes()`, which `BaseTrainer` calls in exactly that window:
+
+```python
+from torch import nn
+
+from ultralytics import RTDETR
+from ultralytics.models.rtdetr.train import RTDETRTrainer
+
+
+class SyncBNTrainer(RTDETRTrainer):
+    """RT-DETR trainer that converts BatchNorm to SyncBatchNorm for multi-GPU training."""
+
+    def set_model_attributes(self):
+        """Run the parent setup, then convert BN to SyncBatchNorm when training on multiple GPUs."""
+        super().set_model_attributes()
+        if self.world_size > 1:
+            self.model = nn.SyncBatchNorm.convert_sync_batchnorm(self.model)
+
+
+model = RTDETR("rtdetr-l.pt")
+model.train(data="coco8.yaml", epochs=20, device=[0, 1], trainer=SyncBNTrainer)
+```
+
+The `world_size > 1` guard ensures the trainer is safe to use in single-GPU runs as well; on a single GPU the conversion is skipped and training proceeds with regular `BatchNorm2d`. The same pattern works for YOLO by switching the parent class to `DetectionTrainer`.
+
+!!! tip "When to use SyncBatchNorm"
+
+    | Scenario                                       | Recommendation           |
+    | ---------------------------------------------- | ------------------------ |
+    | Multi-GPU training, small per-GPU batch (≤ 16) | Enable                   |
+    | Multi-GPU training, large per-GPU batch (≥ 32) | Optional; minor benefit  |
+    | Single-GPU training                            | Not applicable (skipped) |
 
 ## FAQ
 


### PR DESCRIPTION
Shows how to subclass RTDETRTrainer to convert BatchNorm to SyncBatchNorm before DDP wraps the model, useful for multi-GPU fine-tuning with small per-GPU batches.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

Adds a `## Synchronized BatchNorm for Multi-GPU Training` section to the custom trainer guide showing how to subclass `RTDETRTrainer` and override `set_model_attributes()` to convert BatchNorm to SyncBatchNorm before DDP wraps the model. The conversion is gated by a `world_size > 1` guard so the same trainer is safe in single-GPU runs, and the change is docs-only with no library or `default.yaml` modifications.

```python
from torch import nn

from ultralytics import RTDETR
from ultralytics.models.rtdetr.train import RTDETRTrainer


class SyncBNTrainer(RTDETRTrainer):
    """RT-DETR trainer with SyncBatchNorm for multi-GPU training."""

    def set_model_attributes(self):
        super().set_model_attributes()
        if self.world_size > 1:
            self.model = nn.SyncBatchNorm.convert_sync_batchnorm(self.model)


RTDETR("rtdetr-l.pt").train(data="coco8.yaml", epochs=20, device=[0, 1], trainer=SyncBNTrainer)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR expands the custom trainer guide by adding a new example for using `SyncBatchNorm` in multi-GPU training, helping users improve training stability in small-batch distributed setups.

### 📊 Key Changes
- Added a **sixth customization example** to the [custom trainer guide](https://github.com/ultralytics/ultralytics/blob/main/docs/en/guides/custom-trainer.md): **Synchronized BatchNorm for Multi-GPU Training** 🚀
- Updated the guide’s **description and keywords** to include `SyncBatchNorm` and **multi-GPU training** for better discoverability 🔍
- Documented **when and why** to use `SyncBatchNorm`, especially for **RT-DETR fine-tuning** and other cases with **small per-GPU batch sizes**
- Included a practical code example showing how to:
  - subclass `RTDETRTrainer`
  - override `set_model_attributes()`
  - convert `BatchNorm` layers to `SyncBatchNorm` only when `world_size > 1` 🛠️
- Added a simple recommendation table covering:
  - small-batch multi-GPU training ✅
  - large-batch multi-GPU training ⚖️
  - single-GPU training 🚫

### 🎯 Purpose & Impact
- Helps users better understand **how to customize training for distributed multi-GPU workloads** 🤝
- Improves documentation for **advanced training setups**, especially for users fine-tuning RT-DETR or similar models with limited batch size per GPU
- Gives a **safe, reusable implementation pattern** that avoids applying `SyncBatchNorm` in single-GPU runs
- Can lead to **more stable convergence and better training behavior** in the right scenarios, with the tradeoff of a small communication overhead 📈
- Makes the custom trainer docs more complete and practical for both **researchers and production users** using Ultralytics training workflows ✨