### PR TITLE
Fix Platform `bestEpoch` reporting wrong value at training_complete

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -505,12 +505,15 @@ def on_train_end(trainer):
     names = getattr(getattr(trainer, "validator", None), "names", None) or (trainer.data or {}).get("names")
     class_names = list(names.values()) if isinstance(names, dict) else list(names) if names else None
 
+    # stopper.best_epoch is 1-indexed; -1 aligns with the 0-indexed `epoch` field
+    best_epoch = max(0, getattr(getattr(trainer, "stopper", None), "best_epoch", trainer.epoch + 1) - 1)
+
     _send(
         "training_complete",
         {
             "results": {
                 "metrics": {**trainer.metrics, "fitness": trainer.fitness},
-                "bestEpoch": getattr(trainer, "best_epoch", trainer.epoch),
+                "bestEpoch": best_epoch,
                 "bestFitness": trainer.best_fitness,
                 "modelPath": gcs_path,  # Only send GCS path, not local path
                 "modelSize": model_size,


### PR DESCRIPTION
## Summary

The Platform `training_complete` payload has been reporting the **stop epoch** (last trained epoch) as `bestEpoch` instead of the actual best epoch. Root cause: `getattr(trainer, "best_epoch", trainer.epoch)` looks for an attribute that doesn't exist on the trainer — `best_epoch` lives on `trainer.stopper` (the `EarlyStopping` instance) — so the `getattr` always silently fell back to `trainer.epoch`.



## Fix

Read from `trainer.stopper.best_epoch` (1-indexed inside `EarlyStopping`) and subtract 1 to align with the 0-indexed `epoch` field used elsewhere in the same payload. Defensive `getattr` shape preserved; clamp at 0 covers runs that complete without ever recording a best.

```python
# stopper.best_epoch is 1-indexed; -1 aligns with the 0-indexed `epoch` field
best_epoch = max(0, getattr(getattr(trainer, "stopper", None), "best_epoch", trainer.epoch + 1) - 1)
```


## Out of scope

**Resume scenarios.** On resume, `_setup_train` builds a fresh `EarlyStopping`, so `stopper.best_epoch` resets to 0. This affects:

- Local CLI users (`yolo train resume=True`) — pre-existing latent bug, not Platform-visible.
- Future Platform "resume run" UI — does not exist today (`grep -rn "resume" apps/alpha | grep train` returns nothing in the training launch flow).

A larger PR with stopper-state persistence in checkpoints can land separately if/when resume becomes a Platform feature.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Normal run, best at epoch 30, stops at 50 | `bestEpoch=50` ❌ | `bestEpoch=30` ✓ |
| Normal run, never improves | `bestEpoch=49` (last epoch) | `bestEpoch=0`, `bestFitness=0` ✓ |
| Run with NaN recovery | wrong (still falls back to stop epoch) | correct (stopper preserved across recovery) ✓ |
| `trainer.stopper` somehow missing | falls back to `trainer.epoch` | falls back to `trainer.epoch` ✓ identical |


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes how the best training epoch is reported to the Ultralytics Platform callback, making end-of-training results more accurate.

### 📊 Key Changes
- Updated `on_train_end()` in `ultralytics/utils/callbacks/platform.py` to calculate `bestEpoch` from `trainer.stopper.best_epoch` instead of relying on `trainer.best_epoch` or the current epoch.
- Added a correction for indexing differences:
  - `stopper.best_epoch` is treated as 1-indexed
  - the reported `epoch` field is 0-indexed
- Added a safety guard with `max(0, ...)` to prevent invalid negative epoch values.
- The `training_complete` payload sent to the platform now reports a more reliable `bestEpoch` value 📡

### 🎯 Purpose & Impact
- Improves accuracy of training summaries sent to the Ultralytics Platform ✅
- Helps users see the true best-performing epoch instead of a potentially shifted or incorrect one 📈
- Reduces confusion when reviewing training results, early stopping behavior, or model performance history 🔍
- Makes downstream dashboards, logs, and integrations more consistent and trustworthy for both developers and end users 🤝