### PR TITLE
Fix duplicate `data` argument in `benchmark` call

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -196,6 +196,9 @@ abi@ultralytics.com:
 abirami.vina@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/25847604?v=4
   username: abirami-vina
+afaisal.bese21seecs@seecs.edu.pk:
+  avatar: https://avatars.githubusercontent.com/u/115661779?v=4
+  username: AffanBinFaisal
 ahmelsamahy@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/10195309?v=4
   username: Ahelsamahy

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -654,7 +654,7 @@ class Model(torch.nn.Module):
         custom = {"verbose": False}  # method defaults
         args = {**DEFAULT_CFG_DICT, **self.model.args, **custom, **kwargs, "mode": "benchmark"}
         fmts = export_formats()
-        export_args = set(dict(zip(fmts["Argument"], fmts["Arguments"])).get(format, [])) - {"batch"}
+        export_args = set(dict(zip(fmts["Argument"], fmts["Arguments"])).get(format, [])) - {"batch", "data"}
         export_kwargs = {k: v for k, v in args.items() if k in export_args}
         return benchmark(
             model=self,


### PR DESCRIPTION
Fixes #24449 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes model benchmarking argument handling by preventing the `data` parameter from being incorrectly passed to export formats, while also adding a new GitHub author entry for documentation attribution.

### 📊 Key Changes
- Updated `benchmark()` in `ultralytics/engine/model.py` to exclude `data` from export-specific arguments during benchmarking.
- Previously, only `batch` was filtered out; now both `batch` and `data` are excluded from `export_kwargs`.
- Added a new contributor entry in `docs/mkdocs_github_authors.yaml` for GitHub user @AffanBinFaisal with avatar and username metadata. 👤

### 🎯 Purpose & Impact
- Improves benchmarking reliability by ensuring dataset-related arguments are not mistakenly forwarded to export backends. ✅
- Helps avoid potential errors or unexpected behavior when benchmarking models across different export formats. 🚀
- Makes the benchmarking pipeline cleaner and more format-aware, especially for users testing model export performance.
- Enhances documentation contributor tracking by properly crediting a new author. 🙌