### PR TITLE
Fix docs language banner links

### DIFF
--- a/docs/en/datasets/explorer/explorer.md
+++ b/docs/en/datasets/explorer/explorer.md
@@ -9,6 +9,9 @@ keywords: Ultralytics Explorer, data exploration, semantic search, vector simila
 <div align="center">
 
 <a href="https://www.ultralytics.com/events/yolovision" target="_blank"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-yolov8-banner.avif" alt="Ultralytics YOLO banner"></a>
+</div>
+
+<p align="center">
 <a href="https://docs.ultralytics.com/zh">中文</a> |
 <a href="https://docs.ultralytics.com/ko">한국어</a> |
 <a href="https://docs.ultralytics.com/ja">日本語</a> |
@@ -20,8 +23,9 @@ keywords: Ultralytics Explorer, data exploration, semantic search, vector simila
 <a href="https://docs.ultralytics.com/tr">Türkçe</a> |
 <a href="https://docs.ultralytics.com/vi">Tiếng Việt</a> |
 <a href="https://docs.ultralytics.com/ar">العربية</a>
-<br>
+</p>
 
+<div align="center">
 <br>
     <a href="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml/badge.svg" alt="Ultralytics CI"></a>
     <a href="https://clickpy.clickhouse.com/dashboard/ultralytics"><img src="https://static.pepy.tech/badge/ultralytics" alt="Ultralytics Downloads"></a>

--- a/docs/en/datasets/explorer/explorer.md
+++ b/docs/en/datasets/explorer/explorer.md
@@ -9,6 +9,7 @@ keywords: Ultralytics Explorer, data exploration, semantic search, vector simila
 <div align="center">
 
 <a href="https://www.ultralytics.com/events/yolovision" target="_blank"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-yolov8-banner.avif" alt="Ultralytics YOLO banner"></a>
+
 </div>
 
 <p align="center">

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -8,6 +8,9 @@ keywords: Ultralytics, YOLO, YOLO26, YOLO11, object detection, image segmentatio
 <br><br>
 <a href="https://platform.ultralytics.com/ultralytics/yolo26?utm_source=docs&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=ultralytics_docs" target="_blank"><img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
 <br><br>
+</div>
+
+<p align="center">
 <a href="https://docs.ultralytics.com/zh">中文</a> ·
 <a href="https://docs.ultralytics.com/ko">한국어</a> ·
 <a href="https://docs.ultralytics.com/ja">日本語</a> ·
@@ -19,7 +22,10 @@ keywords: Ultralytics, YOLO, YOLO26, YOLO11, object detection, image segmentatio
 <a href="https://docs.ultralytics.com/tr">Türkçe</a> ·
 <a href="https://docs.ultralytics.com/vi">Tiếng Việt</a> ·
 <a href="https://docs.ultralytics.com/ar">العربية</a>
-<br><br>
+</p>
+
+<div align="center">
+<br>
     <a href="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml/badge.svg" alt="Ultralytics CI"></a>
     <a href="https://clickpy.clickhouse.com/dashboard/ultralytics"><img src="https://static.pepy.tech/badge/ultralytics" alt="Ultralytics Downloads"></a>
     <a href="https://zenodo.org/badge/latestdoi/264818686"><img src="https://zenodo.org/badge/264818686.svg" alt="Ultralytics YOLO Citation"></a>


### PR DESCRIPTION
## Summary
- move homepage language links into their own centered paragraph below the docs banner
- apply the same fix to the Explorer VOC page language links
- keep badge blocks and banner assets unchanged

## Validation
- git diff --check -- docs/en/index.md docs/en/datasets/explorer/explorer.md
- mkdocs build --clean (completed; existing unrelated config/nav/plugin warnings remain)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small HTML/Markdown layout fixes in the Ultralytics docs to improve how the homepage and Explorer dataset pages render language links and badges.

### 📊 Key Changes
- Adjusted the HTML structure in `docs/en/index.md` to better separate:
  - the top banner
  - the language selection links
  - the project badges
- Made similar formatting updates in `docs/en/datasets/explorer/explorer.md`.
- Replaced inline line breaks with clearer block structure using:
  - `</div>`
  - `<p align="center">`
  - a new centered `<div>` wrapper for badges and spacing
- Improved the visual grouping of multilingual links so they sit in their own centered paragraph instead of being mixed into the surrounding layout.

### 🎯 Purpose & Impact
- ✅ Improves documentation page layout and consistency across key docs pages.
- 🌍 Makes multilingual navigation links cleaner and easier to read for global users.
- 🎨 Helps banners, language links, and badges render more predictably across browsers and documentation builds.
- 🔧 This is a docs-only change, so it should have no impact on model training, inference, or Ultralytics package behavior.
- 📚 Overall, it polishes the user experience for readers landing on the docs homepage or Explorer documentation.