### PR TITLE
Fix dtype mismatch in `fuse_conv_and_bn` and `fuse_deconv_and_bn`

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -286,7 +286,11 @@ def fuse_conv_and_bn(conv, bn):
     conv.weight.data = torch.mm(w_bn, w_conv).view(conv.weight.shape)
 
     # Compute fused bias
-    b_conv = torch.zeros(conv.out_channels, device=conv.weight.device) if conv.bias is None else conv.bias
+    b_conv = (
+        torch.zeros(conv.out_channels, device=conv.weight.device, dtype=conv.weight.dtype)
+        if conv.bias is None
+        else conv.bias
+    )
     b_bn = bn.bias - bn.weight.mul(bn.running_mean).div(torch.sqrt(bn.running_var + bn.eps))
     fused_bias = torch.mm(w_bn, b_conv.reshape(-1, 1)).reshape(-1) + b_bn
 
@@ -319,7 +323,11 @@ def fuse_deconv_and_bn(deconv, bn):
     deconv.weight.data = torch.mm(w_bn, w_deconv).view(deconv.weight.shape)
 
     # Compute fused bias
-    b_conv = torch.zeros(deconv.out_channels, device=deconv.weight.device) if deconv.bias is None else deconv.bias
+    b_conv = (
+        torch.zeros(deconv.out_channels, device=deconv.weight.device, dtype=deconv.weight.dtype)
+        if deconv.bias is None
+        else deconv.bias
+    )
     b_bn = bn.bias - bn.weight.mul(bn.running_mean).div(torch.sqrt(bn.running_var + bn.eps))
     fused_bias = torch.mm(w_bn, b_conv.reshape(-1, 1)).reshape(-1) + b_bn
 


### PR DESCRIPTION
## Summary

`fuse_conv_and_bn` and `fuse_deconv_and_bn` in `ultralytics/utils/torch_utils.py` built the bias placeholder with `torch.zeros(out_channels, device=weight.device)`, which defaults to `float32`. When the model was cast to `bfloat16` or `float16` before `fuse()`, the subsequent `torch.mm(w_bn, b_conv.reshape(-1, 1))` raised `RuntimeError: expected m1 and m2 to have the same dtype`. Passing `dtype=weight.dtype` to the placeholder restores dtype parity and unblocks `model.to(torch.bfloat16).fuse()` and `model.to(torch.float16).fuse()`.

Verified empirically on `float32`, `float16`, `bfloat16` across both fuse paths (with and without bias). Outputs match the unfused reference within dtype precision, and the end-to-end `YOLO('yolo11n.pt').model.to(torch.bfloat16).fuse()` repro now succeeds.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes a dtype consistency issue in batch normalization fusion so fused Conv/Deconv layers work more reliably, especially with non-default precision settings.

### 📊 Key Changes
- Updated `fuse_conv_and_bn()` in `ultralytics/utils/torch_utils.py` to create zero bias tensors with the same `dtype` as the convolution weights when no bias exists.
- Updated `fuse_deconv_and_bn()` with the same fix for deconvolution layers.
- Previously, missing bias tensors were created only with the correct device, but not explicitly with the correct data type.

### 🎯 Purpose & Impact
- ✅ Prevents potential dtype mismatches during Conv+BN and Deconv+BN fusion.
- ⚡ Improves stability for inference optimization workflows that rely on fused layers.
- 🎯 Helps models behave more consistently when using mixed precision or lower-precision datatypes.
- 🔧 Reduces the chance of subtle runtime issues in deployment and export scenarios.