### PR TITLE
Remove Weglot docs overrides

### DIFF
--- a/docs/overrides/javascript/extra.js
+++ b/docs/overrides/javascript/extra.js
@@ -1,43 +1,5 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-// Block sitemap.xml fetches triggered by Weglot's hreflang tags detected by MkDocs Material
-(() => {
-  const EMPTY_SITEMAP = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`;
-
-  const originalFetch = window.fetch;
-  window.fetch = function (url, options) {
-    if (typeof url === "string" && url.includes("/sitemap.xml")) {
-      return Promise.resolve(
-        new Response(EMPTY_SITEMAP, { status: 200, headers: { "Content-Type": "application/xml" } }),
-      );
-    }
-    return originalFetch.apply(this, arguments);
-  };
-
-  const originalXHROpen = XMLHttpRequest.prototype.open;
-  XMLHttpRequest.prototype.open = function (method, url) {
-    if (typeof url === "string" && url.includes("/sitemap.xml")) {
-      this._blockRequest = true;
-    }
-    return originalXHROpen.apply(this, arguments);
-  };
-
-  const originalXHRSend = XMLHttpRequest.prototype.send;
-  XMLHttpRequest.prototype.send = function () {
-    if (this._blockRequest) {
-      Object.defineProperty(this, "status", { value: 200 });
-      Object.defineProperty(this, "responseText", { value: EMPTY_SITEMAP });
-      Object.defineProperty(this, "response", { value: EMPTY_SITEMAP });
-      Object.defineProperty(this, "responseXML", {
-        value: new DOMParser().parseFromString(EMPTY_SITEMAP, "application/xml"),
-      });
-      this.dispatchEvent(new Event("load"));
-      return;
-    }
-    return originalXHRSend.apply(this, arguments);
-  };
-})();
-
 // Apply theme colors based on dark/light mode
 const applyTheme = (isDark) => {
   document.body.setAttribute("data-md-color-scheme", isDark ? "slate" : "default");

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -357,11 +357,3 @@ div.highlight {
 .md-typeset a {
   text-decoration: none;
 }
-
-/* Remove language switcher */
-.weglot-container,
-.weglot_switcher,
-[id^="weglot-switcher"],
-.weglot-container[id^="weglot-switcher"] {
-  display: none;
-}


### PR DESCRIPTION
## Summary
- remove the old Weglot switcher CSS kill-switch from docs styles
- remove the Weglot sitemap request shim from docs JavaScript overrides

## Tests
- `rg -n "Weglot|weglot|WEGLOT|weglot-container|weglot_switcher|weglot-switcher" docs/overrides -S` (no matches)
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR simplifies the Ultralytics docs frontend by removing custom Weglot-related sitemap request blocking and language-switcher hiding code.

### 📊 Key Changes
- Removed JavaScript in `docs/overrides/javascript/extra.js` that intercepted `fetch` and `XMLHttpRequest` calls to block `/sitemap.xml` requests.
- Deleted the fallback logic that returned an empty sitemap response when those requests were detected.
- Removed CSS in `docs/overrides/stylesheets/style.css` that forcibly hid Weglot language switcher elements.
- Left the rest of the docs theme behavior unchanged, including the dark/light mode theme handling.

### 🎯 Purpose & Impact
- ✅ Reduces custom frontend hacks, making the docs codebase cleaner and easier to maintain.
- 🔧 Lowers the risk of unintended side effects from overriding browser network behavior globally.
- 🌍 Allows Weglot-related UI elements, such as the language switcher, to appear normally instead of being hidden by CSS.
- 📘 Helps keep the documentation site behavior more standard and predictable for users and developers alike.