### PR TITLE
Warn that exported YOLOE models are static

### DIFF
--- a/docs/en/models/yoloe.md
+++ b/docs/en/models/yoloe.md
@@ -482,6 +482,10 @@ Model validation on a dataset is streamlined as follows:
 
 The export process is similar to other YOLO models, with the added flexibility of handling text and visual prompts:
 
+!!! warning "Exported models are static"
+
+    Classes configured with `set_classes()` (or via `refer_image` for visual prompts) are baked into the exported weights. Once exported, the model can no longer accept new prompts: calling `set_classes()` or passing `visual_prompts=...` to `predict()` on a loaded export will fail. To change the detected classes, re-export from the original `.pt` checkpoint with the new prompts configured. The exported file behaves like a standard YOLO detector and can also be loaded with `YOLO()` instead of `YOLOE()`.
+
 !!! example
 
     ```python


### PR DESCRIPTION
## summary

adds a warning to the yoloe export usage section explaining that classes configured before export are baked into the weights. once exported, the model cannot accept new text or visual prompts; calling `set_classes()` or passing `visual_prompts` to `predict()` on a loaded export will fail. notes that the exported file can also be loaded with `YOLO()` since it behaves like a standard yolo detector.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR adds a clear warning to the YOLOE export docs explaining that exported models are static and cannot accept new text or visual prompts after export.

### 📊 Key Changes
- Added a new **warning note** in [`docs/en/models/yoloe.md`](https://github.com/ultralytics/ultralytics) about exported YOLOE model behavior.
- Clarified that classes set with `set_classes()` or through `refer_image` are **embedded into the exported weights**.
- Documented that, after export, calling `set_classes()` or passing `visual_prompts=...` to `predict()` on the exported model will **not work**.
- Explained that changing detected classes requires **re-exporting from the original `.pt` checkpoint** with new prompts.
- Noted that the exported file behaves like a **standard YOLO detector** and can be loaded with `YOLO()` instead of `YOLOE()`.

### 🎯 Purpose & Impact
- ✅ Reduces confusion for users who expect exported YOLOE models to remain dynamically promptable.
- 🚫 Helps prevent runtime errors caused by trying to apply new prompts to an already exported model.
- 📚 Improves documentation clarity around the difference between **training/checkpoint behavior** and **exported model behavior**.
- 🔄 Makes deployment expectations clearer: exported models are easier to use in production, but prompt changes require going back to the original checkpoint and exporting again.
- 🤝 Benefits both new and experienced users by setting the right expectations before deployment.