### PR TITLE
docs: normalize casing for PyTorch / NumPy / Matplotlib in prose

### DIFF
--- a/docs/en/datasets/explorer/api.md
+++ b/docs/en/datasets/explorer/api.md
@@ -301,7 +301,7 @@ sim_idx["im_file"][sim_count > 30]
 
 ### Visualize Embedding Space
 
-You can also visualize the embedding space using the plotting tool of your choice. For example here is a simple example using matplotlib:
+You can also visualize the embedding space using the plotting tool of your choice. For example here is a simple example using Matplotlib:
 
 ```python
 import matplotlib.pyplot as plt

--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 description: Export any PyTorch model (timm, torchvision, or custom) to ONNX, OpenVINO, CoreML, TensorFlow SavedModel, TorchScript, NCNN, MNN, PaddlePaddle, and ExecuTorch with Ultralytics export utilities.
-keywords: export PyTorch model, convert PyTorch to ONNX, PyTorch to CoreML, PyTorch to OpenVINO, PyTorch to TensorFlow, non-YOLO export, timm export, torchvision export, TorchScript export, NCNN export, MNN export, PaddlePaddle export, ExecuTorch export, TFLite export, Ultralytics export utilities, torch.nn.Module export, model conversion, model deployment, pytorch deployment
+keywords: export PyTorch model, convert PyTorch to ONNX, PyTorch to CoreML, PyTorch to OpenVINO, PyTorch to TensorFlow, non-YOLO export, timm export, torchvision export, TorchScript export, NCNN export, MNN export, PaddlePaddle export, ExecuTorch export, TFLite export, Ultralytics export utilities, torch.nn.Module export, model conversion, model deployment, PyTorch deployment
 ---
 
 # How to Export Non-YOLO PyTorch Models with Ultralytics

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -294,7 +294,7 @@ pip install onnxruntime_gpu-1.17.0-cp38-cp38-linux_aarch64.whl
 
 !!! note
 
-    `onnxruntime-gpu` will automatically revert back the numpy version to latest. So we need to reinstall numpy to `1.23.5` to fix an issue by executing:
+    `onnxruntime-gpu` will automatically revert back the NumPy version to latest. So we need to reinstall NumPy to `1.23.5` to fix an issue by executing:
 
     `pip install numpy==1.23.5`
 

--- a/docs/en/guides/ros-quickstart.md
+++ b/docs/en/guides/ros-quickstart.md
@@ -55,7 +55,7 @@ This guide has been tested using [this ROS environment](https://github.com/ambit
 
 Apart from the ROS environment, you will need to install the following dependencies:
 
-- **[ROS Numpy package](https://github.com/eric-wieser/ros_numpy)**: This is required for fast conversion between ROS Image messages and numpy arrays.
+- **[ROS NumPy package](https://github.com/eric-wieser/ros_numpy)**: This is required for fast conversion between ROS Image messages and NumPy arrays.
 
     ```bash
     pip install ros_numpy
@@ -103,7 +103,7 @@ det_image_pub = rospy.Publisher("/ultralytics/detection/image", Image, queue_siz
 seg_image_pub = rospy.Publisher("/ultralytics/segmentation/image", Image, queue_size=5)
 ```
 
-Finally, create a subscriber that listens to messages on the `/camera/color/image_raw` topic and calls a callback function for each new message. This callback function receives messages of type `sensor_msgs/Image`, converts them into a numpy array using `ros_numpy`, processes the images with the previously instantiated YOLO models, annotates the images, and then publishes them back to the respective topics: `/ultralytics/detection/image` for detection and `/ultralytics/segmentation/image` for segmentation.
+Finally, create a subscriber that listens to messages on the `/camera/color/image_raw` topic and calls a callback function for each new message. This callback function receives messages of type `sensor_msgs/Image`, converts them into a NumPy array using `ros_numpy`, processes the images with the previously instantiated YOLO models, annotates the images, and then publishes them back to the respective topics: `/ultralytics/detection/image` for detection and `/ultralytics/segmentation/image` for segmentation.
 
 ```python
 import ros_numpy
@@ -188,7 +188,7 @@ Consider a warehouse robot equipped with a camera and object [detection model](.
 
 ### String Step-by-Step Usage
 
-This example demonstrates how to use the Ultralytics YOLO package with ROS. In this example, we subscribe to a camera topic, process the incoming image using YOLO, and publish the detected objects to new topic `/ultralytics/detection/classes` using `std_msgs/String` messages. The `ros_numpy` package is used to convert the ROS Image message to a numpy array for processing with YOLO.
+This example demonstrates how to use the Ultralytics YOLO package with ROS. In this example, we subscribe to a camera topic, process the incoming image using YOLO, and publish the detected objects to new topic `/ultralytics/detection/classes` using `std_msgs/String` messages. The `ros_numpy` package is used to convert the ROS Image message to a NumPy array for processing with YOLO.
 
 ```python
 import time
@@ -265,7 +265,7 @@ segmentation_model = YOLO("yolo26m-seg.pt")
 classes_pub = rospy.Publisher("/ultralytics/detection/distance", String, queue_size=5)
 ```
 
-Next, define a callback function that processes the incoming depth image message. The function waits for the depth image and RGB image messages, converts them into numpy arrays, and applies the segmentation model to the RGB image. It then extracts the segmentation mask for each detected object and calculates the average distance of the object from the camera using the depth image. Most sensors have a maximum distance, known as the clip distance, beyond which values are represented as inf (`np.inf`). Before processing, it is important to filter out these null values and assign them a value of `0`. Finally, it publishes the detected objects along with their average distances to the `/ultralytics/detection/distance` topic.
+Next, define a callback function that processes the incoming depth image message. The function waits for the depth image and RGB image messages, converts them into NumPy arrays, and applies the segmentation model to the RGB image. It then extracts the segmentation mask for each detected object and calculates the average distance of the object from the camera using the depth image. Most sensors have a maximum distance, known as the clip distance, beyond which values are represented as inf (`np.inf`). Before processing, it is important to filter out these null values and assign them a value of `0`. Finally, it publishes the detected objects along with their average distances to the `/ultralytics/detection/distance` topic.
 
 ```python
 import numpy as np
@@ -391,7 +391,7 @@ time.sleep(1)
 segmentation_model = YOLO("yolo26m-seg.pt")
 ```
 
-Create a function `pointcloud2_to_array`, which transforms a `sensor_msgs/PointCloud2` message into two numpy arrays. The `sensor_msgs/PointCloud2` messages contain `n` points based on the `width` and `height` of the acquired image. For instance, a `480 x 640` image will have `307,200` points. Each point includes three spatial coordinates (`xyz`) and the corresponding color in `RGB` format. These can be considered as two separate channels of information.
+Create a function `pointcloud2_to_array`, which transforms a `sensor_msgs/PointCloud2` message into two NumPy arrays. The `sensor_msgs/PointCloud2` messages contain `n` points based on the `width` and `height` of the acquired image. For instance, a `480 x 640` image will have `307,200` points. Each point includes three spatial coordinates (`xyz`) and the corresponding color in `RGB` format. These can be considered as two separate channels of information.
 
 The function returns the `xyz` coordinates and `RGB` values in the format of the original camera resolution (`width x height`). Most sensors have a maximum distance, known as the clip distance, beyond which values are represented as inf (`np.inf`). Before processing, it is important to filter out these null values and assign them a value of `0`.
 
@@ -420,7 +420,7 @@ def pointcloud2_to_array(pointcloud2: PointCloud2) -> tuple:
     return xyz, rgb
 ```
 
-Next, subscribe to the `/camera/depth/points` topic to receive the point cloud message and convert the `sensor_msgs/PointCloud2` message into numpy arrays containing the XYZ coordinates and RGB values (using the `pointcloud2_to_array` function). Process the RGB image using the YOLO model to extract segmented objects. For each detected object, extract the segmentation mask and apply it to both the RGB image and the XYZ coordinates to isolate the object in 3D space.
+Next, subscribe to the `/camera/depth/points` topic to receive the point cloud message and convert the `sensor_msgs/PointCloud2` message into NumPy arrays containing the XYZ coordinates and RGB values (using the `pointcloud2_to_array` function). Process the RGB image using the YOLO model to extract segmented objects. For each detected object, extract the segmentation mask and apply it to both the RGB image and the XYZ coordinates to isolate the object in 3D space.
 
 Processing the mask is straightforward since it consists of binary values, with `1` indicating the presence of the object and `0` indicating the absence. To apply the mask, simply multiply the original channels by the mask. This operation effectively isolates the object of interest within the image. Finally, create an Open3D point cloud object and visualize the segmented object in 3D space with associated colors.
 
@@ -575,7 +575,7 @@ With YOLO, you can extract [segmentation masks](https://www.ultralytics.com/glos
 
 To visualize 3D point clouds in ROS with YOLO:
 
-1. Convert `sensor_msgs/PointCloud2` messages to numpy arrays.
+1. Convert `sensor_msgs/PointCloud2` messages to NumPy arrays.
 2. Use YOLO to segment RGB images.
 3. Apply the segmentation mask to the point cloud.
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -112,7 +112,7 @@ YOLO26 can process different types of input sources for inference, as shown in t
 | screenshot                                            | `'screen'`                                 | `str`           | Capture a screenshot.                                                                        |
 | PIL                                                   | `Image.open('image.jpg')`                  | `PIL.Image`     | HWC format with RGB channels.                                                                |
 | [OpenCV](https://www.ultralytics.com/glossary/opencv) | `cv2.imread('image.jpg')`                  | `np.ndarray`    | HWC format with BGR channels `uint8 (0-255)`.                                                |
-| numpy                                                 | `np.zeros((640,1280,3))`                   | `np.ndarray`    | HWC format with BGR channels `uint8 (0-255)`.                                                |
+| NumPy                                                 | `np.zeros((640,1280,3))`                   | `np.ndarray`    | HWC format with BGR channels `uint8 (0-255)`.                                                |
 | torch                                                 | `torch.zeros(16,3,320,640)`                | `torch.Tensor`  | BCHW format with RGB channels `float32 (0.0-1.0)`.                                           |
 | CSV                                                   | `'sources.csv'`                            | `str` or `Path` | CSV file containing paths to images, videos, or directories.                                 |
 | video ✅                                              | `'video.mp4'`                              | `str` or `Path` | Video file in formats like MP4, AVI, etc.                                                    |
@@ -211,9 +211,9 @@ Below are code examples for using each source type:
         results = model(source)  # list of Results objects
         ```
 
-    === "numpy"
+    === "NumPy"
 
-        Run inference on an image represented as a numpy array.
+        Run inference on an image represented as a NumPy array.
         ```python
         import numpy as np
 
@@ -514,7 +514,7 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 
 | Attribute    | Type                  | Description                                                                              |
 | ------------ | --------------------- | ---------------------------------------------------------------------------------------- |
-| `orig_img`   | `np.ndarray`          | The original image as a numpy array.                                                     |
+| `orig_img`   | `np.ndarray`          | The original image as a NumPy array.                                                     |
 | `orig_shape` | `tuple`               | The original image shape in (height, width) format.                                      |
 | `boxes`      | `Boxes, optional`     | A Boxes object containing the detection bounding boxes.                                  |
 | `masks`      | `Masks, optional`     | A Masks object containing the detection masks.                                           |
@@ -532,7 +532,7 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 | ------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
 | `update()`    | `None`                 | Updates the Results object with new detection data (boxes, masks, probs, obb, keypoints). |
 | `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                |
-| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to numpy arrays.          |
+| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.          |
 | `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                |
 | `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.    |
 | `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.      |
@@ -574,7 +574,7 @@ Here is a table for the `Boxes` class methods and properties, including their na
 | Name      | Type                      | Description                                                        |
 | --------- | ------------------------- | ------------------------------------------------------------------ |
 | `cpu()`   | Method                    | Move the object to CPU memory.                                     |
-| `numpy()` | Method                    | Convert the object to a numpy array.                               |
+| `numpy()` | Method                    | Convert the object to a NumPy array.                               |
 | `cuda()`  | Method                    | Move the object to CUDA memory.                                    |
 | `to()`    | Method                    | Move the object to the specified device.                           |
 | `xyxy`    | Property (`torch.Tensor`) | Return the boxes in xyxy format.                                   |
@@ -612,7 +612,7 @@ Here is a table for the `Masks` class methods and properties, including their na
 | Name      | Type                      | Description                                                     |
 | --------- | ------------------------- | --------------------------------------------------------------- |
 | `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                         |
-| `numpy()` | Method                    | Returns the masks tensor as a numpy array.                      |
+| `numpy()` | Method                    | Returns the masks tensor as a NumPy array.                      |
 | `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                         |
 | `to()`    | Method                    | Returns the masks tensor with the specified device and dtype.   |
 | `xyn`     | Property (`torch.Tensor`) | A list of normalized segments represented as tensors.           |
@@ -645,7 +645,7 @@ Here is a table for the `Keypoints` class methods and properties, including thei
 | Name      | Type                      | Description                                                       |
 | --------- | ------------------------- | ----------------------------------------------------------------- |
 | `cpu()`   | Method                    | Returns the keypoints tensor on CPU memory.                       |
-| `numpy()` | Method                    | Returns the keypoints tensor as a numpy array.                    |
+| `numpy()` | Method                    | Returns the keypoints tensor as a NumPy array.                    |
 | `cuda()`  | Method                    | Returns the keypoints tensor on GPU memory.                       |
 | `to()`    | Method                    | Returns the keypoints tensor with the specified device and dtype. |
 | `xyn`     | Property (`torch.Tensor`) | A list of normalized keypoints represented as tensors.            |
@@ -679,7 +679,7 @@ Here's a table summarizing the methods and properties for the `Probs` class:
 | Name       | Type                      | Description                                                             |
 | ---------- | ------------------------- | ----------------------------------------------------------------------- |
 | `cpu()`    | Method                    | Returns a copy of the probs tensor on CPU memory.                       |
-| `numpy()`  | Method                    | Returns a copy of the probs tensor as a numpy array.                    |
+| `numpy()`  | Method                    | Returns a copy of the probs tensor as a NumPy array.                    |
 | `cuda()`   | Method                    | Returns a copy of the probs tensor on GPU memory.                       |
 | `to()`     | Method                    | Returns a copy of the probs tensor with the specified device and dtype. |
 | `top1`     | Property (`int`)          | Index of the top 1 class.                                               |
@@ -714,7 +714,7 @@ Here is a table for the `OBB` class methods and properties, including their name
 | Name        | Type                      | Description                                                           |
 | ----------- | ------------------------- | --------------------------------------------------------------------- |
 | `cpu()`     | Method                    | Move the object to CPU memory.                                        |
-| `numpy()`   | Method                    | Convert the object to a numpy array.                                  |
+| `numpy()`   | Method                    | Convert the object to a NumPy array.                                  |
 | `cuda()`    | Method                    | Move the object to CUDA memory.                                       |
 | `to()`      | Method                    | Move the object to the specified device.                              |
 | `conf`      | Property (`torch.Tensor`) | Return the confidence values of the boxes.                            |

--- a/docs/en/reference/models/utils/ops.md
+++ b/docs/en/reference/models/utils/ops.md
@@ -1,6 +1,6 @@
 ---
 description: Explore the utilities and operations in Ultralytics models like HungarianMatcher and get_cdn_group. Learn how to optimize and manage model operations efficiently.
-keywords: Ultralytics, models, utils, operations, HungarianMatcher, get_cdn_group, model optimization, pytorch, machine learning
+keywords: Ultralytics, models, utils, operations, HungarianMatcher, get_cdn_group, model optimization, PyTorch, machine learning
 ---
 
 # Reference for `ultralytics/models/utils/ops.py`

--- a/docs/en/usage/cfg.md
+++ b/docs/en/usage/cfg.md
@@ -158,7 +158,7 @@ Logging, checkpoints, plotting, and file management are important when training 
 
 - **Logging**: Track the model's progress and diagnose issues using libraries like [TensorBoard](https://docs.ultralytics.com/integrations/tensorboard) or by writing to a file.
 - **Checkpoints**: Save the model at regular intervals to resume training or experiment with different configurations.
-- **Plotting**: Visualize performance and training progress using libraries like matplotlib or TensorBoard.
+- **Plotting**: Visualize performance and training progress using libraries like Matplotlib or TensorBoard.
 - **File management**: Organize files generated during training, such as checkpoints, log files, and plots, for easy access and analysis.
 
 Effective management of these aspects helps track progress and makes debugging and optimization easier.


### PR DESCRIPTION
## Summary

Sweep `docs/en/**/*.md` for lowercase appearances of library / framework names that have a canonical title-cased spelling and normalize them in prose.

Touches **prose only** — code blocks, inline code, URLs, link hrefs, and HTML tags were left untouched by a one-off regex that splits each file into prose vs. protected chunks before substituting. The protection rules cover:

- Fenced code blocks (`` ``` `` / `~~~`)
- Inline code (`` ` ``)
- Markdown link hrefs `](url)`
- Plain `http(s)://` URLs
- HTML/XML tags

Substitution pattern is `(?<![./\w])TERM(?![-_./\w])` so file extensions (`model.onnx`), paths (`/path/to`), package names (`opencv-python`), and identifiers (`onnx_model`) are also skipped.

## Replacements

```
19  numpy → NumPy
 2  matplotlib → Matplotlib
 2  pytorch → PyTorch
 1  Numpy → NumPy
```

7 files: `datasets/explorer/api.md`, `guides/export-non-yolo-models.md`, `guides/nvidia-jetson.md`, `guides/ros-quickstart.md`, `modes/predict.md`, `reference/models/utils/ops.md`, `usage/cfg.md`.

## Why

The portal translation pipeline keeps a `DO_NOT_TRANSLATE_TERMS` list of brand/framework names to forward through Gemini verbatim. The check that enforces this used to be strict case-sensitive substring matching, so a docs page saying *"numpy arrays"* that legitimately translated into *"NumPy arrays"* failed validation and forced an English fallback for that paragraph (portal PR #2033 makes that check case-insensitive going forward).

The portal-side fix is the right defense, but keeping the English source canonical is the right baseline — it gives readers consistent prose, and downstream locales get clean inputs.

## Test plan

- [x] Diff inspected manually — every change is in a prose context, no code or URLs altered
- [x] Tab labels like `=== "numpy"` correctly normalized to `=== "NumPy"`
- [ ] Render once on the docs preview to confirm no markdown structure regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small but broad documentation cleanups across Ultralytics docs, mainly standardizing library names like **NumPy**, **PyTorch**, and **Matplotlib** for clearer, more professional documentation.

### 📊 Key Changes
- Standardized capitalization of common library names across multiple docs pages:
  - `numpy` → **NumPy**
  - `pytorch` → **PyTorch**
  - `matplotlib` → **Matplotlib**
- Updated terminology in several guides and references, including:
  - Dataset Explorer API docs
  - Non-YOLO model export guide
  - NVIDIA Jetson guide
  - ROS quickstart guide
  - Predict mode documentation
  - Model utils reference
  - Configuration usage docs
- Improved consistency in examples, tables, descriptive text, and SEO keyword metadata.
- Clarified wording in places where arrays and tensors are discussed, especially in ROS and prediction documentation. ✨

### 🎯 Purpose & Impact
- Improves documentation consistency and readability across the repository 📚
- Makes technical content look more polished and aligned with official library naming conventions ✅
- Reduces minor confusion for new users reading examples involving NumPy, PyTorch, and Matplotlib
- Has **no code or model behavior changes**—this is a documentation-only PR, so there is no runtime impact ⚙️
- Helps maintain higher-quality docs for both beginners and experienced developers using Ultralytics 🚀