### PR TITLE
Fix `get_flops` dtype mismatch on half-precision models

### DIFF
--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -457,12 +457,12 @@ def get_flops(model, imgsz=640):
         try:
             # Method 1: Use stride-based input tensor
             stride = max(int(model.stride.max()), 32) if hasattr(model, "stride") else 32  # max stride
-            im = torch.empty((1, p.shape[1], stride, stride), device=p.device)  # input image in BCHW format
+            im = torch.empty((1, p.shape[1], stride, stride), device=p.device, dtype=p.dtype)  # input image in BCHW
             flops = thop.profile(deepcopy(model), inputs=[im], verbose=False)[0] / 1e9 * 2  # stride GFLOPs
             return flops * imgsz[0] / stride * imgsz[1] / stride  # imgsz GFLOPs
         except Exception:
             # Method 2: Use actual image size (required for RTDETR models)
-            im = torch.empty((1, p.shape[1], *imgsz), device=p.device)  # input image in BCHW format
+            im = torch.empty((1, p.shape[1], *imgsz), device=p.device, dtype=p.dtype)  # input image in BCHW format
             return thop.profile(deepcopy(model), inputs=[im], verbose=False)[0] / 1e9 * 2  # imgsz GFLOPs
     except Exception:
         return 0.0
@@ -487,14 +487,14 @@ def get_flops_with_torch_profiler(model, imgsz=640):
     try:
         # Use stride size for input tensor
         stride = (max(int(model.stride.max()), 32) if hasattr(model, "stride") else 32) * 2  # max stride
-        im = torch.empty((1, p.shape[1], stride, stride), device=p.device)  # input image in BCHW format
+        im = torch.empty((1, p.shape[1], stride, stride), device=p.device, dtype=p.dtype)  # input image in BCHW
         with torch.profiler.profile(with_flops=True) as prof:
             model(im)
         flops = sum(x.flops for x in prof.key_averages()) / 1e9
         flops = flops * imgsz[0] / stride * imgsz[1] / stride  # 640x640 GFLOPs
     except Exception:
         # Use actual image size for input tensor (i.e. required for RTDETR models)
-        im = torch.empty((1, p.shape[1], *imgsz), device=p.device)  # input image in BCHW format
+        im = torch.empty((1, p.shape[1], *imgsz), device=p.device, dtype=p.dtype)  # input image in BCHW format
         with torch.profiler.profile(with_flops=True) as prof:
             model(im)
         flops = sum(x.flops for x in prof.key_averages()) / 1e9


### PR DESCRIPTION
## Summary

`get_flops` and `get_flops_with_torch_profiler` create their dummy input with `torch.empty(...)` and no `dtype`. This defaults to `float32`, so the forward pass fails on a half-precision model with:

```
RuntimeError: Input type (float) and bias type (c10::Half) should be the same
```

The outer `try/except Exception` then swallows the error and returns `0.0`, so any fp16/bf16 model silently reports `0.0 GFLOPs`.

This matches the pattern already fixed in `fuse_conv_and_bn` / `fuse_deconv_and_bn` (#24480) — the dummy tensor needs to follow the model parameter `dtype`.

## Reproduction

```python
import torch, torch.nn as nn
from ultralytics.utils.torch_utils import get_flops

class M(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv = nn.Conv2d(3, 16, 3)
        self.stride = torch.tensor([32])
    def forward(self, x): return self.conv(x)

print(get_flops(M().half()))   # before: 0.0 (silent failure)
                                # after:  0.31104
print(get_flops(M().float()))  # 0.31104 (unchanged)
```

## Test plan

- [x] fp16 model now returns a non-zero GFLOPs value matching the fp32 result
- [x] fp32 model behavior unchanged
- [x] Both `get_flops` and `get_flops_with_torch_profiler` covered

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `get_flops` input tensor creation to match the model parameter dtype, preventing dtype mismatch errors on half-precision models. ⚙️

### 📊 Key Changes
- Updated `get_flops()` to create profiling input tensors with `dtype=p.dtype` in both the stride-based and fallback image-size paths.
- Updated `get_flops_with_torch_profiler()` similarly so profiler inputs also match the model parameter dtype.
- Preserves existing FLOPs calculation logic while improving compatibility with FP16 and other non-default model dtypes. 🧠

### 🎯 Purpose & Impact
- Fixes a bug where FLOPs profiling could fail when a model is loaded or converted in half precision. 🐛
- Improves reliability of model analysis utilities for mixed-precision and deployment-oriented workflows.
- Keeps the change minimal and low risk since it only adjusts input tensor dtype during profiling, without altering model behavior or inference outputs. ✅