### PR TITLE
Update Platform GPU docs for B300

### DIFF
--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -25,8 +25,8 @@ Choose the plan that fits your needs. Compare plans in `Settings > Plans`:
 | **Storage**                                                | 100 GB     | 500 GB          | Unlimited  |
 | **Dataset Upload (ZIP/TAR incl. `.tar.gz`/`.tgz`/NDJSON)** | 10 GB      | 20 GB           | 50 GB      |
 | **Deployments**                                            | 3          | 10              | Unlimited  |
-| **Cloud GPU Types**                                        | 20         | 23              | 23         |
-| **Best GPUs (H200, B200)**                                 | -          | Yes             | Yes        |
+| **Cloud GPU Types**                                        | 22         | 24              | 24         |
+| **Best GPUs (B200, B300)**                                 | -          | Yes             | Yes        |
 | **Teams**                                                  | -          | Up to 5 members | Up to 50   |
 | **SSO / SAML**                                             | -          | -               | Yes        |
 | **Enterprise License**                                     | -          | -               | Yes        |
@@ -46,7 +46,7 @@ Get started at no cost:
 - 100 GB storage · 10 GB dataset upload limit
 - Model export to all 17+ formats
 - Manual, SAM 3 & YOLO Smart annotation
-- 20 cloud GPU types including 5090 & H100 ($0.24–$3.07/hr)
+- 22 cloud GPU types including 5090, H100 & H200 ($0.24–$3.99/hr)
 - Community support
 
 !!! tip "Company Email Bonus"
@@ -63,7 +63,7 @@ For professionals and small teams ($29/month or $290/year):
 - 500 GB storage · 20 GB dataset upload limit
 - 10 cloud deployments
 - [Team collaboration](teams.md) with 4-role RBAC (up to 5 members)
-- Access to the best GPUs (H200, B200)
+- Access to the best GPUs (B200, B300)
 - Priority support
 
 !!! tip "Save with Yearly Billing"
@@ -192,7 +192,7 @@ Cloud training costs depend on GPU selection:
 
 {% include "macros/platform-gpu-table.md" %}
 
-H200 and B200 GPUs require a [Pro or Enterprise plan](#plans). All other GPUs are available on all plans.
+B200 and B300 GPUs require a [Pro or Enterprise plan](#plans). All other GPUs are available on all plans.
 
 See [Cloud Training](../train/cloud-training.md) for complete GPU options and pricing.
 
@@ -229,7 +229,7 @@ After upgrading:
 - 10 concurrent cloud trainings
 - 10 cloud deployments
 - [Team collaboration](teams.md) (up to 5 members)
-- Access to best GPUs (H200, B200)
+- Access to best GPUs (B200, B300)
 - Full monitoring dashboard
 - Priority support
 
@@ -260,7 +260,7 @@ When your Pro subscription ends (cancelled or expired), your account reverts to 
 | **Credit Balance**                                         | Existing credits preserved and usable                                            |
 | **Monthly Credits**                                        | $30/seat/month grants stop immediately                                           |
 | **Team Members**                                           | Members notified and lose access to team resources                               |
-| **GPU Access**                                             | Standard GPUs remain available. Best GPUs (H200, B200) require Pro or Enterprise |
+| **GPU Access**                                             | Standard GPUs remain available. Best GPUs (B200, B300) require Pro or Enterprise |
 | **Concurrent Trainings**                                   | Limit reduced from 10 to 3                                                       |
 
 !!! tip "No Data Loss"

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -890,7 +890,7 @@ POST /api/models/{modelId}/predict/warmup
 
 ## Training API
 
-Launch YOLO training on cloud GPUs (23 GPU types from RTX 2000 Ada to B200) and monitor progress in real time. See [Cloud Training documentation](../train/cloud-training.md).
+Launch YOLO training on cloud GPUs (24 GPU types from RTX 2000 Ada to B300) and monitor progress in real time. See [Cloud Training documentation](../train/cloud-training.md).
 
 ```mermaid
 graph LR
@@ -952,7 +952,7 @@ POST /api/training/start
 
 !!! note "GPU Types"
 
-    Available GPU types include `rtx-4090`, `a100-80gb-pcie`, `a100-80gb-sxm`, `h100-sxm`, `rtx-pro-6000`, and others. See [Cloud Training](../train/cloud-training.md) for the full list with pricing.
+    Available GPU types include `rtx-4090`, `a100-80gb-pcie`, `a100-80gb-sxm`, `h100-sxm`, `rtx-pro-6000`, `b300`, and others. See [Cloud Training](../train/cloud-training.md) for the full list with pricing.
 
 ### Get Training Status
 

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -47,7 +47,7 @@ graph LR
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Upload**   | Images (50MB), videos (1GB), and dataset files (ZIP, TAR including `.tar.gz`/`.tgz`, NDJSON) with automatic processing                                                                                       |
 | **Annotate** | Manual tools for all 5 task types, plus [Smart Annotation](data/annotation.md#smart-annotation) with SAM and YOLO models for detect, segment, and OBB (see [supported tasks](data/index.md#supported-tasks)) |
-| **Train**    | Cloud GPUs (20 on all plans + 3 Pro/Enterprise-only: H200 NVL, H200 SXM, B200), real-time metrics, project organization                                                                                      |
+| **Train**    | Cloud GPUs (22 on all plans + 2 Pro/Enterprise-only: B200, B300), real-time metrics, project organization                                                                                                    |
 | **Export**   | [17 deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, TFLite, etc.; see [supported formats](train/models.md#supported-formats))                                                               |
 | **Deploy**   | 43 global regions with dedicated endpoints, scale-to-zero by default (single active instance), and monitoring                                                                                                |
 
@@ -55,7 +55,7 @@ graph LR
 
 - **Upload** images, videos, and dataset files to create training datasets
 - **Visualize** annotations with interactive overlays for all 5 YOLO task types (see [supported tasks](data/index.md#supported-tasks))
-- **Train** models on cloud GPUs (20 on all plans, 23 with Pro or Enterprise for H200 and B200) with real-time metrics
+- **Train** models on cloud GPUs (22 on all plans, 24 with Pro or Enterprise for B200 and B300) with real-time metrics
 - **Export** to [17 deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, TFLite, etc.)
 - **Deploy** to 43 global regions with one-click dedicated endpoints
 - **Monitor** training progress, deployment health, and usage metrics
@@ -107,7 +107,7 @@ graph LR
 
 ### Model Training
 
-- **Cloud Training**: Train on cloud GPUs (20 on all plans, 23 with [Pro or Enterprise](account/billing.md#plans) for H200 and B200) with real-time metrics
+- **Cloud Training**: Train on cloud GPUs (22 on all plans, 24 with [Pro or Enterprise](account/billing.md#plans) for B200 and B300) with real-time metrics
 - **Remote Training**: Train anywhere and stream metrics to the platform (W&B-style)
 - **Project Organization**: Group related models, compare experiments, track activity
 - **17 Export Formats**: ONNX, TensorRT, CoreML, TFLite, and more (see [supported formats](train/models.md#supported-formats))
@@ -232,7 +232,7 @@ Once deployed, call your endpoint from any language:
     | Concurrent Trainings | 3              | 10                      | Unlimited      |
     | Deployments          | 3              | 10                      | Unlimited      |
     | Storage              | 100 GB         | 500 GB                  | Unlimited      |
-    | Cloud GPU Types      | 20             | 23 (incl. H200 / B200)  | 23             |
+    | Cloud GPU Types      | 22             | 24 (incl. B200 / B300)  | 24             |
     | Teams                | -              | Up to 5 members         | Up to 50       |
     | Support              | Community      | Priority                | Dedicated      |
 

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -239,7 +239,7 @@ From your project, click `Train Model` to start cloud training.
 1. **Select Dataset**: Choose from your uploaded datasets (only datasets with a [`train` split](data/datasets.md#filter-by-split) are shown)
 2. **Choose Model**: Select a base model - official Ultralytics models or your own trained models
 3. **Set Epochs**: Number of training iterations (default: 100)
-4. **Select GPU**: Choose compute resources based on your budget and model size. The default is **RTX PRO 6000** (96 GB Blackwell, $1.69/hr), which handles every YOLO26 variant. See the full [GPU pricing table](index.md#what-gpu-options-are-available-for-cloud-training) or the [Cloud Training GPU step](train/cloud-training.md#step-5-select-gpu-cloud-tab) for the complete list and tier gating.
+4. **Select GPU**: Choose compute resources based on your budget and model size. The default is **RTX PRO 6000** (96 GB Blackwell, $1.89/hr), which handles every YOLO26 variant. See the full [GPU pricing table](index.md#what-gpu-options-are-available-for-cloud-training) or the [Cloud Training GPU step](train/cloud-training.md#step-5-select-gpu-cloud-tab) for the complete list and tier gating.
 
 !!! warning "Credit Balance Required"
 

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -112,8 +112,8 @@ Choose your GPU from Ultralytics Cloud:
     - **RTX PRO 6000**: 96 GB Blackwell, recommended default for most jobs
     - **A100 SXM**: 80 GB HBM2e — strong choice for large batch sizes or bigger models
     - **H100 PCIe / H100 SXM / H100 NVL**: 80–94 GB Hopper for time-sensitive training (available on all plans)
-    - **H200 NVL / H200 SXM**: 141–143 GB Hopper — requires [Pro or Enterprise](../account/billing.md#plans)
-    - **B200**: 180 GB NVIDIA Blackwell for cutting-edge workloads — requires [Pro or Enterprise](../account/billing.md#plans)
+    - **H200 NVL / H200 SXM**: 141–143 GB Hopper for high-memory workloads (available on all plans)
+    - **B200 / B300**: 180–288 GB NVIDIA Blackwell for cutting-edge workloads — requires [Pro or Enterprise](../account/billing.md#plans)
 
 The dialog shows your current **balance** and a **Top Up** button. An estimated cost and duration are calculated based on your configuration (model size, dataset images, epochs, GPU speed).
 

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -73,7 +73,7 @@ Available GPUs for cloud training on Ultralytics Cloud:
 
 !!! info "GPU Tier Access"
 
-    H200 and B200 GPUs require a [Pro or Enterprise plan](../account/billing.md#plans). All other GPUs are available on all plans including Free.
+    B200 and B300 GPUs require a [Pro or Enterprise plan](../account/billing.md#plans). All other GPUs are available on all plans including Free.
 
 !!! tip "Signup Credits"
 
@@ -176,5 +176,5 @@ If training fails:
 | Scenario                      | Recommended GPU         |
 | ----------------------------- | ----------------------- |
 | Most training jobs            | RTX PRO 6000            |
-| Large datasets or batch sizes | H100 SXM or H200 (Pro+) |
+| Large datasets or batch sizes | H100 SXM or H200        |
 | Budget-conscious              | RTX 4090                |

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -173,8 +173,8 @@ If training fails:
 
 ### How do I choose the right GPU?
 
-| Scenario                      | Recommended GPU         |
-| ----------------------------- | ----------------------- |
-| Most training jobs            | RTX PRO 6000            |
-| Large datasets or batch sizes | H100 SXM or H200        |
-| Budget-conscious              | RTX 4090                |
+| Scenario                      | Recommended GPU  |
+| ----------------------------- | ---------------- |
+| Most training jobs            | RTX PRO 6000     |
+| Large datasets or batch sizes | H100 SXM or H200 |
+| Budget-conscious              | RTX 4090         |

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -258,7 +258,7 @@ Export jobs progress through the following statuses:
 
 !!! tip "Export Time"
 
-    Export time varies by format. TensorRT exports may take several minutes due to engine optimization. GPU-required formats (TensorRT) run on Ultralytics Cloud GPUs — the default export GPU is RTX 5090.
+    Export time varies by format. TensorRT exports may take several minutes due to engine optimization. GPU-required formats (TensorRT) run on Ultralytics Cloud GPUs — the default export GPU is RTX 4090.
 
 ### Bulk Export Actions
 

--- a/docs/macros/platform-gpu-table.md
+++ b/docs/macros/platform-gpu-table.md
@@ -5,21 +5,22 @@
 | RTX 4000 Ada | Ada        | 20 GB  | $0.26     | Medium datasets            |
 | RTX A5000    | Ampere     | 24 GB  | $0.27     | Medium datasets            |
 | L4           | Ada        | 24 GB  | $0.39     | Inference optimized        |
-| A40          | Ampere     | 48 GB  | $0.40     | Larger batch sizes         |
+| A40          | Ampere     | 48 GB  | $0.44     | Larger batch sizes         |
 | RTX 3090     | Ampere     | 24 GB  | $0.46     | General training           |
 | RTX A6000    | Ampere     | 48 GB  | $0.49     | Large models               |
-| RTX PRO 4500 | Blackwell  | 32 GB  | $0.54     | Great price/performance    |
-| RTX 4090     | Ada        | 24 GB  | $0.59     | Best price/performance     |
+| RTX PRO 4500 | Blackwell  | 32 GB  | $0.64     | Great price/performance    |
+| RTX 4090     | Ada        | 24 GB  | $0.69     | Best price/performance     |
 | RTX 6000 Ada | Ada        | 48 GB  | $0.77     | Large batch training       |
 | L40S         | Ada        | 48 GB  | $0.86     | Large batch training       |
-| RTX 5090     | Blackwell  | 32 GB  | $0.89     | Latest consumer generation |
+| RTX 5090     | Blackwell  | 32 GB  | $0.99     | Latest consumer generation |
 | L40          | Ada        | 48 GB  | $0.99     | Large models               |
 | A100 PCIe    | Ampere     | 80 GB  | $1.39     | Production training        |
 | A100 SXM     | Ampere     | 80 GB  | $1.49     | Production training        |
-| RTX PRO 6000 | Blackwell  | 96 GB  | $1.69     | Recommended default        |
+| RTX PRO 6000 | Blackwell  | 96 GB  | $1.89     | Recommended default        |
 | H100 PCIe    | Hopper     | 80 GB  | $2.39     | High-performance training  |
-| H100 SXM     | Hopper     | 80 GB  | $2.69     | Fastest training           |
+| H100 SXM     | Hopper     | 80 GB  | $2.99     | Fastest training           |
 | H100 NVL     | Hopper     | 94 GB  | $3.07     | Maximum performance        |
-| H200 NVL     | Hopper     | 143 GB | $3.39     | Maximum memory (Pro+)      |
-| H200 SXM     | Hopper     | 141 GB | $3.59     | Maximum performance (Pro+) |
-| B200         | Blackwell  | 180 GB | $4.99     | Largest models (Pro+)      |
+| H200 NVL     | Hopper     | 143 GB | $3.39     | Maximum memory             |
+| H200 SXM     | Hopper     | 141 GB | $3.99     | Maximum performance        |
+| B200         | Blackwell  | 180 GB | $5.49     | Large models (Pro+)        |
+| B300         | Blackwell  | 288 GB | $7.39     | Largest models (Pro+)      |


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR refreshes Ultralytics Platform documentation to reflect expanded cloud GPU options, updated plan access, and revised pricing across training and export workflows.

### 📊 Key Changes
- 🚀 Increased documented cloud GPU availability:
  - Free plan: from **20 → 22** GPU types
  - Pro/Enterprise: from **23 → 24** GPU types
- 🆕 Replaced older “best GPU” messaging from **H200/B200** to **B200/B300** for Pro and Enterprise plans.
- 🔓 Clarified that **H200 GPUs are now available on all plans**, while **B200 and B300 remain gated to Pro or Enterprise**.
- 💰 Updated GPU pricing throughout the docs, including:
  - **RTX PRO 6000**: `$1.69/hr → $1.89/hr`
  - **RTX 4090**: `$0.59/hr → $0.69/hr`
  - **RTX 5090**: `$0.89/hr → $0.99/hr`
  - **H100 SXM**: `$2.69/hr → $2.99/hr`
  - **H200 SXM**: `$3.59/hr → $3.99/hr`
  - **B200**: `$4.99/hr → $5.49/hr`
- ➕ Added the new **B300** GPU to platform docs and API references, with **288 GB** memory and **$7.39/hr** pricing.
- 🛠️ Updated platform, billing, quickstart, training, and API docs so GPU counts, recommendations, and access rules are consistent.
- 🔄 Changed the default export GPU note from **RTX 5090** to **RTX 4090**.

### 🎯 Purpose & Impact
- ✅ Gives users a more accurate view of current **cloud training hardware**, pricing, and subscription entitlements.
- 📈 Makes it easier to choose the right plan by clearly showing which GPUs are available on **Free vs Pro/Enterprise**.
- ⚡ Highlights stronger high-end compute options with the addition of **B300**, useful for larger or more demanding training jobs.
- 💵 Helps teams better estimate training costs since several hourly GPU prices were updated.
- 🧭 Reduces confusion by aligning billing, quickstart, platform, and API documentation around the same GPU lineup and access rules.