### PR TITLE
fix: 🐞 add googleapis-common-protos dependency to resolve protobuf compatibility issues with TensorFlow and raytune

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ export = [
     "tensorflow>=2.0.0,<=2.19.0", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
     "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
     "ydf<0.13.0; platform_machine != 'aarch64'", # ydf>=0.13 has protobuf gencode 6.x but tensorflow<=2.19 requires protobuf<6
+    "googleapis-common-protos<1.74.0", # >=1.74.0 uses protobuf gencode 7.34.1, incompatible with tensorflow<=2.19 (protobuf<6) and breaks ray[tune] import
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
     "setuptools<=81.0.0",  # pin due to >=82.0.0 breaking tensorflow.js package

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -404,7 +404,7 @@ def check_apt_requirements(requirements):
 
 
 @TryExcept()
-def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=(), install=True, cmds=""):
+def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=(), install=True, cmds="", constrain=()):
     """Check if installed dependencies meet Ultralytics YOLO models requirements and attempt to auto-update if needed.
 
     Args:
@@ -414,6 +414,8 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         exclude (tuple): Tuple of package names to exclude from checking.
         install (bool): If True, attempt to auto-update packages that don't meet requirements.
         cmds (str): Additional commands to pass to the pip install command when auto-updating.
+        constrain (tuple | list): Extra version constraints always appended to the install command even if already
+            satisfied, preventing the resolver from upgrading those packages during install.
 
     Examples:
         >>> from ultralytics.utils.checks import check_requirements
@@ -487,6 +489,8 @@ def check_requirements(requirements=ROOT.parent / "requirements.txt", exclude=()
         )
 
     s = " ".join(f'"{x}"' for x in pkgs)  # console string
+    if s and constrain:  # append version constraints to prevent upgrades during install
+        s += " " + " ".join(f'"{c}"' for c in constrain)
     if s:
         if install and AUTOINSTALL:  # check environment variable
             # Note uv fails on arm64 macOS and Raspberry Pi runners

--- a/ultralytics/utils/export/imx.py
+++ b/ultralytics/utils/export/imx.py
@@ -267,7 +267,7 @@ def torch2imx(
             "model-compression-toolkit>=2.4.1",
             "edge-mdt-cl<1.1.0",
             "edge-mdt-tpc>=1.2.0",
-            "pydantic<=2.11.7",
+            "pydantic<2.12",
         )
     )
     check_requirements("imx500-converter[pt]>=3.17.3")

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -365,7 +365,7 @@ def run_ray_tune(
     """
     LOGGER.info("💡 Learn about RayTune at https://docs.ultralytics.com/integrations/ray-tune")
     try:
-        checks.check_requirements("ray[tune]")
+        checks.check_requirements("ray[tune]", constrain=["pydantic>=2.0,<2.12"])
 
         import ray
         from ray import tune


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves dependency management to prevent package version conflicts during installs and exports, making TensorFlow, Ray Tune, and IMX export workflows more reliable 🛠️📦

### 📊 Key Changes
- Added a new export dependency pin in `pyproject.toml`:
  - `googleapis-common-protos<1.74.0`
  - This avoids newer protobuf code generation versions that conflict with `tensorflow<=2.19` and can also break `ray[tune]` imports.
- Enhanced `check_requirements()` with a new `constrain` argument:
  - Lets Ultralytics append fixed version constraints during auto-install.
  - Helps prevent pip from upgrading compatible packages into broken versions during dependency resolution.
- Updated Ray Tune dependency checks:
  - `check_requirements("ray[tune]", constrain=["pydantic>=2.0,<2.12"])`
  - Ensures Ray Tune installs without pulling incompatible `pydantic` versions.
- Relaxed the IMX export `pydantic` pin slightly:
  - Changed from `pydantic<=2.11.7` to `pydantic<2.12`
  - Keeps compatibility while allowing more patch releases within the safe range.

### 🎯 Purpose & Impact
- Reduces installation issues caused by dependency conflicts, especially around TensorFlow, protobuf, Ray Tune, and `pydantic` ✅
- Makes auto-install behavior safer by preventing unintended package upgrades during requirement checks 🔒
- Improves reliability for users working with:
  - TensorFlow-based export flows
  - Ray Tune hyperparameter tuning
  - Sony IMX500 export tooling
- Lowers the chance of environment breakage, meaning fewer manual fixes and smoother setup for both new and advanced users 🚀