### PR TITLE
Docs: Add INT8 quantization notes for RKNN export

### DIFF
--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -108,6 +108,16 @@ For detailed instructions and best practices related to the installation process
 
 For more details about the export process, visit the [Ultralytics documentation page on exporting](../modes/export.md).
 
+## INT8 Quantization Notes
+When exporting YOLO26 models to RKNN with INT8 quantization, many users reported that they encounter
+cases where the exported model runs successfully but produces no detections at
+inference time.
+
+As a workaround, a hybrid quantization approach (FP16 + INT8) has been shown to
+produce valid detections on supported Rockchip platforms. A reference workflow
+and reproducible example are available here:
+[YOLO to RKNN INT8 Quantization Pipeline](https://github.com/mahdieh-jokar/yolo26n-rknn-int8-quantization)
+
 ## Deploying Exported YOLO26 RKNN Models
 
 Once you've successfully exported your Ultralytics YOLO26 models to RKNN format, the next step is deploying these models on Rockchip-based devices.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->
This PR adds a short documentation note about observed INT8 quantization
behavior during RKNN export and links to a reproducible reference workflow.

It does not change export behavior or implementation; it only clarifies a
potential issue users may encounter when experimenting with INT8 deployment.

If useful, I’d also be happy to help investigate or contribute code changes
related to RKNN INT8 quantization support in a separate PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds documentation notes for RKNN INT8 export to clarify a known detection issue and point users to a practical hybrid quantization workaround. 🚀

### 📊 Key Changes
- Added a new **INT8 Quantization Notes** section to `docs/en/integrations/rockchip-rknn.md`.
- Documented that some exported YOLO26 RKNN models may run successfully with INT8 quantization but return **no detections** during inference.
- Noted that a **hybrid quantization approach (FP16 + INT8)** can help produce valid detections on supported Rockchip devices.
- Included a reference link to a reproducible RKNN INT8 quantization workflow for affected users. 📘

### 🎯 Purpose & Impact
- Improves RKNN export documentation by surfacing an important deployment caveat for YOLO26 users on Rockchip platforms.
- Helps users troubleshoot silent inference failures more quickly by documenting an observed workaround. 🔧
- Reduces confusion and support burden around INT8 RKNN exports by setting clearer expectations in the docs.