### PR TITLE
Fix unrendered links in YOLOv5 compatibility warning

### DIFF
--- a/docs/en/models/yolov5.md
+++ b/docs/en/models/yolov5.md
@@ -12,9 +12,9 @@ YOLOv5u represents an advancement in [object detection](https://www.ultralytics.
 
 ![YOLOv5 object detection model architecture and performance](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-yolov5-splash.avif)
 
-!!! warning "YOLOv5 models trained by [ultralytics/yolov5](https://github.com/ultralytics/yolov5) are not compatible with [ultralytics/ultralytics](https://github.com/ultralytics/ultralytics) library"
+!!! warning "Models trained with the original YOLOv5 repo are not compatible with the Ultralytics library"
 
-    Ultralytics provides an [anchor-free variant of YOLOv5 model](#performance-metrics). Models trained with the [original YOLOv5 repo](https://github.com/ultralytics/yolov5) cannot be used with the Ultralytics library.
+    Ultralytics provides an [anchor-free variant of YOLOv5 model](#performance-metrics). Models trained with the [ultralytics/yolov5](https://github.com/ultralytics/yolov5) repo cannot be loaded with the [ultralytics/ultralytics](https://github.com/ultralytics/ultralytics) library. To use YOLOv5 here, train a new model from an Ultralytics YOLOv5u checkpoint (e.g. `yolov5su.pt`).
 
 !!! tip "Try on Ultralytics Platform"
 


### PR DESCRIPTION
- move the github links out of the admonition title into the body so they render (markdown is not parsed in admonition titles, the title showed raw `[text](url)`)
- keep the title as plain text, consistent with every other admonition in the docs
- add a migration note pointing users to an ultralytics `yolov5su.pt` checkpoint

<img width="907" height="716" alt="image" src="https://github.com/user-attachments/assets/2a97d791-706f-4703-9e28-7627c52d1e7f" />

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR clarifies the YOLOv5 documentation to better explain model compatibility between the original `ultralytics/yolov5` repo and the main Ultralytics library.

### 📊 Key Changes
- Updated the warning message in `docs/en/models/yolov5.md` to use clearer, more user-friendly wording.
- Explicitly states that models trained with the original [ultralytics/yolov5 repository](https://github.com/ultralytics/yolov5) cannot be loaded in the [Ultralytics library](https://github.com/ultralytics/ultralytics).
- Added practical guidance for users: to use YOLOv5 in the Ultralytics library, they should train from an Ultralytics YOLOv5u checkpoint such as `yolov5su.pt`.
- Keeps the distinction clear that Ultralytics supports an anchor-free YOLOv5u variant, not the original repo’s trained weights.

### 🎯 Purpose & Impact
- Helps prevent confusion 😌 by making compatibility limitations more obvious in the docs.
- Reduces user errors and support issues 🛠️, especially from people trying to load original YOLOv5 weights into the Ultralytics package.
- Gives users a clear next step ✅ instead of only warning about incompatibility.
- Improves the onboarding experience for both new and existing users by making the documentation more actionable and easier to understand.