### PR TITLE
Fix: set ckpt_path in model.load() so resume works

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -368,6 +368,7 @@ class Model(torch.nn.Module):
         self._check_is_pytorch_model()
         if isinstance(weights, (str, Path)):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
+            self.ckpt_path = weights  # remember source path so resume=True can locate the checkpoint
             weights, self.ckpt = load_checkpoint(weights)
         self.model.load(weights)
         return self

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -368,8 +368,8 @@ class Model(torch.nn.Module):
         self._check_is_pytorch_model()
         if isinstance(weights, (str, Path)):
             self.overrides["pretrained"] = weights  # remember the weights for DDP training
-            self.ckpt_path = weights  # remember source path so resume=True can locate the checkpoint
             weights, self.ckpt = load_checkpoint(weights)
+            self.ckpt_path = weights.pt_path  # resolved checkpoint path so resume=True can locate it
         self.model.load(weights)
         return self
 


### PR DESCRIPTION
- set `ckpt_path` in `model.load()` from the resolved path returned by `load_checkpoint()` (`weights.pt_path`), mirroring `model._load()`
- without it, `yolo("arch.yaml").load("last.pt").train(resume=true)` silently restarts from epoch 0 because `check_resume()` requires `path(resume).exists()` and an unresolved stem or remote input fails that gate

resolves #24522