### PR TITLE
Fix custom get_model signature in usage/engine.md

### DIFF
--- a/docs/en/usage/engine.md
+++ b/docs/en/usage/engine.md
@@ -53,7 +53,7 @@ from ultralytics.models.yolo.detect import DetectionTrainer
 
 
 class CustomTrainer(DetectionTrainer):
-    def get_model(self, cfg, weights):
+    def get_model(self, cfg=None, weights=None, verbose=True):
         """Loads a custom detection model given configuration and weight files."""
         ...
 
@@ -76,7 +76,7 @@ class MyCustomModel(DetectionModel):
 
 
 class CustomTrainer(DetectionTrainer):
-    def get_model(self, cfg, weights):
+    def get_model(self, cfg=None, weights=None, verbose=True):
         """Returns a customized detection model instance configured with specified config and weights."""
         return MyCustomModel(...)
 
@@ -110,7 +110,7 @@ from ultralytics.models.yolo.detect import DetectionTrainer
 
 # Create a custom trainer
 class MyCustomTrainer(DetectionTrainer):
-    def get_model(self, cfg, weights):
+    def get_model(self, cfg=None, weights=None, verbose=True):
         """Custom code implementation."""
         ...
 
@@ -135,7 +135,7 @@ from ultralytics.models.yolo.detect import DetectionTrainer
 
 
 class CustomTrainer(DetectionTrainer):
-    def get_model(self, cfg, weights):
+    def get_model(self, cfg=None, weights=None, verbose=True):
         """Loads a custom detection model given configuration and weight files."""
         ...
 
@@ -202,7 +202,7 @@ from ultralytics.models.yolo.detect import DetectionTrainer
 
 
 class CustomDetectionTrainer(DetectionTrainer):
-    def get_model(self, cfg, weights):
+    def get_model(self, cfg=None, weights=None, verbose=True):
         """Loads a custom detection model."""
         ...
 


### PR DESCRIPTION
## summary

The custom-trainer examples in `docs/en/usage/engine.md` defined `get_model(self, cfg, weights)`, but `BaseTrainer.setup_model()` calls `self.get_model(cfg=cfg, weights=weights, verbose=...)`. Running a custom trainer directly (`CustomTrainer(overrides=...).train()`) therefore raised `TypeError: get_model() got an unexpected keyword argument 'verbose'`. Aligned all five overrides with the real signature `get_model(self, cfg=None, weights=None, verbose=True)` (matching `models/yolo/detect/train.py` and the guides/custom-trainer.md page); verified the examples now train on both the direct and `model.train(trainer=...)` paths.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the custom trainer documentation to reflect the current `get_model()` method signature, improving accuracy for users extending Ultralytics training workflows.

### 📊 Key Changes
- Updated all `get_model()` examples in `docs/en/usage/engine.md` from:
  - `get_model(self, cfg, weights)`
- To the current form:
  - `get_model(self, cfg=None, weights=None, verbose=True)`
- Applied this change across multiple custom trainer examples, including:
  - `CustomTrainer`
  - `MyCustomTrainer`
  - `CustomDetectionTrainer`
- Kept the example logic the same while aligning docs with the actual API usage 📚

### 🎯 Purpose & Impact
- Helps developers avoid confusion or errors when creating custom trainers based on outdated method signatures ✅
- Makes the documentation match the current Ultralytics engine interface, improving reliability and developer experience 🔧
- Supports smoother customization of training pipelines for advanced users working with custom models and trainers 🚀
- Since this is a documentation-only update, it does not change runtime behavior, but it can prevent implementation mistakes caused by stale examples 👍