### PR TITLE
Update tasks banner to yolo26 and fix pypi rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Discover more examples in the YOLO [Python Docs](https://docs.ultralytics.com/us
 Ultralytics supports a wide range of YOLO models, from early versions like [YOLOv3](https://docs.ultralytics.com/models/yolov3) to the latest [YOLO26](https://docs.ultralytics.com/models/yolo26). The tables below showcase YOLO26 models pretrained on the [COCO](https://docs.ultralytics.com/datasets/detect/coco) dataset for [Detection](https://docs.ultralytics.com/tasks/detect), [Segmentation](https://docs.ultralytics.com/tasks/segment), and [Pose Estimation](https://docs.ultralytics.com/tasks/pose). Additionally, [Classification](https://docs.ultralytics.com/tasks/classify) models pretrained on the [ImageNet](https://docs.ultralytics.com/datasets/classify/imagenet) dataset are available. [Tracking](https://docs.ultralytics.com/modes/track) mode is compatible with all Detection, Segmentation, and Pose models. All [Models](https://docs.ultralytics.com/models) are automatically downloaded from the latest Ultralytics [release](https://github.com/ultralytics/assets/releases) upon first use.
 
 <a href="https://docs.ultralytics.com/tasks" target="_blank">
-    <img width="100%" src="https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-tasks-banner.avif" alt="Ultralytics YOLO supported tasks">
+    <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/docs/ultralytics-yolo26-tasks-banner.avif" alt="Ultralytics YOLO supported tasks">
 </a>
 <br>
 <br>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,7 +120,7 @@ path = model.export(format="onnx")  # 返回导出模型的路径
 Ultralytics 支持广泛的 YOLO 模型，从早期的版本如 [YOLOv3](https://docs.ultralytics.com/models/yolov3) 到最新的 [YOLO26](https://docs.ultralytics.com/models/yolo26)。下表展示了在 [COCO](https://docs.ultralytics.com/datasets/detect/coco) 数据集上预训练的 YOLO26 模型，用于[检测](https://docs.ultralytics.com/tasks/detect)、[分割](https://docs.ultralytics.com/tasks/segment)和[姿态估计](https://docs.ultralytics.com/tasks/pose)任务。此外，还提供了在 [ImageNet](https://docs.ultralytics.com/datasets/classify/imagenet) 数据集上预训练的[分类](https://docs.ultralytics.com/tasks/classify)模型。[跟踪](https://docs.ultralytics.com/modes/track)模式与所有检测、分割和姿态模型兼容。所有[模型](https://docs.ultralytics.com/models)在首次使用时都会自动从最新的 Ultralytics [发布版本](https://github.com/ultralytics/assets/releases)下载。
 
 <a href="https://docs.ultralytics.com/tasks" target="_blank">
-    <img width="100%" src="https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-tasks-banner.avif" alt="Ultralytics YOLO supported tasks">
+    <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/docs/ultralytics-yolo26-tasks-banner.avif" alt="Ultralytics YOLO supported tasks">
 </a>
 <br>
 <br>

--- a/docs/en/tasks/index.md
+++ b/docs/en/tasks/index.md
@@ -6,7 +6,7 @@ keywords: Ultralytics YOLO26, detection, segmentation, classification, oriented 
 
 # Computer Vision Tasks Supported by Ultralytics YOLO26
 
-<img width="1024" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-yolov8-tasks-banner.avif" alt="Ultralytics YOLO supported computer vision tasks">
+<img width="1024" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-yolo26-tasks-banner.avif" alt="Ultralytics YOLO supported computer vision tasks">
 
 Ultralytics YOLO26 is a versatile AI framework that supports multiple [computer vision](https://www.ultralytics.com/blog/everything-you-need-to-know-about-computer-vision-in-2025) **tasks**. The framework can be used to perform [detection](detect.md), [segmentation](segment.md), [OBB](obb.md), [classification](classify.md), and [pose](pose.md) estimation. Each of these tasks has a different objective and use case, allowing you to address various computer vision challenges with a single framework.
 


### PR DESCRIPTION
## summary

updates the tasks banner to a new yolo26 version that includes the `semantic` task (now 7 tasks vs 6). also switches the readme image source from github releases (`application/octet-stream`) to raw github (`image/avif`), which fixes the banner not rendering on https://pypi.org/project/ultralytics/ — pypi's camo proxy rejects non-image mime types with `Unsupported content-type returned`.

depends on ultralytics/assets#162 (the banner file) — merge that first.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🖼️ This PR refreshes Ultralytics documentation visuals by replacing older YOLOv8 task banner images with updated YOLO26 banners across the main README, Chinese README, and task docs.

### 📊 Key Changes
- Updated the task banner image in `README.md` to use a new YOLO26-branded asset.
- Updated the same banner in `README.zh-CN.md` for consistency in the Chinese documentation.
- Replaced the banner in `docs/en/tasks/index.md` with the matching YOLO26 version.
- Switched image sources from older hosted locations to current assets hosted in the Ultralytics assets repository/CDN.

### 🎯 Purpose & Impact
- Improves documentation consistency by aligning visuals with the latest recommended model family, YOLO26 🚀
- Reduces branding confusion for users who might otherwise see outdated YOLOv8 imagery in current docs.
- Keeps English and Chinese docs visually synchronized 🌍
- Helps present a more polished, up-to-date first impression for new users exploring Ultralytics documentation and supported tasks ✨