### PR TITLE
Fix tasks banner not rendering on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Discover more examples in the YOLO [Python Docs](https://docs.ultralytics.com/us
 Ultralytics supports a wide range of YOLO models, from early versions like [YOLOv3](https://docs.ultralytics.com/models/yolov3) to the latest [YOLO26](https://docs.ultralytics.com/models/yolo26). The tables below showcase YOLO26 models pretrained on [COCO](https://docs.ultralytics.com/datasets/detect/coco) for [Detection](https://docs.ultralytics.com/tasks/detect), [Segmentation](https://docs.ultralytics.com/tasks/segment), and [Pose Estimation](https://docs.ultralytics.com/tasks/pose). [Semantic Segmentation](https://docs.ultralytics.com/tasks/semantic) models are pretrained on [Cityscapes](https://docs.ultralytics.com/datasets/semantic/cityscapes), and [Classification](https://docs.ultralytics.com/tasks/classify) models are pretrained on [ImageNet](https://docs.ultralytics.com/datasets/classify/imagenet). [Tracking](https://docs.ultralytics.com/modes/track) mode is compatible with Detection, Segmentation, and Pose models. All [Models](https://docs.ultralytics.com/models) download automatically from the latest Ultralytics [release](https://github.com/ultralytics/assets/releases) on first use.
 
 <a href="https://docs.ultralytics.com/tasks" target="_blank">
-    <img width="100%" src="https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-tasks-banner.avif" alt="Ultralytics YOLO supported tasks">
+    <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/docs/ultralytics-yolov8-tasks-banner.avif" alt="Ultralytics YOLO supported tasks">
 </a>
 <br>
 <br>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,7 +120,7 @@ path = model.export(format="onnx")  # 返回导出模型的路径
 Ultralytics 支持广泛的 YOLO 模型，从早期的版本如 [YOLOv3](https://docs.ultralytics.com/models/yolov3) 到最新的 [YOLO26](https://docs.ultralytics.com/models/yolo26)。下表展示了在 [COCO](https://docs.ultralytics.com/datasets/detect/coco) 上预训练的 YOLO26 模型，用于[检测](https://docs.ultralytics.com/tasks/detect)、[分割](https://docs.ultralytics.com/tasks/segment)和[姿态估计](https://docs.ultralytics.com/tasks/pose)任务。[语义分割](https://docs.ultralytics.com/tasks/semantic)模型在 [Cityscapes](https://docs.ultralytics.com/datasets/semantic/cityscapes) 上预训练，[分类](https://docs.ultralytics.com/tasks/classify)模型在 [ImageNet](https://docs.ultralytics.com/datasets/classify/imagenet) 上预训练。[跟踪](https://docs.ultralytics.com/modes/track)模式与检测、分割和姿态模型兼容。所有[模型](https://docs.ultralytics.com/models)在首次使用时都会自动从最新的 Ultralytics [发布版本](https://github.com/ultralytics/assets/releases)下载。
 
 <a href="https://docs.ultralytics.com/tasks" target="_blank">
-    <img width="100%" src="https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-tasks-banner.avif" alt="Ultralytics YOLO supported tasks">
+    <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/docs/ultralytics-yolov8-tasks-banner.avif" alt="Ultralytics YOLO supported tasks">
 </a>
 <br>
 <br>


### PR DESCRIPTION
## summary

switches the tasks banner image source in `README.md` and `README.zh-CN.md` from github releases to `raw.githubusercontent.com` so it renders on https://pypi.org/project/ultralytics/.

pypi proxies all readme images through `pypi-camo.freetls.fastly.net`, which accepts only `image/*` mime types. github releases serves all assets as `application/octet-stream`, so camo rejects the banner with `HTTP 400 Unsupported content-type returned`. raw github serves the same file with `content-type: image/avif`, which camo allows. matches the pattern already used by the hero `banner-yolov8.png` at the top of the readme — that banner renders correctly on pypi today.

<img width="1470" height="832" alt="image" src="https://github.com/user-attachments/assets/762b6310-b402-4f76-abf4-d587dbb72089" />

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🖼️ This PR updates the task banner image source in both the English and Chinese READMEs to use the Ultralytics assets repository directly instead of a GitHub release URL.

### 📊 Key Changes
- Updated the banner image URL in `README.md` to load from `raw.githubusercontent.com/ultralytics/assets/main/docs/...`.
- Made the same image source update in `README.zh-CN.md` for consistency across languages.
- Kept the linked destination and displayed content unchanged; only the image hosting location was changed.

### 🎯 Purpose & Impact
- Improves documentation reliability by pointing to a direct, centralized asset source 📚
- Reduces dependence on a specific GitHub release asset URL, which can be less flexible over time 🔗
- Helps ensure the README banner continues to load correctly for users viewing the repository in different languages 🌍
- No impact on YOLO model behavior, training, or inference; this is a documentation-only maintenance update ✅