### PR TITLE
Fix Cityscapes glossary link

### DIFF
--- a/docs/en/datasets/semantic/cityscapes.md
+++ b/docs/en/datasets/semantic/cityscapes.md
@@ -34,7 +34,7 @@ The semantic masks are single-channel PNG files. The original Cityscapes label I
 
 ## Applications
 
-Cityscapes is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in semantic segmentation, particularly for [autonomous driving](https://www.ultralytics.com/glossary/self-driving-cars), advanced driver-assistance systems (ADAS), and urban robotics.
+Cityscapes is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in semantic segmentation, particularly for [autonomous driving](https://www.ultralytics.com/glossary/autonomous-vehicles), advanced driver-assistance systems (ADAS), and urban robotics.
 
 Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments.
 


### PR DESCRIPTION
## Summary
- replace the broken Cityscapes self-driving cars glossary link with the existing autonomous vehicles glossary term from assistant/sitemaps/sitemap.json

## Validation
- rg -n "self-driving-cars|autonomous-vehicles" docs/en/datasets/semantic/cityscapes.md ../assistant/assistant/sitemaps/sitemap.json
- curl -I -L --max-time 20 https://www.ultralytics.com/glossary/autonomous-vehicles

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR makes a small documentation fix by updating the Cityscapes dataset page to use a more accurate glossary link for autonomous driving terminology.

### 📊 Key Changes
- Replaced the glossary link in the [Cityscapes dataset documentation](https://github.com/ultralytics/ultralytics) from **self-driving cars** to **autonomous vehicles**.
- Kept the visible text as “autonomous driving,” while pointing it to a glossary entry that better matches the topic.
- No code, model, training, or dataset behavior was changed—this is a documentation-only update. 📝

### 🎯 Purpose & Impact
- Improves documentation accuracy and consistency across Ultralytics docs.
- Helps readers reach a more relevant glossary definition when learning about Cityscapes use cases.
- Makes the docs slightly clearer for users working on ADAS, robotics, and autonomous driving applications. 🚗
- Carries no functional impact on YOLO training or inference, but improves the overall documentation experience.