### PR TITLE
Fix semantic docs typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See the [Semantic Segmentation Docs](https://docs.ultralytics.com/tasks/semantic
 | [YOLO26x-sem](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-sem.pt) | 1024 &times; 2048           | 83.6               | 48.9 ± 0.2                                  | 40.2                     | 861.7                   |
 
 - **mIoU<sup>val</sup>** values are for single-model single-scale on the [Cityscapes](https://www.cityscapes-dataset.com/) validation set. <br>Reproduce with `yolo semantic val data=cityscapes.yaml device=0 imgsz=2048`
-- **Speed** metrics are averaged over Cityscapes validation images using an RTX3090 instance. <br>Reproduce with `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`
+- **Speed** metrics are averaged over Cityscapes validation images using a RTX3090 instance. <br>Reproduce with `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See the [Semantic Segmentation Docs](https://docs.ultralytics.com/tasks/semantic
 | [YOLO26x-sem](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-sem.pt) | 1024 &times; 2048           | 83.6               | 48.9 ± 0.2                                  | 40.2                     | 861.7                   |
 
 - **mIoU<sup>val</sup>** values are for single-model single-scale on the [Cityscapes](https://www.cityscapes-dataset.com/) validation set. <br>Reproduce with `yolo semantic val data=cityscapes.yaml device=0 imgsz=2048`
-- **Speed** metrics are averaged over Cityscapes validation images using a RTX3090 instance. <br>Reproduce with `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`
+- **Speed** metrics are averaged over Cityscapes validation images using an RTX3090 instance. <br>Reproduce with `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`
 
 </details>
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -26,7 +26,7 @@ YOLO26 semantic segmentation models pretrained on the [Cityscapes](https://githu
 {% include "macros/yolo-semantic-perf.md" %}
 
 - **mIoU<sup>val</sup>** values are for single-model single-scale on the [Cityscapes](https://www.cityscapes-dataset.com/) validation set. <br>Reproduce with `yolo semantic val data=cityscapes.yaml device=0 imgsz=2048`
-- **Speed** metrics are averaged over Cityscapes validation images using an [Amazon EC2 P4d](https://aws.amazon.com/ec2/instance-types/p4/) instance. <br>Reproduce with `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`
+- **Speed** metrics are averaged over Cityscapes validation images using a RTX3090 instance. <br>Reproduce with `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`
 - **Params** and **FLOPs** values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers. Pretrained checkpoints retain the full training architecture and may show higher counts.
 
 ## Train

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -26,7 +26,7 @@ YOLO26 semantic segmentation models pretrained on the [Cityscapes](https://githu
 {% include "macros/yolo-semantic-perf.md" %}
 
 - **mIoU<sup>val</sup>** values are for single-model single-scale on the [Cityscapes](https://www.cityscapes-dataset.com/) validation set. <br>Reproduce with `yolo semantic val data=cityscapes.yaml device=0 imgsz=2048`
-- **Speed** metrics are averaged over Cityscapes validation images using a RTX3090 instance. <br>Reproduce with `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`
+- **Speed** metrics are averaged over Cityscapes validation images using an RTX3090 instance. <br>Reproduce with `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`
 - **Params** and **FLOPs** values are for the fused model after `model.fuse()`, which merges Conv and BatchNorm layers. Pretrained checkpoints retain the full training architecture and may show higher counts.
 
 ## Train


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the semantic segmentation docs to correct the hardware used for reported speed benchmarks, changing it from an Amazon EC2 P4d instance to an RTX3090 instance.

### 📊 Key Changes
- Updated the **semantic segmentation documentation** in `docs/en/tasks/semantic.md`.
- Changed the description of **Speed** benchmark hardware:
  - from **Amazon EC2 P4d**
  - to **RTX3090**
- Kept the existing benchmark reproduction command unchanged:
  - `yolo semantic val data=cityscapes.yaml batch=1 device=0|cpu imgsz=2048`

### 🎯 Purpose & Impact
- ✅ **Improves documentation accuracy** by aligning the reported speed metrics with the actual hardware used.
- 🔍 **Reduces confusion** for users comparing benchmark numbers against their own systems.
- 📈 **Sets clearer performance expectations** for anyone evaluating YOLO26 semantic segmentation results.
- 🛠️ **Helps reproducibility** by making the benchmark context more transparent for developers and researchers.