### PR TITLE
Fix semantic `nt_per_image` printing issue

### DIFF
--- a/ultralytics/models/yolo/semantic/val.py
+++ b/ultralytics/models/yolo/semantic/val.py
@@ -163,7 +163,6 @@ class SemanticSegmentationValidator(DetectionValidator):
         if self.metrics.matrix is not None:
             # Internal layout is [gt, pred]; transpose to [pred, gt] for ConfusionMatrix export format.
             self.confusion_matrix.matrix = self.metrics.matrix.detach().cpu().numpy().T.astype(float)
-        self.metrics.clear_stats()
         return self.metrics.results_dict
 
     def get_desc(self):

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1740,7 +1740,7 @@ class SemanticMetrics(SimpleClass, DataExportMixin):
 
         intersection = torch.diagonal(self.matrix)
         union = self.matrix.sum(1) + self.matrix.sum(0) - intersection
-        iou = torch.where(union > 0, intersection / union, torch.tensor(float("nan"), device=union.device))
+        iou = torch.where(union > 0, intersection / union, 0)
         row_sum = self.matrix.sum(1)
         pa = intersection / (row_sum + 1e-10)
 
@@ -1750,7 +1750,7 @@ class SemanticMetrics(SimpleClass, DataExportMixin):
             self._per_class_pixel_acc = pa[1:].cpu().numpy()
             self.nt_per_class = np.array([row_sum[1].item()], dtype=np.int32)
         else:
-            self._miou = float(iou[~torch.isnan(iou)].mean().item())
+            self._miou = float(iou.mean().item())
             self._per_class_iou = iou.cpu().numpy()
             self._per_class_pixel_acc = pa.cpu().numpy()
             self.nt_per_class = row_sum[: self.nc].cpu().numpy().astype(np.int32)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1740,7 +1740,7 @@ class SemanticMetrics(SimpleClass, DataExportMixin):
 
         intersection = torch.diagonal(self.matrix)
         union = self.matrix.sum(1) + self.matrix.sum(0) - intersection
-        iou = torch.where(union > 0, intersection / union, 0)
+        iou = torch.where(union > 0, intersection / union, torch.zeros_like(intersection, dtype=torch.float32))
         row_sum = self.matrix.sum(1)
         pa = intersection / (row_sum + 1e-10)
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes semantic segmentation validation so metrics remain available after evaluation and mIoU is computed more robustly when some classes are absent 🧩📈

### 📊 Key Changes
- Removed a call to `self.metrics.clear_stats()` in `ultralytics/models/yolo/semantic/val.py`
  - This prevents semantic segmentation validation stats from being cleared too early after `get_stats()` runs.
- Updated IoU handling in `ultralytics/utils/metrics.py`
  - Classes with zero union now produce `0` IoU instead of `NaN`.
- Simplified mean IoU calculation
  - `mIoU` is now computed using a direct mean over all class IoUs, since missing classes no longer introduce `NaN` values.
- Preserved confusion matrix export behavior
  - The confusion matrix is still transposed into the expected export format before being returned.

### 🎯 Purpose & Impact
- Improves reliability of semantic segmentation validation results ✅
  - Metrics are no longer wiped immediately, which helps downstream reporting, logging, and result access.
- Makes mIoU calculation more stable 🛠️
  - Validation won’t be skewed by `NaN` values when certain classes do not appear in a batch or dataset split.
- Produces more predictable outputs for users and integrations 🤝
  - Tools that consume per-class metrics or validation summaries can handle results more consistently.
- Especially helpful for sparse or imbalanced segmentation datasets 🎯
  - If some classes are missing, validation still completes with clean numeric outputs instead of undefined values.