### PR TITLE
Add segmentation results output details to task docs

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -512,20 +512,20 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 
 `Results` objects have the following attributes:
 
-| Attribute    | Type                  | Description                                                                              |
-| ------------ | --------------------- | ---------------------------------------------------------------------------------------- |
-| `orig_img`   | `np.ndarray`          | The original image as a NumPy array.                                                     |
-| `orig_shape` | `tuple`               | The original image shape in (height, width) format.                                      |
-| `boxes`      | `Boxes, optional`     | A Boxes object containing the detection bounding boxes.                                  |
-| `masks`      | `Masks, optional`     | A Masks object containing the detection masks.                                           |
-| `probs`      | `Probs, optional`     | A Probs object containing probabilities of each class for classification task.           |
-| `keypoints`  | `Keypoints, optional` | A Keypoints object containing detected keypoints for each object.                        |
-| `obb`        | `OBB, optional`       | An OBB object containing oriented bounding boxes.                                        |
-| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                        |
-| `speed`      | `dict`                | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
-| `names`      | `dict`                | A dictionary mapping class indices to class names.                                       |
-| `path`       | `str`                 | The path to the image file.                                                              |
-| `save_dir`   | `str, optional`       | Directory to save results.                                                               |
+| Attribute       | Type                     | Description                                                                              |
+| --------------- | ------------------------ | ---------------------------------------------------------------------------------------- |
+| `orig_img`      | `np.ndarray`             | The original image as a NumPy array.                                                     |
+| `orig_shape`    | `tuple`                  | The original image shape in (height, width) format.                                      |
+| `boxes`         | `Boxes, optional`        | A Boxes object containing the detection bounding boxes.                                  |
+| `masks`         | `Masks, optional`        | A Masks object containing the detection masks.                                           |
+| `probs`         | `Probs, optional`        | A Probs object containing probabilities of each class for classification task.           |
+| `keypoints`     | `Keypoints, optional`    | A Keypoints object containing detected keypoints for each object.                        |
+| `obb`           | `OBB, optional`          | An OBB object containing oriented bounding boxes.                                        |
+| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                            |
+| `speed`         | `dict`                   | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
+| `names`         | `dict`                   | A dictionary mapping class indices to class names.                                       |
+| `path`          | `str`                    | The path to the image file.                                                              |
+| `save_dir`      | `str, optional`          | Directory to save results.                                                               |
 
 ### Results by Task
 
@@ -595,24 +595,24 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
 
 `Results` objects have the following methods:
 
-| Method        | Return Type            | Description                                                                               |
-| ------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
+| Method        | Return Type            | Description                                                                                              |
+| ------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
 | `update()`    | `None`                 | Updates the Results object with new data such as boxes, masks, probs, obb, keypoints, or semantic masks. |
-| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                |
-| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.          |
-| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                |
-| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.    |
-| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.      |
-| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.            |
-| `show()`      | `None`                 | Displays the image with annotated inference results.                                      |
-| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                 |
-| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.      |
-| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.            |
-| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                    |
-| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.        |
-| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                         |
-| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                 |
-| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                |
+| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                               |
+| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.                         |
+| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                               |
+| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.                   |
+| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.                     |
+| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.                           |
+| `show()`      | `None`                 | Displays the image with annotated inference results.                                                     |
+| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                                |
+| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.                     |
+| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.                           |
+| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                                   |
+| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.                       |
+| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                                        |
+| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                                |
+| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                               |
 
 For more details see the [`Results` class documentation](../reference/engine/results.md).
 
@@ -676,15 +676,15 @@ For more details see the [`Boxes` class documentation](../reference/engine/resul
 
 Here is a table for the `Masks` class methods and properties, including their name, type, and description:
 
-| Name      | Type                      | Description                                                   |
-| --------- | ------------------------- | ------------------------------------------------------------- |
-| `data`    | Property (`torch.Tensor`) | `torch.uint8` binary mask tensor with shape `(N,H,W)` and values `0` or `1`. |
-| `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                       |
-| `numpy()` | Method                    | Returns the masks tensor as a NumPy array.                    |
-| `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                       |
-| `to()`    | Method                    | Returns the masks tensor with the specified device and dtype. |
-| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                        |
-| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.              |
+| Name      | Type                          | Description                                                                  |
+| --------- | ----------------------------- | ---------------------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`)     | `torch.uint8` binary mask tensor with shape `(N,H,W)` and values `0` or `1`. |
+| `cpu()`   | Method                        | Returns the masks tensor on CPU memory.                                      |
+| `numpy()` | Method                        | Returns the masks tensor as a NumPy array.                                   |
+| `cuda()`  | Method                        | Returns the masks tensor on GPU memory.                                      |
+| `to()`    | Method                        | Returns the masks tensor with the specified device and dtype.                |
+| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                                          |
+| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.                                |
 
 For more details see the [`Masks` class documentation](../reference/engine/results.md#ultralytics.engine.results.Masks).
 
@@ -709,14 +709,14 @@ binary mask per object and does not provide polygon helpers.
         print(r.semantic_mask.data)  # print the H x W class-ID map
     ```
 
-| Name      | Type                      | Description                                                             |
-| --------- | ------------------------- | ----------------------------------------------------------------------- |
+| Name      | Type                      | Description                                                                                |
+| --------- | ------------------------- | ------------------------------------------------------------------------------------------ |
 | `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H,W)` and dtype `torch.uint8`<br>`torch.int16`<br>`torch.int32`. |
-| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.           |
-| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                         |
-| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                      |
-| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                         |
-| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.   |
+| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.                              |
+| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                                            |
+| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                                         |
+| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                                            |
+| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.                      |
 
 ### Keypoints
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -539,7 +539,7 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
     | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
     | `result.boxes` | `Boxes` | `(N)` | - | Detection boxes. |
-    | `result.boxes.data` | `Tensor` | `(N,6|7)` | `torch.float32` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
+    | `result.boxes.data` | `Tensor` | `(N,6/7)` | `torch.float32` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
     | `result.boxes.xyxy` | `Tensor` | `(N,4)` | `torch.float32` | `xyxy` pixel boxes. |
     | `result.boxes.conf` | `Tensor` | `(N,)` | `torch.float32` | Confidence scores. |
     | `result.boxes.cls` | `Tensor` | `(N,)` | `torch.float32` | Class IDs; cast to `int` for names. |
@@ -558,7 +558,7 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
 
     | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
-    | `result.semantic_mask` | `SemanticMask` | `(H,W)` | - | Dense class-map container. |
+    | `result.semantic_mask` | `SemanticMask` | `(H,W)` | - | Dense class map. |
     | `result.semantic_mask.data` | `Tensor` | `(H,W)` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs. |
     | `result.masks` | `None` | - | - | No instance masks. |
     | `result.boxes` | `None` | - | - | No instance boxes/confidences. |
@@ -578,8 +578,8 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
     | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
     | `result.boxes` | `Boxes` | `(N)` | - | Instance boxes. |
-    | `result.keypoints` | `Keypoints` | `(N)` | - | Keypoint container. |
-    | `result.keypoints.data` | `Tensor` | `(N,K,2|3)` | `torch.float32` | `x,y` plus optional visibility/confidence. |
+    | `result.keypoints` | `Keypoints` | `(N)` | - | Keypoints. |
+    | `result.keypoints.data` | `Tensor` | `(N,K,2/3)` | `torch.float32` | `x,y` plus optional visibility/confidence. |
     | `result.keypoints.xy` | `Tensor` | `(N,K,2)` | `torch.float32` | Pixel keypoints. |
     | `result.keypoints.xyn` | `Tensor` | `(N,K,2)` | `torch.float32` | Normalized keypoints. |
 
@@ -588,7 +588,7 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
     | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
     | `result.obb` | `OBB` | `(N)` | - | Oriented boxes. |
-    | `result.obb.data` | `Tensor` | `(N,7|8)` | `torch.float32` | Raw rotated boxes with confidence/class. |
+    | `result.obb.data` | `Tensor` | `(N,7/8)` | `torch.float32` | Raw rotated boxes with confidence/class. |
     | `result.obb.xywhr` | `Tensor` | `(N,5)` | `torch.float32` | `xywhr` rotated boxes. |
     | `result.obb.xyxyxyxy` | `Tensor` | `(N,4,2)` | `torch.float32` | Four corner points. |
     | `result.obb.conf` | `Tensor` | `(N,)` | `torch.float32` | Confidence scores. |

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -512,108 +512,107 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 
 `Results` objects have the following attributes:
 
-| Attribute       | Type                     | Description                                                                              |
-| --------------- | ------------------------ | ---------------------------------------------------------------------------------------- |
-| `orig_img`      | `np.ndarray`             | The original image as a NumPy array.                                                     |
-| `orig_shape`    | `tuple`                  | The original image shape in (height, width) format.                                      |
-| `boxes`         | `Boxes, optional`        | A Boxes object containing the detection bounding boxes.                                  |
-| `masks`         | `Masks, optional`        | A Masks object containing the detection masks.                                           |
-| `probs`         | `Probs, optional`        | A Probs object containing probabilities of each class for classification task.           |
-| `keypoints`     | `Keypoints, optional`    | A Keypoints object containing detected keypoints for each object.                        |
-| `obb`           | `OBB, optional`          | An OBB object containing oriented bounding boxes.                                        |
-| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                            |
-| `speed`         | `dict`                   | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
-| `names`         | `dict`                   | A dictionary mapping class indices to class names.                                       |
-| `path`          | `str`                    | The path to the image file.                                                              |
-| `save_dir`      | `str, optional`          | Directory to save results.                                                               |
+| Attribute    | Type                  | Description                                                                              |
+| ------------ | --------------------- | ---------------------------------------------------------------------------------------- |
+| `orig_img`   | `np.ndarray`          | The original image as a NumPy array.                                                     |
+| `orig_shape` | `tuple`               | The original image shape in (height, width) format.                                      |
+| `boxes`      | `Boxes, optional`     | A Boxes object containing the detection bounding boxes.                                  |
+| `masks`      | `Masks, optional`     | A Masks object containing the detection masks.                                           |
+| `probs`      | `Probs, optional`     | A Probs object containing probabilities of each class for classification task.           |
+| `keypoints`  | `Keypoints, optional` | A Keypoints object containing detected keypoints for each object.                        |
+| `obb`        | `OBB, optional`       | An OBB object containing oriented bounding boxes.                                        |
+| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                        |
+| `speed`      | `dict`                | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
+| `names`      | `dict`                | A dictionary mapping class indices to class names.                                       |
+| `path`       | `str`                 | The path to the image file.                                                              |
+| `save_dir`   | `str, optional`       | Directory to save results.                                                               |
 
 ### Results by Task
 
 Each prediction returns one `Results` object per image or frame. The common fields above are always available, while the
 task-specific prediction data is stored in the fields below. Coordinate, confidence, and probability tensors are
-floating point tensors, usually `torch.float32` in standard PyTorch inference. They may be `torch.float16` when using
-half-precision inference or some exported backends, and they become NumPy floating dtypes after `result.numpy()`.
+`torch.float32` unless half precision is used, then `torch.float16`. After `result.numpy()`, tensors become NumPy arrays with matching NumPy dtypes.
 Instance masks are `torch.uint8` binary tensors, while semantic masks use compact integer class IDs.
 
 === "Detect"
 
-    | Field | Type | Shape / Values | Dtype | Description |
+    | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
-    | `result.boxes` | `Boxes` | `N` boxes | Container | Detection boxes for each object. |
-    | `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Floating point | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
-    | `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)` | Floating point | Box coordinates in `[x1, y1, x2, y2]` pixel format. |
-    | `result.boxes.conf` | `torch.Tensor` | `(N,)` | Floating point | Confidence score for each detection. |
-    | `result.boxes.cls` | `torch.Tensor` | `(N,)` | Floating point class IDs | Class ID for each detection; cast to `int` for name lookup. |
+    | `result.boxes` | `Boxes` | `(N)` | - | Detection boxes. |
+    | `result.boxes.data` | `Tensor` | `(N,6|7)` | `torch.float32` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
+    | `result.boxes.xyxy` | `Tensor` | `(N,4)` | `torch.float32` | `xyxy` pixel boxes. |
+    | `result.boxes.conf` | `Tensor` | `(N,)` | `torch.float32` | Confidence scores. |
+    | `result.boxes.cls` | `Tensor` | `(N,)` | `torch.float32` | Class IDs; cast to `int` for names. |
 
 === "Segment"
 
-    | Field | Type | Shape / Values | Dtype | Description |
+    | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
-    | `result.boxes` | `Boxes` | `N` boxes | Container | Boxes, confidences, and class IDs for each detected instance. |
-    | `result.masks` | `Masks` | `N` masks | Container | Instance mask container aligned with `result.boxes`. |
-    | `result.masks.data` | `torch.Tensor` | `(N, H, W)` | `torch.uint8` | Binary mask stack with values `0` or `1`, one mask per instance. |
-    | `result.masks.xy` | `list[np.ndarray]` | One `(points, 2)` array per instance | Floating point | Mask polygons in pixel coordinates. |
-    | `result.masks.xyn` | `list[np.ndarray]` | One `(points, 2)` array per instance | Floating point | Normalized mask polygons. |
+    | `result.boxes` | `Boxes` | `(N)` | - | Instance boxes/classes/confidences. |
+    | `result.masks` | `Masks` | `(N)` | - | Instance masks. |
+    | `result.masks.data` | `Tensor` | `(N,H,W)` | `torch.uint8` | Binary masks, values `0` or `1`. |
+    | `result.masks.xy` | `list[ndarray]` | `list[(P,2)]` | `np.float32` | Pixel polygons. |
+    | `result.masks.xyn` | `list[ndarray]` | `list[(P,2)]` | `np.float32` | Normalized polygons. |
 
 === "Semantic"
 
-    | Field | Type | Shape / Values | Dtype | Description |
+    | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
-    | `result.semantic_mask` | `SemanticMask` | One mask per image | Container | Dense semantic class-map container. |
-    | `result.semantic_mask.data` | `torch.Tensor` | `(H, W)` | `torch.uint8`, `torch.int16`, or `torch.int32` | Per-pixel class IDs for the full image. |
-    | `result.masks` | `None` | Not applicable | Not applicable | Semantic segmentation does not return per-instance mask stacks. |
-    | `result.boxes` | `None` | Not applicable | Not applicable | Semantic segmentation does not return per-instance boxes or confidence scores. |
+    | `result.semantic_mask` | `SemanticMask` | `(H,W)` | - | Dense class-map container. |
+    | `result.semantic_mask.data` | `Tensor` | `(H,W)` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs. |
+    | `result.masks` | `None` | - | - | No instance masks. |
+    | `result.boxes` | `None` | - | - | No instance boxes/confidences. |
 
 === "Classify"
 
-    | Field | Type | Shape / Values | Dtype | Description |
+    | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
-    | `result.probs` | `Probs` | One probability vector | Container | Classification probabilities for the image. |
-    | `result.probs.data` | `torch.Tensor` | `(num_classes,)` | Floating point | Probability score for each class. |
-    | `result.probs.top1` | `int` | Class index | Python `int` | Highest-probability class ID. |
-    | `result.probs.top1conf` | `torch.Tensor` | Scalar | Floating point | Confidence for the top class. |
-    | `result.probs.top5` | `list[int]` | Up to 5 class indices | Python `int` list | Top-5 class IDs ordered by confidence. |
+    | `result.probs` | `Probs` | `(C,)` | - | Class probabilities. |
+    | `result.probs.data` | `Tensor` | `(C,)` | `torch.float32` | Probability per class. |
+    | `result.probs.top1` | `int` | `()` | `int` | Top class ID. |
+    | `result.probs.top1conf` | `Tensor` | `()` | `torch.float32` | Top confidence. |
+    | `result.probs.top5` | `list[int]` | `(<=5)` | `list[int]` | Top-5 class IDs. |
 
 === "Pose"
 
-    | Field | Type | Shape / Values | Dtype | Description |
+    | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
-    | `result.boxes` | `Boxes` | `N` boxes | Container | Person or object boxes associated with keypoints. |
-    | `result.keypoints` | `Keypoints` | `N` instances | Container | Keypoint container for each detected instance. |
-    | `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Floating point | Keypoints as `x, y` plus optional visibility/confidence. |
-    | `result.keypoints.xy` | `torch.Tensor` | `(N, K, 2)` | Floating point | Keypoint coordinates in pixels. |
-    | `result.keypoints.xyn` | `torch.Tensor` | `(N, K, 2)` | Floating point | Normalized keypoint coordinates. |
+    | `result.boxes` | `Boxes` | `(N)` | - | Instance boxes. |
+    | `result.keypoints` | `Keypoints` | `(N)` | - | Keypoint container. |
+    | `result.keypoints.data` | `Tensor` | `(N,K,2|3)` | `torch.float32` | `x,y` plus optional visibility/confidence. |
+    | `result.keypoints.xy` | `Tensor` | `(N,K,2)` | `torch.float32` | Pixel keypoints. |
+    | `result.keypoints.xyn` | `Tensor` | `(N,K,2)` | `torch.float32` | Normalized keypoints. |
 
 === "OBB"
 
-    | Field | Type | Shape / Values | Dtype | Description |
+    | Field | Type | Shape | Dtype | Description |
     |---|---|---|---|---|
-    | `result.obb` | `OBB` | `N` rotated boxes | Container | Oriented bounding boxes for each detection. |
-    | `result.obb.data` | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Floating point | Raw rotated boxes with confidence, class, and optional track ID. |
-    | `result.obb.xywhr` | `torch.Tensor` | `(N, 5)` | Floating point | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
-    | `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)` | Floating point | Four corner points for each rotated box. |
-    | `result.obb.conf` | `torch.Tensor` | `(N,)` | Floating point | Confidence score for each rotated box. |
+    | `result.obb` | `OBB` | `(N)` | - | Oriented boxes. |
+    | `result.obb.data` | `Tensor` | `(N,7|8)` | `torch.float32` | Raw rotated boxes with confidence/class. |
+    | `result.obb.xywhr` | `Tensor` | `(N,5)` | `torch.float32` | `xywhr` rotated boxes. |
+    | `result.obb.xyxyxyxy` | `Tensor` | `(N,4,2)` | `torch.float32` | Four corner points. |
+    | `result.obb.conf` | `Tensor` | `(N,)` | `torch.float32` | Confidence scores. |
 
 `Results` objects have the following methods:
 
-| Method        | Return Type            | Description                                                                                              |
-| ------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| Method        | Return Type            | Description                                                                               |
+| ------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
 | `update()`    | `None`                 | Updates the Results object with new data such as boxes, masks, probs, obb, keypoints, or semantic masks. |
-| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                               |
-| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.                         |
-| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                               |
-| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.                   |
-| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.                     |
-| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.                           |
-| `show()`      | `None`                 | Displays the image with annotated inference results.                                                     |
-| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                                |
-| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.                     |
-| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.                           |
-| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                                   |
-| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.                       |
-| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                                        |
-| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                                |
-| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                               |
+| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                |
+| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.          |
+| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                |
+| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.    |
+| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.      |
+| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.            |
+| `show()`      | `None`                 | Displays the image with annotated inference results.                                      |
+| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                 |
+| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.      |
+| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.            |
+| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                    |
+| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.        |
+| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                         |
+| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                 |
+| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                |
 
 For more details see the [`Results` class documentation](../reference/engine/results.md).
 
@@ -677,15 +676,15 @@ For more details see the [`Boxes` class documentation](../reference/engine/resul
 
 Here is a table for the `Masks` class methods and properties, including their name, type, and description:
 
-| Name      | Type                          | Description                                                                    |
-| --------- | ----------------------------- | ------------------------------------------------------------------------------ |
-| `data`    | Property (`torch.Tensor`)     | `torch.uint8` binary mask tensor with shape `(N, H, W)` and values `0` or `1`. |
-| `cpu()`   | Method                        | Returns the masks tensor on CPU memory.                                        |
-| `numpy()` | Method                        | Returns the masks tensor as a NumPy array.                                     |
-| `cuda()`  | Method                        | Returns the masks tensor on GPU memory.                                        |
-| `to()`    | Method                        | Returns the masks tensor with the specified device and dtype.                  |
-| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                                            |
-| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.                                  |
+| Name      | Type                      | Description                                                   |
+| --------- | ------------------------- | ------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`) | `torch.uint8` binary mask tensor with shape `(N,H,W)` and values `0` or `1`. |
+| `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                       |
+| `numpy()` | Method                    | Returns the masks tensor as a NumPy array.                    |
+| `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                       |
+| `to()`    | Method                    | Returns the masks tensor with the specified device and dtype. |
+| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                        |
+| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.              |
 
 For more details see the [`Masks` class documentation](../reference/engine/results.md#ultralytics.engine.results.Masks).
 
@@ -710,14 +709,14 @@ binary mask per object and does not provide polygon helpers.
         print(r.semantic_mask.data)  # print the H x W class-ID map
     ```
 
-| Name      | Type                      | Description                                                                                |
-| --------- | ------------------------- | ------------------------------------------------------------------------------------------ |
-| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H, W)` and dtype `torch.uint8`, `torch.int16`, or `torch.int32`. |
-| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.                              |
-| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                                            |
-| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                                         |
-| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                                            |
-| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.                      |
+| Name      | Type                      | Description                                                             |
+| --------- | ------------------------- | ----------------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H,W)` and dtype `torch.uint8`<br>`torch.int16`<br>`torch.int32`. |
+| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.           |
+| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                         |
+| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                      |
+| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                         |
+| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.   |
 
 ### Keypoints
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -536,62 +536,62 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
 
 === "Detect"
 
-    | Field | Type | Shape | Dtype | Description |
-    |---|---|---|---|---|
-    | `result.boxes` | `Boxes` | `(N)` | - | Detection boxes. |
-    | `result.boxes.data` | `Tensor` | `(N,6/7)` | `torch.float32` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
-    | `result.boxes.xyxy` | `Tensor` | `(N,4)` | `torch.float32` | `xyxy` pixel boxes. |
-    | `result.boxes.conf` | `Tensor` | `(N,)` | `torch.float32` | Confidence scores. |
-    | `result.boxes.cls` | `Tensor` | `(N,)` | `torch.float32` | Class IDs; cast to `int` for names. |
+    | Field | Type | Shape | Description |
+    |---|---|---|---|
+    | `result.boxes` | `Boxes` | `(N)` | Detection boxes. |
+    | `result.boxes.data` | `torch.float32` | `(N,6/7)` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
+    | `result.boxes.xyxy` | `torch.float32` | `(N,4)` | `xyxy` pixel boxes. |
+    | `result.boxes.conf` | `torch.float32` | `(N,)` | Confidence scores. |
+    | `result.boxes.cls` | `torch.float32` | `(N,)` | Class IDs; cast to `int` for names. |
 
 === "Segment"
 
-    | Field | Type | Shape | Dtype | Description |
-    |---|---|---|---|---|
-    | `result.boxes` | `Boxes` | `(N)` | - | Instance boxes/classes/confidences. |
-    | `result.masks` | `Masks` | `(N)` | - | Instance masks. |
-    | `result.masks.data` | `Tensor` | `(N,H,W)` | `torch.uint8` | Binary masks, values `0` or `1`. |
-    | `result.masks.xy` | `list[ndarray]` | `list[(P,2)]` | `np.float32` | Pixel polygons. |
-    | `result.masks.xyn` | `list[ndarray]` | `list[(P,2)]` | `np.float32` | Normalized polygons. |
+    | Field | Type | Shape | Description |
+    |---|---|---|---|
+    | `result.boxes` | `Boxes` | `(N)` | Instance boxes/classes/confidences. |
+    | `result.masks` | `Masks` | `(N)` | Instance masks. |
+    | `result.masks.data` | `torch.uint8` | `(N,H,W)` | Binary masks, values `0` or `1`. |
+    | `result.masks.xy` | `np.float32` | `list[(P,2)]` | Pixel polygons. |
+    | `result.masks.xyn` | `np.float32` | `list[(P,2)]` | Normalized polygons. |
 
 === "Semantic"
 
-    | Field | Type | Shape | Dtype | Description |
-    |---|---|---|---|---|
-    | `result.semantic_mask` | `SemanticMask` | `(H,W)` | - | Dense class map. |
-    | `result.semantic_mask.data` | `Tensor` | `(H,W)` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs. |
-    | `result.masks` | `None` | - | - | No instance masks. |
-    | `result.boxes` | `None` | - | - | No instance boxes/confidences. |
+    | Field | Type | Shape | Description |
+    |---|---|---|---|
+    | `result.semantic_mask` | `SemanticMask` | `(H,W)` | Dense class map. |
+    | `result.semantic_mask.data` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | `(H,W)` | Per-pixel class IDs. |
+    | `result.masks` | - | - | No instance masks. |
+    | `result.boxes` | - | - | No instance boxes/confidences. |
 
 === "Classify"
 
-    | Field | Type | Shape | Dtype | Description |
-    |---|---|---|---|---|
-    | `result.probs` | `Probs` | `(C,)` | - | Class probabilities. |
-    | `result.probs.data` | `Tensor` | `(C,)` | `torch.float32` | Probability per class. |
-    | `result.probs.top1` | `int` | `()` | `int` | Top class ID. |
-    | `result.probs.top1conf` | `Tensor` | `()` | `torch.float32` | Top confidence. |
-    | `result.probs.top5` | `list[int]` | `(<=5)` | `list[int]` | Top-5 class IDs. |
+    | Field | Type | Shape | Description |
+    |---|---|---|---|
+    | `result.probs` | `Probs` | `(C,)` | Class probabilities. |
+    | `result.probs.data` | `torch.float32` | `(C,)` | Probability per class. |
+    | `result.probs.top1` | `int` | `()` | Top class ID. |
+    | `result.probs.top1conf` | `torch.float32` | `()` | Top confidence. |
+    | `result.probs.top5` | `list[int]` | `(<=5)` | Top-5 class IDs. |
 
 === "Pose"
 
-    | Field | Type | Shape | Dtype | Description |
-    |---|---|---|---|---|
-    | `result.boxes` | `Boxes` | `(N)` | - | Instance boxes. |
-    | `result.keypoints` | `Keypoints` | `(N)` | - | Keypoints. |
-    | `result.keypoints.data` | `Tensor` | `(N,K,2/3)` | `torch.float32` | `x,y` plus optional visibility/confidence. |
-    | `result.keypoints.xy` | `Tensor` | `(N,K,2)` | `torch.float32` | Pixel keypoints. |
-    | `result.keypoints.xyn` | `Tensor` | `(N,K,2)` | `torch.float32` | Normalized keypoints. |
+    | Field | Type | Shape | Description |
+    |---|---|---|---|
+    | `result.boxes` | `Boxes` | `(N)` | Instance boxes. |
+    | `result.keypoints` | `Keypoints` | `(N)` | Keypoints. |
+    | `result.keypoints.data` | `torch.float32` | `(N,K,2/3)` | `x,y` plus optional visibility/confidence. |
+    | `result.keypoints.xy` | `torch.float32` | `(N,K,2)` | Pixel keypoints. |
+    | `result.keypoints.xyn` | `torch.float32` | `(N,K,2)` | Normalized keypoints. |
 
 === "OBB"
 
-    | Field | Type | Shape | Dtype | Description |
-    |---|---|---|---|---|
-    | `result.obb` | `OBB` | `(N)` | - | Oriented boxes. |
-    | `result.obb.data` | `Tensor` | `(N,7/8)` | `torch.float32` | Raw rotated boxes with confidence/class. |
-    | `result.obb.xywhr` | `Tensor` | `(N,5)` | `torch.float32` | `xywhr` rotated boxes. |
-    | `result.obb.xyxyxyxy` | `Tensor` | `(N,4,2)` | `torch.float32` | Four corner points. |
-    | `result.obb.conf` | `Tensor` | `(N,)` | `torch.float32` | Confidence scores. |
+    | Field | Type | Shape | Description |
+    |---|---|---|---|
+    | `result.obb` | `OBB` | `(N)` | Oriented boxes. |
+    | `result.obb.data` | `torch.float32` | `(N,7/8)` | Raw rotated boxes with confidence/class. |
+    | `result.obb.xywhr` | `torch.float32` | `(N,5)` | `xywhr` rotated boxes. |
+    | `result.obb.xyxyxyxy` | `torch.float32` | `(N,4,2)` | Four corner points. |
+    | `result.obb.conf` | `torch.float32` | `(N,)` | Confidence scores. |
 
 `Results` objects have the following methods:
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -512,20 +512,20 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 
 `Results` objects have the following attributes:
 
-| Attribute    | Type                  | Description                                                                              |
-| ------------ | --------------------- | ---------------------------------------------------------------------------------------- |
-| `orig_img`   | `np.ndarray`          | The original image as a NumPy array.                                                     |
-| `orig_shape` | `tuple`               | The original image shape in (height, width) format.                                      |
-| `boxes`      | `Boxes, optional`     | A Boxes object containing the detection bounding boxes.                                  |
-| `masks`      | `Masks, optional`     | A Masks object containing the detection masks.                                           |
-| `probs`      | `Probs, optional`     | A Probs object containing probabilities of each class for classification task.           |
-| `keypoints`  | `Keypoints, optional` | A Keypoints object containing detected keypoints for each object.                        |
-| `obb`        | `OBB, optional`       | An OBB object containing oriented bounding boxes.                                        |
-| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                        |
-| `speed`      | `dict`                | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
-| `names`      | `dict`                | A dictionary mapping class indices to class names.                                       |
-| `path`       | `str`                 | The path to the image file.                                                              |
-| `save_dir`   | `str, optional`       | Directory to save results.                                                               |
+| Attribute       | Type                     | Description                                                                              |
+| --------------- | ------------------------ | ---------------------------------------------------------------------------------------- |
+| `orig_img`      | `np.ndarray`             | The original image as a NumPy array.                                                     |
+| `orig_shape`    | `tuple`                  | The original image shape in (height, width) format.                                      |
+| `boxes`         | `Boxes, optional`        | A Boxes object containing the detection bounding boxes.                                  |
+| `masks`         | `Masks, optional`        | A Masks object containing the detection masks.                                           |
+| `probs`         | `Probs, optional`        | A Probs object containing probabilities of each class for classification task.           |
+| `keypoints`     | `Keypoints, optional`    | A Keypoints object containing detected keypoints for each object.                        |
+| `obb`           | `OBB, optional`          | An OBB object containing oriented bounding boxes.                                        |
+| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                            |
+| `speed`         | `dict`                   | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
+| `names`         | `dict`                   | A dictionary mapping class indices to class names.                                       |
+| `path`          | `str`                    | The path to the image file.                                                              |
+| `save_dir`      | `str, optional`          | Directory to save results.                                                               |
 
 ### Results by Task
 
@@ -596,24 +596,24 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
 
 `Results` objects have the following methods:
 
-| Method        | Return Type            | Description                                                                               |
-| ------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
+| Method        | Return Type            | Description                                                                                              |
+| ------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
 | `update()`    | `None`                 | Updates the Results object with new data such as boxes, masks, probs, obb, keypoints, or semantic masks. |
-| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                |
-| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.          |
-| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                |
-| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.    |
-| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.      |
-| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.            |
-| `show()`      | `None`                 | Displays the image with annotated inference results.                                      |
-| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                 |
-| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.      |
-| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.            |
-| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                    |
-| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.        |
-| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                         |
-| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                 |
-| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                |
+| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                               |
+| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.                         |
+| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                               |
+| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.                   |
+| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.                     |
+| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.                           |
+| `show()`      | `None`                 | Displays the image with annotated inference results.                                                     |
+| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                                |
+| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.                     |
+| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.                           |
+| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                                   |
+| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.                       |
+| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                                        |
+| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                                |
+| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                               |
 
 For more details see the [`Results` class documentation](../reference/engine/results.md).
 
@@ -677,15 +677,15 @@ For more details see the [`Boxes` class documentation](../reference/engine/resul
 
 Here is a table for the `Masks` class methods and properties, including their name, type, and description:
 
-| Name      | Type                      | Description                                                   |
-| --------- | ------------------------- | ------------------------------------------------------------- |
-| `data`    | Property (`torch.Tensor`) | `torch.uint8` binary mask tensor with shape `(N, H, W)` and values `0` or `1`. |
-| `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                       |
-| `numpy()` | Method                    | Returns the masks tensor as a NumPy array.                    |
-| `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                       |
-| `to()`    | Method                    | Returns the masks tensor with the specified device and dtype. |
-| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                        |
-| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.              |
+| Name      | Type                          | Description                                                                    |
+| --------- | ----------------------------- | ------------------------------------------------------------------------------ |
+| `data`    | Property (`torch.Tensor`)     | `torch.uint8` binary mask tensor with shape `(N, H, W)` and values `0` or `1`. |
+| `cpu()`   | Method                        | Returns the masks tensor on CPU memory.                                        |
+| `numpy()` | Method                        | Returns the masks tensor as a NumPy array.                                     |
+| `cuda()`  | Method                        | Returns the masks tensor on GPU memory.                                        |
+| `to()`    | Method                        | Returns the masks tensor with the specified device and dtype.                  |
+| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                                            |
+| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.                                  |
 
 For more details see the [`Masks` class documentation](../reference/engine/results.md#ultralytics.engine.results.Masks).
 
@@ -710,14 +710,14 @@ binary mask per object and does not provide polygon helpers.
         print(r.semantic_mask.data)  # print the H x W class-ID map
     ```
 
-| Name      | Type                      | Description                                                             |
-| --------- | ------------------------- | ----------------------------------------------------------------------- |
+| Name      | Type                      | Description                                                                                |
+| --------- | ------------------------- | ------------------------------------------------------------------------------------------ |
 | `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H, W)` and dtype `torch.uint8`, `torch.int16`, or `torch.int32`. |
-| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.           |
-| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                         |
-| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                      |
-| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                         |
-| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.   |
+| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.                              |
+| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                                            |
+| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                                         |
+| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                                            |
+| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.                      |
 
 ### Keypoints
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -521,16 +521,82 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 | `probs`      | `Probs, optional`     | A Probs object containing probabilities of each class for classification task.           |
 | `keypoints`  | `Keypoints, optional` | A Keypoints object containing detected keypoints for each object.                        |
 | `obb`        | `OBB, optional`       | An OBB object containing oriented bounding boxes.                                        |
+| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                        |
 | `speed`      | `dict`                | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
 | `names`      | `dict`                | A dictionary mapping class indices to class names.                                       |
 | `path`       | `str`                 | The path to the image file.                                                              |
 | `save_dir`   | `str, optional`       | Directory to save results.                                                               |
 
+### Results by Task
+
+Each prediction returns one `Results` object per image or frame. The common fields above are always available, while the
+task-specific prediction data is stored in the fields below.
+
+=== "Detect"
+
+    | Field | Type | Shape / Values | Description |
+    |---|---|---|---|
+    | `result.boxes` | `Boxes` | `N` boxes | Detection boxes for each object. |
+    | `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
+    | `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)` | Box coordinates in `[x1, y1, x2, y2]` pixel format. |
+    | `result.boxes.conf` | `torch.Tensor` | `(N,)` | Confidence score for each detection. |
+    | `result.boxes.cls` | `torch.Tensor` | `(N,)` | Class ID for each detection. |
+
+=== "Segment"
+
+    | Field | Type | Shape / Values | Description |
+    |---|---|---|---|
+    | `result.boxes` | `Boxes` | `N` boxes | Boxes, confidences, and class IDs for each detected instance. |
+    | `result.masks` | `Masks` | `N` masks | Instance mask container aligned with `result.boxes`. |
+    | `result.masks.data` | `torch.Tensor` | `(N, H, W)`, `torch.uint8` | Binary mask stack with values `0` or `1`, one mask per instance. |
+    | `result.masks.xy` | `list[np.ndarray]` | One `(points, 2)` array per instance | Mask polygons in pixel coordinates. |
+    | `result.masks.xyn` | `list[np.ndarray]` | One `(points, 2)` array per instance | Normalized mask polygons. |
+
+=== "Semantic"
+
+    | Field | Type | Shape / Values | Description |
+    |---|---|---|---|
+    | `result.semantic_mask` | `SemanticMask` | One mask per image | Dense semantic class-map container. |
+    | `result.semantic_mask.data` | `torch.Tensor` | `(H, W)` | Per-pixel class IDs for the full image. |
+    | Class map dtype | `torch.dtype` | `uint8`, `int16`, or `int32` | Uses `torch.uint8` for up to 256 classes, then larger integer dtypes as needed. |
+    | `result.masks` | `None` | Not applicable | Semantic segmentation does not return per-instance mask stacks. |
+    | `result.boxes` | `None` | Not applicable | Semantic segmentation does not return per-instance boxes or confidence scores. |
+
+=== "Classify"
+
+    | Field | Type | Shape / Values | Description |
+    |---|---|---|---|
+    | `result.probs` | `Probs` | One probability vector | Classification probabilities for the image. |
+    | `result.probs.data` | `torch.Tensor` | `(num_classes,)` | Probability score for each class. |
+    | `result.probs.top1` | `int` | Class index | Highest-probability class ID. |
+    | `result.probs.top1conf` | `torch.Tensor` | Scalar | Confidence for the top class. |
+    | `result.probs.top5` | `list[int]` | Up to 5 class indices | Top-5 class IDs ordered by confidence. |
+
+=== "Pose"
+
+    | Field | Type | Shape / Values | Description |
+    |---|---|---|---|
+    | `result.boxes` | `Boxes` | `N` boxes | Person or object boxes associated with keypoints. |
+    | `result.keypoints` | `Keypoints` | `N` instances | Keypoint container for each detected instance. |
+    | `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Keypoints as `x, y` plus optional visibility/confidence. |
+    | `result.keypoints.xy` | `torch.Tensor` | `(N, K, 2)` | Keypoint coordinates in pixels. |
+    | `result.keypoints.xyn` | `torch.Tensor` | `(N, K, 2)` | Normalized keypoint coordinates. |
+
+=== "OBB"
+
+    | Field | Type | Shape / Values | Description |
+    |---|---|---|---|
+    | `result.obb` | `OBB` | `N` rotated boxes | Oriented bounding boxes for each detection. |
+    | `result.obb.data` | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Raw rotated boxes with confidence, class, and optional track ID. |
+    | `result.obb.xywhr` | `torch.Tensor` | `(N, 5)` | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
+    | `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)` | Four corner points for each rotated box. |
+    | `result.obb.conf` | `torch.Tensor` | `(N,)` | Confidence score for each rotated box. |
+
 `Results` objects have the following methods:
 
 | Method        | Return Type            | Description                                                                               |
 | ------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
-| `update()`    | `None`                 | Updates the Results object with new detection data (boxes, masks, probs, obb, keypoints). |
+| `update()`    | `None`                 | Updates the Results object with new data such as boxes, masks, probs, obb, keypoints, or semantic masks. |
 | `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                |
 | `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.          |
 | `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                |
@@ -609,16 +675,47 @@ For more details see the [`Boxes` class documentation](../reference/engine/resul
 
 Here is a table for the `Masks` class methods and properties, including their name, type, and description:
 
-| Name      | Type                      | Description                                                     |
-| --------- | ------------------------- | --------------------------------------------------------------- |
-| `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                         |
-| `numpy()` | Method                    | Returns the masks tensor as a NumPy array.                      |
-| `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                         |
-| `to()`    | Method                    | Returns the masks tensor with the specified device and dtype.   |
-| `xyn`     | Property (`torch.Tensor`) | A list of normalized segments represented as tensors.           |
-| `xy`      | Property (`torch.Tensor`) | A list of segments in pixel coordinates represented as tensors. |
+| Name      | Type                      | Description                                                   |
+| --------- | ------------------------- | ------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`) | Binary mask tensor with shape `(N, H, W)` and values `0` or `1`. |
+| `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                       |
+| `numpy()` | Method                    | Returns the masks tensor as a NumPy array.                    |
+| `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                       |
+| `to()`    | Method                    | Returns the masks tensor with the specified device and dtype. |
+| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                        |
+| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.              |
 
 For more details see the [`Masks` class documentation](../reference/engine/results.md#ultralytics.engine.results.Masks).
+
+### SemanticMask
+
+`SemanticMask` stores one dense class map for semantic segmentation results. Unlike `Masks`, it does not contain one
+binary mask per object and does not provide polygon helpers.
+
+!!! example "SemanticMask"
+
+    ```python
+    from ultralytics import YOLO
+
+    # Load a pretrained YOLO26n-sem Semantic model
+    model = YOLO("yolo26n-sem.pt")
+
+    # Run inference on an image
+    results = model("https://ultralytics.com/images/bus.jpg")  # results list
+
+    # View results
+    for r in results:
+        print(r.semantic_mask.data)  # print the H x W class-ID map
+    ```
+
+| Name      | Type                      | Description                                                             |
+| --------- | ------------------------- | ----------------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H, W)`.                                       |
+| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.           |
+| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                         |
+| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                      |
+| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                         |
+| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.   |
 
 ### Keypoints
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -532,11 +532,12 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 Each prediction returns one `Results` object per image or frame. The common fields above are always available, while the
 task-specific prediction data is stored in the fields below. Coordinate, confidence, and probability tensors are
 `torch.float32` unless half precision is used, then `torch.float16`. After `result.numpy()`, tensors become NumPy arrays with matching NumPy dtypes.
-Instance masks are `torch.uint8` binary tensors, while semantic masks use compact integer class IDs.
+Instance masks are `torch.uint8` binary tensors, while semantic masks use the smallest practical integer dtype for class
+IDs: `torch.uint8`, `torch.int16`, or `torch.int32`, depending on class count.
 
 === "Detect"
 
-    | Field | Type | Shape | Description |
+    | Attribute | Type | Shape | Description |
     |---|---|---|---|
     | `result.boxes` | `Boxes` | `(N)` | Detection boxes. |
     | `result.boxes.data` | `torch.float32` | `(N,6/7)` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
@@ -546,7 +547,7 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
 
 === "Segment"
 
-    | Field | Type | Shape | Description |
+    | Attribute | Type | Shape | Description |
     |---|---|---|---|
     | `result.boxes` | `Boxes` | `(N)` | Instance boxes/classes/confidences. |
     | `result.masks` | `Masks` | `(N)` | Instance masks. |
@@ -556,16 +557,16 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
 
 === "Semantic"
 
-    | Field | Type | Shape | Description |
+    | Attribute | Type | Shape | Description |
     |---|---|---|---|
     | `result.semantic_mask` | `SemanticMask` | `(H,W)` | Dense class map. |
-    | `result.semantic_mask.data` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | `(H,W)` | Per-pixel class IDs. |
+    | `result.semantic_mask.data` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | `(H,W)` | Per-pixel class IDs, dtype selected by class count. |
     | `result.masks` | - | - | No instance masks. |
     | `result.boxes` | - | - | No instance boxes/confidences. |
 
 === "Classify"
 
-    | Field | Type | Shape | Description |
+    | Attribute | Type | Shape | Description |
     |---|---|---|---|
     | `result.probs` | `Probs` | `(C,)` | Class probabilities. |
     | `result.probs.data` | `torch.float32` | `(C,)` | Probability per class. |
@@ -575,7 +576,7 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
 
 === "Pose"
 
-    | Field | Type | Shape | Description |
+    | Attribute | Type | Shape | Description |
     |---|---|---|---|
     | `result.boxes` | `Boxes` | `(N)` | Instance boxes. |
     | `result.keypoints` | `Keypoints` | `(N)` | Keypoints. |
@@ -585,7 +586,7 @@ Instance masks are `torch.uint8` binary tensors, while semantic masks use compac
 
 === "OBB"
 
-    | Field | Type | Shape | Description |
+    | Attribute | Type | Shape | Description |
     |---|---|---|---|
     | `result.obb` | `OBB` | `(N)` | Oriented boxes. |
     | `result.obb.data` | `torch.float32` | `(N,7/8)` | Raw rotated boxes with confidence/class. |
@@ -711,7 +712,7 @@ binary mask per object and does not provide polygon helpers.
 
 | Name      | Type                      | Description                                                                                |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------ |
-| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H,W)` and dtype `torch.uint8`<br>`torch.int16`<br>`torch.int32`. |
+| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H,W)`. Dtype is `torch.uint8`, `torch.int16`, or `torch.int32`, selected by class count. |
 | `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.                              |
 | `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                                            |
 | `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                                         |

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -512,106 +512,108 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 
 `Results` objects have the following attributes:
 
-| Attribute       | Type                     | Description                                                                              |
-| --------------- | ------------------------ | ---------------------------------------------------------------------------------------- |
-| `orig_img`      | `np.ndarray`             | The original image as a NumPy array.                                                     |
-| `orig_shape`    | `tuple`                  | The original image shape in (height, width) format.                                      |
-| `boxes`         | `Boxes, optional`        | A Boxes object containing the detection bounding boxes.                                  |
-| `masks`         | `Masks, optional`        | A Masks object containing the detection masks.                                           |
-| `probs`         | `Probs, optional`        | A Probs object containing probabilities of each class for classification task.           |
-| `keypoints`     | `Keypoints, optional`    | A Keypoints object containing detected keypoints for each object.                        |
-| `obb`           | `OBB, optional`          | An OBB object containing oriented bounding boxes.                                        |
-| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                            |
-| `speed`         | `dict`                   | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
-| `names`         | `dict`                   | A dictionary mapping class indices to class names.                                       |
-| `path`          | `str`                    | The path to the image file.                                                              |
-| `save_dir`      | `str, optional`          | Directory to save results.                                                               |
+| Attribute    | Type                  | Description                                                                              |
+| ------------ | --------------------- | ---------------------------------------------------------------------------------------- |
+| `orig_img`   | `np.ndarray`          | The original image as a NumPy array.                                                     |
+| `orig_shape` | `tuple`               | The original image shape in (height, width) format.                                      |
+| `boxes`      | `Boxes, optional`     | A Boxes object containing the detection bounding boxes.                                  |
+| `masks`      | `Masks, optional`     | A Masks object containing the detection masks.                                           |
+| `probs`      | `Probs, optional`     | A Probs object containing probabilities of each class for classification task.           |
+| `keypoints`  | `Keypoints, optional` | A Keypoints object containing detected keypoints for each object.                        |
+| `obb`        | `OBB, optional`       | An OBB object containing oriented bounding boxes.                                        |
+| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                        |
+| `speed`      | `dict`                | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
+| `names`      | `dict`                | A dictionary mapping class indices to class names.                                       |
+| `path`       | `str`                 | The path to the image file.                                                              |
+| `save_dir`   | `str, optional`       | Directory to save results.                                                               |
 
 ### Results by Task
 
 Each prediction returns one `Results` object per image or frame. The common fields above are always available, while the
-task-specific prediction data is stored in the fields below.
+task-specific prediction data is stored in the fields below. Coordinate, confidence, and probability tensors are
+floating point tensors, usually `torch.float32` in standard PyTorch inference. They may be `torch.float16` when using
+half-precision inference or some exported backends, and they become NumPy floating dtypes after `result.numpy()`.
+Instance masks are `torch.uint8` binary tensors, while semantic masks use compact integer class IDs.
 
 === "Detect"
 
-    | Field | Type | Shape / Values | Description |
-    |---|---|---|---|
-    | `result.boxes` | `Boxes` | `N` boxes | Detection boxes for each object. |
-    | `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
-    | `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)` | Box coordinates in `[x1, y1, x2, y2]` pixel format. |
-    | `result.boxes.conf` | `torch.Tensor` | `(N,)` | Confidence score for each detection. |
-    | `result.boxes.cls` | `torch.Tensor` | `(N,)` | Class ID for each detection. |
+    | Field | Type | Shape / Values | Dtype | Description |
+    |---|---|---|---|---|
+    | `result.boxes` | `Boxes` | `N` boxes | Container | Detection boxes for each object. |
+    | `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Floating point | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
+    | `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)` | Floating point | Box coordinates in `[x1, y1, x2, y2]` pixel format. |
+    | `result.boxes.conf` | `torch.Tensor` | `(N,)` | Floating point | Confidence score for each detection. |
+    | `result.boxes.cls` | `torch.Tensor` | `(N,)` | Floating point class IDs | Class ID for each detection; cast to `int` for name lookup. |
 
 === "Segment"
 
-    | Field | Type | Shape / Values | Description |
-    |---|---|---|---|
-    | `result.boxes` | `Boxes` | `N` boxes | Boxes, confidences, and class IDs for each detected instance. |
-    | `result.masks` | `Masks` | `N` masks | Instance mask container aligned with `result.boxes`. |
-    | `result.masks.data` | `torch.Tensor` | `(N, H, W)`, `torch.uint8` | Binary mask stack with values `0` or `1`, one mask per instance. |
-    | `result.masks.xy` | `list[np.ndarray]` | One `(points, 2)` array per instance | Mask polygons in pixel coordinates. |
-    | `result.masks.xyn` | `list[np.ndarray]` | One `(points, 2)` array per instance | Normalized mask polygons. |
+    | Field | Type | Shape / Values | Dtype | Description |
+    |---|---|---|---|---|
+    | `result.boxes` | `Boxes` | `N` boxes | Container | Boxes, confidences, and class IDs for each detected instance. |
+    | `result.masks` | `Masks` | `N` masks | Container | Instance mask container aligned with `result.boxes`. |
+    | `result.masks.data` | `torch.Tensor` | `(N, H, W)` | `torch.uint8` | Binary mask stack with values `0` or `1`, one mask per instance. |
+    | `result.masks.xy` | `list[np.ndarray]` | One `(points, 2)` array per instance | Floating point | Mask polygons in pixel coordinates. |
+    | `result.masks.xyn` | `list[np.ndarray]` | One `(points, 2)` array per instance | Floating point | Normalized mask polygons. |
 
 === "Semantic"
 
-    | Field | Type | Shape / Values | Description |
-    |---|---|---|---|
-    | `result.semantic_mask` | `SemanticMask` | One mask per image | Dense semantic class-map container. |
-    | `result.semantic_mask.data` | `torch.Tensor` | `(H, W)` | Per-pixel class IDs for the full image. |
-    | Class map dtype | `torch.dtype` | `uint8`, `int16`, or `int32` | Uses `torch.uint8` for up to 256 classes, then larger integer dtypes as needed. |
-    | `result.masks` | `None` | Not applicable | Semantic segmentation does not return per-instance mask stacks. |
-    | `result.boxes` | `None` | Not applicable | Semantic segmentation does not return per-instance boxes or confidence scores. |
+    | Field | Type | Shape / Values | Dtype | Description |
+    |---|---|---|---|---|
+    | `result.semantic_mask` | `SemanticMask` | One mask per image | Container | Dense semantic class-map container. |
+    | `result.semantic_mask.data` | `torch.Tensor` | `(H, W)` | `torch.uint8`, `torch.int16`, or `torch.int32` | Per-pixel class IDs for the full image. |
+    | `result.masks` | `None` | Not applicable | Not applicable | Semantic segmentation does not return per-instance mask stacks. |
+    | `result.boxes` | `None` | Not applicable | Not applicable | Semantic segmentation does not return per-instance boxes or confidence scores. |
 
 === "Classify"
 
-    | Field | Type | Shape / Values | Description |
-    |---|---|---|---|
-    | `result.probs` | `Probs` | One probability vector | Classification probabilities for the image. |
-    | `result.probs.data` | `torch.Tensor` | `(num_classes,)` | Probability score for each class. |
-    | `result.probs.top1` | `int` | Class index | Highest-probability class ID. |
-    | `result.probs.top1conf` | `torch.Tensor` | Scalar | Confidence for the top class. |
-    | `result.probs.top5` | `list[int]` | Up to 5 class indices | Top-5 class IDs ordered by confidence. |
+    | Field | Type | Shape / Values | Dtype | Description |
+    |---|---|---|---|---|
+    | `result.probs` | `Probs` | One probability vector | Container | Classification probabilities for the image. |
+    | `result.probs.data` | `torch.Tensor` | `(num_classes,)` | Floating point | Probability score for each class. |
+    | `result.probs.top1` | `int` | Class index | Python `int` | Highest-probability class ID. |
+    | `result.probs.top1conf` | `torch.Tensor` | Scalar | Floating point | Confidence for the top class. |
+    | `result.probs.top5` | `list[int]` | Up to 5 class indices | Python `int` list | Top-5 class IDs ordered by confidence. |
 
 === "Pose"
 
-    | Field | Type | Shape / Values | Description |
-    |---|---|---|---|
-    | `result.boxes` | `Boxes` | `N` boxes | Person or object boxes associated with keypoints. |
-    | `result.keypoints` | `Keypoints` | `N` instances | Keypoint container for each detected instance. |
-    | `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Keypoints as `x, y` plus optional visibility/confidence. |
-    | `result.keypoints.xy` | `torch.Tensor` | `(N, K, 2)` | Keypoint coordinates in pixels. |
-    | `result.keypoints.xyn` | `torch.Tensor` | `(N, K, 2)` | Normalized keypoint coordinates. |
+    | Field | Type | Shape / Values | Dtype | Description |
+    |---|---|---|---|---|
+    | `result.boxes` | `Boxes` | `N` boxes | Container | Person or object boxes associated with keypoints. |
+    | `result.keypoints` | `Keypoints` | `N` instances | Container | Keypoint container for each detected instance. |
+    | `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Floating point | Keypoints as `x, y` plus optional visibility/confidence. |
+    | `result.keypoints.xy` | `torch.Tensor` | `(N, K, 2)` | Floating point | Keypoint coordinates in pixels. |
+    | `result.keypoints.xyn` | `torch.Tensor` | `(N, K, 2)` | Floating point | Normalized keypoint coordinates. |
 
 === "OBB"
 
-    | Field | Type | Shape / Values | Description |
-    |---|---|---|---|
-    | `result.obb` | `OBB` | `N` rotated boxes | Oriented bounding boxes for each detection. |
-    | `result.obb.data` | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Raw rotated boxes with confidence, class, and optional track ID. |
-    | `result.obb.xywhr` | `torch.Tensor` | `(N, 5)` | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
-    | `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)` | Four corner points for each rotated box. |
-    | `result.obb.conf` | `torch.Tensor` | `(N,)` | Confidence score for each rotated box. |
+    | Field | Type | Shape / Values | Dtype | Description |
+    |---|---|---|---|---|
+    | `result.obb` | `OBB` | `N` rotated boxes | Container | Oriented bounding boxes for each detection. |
+    | `result.obb.data` | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Floating point | Raw rotated boxes with confidence, class, and optional track ID. |
+    | `result.obb.xywhr` | `torch.Tensor` | `(N, 5)` | Floating point | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
+    | `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)` | Floating point | Four corner points for each rotated box. |
+    | `result.obb.conf` | `torch.Tensor` | `(N,)` | Floating point | Confidence score for each rotated box. |
 
 `Results` objects have the following methods:
 
-| Method        | Return Type            | Description                                                                                              |
-| ------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| Method        | Return Type            | Description                                                                               |
+| ------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
 | `update()`    | `None`                 | Updates the Results object with new data such as boxes, masks, probs, obb, keypoints, or semantic masks. |
-| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                               |
-| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.                         |
-| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                               |
-| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.                   |
-| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.                     |
-| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.                           |
-| `show()`      | `None`                 | Displays the image with annotated inference results.                                                     |
-| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                                |
-| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.                     |
-| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.                           |
-| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                                   |
-| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.                       |
-| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                                        |
-| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                                |
-| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                               |
+| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                |
+| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.          |
+| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                |
+| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.    |
+| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.      |
+| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.            |
+| `show()`      | `None`                 | Displays the image with annotated inference results.                                      |
+| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                 |
+| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.      |
+| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.            |
+| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                    |
+| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.        |
+| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                         |
+| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                 |
+| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                |
 
 For more details see the [`Results` class documentation](../reference/engine/results.md).
 
@@ -675,15 +677,15 @@ For more details see the [`Boxes` class documentation](../reference/engine/resul
 
 Here is a table for the `Masks` class methods and properties, including their name, type, and description:
 
-| Name      | Type                          | Description                                                      |
-| --------- | ----------------------------- | ---------------------------------------------------------------- |
-| `data`    | Property (`torch.Tensor`)     | Binary mask tensor with shape `(N, H, W)` and values `0` or `1`. |
-| `cpu()`   | Method                        | Returns the masks tensor on CPU memory.                          |
-| `numpy()` | Method                        | Returns the masks tensor as a NumPy array.                       |
-| `cuda()`  | Method                        | Returns the masks tensor on GPU memory.                          |
-| `to()`    | Method                        | Returns the masks tensor with the specified device and dtype.    |
-| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                              |
-| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.                    |
+| Name      | Type                      | Description                                                   |
+| --------- | ------------------------- | ------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`) | `torch.uint8` binary mask tensor with shape `(N, H, W)` and values `0` or `1`. |
+| `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                       |
+| `numpy()` | Method                    | Returns the masks tensor as a NumPy array.                    |
+| `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                       |
+| `to()`    | Method                    | Returns the masks tensor with the specified device and dtype. |
+| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                        |
+| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.              |
 
 For more details see the [`Masks` class documentation](../reference/engine/results.md#ultralytics.engine.results.Masks).
 
@@ -708,14 +710,14 @@ binary mask per object and does not provide polygon helpers.
         print(r.semantic_mask.data)  # print the H x W class-ID map
     ```
 
-| Name      | Type                      | Description                                                           |
-| --------- | ------------------------- | --------------------------------------------------------------------- |
-| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H, W)`.                                     |
-| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.         |
-| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                       |
-| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                    |
-| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                       |
-| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype. |
+| Name      | Type                      | Description                                                             |
+| --------- | ------------------------- | ----------------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H, W)` and dtype `torch.uint8`, `torch.int16`, or `torch.int32`. |
+| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.           |
+| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                         |
+| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                      |
+| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                         |
+| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.   |
 
 ### Keypoints
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -512,20 +512,20 @@ All Ultralytics `predict()` calls will return a list of `Results` objects:
 
 `Results` objects have the following attributes:
 
-| Attribute    | Type                  | Description                                                                              |
-| ------------ | --------------------- | ---------------------------------------------------------------------------------------- |
-| `orig_img`   | `np.ndarray`          | The original image as a NumPy array.                                                     |
-| `orig_shape` | `tuple`               | The original image shape in (height, width) format.                                      |
-| `boxes`      | `Boxes, optional`     | A Boxes object containing the detection bounding boxes.                                  |
-| `masks`      | `Masks, optional`     | A Masks object containing the detection masks.                                           |
-| `probs`      | `Probs, optional`     | A Probs object containing probabilities of each class for classification task.           |
-| `keypoints`  | `Keypoints, optional` | A Keypoints object containing detected keypoints for each object.                        |
-| `obb`        | `OBB, optional`       | An OBB object containing oriented bounding boxes.                                        |
-| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                        |
-| `speed`      | `dict`                | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
-| `names`      | `dict`                | A dictionary mapping class indices to class names.                                       |
-| `path`       | `str`                 | The path to the image file.                                                              |
-| `save_dir`   | `str, optional`       | Directory to save results.                                                               |
+| Attribute       | Type                     | Description                                                                              |
+| --------------- | ------------------------ | ---------------------------------------------------------------------------------------- |
+| `orig_img`      | `np.ndarray`             | The original image as a NumPy array.                                                     |
+| `orig_shape`    | `tuple`                  | The original image shape in (height, width) format.                                      |
+| `boxes`         | `Boxes, optional`        | A Boxes object containing the detection bounding boxes.                                  |
+| `masks`         | `Masks, optional`        | A Masks object containing the detection masks.                                           |
+| `probs`         | `Probs, optional`        | A Probs object containing probabilities of each class for classification task.           |
+| `keypoints`     | `Keypoints, optional`    | A Keypoints object containing detected keypoints for each object.                        |
+| `obb`           | `OBB, optional`          | An OBB object containing oriented bounding boxes.                                        |
+| `semantic_mask` | `SemanticMask, optional` | A SemanticMask object containing a dense per-pixel class map.                            |
+| `speed`         | `dict`                   | A dictionary of preprocess, inference, and postprocess speeds in milliseconds per image. |
+| `names`         | `dict`                   | A dictionary mapping class indices to class names.                                       |
+| `path`          | `str`                    | The path to the image file.                                                              |
+| `save_dir`      | `str, optional`          | Directory to save results.                                                               |
 
 ### Results by Task
 
@@ -594,24 +594,24 @@ task-specific prediction data is stored in the fields below.
 
 `Results` objects have the following methods:
 
-| Method        | Return Type            | Description                                                                               |
-| ------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
+| Method        | Return Type            | Description                                                                                              |
+| ------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
 | `update()`    | `None`                 | Updates the Results object with new data such as boxes, masks, probs, obb, keypoints, or semantic masks. |
-| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                |
-| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.          |
-| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                |
-| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.    |
-| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.      |
-| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.            |
-| `show()`      | `None`                 | Displays the image with annotated inference results.                                      |
-| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                 |
-| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.      |
-| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.            |
-| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                    |
-| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.        |
-| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                         |
-| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                 |
-| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                |
+| `cpu()`       | `Results`              | Returns a copy of the Results object with all tensors moved to CPU memory.                               |
+| `numpy()`     | `Results`              | Returns a copy of the Results object with all tensors converted to NumPy arrays.                         |
+| `cuda()`      | `Results`              | Returns a copy of the Results object with all tensors moved to GPU memory.                               |
+| `to()`        | `Results`              | Returns a copy of the Results object with tensors moved to specified device and dtype.                   |
+| `new()`       | `Results`              | Creates a new Results object with the same image, path, names, and speed attributes.                     |
+| `plot()`      | `np.ndarray`           | Plots detection results on an input RGB image and returns the annotated image.                           |
+| `show()`      | `None`                 | Displays the image with annotated inference results.                                                     |
+| `save()`      | `str`                  | Saves annotated inference results image to file and returns the filename.                                |
+| `verbose()`   | `str`                  | Returns a log string for each task, detailing detection and classification outcomes.                     |
+| `save_txt()`  | `str`                  | Saves detection results to a text file and returns the path to the saved file.                           |
+| `save_crop()` | `None`                 | Saves cropped detection images to specified directory.                                                   |
+| `summary()`   | `List[Dict[str, Any]]` | Converts inference results to a summarized dictionary with optional normalization.                       |
+| `to_df()`     | `DataFrame`            | Converts detection results to a Polars DataFrame.                                                        |
+| `to_csv()`    | `str`                  | Converts detection results to CSV format.                                                                |
+| `to_json()`   | `str`                  | Converts detection results to JSON format.                                                               |
 
 For more details see the [`Results` class documentation](../reference/engine/results.md).
 
@@ -675,15 +675,15 @@ For more details see the [`Boxes` class documentation](../reference/engine/resul
 
 Here is a table for the `Masks` class methods and properties, including their name, type, and description:
 
-| Name      | Type                      | Description                                                   |
-| --------- | ------------------------- | ------------------------------------------------------------- |
-| `data`    | Property (`torch.Tensor`) | Binary mask tensor with shape `(N, H, W)` and values `0` or `1`. |
-| `cpu()`   | Method                    | Returns the masks tensor on CPU memory.                       |
-| `numpy()` | Method                    | Returns the masks tensor as a NumPy array.                    |
-| `cuda()`  | Method                    | Returns the masks tensor on GPU memory.                       |
-| `to()`    | Method                    | Returns the masks tensor with the specified device and dtype. |
-| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                        |
-| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.              |
+| Name      | Type                          | Description                                                      |
+| --------- | ----------------------------- | ---------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`)     | Binary mask tensor with shape `(N, H, W)` and values `0` or `1`. |
+| `cpu()`   | Method                        | Returns the masks tensor on CPU memory.                          |
+| `numpy()` | Method                        | Returns the masks tensor as a NumPy array.                       |
+| `cuda()`  | Method                        | Returns the masks tensor on GPU memory.                          |
+| `to()`    | Method                        | Returns the masks tensor with the specified device and dtype.    |
+| `xyn`     | Property (`list[np.ndarray]`) | A list of normalized mask polygons.                              |
+| `xy`      | Property (`list[np.ndarray]`) | A list of mask polygons in pixel coordinates.                    |
 
 For more details see the [`Masks` class documentation](../reference/engine/results.md#ultralytics.engine.results.Masks).
 
@@ -708,14 +708,14 @@ binary mask per object and does not provide polygon helpers.
         print(r.semantic_mask.data)  # print the H x W class-ID map
     ```
 
-| Name      | Type                      | Description                                                             |
-| --------- | ------------------------- | ----------------------------------------------------------------------- |
-| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H, W)`.                                       |
-| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.           |
-| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                         |
-| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                      |
-| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                         |
-| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.   |
+| Name      | Type                      | Description                                                           |
+| --------- | ------------------------- | --------------------------------------------------------------------- |
+| `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H, W)`.                                     |
+| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.         |
+| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                       |
+| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                    |
+| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                       |
+| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype. |
 
 ### Keypoints
 

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -710,14 +710,14 @@ binary mask per object and does not provide polygon helpers.
         print(r.semantic_mask.data)  # print the H x W class-ID map
     ```
 
-| Name      | Type                      | Description                                                                                |
-| --------- | ------------------------- | ------------------------------------------------------------------------------------------ |
+| Name      | Type                      | Description                                                                                                        |
+| --------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `data`    | Property (`torch.Tensor`) | Class-ID map with shape `(H,W)`. Dtype is `torch.uint8`, `torch.int16`, or `torch.int32`, selected by class count. |
-| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.                              |
-| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                                            |
-| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                                         |
-| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                                            |
-| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.                      |
+| `shape`   | Property (`tuple`)        | Shape of the class map, usually matching `result.orig_shape`.                                                      |
+| `cpu()`   | Method                    | Returns the semantic mask tensor on CPU memory.                                                                    |
+| `numpy()` | Method                    | Returns the semantic mask tensor as a NumPy array.                                                                 |
+| `cuda()`  | Method                    | Returns the semantic mask tensor on GPU memory.                                                                    |
+| `to()`    | Method                    | Returns the semantic mask tensor with the specified device and dtype.                                              |
 
 ### Keypoints
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -197,6 +197,12 @@ Use a trained YOLO26n-cls model to run predictions on images.
 
         # Predict with the model
         results = model("https://ultralytics.com/images/bus.jpg")  # predict on an image
+
+        # Access the results
+        for result in results:
+            top1 = result.probs.top1  # top predicted class ID
+            top1_conf = result.probs.top1conf  # top prediction confidence
+            top1_name = result.names[top1]  # top predicted class name
         ```
 
     === "CLI"
@@ -207,6 +213,21 @@ Use a trained YOLO26n-cls model to run predictions on images.
         ```
 
 See full `predict` mode details in the [Predict](../modes/predict.md) page.
+
+### Results Output
+
+Image classification returns one `Results` object per image. The primary prediction field is `result.probs`, which
+contains the class probability vector and helpers for top predictions.
+
+| Attribute | Type | Shape / Format | Description |
+|---|---|---|---|
+| `result.probs` | `Probs` | One probability vector | Classification probabilities for the image. |
+| `result.probs.data` | `torch.Tensor` | `(num_classes,)` | Probability score for each class. |
+| `result.probs.top1` | `int` | Class index | Highest-probability class ID. |
+| `result.probs.top1conf` | `torch.Tensor` | Scalar | Confidence score for the top class. |
+| `result.probs.top5` | `list[int]` | Up to 5 class indices | Top-5 class IDs ordered by confidence. |
+
+For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
 ## Export
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -219,13 +219,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Image classification returns one `Results` object per image. The primary prediction field is `result.probs`, which
 contains the class probability vector and helpers for top predictions.
 
-| Attribute              | Type           | Shape / Format          | Dtype             | Description                                  |
-| ---------------------- | -------------- | ----------------------- | ----------------- | -------------------------------------------- |
-| `result.probs`         | `Probs`        | One probability vector  | Container         | Classification probabilities for the image.  |
-| `result.probs.data`    | `torch.Tensor` | `(num_classes,)`        | Floating point    | Probability score for each class.            |
-| `result.probs.top1`    | `int`          | Class index             | Python `int`      | Highest-probability class ID.                |
-| `result.probs.top1conf` | `torch.Tensor` | Scalar                 | Floating point    | Confidence score for the top class.          |
-| `result.probs.top5`    | `list[int]`    | Up to 5 class indices   | Python `int` list | Top-5 class IDs ordered by confidence.       |
+| Attribute               | Type           | Shape / Format         | Dtype             | Description                                 |
+| ----------------------- | -------------- | ---------------------- | ----------------- | ------------------------------------------- |
+| `result.probs`          | `Probs`        | One probability vector | Container         | Classification probabilities for the image. |
+| `result.probs.data`     | `torch.Tensor` | `(num_classes,)`       | Floating point    | Probability score for each class.           |
+| `result.probs.top1`     | `int`          | Class index            | Python `int`      | Highest-probability class ID.               |
+| `result.probs.top1conf` | `torch.Tensor` | Scalar                 | Floating point    | Confidence score for the top class.         |
+| `result.probs.top5`     | `list[int]`    | Up to 5 class indices  | Python `int` list | Top-5 class IDs ordered by confidence.      |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -219,13 +219,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Image classification returns one `Results` object per image. The primary prediction field is `result.probs`, which
 contains the class probability vector and helpers for top predictions.
 
-| Attribute               | Type           | Shape / Format         | Description                                 |
-| ----------------------- | -------------- | ---------------------- | ------------------------------------------- |
-| `result.probs`          | `Probs`        | One probability vector | Classification probabilities for the image. |
-| `result.probs.data`     | `torch.Tensor` | `(num_classes,)`       | Probability score for each class.           |
-| `result.probs.top1`     | `int`          | Class index            | Highest-probability class ID.               |
-| `result.probs.top1conf` | `torch.Tensor` | Scalar                 | Confidence score for the top class.         |
-| `result.probs.top5`     | `list[int]`    | Up to 5 class indices  | Top-5 class IDs ordered by confidence.      |
+| Attribute              | Type           | Shape / Format          | Dtype             | Description                                  |
+| ---------------------- | -------------- | ----------------------- | ----------------- | -------------------------------------------- |
+| `result.probs`         | `Probs`        | One probability vector  | Container         | Classification probabilities for the image.  |
+| `result.probs.data`    | `torch.Tensor` | `(num_classes,)`        | Floating point    | Probability score for each class.            |
+| `result.probs.top1`    | `int`          | Class index             | Python `int`      | Highest-probability class ID.                |
+| `result.probs.top1conf` | `torch.Tensor` | Scalar                 | Floating point    | Confidence score for the top class.          |
+| `result.probs.top5`    | `list[int]`    | Up to 5 class indices   | Python `int` list | Top-5 class IDs ordered by confidence.       |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -219,13 +219,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Image classification returns one `Results` object per image. The primary prediction field is `result.probs`, which
 contains the class probability vector and helpers for top predictions.
 
-| Attribute | Type | Shape / Format | Description |
-|---|---|---|---|
-| `result.probs` | `Probs` | One probability vector | Classification probabilities for the image. |
-| `result.probs.data` | `torch.Tensor` | `(num_classes,)` | Probability score for each class. |
-| `result.probs.top1` | `int` | Class index | Highest-probability class ID. |
-| `result.probs.top1conf` | `torch.Tensor` | Scalar | Confidence score for the top class. |
-| `result.probs.top5` | `list[int]` | Up to 5 class indices | Top-5 class IDs ordered by confidence. |
+| Attribute               | Type           | Shape / Format         | Description                                 |
+| ----------------------- | -------------- | ---------------------- | ------------------------------------------- |
+| `result.probs`          | `Probs`        | One probability vector | Classification probabilities for the image. |
+| `result.probs.data`     | `torch.Tensor` | `(num_classes,)`       | Probability score for each class.           |
+| `result.probs.top1`     | `int`          | Class index            | Highest-probability class ID.               |
+| `result.probs.top1conf` | `torch.Tensor` | Scalar                 | Confidence score for the top class.         |
+| `result.probs.top5`     | `list[int]`    | Up to 5 class indices  | Top-5 class IDs ordered by confidence.      |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -219,13 +219,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Image classification returns one `Results` object per image. The primary prediction field is `result.probs`, which
 contains the class probability vector and helpers for top predictions.
 
-| Attribute               | Type           | Shape / Format         | Dtype             | Description                                 |
-| ----------------------- | -------------- | ---------------------- | ----------------- | ------------------------------------------- |
-| `result.probs`          | `Probs`        | One probability vector | Container         | Classification probabilities for the image. |
-| `result.probs.data`     | `torch.Tensor` | `(num_classes,)`       | Floating point    | Probability score for each class.           |
-| `result.probs.top1`     | `int`          | Class index            | Python `int`      | Highest-probability class ID.               |
-| `result.probs.top1conf` | `torch.Tensor` | Scalar                 | Floating point    | Confidence score for the top class.         |
-| `result.probs.top5`     | `list[int]`    | Up to 5 class indices  | Python `int` list | Top-5 class IDs ordered by confidence.      |
+| Attribute              | Type           | Shape          | Dtype             | Description                                  |
+| ---------------------- | -------------- | ----------------------- | ----------------- | -------------------------------------------- |
+| `result.probs`         | `Probs`        | `(C,)`  | - | Class probabilities.  |
+| `result.probs.data`    | `Tensor` | `(C,)`        | `torch.float32` | Probability per class.            |
+| `result.probs.top1`    | `int`          | `()`             | `int`      | Top class ID.                |
+| `result.probs.top1conf` | `Tensor` | `()`                 | `torch.float32` | Top confidence.          |
+| `result.probs.top5`    | `list[int]`    | `(<=5)`   | `list[int]` | Top-5 class IDs.       |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -219,13 +219,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Image classification returns one `Results` object per image. The primary prediction field is `result.probs`, which
 contains the class probability vector and helpers for top predictions.
 
-| Attribute              | Type           | Shape          | Dtype             | Description                                  |
-| ---------------------- | -------------- | ----------------------- | ----------------- | -------------------------------------------- |
-| `result.probs`         | `Probs`        | `(C,)`  | - | Class probabilities.  |
-| `result.probs.data`    | `Tensor` | `(C,)`        | `torch.float32` | Probability per class.            |
-| `result.probs.top1`    | `int`          | `()`             | `int`      | Top class ID.                |
-| `result.probs.top1conf` | `Tensor` | `()`                 | `torch.float32` | Top confidence.          |
-| `result.probs.top5`    | `list[int]`    | `(<=5)`   | `list[int]` | Top-5 class IDs.       |
+| Attribute               | Type        | Shape   | Dtype           | Description            |
+| ----------------------- | ----------- | ------- | --------------- | ---------------------- |
+| `result.probs`          | `Probs`     | `(C,)`  | -               | Class probabilities.   |
+| `result.probs.data`     | `Tensor`    | `(C,)`  | `torch.float32` | Probability per class. |
+| `result.probs.top1`     | `int`       | `()`    | `int`           | Top class ID.          |
+| `result.probs.top1conf` | `Tensor`    | `()`    | `torch.float32` | Top confidence.        |
+| `result.probs.top5`     | `list[int]` | `(<=5)` | `list[int]`     | Top-5 class IDs.       |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/classify.md
+++ b/docs/en/tasks/classify.md
@@ -219,13 +219,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Image classification returns one `Results` object per image. The primary prediction field is `result.probs`, which
 contains the class probability vector and helpers for top predictions.
 
-| Attribute               | Type        | Shape   | Dtype           | Description            |
-| ----------------------- | ----------- | ------- | --------------- | ---------------------- |
-| `result.probs`          | `Probs`     | `(C,)`  | -               | Class probabilities.   |
-| `result.probs.data`     | `Tensor`    | `(C,)`  | `torch.float32` | Probability per class. |
-| `result.probs.top1`     | `int`       | `()`    | `int`           | Top class ID.          |
-| `result.probs.top1conf` | `Tensor`    | `()`    | `torch.float32` | Top confidence.        |
-| `result.probs.top5`     | `list[int]` | `(<=5)` | `list[int]`     | Top-5 class IDs.       |
+| Attribute               | Type            | Shape   | Description            |
+| ----------------------- | --------------- | ------- | ---------------------- |
+| `result.probs`          | `Probs`         | `(C,)`  | Class probabilities.   |
+| `result.probs.data`     | `torch.float32` | `(C,)`  | Probability per class. |
+| `result.probs.top1`     | `int`           | `()`    | Top class ID.          |
+| `result.probs.top1conf` | `torch.float32` | `()`    | Top confidence.        |
+| `result.probs.top5`     | `list[int]`     | `(<=5)` | Top-5 class IDs.       |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -151,13 +151,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Object detection returns one `Results` object per image. The primary prediction field is `result.boxes`, which contains
 box coordinates, class IDs, and confidence scores for each detected object.
 
-| Attribute | Type | Shape / Format | Description |
-|---|---|---|---|
-| `result.boxes` | `Boxes` | `N` boxes | Detection boxes for each object. |
+| Attribute           | Type           | Shape / Format       | Description                                                         |
+| ------------------- | -------------- | -------------------- | ------------------------------------------------------------------- |
+| `result.boxes`      | `Boxes`        | `N` boxes            | Detection boxes for each object.                                    |
 | `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
-| `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)` | Boxes in `[x1, y1, x2, y2]` pixel coordinates. |
-| `result.boxes.conf` | `torch.Tensor` | `(N,)` | Confidence score for each detection. |
-| `result.boxes.cls` | `torch.Tensor` | `(N,)` | Class ID for each detection. |
+| `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)`             | Boxes in `[x1, y1, x2, y2]` pixel coordinates.                      |
+| `result.boxes.conf` | `torch.Tensor` | `(N,)`               | Confidence score for each detection.                                |
+| `result.boxes.cls`  | `torch.Tensor` | `(N,)`               | Class ID for each detection.                                        |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -146,6 +146,21 @@ Use a trained YOLO26n model to run predictions on images.
 
 See full `predict` mode details in the [Predict](../modes/predict.md) page.
 
+### Results Output
+
+Object detection returns one `Results` object per image. The primary prediction field is `result.boxes`, which contains
+box coordinates, class IDs, and confidence scores for each detected object.
+
+| Attribute | Type | Shape / Format | Description |
+|---|---|---|---|
+| `result.boxes` | `Boxes` | `N` boxes | Detection boxes for each object. |
+| `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
+| `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)` | Boxes in `[x1, y1, x2, y2]` pixel coordinates. |
+| `result.boxes.conf` | `torch.Tensor` | `(N,)` | Confidence score for each detection. |
+| `result.boxes.cls` | `torch.Tensor` | `(N,)` | Class ID for each detection. |
+
+For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
+
 ## Export
 
 Export a YOLO26n model to a different format like ONNX, CoreML, etc.

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -151,13 +151,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Object detection returns one `Results` object per image. The primary prediction field is `result.boxes`, which contains
 box coordinates, class IDs, and confidence scores for each detected object.
 
-| Attribute           | Type            | Shape     | Description                                                 |
-| ------------------- | --------------- | --------- | ----------------------------------------------------------- |
-| `result.boxes`      | `Boxes`         | `(N)`     | Detection boxes.                                            |
-| `result.boxes.data` | `torch.float32` | `(N,6/7)` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID.       |
-| `result.boxes.xyxy` | `torch.float32` | `(N,4)`   | `xyxy` pixel boxes.                                         |
-| `result.boxes.conf` | `torch.float32` | `(N,)`    | Confidence scores.                                          |
-| `result.boxes.cls`  | `torch.float32` | `(N,)`    | Class IDs; cast to `int` for names.                         |
+| Attribute           | Type            | Shape     | Description                                           |
+| ------------------- | --------------- | --------- | ----------------------------------------------------- |
+| `result.boxes`      | `Boxes`         | `(N)`     | Detection boxes.                                      |
+| `result.boxes.data` | `torch.float32` | `(N,6/7)` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
+| `result.boxes.xyxy` | `torch.float32` | `(N,4)`   | `xyxy` pixel boxes.                                   |
+| `result.boxes.conf` | `torch.float32` | `(N,)`    | Confidence scores.                                    |
+| `result.boxes.cls`  | `torch.float32` | `(N,)`    | Class IDs; cast to `int` for names.                   |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -151,13 +151,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Object detection returns one `Results` object per image. The primary prediction field is `result.boxes`, which contains
 box coordinates, class IDs, and confidence scores for each detected object.
 
-| Attribute           | Type           | Shape / Format       | Description                                                         |
-| ------------------- | -------------- | -------------------- | ------------------------------------------------------------------- |
-| `result.boxes`      | `Boxes`        | `N` boxes            | Detection boxes for each object.                                    |
-| `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
-| `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)`             | Boxes in `[x1, y1, x2, y2]` pixel coordinates.                      |
-| `result.boxes.conf` | `torch.Tensor` | `(N,)`               | Confidence score for each detection.                                |
-| `result.boxes.cls`  | `torch.Tensor` | `(N,)`               | Class ID for each detection.                                        |
+| Attribute           | Type           | Shape / Format         | Dtype                    | Description                                                                  |
+| ------------------- | -------------- | ---------------------- | ------------------------ | ---------------------------------------------------------------------------- |
+| `result.boxes`      | `Boxes`        | `N` boxes              | Container                | Detection boxes for each object.                                             |
+| `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)`   | Floating point           | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID.          |
+| `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)`               | Floating point           | Boxes in `[x1, y1, x2, y2]` pixel coordinates.                               |
+| `result.boxes.conf` | `torch.Tensor` | `(N,)`                 | Floating point           | Confidence score for each detection.                                         |
+| `result.boxes.cls`  | `torch.Tensor` | `(N,)`                 | Floating point class IDs | Class ID for each detection; cast to `int` for name lookup.                  |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -151,13 +151,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Object detection returns one `Results` object per image. The primary prediction field is `result.boxes`, which contains
 box coordinates, class IDs, and confidence scores for each detected object.
 
-| Attribute           | Type           | Shape / Format       | Dtype                    | Description                                                         |
-| ------------------- | -------------- | -------------------- | ------------------------ | ------------------------------------------------------------------- |
-| `result.boxes`      | `Boxes`        | `N` boxes            | Container                | Detection boxes for each object.                                    |
-| `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Floating point           | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
-| `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)`             | Floating point           | Boxes in `[x1, y1, x2, y2]` pixel coordinates.                      |
-| `result.boxes.conf` | `torch.Tensor` | `(N,)`               | Floating point           | Confidence score for each detection.                                |
-| `result.boxes.cls`  | `torch.Tensor` | `(N,)`               | Floating point class IDs | Class ID for each detection; cast to `int` for name lookup.         |
+| Attribute           | Type           | Shape         | Dtype                    | Description                                                                  |
+| ------------------- | -------------- | ---------------------- | ------------------------ | ---------------------------------------------------------------------------- |
+| `result.boxes`      | `Boxes`        | `(N)`              | - | Detection boxes.                                             |
+| `result.boxes.data` | `Tensor` | `(N,6|7)`   | `torch.float32` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID.          |
+| `result.boxes.xyxy` | `Tensor` | `(N,4)`               | `torch.float32` | `xyxy` pixel boxes.                               |
+| `result.boxes.conf` | `Tensor` | `(N,)`                 | `torch.float32` | Confidence scores.                                         |
+| `result.boxes.cls`  | `Tensor` | `(N,)`                 | `torch.float32` | Class IDs; cast to `int` for names.                  |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -151,13 +151,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Object detection returns one `Results` object per image. The primary prediction field is `result.boxes`, which contains
 box coordinates, class IDs, and confidence scores for each detected object.
 
-| Attribute           | Type     | Shape   | Dtype           | Description                         |
-| ------------------- | -------- | ------- | --------------- | ----------------------------------- | ----------------------------------------------------- |
-| `result.boxes`      | `Boxes`  | `(N)`   | -               | Detection boxes.                    |
-| `result.boxes.data` | `Tensor` | `(N,6   | 7)`             | `torch.float32`                     | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
-| `result.boxes.xyxy` | `Tensor` | `(N,4)` | `torch.float32` | `xyxy` pixel boxes.                 |
-| `result.boxes.conf` | `Tensor` | `(N,)`  | `torch.float32` | Confidence scores.                  |
-| `result.boxes.cls`  | `Tensor` | `(N,)`  | `torch.float32` | Class IDs; cast to `int` for names. |
+| Attribute           | Type            | Shape     | Description                                                 |
+| ------------------- | --------------- | --------- | ----------------------------------------------------------- |
+| `result.boxes`      | `Boxes`         | `(N)`     | Detection boxes.                                            |
+| `result.boxes.data` | `torch.float32` | `(N,6/7)` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID.       |
+| `result.boxes.xyxy` | `torch.float32` | `(N,4)`   | `xyxy` pixel boxes.                                         |
+| `result.boxes.conf` | `torch.float32` | `(N,)`    | Confidence scores.                                          |
+| `result.boxes.cls`  | `torch.float32` | `(N,)`    | Class IDs; cast to `int` for names.                         |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -151,13 +151,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Object detection returns one `Results` object per image. The primary prediction field is `result.boxes`, which contains
 box coordinates, class IDs, and confidence scores for each detected object.
 
-| Attribute           | Type           | Shape         | Dtype                    | Description                                                                  |
-| ------------------- | -------------- | ---------------------- | ------------------------ | ---------------------------------------------------------------------------- |
-| `result.boxes`      | `Boxes`        | `(N)`              | - | Detection boxes.                                             |
-| `result.boxes.data` | `Tensor` | `(N,6|7)`   | `torch.float32` | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID.          |
-| `result.boxes.xyxy` | `Tensor` | `(N,4)`               | `torch.float32` | `xyxy` pixel boxes.                               |
-| `result.boxes.conf` | `Tensor` | `(N,)`                 | `torch.float32` | Confidence scores.                                         |
-| `result.boxes.cls`  | `Tensor` | `(N,)`                 | `torch.float32` | Class IDs; cast to `int` for names.                  |
+| Attribute           | Type     | Shape   | Dtype           | Description                         |
+| ------------------- | -------- | ------- | --------------- | ----------------------------------- | ----------------------------------------------------- |
+| `result.boxes`      | `Boxes`  | `(N)`   | -               | Detection boxes.                    |
+| `result.boxes.data` | `Tensor` | `(N,6   | 7)`             | `torch.float32`                     | Raw `[x1,y1,x2,y2,conf,cls]`, plus optional track ID. |
+| `result.boxes.xyxy` | `Tensor` | `(N,4)` | `torch.float32` | `xyxy` pixel boxes.                 |
+| `result.boxes.conf` | `Tensor` | `(N,)`  | `torch.float32` | Confidence scores.                  |
+| `result.boxes.cls`  | `Tensor` | `(N,)`  | `torch.float32` | Class IDs; cast to `int` for names. |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/detect.md
+++ b/docs/en/tasks/detect.md
@@ -151,13 +151,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Object detection returns one `Results` object per image. The primary prediction field is `result.boxes`, which contains
 box coordinates, class IDs, and confidence scores for each detected object.
 
-| Attribute           | Type           | Shape / Format         | Dtype                    | Description                                                                  |
-| ------------------- | -------------- | ---------------------- | ------------------------ | ---------------------------------------------------------------------------- |
-| `result.boxes`      | `Boxes`        | `N` boxes              | Container                | Detection boxes for each object.                                             |
-| `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)`   | Floating point           | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID.          |
-| `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)`               | Floating point           | Boxes in `[x1, y1, x2, y2]` pixel coordinates.                               |
-| `result.boxes.conf` | `torch.Tensor` | `(N,)`                 | Floating point           | Confidence score for each detection.                                         |
-| `result.boxes.cls`  | `torch.Tensor` | `(N,)`                 | Floating point class IDs | Class ID for each detection; cast to `int` for name lookup.                  |
+| Attribute           | Type           | Shape / Format       | Dtype                    | Description                                                         |
+| ------------------- | -------------- | -------------------- | ------------------------ | ------------------------------------------------------------------- |
+| `result.boxes`      | `Boxes`        | `N` boxes            | Container                | Detection boxes for each object.                                    |
+| `result.boxes.data` | `torch.Tensor` | `(N, 6)` or `(N, 7)` | Floating point           | Raw boxes as `[x1, y1, x2, y2, conf, cls]`, with optional track ID. |
+| `result.boxes.xyxy` | `torch.Tensor` | `(N, 4)`             | Floating point           | Boxes in `[x1, y1, x2, y2]` pixel coordinates.                      |
+| `result.boxes.conf` | `torch.Tensor` | `(N,)`               | Floating point           | Confidence score for each detection.                                |
+| `result.boxes.cls`  | `torch.Tensor` | `(N,)`               | Floating point class IDs | Class ID for each detection; cast to `int` for name lookup.         |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -188,13 +188,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Oriented bounding box detection returns one `Results` object per image. The primary prediction field is `result.obb`,
 which contains rotated boxes, class IDs, and confidence scores for each detected object.
 
-| Attribute             | Type           | Shape / Format       | Description                                                       |
-| --------------------- | -------------- | -------------------- | ----------------------------------------------------------------- |
-| `result.obb`          | `OBB`          | `N` rotated boxes    | Oriented bounding boxes for each detection.                       |
-| `result.obb.data`     | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Raw rotated boxes with confidence, class, and optional track ID.  |
-| `result.obb.xywhr`    | `torch.Tensor` | `(N, 5)`             | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
-| `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)`          | Four corner points for each rotated box.                          |
-| `result.obb.conf`     | `torch.Tensor` | `(N,)`               | Confidence score for each rotated box.                            |
+| Attribute              | Type           | Shape / Format       | Dtype          | Description                                                                  |
+| ---------------------- | -------------- | -------------------- | -------------- | ---------------------------------------------------------------------------- |
+| `result.obb`           | `OBB`          | `N` rotated boxes    | Container      | Oriented bounding boxes for each detection.                                   |
+| `result.obb.data`      | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Floating point | Raw rotated boxes with confidence, class, and optional track ID.              |
+| `result.obb.xywhr`     | `torch.Tensor` | `(N, 5)`             | Floating point | Rotated boxes as `[x_center, y_center, width, height, rotation]`.             |
+| `result.obb.xyxyxyxy`  | `torch.Tensor` | `(N, 4, 2)`          | Floating point | Four corner points for each rotated box.                                      |
+| `result.obb.conf`      | `torch.Tensor` | `(N,)`               | Floating point | Confidence score for each rotated box.                                        |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -188,13 +188,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Oriented bounding box detection returns one `Results` object per image. The primary prediction field is `result.obb`,
 which contains rotated boxes, class IDs, and confidence scores for each detected object.
 
-| Attribute             | Type     | Shape     | Dtype           | Description            |
-| --------------------- | -------- | --------- | --------------- | ---------------------- | ---------------------------------------- |
-| `result.obb`          | `OBB`    | `(N)`     | -               | Oriented boxes.        |
-| `result.obb.data`     | `Tensor` | `(N,7     | 8)`             | `torch.float32`        | Raw rotated boxes with confidence/class. |
-| `result.obb.xywhr`    | `Tensor` | `(N,5)`   | `torch.float32` | `xywhr` rotated boxes. |
-| `result.obb.xyxyxyxy` | `Tensor` | `(N,4,2)` | `torch.float32` | Four corner points.    |
-| `result.obb.conf`     | `Tensor` | `(N,)`    | `torch.float32` | Confidence scores.     |
+| Attribute             | Type            | Shape     | Description                              |
+| --------------------- | --------------- | --------- | ---------------------------------------- |
+| `result.obb`          | `OBB`           | `(N)`     | Oriented boxes.                          |
+| `result.obb.data`     | `torch.float32` | `(N,7/8)` | Raw rotated boxes with confidence/class. |
+| `result.obb.xywhr`    | `torch.float32` | `(N,5)`   | `xywhr` rotated boxes.                   |
+| `result.obb.xyxyxyxy` | `torch.float32` | `(N,4,2)` | Four corner points.                      |
+| `result.obb.conf`     | `torch.float32` | `(N,)`    | Confidence scores.                       |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -188,13 +188,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Oriented bounding box detection returns one `Results` object per image. The primary prediction field is `result.obb`,
 which contains rotated boxes, class IDs, and confidence scores for each detected object.
 
-| Attribute              | Type           | Shape       | Dtype          | Description                                                                  |
-| ---------------------- | -------------- | -------------------- | -------------- | ---------------------------------------------------------------------------- |
-| `result.obb`           | `OBB`          | `(N)`    | - | Oriented boxes.                                   |
-| `result.obb.data`      | `Tensor` | `(N,7|8)` | `torch.float32` | Raw rotated boxes with confidence/class.              |
-| `result.obb.xywhr`     | `Tensor` | `(N,5)`             | `torch.float32` | `xywhr` rotated boxes.             |
-| `result.obb.xyxyxyxy`  | `Tensor` | `(N,4,2)`          | `torch.float32` | Four corner points.                                      |
-| `result.obb.conf`      | `Tensor` | `(N,)`               | `torch.float32` | Confidence scores.                                        |
+| Attribute             | Type     | Shape     | Dtype           | Description            |
+| --------------------- | -------- | --------- | --------------- | ---------------------- | ---------------------------------------- |
+| `result.obb`          | `OBB`    | `(N)`     | -               | Oriented boxes.        |
+| `result.obb.data`     | `Tensor` | `(N,7     | 8)`             | `torch.float32`        | Raw rotated boxes with confidence/class. |
+| `result.obb.xywhr`    | `Tensor` | `(N,5)`   | `torch.float32` | `xywhr` rotated boxes. |
+| `result.obb.xyxyxyxy` | `Tensor` | `(N,4,2)` | `torch.float32` | Four corner points.    |
+| `result.obb.conf`     | `Tensor` | `(N,)`    | `torch.float32` | Confidence scores.     |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -183,6 +183,21 @@ Use a trained YOLO26n-obb model to run predictions on images.
 
 See full `predict` mode details in the [Predict](../modes/predict.md) page.
 
+### Results Output
+
+Oriented bounding box detection returns one `Results` object per image. The primary prediction field is `result.obb`,
+which contains rotated boxes, class IDs, and confidence scores for each detected object.
+
+| Attribute | Type | Shape / Format | Description |
+|---|---|---|---|
+| `result.obb` | `OBB` | `N` rotated boxes | Oriented bounding boxes for each detection. |
+| `result.obb.data` | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Raw rotated boxes with confidence, class, and optional track ID. |
+| `result.obb.xywhr` | `torch.Tensor` | `(N, 5)` | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
+| `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)` | Four corner points for each rotated box. |
+| `result.obb.conf` | `torch.Tensor` | `(N,)` | Confidence score for each rotated box. |
+
+For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
+
 ## Export
 
 Export a YOLO26n-obb model to a different format like ONNX, CoreML, etc.

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -188,13 +188,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Oriented bounding box detection returns one `Results` object per image. The primary prediction field is `result.obb`,
 which contains rotated boxes, class IDs, and confidence scores for each detected object.
 
-| Attribute | Type | Shape / Format | Description |
-|---|---|---|---|
-| `result.obb` | `OBB` | `N` rotated boxes | Oriented bounding boxes for each detection. |
-| `result.obb.data` | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Raw rotated boxes with confidence, class, and optional track ID. |
-| `result.obb.xywhr` | `torch.Tensor` | `(N, 5)` | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
-| `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)` | Four corner points for each rotated box. |
-| `result.obb.conf` | `torch.Tensor` | `(N,)` | Confidence score for each rotated box. |
+| Attribute             | Type           | Shape / Format       | Description                                                       |
+| --------------------- | -------------- | -------------------- | ----------------------------------------------------------------- |
+| `result.obb`          | `OBB`          | `N` rotated boxes    | Oriented bounding boxes for each detection.                       |
+| `result.obb.data`     | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Raw rotated boxes with confidence, class, and optional track ID.  |
+| `result.obb.xywhr`    | `torch.Tensor` | `(N, 5)`             | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
+| `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)`          | Four corner points for each rotated box.                          |
+| `result.obb.conf`     | `torch.Tensor` | `(N,)`               | Confidence score for each rotated box.                            |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -188,13 +188,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Oriented bounding box detection returns one `Results` object per image. The primary prediction field is `result.obb`,
 which contains rotated boxes, class IDs, and confidence scores for each detected object.
 
-| Attribute             | Type           | Shape / Format       | Dtype          | Description                                                       |
-| --------------------- | -------------- | -------------------- | -------------- | ----------------------------------------------------------------- |
-| `result.obb`          | `OBB`          | `N` rotated boxes    | Container      | Oriented bounding boxes for each detection.                       |
-| `result.obb.data`     | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Floating point | Raw rotated boxes with confidence, class, and optional track ID.  |
-| `result.obb.xywhr`    | `torch.Tensor` | `(N, 5)`             | Floating point | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
-| `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)`          | Floating point | Four corner points for each rotated box.                          |
-| `result.obb.conf`     | `torch.Tensor` | `(N,)`               | Floating point | Confidence score for each rotated box.                            |
+| Attribute              | Type           | Shape       | Dtype          | Description                                                                  |
+| ---------------------- | -------------- | -------------------- | -------------- | ---------------------------------------------------------------------------- |
+| `result.obb`           | `OBB`          | `(N)`    | - | Oriented boxes.                                   |
+| `result.obb.data`      | `Tensor` | `(N,7|8)` | `torch.float32` | Raw rotated boxes with confidence/class.              |
+| `result.obb.xywhr`     | `Tensor` | `(N,5)`             | `torch.float32` | `xywhr` rotated boxes.             |
+| `result.obb.xyxyxyxy`  | `Tensor` | `(N,4,2)`          | `torch.float32` | Four corner points.                                      |
+| `result.obb.conf`      | `Tensor` | `(N,)`               | `torch.float32` | Confidence scores.                                        |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/obb.md
+++ b/docs/en/tasks/obb.md
@@ -188,13 +188,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Oriented bounding box detection returns one `Results` object per image. The primary prediction field is `result.obb`,
 which contains rotated boxes, class IDs, and confidence scores for each detected object.
 
-| Attribute              | Type           | Shape / Format       | Dtype          | Description                                                                  |
-| ---------------------- | -------------- | -------------------- | -------------- | ---------------------------------------------------------------------------- |
-| `result.obb`           | `OBB`          | `N` rotated boxes    | Container      | Oriented bounding boxes for each detection.                                   |
-| `result.obb.data`      | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Floating point | Raw rotated boxes with confidence, class, and optional track ID.              |
-| `result.obb.xywhr`     | `torch.Tensor` | `(N, 5)`             | Floating point | Rotated boxes as `[x_center, y_center, width, height, rotation]`.             |
-| `result.obb.xyxyxyxy`  | `torch.Tensor` | `(N, 4, 2)`          | Floating point | Four corner points for each rotated box.                                      |
-| `result.obb.conf`      | `torch.Tensor` | `(N,)`               | Floating point | Confidence score for each rotated box.                                        |
+| Attribute             | Type           | Shape / Format       | Dtype          | Description                                                       |
+| --------------------- | -------------- | -------------------- | -------------- | ----------------------------------------------------------------- |
+| `result.obb`          | `OBB`          | `N` rotated boxes    | Container      | Oriented bounding boxes for each detection.                       |
+| `result.obb.data`     | `torch.Tensor` | `(N, 7)` or `(N, 8)` | Floating point | Raw rotated boxes with confidence, class, and optional track ID.  |
+| `result.obb.xywhr`    | `torch.Tensor` | `(N, 5)`             | Floating point | Rotated boxes as `[x_center, y_center, width, height, rotation]`. |
+| `result.obb.xyxyxyxy` | `torch.Tensor` | `(N, 4, 2)`          | Floating point | Four corner points for each rotated box.                          |
+| `result.obb.conf`     | `torch.Tensor` | `(N,)`               | Floating point | Confidence score for each rotated box.                            |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -176,13 +176,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
 coordinates and `result.boxes` for the detected instances that those keypoints belong to.
 
-| Attribute               | Type        | Shape     | Dtype           | Description           |
-| ----------------------- | ----------- | --------- | --------------- | --------------------- | ------------------------------------------ |
-| `result.keypoints`      | `Keypoints` | `(N)`     | -               | Keypoint container.   |
-| `result.keypoints.data` | `Tensor`    | `(N,K,2   | 3)`             | `torch.float32`       | `x,y` plus optional visibility/confidence. |
-| `result.keypoints.xy`   | `Tensor`    | `(N,K,2)` | `torch.float32` | Pixel keypoints.      |
-| `result.keypoints.xyn`  | `Tensor`    | `(N,K,2)` | `torch.float32` | Normalized keypoints. |
-| `result.boxes`          | `Boxes`     | `(N)`     | -               | Instance boxes.       |
+| Attribute               | Type           | Shape              | Dtype          | Description                                                        |
+| ----------------------- | -------------- | --------------------------- | -------------- | ------------------------------------------------------------------ |
+| `result.keypoints`      | `Keypoints`    | `(N)`               | - | Keypoints.                     |
+| `result.keypoints.data` | `Tensor` | `(N,K,2/3)`  | `torch.float32` | `x,y` plus optional visibility/confidence.           |
+| `result.keypoints.xy`   | `Tensor` | `(N,K,2)`                 | `torch.float32` | Pixel keypoints.                                    |
+| `result.keypoints.xyn`  | `Tensor` | `(N,K,2)`                 | `torch.float32` | Normalized keypoints.                                   |
+| `result.boxes`          | `Boxes`        | `(N)`                   | - | Instance boxes.      |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -176,13 +176,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
 coordinates and `result.boxes` for the detected instances that those keypoints belong to.
 
-| Attribute               | Type           | Shape / Format             | Description                                                   |
-| ----------------------- | -------------- | -------------------------- | ------------------------------------------------------------- |
-| `result.keypoints`      | `Keypoints`    | `N` instances              | Keypoint container for each detected instance.                |
-| `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Keypoints as `x, y` plus optional visibility/confidence.      |
-| `result.keypoints.xy`   | `torch.Tensor` | `(N, K, 2)`                | Keypoint coordinates in pixels.                               |
-| `result.keypoints.xyn`  | `torch.Tensor` | `(N, K, 2)`                | Normalized keypoint coordinates.                              |
-| `result.boxes`          | `Boxes`        | `N` boxes                  | Boxes, confidences, and class IDs for the detected instances. |
+| Attribute               | Type           | Shape / Format              | Dtype          | Description                                                        |
+| ----------------------- | -------------- | --------------------------- | -------------- | ------------------------------------------------------------------ |
+| `result.keypoints`      | `Keypoints`    | `N` instances               | Container      | Keypoint container for each detected instance.                     |
+| `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)`  | Floating point | Keypoints as `x, y` plus optional visibility/confidence.           |
+| `result.keypoints.xy`   | `torch.Tensor` | `(N, K, 2)`                 | Floating point | Keypoint coordinates in pixels.                                    |
+| `result.keypoints.xyn`  | `torch.Tensor` | `(N, K, 2)`                 | Floating point | Normalized keypoint coordinates.                                   |
+| `result.boxes`          | `Boxes`        | `N` boxes                   | Container      | Boxes, confidences, and class IDs for the detected instances.      |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -176,13 +176,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
 coordinates and `result.boxes` for the detected instances that those keypoints belong to.
 
-| Attribute               | Type            | Shape       | Description                              |
-| ----------------------- | --------------- | ----------- | ---------------------------------------- |
-| `result.keypoints`      | `Keypoints`     | `(N)`       | Keypoints.                               |
+| Attribute               | Type            | Shape       | Description                                |
+| ----------------------- | --------------- | ----------- | ------------------------------------------ |
+| `result.keypoints`      | `Keypoints`     | `(N)`       | Keypoints.                                 |
 | `result.keypoints.data` | `torch.float32` | `(N,K,2/3)` | `x,y` plus optional visibility/confidence. |
-| `result.keypoints.xy`   | `torch.float32` | `(N,K,2)`   | Pixel keypoints.                         |
-| `result.keypoints.xyn`  | `torch.float32` | `(N,K,2)`   | Normalized keypoints.                    |
-| `result.boxes`          | `Boxes`         | `(N)`       | Instance boxes.                          |
+| `result.keypoints.xy`   | `torch.float32` | `(N,K,2)`   | Pixel keypoints.                           |
+| `result.keypoints.xyn`  | `torch.float32` | `(N,K,2)`   | Normalized keypoints.                      |
+| `result.boxes`          | `Boxes`         | `(N)`       | Instance boxes.                            |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -176,13 +176,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
 coordinates and `result.boxes` for the detected instances that those keypoints belong to.
 
-| Attribute               | Type           | Shape              | Dtype          | Description                                                        |
-| ----------------------- | -------------- | --------------------------- | -------------- | ------------------------------------------------------------------ |
-| `result.keypoints`      | `Keypoints`    | `(N)`               | - | Keypoint container.                     |
-| `result.keypoints.data` | `Tensor` | `(N,K,2|3)`  | `torch.float32` | `x,y` plus optional visibility/confidence.           |
-| `result.keypoints.xy`   | `Tensor` | `(N,K,2)`                 | `torch.float32` | Pixel keypoints.                                    |
-| `result.keypoints.xyn`  | `Tensor` | `(N,K,2)`                 | `torch.float32` | Normalized keypoints.                                   |
-| `result.boxes`          | `Boxes`        | `(N)`                   | - | Instance boxes.      |
+| Attribute               | Type        | Shape     | Dtype           | Description           |
+| ----------------------- | ----------- | --------- | --------------- | --------------------- | ------------------------------------------ |
+| `result.keypoints`      | `Keypoints` | `(N)`     | -               | Keypoint container.   |
+| `result.keypoints.data` | `Tensor`    | `(N,K,2   | 3)`             | `torch.float32`       | `x,y` plus optional visibility/confidence. |
+| `result.keypoints.xy`   | `Tensor`    | `(N,K,2)` | `torch.float32` | Pixel keypoints.      |
+| `result.keypoints.xyn`  | `Tensor`    | `(N,K,2)` | `torch.float32` | Normalized keypoints. |
+| `result.boxes`          | `Boxes`     | `(N)`     | -               | Instance boxes.       |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -176,13 +176,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
 coordinates and `result.boxes` for the detected instances that those keypoints belong to.
 
-| Attribute               | Type           | Shape              | Dtype          | Description                                                        |
-| ----------------------- | -------------- | --------------------------- | -------------- | ------------------------------------------------------------------ |
-| `result.keypoints`      | `Keypoints`    | `(N)`               | - | Keypoints.                     |
-| `result.keypoints.data` | `Tensor` | `(N,K,2/3)`  | `torch.float32` | `x,y` plus optional visibility/confidence.           |
-| `result.keypoints.xy`   | `Tensor` | `(N,K,2)`                 | `torch.float32` | Pixel keypoints.                                    |
-| `result.keypoints.xyn`  | `Tensor` | `(N,K,2)`                 | `torch.float32` | Normalized keypoints.                                   |
-| `result.boxes`          | `Boxes`        | `(N)`                   | - | Instance boxes.      |
+| Attribute               | Type            | Shape       | Description                              |
+| ----------------------- | --------------- | ----------- | ---------------------------------------- |
+| `result.keypoints`      | `Keypoints`     | `(N)`       | Keypoints.                               |
+| `result.keypoints.data` | `torch.float32` | `(N,K,2/3)` | `x,y` plus optional visibility/confidence. |
+| `result.keypoints.xy`   | `torch.float32` | `(N,K,2)`   | Pixel keypoints.                         |
+| `result.keypoints.xyn`  | `torch.float32` | `(N,K,2)`   | Normalized keypoints.                    |
+| `result.boxes`          | `Boxes`         | `(N)`       | Instance boxes.                          |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -176,13 +176,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
 coordinates and `result.boxes` for the detected instances that those keypoints belong to.
 
-| Attribute | Type | Shape / Format | Description |
-|---|---|---|---|
-| `result.keypoints` | `Keypoints` | `N` instances | Keypoint container for each detected instance. |
-| `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Keypoints as `x, y` plus optional visibility/confidence. |
-| `result.keypoints.xy` | `torch.Tensor` | `(N, K, 2)` | Keypoint coordinates in pixels. |
-| `result.keypoints.xyn` | `torch.Tensor` | `(N, K, 2)` | Normalized keypoint coordinates. |
-| `result.boxes` | `Boxes` | `N` boxes | Boxes, confidences, and class IDs for the detected instances. |
+| Attribute               | Type           | Shape / Format             | Description                                                   |
+| ----------------------- | -------------- | -------------------------- | ------------------------------------------------------------- |
+| `result.keypoints`      | `Keypoints`    | `N` instances              | Keypoint container for each detected instance.                |
+| `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Keypoints as `x, y` plus optional visibility/confidence.      |
+| `result.keypoints.xy`   | `torch.Tensor` | `(N, K, 2)`                | Keypoint coordinates in pixels.                               |
+| `result.keypoints.xyn`  | `torch.Tensor` | `(N, K, 2)`                | Normalized keypoint coordinates.                              |
+| `result.boxes`          | `Boxes`        | `N` boxes                  | Boxes, confidences, and class IDs for the detected instances. |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -176,13 +176,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
 coordinates and `result.boxes` for the detected instances that those keypoints belong to.
 
-| Attribute               | Type           | Shape / Format              | Dtype          | Description                                                        |
-| ----------------------- | -------------- | --------------------------- | -------------- | ------------------------------------------------------------------ |
-| `result.keypoints`      | `Keypoints`    | `N` instances               | Container      | Keypoint container for each detected instance.                     |
-| `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)`  | Floating point | Keypoints as `x, y` plus optional visibility/confidence.           |
-| `result.keypoints.xy`   | `torch.Tensor` | `(N, K, 2)`                 | Floating point | Keypoint coordinates in pixels.                                    |
-| `result.keypoints.xyn`  | `torch.Tensor` | `(N, K, 2)`                 | Floating point | Normalized keypoint coordinates.                                   |
-| `result.boxes`          | `Boxes`        | `N` boxes                   | Container      | Boxes, confidences, and class IDs for the detected instances.      |
+| Attribute               | Type           | Shape / Format             | Dtype          | Description                                                   |
+| ----------------------- | -------------- | -------------------------- | -------------- | ------------------------------------------------------------- |
+| `result.keypoints`      | `Keypoints`    | `N` instances              | Container      | Keypoint container for each detected instance.                |
+| `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Floating point | Keypoints as `x, y` plus optional visibility/confidence.      |
+| `result.keypoints.xy`   | `torch.Tensor` | `(N, K, 2)`                | Floating point | Keypoint coordinates in pixels.                               |
+| `result.keypoints.xyn`  | `torch.Tensor` | `(N, K, 2)`                | Floating point | Normalized keypoint coordinates.                              |
+| `result.boxes`          | `Boxes`        | `N` boxes                  | Container      | Boxes, confidences, and class IDs for the detected instances. |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -171,6 +171,21 @@ Use a trained YOLO26n-pose model to run predictions on images. The [predict mode
 
 See full `predict` mode details in the [Predict](../modes/predict.md) page.
 
+### Results Output
+
+Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
+coordinates and `result.boxes` for the detected instances that those keypoints belong to.
+
+| Attribute | Type | Shape / Format | Description |
+|---|---|---|---|
+| `result.keypoints` | `Keypoints` | `N` instances | Keypoint container for each detected instance. |
+| `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Keypoints as `x, y` plus optional visibility/confidence. |
+| `result.keypoints.xy` | `torch.Tensor` | `(N, K, 2)` | Keypoint coordinates in pixels. |
+| `result.keypoints.xyn` | `torch.Tensor` | `(N, K, 2)` | Normalized keypoint coordinates. |
+| `result.boxes` | `Boxes` | `N` boxes | Boxes, confidences, and class IDs for the detected instances. |
+
+For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
+
 ## Export
 
 Export a YOLO26n Pose model to a different format like ONNX, CoreML, etc. This allows you to deploy your model on various platforms and devices for [real-time inference](https://www.ultralytics.com/glossary/real-time-inference).

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -176,13 +176,13 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 Pose estimation returns one `Results` object per image. The primary prediction fields are `result.keypoints` for pose
 coordinates and `result.boxes` for the detected instances that those keypoints belong to.
 
-| Attribute               | Type           | Shape / Format             | Dtype          | Description                                                   |
-| ----------------------- | -------------- | -------------------------- | -------------- | ------------------------------------------------------------- |
-| `result.keypoints`      | `Keypoints`    | `N` instances              | Container      | Keypoint container for each detected instance.                |
-| `result.keypoints.data` | `torch.Tensor` | `(N, K, 2)` or `(N, K, 3)` | Floating point | Keypoints as `x, y` plus optional visibility/confidence.      |
-| `result.keypoints.xy`   | `torch.Tensor` | `(N, K, 2)`                | Floating point | Keypoint coordinates in pixels.                               |
-| `result.keypoints.xyn`  | `torch.Tensor` | `(N, K, 2)`                | Floating point | Normalized keypoint coordinates.                              |
-| `result.boxes`          | `Boxes`        | `N` boxes                  | Container      | Boxes, confidences, and class IDs for the detected instances. |
+| Attribute               | Type           | Shape              | Dtype          | Description                                                        |
+| ----------------------- | -------------- | --------------------------- | -------------- | ------------------------------------------------------------------ |
+| `result.keypoints`      | `Keypoints`    | `(N)`               | - | Keypoint container.                     |
+| `result.keypoints.data` | `Tensor` | `(N,K,2|3)`  | `torch.float32` | `x,y` plus optional visibility/confidence.           |
+| `result.keypoints.xy`   | `Tensor` | `(N,K,2)`                 | `torch.float32` | Pixel keypoints.                                    |
+| `result.keypoints.xyn`  | `Tensor` | `(N,K,2)`                 | `torch.float32` | Normalized keypoints.                                   |
+| `result.boxes`          | `Boxes`        | `(N)`                   | - | Instance boxes.      |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -137,7 +137,7 @@ Use a trained YOLO26n-seg model to run predictions on images.
         for result in results:
             xy = result.masks.xy  # mask polygons in pixel coordinates
             xyn = result.masks.xyn  # normalized mask polygons
-            masks = result.masks.data  # binary masks, shape (N,H,W), dtype uint8
+            masks = result.masks.data  # binary masks, shape (N,H,W), dtype torch.uint8
         ```
 
     === "CLI"

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -161,19 +161,15 @@ each detected instance has its own binary mask, class, confidence, and box.
 | `result.masks.xy`   | `list[np.ndarray]` | One `(points, 2)` array per instance | Mask polygons in pixel coordinates.                                               |
 | `result.masks.xyn`  | `list[np.ndarray]` | One `(points, 2)` array per instance | Normalized mask polygons with coordinates in `[0, 1]`.                            |
 | `result.boxes`      | `Boxes`            | `N` boxes                            | Bounding boxes, confidences, and class IDs aligned with the masks.                |
+| `result.boxes.cls`  | `torch.Tensor`     | `(N,)`                              | Class ID for each detected instance.                                              |
 
-### Instance vs Semantic Segmentation
+For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
-| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
-| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
-| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
-| Shape                | `(N, H, W)`                                           | `(H, W)`                                                                          |
-| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
-| Dtype                | `torch.uint8`                                         | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
-| Object separation    | Separates each detected object instance               | Groups all pixels of the same class together                                      |
-| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
-| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
+### How This Differs from Semantic Segmentation
+
+Instance segmentation is object-level segmentation: two cars produce two masks, two boxes, and two confidence scores.
+[Semantic segmentation](semantic.md) is pixel-level classification: those same cars become pixels with the same class ID
+in one image-sized class map, with no per-object boxes, confidences, or default polygon list.
 
 ## Export
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -154,14 +154,14 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 YOLO instance segmentation returns one `Results` object per image. Each result stores object-level predictions, where
 each detected instance has its own binary mask, class, confidence, and box.
 
-| Attribute           | Type               | Shape                       | Dtype                    | Description                                                                       |
-| ------------------- | ------------------ | ------------------------------------ | ------------------------ | --------------------------------------------------------------------------------- |
-| `result.masks`      | `Masks`            | `(N)`                            | - | Instance masks.                                     |
-| `result.masks.data` | `Tensor`     | `(N,H,W)`                          | `torch.uint8`            | Binary masks, values `0` or `1`. |
-| `result.masks.xy`   | `list[ndarray]` | `list[(P,2)]` | `np.float32`            | Pixel polygons.                                               |
-| `result.masks.xyn`  | `list[ndarray]` | `list[(P,2)]` | `np.float32`            | Normalized polygons.                            |
-| `result.boxes`      | `Boxes`            | `(N)`                            | - | Instance boxes/classes/confidences.                |
-| `result.boxes.cls`  | `Tensor`     | `(N,)`                               | `torch.float32` | Class IDs; cast to `int` for names.               |
+| Attribute           | Type            | Shape         | Dtype           | Description                         |
+| ------------------- | --------------- | ------------- | --------------- | ----------------------------------- |
+| `result.masks`      | `Masks`         | `(N)`         | -               | Instance masks.                     |
+| `result.masks.data` | `Tensor`        | `(N,H,W)`     | `torch.uint8`   | Binary masks, values `0` or `1`.    |
+| `result.masks.xy`   | `list[ndarray]` | `list[(P,2)]` | `np.float32`    | Pixel polygons.                     |
+| `result.masks.xyn`  | `list[ndarray]` | `list[(P,2)]` | `np.float32`    | Normalized polygons.                |
+| `result.boxes`      | `Boxes`         | `(N)`         | -               | Instance boxes/classes/confidences. |
+| `result.boxes.cls`  | `Tensor`        | `(N,)`        | `torch.float32` | Class IDs; cast to `int` for names. |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -154,14 +154,14 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 YOLO instance segmentation returns one `Results` object per image. Each result stores object-level predictions, where
 each detected instance has its own binary mask, class, confidence, and box.
 
-| Attribute           | Type               | Shape / Format                       | Description                                                                       |
-| ------------------- | ------------------ | ------------------------------------ | --------------------------------------------------------------------------------- |
-| `result.masks`      | `Masks`            | `N` masks                            | Mask container for detected object instances.                                     |
-| `result.masks.data` | `torch.Tensor`     | `(N, H, W)`, `torch.uint8`           | Binary mask stack where `N` is the number of instances and values are `0` or `1`. |
-| `result.masks.xy`   | `list[np.ndarray]` | One `(points, 2)` array per instance | Mask polygons in pixel coordinates.                                               |
-| `result.masks.xyn`  | `list[np.ndarray]` | One `(points, 2)` array per instance | Normalized mask polygons with coordinates in `[0, 1]`.                            |
-| `result.boxes`      | `Boxes`            | `N` boxes                            | Bounding boxes, confidences, and class IDs aligned with the masks.                |
-| `result.boxes.cls`  | `torch.Tensor`     | `(N,)`                               | Class ID for each detected instance.                                              |
+| Attribute           | Type               | Shape / Format                       | Dtype                    | Description                                                                       |
+| ------------------- | ------------------ | ------------------------------------ | ------------------------ | --------------------------------------------------------------------------------- |
+| `result.masks`      | `Masks`            | `N` masks                            | Container                | Mask container for detected object instances.                                     |
+| `result.masks.data` | `torch.Tensor`     | `(N, H, W)`                          | `torch.uint8`            | Binary mask stack where `N` is the number of instances and values are `0` or `1`. |
+| `result.masks.xy`   | `list[np.ndarray]` | One `(points, 2)` array per instance | Floating point           | Mask polygons in pixel coordinates.                                               |
+| `result.masks.xyn`  | `list[np.ndarray]` | One `(points, 2)` array per instance | Floating point           | Normalized mask polygons with coordinates in `[0, 1]`.                            |
+| `result.boxes`      | `Boxes`            | `N` boxes                            | Container                | Bounding boxes, confidences, and class IDs aligned with the masks.                |
+| `result.boxes.cls`  | `torch.Tensor`     | `(N,)`                               | Floating point class IDs | Class ID for each detected instance; cast to `int` for name lookup.               |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -154,14 +154,14 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 YOLO instance segmentation returns one `Results` object per image. Each result stores object-level predictions, where
 each detected instance has its own binary mask, class, confidence, and box.
 
-| Attribute           | Type            | Shape         | Dtype           | Description                         |
-| ------------------- | --------------- | ------------- | --------------- | ----------------------------------- |
-| `result.masks`      | `Masks`         | `(N)`         | -               | Instance masks.                     |
-| `result.masks.data` | `Tensor`        | `(N,H,W)`     | `torch.uint8`   | Binary masks, values `0` or `1`.    |
-| `result.masks.xy`   | `list[ndarray]` | `list[(P,2)]` | `np.float32`    | Pixel polygons.                     |
-| `result.masks.xyn`  | `list[ndarray]` | `list[(P,2)]` | `np.float32`    | Normalized polygons.                |
-| `result.boxes`      | `Boxes`         | `(N)`         | -               | Instance boxes/classes/confidences. |
-| `result.boxes.cls`  | `Tensor`        | `(N,)`        | `torch.float32` | Class IDs; cast to `int` for names. |
+| Attribute           | Type            | Shape         | Description                         |
+| ------------------- | --------------- | ------------- | ----------------------------------- |
+| `result.masks`      | `Masks`         | `(N)`         | Instance masks.                     |
+| `result.masks.data` | `torch.uint8`   | `(N,H,W)`     | Binary masks, values `0` or `1`.    |
+| `result.masks.xy`   | `np.float32`    | `list[(P,2)]` | Pixel polygons.                     |
+| `result.masks.xyn`  | `np.float32`    | `list[(P,2)]` | Normalized polygons.                |
+| `result.boxes`      | `Boxes`         | `(N)`         | Instance boxes/classes/confidences. |
+| `result.boxes.cls`  | `torch.float32` | `(N,)`        | Class IDs; cast to `int` for names. |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -161,7 +161,7 @@ each detected instance has its own binary mask, class, confidence, and box.
 | `result.masks.xy`   | `list[np.ndarray]` | One `(points, 2)` array per instance | Mask polygons in pixel coordinates.                                               |
 | `result.masks.xyn`  | `list[np.ndarray]` | One `(points, 2)` array per instance | Normalized mask polygons with coordinates in `[0, 1]`.                            |
 | `result.boxes`      | `Boxes`            | `N` boxes                            | Bounding boxes, confidences, and class IDs aligned with the masks.                |
-| `result.boxes.cls`  | `torch.Tensor`     | `(N,)`                              | Class ID for each detected instance.                                              |
+| `result.boxes.cls`  | `torch.Tensor`     | `(N,)`                               | Class ID for each detected instance.                                              |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -154,26 +154,26 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 YOLO instance segmentation returns one `Results` object per image. Each result stores object-level predictions, where
 each detected instance has its own binary mask, class, confidence, and box.
 
-| Attribute | Type | Shape / Format | Description |
-|---|---|---|---|
-| `result.masks` | `Masks` | `N` masks | Mask container for detected object instances. |
-| `result.masks.data` | `torch.Tensor` | `(N, H, W)`, `torch.uint8` | Binary mask stack where `N` is the number of instances and values are `0` or `1`. |
-| `result.masks.xy` | `list[np.ndarray]` | One `(points, 2)` array per instance | Mask polygons in pixel coordinates. |
-| `result.masks.xyn` | `list[np.ndarray]` | One `(points, 2)` array per instance | Normalized mask polygons with coordinates in `[0, 1]`. |
-| `result.boxes` | `Boxes` | `N` boxes | Bounding boxes, confidences, and class IDs aligned with the masks. |
+| Attribute           | Type               | Shape / Format                       | Description                                                                       |
+| ------------------- | ------------------ | ------------------------------------ | --------------------------------------------------------------------------------- |
+| `result.masks`      | `Masks`            | `N` masks                            | Mask container for detected object instances.                                     |
+| `result.masks.data` | `torch.Tensor`     | `(N, H, W)`, `torch.uint8`           | Binary mask stack where `N` is the number of instances and values are `0` or `1`. |
+| `result.masks.xy`   | `list[np.ndarray]` | One `(points, 2)` array per instance | Mask polygons in pixel coordinates.                                               |
+| `result.masks.xyn`  | `list[np.ndarray]` | One `(points, 2)` array per instance | Normalized mask polygons with coordinates in `[0, 1]`.                            |
+| `result.boxes`      | `Boxes`            | `N` boxes                            | Bounding boxes, confidences, and class IDs aligned with the masks.                |
 
 ### Instance vs Semantic Segmentation
 
-| Aspect | Instance Segmentation (`task="segment"`) | Semantic Segmentation (`task="semantic"`) |
-|---|---|---|
-| Output field | `result.masks` | `result.semantic_mask` |
-| Main data | `result.masks.data` | `result.semantic_mask.data` |
-| Shape | `(N, H, W)` | `(H, W)` |
-| Pixel values | Binary mask values: `0` or `1` | Class IDs: `0`, `1`, `2`, ... |
-| Dtype | `torch.uint8` | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
-| Object separation | Separates each detected object instance | Groups all pixels of the same class together |
-| Polygons | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default |
-| Boxes and confidence | Yes, through `result.boxes` | No per-instance boxes or confidence scores |
+| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
+| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
+| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
+| Shape                | `(N, H, W)`                                           | `(H, W)`                                                                          |
+| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
+| Dtype                | `torch.uint8`                                         | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
+| Object separation    | Separates each detected object instance               | Groups all pixels of the same class together                                      |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
+| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
 
 ## Export
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -135,9 +135,9 @@ Use a trained YOLO26n-seg model to run predictions on images.
 
         # Access the results
         for result in results:
-            xy = result.masks.xy  # mask in polygon format
-            xyn = result.masks.xyn  # normalized
-            masks = result.masks.data  # mask in matrix format (num_objects x H x W)
+            xy = result.masks.xy  # mask polygons in pixel coordinates
+            xyn = result.masks.xyn  # normalized mask polygons
+            masks = result.masks.data  # binary masks, shape (N, H, W), dtype uint8
         ```
 
     === "CLI"
@@ -148,6 +148,32 @@ Use a trained YOLO26n-seg model to run predictions on images.
         ```
 
 See full `predict` mode details in the [Predict](../modes/predict.md) page.
+
+### Results Output
+
+YOLO instance segmentation returns one `Results` object per image. Each result stores object-level predictions, where
+each detected instance has its own binary mask, class, confidence, and box.
+
+| Attribute | Type | Shape / Format | Description |
+|---|---|---|---|
+| `result.masks` | `Masks` | `N` masks | Mask container for detected object instances. |
+| `result.masks.data` | `torch.Tensor` | `(N, H, W)`, `torch.uint8` | Binary mask stack where `N` is the number of instances and values are `0` or `1`. |
+| `result.masks.xy` | `list[np.ndarray]` | One `(points, 2)` array per instance | Mask polygons in pixel coordinates. |
+| `result.masks.xyn` | `list[np.ndarray]` | One `(points, 2)` array per instance | Normalized mask polygons with coordinates in `[0, 1]`. |
+| `result.boxes` | `Boxes` | `N` boxes | Bounding boxes, confidences, and class IDs aligned with the masks. |
+
+### Instance vs Semantic Segmentation
+
+| Aspect | Instance Segmentation (`task="segment"`) | Semantic Segmentation (`task="semantic"`) |
+|---|---|---|
+| Output field | `result.masks` | `result.semantic_mask` |
+| Main data | `result.masks.data` | `result.semantic_mask.data` |
+| Shape | `(N, H, W)` | `(H, W)` |
+| Pixel values | Binary mask values: `0` or `1` | Class IDs: `0`, `1`, `2`, ... |
+| Dtype | `torch.uint8` | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
+| Object separation | Separates each detected object instance | Groups all pixels of the same class together |
+| Polygons | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default |
+| Boxes and confidence | Yes, through `result.boxes` | No per-instance boxes or confidence scores |
 
 ## Export
 

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -137,7 +137,7 @@ Use a trained YOLO26n-seg model to run predictions on images.
         for result in results:
             xy = result.masks.xy  # mask polygons in pixel coordinates
             xyn = result.masks.xyn  # normalized mask polygons
-            masks = result.masks.data  # binary masks, shape (N, H, W), dtype uint8
+            masks = result.masks.data  # binary masks, shape (N,H,W), dtype uint8
         ```
 
     === "CLI"
@@ -154,14 +154,14 @@ See full `predict` mode details in the [Predict](../modes/predict.md) page.
 YOLO instance segmentation returns one `Results` object per image. Each result stores object-level predictions, where
 each detected instance has its own binary mask, class, confidence, and box.
 
-| Attribute           | Type               | Shape / Format                       | Dtype                    | Description                                                                       |
+| Attribute           | Type               | Shape                       | Dtype                    | Description                                                                       |
 | ------------------- | ------------------ | ------------------------------------ | ------------------------ | --------------------------------------------------------------------------------- |
-| `result.masks`      | `Masks`            | `N` masks                            | Container                | Mask container for detected object instances.                                     |
-| `result.masks.data` | `torch.Tensor`     | `(N, H, W)`                          | `torch.uint8`            | Binary mask stack where `N` is the number of instances and values are `0` or `1`. |
-| `result.masks.xy`   | `list[np.ndarray]` | One `(points, 2)` array per instance | Floating point           | Mask polygons in pixel coordinates.                                               |
-| `result.masks.xyn`  | `list[np.ndarray]` | One `(points, 2)` array per instance | Floating point           | Normalized mask polygons with coordinates in `[0, 1]`.                            |
-| `result.boxes`      | `Boxes`            | `N` boxes                            | Container                | Bounding boxes, confidences, and class IDs aligned with the masks.                |
-| `result.boxes.cls`  | `torch.Tensor`     | `(N,)`                               | Floating point class IDs | Class ID for each detected instance; cast to `int` for name lookup.               |
+| `result.masks`      | `Masks`            | `(N)`                            | - | Instance masks.                                     |
+| `result.masks.data` | `Tensor`     | `(N,H,W)`                          | `torch.uint8`            | Binary masks, values `0` or `1`. |
+| `result.masks.xy`   | `list[ndarray]` | `list[(P,2)]` | `np.float32`            | Pixel polygons.                                               |
+| `result.masks.xyn`  | `list[ndarray]` | `list[(P,2)]` | `np.float32`            | Normalized polygons.                            |
+| `result.boxes`      | `Boxes`            | `(N)`                            | - | Instance boxes/classes/confidences.                |
+| `result.boxes.cls`  | `Tensor`     | `(N,)`                               | `torch.float32` | Class IDs; cast to `int` for names.               |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -134,13 +134,13 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute                   | Type           | Shape     | Dtype                                      | Description                                                                    |
-| --------------------------- | -------------- | ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------ |
-| `result.semantic_mask`      | `SemanticMask` | `(H,W)` | - | Dense class map.                 |
-| `result.semantic_mask.data` | `Tensor` | `(H,W)`           | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs.                  |
-| `result.masks`              | `None`         | - | -                             | No instance masks.                    |
-| `result.boxes`              | `None`         | - | -                             | No instance boxes/confidences. |
-| `result.masks.xy`           | -  | - | -                             | No default polygons.          |
+| Attribute                   | Type                                             | Shape   | Description                    |
+| --------------------------- | ------------------------------------------------ | ------- | ------------------------------ |
+| `result.semantic_mask`      | `SemanticMask`                                   | `(H,W)` | Dense class map.               |
+| `result.semantic_mask.data` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | `(H,W)` | Per-pixel class IDs.           |
+| `result.masks`              | -                                                | -       | No instance masks.             |
+| `result.boxes`              | -                                                | -       | No instance boxes/confidences. |
+| `result.masks.xy`           | -                                                | -       | No default polygons.           |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -140,20 +140,25 @@ belong to separate objects.
 | `result.semantic_mask.data` | `torch.Tensor` | `(H, W)`                     | Class map where each pixel value is a predicted class ID.                       |
 | Class map dtype             | `torch.dtype`  | `uint8`, `int16`, or `int32` | Uses `torch.uint8` for up to 256 classes, then larger integer dtypes as needed. |
 | `result.masks`              | `None`         | Not applicable               | Semantic segmentation does not return instance mask stacks.                     |
+| `result.boxes`              | `None`         | Not applicable               | Semantic segmentation does not return per-instance boxes or confidence scores.  |
 | `result.masks.xy`           | Not available  | Not applicable               | Polygon coordinates are not returned by default for semantic results.           |
+
+For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
 ### Instance vs Semantic Segmentation
 
 | Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
 | -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Prediction goal      | Segment each detected object separately               | Assign one class ID to every pixel                                                |
 | Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
 | Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
 | Shape                | `(N, H, W)`                                           | `(H, W)`                                                                          |
 | Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
 | Dtype                | `torch.uint8`                                         | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
-| Object separation    | Separates each detected object instance               | Groups all pixels of the same class together                                      |
+| Same-class objects   | Kept as separate instances                            | Merged into the same class region                                                 |
 | Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
 | Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
+| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                 |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -116,7 +116,7 @@ Use a trained YOLO26n-sem model to run predictions on images.
 
         # Access the results
         for result in results:
-            semantic_mask = result.semantic_mask.data  # class map, shape (H, W), dtype uint8 for most datasets
+            semantic_mask = result.semantic_mask.data  # class map, shape (H,W), dtype uint8 for most datasets
         ```
 
     === "CLI"
@@ -134,30 +134,30 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute                   | Type           | Shape / Format     | Dtype                                          | Description                                                                    |
-| --------------------------- | -------------- | ------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| `result.semantic_mask`      | `SemanticMask` | One mask per image | Container                                      | Semantic mask container for dense per-pixel class predictions.                 |
-| `result.semantic_mask.data` | `torch.Tensor` | `(H, W)`           | `torch.uint8`, `torch.int16`, or `torch.int32` | Class map where each pixel value is a predicted class ID.                      |
-| `result.masks`              | `None`         | Not applicable     | Not applicable                                 | Semantic segmentation does not return instance mask stacks.                    |
-| `result.boxes`              | `None`         | Not applicable     | Not applicable                                 | Semantic segmentation does not return per-instance boxes or confidence scores. |
-| `result.masks.xy`           | Not available  | Not applicable     | Not applicable                                 | Polygon coordinates are not returned by default for semantic results.          |
+| Attribute                   | Type           | Shape     | Dtype                                      | Description                                                                    |
+| --------------------------- | -------------- | ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------ |
+| `result.semantic_mask`      | `SemanticMask` | `(H,W)` | - | Dense class-map container.                 |
+| `result.semantic_mask.data` | `Tensor` | `(H,W)`           | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs.                  |
+| `result.masks`              | `None`         | - | -                             | No instance masks.                    |
+| `result.boxes`              | `None`         | - | -                             | No instance boxes/confidences. |
+| `result.masks.xy`           | -  | - | -                             | No default polygons.          |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
 ### Instance vs Semantic Segmentation
 
-| Aspect               | Instance Segmentation (`task="segment"`)               | Semantic Segmentation (`task="semantic"`)                        |
-| -------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
-| Prediction goal      | Segment each detected object separately                | Assign one class ID to every pixel                               |
-| Output field         | `result.masks`                                         | `result.semantic_mask`                                           |
-| Main data            | `result.masks.data`                                    | `result.semantic_mask.data`                                      |
-| Shape                | `(N, H, W)`                                            | `(H, W)`                                                         |
-| Pixel values         | Binary mask values: `0` or `1`                         | Class IDs: `0`, `1`, `2`, ...                                    |
-| Dtype                | `torch.uint8`                                          | `torch.uint8`, `torch.int16`, or `torch.int32`                   |
-| Same-class objects   | Kept as separate instances                             | Merged into the same class region                                |
-| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn`  | No polygon output by default                                     |
-| Boxes and confidence | Yes, through `result.boxes`                            | No per-instance boxes or confidence scores                       |
-| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions |
+| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
+| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Prediction goal      | Segment each detected object separately               | Assign one class ID to every pixel                                                |
+| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
+| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
+| Shape                | `(N,H,W)`                                           | `(H,W)`                                                                          |
+| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
+| Dtype                | `torch.uint8`                                         | `torch.uint8`<br>`torch.int16`<br>`torch.int32`                                    |
+| Same-class objects   | Kept as separate instances                            | Merged into the same class region                                                 |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
+| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
+| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                 |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -134,26 +134,26 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute | Type | Shape / Format | Description |
-|---|---|---|---|
-| `result.semantic_mask` | `SemanticMask` | One mask per image | Semantic mask container for dense per-pixel class predictions. |
-| `result.semantic_mask.data` | `torch.Tensor` | `(H, W)` | Class map where each pixel value is a predicted class ID. |
-| Class map dtype | `torch.dtype` | `uint8`, `int16`, or `int32` | Uses `torch.uint8` for up to 256 classes, then larger integer dtypes as needed. |
-| `result.masks` | `None` | Not applicable | Semantic segmentation does not return instance mask stacks. |
-| `result.masks.xy` | Not available | Not applicable | Polygon coordinates are not returned by default for semantic results. |
+| Attribute                   | Type           | Shape / Format               | Description                                                                     |
+| --------------------------- | -------------- | ---------------------------- | ------------------------------------------------------------------------------- |
+| `result.semantic_mask`      | `SemanticMask` | One mask per image           | Semantic mask container for dense per-pixel class predictions.                  |
+| `result.semantic_mask.data` | `torch.Tensor` | `(H, W)`                     | Class map where each pixel value is a predicted class ID.                       |
+| Class map dtype             | `torch.dtype`  | `uint8`, `int16`, or `int32` | Uses `torch.uint8` for up to 256 classes, then larger integer dtypes as needed. |
+| `result.masks`              | `None`         | Not applicable               | Semantic segmentation does not return instance mask stacks.                     |
+| `result.masks.xy`           | Not available  | Not applicable               | Polygon coordinates are not returned by default for semantic results.           |
 
 ### Instance vs Semantic Segmentation
 
-| Aspect | Instance Segmentation (`task="segment"`) | Semantic Segmentation (`task="semantic"`) |
-|---|---|---|
-| Output field | `result.masks` | `result.semantic_mask` |
-| Main data | `result.masks.data` | `result.semantic_mask.data` |
-| Shape | `(N, H, W)` | `(H, W)` |
-| Pixel values | Binary mask values: `0` or `1` | Class IDs: `0`, `1`, `2`, ... |
-| Dtype | `torch.uint8` | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
-| Object separation | Separates each detected object instance | Groups all pixels of the same class together |
-| Polygons | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default |
-| Boxes and confidence | Yes, through `result.boxes` | No per-instance boxes or confidence scores |
+| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
+| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
+| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
+| Shape                | `(N, H, W)`                                           | `(H, W)`                                                                          |
+| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
+| Dtype                | `torch.uint8`                                         | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
+| Object separation    | Separates each detected object instance               | Groups all pixels of the same class together                                      |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
+| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -147,18 +147,18 @@ For task-specific `Results` fields across every task, see the [Predict Results b
 
 ### Instance vs Semantic Segmentation
 
-| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
-| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Prediction goal      | Segment each detected object separately               | Assign one class ID to every pixel                                                |
-| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
-| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
-| Shape                | `(N, H, W)`                                           | `(H, W)`                                                                          |
-| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
-| Dtype                | `torch.uint8`                                         | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
-| Same-class objects   | Kept as separate instances                            | Merged into the same class region                                                 |
-| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
-| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
-| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                 |
+| Aspect               | Instance Segmentation (`task="segment"`)               | Semantic Segmentation (`task="semantic"`)                                         |
+| -------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| Prediction goal      | Segment each detected object separately                | Assign one class ID to every pixel                                                |
+| Output field         | `result.masks`                                         | `result.semantic_mask`                                                            |
+| Main data            | `result.masks.data`                                    | `result.semantic_mask.data`                                                       |
+| Shape                | `(N, H, W)`                                            | `(H, W)`                                                                          |
+| Pixel values         | Binary mask values: `0` or `1`                         | Class IDs: `0`, `1`, `2`, ...                                                     |
+| Dtype                | `torch.uint8`                                          | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
+| Same-class objects   | Kept as separate instances                             | Merged into the same class region                                                 |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn`  | No polygon output by default                                                      |
+| Boxes and confidence | Yes, through `result.boxes`                            | No per-instance boxes or confidence scores                                        |
+| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                  |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -134,30 +134,30 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute                   | Type           | Shape / Format     | Dtype                                      | Description                                                                    |
-| --------------------------- | -------------- | ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------ |
-| `result.semantic_mask`      | `SemanticMask` | One mask per image | Container                                  | Semantic mask container for dense per-pixel class predictions.                 |
-| `result.semantic_mask.data` | `torch.Tensor` | `(H, W)`           | `torch.uint8`, `torch.int16`, or `torch.int32` | Class map where each pixel value is a predicted class ID.                  |
-| `result.masks`              | `None`         | Not applicable     | Not applicable                             | Semantic segmentation does not return instance mask stacks.                    |
-| `result.boxes`              | `None`         | Not applicable     | Not applicable                             | Semantic segmentation does not return per-instance boxes or confidence scores. |
-| `result.masks.xy`           | Not available  | Not applicable     | Not applicable                             | Polygon coordinates are not returned by default for semantic results.          |
+| Attribute                   | Type           | Shape / Format     | Dtype                                          | Description                                                                    |
+| --------------------------- | -------------- | ------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| `result.semantic_mask`      | `SemanticMask` | One mask per image | Container                                      | Semantic mask container for dense per-pixel class predictions.                 |
+| `result.semantic_mask.data` | `torch.Tensor` | `(H, W)`           | `torch.uint8`, `torch.int16`, or `torch.int32` | Class map where each pixel value is a predicted class ID.                      |
+| `result.masks`              | `None`         | Not applicable     | Not applicable                                 | Semantic segmentation does not return instance mask stacks.                    |
+| `result.boxes`              | `None`         | Not applicable     | Not applicable                                 | Semantic segmentation does not return per-instance boxes or confidence scores. |
+| `result.masks.xy`           | Not available  | Not applicable     | Not applicable                                 | Polygon coordinates are not returned by default for semantic results.          |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
 ### Instance vs Semantic Segmentation
 
-| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
-| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Prediction goal      | Segment each detected object separately               | Assign one class ID to every pixel                                                |
-| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
-| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
-| Shape                | `(N, H, W)`                                           | `(H, W)`                                                                          |
-| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
-| Dtype                | `torch.uint8`                                         | `torch.uint8`, `torch.int16`, or `torch.int32`                                    |
-| Same-class objects   | Kept as separate instances                            | Merged into the same class region                                                 |
-| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
-| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
-| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                 |
+| Aspect               | Instance Segmentation (`task="segment"`)               | Semantic Segmentation (`task="semantic"`)                        |
+| -------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
+| Prediction goal      | Segment each detected object separately                | Assign one class ID to every pixel                               |
+| Output field         | `result.masks`                                         | `result.semantic_mask`                                           |
+| Main data            | `result.masks.data`                                    | `result.semantic_mask.data`                                      |
+| Shape                | `(N, H, W)`                                            | `(H, W)`                                                         |
+| Pixel values         | Binary mask values: `0` or `1`                         | Class IDs: `0`, `1`, `2`, ...                                    |
+| Dtype                | `torch.uint8`                                          | `torch.uint8`, `torch.int16`, or `torch.int32`                   |
+| Same-class objects   | Kept as separate instances                             | Merged into the same class region                                |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn`  | No polygon output by default                                     |
+| Boxes and confidence | Yes, through `result.boxes`                            | No per-instance boxes or confidence scores                       |
+| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -116,7 +116,7 @@ Use a trained YOLO26n-sem model to run predictions on images.
 
         # Access the results
         for result in results:
-            semantic_mask = result.semantic_mask.data  # height x width class map (torch.Tensor)
+            semantic_mask = result.semantic_mask.data  # class map, shape (H, W), dtype uint8 for most datasets
         ```
 
     === "CLI"
@@ -127,6 +127,33 @@ Use a trained YOLO26n-sem model to run predictions on images.
         ```
 
 See full `predict` mode details in the [Predict](../modes/predict.md) page.
+
+### Results Output
+
+YOLO semantic segmentation returns one `Results` object per image. Each result stores one dense class map for the full
+image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
+belong to separate objects.
+
+| Attribute | Type | Shape / Format | Description |
+|---|---|---|---|
+| `result.semantic_mask` | `SemanticMask` | One mask per image | Semantic mask container for dense per-pixel class predictions. |
+| `result.semantic_mask.data` | `torch.Tensor` | `(H, W)` | Class map where each pixel value is a predicted class ID. |
+| Class map dtype | `torch.dtype` | `uint8`, `int16`, or `int32` | Uses `torch.uint8` for up to 256 classes, then larger integer dtypes as needed. |
+| `result.masks` | `None` | Not applicable | Semantic segmentation does not return instance mask stacks. |
+| `result.masks.xy` | Not available | Not applicable | Polygon coordinates are not returned by default for semantic results. |
+
+### Instance vs Semantic Segmentation
+
+| Aspect | Instance Segmentation (`task="segment"`) | Semantic Segmentation (`task="semantic"`) |
+|---|---|---|
+| Output field | `result.masks` | `result.semantic_mask` |
+| Main data | `result.masks.data` | `result.semantic_mask.data` |
+| Shape | `(N, H, W)` | `(H, W)` |
+| Pixel values | Binary mask values: `0` or `1` | Class IDs: `0`, `1`, `2`, ... |
+| Dtype | `torch.uint8` | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
+| Object separation | Separates each detected object instance | Groups all pixels of the same class together |
+| Polygons | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default |
+| Boxes and confidence | Yes, through `result.boxes` | No per-instance boxes or confidence scores |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -134,31 +134,30 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute                   | Type           | Shape / Format               | Description                                                                     |
-| --------------------------- | -------------- | ---------------------------- | ------------------------------------------------------------------------------- |
-| `result.semantic_mask`      | `SemanticMask` | One mask per image           | Semantic mask container for dense per-pixel class predictions.                  |
-| `result.semantic_mask.data` | `torch.Tensor` | `(H, W)`                     | Class map where each pixel value is a predicted class ID.                       |
-| Class map dtype             | `torch.dtype`  | `uint8`, `int16`, or `int32` | Uses `torch.uint8` for up to 256 classes, then larger integer dtypes as needed. |
-| `result.masks`              | `None`         | Not applicable               | Semantic segmentation does not return instance mask stacks.                     |
-| `result.boxes`              | `None`         | Not applicable               | Semantic segmentation does not return per-instance boxes or confidence scores.  |
-| `result.masks.xy`           | Not available  | Not applicable               | Polygon coordinates are not returned by default for semantic results.           |
+| Attribute                   | Type           | Shape / Format     | Dtype                                      | Description                                                                    |
+| --------------------------- | -------------- | ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------ |
+| `result.semantic_mask`      | `SemanticMask` | One mask per image | Container                                  | Semantic mask container for dense per-pixel class predictions.                 |
+| `result.semantic_mask.data` | `torch.Tensor` | `(H, W)`           | `torch.uint8`, `torch.int16`, or `torch.int32` | Class map where each pixel value is a predicted class ID.                  |
+| `result.masks`              | `None`         | Not applicable     | Not applicable                             | Semantic segmentation does not return instance mask stacks.                    |
+| `result.boxes`              | `None`         | Not applicable     | Not applicable                             | Semantic segmentation does not return per-instance boxes or confidence scores. |
+| `result.masks.xy`           | Not available  | Not applicable     | Not applicable                             | Polygon coordinates are not returned by default for semantic results.          |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
 ### Instance vs Semantic Segmentation
 
-| Aspect               | Instance Segmentation (`task="segment"`)               | Semantic Segmentation (`task="semantic"`)                                         |
-| -------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| Prediction goal      | Segment each detected object separately                | Assign one class ID to every pixel                                                |
-| Output field         | `result.masks`                                         | `result.semantic_mask`                                                            |
-| Main data            | `result.masks.data`                                    | `result.semantic_mask.data`                                                       |
-| Shape                | `(N, H, W)`                                            | `(H, W)`                                                                          |
-| Pixel values         | Binary mask values: `0` or `1`                         | Class IDs: `0`, `1`, `2`, ...                                                     |
-| Dtype                | `torch.uint8`                                          | Usually `torch.uint8`; larger class counts may use `torch.int16` or `torch.int32` |
-| Same-class objects   | Kept as separate instances                             | Merged into the same class region                                                 |
-| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn`  | No polygon output by default                                                      |
-| Boxes and confidence | Yes, through `result.boxes`                            | No per-instance boxes or confidence scores                                        |
-| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                  |
+| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
+| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Prediction goal      | Segment each detected object separately               | Assign one class ID to every pixel                                                |
+| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
+| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
+| Shape                | `(N, H, W)`                                           | `(H, W)`                                                                          |
+| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
+| Dtype                | `torch.uint8`                                         | `torch.uint8`, `torch.int16`, or `torch.int32`                                    |
+| Same-class objects   | Kept as separate instances                            | Merged into the same class region                                                 |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
+| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
+| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                 |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -134,30 +134,30 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute                   | Type           | Shape   | Dtype                                           | Description                    |
-| --------------------------- | -------------- | ------- | ----------------------------------------------- | ------------------------------ |
-| `result.semantic_mask`      | `SemanticMask` | `(H,W)` | -                                               | Dense class-map container.     |
-| `result.semantic_mask.data` | `Tensor`       | `(H,W)` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs.           |
-| `result.masks`              | `None`         | -       | -                                               | No instance masks.             |
-| `result.boxes`              | `None`         | -       | -                                               | No instance boxes/confidences. |
-| `result.masks.xy`           | -              | -       | -                                               | No default polygons.           |
+| Attribute                   | Type           | Shape     | Dtype                                      | Description                                                                    |
+| --------------------------- | -------------- | ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------ |
+| `result.semantic_mask`      | `SemanticMask` | `(H,W)` | - | Dense class map.                 |
+| `result.semantic_mask.data` | `Tensor` | `(H,W)`           | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs.                  |
+| `result.masks`              | `None`         | - | -                             | No instance masks.                    |
+| `result.boxes`              | `None`         | - | -                             | No instance boxes/confidences. |
+| `result.masks.xy`           | -  | - | -                             | No default polygons.          |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
 ### Instance vs Semantic Segmentation
 
-| Aspect               | Instance Segmentation (`task="segment"`)               | Semantic Segmentation (`task="semantic"`)                        |
-| -------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
-| Prediction goal      | Segment each detected object separately                | Assign one class ID to every pixel                               |
-| Output field         | `result.masks`                                         | `result.semantic_mask`                                           |
-| Main data            | `result.masks.data`                                    | `result.semantic_mask.data`                                      |
-| Shape                | `(N,H,W)`                                              | `(H,W)`                                                          |
-| Pixel values         | Binary mask values: `0` or `1`                         | Class IDs: `0`, `1`, `2`, ...                                    |
-| Dtype                | `torch.uint8`                                          | `torch.uint8`<br>`torch.int16`<br>`torch.int32`                  |
-| Same-class objects   | Kept as separate instances                             | Merged into the same class region                                |
-| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn`  | No polygon output by default                                     |
-| Boxes and confidence | Yes, through `result.boxes`                            | No per-instance boxes or confidence scores                       |
-| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions |
+| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
+| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Prediction goal      | Segment each detected object separately               | Assign one class ID to every pixel                                                |
+| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
+| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
+| Shape                | `(N,H,W)`                                           | `(H,W)`                                                                          |
+| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
+| Dtype                | `torch.uint8`                                         | `torch.uint8`<br>`torch.int16`<br>`torch.int32`                                    |
+| Same-class objects   | Kept as separate instances                            | Merged into the same class region                                                 |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
+| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
+| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                 |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -116,7 +116,7 @@ Use a trained YOLO26n-sem model to run predictions on images.
 
         # Access the results
         for result in results:
-            semantic_mask = result.semantic_mask.data  # class map, shape (H,W), dtype uint8 for most datasets
+            semantic_mask = result.semantic_mask.data  # class map, shape (H,W), integer dtype selected by class count
         ```
 
     === "CLI"
@@ -134,13 +134,13 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute                   | Type                                            | Shape   | Description                    |
-| --------------------------- | ----------------------------------------------- | ------- | ------------------------------ |
-| `result.semantic_mask`      | `SemanticMask`                                  | `(H,W)` | Dense class map.               |
-| `result.semantic_mask.data` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | `(H,W)` | Per-pixel class IDs.           |
-| `result.masks`              | -                                               | -       | No instance masks.             |
-| `result.boxes`              | -                                               | -       | No instance boxes/confidences. |
-| `result.masks.xy`           | -                                               | -       | No default polygons.           |
+| Attribute                   | Type                                            | Shape   | Description                               |
+| --------------------------- | ----------------------------------------------- | ------- | ----------------------------------------- |
+| `result.semantic_mask`      | `SemanticMask`                                  | `(H,W)` | Dense class map.                          |
+| `result.semantic_mask.data` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | `(H,W)` | Class IDs; dtype selected by class count. |
+| `result.masks`              | -                                               | -       | No instance masks.                        |
+| `result.boxes`              | -                                               | -       | No instance boxes/confidences.            |
+| `result.masks.xy`           | -                                               | -       | No default polygons.                      |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -134,30 +134,30 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute                   | Type           | Shape     | Dtype                                      | Description                                                                    |
-| --------------------------- | -------------- | ------------------ | ------------------------------------------ | ------------------------------------------------------------------------------ |
-| `result.semantic_mask`      | `SemanticMask` | `(H,W)` | - | Dense class-map container.                 |
-| `result.semantic_mask.data` | `Tensor` | `(H,W)`           | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs.                  |
-| `result.masks`              | `None`         | - | -                             | No instance masks.                    |
-| `result.boxes`              | `None`         | - | -                             | No instance boxes/confidences. |
-| `result.masks.xy`           | -  | - | -                             | No default polygons.          |
+| Attribute                   | Type           | Shape   | Dtype                                           | Description                    |
+| --------------------------- | -------------- | ------- | ----------------------------------------------- | ------------------------------ |
+| `result.semantic_mask`      | `SemanticMask` | `(H,W)` | -                                               | Dense class-map container.     |
+| `result.semantic_mask.data` | `Tensor`       | `(H,W)` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | Per-pixel class IDs.           |
+| `result.masks`              | `None`         | -       | -                                               | No instance masks.             |
+| `result.boxes`              | `None`         | -       | -                                               | No instance boxes/confidences. |
+| `result.masks.xy`           | -              | -       | -                                               | No default polygons.           |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
 ### Instance vs Semantic Segmentation
 
-| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
-| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Prediction goal      | Segment each detected object separately               | Assign one class ID to every pixel                                                |
-| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
-| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
-| Shape                | `(N,H,W)`                                           | `(H,W)`                                                                          |
-| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
-| Dtype                | `torch.uint8`                                         | `torch.uint8`<br>`torch.int16`<br>`torch.int32`                                    |
-| Same-class objects   | Kept as separate instances                            | Merged into the same class region                                                 |
-| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
-| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
-| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                 |
+| Aspect               | Instance Segmentation (`task="segment"`)               | Semantic Segmentation (`task="semantic"`)                        |
+| -------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
+| Prediction goal      | Segment each detected object separately                | Assign one class ID to every pixel                               |
+| Output field         | `result.masks`                                         | `result.semantic_mask`                                           |
+| Main data            | `result.masks.data`                                    | `result.semantic_mask.data`                                      |
+| Shape                | `(N,H,W)`                                              | `(H,W)`                                                          |
+| Pixel values         | Binary mask values: `0` or `1`                         | Class IDs: `0`, `1`, `2`, ...                                    |
+| Dtype                | `torch.uint8`                                          | `torch.uint8`<br>`torch.int16`<br>`torch.int32`                  |
+| Same-class objects   | Kept as separate instances                             | Merged into the same class region                                |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn`  | No polygon output by default                                     |
+| Boxes and confidence | Yes, through `result.boxes`                            | No per-instance boxes or confidence scores                       |
+| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions |
 
 ## Export
 

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -134,30 +134,30 @@ YOLO semantic segmentation returns one `Results` object per image. Each result s
 image instead of a list of object masks. Pixels with the same predicted class share the same class ID, even when they
 belong to separate objects.
 
-| Attribute                   | Type                                             | Shape   | Description                    |
-| --------------------------- | ------------------------------------------------ | ------- | ------------------------------ |
-| `result.semantic_mask`      | `SemanticMask`                                   | `(H,W)` | Dense class map.               |
+| Attribute                   | Type                                            | Shape   | Description                    |
+| --------------------------- | ----------------------------------------------- | ------- | ------------------------------ |
+| `result.semantic_mask`      | `SemanticMask`                                  | `(H,W)` | Dense class map.               |
 | `result.semantic_mask.data` | `torch.uint8`<br>`torch.int16`<br>`torch.int32` | `(H,W)` | Per-pixel class IDs.           |
-| `result.masks`              | -                                                | -       | No instance masks.             |
-| `result.boxes`              | -                                                | -       | No instance boxes/confidences. |
-| `result.masks.xy`           | -                                                | -       | No default polygons.           |
+| `result.masks`              | -                                               | -       | No instance masks.             |
+| `result.boxes`              | -                                               | -       | No instance boxes/confidences. |
+| `result.masks.xy`           | -                                               | -       | No default polygons.           |
 
 For task-specific `Results` fields across every task, see the [Predict Results by Task](../modes/predict.md#results-by-task) section.
 
 ### Instance vs Semantic Segmentation
 
-| Aspect               | Instance Segmentation (`task="segment"`)              | Semantic Segmentation (`task="semantic"`)                                         |
-| -------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Prediction goal      | Segment each detected object separately               | Assign one class ID to every pixel                                                |
-| Output field         | `result.masks`                                        | `result.semantic_mask`                                                            |
-| Main data            | `result.masks.data`                                   | `result.semantic_mask.data`                                                       |
-| Shape                | `(N,H,W)`                                           | `(H,W)`                                                                          |
-| Pixel values         | Binary mask values: `0` or `1`                        | Class IDs: `0`, `1`, `2`, ...                                                     |
-| Dtype                | `torch.uint8`                                         | `torch.uint8`<br>`torch.int16`<br>`torch.int32`                                    |
-| Same-class objects   | Kept as separate instances                            | Merged into the same class region                                                 |
-| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn` | No polygon output by default                                                      |
-| Boxes and confidence | Yes, through `result.boxes`                           | No per-instance boxes or confidence scores                                        |
-| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions                 |
+| Aspect               | Instance Segmentation (`task="segment"`)               | Semantic Segmentation (`task="semantic"`)                        |
+| -------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
+| Prediction goal      | Segment each detected object separately                | Assign one class ID to every pixel                               |
+| Output field         | `result.masks`                                         | `result.semantic_mask`                                           |
+| Main data            | `result.masks.data`                                    | `result.semantic_mask.data`                                      |
+| Shape                | `(N,H,W)`                                              | `(H,W)`                                                          |
+| Pixel values         | Binary mask values: `0` or `1`                         | Class IDs: `0`, `1`, `2`, ...                                    |
+| Dtype                | `torch.uint8`                                          | `torch.uint8`<br>`torch.int16`<br>`torch.int32`                  |
+| Same-class objects   | Kept as separate instances                             | Merged into the same class region                                |
+| Polygons             | Yes, through `result.masks.xy` and `result.masks.xyn`  | No polygon output by default                                     |
+| Boxes and confidence | Yes, through `result.boxes`                            | No per-instance boxes or confidence scores                       |
+| Typical use          | Counting, tracking, cropping, object-level measurement | Dense scene labeling, drivable area, land cover, medical regions |
 
 ## Export
 


### PR DESCRIPTION
## Summary
- document instance segmentation `Results` output fields, mask shape, dtype, polygons, and boxes
- document semantic segmentation `semantic_mask` output shape, class-map dtype, and lack of instance polygons
- add instance-vs-semantic comparison tables to both task pages

## Validation
- `git diff --check -- docs/en/tasks/segment.md docs/en/tasks/semantic.md`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR significantly improves Ultralytics docs by clearly explaining `Results` outputs across all prediction tasks, with especially strong new coverage for semantic segmentation and `SemanticMask`.

### 📊 Key Changes
- Added `semantic_mask` to the main `Results` attribute table in the [Predict docs](../modes/predict.md), documenting it as the semantic segmentation output. 🧠
- Introduced a new **“Results by Task”** section in the Predict guide, breaking down output fields, shapes, and data types for:
  - Detect
  - Segment
  - Semantic
  - Classify
  - Pose
  - OBB 📦
- Expanded `Results` method docs so `update()` now explicitly mentions semantic masks too. ✨
- Improved `Masks` documentation by clarifying:
  - `data` is a binary `torch.uint8` tensor
  - `xy` and `xyn` return polygon lists, not raw tensors 🎭
- Added a brand-new **`SemanticMask`** documentation section with:
  - description of its purpose
  - supported properties and methods
  - a simple YOLO26 semantic inference example 🖼️
- Added **“Results Output”** sections to multiple task pages so users can quickly see what each task returns:
  - classification
  - detection
  - segmentation
  - pose
  - OBB
  - semantic 📄
- Clarified the difference between **instance segmentation** and **semantic segmentation** in both segment and semantic task docs, including side-by-side comparison tables. 🔍
- Improved code comments and examples to better explain how to access top classification predictions and segmentation outputs. ✅

### 🎯 Purpose & Impact
- Makes prediction outputs much easier to understand for both beginners and experienced users. 🙌
- Reduces confusion around which `Results` fields are available for each task, especially for semantic segmentation vs instance segmentation. 🎯
- Helps developers use YOLO26 outputs correctly by documenting expected shapes, dtypes, and helper properties more explicitly. 🛠️
- Improves discoverability of task-specific outputs without forcing users to dig through API reference pages. 🚀
- Likely lowers support burden and user mistakes when parsing model outputs in custom apps and pipelines. 📉