### PR TITLE
Fix stale line anchor for `track_high_thresh` in track docs

### DIFF
--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -152,7 +152,7 @@ The following table provides a description of each parameter:
 
 !!! warning "Tracker Threshold Information"
 
-    If a detection's confidence score falls below [`track_high_thresh`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/trackers/bytetrack.yaml#L5), the tracker will not update that object, resulting in no active tracks.
+    If a detection's confidence score falls below [`track_high_thresh`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/trackers/bytetrack.yaml#L7), the tracker will not update that object, resulting in no active tracks.
 
 | **Parameter**       | **Valid Values or Ranges**                    | **Description**                                                                                                                                        |
 | ------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
## summary

the `track_high_thresh` deep-link in `docs/en/modes/track.md` pointed at `bytetrack.yaml#L5`, which is now a blank line. `track_high_thresh` is on line 7 of the current `bytetrack.yaml`, so the anchor is updated to `#L7`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes a small documentation fix in the tracking guide by correcting the `track_high_thresh` source link to the right line in the ByteTrack config file.

### 📊 Key Changes
- Updated the link in `docs/en/modes/track.md` for `track_high_thresh`
- Changed the referenced line in `bytetrack.yaml` from line 5 to line 7
- No code, model, or tracking behavior was changed — this is a docs-only update

### 🎯 Purpose & Impact
- Improves documentation accuracy ✅
- Helps users find the correct tracker setting definition more easily 🔎
- Reduces confusion when reviewing or tuning ByteTrack parameters for object tracking 🎯
- Has no impact on runtime performance, training, or inference behavior ⚙️