### PR TITLE
`ultralytics 8.4.53` Retry CUDA backend memory errors during training

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.52"
+__version__ = "8.4.53"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -457,14 +457,17 @@ class BaseTrainer:
 
                     # Backward
                     self.scaler.scale(self.loss).backward()
-                except torch.cuda.OutOfMemoryError:
+                except RuntimeError as e:
+                    is_oom = isinstance(e, torch.cuda.OutOfMemoryError)
+                    if not is_oom and not any(s in str(e) for s in ("CUDNN_STATUS_INTERNAL_ERROR", "unable to find an engine")):
+                        raise
                     if epoch > self.start_epoch or self._oom_retries >= 3 or RANK != -1:
                         raise  # only auto-reduce during first epoch on single GPU, max 3 retries
                     self._oom_retries += 1
                     old_batch = self.batch_size
                     self.args.batch = self.batch_size = max(self.batch_size // 2, 1)
                     LOGGER.warning(
-                        f"CUDA out of memory with batch={old_batch}. "
+                        f"{'CUDA out of memory' if is_oom else 'CUDA backend memory error'} with batch={old_batch}. "
                         f"Reducing to batch={self.batch_size} and retrying ({self._oom_retries}/3)."
                     )
                     batch = loss = preds = None

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -459,7 +459,9 @@ class BaseTrainer:
                     self.scaler.scale(self.loss).backward()
                 except RuntimeError as e:
                     is_oom = isinstance(e, torch.cuda.OutOfMemoryError)
-                    if not is_oom and not any(s in str(e) for s in ("CUDNN_STATUS_INTERNAL_ERROR", "unable to find an engine")):
+                    if not is_oom and not any(
+                        s in str(e) for s in ("CUDNN_STATUS_INTERNAL_ERROR", "unable to find an engine")
+                    ):
                         raise
                     if epoch > self.start_epoch or self._oom_retries >= 3 or RANK != -1:
                         raise  # only auto-reduce during first epoch on single GPU, max 3 retries


### PR DESCRIPTION
## Summary
- extend the existing first-epoch single-GPU batch reduction path to handle CUDA backend memory allocation failures
- keep the same retry limits and DDP exclusions as the existing OOM retry behavior

## Context
logs.txt showed large-batch GPU runs first reducing batch after CUDA OOM, then failing during backward with CUDA backend allocation errors instead of continuing the same batch reduction path:
- RuntimeError: CUDNN_STATUS_INTERNAL_ERROR
- RuntimeError: GET was unable to find an engine to execute this computation

## Validation
- python -m py_compile ultralytics/engine/trainer.py
- ruff check ultralytics/engine/trainer.py
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves training stability by expanding automatic batch-size recovery to handle more GPU memory-related runtime errors, alongside a small version bump to `8.4.53` 🚀

### 📊 Key Changes
- Updated the Ultralytics package version from `8.4.52` to `8.4.53` 📦
- Enhanced training error handling in `ultralytics/engine/trainer.py` to catch a broader set of GPU backend failures during backward pass ⚙️
- Added logic to recognize not only `torch.cuda.OutOfMemoryError`, but also related runtime errors such as:
  - `CUDNN_STATUS_INTERNAL_ERROR`
  - `"unable to find an engine"` 🧠
- Kept the existing automatic recovery behavior: during early single-GPU training, the trainer can reduce the batch size and retry up to 3 times instead of failing immediately 🔁
- Improved warning messages so users can better tell whether the issue was a true CUDA out-of-memory error or a more general CUDA backend memory error 📝

### 🎯 Purpose & Impact
- Makes training more robust on GPUs that may fail with backend memory errors instead of a clean out-of-memory exception 💪
- Helps more training runs recover automatically without manual intervention, especially on limited-memory setups or unstable CUDA/cuDNN environments 🎛️
- Reduces frustrating early-run crashes by falling back to a smaller batch size when possible ✅
- Preserves safety by only applying auto-retry in limited cases: first epoch, single-GPU training, and up to 3 retries only 🔒
- For users, this means a smoother training experience and fewer unexpected failures when training YOLO models locally or on custom hardware 🎉