### PR TITLE
Use `mobileclip2_b` model for `VisualAISearch` solution

### DIFF
--- a/ultralytics/solutions/similarity_search.py
+++ b/ultralytics/solutions/similarity_search.py
@@ -66,7 +66,7 @@ class VisualAISearch:
             safe_download(url=f"{ASSETS_URL}/images.zip", unzip=True, retry=3)
             self.data_dir = Path("images")
 
-        model = kwargs.get("model", "mobileclip2_b.ts")
+        model = kwargs.get("model", "mobileclip2:b")
         self.model = build_text_model(model, device=self.device)
         model_str = model.replace(":", "_").replace("/", "_")
         self.faiss_index = f"faiss-{model_str}.index"

--- a/ultralytics/solutions/similarity_search.py
+++ b/ultralytics/solutions/similarity_search.py
@@ -68,7 +68,7 @@ class VisualAISearch:
             safe_download(url=f"{ASSETS_URL}/images.zip", unzip=True, retry=3)
             self.data_dir = Path("images")
 
-        self.model = build_text_model("clip:ViT-B/32", device=self.device)
+        self.model = build_text_model("mobileclip2_b.ts", device=self.device)
 
         self.index = None
         self.image_paths = []

--- a/ultralytics/solutions/similarity_search.py
+++ b/ultralytics/solutions/similarity_search.py
@@ -54,8 +54,6 @@ class VisualAISearch:
         check_requirements("faiss-cpu")
 
         self.faiss = __import__("faiss")
-        self.faiss_index = "faiss.index"
-        self.data_path_npy = "paths.npy"
         self.data_dir = Path(kwargs.get("data", "images"))
         self.device = select_device(kwargs.get("device", "cpu"))
 
@@ -68,7 +66,10 @@ class VisualAISearch:
             safe_download(url=f"{ASSETS_URL}/images.zip", unzip=True, retry=3)
             self.data_dir = Path("images")
 
-        self.model = build_text_model("mobileclip2_b.ts", device=self.device)
+        model = kwargs.get("model", "mobileclip2_b.ts")
+        self.model = build_text_model(model, device=self.device)
+        self.faiss_index = f"faiss-{Path(model).stem}.index"
+        self.data_path_npy = f"paths-{Path(model).stem}.npy"
 
         self.index = None
         self.image_paths = []

--- a/ultralytics/solutions/similarity_search.py
+++ b/ultralytics/solutions/similarity_search.py
@@ -68,8 +68,9 @@ class VisualAISearch:
 
         model = kwargs.get("model", "mobileclip2_b.ts")
         self.model = build_text_model(model, device=self.device)
-        self.faiss_index = f"faiss-{Path(model).stem}.index"
-        self.data_path_npy = f"paths-{Path(model).stem}.npy"
+        model_str = model.replace(":", "_").replace("/", "_")
+        self.faiss_index = f"faiss-{model_str}.index"
+        self.data_path_npy = f"paths-{model_str}.npy"
 
         self.index = None
         self.image_paths = []


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR makes the similarity search solution more flexible by allowing different text-image embedding models and saving each model’s search index files separately.

### 📊 Key Changes
- Added support for selecting the similarity search model through `kwargs.get("model", "mobileclip2:b")`.
- Changed the default embedding model from `clip:ViT-B/32` to `mobileclip2:b`.
- Updated FAISS index and image path cache filenames to include the model name, for example:
  - `faiss-mobileclip2_b.index`
  - `paths-mobileclip2_b.npy`
- Removed hardcoded shared filenames like `faiss.index` and `paths.npy`.

### 🎯 Purpose & Impact
- 🚀 **More flexibility:** Users can now choose different embedding models for similarity search without editing the source code.
- 🧠 **Better defaults:** Switching to `mobileclip2:b` suggests a newer or preferred default model for this feature.
- 🗂️ **Safer caching:** Model-specific index and path files prevent different models from overwriting each other’s saved search data.
- 🔁 **Easier experimentation:** Developers can test multiple models side by side with less risk of file conflicts or confusing results.
- 👥 **Better user experience:** This makes the similarity search workflow cleaner and more reliable for both casual users and advanced developers.