### PR TITLE
Match aux_loss dtype to ce_loss in SemanticSegmentationLoss

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1378,8 +1378,8 @@ class SemanticSegmentationLoss(nn.Module):
         if aux_logits is not None:
             if aux_logits.shape[2:] != masks.shape[1:]:
                 aux_logits = F.interpolate(aux_logits, size=masks.shape[1:], mode="bilinear", align_corners=False)
-            aux_loss = (self._ce_loss(aux_logits, masks)) * 0.4
-            total = total + aux_loss
+            aux_loss = self._ce_loss(aux_logits, masks) * 0.4
+            total += aux_loss
 
         loss_items = torch.stack([ce_loss, dice_loss, aux_loss]).detach()
         return total * preds.shape[0], loss_items

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1373,8 +1373,8 @@ class SemanticSegmentationLoss(nn.Module):
         dice_loss = self._dice_loss(preds, masks)
         total = ce_loss + dice_loss
 
-        # Auxiliary cross-entropy loss.
-        aux_loss = torch.tensor(0.0, device=preds.device)
+        # Auxiliary cross-entropy loss. Match ce_loss dtype so torch.stack below succeeds under AMP.
+        aux_loss = torch.tensor(0.0, device=preds.device, dtype=ce_loss.dtype)
         if aux_logits is not None:
             if aux_logits.shape[2:] != masks.shape[1:]:
                 aux_logits = F.interpolate(aux_logits, size=masks.shape[1:], mode="bilinear", align_corners=False)


### PR DESCRIPTION
## Summary

`SemanticSegmentationLoss.forward` builds the auxiliary-loss placeholder with `torch.tensor(0.0, device=preds.device)`, which always allocates a float32 scalar. When the surrounding losses are produced under a different dtype path (e.g. AMP), the three components fed into `torch.stack([ce_loss, dice_loss, aux_loss])` no longer share a dtype. Today PyTorch silently promotes, but this is fragile — any future tightening of stack's dtype rules, or a change in `_ce_loss`/`_dice_loss` casting, would surface here as a runtime error.

This PR pins the placeholder to `ce_loss.dtype` so `loss_items` has a single, predictable dtype.

## Change

```diff
- # Auxiliary cross-entropy loss.
- aux_loss = torch.tensor(0.0, device=preds.device)
+ # Auxiliary cross-entropy loss. Match ce_loss dtype so torch.stack below succeeds under AMP.
+ aux_loss = torch.tensor(0.0, device=preds.device, dtype=ce_loss.dtype)
```

Only [`ultralytics/utils/loss.py`](ultralytics/utils/loss.py) is touched.

## Test plan

- [x] Local sanity script exercising both `aux_logits is None` and the `(main, aux)` tuple branch — `loss_items` returned as a single-dtype tensor in both cases.
- [ ] Existing semantic CI (`tests/test_engine.py::test_task[semantic-...]`) continues to pass.

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a mixed-precision edge case in `SemanticSegmentationLoss` by aligning `aux_loss` dtype with `ce_loss` so loss aggregation works reliably under AMP. ⚙️

### 📊 Key Changes
- Updates the auxiliary loss initialization in `ultralytics/utils/loss.py` to use `dtype=ce_loss.dtype`.
- Adds an inline comment clarifying that this prevents `torch.stack` failures during AMP execution.
- Leaves the existing auxiliary loss computation logic unchanged when `aux_logits` is present.

### 🎯 Purpose & Impact
- Prevents dtype mismatches between loss tensors in semantic segmentation training. ✅
- Improves stability for AMP and mixed-precision workflows. 🚀
- Delivers a minimal, low-risk bug fix with no expected behavior change outside the affected edge case.