### PR TITLE
Fix: Squeeze single-channel 3D mask arrays from patched `cv2.imread`

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -823,6 +823,8 @@ class SemanticDataset(YOLODataset):
         mask = cv2.imread(mask_file, cv2.IMREAD_GRAYSCALE)
         if mask is None:
             raise FileNotFoundError(f"Semantic mask not found or unreadable: {mask_file}")
+        if mask.ndim == 3 and mask.shape[2] == 1:
+            mask = np.squeeze(mask)
         if int(self.data.get("nc", 0)) == 1:
             with Image.open(mask_file) as im:
                 if im.mode == "1":  # cv2 expands 1-bit PNGs to {0, 255}; map only true 1-bit foreground to 1.

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -824,7 +824,7 @@ class SemanticDataset(YOLODataset):
         if mask is None:
             raise FileNotFoundError(f"Semantic mask not found or unreadable: {mask_file}")
         if mask.ndim == 3 and mask.shape[2] == 1:
-            mask = np.squeeze(mask)
+            mask = np.squeeze(mask, axis=2)
         if int(self.data.get("nc", 0)) == 1:
             with Image.open(mask_file) as im:
                 if im.mode == "1":  # cv2 expands 1-bit PNGs to {0, 255}; map only true 1-bit foreground to 1.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves semantic segmentation mask loading by safely handling single-channel masks with an extra dimension, helping prevent shape-related errors during training and inference.

### 📊 Key Changes
- Added a check in `ultralytics/data/dataset.py` to detect masks shaped like `(H, W, 1)`.
- Automatically removes the unnecessary last dimension using `np.squeeze(mask, axis=2)`.
- Keeps existing logic for grayscale and 1-bit semantic masks unchanged.

### 🎯 Purpose & Impact
- ✅ Makes mask loading more robust across different image-reading edge cases and file formats.
- ✅ Prevents downstream issues caused by unexpected mask shapes in semantic segmentation workflows.
- ✅ Improves compatibility with datasets where masks may be stored or decoded as single-channel images with an extra dimension.
- ✅ Reduces potential training/debugging friction for users working with custom segmentation datasets.