### PR TITLE
Fix grayscale test failure from stale .npy cache files

### DIFF
--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -234,7 +234,9 @@ class BaseDataset(Dataset):
                     # Validate channel count; stale .npy files from other configs may have wrong channels
                     npy_channels = im.shape[-1] if im.ndim >= 3 else 1
                     if npy_channels != self.channels:
-                        LOGGER.warning(f"{self.prefix}Removing stale *.npy image file {fn} with {npy_channels} channels, expected {self.channels}")
+                        LOGGER.warning(
+                            f"{self.prefix}Removing stale *.npy image file {fn} with {npy_channels} channels, expected {self.channels}"
+                        )
                         Path(fn).unlink(missing_ok=True)
                         im = imread(f, flags=self.cv2_flag)
                 except Exception as e:

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -231,6 +231,10 @@ class BaseDataset(Dataset):
             if fn.exists():  # load npy
                 try:
                     im = np.load(fn)
+                    # Validate channel count; stale .npy files from other configs may have wrong channels
+                    npy_channels = im.shape[-1] if im.ndim >= 3 else 1
+                    if npy_channels != self.channels:
+                        im = imread(f, flags=self.cv2_flag)
                 except Exception as e:
                     LOGGER.warning(f"{self.prefix}Removing corrupt *.npy image file {fn} due to: {e}")
                     Path(fn).unlink(missing_ok=True)

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -234,6 +234,8 @@ class BaseDataset(Dataset):
                     # Validate channel count; stale .npy files from other configs may have wrong channels
                     npy_channels = im.shape[-1] if im.ndim >= 3 else 1
                     if npy_channels != self.channels:
+                        LOGGER.warning(f"{self.prefix}Removing stale *.npy image file {fn} with {npy_channels} channels, expected {self.channels}")
+                        Path(fn).unlink(missing_ok=True)
                         im = imread(f, flags=self.cv2_flag)
                 except Exception as e:
                     LOGGER.warning(f"{self.prefix}Removing corrupt *.npy image file {fn} due to: {e}")

--- a/ultralytics/data/base.py
+++ b/ultralytics/data/base.py
@@ -231,7 +231,6 @@ class BaseDataset(Dataset):
             if fn.exists():  # load npy
                 try:
                     im = np.load(fn)
-                    # Validate channel count; stale .npy files from other configs may have wrong channels
                     npy_channels = im.shape[-1] if im.ndim >= 3 else 1
                     if npy_channels != self.channels:
                         LOGGER.warning(


### PR DESCRIPTION
## Bug
The grayscale test `test_grayscale[detect-model1-coco8.yaml]` fails intermittently with:

```
RuntimeError: Given groups=1, weight of size [16, 1, 3, 3], expected input[4, 3, 64, 64] to have 1 channels, but got 3 channels instead
```

## Root Cause
`BaseDataset.load_image()` loads `.npy` cache files directly via `np.load()` without checking whether their channel count matches `self.channels`. Under `pytest-xdist`, parallel tests can create 3-channel `.npy` files in shared dataset directories between the train and validation phases of the grayscale test, causing the validator to load RGB images into a grayscale model.

## Fix
After loading a `.npy` file, validate its channel count. If it doesn't match `self.channels`, fall back to `imread(f, flags=self.cv2_flag)` to load the image with the correct grayscale/color flag.

## Validation
- Syntax checked with `py_compile`
- The fix is minimal and only affects the `.npy` loading path, preserving existing behavior when cache files are valid.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves image loading by detecting and removing stale cached `.npy` image files when their channel count no longer matches the dataset’s expected format.

### 📊 Key Changes
- Added a channel-count check when loading cached `.npy` image files in `ultralytics/data/base.py`.
- If a cached `.npy` file has the wrong number of channels, Ultralytics now:
  - logs a warning message,
  - deletes the stale cache file,
  - reloads the original image using the expected OpenCV flags.
- Existing corrupt `.npy` handling remains in place, so bad cache files are still removed and rebuilt as before.

### 🎯 Purpose & Impact
- ✅ Prevents bugs caused by outdated image caches, especially when switching between image modes like grayscale and RGB.
- 🔄 Ensures cached data stays consistent with the current dataset configuration without requiring manual cleanup.
- 📉 Reduces confusing training or validation issues that can come from loading images with unexpected channel layouts.
- 👥 Improves reliability for both developers and everyday users by making dataset caching more robust and self-healing.