### PR TITLE
Add jpeg2000 to predict images formats table

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -462,6 +462,7 @@ The below table contains valid Ultralytics image formats.
 | `.heif`        | `yolo predict source=image.heif` | [High Efficiency Image Format](https://en.wikipedia.org/wiki/HEIF)         |
 | `.jp2`         | `yolo predict source=image.jp2`  | [JPEG 2000](https://en.wikipedia.org/wiki/JPEG_2000)                       |
 | `.jpeg`        | `yolo predict source=image.jpeg` | [JPEG](https://en.wikipedia.org/wiki/JPEG)                                 |
+| `.jpeg2000`    | `yolo predict source=image.jpeg2000` | [JPEG 2000](https://en.wikipedia.org/wiki/JPEG_2000)                   |
 | `.jpg`         | `yolo predict source=image.jpg`  | [JPEG](https://en.wikipedia.org/wiki/JPEG)                                 |
 | `.mpo`         | `yolo predict source=image.mpo`  | [Multi Picture Object](https://fileinfo.com/extension/mpo)                 |
 | `.png`         | `yolo predict source=image.png`  | [Portable Network Graphics](https://en.wikipedia.org/wiki/PNG)             |

--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -453,22 +453,22 @@ The below table contains valid Ultralytics image formats.
 
     HEIC/HEIF formats require `pi-heif`, which is installed automatically on first use. AVIF is supported natively by Pillow.
 
-| Image Suffixes | Example Predict Command          | Reference                                                                  |
-| -------------- | -------------------------------- | -------------------------------------------------------------------------- |
-| `.avif`        | `yolo predict source=image.avif` | [AV1 Image File Format](https://en.wikipedia.org/wiki/AVIF)                |
-| `.bmp`         | `yolo predict source=image.bmp`  | [Microsoft BMP File Format](https://en.wikipedia.org/wiki/BMP_file_format) |
-| `.dng`         | `yolo predict source=image.dng`  | [Adobe DNG](https://en.wikipedia.org/wiki/Digital_Negative)                |
-| `.heic`        | `yolo predict source=image.heic` | [High Efficiency Image Format](https://en.wikipedia.org/wiki/HEIF)         |
-| `.heif`        | `yolo predict source=image.heif` | [High Efficiency Image Format](https://en.wikipedia.org/wiki/HEIF)         |
-| `.jp2`         | `yolo predict source=image.jp2`  | [JPEG 2000](https://en.wikipedia.org/wiki/JPEG_2000)                       |
-| `.jpeg`        | `yolo predict source=image.jpeg` | [JPEG](https://en.wikipedia.org/wiki/JPEG)                                 |
-| `.jpeg2000`    | `yolo predict source=image.jpeg2000` | [JPEG 2000](https://en.wikipedia.org/wiki/JPEG_2000)                   |
-| `.jpg`         | `yolo predict source=image.jpg`  | [JPEG](https://en.wikipedia.org/wiki/JPEG)                                 |
-| `.mpo`         | `yolo predict source=image.mpo`  | [Multi Picture Object](https://fileinfo.com/extension/mpo)                 |
-| `.png`         | `yolo predict source=image.png`  | [Portable Network Graphics](https://en.wikipedia.org/wiki/PNG)             |
-| `.tif`         | `yolo predict source=image.tif`  | [Tag Image File Format](https://en.wikipedia.org/wiki/TIFF)                |
-| `.tiff`        | `yolo predict source=image.tiff` | [Tag Image File Format](https://en.wikipedia.org/wiki/TIFF)                |
-| `.webp`        | `yolo predict source=image.webp` | [WebP](https://en.wikipedia.org/wiki/WebP)                                 |
+| Image Suffixes | Example Predict Command              | Reference                                                                  |
+| -------------- | ------------------------------------ | -------------------------------------------------------------------------- |
+| `.avif`        | `yolo predict source=image.avif`     | [AV1 Image File Format](https://en.wikipedia.org/wiki/AVIF)                |
+| `.bmp`         | `yolo predict source=image.bmp`      | [Microsoft BMP File Format](https://en.wikipedia.org/wiki/BMP_file_format) |
+| `.dng`         | `yolo predict source=image.dng`      | [Adobe DNG](https://en.wikipedia.org/wiki/Digital_Negative)                |
+| `.heic`        | `yolo predict source=image.heic`     | [High Efficiency Image Format](https://en.wikipedia.org/wiki/HEIF)         |
+| `.heif`        | `yolo predict source=image.heif`     | [High Efficiency Image Format](https://en.wikipedia.org/wiki/HEIF)         |
+| `.jp2`         | `yolo predict source=image.jp2`      | [JPEG 2000](https://en.wikipedia.org/wiki/JPEG_2000)                       |
+| `.jpeg`        | `yolo predict source=image.jpeg`     | [JPEG](https://en.wikipedia.org/wiki/JPEG)                                 |
+| `.jpeg2000`    | `yolo predict source=image.jpeg2000` | [JPEG 2000](https://en.wikipedia.org/wiki/JPEG_2000)                       |
+| `.jpg`         | `yolo predict source=image.jpg`      | [JPEG](https://en.wikipedia.org/wiki/JPEG)                                 |
+| `.mpo`         | `yolo predict source=image.mpo`      | [Multi Picture Object](https://fileinfo.com/extension/mpo)                 |
+| `.png`         | `yolo predict source=image.png`      | [Portable Network Graphics](https://en.wikipedia.org/wiki/PNG)             |
+| `.tif`         | `yolo predict source=image.tif`      | [Tag Image File Format](https://en.wikipedia.org/wiki/TIFF)                |
+| `.tiff`        | `yolo predict source=image.tiff`     | [Tag Image File Format](https://en.wikipedia.org/wiki/TIFF)                |
+| `.webp`        | `yolo predict source=image.webp`     | [WebP](https://en.wikipedia.org/wiki/WebP)                                 |
 
 ### Videos
 


### PR DESCRIPTION
## Summary

The Images table in `docs/en/modes/predict.md` listed `.jp2` but omitted `.jpeg2000`, even though `IMG_FORMATS` in `ultralytics/data/utils.py` accepts both. Added a `.jpeg2000` row pointing to the same JPEG 2000 reference.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🖼️ This PR updates the prediction docs to explicitly list `.jpeg2000` as a supported image input format for Ultralytics inference.

### 📊 Key Changes
- Added `.jpeg2000` to the supported image suffixes table in `docs/en/modes/predict.md`.
- Included a matching CLI example: `yolo predict source=image.jpeg2000`.
- Linked `.jpeg2000` to the existing JPEG 2000 reference for clarity.
- Minor table formatting adjustments were made to keep the documentation aligned and readable ✨

### 🎯 Purpose & Impact
- Helps users quickly confirm that JPEG 2000 images can be used for prediction 📘
- Reduces confusion for users working with less common image formats, especially in professional or archival imaging workflows 🧩
- Improves documentation accuracy so supported formats are more completely reflected in the docs ✅
- No code behavior appears to change in this PR; the main impact is better guidance and discoverability for users 📚