### PR TITLE
Fix tuner trial ID retrieval for Ray 2.7+ compatibility

### DIFF
--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -425,9 +425,12 @@ def run_ray_tune(
         config = _sanitize_tune_value(dict(config))
         config.update(train_args)
 
-        # Set trial-specific name for W&B logging
+        # Ray ≥2.7 moved the API from `tune.get_trial_id()` to `tune.get_context().get_trial_id()`.
         try:
-            trial_id = tune.get_trial_id()  # Get current trial ID (e.g., "2c2fc_00000")
+            if hasattr(tune, "get_context"):
+                trial_id = tune.get_context().get_trial_id()
+            else:
+                trial_id = tune.get_trial_id()  # Ray <2.7
             trial_suffix = trial_id.split("_")[-1] if "_" in trial_id else trial_id
             config["name"] = f"{base_name}_{trial_suffix}"
         except Exception:

--- a/ultralytics/utils/tuner.py
+++ b/ultralytics/utils/tuner.py
@@ -425,10 +425,10 @@ def run_ray_tune(
         config = _sanitize_tune_value(dict(config))
         config.update(train_args)
 
-        # Ray ≥2.7 moved the API from `tune.get_trial_id()` to `tune.get_context().get_trial_id()`.
+        # Set trial-specific name for W&B logging
         try:
             if hasattr(tune, "get_context"):
-                trial_id = tune.get_context().get_trial_id()
+                trial_id = tune.get_context().get_trial_id()  # Ray ≥2.7, get current trial ID (e.g., "tune_c1c1ce99")
             else:
                 trial_id = tune.get_trial_id()  # Ray <2.7
             trial_suffix = trial_id.split("_")[-1] if "_" in trial_id else trial_id


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the hyperparameter tuner to support newer Ray versions while keeping compatibility with older ones, improving experiment tracking reliability.

### 📊 Key Changes
- Added version-aware logic in `ultralytics/utils/tuner.py` for retrieving the current Ray Tune trial ID.
- Uses `tune.get_context().get_trial_id()` for Ray 2.7 and newer.
- Falls back to `tune.get_trial_id()` for older Ray versions.
- Keeps the trial-specific naming behavior used for W&B logging, so each tuning run still gets a unique, readable experiment name.

### 🎯 Purpose & Impact
- ✅ Improves compatibility across different Ray Tune versions without breaking existing workflows.
- 📈 Helps ensure W&B experiment names remain correctly assigned during hyperparameter tuning.
- 🔄 Reduces the chance of logging or naming issues for users running newer Ray releases.
- 👥 Benefits both current users on older environments and teams upgrading their tuning stack.