### PR TITLE
Document missing COMET_* environment variables

### DIFF
--- a/docs/en/integrations/comet.md
+++ b/docs/en/integrations/comet.md
@@ -142,16 +142,16 @@ Comet logs system metrics to help identify any bottlenecks in the training proce
 
 Comet offers the flexibility to customize its logging behavior by setting environment variables. These configurations allow you to tailor Comet to your specific needs and preferences. The Ultralytics callback reads the following environment variables (set them before training starts):
 
-| Environment Variable                | Default        | Description                                                                                              |
-| ----------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------- |
-| `COMET_START_ONLINE`                | `1`            | Run the experiment in online (`1`) or offline (`0`) mode.                                                |
-| `COMET_PROJECT_NAME`                | `args.project` | Comet workspace project. Falls back to the YOLO `project` training argument when unset.                  |
-| `COMET_MODEL_NAME`                  | `Ultralytics`  | Name registered for the logged model artifact.                                                           |
-| `COMET_MAX_IMAGE_PREDICTIONS`       | `100`          | Total number of validation image predictions to log per run.                                             |
-| `COMET_EVAL_BATCH_LOGGING_INTERVAL` | `1`            | Log image predictions every Nth validation batch.                                                        |
-| `COMET_EVAL_LOG_IMAGE_PREDICTIONS`  | `true`         | Toggle image prediction logging on (`true`) or off (`false`).                                            |
-| `COMET_EVAL_LOG_CONFUSION_MATRIX`   | `false`        | Log a confusion matrix on every validation epoch. A final matrix is always logged at end of training.    |
-| `COMET_MAX_CONFIDENCE_SCORE`        | `100.0`        | Multiplier applied to detection confidence scores before logging (Comet's UI expects a percentage scale). |
+| Environment Variable                | Default        | Description                                                                                                |
+| ----------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- |
+| `COMET_START_ONLINE`                | `1`            | Run the experiment in online (`1`) or offline (`0`) mode.                                                  |
+| `COMET_PROJECT_NAME`                | `args.project` | Comet workspace project. Falls back to the YOLO `project` training argument when unset.                    |
+| `COMET_MODEL_NAME`                  | `Ultralytics`  | Name registered for the logged model artifact.                                                             |
+| `COMET_MAX_IMAGE_PREDICTIONS`       | `100`          | Total number of validation image predictions to log per run.                                               |
+| `COMET_EVAL_BATCH_LOGGING_INTERVAL` | `1`            | Log image predictions every Nth validation batch.                                                          |
+| `COMET_EVAL_LOG_IMAGE_PREDICTIONS`  | `true`         | Toggle image prediction logging on (`true`) or off (`false`).                                              |
+| `COMET_EVAL_LOG_CONFUSION_MATRIX`   | `false`        | Log a confusion matrix on every validation epoch. A final matrix is always logged at end of training.      |
+| `COMET_MAX_CONFIDENCE_SCORE`        | `100.0`        | Multiplier applied to detection confidence scores before logging (Comet's UI expects a percentage scale).  |
 | `COMET_MODE` _(deprecated)_         | `online`       | Legacy alias of `COMET_START_ONLINE` (`"online"` ↔ `1`, `"offline"` ↔ `0`). Emits a deprecation warning. |
 
 ### Logging Image Predictions

--- a/docs/en/integrations/comet.md
+++ b/docs/en/integrations/comet.md
@@ -140,7 +140,19 @@ Comet logs system metrics to help identify any bottlenecks in the training proce
 
 ## Customizing Comet Logging
 
-Comet offers the flexibility to customize its logging behavior by setting environment variables. These configurations allow you to tailor Comet to your specific needs and preferences. Here are some helpful customization options:
+Comet offers the flexibility to customize its logging behavior by setting environment variables. These configurations allow you to tailor Comet to your specific needs and preferences. The Ultralytics callback reads the following environment variables (set them before training starts):
+
+| Environment Variable                | Default        | Description                                                                                              |
+| ----------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------- |
+| `COMET_START_ONLINE`                | `1`            | Run the experiment in online (`1`) or offline (`0`) mode.                                                |
+| `COMET_PROJECT_NAME`                | `args.project` | Comet workspace project. Falls back to the YOLO `project` training argument when unset.                  |
+| `COMET_MODEL_NAME`                  | `Ultralytics`  | Name registered for the logged model artifact.                                                           |
+| `COMET_MAX_IMAGE_PREDICTIONS`       | `100`          | Total number of validation image predictions to log per run.                                             |
+| `COMET_EVAL_BATCH_LOGGING_INTERVAL` | `1`            | Log image predictions every Nth validation batch.                                                        |
+| `COMET_EVAL_LOG_IMAGE_PREDICTIONS`  | `true`         | Toggle image prediction logging on (`true`) or off (`false`).                                            |
+| `COMET_EVAL_LOG_CONFUSION_MATRIX`   | `false`        | Log a confusion matrix on every validation epoch. A final matrix is always logged at end of training.    |
+| `COMET_MAX_CONFIDENCE_SCORE`        | `100.0`        | Multiplier applied to detection confidence scores before logging (Comet's UI expects a percentage scale). |
+| `COMET_MODE` _(deprecated)_         | `online`       | Legacy alias of `COMET_START_ONLINE` (`"online"` ↔ `1`, `"offline"` ↔ `0`). Emits a deprecation warning. |
 
 ### Logging Image Predictions
 
@@ -150,6 +162,14 @@ You can control the number of image predictions that Comet logs during your expe
 import os
 
 os.environ["COMET_MAX_IMAGE_PREDICTIONS"] = "200"
+```
+
+To disable image prediction logging entirely (for example, to reduce upload volume on slow connections), set `COMET_EVAL_LOG_IMAGE_PREDICTIONS` to `"false"`:
+
+```python
+import os
+
+os.environ["COMET_EVAL_LOG_IMAGE_PREDICTIONS"] = "false"
 ```
 
 ### Batch Logging Interval
@@ -170,6 +190,36 @@ In some cases, you may not want to log the confusion matrix from your validation
 import os
 
 os.environ["COMET_EVAL_LOG_CONFUSION_MATRIX"] = "false"
+```
+
+### Project Name
+
+By default, Comet groups runs under the YOLO `project` training argument (`runs/detect/train`, `runs/segment/train`, etc.). Override this with `COMET_PROJECT_NAME` to send all experiments to a specific Comet workspace project regardless of the training output directory:
+
+```python
+import os
+
+os.environ["COMET_PROJECT_NAME"] = "my-yolo26-experiments"
+```
+
+### Model Artifact Name
+
+`COMET_MODEL_NAME` sets the name Comet registers for the logged model artifact (defaults to `Ultralytics`). Use it to differentiate model variants in a shared workspace:
+
+```python
+import os
+
+os.environ["COMET_MODEL_NAME"] = "yolo26n-coco128"
+```
+
+### Confidence Score Scaling
+
+Detection confidence scores are emitted in the `[0, 1]` range, but the Comet UI displays them on a percentage scale by default. The callback multiplies each score by `COMET_MAX_CONFIDENCE_SCORE` (default `100.0`) before logging. Adjust this if you prefer raw probabilities or a different scale:
+
+```python
+import os
+
+os.environ["COMET_MAX_CONFIDENCE_SCORE"] = "1.0"  # log raw [0, 1] scores
 ```
 
 ### Offline Logging
@@ -275,7 +325,23 @@ Comet allows for extensive customization of its logging behavior using environme
     os.environ["COMET_EVAL_LOG_CONFUSION_MATRIX"] = "false"
     ```
 
-Refer to the [Customizing Comet Logging](#customizing-comet-logging) section for more customization options.
+- **Set the Comet project name**:
+
+    ```python
+    import os
+
+    os.environ["COMET_PROJECT_NAME"] = "my-yolo26-experiments"
+    ```
+
+- **Set the logged model artifact name**:
+
+    ```python
+    import os
+
+    os.environ["COMET_MODEL_NAME"] = "yolo26n-coco128"
+    ```
+
+See the [Customizing Comet Logging](#customizing-comet-logging) section for the full list, including image prediction toggles, confidence score scaling, and online/offline mode.
 
 ### How do I view detailed metrics and visualizations of my YOLO26 training on Comet?
 

--- a/docs/en/integrations/comet.md
+++ b/docs/en/integrations/comet.md
@@ -192,6 +192,20 @@ import os
 os.environ["COMET_EVAL_LOG_CONFUSION_MATRIX"] = "false"
 ```
 
+### Online and Offline Mode
+
+By default, Comet runs in online mode and streams experiment data to the Comet servers. If you need to train without internet access, set `COMET_START_ONLINE=0` before training starts. Experiment data is saved locally and can be uploaded later with the [`comet upload`](https://www.comet.com/docs/v2/guides/comet-cli/comet-upload-cli/) CLI.
+
+```python
+import os
+
+os.environ["COMET_START_ONLINE"] = "0"  # 1 (default) = online, 0 = offline
+```
+
+!!! note "`COMET_MODE` is deprecated"
+
+    Earlier versions used `COMET_MODE="offline"` for this purpose. The variable is still honored for backward compatibility but emits a deprecation warning. Use `COMET_START_ONLINE` going forward.
+
 ### Project Name
 
 By default, Comet groups runs under the YOLO `project` training argument (`runs/detect/train`, `runs/segment/train`, etc.). Override this with `COMET_PROJECT_NAME` to send all experiments to a specific Comet workspace project regardless of the training output directory:
@@ -220,16 +234,6 @@ Detection confidence scores are emitted in the `[0, 1]` range, but the Comet UI 
 import os
 
 os.environ["COMET_MAX_CONFIDENCE_SCORE"] = "1.0"  # log raw [0, 1] scores
-```
-
-### Offline Logging
-
-If you find yourself in a situation where internet access is limited, Comet provides an offline logging option. You can set the `COMET_MODE` environment variable to "offline" to enable this feature. Your experiment data will be saved locally in a directory that you can later upload to Comet when internet connectivity is available.
-
-```python
-import os
-
-os.environ["COMET_MODE"] = "offline"
 ```
 
 ## Summary
@@ -356,12 +360,12 @@ For a detailed overview of these features, visit the [Understanding Your Model's
 
 ### Can I use Comet for offline logging when training YOLO26 models?
 
-Yes, you can enable offline logging in Comet by setting the `COMET_MODE` environment variable to "offline":
+Yes. Set `COMET_START_ONLINE=0` before training starts to log locally:
 
 ```python
 import os
 
-os.environ["COMET_MODE"] = "offline"
+os.environ["COMET_START_ONLINE"] = "0"
 ```
 
-This feature allows you to log your experiment data locally, which can later be uploaded to Comet when internet connectivity is available. This is particularly useful when working in environments with limited internet access. For more details, refer to the [Offline Logging](#offline-logging) section.
+Experiment data is saved on disk and can be uploaded to Comet later with the [`comet upload`](https://www.comet.com/docs/v2/guides/comet-cli/comet-upload-cli/) CLI when connectivity is available. The earlier `COMET_MODE="offline"` variable still works but emits a deprecation warning. For more details, see the [Online and Offline Mode](#online-and-offline-mode) section.

--- a/docs/en/integrations/comet.md
+++ b/docs/en/integrations/comet.md
@@ -208,7 +208,7 @@ os.environ["COMET_START_ONLINE"] = "0"  # 1 (default) = online, 0 = offline
 
 ### Project Name
 
-By default, Comet groups runs under the YOLO `project` training argument (`runs/detect/train`, `runs/segment/train`, etc.). Override this with `COMET_PROJECT_NAME` to send all experiments to a specific Comet workspace project regardless of the training output directory:
+By default, the Comet callback passes the YOLO `project` training argument to Comet (or `None` when the argument is unset, in which case Comet uses your workspace default). Override this with `COMET_PROJECT_NAME` to send all experiments to a specific Comet workspace project regardless of the YOLO training argument:
 
 ```python
 import os


### PR DESCRIPTION
## summary

The Comet integration page documented 4 of the 9 `COMET_*` environment variables read by `ultralytics/utils/callbacks/comet.py` and described the offline workflow via the deprecated `COMET_MODE`. This adds a summary table and per-variable subsections for `COMET_START_ONLINE`, `COMET_PROJECT_NAME`, `COMET_MODEL_NAME`, `COMET_EVAL_LOG_IMAGE_PREDICTIONS`, and `COMET_MAX_CONFIDENCE_SCORE`, and migrates the offline guidance to `COMET_START_ONLINE` (keeping `COMET_MODE` documented as the deprecated alias the callback still honors).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves the Comet integration docs by clearly documenting all supported environment variables, adding newer configuration options, and clarifying online/offline logging behavior.

### 📊 Key Changes
- 📚 Expanded the **Comet logging customization** section with a table of supported environment variables, including defaults and descriptions.
- 🔧 Documented additional settings such as:
  - `COMET_PROJECT_NAME`
  - `COMET_MODEL_NAME`
  - `COMET_EVAL_LOG_IMAGE_PREDICTIONS`
  - `COMET_MAX_CONFIDENCE_SCORE`
  - `COMET_START_ONLINE`
- 🖼️ Added an example for **disabling image prediction logging** to reduce uploads and bandwidth use.
- 🌐 Reworked **offline logging** guidance into a clearer **online/offline mode** section using `COMET_START_ONLINE=0`.
- ⚠️ Marked `COMET_MODE` as **deprecated**, while noting it is still supported for backward compatibility.
- 🏷️ Added examples for setting a **Comet project name** and **logged model artifact name**.
- 📈 Explained how **confidence score scaling** works for Comet’s UI display.
- ❓ Updated the FAQ and summary examples to match the new recommended variables and terminology.

### 🎯 Purpose & Impact
- ✅ Makes Comet integration easier to understand and configure for both new and experienced users.
- 🚀 Helps users better control logging volume, project organization, artifact naming, and offline training workflows.
- 📡 Reduces confusion by promoting `COMET_START_ONLINE` as the new recommended setting instead of the older `COMET_MODE`.
- 🧭 Improves documentation accuracy and discoverability, which should lower setup mistakes and support questions.
- 🔄 Maintains backward compatibility while guiding users toward the updated configuration style.