### PR TITLE
Bump actions/cache from v4 to v5 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         shell: bash # for Windows compatibility
         run: yolo settings weights_dir="${GITHUB_WORKSPACE}/.ultralytics_cache/weights" datasets_dir="${GITHUB_WORKSPACE}/.ultralytics_cache/datasets"
       - name: Cache test assets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.ultralytics_cache
           key: ultralytics-test-assets-${{ runner.os }}-${{ hashFiles('tests/cache_test_assets.py', 'tests/__init__.py') }}
@@ -285,7 +285,7 @@ jobs:
         shell: bash # for Windows compatibility
         run: yolo settings weights_dir="${GITHUB_WORKSPACE}/.ultralytics_cache/weights" datasets_dir="${GITHUB_WORKSPACE}/.ultralytics_cache/datasets"
       - name: Cache test assets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.ultralytics_cache
           key: ultralytics-test-assets-${{ runner.os }}-${{ hashFiles('tests/cache_test_assets.py', 'tests/__init__.py') }}
@@ -365,7 +365,7 @@ jobs:
       - name: Configure Ultralytics cache paths
         run: yolo settings weights_dir="${GITHUB_WORKSPACE}/.ultralytics_cache/weights" datasets_dir="${GITHUB_WORKSPACE}/.ultralytics_cache/datasets"
       - name: Cache test assets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.ultralytics_cache
           key: ultralytics-test-assets-${{ runner.os }}-${{ hashFiles('tests/cache_test_assets.py', 'tests/__init__.py') }}


### PR DESCRIPTION
Bump actions/cache from v4 to v5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions cache step in CI from `actions/cache@v4` to `actions/cache@v5` to keep Ultralytics automation current and reliable.

### 📊 Key Changes
- 🚀 Replaced `actions/cache@v4` with `actions/cache@v5` in `.github/workflows/ci.yml`.
- 🧪 Applied the update to all CI jobs that cache Ultralytics test assets.
- 📦 Kept the existing cache paths and cache keys unchanged, so only the cache action version is updated.

### 🎯 Purpose & Impact
- ✅ Improves CI workflow maintenance by using the latest cache action version.
- 🛠️ Helps reduce risk of compatibility or support issues with older GitHub Actions dependencies.
- ⚡ Preserves current test-asset caching behavior, so users and contributors should see no functional changes beyond a safer, more up-to-date CI setup.
- 👥 Mainly benefits developers and maintainers by keeping automated testing infrastructure modern and stable.