### PR TITLE
Fix race condition in test_cli.py::test_export

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -47,12 +48,17 @@ def test_predict(task: str, model: str, data: str) -> None:
 
 
 @pytest.mark.parametrize("model", MODELS)
-def test_export(model: str, tmp_path: Path) -> None:  # use tmp_path to prevent the race condition with test_exports.py
+def test_export(model: str, tmp_path: Path) -> None:
     """Test exporting a YOLO model to TorchScript format."""
+    from ultralytics.utils.downloads import attempt_download_asset
+
+    model_path = WEIGHTS_DIR / model
+    if not model_path.exists():
+        model_path = Path(attempt_download_asset(model))
+    isolated = tmp_path / model
+    shutil.copy(model_path, isolated)
     for end2end in {False, True}:
-        run(
-            f"yolo export model={model} format=torchscript imgsz=32 end2end={end2end} max_det=100 project={tmp_path} name=export"
-        )
+        run(f"yolo export model={isolated} format=torchscript imgsz=32 end2end={end2end} max_det=100")
 
 
 @pytest.mark.skipif(not TORCH_1_11, reason="RTDETR requires torch>=1.11")


### PR DESCRIPTION
## Problem

CI failures in \SlowTests\ with:

> AssertionError: 0.0 MB output model size

The root cause is a race condition between:
- <code>tests/test_cli.py::test_export[yolo26n-seg.pt]</code>
- <code>tests/test_exports.py::test_export_torchscript_matrix[segment-...]</code>

Both tests export the same segmentation model to TorchScript. The TorchScript exporter writes the output file (<code>*.torchscript</code>) next to the input model path, ignoring the <code>project</code>/<code>name</code> CLI arguments. When pytest-xdist runs these tests concurrently on different workers, they overwrite/truncate the same shared file, causing one worker to see a 0-byte output.

## Fix

Follow the same isolation pattern already used by the <code>isolated_model</code> fixture in <code>conftest.py</code>:

1. Copy the model under test into the per-test <code>tmp_path</code>.
2. Run the CLI export against that isolated copy.

This guarantees each concurrent export writes to a unique temporary directory, eliminating the race.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes CLI export tests more reliable by isolating model files before export, reducing test conflicts and improving consistency across environments.

### 📊 Key Changes
- Added `shutil` import to support copying model files into a temporary test directory.
- Updated `test_export()` in `tests/test_cli.py` to:
  - Check whether the test model file exists locally.
  - Download the model asset if it is missing using `attempt_download_asset`.
  - Copy the model into a unique temporary path for the test run.
- Changed the export command to use the isolated model file directly instead of the shared model name/path.
- Removed the custom `project` and `name` export arguments, simplifying the test setup.

### 🎯 Purpose & Impact
- ✅ Prevents race conditions and file conflicts when export tests run in parallel or reuse the same model files.
- 📦 Makes the test more robust in clean environments where model weights may not already be downloaded.
- 🔁 Improves test reproducibility by ensuring each run works from its own temporary copy of the model.
- 🚀 Helps maintain more stable CI results and reduces flaky test failures for contributors and maintainers.