### PR TITLE
`ultralytics 8.4.55` Accept onnxruntime variants in ONNX export requirements check

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.54"
+__version__ = "8.4.55"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -645,7 +645,12 @@ class Exporter:
         """Export YOLO model to ONNX format."""
         requirements = ["onnx>=1.12.0,<2.0.0"]
         if self.args.simplify:
-            requirements += ["onnxslim>=0.1.71", "onnxruntime" + ("-gpu" if torch.cuda.is_available() else "")]
+            # onnxruntime variants (onnxruntime-gpu/-qnn/etc.) all provide the `onnxruntime` module; pass them as
+            # interchangeable candidates so AutoUpdate does not reinstall stable onnxruntime over an existing build
+            # (e.g. the nightly onnxruntime-qnn used for QNN export), which breaks the provider ABI. The first
+            # candidate is the install target when none is already present.
+            ort = "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"
+            requirements += ["onnxslim>=0.1.71", (ort, "onnxruntime", "onnxruntime-gpu", "onnxruntime-qnn")]
         check_requirements(requirements)
         import onnx
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -645,11 +645,9 @@ class Exporter:
         """Export YOLO model to ONNX format."""
         requirements = ["onnx>=1.12.0,<2.0.0"]
         if self.args.simplify:
-            # onnxruntime variants (onnxruntime-gpu/-qnn/etc.) all provide the `onnxruntime` module; pass them as
-            # interchangeable candidates so AutoUpdate does not reinstall stable onnxruntime over an existing build
-            # (e.g. the nightly onnxruntime-qnn used for QNN export), which breaks the provider ABI. The first
-            # candidate is the install target when none is already present.
-            ort = "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"
+            # Pass onnxruntime variants as interchangeable candidates so AutoUpdate keeps an installed build
+            # (e.g. onnxruntime-qnn for QNN export) instead of reinstalling stable onnxruntime and breaking its ABI.
+            ort = "onnxruntime-gpu" if "cuda" in self.device.type else "onnxruntime"
             requirements += ["onnxslim>=0.1.71", (ort, "onnxruntime", "onnxruntime-gpu", "onnxruntime-qnn")]
         check_requirements(requirements)
         import onnx


### PR DESCRIPTION
## Summary

`Exporter.export_onnx` (which is also the first stage of `export_qnn`) requires the bare distribution name `onnxruntime` (or `onnxruntime-gpu` under CUDA). `check_requirements` resolves requirements by **distribution name**, so when a differently-named build such as `onnxruntime-qnn` is installed, the lookup misses and AutoUpdate reinstalls stable `onnxruntime` into the same `onnxruntime/capi` namespace — overwriting the matched build and breaking its provider ABI.

For QNN export this surfaces as:

```
[ONNXRuntimeError] : 1 : FAIL : Failed to get symbol CreateEpFactories with error:
.../onnxruntime/capi/libonnxruntime_providers_qnn.so: undefined symbol: CreateEpFactories
```

The same class of breakage applies to any non-`onnxruntime`/`-gpu` distribution that provides the `onnxruntime` module (`onnxruntime-qnn`, `-directml`, `-openvino`, `-training`).

## Fix

`check_requirements` already supports interchangeable candidates via a tuple (see its docstring: `[("onnxruntime", "onnxruntime-gpu"), "numpy"]`) — a requirement is satisfied if **any** candidate's metadata is found, and only `candidates[0]` is installed when none are present. This passes the onnxruntime variants as such a tuple, keeping the CPU/GPU install preference as the first candidate:

```python
ort = "onnxruntime-gpu" if torch.cuda.is_available() else "onnxruntime"
requirements += ["onnxslim>=0.1.71", (ort, "onnxruntime", "onnxruntime-gpu", "onnxruntime-qnn")]
```

With this, an installed `onnxruntime-qnn` satisfies the check, AutoUpdate no longer reinstalls stable onnxruntime over it, and behavior is unchanged when nothing is installed (still installs `onnxruntime`, or `onnxruntime-gpu` under CUDA).

## Test plan

- [ ] CPU env with `onnxruntime-qnn` only installed: `yolo export format=qnn model=yolo26n.pt imgsz=32 name=73` no longer reinstalls onnxruntime and exports successfully
- [ ] Clean env: ONNX/QNN export still auto-installs `onnxruntime` (CPU) / `onnxruntime-gpu` (CUDA) as before
- [ ] Existing ONNX export with `simplify=True` unaffected

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR bumps Ultralytics to version `8.4.55` and improves ONNX export dependency handling to better preserve compatible `onnxruntime` installations during model simplification.

### 📊 Key Changes
- Updated the package version from `8.4.54` to `8.4.55` 📦
- Refined ONNX export logic in `ultralytics/engine/exporter.py` when `simplify=True` is used
- Changed `onnxruntime` dependency checks to treat multiple runtime variants as acceptable alternatives, including:
  - `onnxruntime`
  - `onnxruntime-gpu`
  - `onnxruntime-qnn`
- Improved runtime selection logic to prefer `onnxruntime-gpu` when exporting on CUDA devices ⚡
- Added safeguards to avoid AutoUpdate replacing an already installed specialized runtime with the standard one

### 🎯 Purpose & Impact
- Prevents export workflows from accidentally breaking specialized ONNX setups, especially for users relying on `onnxruntime-qnn` or GPU-enabled runtimes 🛡️
- Makes ONNX simplification more reliable across different hardware and deployment environments
- Reduces the chance of dependency conflicts or ABI issues caused by reinstalling the wrong runtime package
- Helps advanced deployment users keep their existing optimized inference stack intact while exporting models 🚀