### PR TITLE
Fix QNN export with built-in provider wheels

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.55"
+__version__ = "8.4.56"
 
 import importlib
 import os

--- a/ultralytics/utils/export/qnn.py
+++ b/ultralytics/utils/export/qnn.py
@@ -46,9 +46,9 @@ def onnx2qnn(
     """Convert an ONNX model to an INT8 Qualcomm QNN context binary using the ONNX Runtime QNN Execution Provider.
 
     The conversion runs entirely on the host with no Qualcomm account or cloud upload. The model is INT8-quantized with
-    ONNX Runtime's QNN QDQ flow (the Hexagon NPU is an int8 accelerator), then the `onnxruntime-qnn` Execution
-    Provider — which bundles the Qualcomm AI Runtime (QAIRT) libraries — compiles the
-    quantized graph into a QNN context binary embedded in `<stem>_qnn.onnx`. No inference is run.
+    ONNX Runtime's QNN QDQ flow (the Hexagon NPU is an int8 accelerator), then the `onnxruntime-qnn` Execution Provider
+    — which bundles the Qualcomm AI Runtime (QAIRT) libraries — compiles the quantized graph into a QNN context binary
+    embedded in `<stem>_qnn.onnx`. No inference is run.
 
     Args:
         onnx_file (str | Path): Path to the source ONNX file (already exported).
@@ -128,7 +128,9 @@ def onnx2qnn(
             options.add_provider_for_devices(devices, ep_options)
             ort.InferenceSession(str(qdq_file), sess_options=options)
         else:
-            ort.InferenceSession(str(qdq_file), sess_options=options, providers=[ep_name], provider_options=[ep_options])
+            ort.InferenceSession(
+                str(qdq_file), sess_options=options, providers=[ep_name], provider_options=[ep_options]
+            )
     finally:
         if ep_library:
             ort.unregister_execution_provider_library(ep_name)

--- a/ultralytics/utils/export/qnn.py
+++ b/ultralytics/utils/export/qnn.py
@@ -8,16 +8,15 @@ from ultralytics.utils import LOGGER, WINDOWS, YAML
 from ultralytics.utils.checks import check_requirements
 
 
-def qnn_library_paths() -> tuple[str, str]:
+def qnn_library_paths() -> tuple[str | None, str]:
     """Resolve the QNN Execution Provider and HTP backend library paths for the installed onnxruntime-qnn build.
 
-    onnxruntime-qnn ships two ways: the Windows/Linux-aarch64 wheels expose an `onnxruntime_qnn` helper module, while
-    the Linux x86-64 build bundles the libraries in `onnxruntime/capi`. Both register the QNN Execution Provider via
-    `register_execution_provider_library`; only the library locations differ.
+    onnxruntime-qnn ships two ways: plugin builds expose an `onnxruntime_qnn` helper module, while monolithic builds
+    expose `QNNExecutionProvider` directly and bundle the QNN backend libraries in `onnxruntime/capi`.
 
     Returns:
-        (tuple[str, str]): `(ep_library_path, htp_backend_path)` for `register_execution_provider_library` and the QNN
-            HTP `backend_path` provider option.
+        (tuple[str | None, str]): `(ep_library_path, htp_backend_path)`. `ep_library_path` is `None` when QNN is already
+            built into ONNX Runtime and does not need `register_execution_provider_library`.
     """
     try:
         import onnxruntime_qnn as qnn_ep
@@ -27,9 +26,12 @@ def qnn_library_paths() -> tuple[str, str]:
         import onnxruntime
 
         capi = Path(onnxruntime.__file__).parent / "capi"
-        ep_lib = "onnxruntime_providers_qnn.dll" if WINDOWS else "libonnxruntime_providers_qnn.so"
+        if "QNNExecutionProvider" in onnxruntime.get_available_providers():
+            ep_lib = None
+        else:
+            ep_lib = capi / ("onnxruntime_providers_qnn.dll" if WINDOWS else "libonnxruntime_providers_qnn.so")
         htp_lib = "QnnHtp.dll" if WINDOWS else "libQnnHtp.so"
-        return str(capi / ep_lib), str(capi / htp_lib)
+        return str(ep_lib) if ep_lib else None, str(capi / htp_lib)
 
 
 def onnx2qnn(
@@ -44,8 +46,8 @@ def onnx2qnn(
     """Convert an ONNX model to an INT8 Qualcomm QNN context binary using the ONNX Runtime QNN Execution Provider.
 
     The conversion runs entirely on the host with no Qualcomm account or cloud upload. The model is INT8-quantized with
-    ONNX Runtime's QNN QDQ flow (the Hexagon NPU is an int8 accelerator), then the `onnxruntime-qnn` plugin Execution
-    Provider — which bundles the Qualcomm AI Runtime (QAIRT) libraries and is registered at runtime — compiles the
+    ONNX Runtime's QNN QDQ flow (the Hexagon NPU is an int8 accelerator), then the `onnxruntime-qnn` Execution
+    Provider — which bundles the Qualcomm AI Runtime (QAIRT) libraries — compiles the
     quantized graph into a QNN context binary embedded in `<stem>_qnn.onnx`. No inference is run.
 
     Args:
@@ -65,9 +67,7 @@ def onnx2qnn(
         (str): Path to the exported `_qnn_model` directory.
 
     Notes:
-        `onnxruntime-qnn` ships prebuilt wheels for Windows (x64/ARM64) and Linux ARM64 (aarch64) only. There is no
-        Linux x86-64 or macOS wheel — on those hosts build ONNX Runtime from source with `--use_qnn`, or generate the
-        context binary on a supported platform.
+        `onnxruntime-qnn` wheels may expose QNN either as a plugin library or as a built-in ONNX Runtime provider.
     """
     check_requirements("onnxruntime-qnn")
     import onnxruntime as ort
@@ -118,15 +118,20 @@ def onnx2qnn(
     options.add_session_config_entry("ep.context_enable", "1")
     options.add_session_config_entry("ep.context_file_path", str(ctx_file))
     options.add_session_config_entry("ep.context_embed_mode", "1")
-    ort.register_execution_provider_library(ep_name, ep_library)
+    if ep_library:
+        ort.register_execution_provider_library(ep_name, ep_library)
     try:
-        devices = [d for d in ort.get_ep_devices() if d.ep_name == ep_name]
-        if not devices:
-            raise RuntimeError("QNN EP registered but no QNN devices were found by ONNX Runtime.")
-        options.add_provider_for_devices(devices, ep_options)
-        ort.InferenceSession(str(qdq_file), sess_options=options)
+        if ep_library:
+            devices = [d for d in ort.get_ep_devices() if d.ep_name == ep_name]
+            if not devices:
+                raise RuntimeError("QNN EP registered but no QNN devices were found by ONNX Runtime.")
+            options.add_provider_for_devices(devices, ep_options)
+            ort.InferenceSession(str(qdq_file), sess_options=options)
+        else:
+            ort.InferenceSession(str(qdq_file), sess_options=options, providers=[ep_name], provider_options=[ep_options])
     finally:
-        ort.unregister_execution_provider_library(ep_name)
+        if ep_library:
+            ort.unregister_execution_provider_library(ep_name)
 
     if not ctx_file.exists():
         raise RuntimeError(f"QNN context binary was not generated at {ctx_file}. See {prefix} logs for details.")


### PR DESCRIPTION
## Summary
- detect when onnxruntime-qnn already exposes QNNExecutionProvider as a built-in provider
- avoid plugin registration in that case, which fails on Linux x86-64 wheels with undefined symbol CreateEpFactories
- keep plugin registration for wheels that still expose the onnxruntime_qnn helper module

## Validation
- ruff check ultralytics/utils/export/qnn.py
- python -m py_compile ultralytics/utils/export/qnn.py
- Linux amd64 worker-host container with patched qnn.py, onnxruntime-qnn==1.25.0.dev20260330004, and libc++1: yolo export format=qnn model=yolo26n.pt imgsz=32 name=73 succeeded and generated yolo26n_qnn_model

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves Qualcomm QNN export support in Ultralytics by handling both plugin-based and built-in ONNX Runtime QNN setups more reliably 🔧📦

### 📊 Key Changes
- Updated Ultralytics version from `8.4.55` to `8.4.56` 🚀
- Improved QNN library path detection in `ultralytics/utils/export/qnn.py`
  - Now supports both:
    - **plugin-based** `onnxruntime-qnn` installs
    - **built-in** QNN Execution Provider installs in ONNX Runtime
- Changed `qnn_library_paths()` so the execution provider library path can be `None` when QNN is already built into ONNX Runtime
- Added logic to check whether `QNNExecutionProvider` is already available before trying to register an external library
- Updated QNN export flow in `onnx2qnn()`:
  - only registers and unregisters the execution provider library when needed
  - uses the built-in provider directly when available
- Refreshed docstrings and comments to reflect the broader range of supported ONNX Runtime QNN packaging styles 📝

### 🎯 Purpose & Impact
- Makes QNN export more robust across different ONNX Runtime builds and environments ✅
- Reduces failures caused by assuming QNN is always provided as a separate plugin library
- Improves compatibility for users working with Qualcomm deployment workflows, especially on systems where QNN support is bundled directly into ONNX Runtime 🤖
- Simplifies maintenance by supporting multiple packaging formats with one code path
- For users exporting models to Qualcomm hardware, this should mean smoother, more reliable QNN context generation with fewer setup-specific issues ⚡