### PR TITLE
Fix semantic segmentation mask offset from sub-pixel LetterBox padding

### DIFF
--- a/ultralytics/models/yolo/semantic/predict.py
+++ b/ultralytics/models/yolo/semantic/predict.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import torch
+import torch.nn.functional as F
 
 from ultralytics.engine.predictor import BasePredictor
 from ultralytics.engine.results import Results
@@ -57,8 +58,12 @@ class SemanticSegmentationPredictor(BasePredictor):
         results = []
         for i, (pred, orig_img) in enumerate(zip(preds, orig_imgs)):
             img_path = self.batch[0][i] if isinstance(self.batch[0], list) else self.batch[0]
-            # pred: [nc, H, W] logits on letterboxed input. Remove padding, then resize to original image.
-            pred = ops.scale_masks(pred.unsqueeze(0), orig_img.shape[:2])[0]
+            pred = pred.unsqueeze(0).float()
+            # Upsample pred to the model input resolution first so LetterBox padding is an integer in this space
+            if pred.shape[2:] != img.shape[2:]:
+                pred = F.interpolate(pred, img.shape[2:], mode="bilinear")
+            # scale_masks then crops it cleanly without the sub-pixel asymmetry
+            pred = ops.scale_masks(pred, orig_img.shape[:2])[0]
             dtype = self._class_map_dtype(max(pred.shape[0], 2))
             class_map = pred.argmax(0).to(dtype) if pred.shape[0] > 1 else pred.gt(0).squeeze(0).to(dtype)
             results.append(Results(orig_img, path=img_path, names=self.model.names, semantic_mask=class_map))


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves semantic segmentation postprocessing by resizing predictions more carefully before removing padding, leading to cleaner and more accurate masks on original images.

### 📊 Key Changes
- Added `torch.nn.functional as F` to use interpolation during semantic prediction postprocessing.
- Updated `semantic/predict.py` so segmentation outputs are first converted to float and expanded with `unsqueeze(0)`.
- Added a step to upsample predictions to the model input resolution with `F.interpolate(..., mode="bilinear")` when needed.
- Kept `ops.scale_masks(...)` for final resizing back to the original image, but now after aligning predictions to the input size first.
- Included comments explaining that this avoids padding-related sub-pixel asymmetry during mask cropping.

### 🎯 Purpose & Impact
- 🎯 Fixes a subtle mask alignment issue in semantic segmentation predictions, especially around image borders and padded regions.
- 🖼️ Produces more accurate semantic masks when mapping model outputs back to the original image size.
- 📏 Makes postprocessing more consistent when prediction resolution does not exactly match the input image resolution.
- 👥 Benefits users by improving output quality without changing the public API or requiring workflow changes.
- 🚀 Helps make semantic segmentation results in Ultralytics more reliable for real-world inference and visualization.