### PR TITLE
Fix mutable default args in metrics and tal

### DIFF
--- a/docs/en/integrations/deepx.md
+++ b/docs/en/integrations/deepx.md
@@ -193,12 +193,12 @@ Verify the runtime is installed correctly with `dxrt-cli --version`. You should 
 ```sh
 DXRT v3.3.2
 Minimum Driver Versions
-  Device Driver: v2.4.0
-  PCIe Driver: v2.2.0
-  Firmware: v2.5.2
+Device Driver: v2.4.0
+PCIe Driver: v2.2.0
+Firmware: v2.5.2
 Minimum Compiler Versions
-  Compiler: v1.18.1
-  .dxnn File Format: v6
+Compiler: v1.18.1
+.dxnn File Format: v6
 ```
 
 Once the runtime is installed, run inference and validation on your DeepX device exactly as shown in the [Usage](#usage) section above — the exported `_deepx_model` loads directly with `YOLO(...)`.

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -220,6 +220,9 @@ chr043416@gmail.com:
 davis.justin@mssm.org:
   avatar: https://avatars.githubusercontent.com/u/23462437?v=4
   username: justincdavis
+dgkim@deepx.ai:
+  avatar: null
+  username: null
 esat@ultralytics.com:
   avatar: https://avatars.githubusercontent.com/u/43647848?v=4
   username: artest08

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -943,8 +943,7 @@ def test_metrics_names_default_isolation():
 
 
 def test_tal_assigner_stride_default_isolation():
-    """Each TaskAlignedAssigner instance with default `stride` must get its own list, not a shared module-level default.
-    """
+    """Each TaskAlignedAssigner instance with default `stride` must get its own list, not a shared module-level default."""
     from ultralytics.utils.tal import TaskAlignedAssigner
 
     a, b = TaskAlignedAssigner(), TaskAlignedAssigner()

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -940,3 +940,13 @@ def test_metrics_names_default_isolation():
         assert a.names is not b.names, f"{cls.__name__} shares default names dict across instances"
         a.names[0] = "mutated"
         assert 0 not in b.names, f"{cls.__name__} mutation in one instance leaked into another"
+
+
+def test_tal_assigner_stride_default_isolation():
+    """Each TaskAlignedAssigner instance with default `stride` must get its own list, not a shared module-level default."""
+    from ultralytics.utils.tal import TaskAlignedAssigner
+
+    a, b = TaskAlignedAssigner(), TaskAlignedAssigner()
+    assert a.stride is not b.stride, "TaskAlignedAssigner shares default stride list across instances"
+    a.stride.append(64)
+    assert 64 not in b.stride, "TaskAlignedAssigner mutation in one instance leaked into another"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -929,3 +929,14 @@ def test_semantic_polygon_data():
     model = YOLO("yolo26n-sem.pt")
     model.train(data="coco8-seg.yaml", epochs=1, imgsz=32, close_mosaic=1)
     model.val(data="coco8-seg.yaml")
+
+
+def test_metrics_names_default_isolation():
+    """Each metrics instance with default `names` must get its own dict, not a shared module-level default."""
+    from ultralytics.utils.metrics import ConfusionMatrix, DetMetrics, OBBMetrics, PoseMetrics, SegmentMetrics
+
+    for cls in (ConfusionMatrix, DetMetrics, SegmentMetrics, PoseMetrics, OBBMetrics):
+        a, b = cls(), cls()
+        assert a.names is not b.names, f"{cls.__name__} shares default names dict across instances"
+        a.names[0] = "mutated"
+        assert 0 not in b.names, f"{cls.__name__} mutation in one instance leaked into another"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -943,7 +943,8 @@ def test_metrics_names_default_isolation():
 
 
 def test_tal_assigner_stride_default_isolation():
-    """Each TaskAlignedAssigner instance with default `stride` must get its own list, not a shared module-level default."""
+    """Each TaskAlignedAssigner instance with default `stride` must get its own list, not a shared module-level default.
+    """
     from ultralytics.utils.tal import TaskAlignedAssigner
 
     a, b = TaskAlignedAssigner(), TaskAlignedAssigner()

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -340,7 +340,7 @@ class ConfusionMatrix(DataExportMixin):
         matches (dict | None): Contains the indices of ground truths and predictions categorized into TP, FP and FN.
     """
 
-    def __init__(self, names: dict[int, str] = {}, task: str = "detect", save_matches: bool = False):
+    def __init__(self, names: dict[int, str] | None = None, task: str = "detect", save_matches: bool = False):
         """Initialize a ConfusionMatrix instance.
 
         Args:
@@ -348,6 +348,7 @@ class ConfusionMatrix(DataExportMixin):
             task (str, optional): Type of task, either 'detect' or 'classify'.
             save_matches (bool, optional): Save the indices of GTs, TPs, FPs, FNs for visualization.
         """
+        names = names if names is not None else {}
         self.task = task
         self.nc = len(names)  # number of classes
         self.matrix = (
@@ -668,7 +669,7 @@ def plot_pr_curve(
     py: np.ndarray,
     ap: np.ndarray,
     save_dir: Path = Path("pr_curve.png"),
-    names: dict[int, str] = {},
+    names: dict[int, str] | None = None,
     on_plot=None,
 ):
     """Plot precision-recall curve.
@@ -683,6 +684,7 @@ def plot_pr_curve(
     """
     import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
 
+    names = names if names is not None else {}
     fig, ax = plt.subplots(1, 1, figsize=(9, 6), tight_layout=True)
     py = np.stack(py, axis=1)
 
@@ -712,7 +714,7 @@ def plot_mc_curve(
     px: np.ndarray,
     py: np.ndarray,
     save_dir: Path = Path("mc_curve.png"),
-    names: dict[int, str] = {},
+    names: dict[int, str] | None = None,
     xlabel: str = "Confidence",
     ylabel: str = "Metric",
     on_plot=None,
@@ -730,6 +732,7 @@ def plot_mc_curve(
     """
     import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
 
+    names = names if names is not None else {}
     fig, ax = plt.subplots(1, 1, figsize=(9, 6), tight_layout=True)
 
     if 0 < len(names) < 21:  # display per-class legend if < 21 classes
@@ -793,7 +796,7 @@ def ap_per_class(
     plot: bool = False,
     on_plot=None,
     save_dir: Path = Path(),
-    names: dict[int, str] = {},
+    names: dict[int, str] | None = None,
     eps: float = 1e-16,
     prefix: str = "",
 ) -> tuple:
@@ -825,6 +828,7 @@ def ap_per_class(
         x (np.ndarray): X-axis values for the curves.
         prec_values (np.ndarray): Precision values at mAP@0.5 for each class.
     """
+    names = names if names is not None else {}
     # Sort by objectness
     i = np.argsort(-conf)
     tp, conf, pred_cls = tp[i], conf[i], pred_cls[i]
@@ -1114,13 +1118,13 @@ class DetMetrics(SimpleClass, DataExportMixin):
         summary: Generate a summarized representation of per-class detection metrics as a list of dictionaries.
     """
 
-    def __init__(self, names: dict[int, str] = {}) -> None:
+    def __init__(self, names: dict[int, str] | None = None) -> None:
         """Initialize a DetMetrics instance with class names.
 
         Args:
             names (dict[int, str], optional): Dictionary of class names.
         """
-        self.names = names
+        self.names = names if names is not None else {}
         self.box = Metric()
         self.speed = {"preprocess": 0.0, "inference": 0.0, "loss": 0.0, "postprocess": 0.0}
         self.stats = dict(tp=[], conf=[], pred_cls=[], target_cls=[], target_img=[])
@@ -1283,7 +1287,7 @@ class SegmentMetrics(DetMetrics):
         summary: Generate a summarized representation of per-class segmentation metrics as a list of dictionaries.
     """
 
-    def __init__(self, names: dict[int, str] = {}) -> None:
+    def __init__(self, names: dict[int, str] | None = None) -> None:
         """Initialize a SegmentMetrics instance with class names.
 
         Args:
@@ -1434,7 +1438,7 @@ class PoseMetrics(DetMetrics):
         summary: Generate a summarized representation of per-class pose metrics as a list of dictionaries.
     """
 
-    def __init__(self, names: dict[int, str] = {}) -> None:
+    def __init__(self, names: dict[int, str] | None = None) -> None:
         """Initialize the PoseMetrics class with class names.
 
         Args:
@@ -1658,7 +1662,7 @@ class OBBMetrics(DetMetrics):
         https://arxiv.org/pdf/2106.06072.pdf
     """
 
-    def __init__(self, names: dict[int, str] = {}) -> None:
+    def __init__(self, names: dict[int, str] | None = None) -> None:
         """Initialize an OBBMetrics instance with class names.
 
         Args:

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -34,7 +34,7 @@ class TaskAlignedAssigner(nn.Module):
         num_classes: int = 80,
         alpha: float = 1.0,
         beta: float = 6.0,
-        stride: list = [8, 16, 32],
+        stride: list | None = None,
         eps: float = 1e-9,
         topk2=None,
     ):
@@ -55,7 +55,7 @@ class TaskAlignedAssigner(nn.Module):
         self.num_classes = num_classes
         self.alpha = alpha
         self.beta = beta
-        self.stride = stride
+        self.stride = stride if stride is not None else [8, 16, 32]
         self.stride_val = self.stride[1] if len(self.stride) > 1 else self.stride[0]
         self.eps = eps
 


### PR DESCRIPTION
## summary

`ConfusionMatrix`, `DetMetrics`, `SegmentMetrics`, `PoseMetrics`, `OBBMetrics` and the helpers `ap_per_class`, `plot_pr_curve`, `plot_mc_curve` in `ultralytics/utils/metrics.py` declared `names: dict[int, str] = {}` as a default. `TaskAlignedAssigner` in `ultralytics/utils/tal.py` declared `stride: list = [8, 16, 32]` the same way. Python evaluates default args once at definition, so every instance using the default shared the same dict / list and a mutation in one leaked into all others. Production callers in `utils/loss.py:365,997` always override `stride` explicitly, so the assigner case is latent on the hot loss path, but the metrics case actively contaminates class-name maps across runs in any long-lived process. Replaced all 9 sites with `dict[int, str] | None = None` / `list | None = None` plus `x if x is not None else <default>` normalization inside the body, and added two regression tests asserting two default-constructed instances do not share their underlying mutable state.