### PR TITLE
Skip format and docs workflows on bot pushes to break auto-format loop

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,8 @@ permissions:
 
 jobs:
   Docs:
-    if: github.repository == 'ultralytics/ultralytics'
+    # Skip self-triggered runs from UltralyticsAssistant PAT pushes to break Auto-format <-> Auto-update-Docs loop.
+    if: github.repository == 'ultralytics/ultralytics' && github.actor != 'UltralyticsAssistant' && github.triggering_actor != 'UltralyticsAssistant'
     runs-on: ubuntu-latest
     env:
       GITHUB_REF: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,6 +20,8 @@ permissions:
 
 jobs:
   actions:
+    # Skip self-triggered runs from UltralyticsAssistant PAT pushes to break Auto-format <-> Auto-update-Docs loop.
+    if: github.actor != 'UltralyticsAssistant' && github.triggering_actor != 'UltralyticsAssistant'
     runs-on: ubuntu-latest
     steps:
       - name: Run Ultralytics Actions

--- a/docs/en/integrations/deepx.md
+++ b/docs/en/integrations/deepx.md
@@ -193,12 +193,12 @@ Verify the runtime is installed correctly with `dxrt-cli --version`. You should 
 ```sh
 DXRT v3.3.2
 Minimum Driver Versions
-  Device Driver: v2.4.0
-  PCIe Driver: v2.2.0
-  Firmware: v2.5.2
+Device Driver: v2.4.0
+PCIe Driver: v2.2.0
+Firmware: v2.5.2
 Minimum Compiler Versions
-  Compiler: v1.18.1
-  .dxnn File Format: v6
+Compiler: v1.18.1
+.dxnn File Format: v6
 ```
 
 Once the runtime is installed, run inference and validation on your DeepX device exactly as shown in the [Usage](#usage) section above — the exported `_deepx_model` loads directly with `YOLO(...)`.


### PR DESCRIPTION
## summary

`.github/workflows/format.yml` (Ultralytics Actions) and `.github/workflows/docs.yml` (Publish Docs) both auto-commit on PR push under `UltralyticsAssistant` via `secrets._GITHUB_TOKEN` (a PAT). PAT pushes re-trigger workflows, and each bot commit fires another run of both workflows. The defensive two-deep loop guard inside `ultralytics/actions` counts only `Auto-format` commit messages, so the interleaving `Auto-update Ultralytics Docs Reference` commit from `docs.yml` keeps the counter stuck at 1 and the guard never fires. On PR #24629 the result was 5+ Auto-format / Auto-update-Docs cycles in 10 minutes before the maintainer closed the PR. Adds a job-level `if: github.actor != 'UltralyticsAssistant' && github.triggering_actor != 'UltralyticsAssistant'` to both workflows. Verified empirically against PR #24629 workflow runs: both fields resolve to `UltralyticsAssistant` on every bot-triggered re-run, so the gate blocks the loop without affecting any human-triggered run.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR prevents GitHub Actions from triggering themselves in a loop and makes a small formatting cleanup in the DeepX documentation.

### 📊 Key Changes
- 🛑 Updated `.github/workflows/docs.yml` to skip the docs workflow when the run is triggered by `UltralyticsAssistant`.
- 🔁 Updated `.github/workflows/format.yml` with the same safeguard to prevent the formatting workflow from re-triggering itself.
- 💬 Added comments in both workflow files explaining that these checks are meant to break the auto-format ↔ auto-docs update loop.
- 🧹 Cleaned up indentation in `docs/en/integrations/deepx.md` so version information displays more consistently in the rendered docs.

### 🎯 Purpose & Impact
- ⚙️ Prevents unnecessary self-triggered CI/CD runs, reducing wasted GitHub Actions time and avoiding automation loops.
- 🚀 Makes repository automation more stable and predictable, especially for bot-driven updates.
- 👀 Improves maintainability by clearly documenting why these workflow conditions exist.
- 📘 Slightly improves documentation readability for DeepX users, with no functional changes to the integration itself.