### PR TITLE
Change CI OS from cpu-latest to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         # Temporarily disable windows-latest due to https://github.com/ultralytics/ultralytics/actions/runs/13020330819/job/36319338854?pr=18921
-        os: [cpu-latest, macos-26, ubuntu-24.04-arm]
+        os: [ubuntu-latest, macos-26, ubuntu-24.04-arm]
         python: ["3.12"]
         model: [yolo26n]
     steps:

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -1,3 +1,6 @@
+100015821+Sunny11092003@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/100015821?v=4
+  username: Sunny11092003
 107626595+pderrenger@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/107626595?v=4
   username: pderrenger


### PR DESCRIPTION
Updated the CI workflow to use 'ubuntu-latest' instead of 'cpu-latest'.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes a small but useful maintenance update by restoring `ubuntu-latest` in CI testing and adding a new GitHub author mapping for documentation attribution.

### 📊 Key Changes
- 🔄 Updated the GitHub Actions CI matrix in `.github/workflows/ci.yml`
  - Replaced `cpu-latest` with `ubuntu-latest` in the test OS list
  - Kept `macos-26` and `ubuntu-24.04-arm` in the matrix
  - Windows remains temporarily disabled due to an existing CI issue
- 👤 Added a new entry to `docs/mkdocs_github_authors.yaml`
  - Maps the GitHub noreply email for a contributor to the username `Sunny11092003`
  - Includes the contributor avatar for proper docs site attribution

### 🎯 Purpose & Impact
- ✅ Improves CI reliability and clarity by using the standard `ubuntu-latest` runner instead of `cpu-latest`
- 🚀 Helps ensure automated tests run in a more typical GitHub Actions Linux environment
- 🙌 Improves documentation contributor recognition by correctly linking commits to the right GitHub profile
- 🔧 Overall, this is a lightweight infrastructure and docs-maintenance PR with no direct effect on YOLO model behavior or user-facing features