### PR TITLE
Fix issue 24607

### DIFF
--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -1005,3 +1005,9 @@ sudo apt-get install -y tensorrt
 ```
 
 After upgrading, re-run your export. For more details, see [GitHub issue #23841](https://github.com/ultralytics/ultralytics/issues/23841).
+
+### Why should I set end2end=False when exporting ONNX for older Jetson TensorRT versions?
+
+When converting a .pth model to ONNX on a host machine, and the ONNX model will later be converted to a TensorRT engine on an older Jetson device (for example, Jetson Nano or Jetson TX2), please check the TensorRT version on the target device first.
+
+If the TensorRT version is older than 8.5.0, set end2end=False when exporting ONNX. Older TensorRT versions do not support the Mod operator required by end-to-end models, which can cause the TensorRT engine export to fail.

--- a/docs/en/integrations/tensorrt.md
+++ b/docs/en/integrations/tensorrt.md
@@ -611,3 +611,7 @@ Performance improvements with TensorRT can vary based on the hardware used. Here
 Detailed performance benchmarks for different hardware configurations can be found in the [performance section](#ultralytics-yolo-tensorrt-export-performance).
 
 For more comprehensive insights into TensorRT performance, refer to the [Ultralytics documentation](../modes/export.md) and our performance analysis reports.
+
+### Why does exporting disable end2end when TensorRT is less than 8.5.0?
+
+Exporting disables the end-to-end mode for TensorRT versions earlier than 8.5.0 due to the lack of support for the Mod operator. To enable end-to-end export, upgrade TensorRT to 8.5.0 or later.

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -350,13 +350,22 @@ class Exporter:
                 # Disable end2end branch for certain export formats as they does not support topk
                 model.end2end = False
                 LOGGER.warning(f"{fmt.upper()} export does not support end2end models, disabling end2end branch.")
-            if fmt == "engine" and self.args.int8:
-                # TensorRT 10.3.0 on JetPack 6 with int8 has known end2end build issues
-                # https://github.com/ultralytics/ultralytics/issues/23841
+            if fmt == "engine":
                 try:
                     import tensorrt as trt
 
-                    if check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
+                    if check_version(trt.__version__, "<8.5.0"):
+                        # TensorRT versions earlier than 8.5.0 do not support the Mod operator in end-to-end models
+                        # https://github.com/ultralytics/ultralytics/issues/24607
+                        model.end2end = False
+                        LOGGER.warning(
+                            "TensorRT versions earlier than 8.5.0 do not support the Mod operator in end-to-end models, disabling the end2end branch. "
+                            "Please upgrade TensorRT to 8.5.0 or later to enable end2end export."
+                        )
+
+                    if self.args.int8 and check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
+                        # TensorRT 10.3.0 on JetPack 6 with int8 has known end2end build issues
+                        # https://github.com/ultralytics/ultralytics/issues/23841
                         model.end2end = False
                         LOGGER.warning(
                             "TensorRT 10.3.0 on JetPack 6 with int8 has known end2end build issues, disabling end2end branch. "


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves TensorRT export compatibility by automatically disabling `end2end` for TensorRT versions earlier than 8.5.0 and documenting the behavior for older Jetson devices ⚙️📘

### 📊 Key Changes
- Updated `ultralytics/engine/exporter.py` to detect TensorRT versions earlier than 8.5.0 during `engine` export.
- Automatically sets `model.end2end = False` for older TensorRT versions because they do not support the required `Mod` operator.
- Preserved the existing JetPack 6 + TensorRT 10.3.0 + INT8 safeguard, now nested under the broader TensorRT engine export logic.
- Added Jetson guide documentation explaining when and why to use `end2end=False` for older devices such as Jetson Nano and Jetson TX2.
- Added TensorRT integration documentation clarifying why end-to-end export is disabled for TensorRT versions earlier than 8.5.0.

### 🎯 Purpose & Impact
- Prevents TensorRT engine export failures on older Jetson and TensorRT environments 🛠️
- Makes export behavior more predictable by handling an important compatibility edge case automatically.
- Reduces user confusion with clearer warnings and targeted documentation updates.
- Improves the export experience for embedded deployments, especially on legacy Jetson hardware 🚀