### PR TITLE
Fix segment2box dropping polygon vertices on image border

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -85,14 +85,11 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
         (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
     """
     x, y = segment.T  # segment xy
-    # Track points that need clipping (outside the image) so they are excluded after being snapped to the border,
-    # while points that natively lie on the border are kept.
-    snapped = (x < 0) | (x > width) | (y < 0) | (y > height)
     # Clip coordinates if 3 out of 4 sides are outside the image
     if np.array([x.min() < 0, y.min() < 0, x.max() > width, y.max() > height]).sum() >= 3:
         x = x.clip(0, width)
         y = y.clip(0, height)
-    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height) & ~snapped
+    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
     x = x[inside]
     y = y[inside]
     return (

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -85,11 +85,14 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
         (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
     """
     x, y = segment.T  # segment xy
+    # Track points that need clipping (outside the image) so they are excluded after being snapped to the border,
+    # while points that natively lie on the border are kept.
+    snapped = (x < 0) | (x > width) | (y < 0) | (y > height)
     # Clip coordinates if 3 out of 4 sides are outside the image
     if np.array([x.min() < 0, y.min() < 0, x.max() > width, y.max() > height]).sum() >= 3:
         x = x.clip(0, width)
         y = y.clip(0, height)
-    inside = (x > 0) & (y > 0) & (x < width) & (y < height)
+    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height) & ~snapped
     x = x[inside]
     y = y[inside]
     return (


### PR DESCRIPTION
## summary

`segment2box` switched to strict inequalities in #23602, which drops polygon vertices that natively lie on an image edge. for polygons that always touch the frame border (e.g. a `ground` class in segmentation training), the resulting bbox collapses on that axis and `RandomPerspective.apply_segments` then clips the polygon to a zero-height region, training the model on a 1-pixel-tall mask.

reverts the boundary check to inclusive comparisons. the original target of #23596 (a polygon entirely outside the image producing a degenerate clipped bbox) is already filtered downstream by `box_candidates` (`wh_thr=2`), so the inclusive form does not regress training. enclosing and crossing polygons whose vertices are all outside the image continue to produce a real image-space bbox under inclusive comparisons.

closes #24638

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐛 This PR fixes a small but important boundary-handling bug in `segment2box()`, ensuring segmentation points exactly on the image edge are included when generating bounding boxes.

### 📊 Key Changes
- Updated the `inside` check in `ultralytics/utils/ops.py` for `segment2box()`.
- Changed boundary conditions from strict comparisons (`> 0`, `< width`, `< height`) to inclusive comparisons (`>= 0`, `<= width`, `<= height`).
- As a result, points lying exactly on the image borders are now treated as valid instead of being incorrectly discarded.

### 🎯 Purpose & Impact
- ✅ Improves accuracy when converting segmentation masks or polygon segments into bounding boxes.
- 🖼️ Prevents edge-aligned objects from being slightly cropped or misrepresented.
- 🔧 Fixes a subtle corner-case bug that can affect datasets with annotations touching image boundaries.
- 🚀 Makes preprocessing and label handling more robust, especially for segmentation workflows in Ultralytics models like YOLO11 and YOLO26.