### PR TITLE
Fix asymmetric eps protection in bbox_iou xyxy branch

### DIFF
--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -139,8 +139,8 @@ def bbox_iou(
     else:  # x1, y1, x2, y2 = box1
         b1_x1, b1_y1, b1_x2, b1_y2 = box1.chunk(4, -1)
         b2_x1, b2_y1, b2_x2, b2_y2 = box2.chunk(4, -1)
-        w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps
-        w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1 + eps
+        w1, h1 = (b1_x2 - b1_x1 + eps), (b1_y2 - b1_y1 + eps)
+        w2, h2 = (b2_x2 - b2_x1 + eps), (b2_y2 - b2_y1 + eps)
 
     # Intersection area
     inter = (b1_x2.minimum(b2_x2) - b1_x1.maximum(b2_x1)).clamp_(0) * (


### PR DESCRIPTION
## Summary

Fix operator-precedence bug in `bbox_iou` xyxy branch where `eps` was silently applied only to `h`, not `w`, due to tuple-unpacking precedence: `w, h = a - b, c - d + eps` parses as `(a - b, c - d + eps)`. Wrapping each pair in parentheses restores the documented symmetric eps protection on width and height for both boxes.

No behaviour change on normal boxes (eps² ≈ 1e-14 noise). On strictly degenerate xyxy boxes (`w=0` and `h=0`), CIoU now uses `atan(1)` instead of `atan(0)` in the aspect-ratio term, matching the docstring's "avoid division by zero" intent.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐛 This PR fixes a small but important bug in bounding box IoU calculation by ensuring both width and height include numerical stability protection.

### 📊 Key Changes
- Updated `bbox_iou()` in `ultralytics/utils/metrics.py` to add `eps` to **both** box width and height when boxes are provided in `x1, y1, x2, y2` format.
- Previously, `eps` was only applied to height in this branch, while width could still become zero and cause unstable calculations.
- The change makes width/height handling consistent with the rest of the IoU computation logic. ✅

### 🎯 Purpose & Impact
- Improves numerical stability in IoU-related metrics and loss calculations. 📈
- Reduces the chance of edge-case issues when boxes have zero or near-zero width. 🛡️
- Helps make training and evaluation more reliable, especially for unusual or degenerate bounding boxes. 🎯
- This is a low-risk fix with potentially meaningful impact on robustness, but no expected changes for most normal workloads. 👍