### PR TITLE
Fix SAM model list and default output dir in auto-annotate docs

### DIFF
--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -132,7 +132,7 @@ To auto-annotate your dataset using the Ultralytics framework, you can use the `
 
 {% include "macros/sam-auto-annotate.md" %}
 
-The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pretrained detection models i.e. [YOLO26](../../models/yolo26.md), [YOLO11](../../models/yolo11.md) or other [models](../../models/index.md) and segmentation models i.e, [SAM](../../models/sam.md), [SAM2](../../models/sam-2.md) or [MobileSAM](../../models/mobile-sam.md), the device to run the models on, and the output directory for saving the annotated results.
+The `auto_annotate` function takes the path to your images, along with optional arguments for specifying the pretrained detection models, e.g. [YOLO26](../../models/yolo26.md), [YOLO11](../../models/yolo11.md), or other [models](../../models/index.md), and segmentation models, e.g. [SAM](../../models/sam.md), [SAM 2](../../models/sam-2.md), [MobileSAM](../../models/mobile-sam.md), or [SAM 3](../../models/sam-3.md), the device to run the models on, and the output directory for saving the annotated results.
 
 By leveraging the power of pretrained models, auto-annotation can significantly reduce the time and effort required for creating high-quality segmentation datasets. This feature is particularly useful for researchers and developers working with large image collections, as it allows them to focus on model development and evaluation rather than manual annotation.
 

--- a/docs/macros/sam-auto-annotate.md
+++ b/docs/macros/sam-auto-annotate.md
@@ -2,11 +2,11 @@
 | ------------ | ----------- | -------------- | ------------------------------------------------------------------------------------ |
 | `data`       | `str`       | required       | Path to directory containing target images for annotation or segmentation.           |
 | `det_model`  | `str`       | `'yolo26x.pt'` | YOLO detection model path for initial object detection.                              |
-| `sam_model`  | `str`       | `'sam_b.pt'`   | SAM model path for segmentation (supports SAM, SAM2 variants, and MobileSAM models). |
+| `sam_model`  | `str`       | `'sam_b.pt'`   | SAM model path for segmentation (supports SAM, SAM 2, MobileSAM, and SAM 3 weights). |
 | `device`     | `str`       | `''`           | Computation device (e.g., 'cuda:0', 'cpu', or '' for automatic device detection).    |
 | `conf`       | `float`     | `0.25`         | YOLO detection confidence threshold for filtering weak detections.                   |
 | `iou`        | `float`     | `0.45`         | IoU threshold for Non-Maximum Suppression to filter overlapping boxes.               |
 | `imgsz`      | `int`       | `640`          | Input size for resizing images (must be multiple of 32).                             |
 | `max_det`    | `int`       | `300`          | Maximum number of detections per image for memory efficiency.                        |
 | `classes`    | `list[int]` | `None`         | List of class indices to detect (e.g., `[0, 1]` for person & bicycle).               |
-| `output_dir` | `str`       | `None`         | Save directory for annotations (defaults to './labels' relative to data path).       |
+| `output_dir` | `str`       | `None`         | Save directory for annotations (default: `<data>_auto_annotate_labels` sibling).     |


### PR DESCRIPTION
## summary

The shared `docs/macros/sam-auto-annotate.md` table (included on `sam.md`, `sam-2.md`, `mobile-sam.md`, and `datasets/segment/index.md`) omitted SAM 3 from the `sam_model` supported list and documented the wrong default for `output_dir`. The actual default is `<data.parent>/<data.stem>_auto_annotate_labels`, not `./labels`, and SAM 3 weights dispatch correctly through `auto_annotate` in bbox-prompted mode via the `is_sam3` flag in `ultralytics/models/sam/model.py`. Wrapped the `<data>` placeholder in backticks so it renders as inline code instead of being parsed as an HTML element, and aligned the parallel prose paragraph on `docs/en/datasets/segment/index.md` to mention SAM 3 and fix `i.e.`/`i.e,` inconsistency.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the segmentation dataset docs to clarify `auto_annotate` model support, including SAM 3, and corrects the documented default output location.

### 📊 Key Changes
- 📚 Updated the `auto_annotate` documentation to explicitly list supported segmentation models more clearly:
  - [YOLO26](../../models/yolo26.md), [YOLO11](../../models/yolo11.md), and other detection models
  - [SAM](../../models/sam.md), [SAM 2](../../models/sam-2.md), [MobileSAM](../../models/mobile-sam.md), and now [SAM 3](../../models/sam-3.md)
- ✏️ Improved wording and punctuation in the docs for better readability and consistency.
- 🏷️ Revised the parameter description for `sam_model` to note support for **SAM 3 weights**.
- 📁 Corrected the `output_dir` description:
  - Previously described as saving to `./labels`
  - Now documented as saving to a **sibling folder named like `<data>_auto_annotate_labels`** by default

### 🎯 Purpose & Impact
- ✅ Helps users better understand which models can be used with `auto_annotate`, especially with the addition of **SAM 3** support.
- 🔍 Reduces confusion around where auto-generated annotations are saved, making the feature easier to use in practice.
- 📖 Improves overall documentation accuracy and clarity, which benefits both new users and experienced developers working with segmentation datasets.
- 🚀 Makes the auto-annotation workflow easier to adopt for creating segmentation datasets with Ultralytics tools.