### PR TITLE
Fix classification cache='ram' leak via shared memory tensor

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -745,7 +745,9 @@ def test_classify_cache_ram_exif(tmp_path):
     exif = img.getexif()
     exif[274] = 6  # Orientation tag
     img.save(root / "c0" / "exif6.jpg", exif=exif, quality=95)
-    Image.fromarray(np.random.RandomState(0).randint(0, 255, (100, 100, 3), dtype=np.uint8)).save(root / "c0" / "sq.png")
+    Image.fromarray(np.random.RandomState(0).randint(0, 255, (100, 100, 3), dtype=np.uint8)).save(
+        root / "c0" / "sq.png"
+    )
 
     def build(cache):
         args = get_cfg(DEFAULT_CFG)
@@ -754,11 +756,15 @@ def test_classify_cache_ram_exif(tmp_path):
 
     ram, off = build("ram"), build(False)
     assert ram.cache_ram and ram.img_cache is not None, "RAM cache was not built"
+
     def name2idx(ds):
         return {Path(ds.samples[i][0]).name: i for i in range(len(ds.samples))}
+
     nr, nf = name2idx(ram), name2idx(off)
     for name in ("exif6.jpg", "sq.png"):
-        assert torch.equal(ram[nr[name]]["img"], off[nf[name]]["img"]), f"cache='ram' differs from cache=False for {name}"
+        assert torch.equal(ram[nr[name]]["img"], off[nf[name]]["img"]), (
+            f"cache='ram' differs from cache=False for {name}"
+        )
 
 
 @pytest.mark.slow

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -729,6 +729,38 @@ def test_classify_transforms_train(image, auto_augment, erasing, force_color_jit
     assert transformed_image.dtype == torch.float32
 
 
+def test_classify_cache_ram_exif(tmp_path):
+    """Verify classification cache='ram' yields images identical to cache=False, including EXIF-rotated ones."""
+    from ultralytics.cfg import get_cfg
+    from ultralytics.data.dataset import ClassificationDataset
+    from ultralytics.utils import DEFAULT_CFG
+
+    root = tmp_path / "cls"
+    (root / "c0").mkdir(parents=True)
+    # EXIF orientation 6 (90 deg) on a non-square image: cv2.imread applies it, PIL .size does not
+    arr = np.zeros((80, 120, 3), dtype=np.uint8)
+    arr[:, :60] = (200, 50, 10)
+    arr[20:, :] = (10, 50, 200)
+    img = Image.fromarray(arr)
+    exif = img.getexif()
+    exif[274] = 6  # Orientation tag
+    img.save(root / "c0" / "exif6.jpg", exif=exif, quality=95)
+    Image.fromarray(np.random.RandomState(0).randint(0, 255, (100, 100, 3), dtype=np.uint8)).save(root / "c0" / "sq.png")
+
+    def build(cache):
+        args = get_cfg(DEFAULT_CFG)
+        args.cache, args.imgsz, args.fraction = cache, 64, 1.0
+        return ClassificationDataset(str(root), args, augment=False)  # val transforms are deterministic
+
+    ram, off = build("ram"), build(False)
+    assert ram.cache_ram and ram.img_cache is not None, "RAM cache was not built"
+    def name2idx(ds):
+        return {Path(ds.samples[i][0]).name: i for i in range(len(ds.samples))}
+    nr, nf = name2idx(ram), name2idx(off)
+    for name in ("exif6.jpg", "sq.png"):
+        assert torch.equal(ram[nr[name]]["img"], off[nf[name]]["img"]), f"cache='ram' differs from cache=False for {name}"
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(IS_RASPBERRYPI or IS_JETSON, reason="Edge devices not intended for tuning")
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -995,8 +995,9 @@ class ClassificationDataset:
         self.img_cache = None
         self.img_offsets = None
         self.img_shapes = None
-        # safety_margin=1.0 budgets ~2x cache size to accommodate streaming overhead (heap fragmentation
-        # from per-image cv2 decode allocations is not promptly returned to the OS by some allocators).
+        # safety_margin=1.0 budgets ~2x the cache estimate: headroom for the 30-image sampling variance plus the
+        # transient decode + shared-memory copy during the two-pass build (cache holds originals, so peak ~1.1x;
+        # the extra margin is conservative since cls images are full-resolution and /dev/shm-bound on Linux).
         if self.cache_ram and not self.check_cache_ram(safety_margin=1.0):
             self.cache_ram = False
         if self.cache_ram:

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import random
 from collections import defaultdict
 from itertools import repeat
 from multiprocessing.pool import ThreadPool
@@ -987,15 +988,19 @@ class ClassificationDataset:
             self.samples = self.samples[: round(len(self.samples) * args.fraction)]
         self.prefix = colorstr(f"{prefix}: ") if prefix else ""
         self.cache_ram = args.cache is True or str(args.cache).lower() == "ram"  # cache images into RAM
-        if self.cache_ram:
-            LOGGER.warning(
-                "Classification `cache_ram` training has known memory leak in "
-                "https://github.com/ultralytics/ultralytics/issues/9824, setting `cache_ram=False`."
-            )
-            self.cache_ram = False
         self.cache_disk = str(args.cache).lower() == "disk"  # cache images on hard drive as uncompressed *.npy files
         self.samples = self.verify_images()  # filter out bad images
         self.samples = [[*list(x), Path(x[0]).with_suffix(".npy"), None] for x in self.samples]  # file, index, npy, im
+        self.imgsz = args.imgsz
+        self.img_cache = None
+        self.img_offsets = None
+        self.img_shapes = None
+        # safety_margin=1.0 budgets ~2x cache size to accommodate streaming overhead (heap fragmentation
+        # from per-image cv2 decode allocations is not promptly returned to the OS by some allocators).
+        if self.cache_ram and not self.check_cache_ram(safety_margin=1.0):
+            self.cache_ram = False
+        if self.cache_ram:
+            self.cache_images()
         scale = (1.0 - args.scale, 1.0)  # (0.08, 1.0)
         self.torch_transforms = (
             classify_augmentations(
@@ -1024,8 +1029,9 @@ class ClassificationDataset:
         """
         f, j, fn, im = self.samples[i]  # filename, index, filename.with_suffix('.npy'), image
         if self.cache_ram:
-            if im is None:  # Warning: two separate if statements required here, do not combine this with previous line
-                im = self.samples[i][3] = cv2.imread(f)
+            pos = self.img_offsets[i]
+            h, w, c = self.img_shapes[i]
+            im = self.img_cache[pos : pos + h * w * c].numpy().reshape(h, w, c)  # zero-copy view
         elif self.cache_disk:
             if not fn.exists():  # load npy
                 np.save(fn.as_posix(), cv2.imread(f), allow_pickle=False)
@@ -1040,6 +1046,103 @@ class ClassificationDataset:
     def __len__(self) -> int:
         """Return the total number of samples in the dataset."""
         return len(self.samples)
+
+    def check_cache_ram(self, safety_margin: float = 0.5) -> bool:
+        """Check if there's enough RAM for caching images.
+
+        Args:
+            safety_margin (float): Safety margin factor for RAM calculation.
+
+        Returns:
+            (bool): True if there's enough RAM, False otherwise.
+        """
+        if not self.samples:
+            return False
+        b, gb = 0, 1 << 30  # bytes of cached images, bytes per gigabytes
+        n = min(len(self.samples), 30)  # extrapolate from 30 random images
+        for _ in range(n):
+            im = cv2.imread(random.choice(self.samples)[0])
+            if im is None:
+                continue
+            b += im.nbytes
+        mem_required = b * len(self.samples) / n * (1 + safety_margin)  # bytes required to cache dataset into RAM
+        mem = __import__("psutil").virtual_memory()
+        if mem_required > mem.available:
+            LOGGER.warning(
+                f"{self.prefix}{mem_required / gb:.1f}GB RAM required to cache images "
+                f"with {int(safety_margin * 100)}% safety margin but only "
+                f"{mem.available / gb:.1f}/{mem.total / gb:.1f}GB available, not caching images"
+            )
+            return False
+        return True
+
+    def cache_images(self) -> None:
+        """Preload all images into a single shared-memory uint8 buffer with per-image offsets.
+
+        Original sizes are preserved so torch_transforms (RandomResizedCrop, validation Resize+CenterCrop)
+        receive the same input as the uncached path. A two-pass design records sizes first, then streams each
+        decoded image directly into the destination buffer to avoid holding the full set of decoded arrays in
+        memory simultaneously. Both passes decode with ``cv2.imread`` so probe and load can never disagree on
+        shape: ``cv2.imread`` applies EXIF orientation while ``PIL.Image.size`` does not, which would otherwise
+        silently transpose rotated images (orientations 5-8) into a corrupted buffer view.
+        """
+        n = len(self.samples)
+        gb = 1 << 30
+
+        def probe(i: int):
+            im = cv2.imread(self.samples[i][0])  # decode with the same decoder as load() so shapes agree
+            if im is None:
+                raise FileNotFoundError(f"Image Not Found {self.samples[i][0]}")
+            return i, im.shape  # (h, w, c) from the actual decoder (cv2.imread returns 3-channel BGR)
+
+        def load(i: int):
+            im = cv2.imread(self.samples[i][0])
+            if im is None:
+                raise FileNotFoundError(f"Image Not Found {self.samples[i][0]}")
+            return i, im
+
+        try:
+            # Pass 1: decode to record true (h, w, c) and total bytes (EXIF-aware, matches load()).
+            shapes = [None] * n
+            with ThreadPool(NUM_THREADS) as pool:
+                pbar = TQDM(pool.imap(probe, range(n)), total=n, disable=LOCAL_RANK > 0)
+                for i, shape in pbar:
+                    shapes[i] = shape
+                    pbar.desc = f"{self.prefix}Probing image sizes"
+                pbar.close()
+
+            offsets = [0] * n
+            pos = 0
+            for i, (h, w, c) in enumerate(shapes):
+                offsets[i] = pos
+                pos += h * w * c
+            total = pos
+
+            # Pass 2: decode and stream each image into the destination buffer.
+            cache = torch.empty(total, dtype=torch.uint8)
+            with ThreadPool(NUM_THREADS) as pool:
+                pbar = TQDM(pool.imap(load, range(n)), total=n, disable=LOCAL_RANK > 0)
+                for i, im in pbar:
+                    sz = im.nbytes
+                    cache[offsets[i] : offsets[i] + sz] = torch.from_numpy(im.reshape(-1))
+                    pbar.desc = f"{self.prefix}Caching images ({(offsets[i] + sz) / gb:.1f}GB RAM)"
+                pbar.close()
+
+            cache.share_memory_()
+        except FileNotFoundError:
+            raise  # surface a corrupt/missing image clearly instead of swallowing it as a cache fallback
+        except (MemoryError, OSError, RuntimeError) as e:
+            LOGGER.warning(
+                f"{self.prefix}cache_ram failed ({type(e).__name__}: {e}); falling back to disk reads. "
+                f"On Linux/Docker this is typically /dev/shm being smaller than RAM — run with "
+                f"`--shm-size=<size>` or set `cache=False`."
+            )
+            self.cache_ram = False
+            return
+
+        self.img_cache = cache
+        self.img_offsets = offsets
+        self.img_shapes = shapes
 
     def verify_images(self) -> list[tuple]:
         """Verify all images in dataset.


### PR DESCRIPTION
## Summary

`ClassificationDataset` with `cache='ram'` leaked RAM linearly when `num_workers > 0` (#9824): the per-sample lazy write-back triggered per-worker copy-on-write on `fork` and full-pickle bloat on `spawn`, so the legacy code force-disabled `cache_ram` with a warning. This replaces it with a single `torch.uint8` buffer preloaded once on the main process and pinned via `share_memory_()` before workers fork, so every worker maps the same shared-memory region instead of duplicating the cache. The buffer is built in two passes (probe sizes, then decode and stream into a preallocated buffer to avoid holding all decoded images at once) with a graceful fallback to disk reads when `/dev/shm` is constrained (e.g. Docker `--shm-size`).

Both passes decode with `cv2.imread` so the probe and load passes can never disagree on shape: `cv2.imread` applies EXIF orientation while `PIL.Image.size` does not, which would otherwise silently transpose rotated images (orientations 5-8) into a corrupted buffer view. Original image sizes are preserved so `torch_transforms` receive the same input as the uncached path, and a regression test covers the EXIF case.

Supersedes #24358, recreated on a clean branch for a readable diff.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧠 This PR re-enables and hardens `cache='ram'` for classification datasets, making RAM caching faster, safer, and consistent with normal image loading—even for EXIF-rotated images.

### 📊 Key Changes
- 🚀 **Restored RAM caching for classification datasets**
  - Removed the previous forced disablement of `cache_ram` caused by an earlier memory leak concern.
- 🗂️ **Added a new RAM cache implementation**
  - Images are now preloaded into a **single shared-memory `uint8` buffer** instead of being stored one-by-one.
  - The dataset tracks each image’s **offset and shape** so cached images can be accessed efficiently.
- 🖼️ **Improved image-loading consistency**
  - Cache building now uses `cv2.imread()` for both size probing and loading, ensuring cached images match uncached images exactly.
  - This specifically fixes issues with **EXIF-rotated images**, where image dimensions can differ depending on the reader.
- 💾 **Added RAM availability checks**
  - Before caching, the dataset estimates required memory from a sample of images and only enables RAM caching if enough memory is available.
- ⚠️ **Added graceful fallback behavior**
  - If RAM caching fails due to memory or shared-memory limits, it logs a warning and falls back to normal disk reads instead of crashing.
- ✅ **Added a regression test**
  - New test verifies that `cache='ram'` produces the same classification image tensors as `cache=False`, including for EXIF-rotated images.

### 🎯 Purpose & Impact
- ⚡ **Faster classification training and validation**
  - Users can benefit from quicker image access when enough RAM is available.
- 🔒 **More reliable caching behavior**
  - The new design reduces risk compared to the previous approach and avoids silently using incorrect cached image shapes.
- 🧭 **Better handling of real-world image data**
  - EXIF-rotated photos now behave consistently, which is especially helpful for datasets built from phones or cameras.
- 🛟 **Safer user experience**
  - If a system does not have enough RAM or shared memory, Ultralytics will automatically fall back instead of failing unexpectedly.
- 🧪 **Higher confidence in correctness**
  - The new test helps prevent future regressions in classification caching behavior.