### PR TITLE
Fix `tip` case in docs

### DIFF
--- a/docs/en/datasets/detect/homeobjects-3k.md
+++ b/docs/en/datasets/detect/homeobjects-3k.md
@@ -34,7 +34,7 @@ Each image is labeled using bounding boxes aligned with the [Ultralytics YOLO](.
 
 The dataset supports 12 everyday object categories, covering furniture, electronics, and decorative items. These classes are chosen to reflect common items encountered in indoor domestic environments and support vision tasks like [object detection](../../tasks/detect.md) and [object tracking](../../modes/track.md).
 
-!!! Tip "HomeObjects-3K classes"
+!!! tip "HomeObjects-3K classes"
 
     0. bed
     1. sofa

--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -52,7 +52,7 @@ Export an Ultralytics YOLO26 model to RKNN format and run inference with the exp
 
 To install the required packages, run:
 
-!!! Tip "Installation"
+!!! tip "Installation"
 
     === "CLI"
 
@@ -168,7 +168,7 @@ Once you've successfully exported your Ultralytics YOLO26 models to RKNN format,
 
 To install the required packages, run:
 
-!!! Tip "Installation"
+!!! tip "Installation"
 
     === "CLI"
 

--- a/docs/en/integrations/seeedstudio-recamera.md
+++ b/docs/en/integrations/seeedstudio-recamera.md
@@ -79,7 +79,7 @@ Export an Ultralytics YOLO26 model to [ONNX model format](https://docs.ultralyti
 
 To install the required packages, run:
 
-!!! Tip "Installation"
+!!! tip "Installation"
 
     === "CLI"
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small documentation formatting fixes by standardizing admonition blocks from `!!! Tip` to `!!! tip` across several dataset and integration pages.

### 📊 Key Changes
- Updated admonition syntax in the [HomeObjects-3K dataset docs](https://github.com/ultralytics/ultralytics) from `!!! Tip` to `!!! tip`.
- Applied the same fix in the [Rockchip RKNN integration docs](https://github.com/ultralytics/ultralytics), including installation sections.
- Updated the [Seeed Studio reCamera integration docs](https://github.com/ultralytics/ultralytics) with the same lowercase admonition style.
- Changes are limited to documentation markup; no model code, training logic, or inference behavior was modified.

### 🎯 Purpose & Impact
- Improves documentation consistency 📚 by using a uniform MkDocs/MkDocs Material admonition style.
- Helps ensure tip/installation callout boxes render correctly and predictably across docs pages ✅
- Reduces minor formatting issues for readers browsing dataset and deployment guides on different platforms 🛠️
- No impact on YOLO26 functionality, APIs, or user workflows—this is a low-risk docs-only cleanup ✨