### PR TITLE
fix: CLIP pkg_resources import failure on Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ solutions = [
     "faiss-cpu",  # for similarity search
     "openai-clip>=1.0.1",  # for similarity search text/image embeddings
     "setuptools>=80.0.0,<81.0.0; python_version >= '3.9'",  # openai-clip imports pkg_resources.packaging, removed in setuptools>=81
+    "setuptools<76.0.0; python_version < '3.9'",  # provide pkg_resources for openai-clip on Python 3.8 (setuptools>=76 drops 3.8, >=81 drops pkg_resources)
     "streamlit>=1.51.0; python_version >= '3.10'",    # for live inference on web browser, i.e `yolo streamlit-predict`
     "streamlit>=1.29.0,<1.51.0; python_version < '3.10' and (platform_machine != 'aarch64' or platform_system != 'Linux')",
     "flask>=3.0.1",  # for similarity search solution


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the `setuptools` dependency rules to keep `openai-clip` working reliably across different Python versions, especially Python 3.8 and 3.9+.

### 📊 Key Changes
- Split the previous single `setuptools<81.0.0` requirement into **version-specific rules** based on Python version.
- For **Python 3.9 and newer**, `setuptools` is now pinned to `>=80.0.0,<81.0.0`.
- For **Python 3.8**, `setuptools` is now pinned to `<76.0.0`.
- Added comments explaining why these limits are needed:
  - `openai-clip` depends on `pkg_resources.packaging`
  - `pkg_resources` is removed in `setuptools>=81`
  - `setuptools>=76` drops support for Python 3.8

### 🎯 Purpose & Impact
- ✅ Improves dependency compatibility for users installing Ultralytics solutions that rely on `openai-clip`.
- 🐍 Prevents installation and runtime issues across mixed Python environments, particularly older Python 3.8 setups.
- 🛠️ Makes package resolution more precise instead of using one broad rule for all Python versions.
- 📦 Helps ensure smoother installs for similarity search and related solution features without unexpected `setuptools` conflicts.