### PR TITLE
Restore setuptools marker for solutions extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,12 +311,16 @@ jobs:
           if [ "${{ matrix.torch }}" != "latest" ]; then
             torch="torch==${{ matrix.torch }} torchvision==${{ matrix.torchvision }}"
           fi
+          legacy_setuptools=()
+          if [ "${{ matrix.python }}" = "3.8" ]; then
+            legacy_setuptools=("setuptools<76.0.0")
+          fi
           clip_package=()
           if [ "${{ matrix.python }}" != "3.12" ]; then
             clip_package=("git+https://github.com/ultralytics/CLIP.git")
           fi
           uv pip install -e ".[export-base,solutions${legacy_extra}]" $torch \
-            aiohttp faster-coco-eval mlflow pytest-cov pytest-xdist "${clip_package[@]}" \
+            aiohttp faster-coco-eval mlflow pytest-cov pytest-xdist "${legacy_setuptools[@]}" "${clip_package[@]}" \
             --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
       - name: Check environment
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ solutions = [
     "lap>=0.5.12",  # for solution tracking linear assignment
     "faiss-cpu",  # for similarity search
     "openai-clip>=1.0.1",  # for similarity search text/image embeddings
-    "setuptools<81.0.0",  # openai-clip imports pkg_resources.packaging, removed in setuptools>=81
+    "setuptools>=80.0.0,<81.0.0; python_version >= '3.9'",  # openai-clip imports pkg_resources.packaging, removed in setuptools>=81
     "streamlit>=1.51.0; python_version >= '3.10'",    # for live inference on web browser, i.e `yolo streamlit-predict`
     "streamlit>=1.29.0,<1.51.0; python_version < '3.10' and (platform_machine != 'aarch64' or platform_system != 'Linux')",
     "flask>=3.0.1",  # for similarity search solution


### PR DESCRIPTION
## Summary\n- restore the original Python >=3.9 setuptools marker for the solutions extra\n- undo the dependency metadata change from #24683 that broke the Docker image build\n\n## Validation\n- git diff --check\n- parsed pyproject.toml and verified the original marker is restored

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Restores the `setuptools` version marker for the `solutions` extra by constraining it to compatible versions only on supported Python releases. 🔧

### 📊 Key Changes
- Updates the `solutions` extra dependency from unconditional `setuptools<81.0.0` to `setuptools>=80.0.0,<81.0.0; python_version >= '3.9'`.
- Preserves compatibility for `openai-clip`, which depends on `pkg_resources.packaging` removed in `setuptools>=81`.
- Adds a Python version environment marker so the dependency is only applied where relevant.

### 🎯 Purpose & Impact
- Prevents installation and runtime issues in the `solutions` extra caused by incompatible `setuptools` versions. ✅
- Reduces unnecessary dependency pinning on unsupported Python versions by making the constraint more precise.
- Improves packaging reliability for users installing solution-related features such as similarity search and tracking. 📦