### PR TITLE
Fix SAM remove_small_regions duplicate suppression

### DIFF
--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -629,7 +629,8 @@ class Predictor(BasePredictor):
 
         # Recalculate boxes and remove any new duplicates
         new_masks = torch.cat(new_masks, dim=0)
-        boxes = batched_mask_to_box(new_masks)
+        # batched_mask_to_box requires bool masks; on uint8 it returns all-zero boxes and the NMS dedup below is a no-op
+        boxes = batched_mask_to_box(new_masks.bool())
         keep = torchvision.ops.nms(boxes.float(), torch.as_tensor(scores), nms_thresh)
 
         return new_masks[keep].to(device=masks.device, dtype=masks.dtype), keep


### PR DESCRIPTION
## summary

`Predictor.remove_small_regions` builds its dedup NMS boxes with `batched_mask_to_box`, but the masks at that point are uint8, and `batched_mask_to_box` only produces valid boxes for bool masks (it relies on a logical-not that becomes bitwise-not on uint8), so every box was zero-area and the NMS pass never removed any duplicates. Computing the boxes from a bool view restores the intended duplicate suppression after island/hole removal. No effect on the default path; only callers passing a positive area threshold are affected.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🩹 This PR fixes a SAM mask post-processing bug by ensuring masks are converted to boolean format before box extraction, so duplicate masks can be removed correctly.

### 📊 Key Changes
- Updated `ultralytics/models/sam/predict.py` in `remove_small_regions()`.
- Changed `batched_mask_to_box(new_masks)` to `batched_mask_to_box(new_masks.bool())`.
- Added an explanatory comment noting that `batched_mask_to_box` expects boolean masks.
- Prevents an issue where `uint8` masks produced all-zero boxes, causing the later NMS duplicate-removal step to silently do nothing.

### 🎯 Purpose & Impact
- ✅ Fixes incorrect bounding box calculation during SAM mask cleanup.
- 🧹 Restores proper NMS-based deduplication of overlapping or duplicate masks.
- 🎯 Improves reliability and quality of segmentation results after small-region removal.
- 👥 Benefits users by making SAM predictions more consistent, especially in workflows that depend on clean, non-duplicated masks.
- 🔍 This is a small code change with a meaningful correctness impact, reducing the chance of subtle segmentation post-processing errors.