### PR TITLE
Clarify YOLOE-26 visual prompt box format

### DIFF
--- a/docs/en/models/yolo26.md
+++ b/docs/en/models/yolo26.md
@@ -263,7 +263,7 @@ YOLOE-26 supports both text-based and visual prompting. Using prompts is straigh
 
     === "Visual Prompt"
 
-        Visual prompts allow you to guide the model by showing it visual examples of the target classes, rather than describing them in text.
+        Visual prompts allow you to guide the model by showing it visual examples of the target classes, rather than describing them in text. Bounding boxes must use absolute pixel coordinates in `[x_min, y_min, x_max, y_max]` format for the image used as the visual prompt.
 
         ```python
         import numpy as np
@@ -279,8 +279,8 @@ YOLOE-26 supports both text-based and visual prompting. Using prompts is straigh
         visual_prompts = dict(
             bboxes=np.array(
                 [
-                    [221.52, 405.8, 344.98, 857.54],  # Box enclosing person
-                    [120, 425, 160, 445],  # Box enclosing glasses
+                    [221.5, 405.8, 345.0, 857.5],  # Person box: [x_min, y_min, x_max, y_max] pixels
+                    [120, 425, 160, 445],  # Glasses box: [x_min, y_min, x_max, y_max] pixels
                 ],
             ),
             cls=np.array(


### PR DESCRIPTION
## Summary
- clarify that YOLOE-26 visual prompt bounding boxes use absolute pixel `[x_min, y_min, x_max, y_max]` coordinates
- update the inline example comments next to each box and round the person box example to one decimal

## Validation
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves the YOLO26 documentation by clarifying exactly how visual prompt bounding boxes must be formatted when using YOLOE-26.

### 📊 Key Changes
- Added a clear note to the [YOLO26 model documentation](https://docs.ultralytics.com/models/yolo26/) stating that visual prompt boxes must use **absolute pixel coordinates**.
- Explicitly documented the required bounding box format as **`[x_min, y_min, x_max, y_max]`**.
- Updated the example bounding boxes and inline comments to make the expected format easier to understand.
- Improved wording around visual prompting so users can more confidently provide image-based guidance instead of text prompts.

### 🎯 Purpose & Impact
- ✅ Reduces confusion for users working with **visual prompts** in YOLOE-26.
- ✅ Helps prevent formatting mistakes that could cause incorrect prompting behavior or poor results.
- ✅ Makes the documentation more beginner-friendly by spelling out coordinate expectations directly in the example.
- ✅ Improves developer experience by making integrations with visual prompting more reliable and easier to implement.