### PR TITLE
Use watch URL for Tiger-Pose video links

### DIFF
--- a/docs/en/datasets/pose/index.md
+++ b/docs/en/datasets/pose/index.md
@@ -119,7 +119,7 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 
 ### Tiger-Pose
 
-- **Description**: The [Ultralytics](https://www.ultralytics.com/) Tiger Pose dataset comprises 263 images sourced from a [YouTube video](https://www.youtube.com/embed/MIBAT6BGE6U), with 210 images allocated for training and 53 for validation.
+- **Description**: The [Ultralytics](https://www.ultralytics.com/) Tiger Pose dataset comprises 263 images sourced from a [YouTube video](https://www.youtube.com/watch?v=MIBAT6BGE6U), with 210 images allocated for training and 53 for validation.
 - **Label Format**: Same as Ultralytics YOLO format as described above, with 12 keypoints for animal pose and no visible dimension.
 - **Number of Classes**: 1 (Tiger).
 - **Keypoints**: 12 keypoints.

--- a/docs/en/datasets/pose/tiger-pose.md
+++ b/docs/en/datasets/pose/tiger-pose.md
@@ -8,7 +8,7 @@ keywords: Ultralytics, Tiger-Pose, dataset, pose estimation, YOLO26, training da
 
 ## Introduction
 
-[Ultralytics](https://www.ultralytics.com/) introduces the Tiger-Pose dataset, a versatile collection designed for pose estimation tasks. This dataset comprises 263 images sourced from a [YouTube video](https://www.youtube.com/embed/MIBAT6BGE6U), with 210 images allocated for training and 53 for validation. It serves as an excellent resource for testing and troubleshooting pose estimation algorithms.
+[Ultralytics](https://www.ultralytics.com/) introduces the Tiger-Pose dataset, a versatile collection designed for pose estimation tasks. This dataset comprises 263 images sourced from a [YouTube video](https://www.youtube.com/watch?v=MIBAT6BGE6U), with 210 images allocated for training and 53 for validation. It serves as an excellent resource for testing and troubleshooting pose estimation algorithms.
 
 Despite its manageable training split of 210 images, the Tiger-Pose dataset offers diversity, making it suitable for assessing training pipelines, identifying potential errors, and serving as a valuable preliminary step before working with larger datasets for [pose estimation](https://docs.ultralytics.com/tasks/pose).
 
@@ -107,7 +107,7 @@ The dataset has been released under the [AGPL-3.0 License](https://github.com/ul
 
 ### What is the Ultralytics Tiger-Pose dataset used for?
 
-The Ultralytics Tiger-Pose dataset is designed for pose estimation tasks, consisting of 263 images sourced from a [YouTube video](https://www.youtube.com/embed/MIBAT6BGE6U). The dataset is divided into 210 training images and 53 validation images. It is particularly useful for testing, training, and refining pose estimation algorithms using [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+The Ultralytics Tiger-Pose dataset is designed for pose estimation tasks, consisting of 263 images sourced from a [YouTube video](https://www.youtube.com/watch?v=MIBAT6BGE6U). The dataset is divided into 210 training images and 53 validation images. It is particularly useful for testing, training, and refining pose estimation algorithms using [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
 
 ### How do I train a YOLO26 model on the Tiger-Pose dataset?
 


### PR DESCRIPTION
## Summary
- replace Tiger-Pose prose links from the YouTube embed URL to the normal watch URL
- keep inference examples unchanged because they intentionally use `youtu.be` as model source input examples

## Validation
- `curl -L` and `curl -I` for `https://www.youtube.com/watch?v=MIBAT6BGE6U`: 200
- `curl -L` and `curl -I` for `https://i.ytimg.com/vi/MIBAT6BGE6U/maxresdefault.jpg`: 200
- fetched YouTube page metadata and confirmed the current `og:image` uses the single-slash thumbnail URL
- scoped `lychee` on `docs/en/datasets/pose/index.md` and `docs/en/datasets/pose/tiger-pose.md`: 0 Errors

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR updates Tiger-Pose dataset documentation to replace embedded YouTube links with standard watch-page links for better compatibility and usability.

### 📊 Key Changes
- Updated the Tiger-Pose dataset link in `docs/en/datasets/pose/index.md` from a YouTube `embed` URL to a standard `watch` URL.
- Made the same YouTube link update in `docs/en/datasets/pose/tiger-pose.md` in:
  - the dataset introduction
  - the FAQ section describing dataset usage
- No changes were made to dataset content, labels, training instructions, or model behavior.

### 🎯 Purpose & Impact
- ✅ Improves documentation usability by linking readers to the normal YouTube page instead of an embedded video URL.
- 🌍 Likely increases compatibility across browsers, documentation renderers, and platforms where embedded links may not behave as expected.
- 🧹 Keeps the docs cleaner and more consistent without affecting any YOLO26 training or inference workflows.
- 📚 Low-risk documentation-only change with a small but helpful improvement for users browsing the Tiger-Pose dataset docs.