### PR TITLE
Register GPU CI runner image at org level

### DIFF
--- a/docker/Dockerfile-runner
+++ b/docker/Dockerfile-runner
@@ -28,7 +28,7 @@ RUN FILENAME=actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     rm -rf /var/lib/apt/lists/*
 
 # JSON ENTRYPOINT command to configure and start runner with default TOKEN and NAME
-ENTRYPOINT ["sh", "-c", "./config.sh --url https://github.com/ultralytics/ultralytics --token ${GITHUB_RUNNER_TOKEN:-TOKEN} --name ${GITHUB_RUNNER_NAME:-NAME} --labels gpu-latest --replace && exec ./run.sh"]
+ENTRYPOINT ["sh", "-c", "./config.sh --url https://github.com/ultralytics --token ${GITHUB_RUNNER_TOKEN:-TOKEN} --name ${GITHUB_RUNNER_NAME:-NAME} --labels gpu-latest --replace && exec ./run.sh"]
 
 # Usage --------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Changes `docker/Dockerfile-runner` to register against the org URL (`https://github.com/ultralytics`) instead of the repo URL, matching `Dockerfile-runner-cpu` which is already org-scoped. The `gpu-latest` label is unchanged, so `runs-on: gpu-latest` jobs in CI continue to schedule normally. Org-level runners can serve any repository in the org permitted by the runner group (the org's CPU runners already serve this public repo today, so group access is already configured).

Pairs with the runner-startup tooling change that requests org-scoped registration tokens for GPU runners.

## Deployment order (important)

1. Merge this PR first — `docker.yml` rebuilds and publishes `ultralytics/ultralytics:latest-runner` on push to main
2. Confirm the published `latest-runner` image contains the org registration URL
3. Drain or remove existing repo-scoped GPU runners (old `repos/ultralytics/ultralytics` scope) before running the updated startup script, or run the switch during an idle GPU window — the first org-scoped drain pass cannot see repo-level registrations, so it would stop old containers without a busy check and leave stale repo-level registrations behind (GitHub auto-removes offline runners after 14 days)
4. Deploy the updated startup tooling and verify new `github_gpu_runner_*` registrations appear at org level with the `gpu-latest` label, then confirm a GPU CI job is picked up

## Validation

- Registration token scope and `config.sh --url` scope must match: after this change plus the tooling change, GPU = org/org (CPU already org/org)
- No other repo-scoped registration references remain (`grep 'repos/ultralytics'` clean; remaining repo URLs in docker/ are comments, clone URLs, and badges)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the self-hosted GitHub Actions runner setup so the Docker runner registers at the **Ultralytics organization level** instead of only the `ultralytics/ultralytics` repository.

### 📊 Key Changes
- Changed the runner configuration URL in `docker/Dockerfile-runner`.
- Updated `./config.sh --url` from the repository URL:
  - `https://github.com/ultralytics/ultralytics`
- To the organization URL:
  - `https://github.com/ultralytics`
- Kept the rest of the runner setup unchanged, including:
  - runner token and name environment variables
  - `gpu-latest` label
  - `--replace` behavior
  - launching the runner with `./run.sh`

### 🎯 Purpose & Impact
- 🚀 **Broader runner availability:** The runner can now be registered for the entire Ultralytics GitHub organization, not just a single repository.
- 🧩 **Better infrastructure reuse:** Makes it easier to share GPU-enabled runners across multiple Ultralytics repos and workflows.
- ⚙️ **Simpler CI/CD management:** Centralizing runners at the org level can reduce duplication and improve maintenance.
- 📈 **Potentially more flexible automation:** Future workflows outside `ultralytics/ultralytics` may be able to use the same runner setup.
- ✅ **Low-risk change:** This is a small configuration update with no direct effect on model behavior, training, or inference.