### PR TITLE
Fix INT8 ONNX calibration batch mismatch and read-only onnx2tf patching

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.60"
+__version__ = "8.4.61"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -927,6 +927,7 @@ class Exporter:
                 f_int8,
                 self.get_int8_calibration_dataloader(prefix),
                 self._transform_fn,
+                batch=0 if self.args.dynamic else self.args.batch,
                 prefix=prefix,
             )
             source.unlink(missing_ok=True)
@@ -1361,6 +1362,7 @@ class Exporter:
             transform_fn=self._transform_fn,
             name=self.args.name,
             metadata=self.metadata,
+            batch=0 if self.args.dynamic else self.args.batch,
             prefix=prefix,
         )
 

--- a/ultralytics/utils/export/onnx.py
+++ b/ultralytics/utils/export/onnx.py
@@ -2,17 +2,28 @@
 
 from pathlib import Path
 
+import numpy as np
+
 from ultralytics.utils import LOGGER
 
 
-def onnx_calibration_reader(dataset, transform_fn, input_name: str = "images"):
-    """Create an ONNX Runtime calibration data reader from an Ultralytics calibration dataloader."""
+def onnx_calibration_reader(dataset, transform_fn, input_name: str = "images", batch: int = 0):
+    """Create an ONNX Runtime calibration data reader from an Ultralytics calibration dataloader.
+
+    `batch` is the graph's static batch dimension (0 for dynamic-batch models): calibration datasets smaller than the
+    export batch yield undersized batches that static graphs reject, so samples are tiled up to exactly `batch`.
+    """
     from onnxruntime.quantization import CalibrationDataReader
 
     class _CalibrationReader(CalibrationDataReader):
         def __init__(self):
             """Materialize calibration inputs as `{input_name: float32_NCHW}` dicts."""
-            self.samples = [{input_name: transform_fn(batch)} for batch in dataset]
+            self.samples = []
+            for b in dataset:
+                im = transform_fn(b)
+                if batch and im.shape[0] != batch:  # tile up to the static batch dimension
+                    im = np.tile(im, (-(-batch // im.shape[0]), 1, 1, 1))[:batch]
+                self.samples.append({input_name: im})
             self.iterator = iter(self.samples)
 
         def get_next(self):
@@ -32,6 +43,7 @@ def onnx_int8_quantize(
     dataset,
     transform_fn,
     input_name: str = "images",
+    batch: int = 0,
     prefix: str = "",
 ) -> str:
     """Quantize an ONNX model to INT8 using ONNX Runtime static quantization."""
@@ -39,5 +51,5 @@ def onnx_int8_quantize(
 
     onnx_file, output_file = Path(onnx_file), Path(output_file)
     LOGGER.info(f"{prefix} quantizing INT8 with ONNX Runtime...")
-    quantize_static(str(onnx_file), str(output_file), onnx_calibration_reader(dataset, transform_fn, input_name))
+    quantize_static(str(onnx_file), str(output_file), onnx_calibration_reader(dataset, transform_fn, input_name, batch))
     return str(output_file)

--- a/ultralytics/utils/export/qnn.py
+++ b/ultralytics/utils/export/qnn.py
@@ -41,6 +41,7 @@ def onnx2qnn(
     transform_fn,
     name: str = "73",
     metadata: dict | None = None,
+    batch: int = 0,
     prefix: str = "",
 ) -> str:
     """Convert an ONNX model to an INT8 Qualcomm QNN context binary using the ONNX Runtime QNN Execution Provider.
@@ -61,6 +62,8 @@ def onnx2qnn(
             (8 Gen 3), `"79"` (8 Elite). Finalizes the graph for the target chip when exporting on a host without a
             Snapdragon NPU.
         metadata (dict | None): Metadata saved as `metadata.yaml`.
+        batch (int): Static batch dimension of the ONNX graph used to tile undersized calibration batches, or 0 for
+            dynamic-batch models.
         prefix (str): Prefix for log messages.
 
     Returns:
@@ -88,7 +91,7 @@ def onnx2qnn(
 
     LOGGER.info(f"\n{prefix} starting INT8 quantization and export with ONNX Runtime QNN (HTP arch {name})...")
     quant_pre_process(str(onnx_file), str(pre_file))
-    qdq_config = get_qnn_qdq_config(str(pre_file), onnx_calibration_reader(dataset, transform_fn))
+    qdq_config = get_qnn_qdq_config(str(pre_file), onnx_calibration_reader(dataset, transform_fn, batch=batch))
     quantize(str(pre_file), str(qdq_file), qdq_config)
 
     # Register the QNN EP, then compile the quantized graph to a context binary during session init (no inference run).

--- a/ultralytics/utils/export/tensorflow.py
+++ b/ultralytics/utils/export/tensorflow.py
@@ -160,13 +160,14 @@ def onnx2saved_model(
     import onnx2tf.ops.TopK as _t
 
     _path = pathlib.Path(inspect.getfile(_t))
-    _path.write_text(
-        _path.read_text().replace(
-            "k_tensor = int(k_tensor)",
-            "k_tensor = int(k_tensor.squeeze()) if hasattr(k_tensor, 'squeeze') else int(k_tensor)",
-        )
+    _text = _path.read_text()
+    _patched = _text.replace(
+        "k_tensor = int(k_tensor)",
+        "k_tensor = int(k_tensor.squeeze()) if hasattr(k_tensor, 'squeeze') else int(k_tensor)",
     )
-    importlib.reload(_t)
+    if _patched != _text:  # write only when unpatched; site-packages may be read-only (pre-patched containers)
+        _path.write_text(_patched)
+        importlib.reload(_t)
     import onnx2tf  # scoped for after ONNX export for reduced conflict during import
 
     LOGGER.info(f"{prefix} starting TFLite export with onnx2tf {onnx2tf.__version__}...")

--- a/ultralytics/utils/export/tensorflow.py
+++ b/ultralytics/utils/export/tensorflow.py
@@ -166,8 +166,11 @@ def onnx2saved_model(
         "k_tensor = int(k_tensor.squeeze()) if hasattr(k_tensor, 'squeeze') else int(k_tensor)",
     )
     if _patched != _text:  # write only when unpatched; site-packages may be read-only (pre-patched containers)
-        _path.write_text(_patched)
-        importlib.reload(_t)
+        try:
+            _path.write_text(_patched)
+            importlib.reload(_t)
+        except OSError as e:  # read-only install: continue unpatched, only TopK-containing models are affected
+            LOGGER.warning(f"{prefix} unable to apply onnx2tf TopK patch: {e}")
     import onnx2tf  # scoped for after ONNX export for reduced conflict during import
 
     LOGGER.info(f"{prefix} starting TFLite export with onnx2tf {onnx2tf.__version__}...")


### PR DESCRIPTION
Fixes two export bugs observed in production error tracking (refs ALPHA-1KW/1KX, ALPHA-1DX/1KN; companion platform PR: https://github.com/ultralytics/portal/pull/2365).

## 1. INT8 ONNX export crashes when the calibration dataset is smaller than the export batch

```bash
yolo export model=yolo26n.pt format=onnx int8=True batch=8 data=coco8.yaml
# [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Got invalid dimensions for input: images
#  index: 0 Got: 4 Expected: 8
```

**Root cause:** `get_int8_calibration_dataloader` reduces the calibration batch to `min(args.batch, n)` so small datasets still yield at least one full batch (`drop_last=True`), but a `dynamic=False` ONNX graph has a static batch dimension equal to `args.batch` — ONNX Runtime rejects the undersized calibration batches during `quantize_static`.

**Fix:** `onnx_calibration_reader` gains a `batch` parameter (the graph's static batch dimension, `0` for dynamic models) and tiles each calibration array up to exactly that size (`np.tile` + trailing slice — duplicated images don't change min/max activation ranges). Threaded through `onnx_int8_quantize` and `onnx2qnn` (QNN exports are always static-batch); both exporter callsites pass `0 if self.args.dynamic else self.args.batch`. Existing levers can't solve this: `drop_last=False` would make ragged batches worse, and `fraction` only subsets.

**Verified:** the command above reproduces the exact error on `main` and exports successfully with this patch (output graph dims `[8, 3, 64, 64]`). Regression paths all pass: plain ONNX, `int8=True batch=1`, and `int8=True dynamic=True batch=8`.

## 2. `saved_model`/`tflite`-family exports fail with `PermissionError` on read-only site-packages

```
PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.12/site-packages/onnx2tf/ops/TopK.py'
```

**Root cause:** `onnx2saved_model` writes the onnx2tf `TopK` monkey-patch to the installed package file unconditionally on every export — even when the file is already patched (e.g. applied at container build time as root). Runtime users without write access to site-packages then fail every TensorFlow-family export on the redundant no-op write.

**Fix:** compute the replaced text and only `write_text` + `importlib.reload` when it actually differs. The patch is idempotent (the patched line no longer contains the search string), so pre-patched read-only environments now skip the write entirely. Behavior is unchanged where the patch is still needed and site-packages is writable.

## Verification
- Live reproduce-then-fix A/B test for the INT8 bug (above)
- `ruff check` and `ruff format --check` clean on all changed files
- `python -m py_compile` on all changed files

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves export reliability for INT8 ONNX/QNN workflows and makes TensorFlow/TFLite export more robust in read-only environments 🚀

### 📊 Key Changes
- Added batch-aware calibration handling for ONNX INT8 export 🧠
  - Calibration now receives the model’s batch setting.
  - For static-batch exports, undersized calibration batches are automatically repeated to match the required batch size.
- Extended the same calibration batch fix to Qualcomm QNN export 📦
  - QNN INT8 export now also respects static vs. dynamic batch settings during calibration.
- Improved TensorFlow/TFLite export patching behavior 🛠️
  - The `onnx2tf` TopK patch is now only written when needed.
  - If the Python environment is read-only, export continues gracefully with a warning instead of failing.
- Bumped package version from `8.4.60` to `8.4.61` 🔖

### 🎯 Purpose & Impact
- Prevents export failures caused by calibration datasets producing smaller batches than a static exported model expects ✅
- Makes INT8 quantization more reliable for ONNX and Qualcomm QNN deployments, especially in edge and mobile workflows 📱
- Improves compatibility with dynamic-batch and static-batch exports without requiring user workarounds 🔄
- Reduces avoidable TensorFlow/TFLite export errors in containerized or restricted environments, improving overall usability and stability 🧩