### PR TITLE
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           coverage xml -o coverage-benchmarks.xml
       - name: Upload Coverage Reports to CodeCov
         if: github.repository == 'ultralytics/ultralytics'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           flags: Benchmarks
         env:
@@ -189,7 +189,7 @@ jobs:
           YOLO_AUTOINSTALL: "false"
       - name: Upload Coverage Reports to CodeCov
         if: github.repository == 'ultralytics/ultralytics' # && matrix.os == 'ubuntu-latest' && matrix.python == '3.13'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           flags: Tests
         env:
@@ -441,7 +441,7 @@ jobs:
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Upload Coverage Reports to CodeCov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           flags: GPU
         env:


### PR DESCRIPTION
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions Codecov uploader from `codecov/codecov-action@v6` to `@v7` across the Ultralytics CI workflow.

### 📊 Key Changes
- 🛠️ Updated the Codecov GitHub Action in `.github/workflows/ci.yml` from `v6` to `v7`.
- 📈 Applied the upgrade in all coverage upload steps:
  - Benchmarks coverage
  - Tests coverage
  - GPU coverage
- ✅ No model, training, or inference logic was changed—this is a CI/CD maintenance update only.

### 🎯 Purpose & Impact
- 🔒 Keeps the repository’s CI pipeline aligned with the latest Codecov GitHub Action version.
- 🚀 May improve reliability, compatibility, and security for coverage report uploads in automated testing.
- 👩‍💻 Has little to no direct impact on end users, but helps maintain a healthier and more up-to-date development workflow for contributors and maintainers.
- 🧹 Reduces technical debt by keeping third-party GitHub Actions current.