### PR TITLE
Fix flaky data asset tests

### DIFF
--- a/tests/cache_test_assets.py
+++ b/tests/cache_test_assets.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from tests import MODEL, SOLUTION_ASSETS
 from ultralytics.cfg import TASK2CALIBRATIONDATA, TASK2DATA, TASK2MODEL
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
-from ultralytics.utils import ARM64, ASSETS_URL, IS_RASPBERRYPI, LINUX, LOGGER, WEIGHTS_DIR, checks
+from ultralytics.utils import ARM64, ASSETS_URL, DATASETS_DIR, IS_RASPBERRYPI, LINUX, LOGGER, WEIGHTS_DIR, checks
 from ultralytics.utils.downloads import attempt_download_asset, safe_download
 
 COMMON_WEIGHTS = [
@@ -66,6 +66,7 @@ def cache_datasets() -> None:
             check_cls_dataset(ds)
         else:
             check_det_dataset(ds, autodownload=True)
+    safe_download(f"{ASSETS_URL}/instances_val2017.json", dir=DATASETS_DIR / "annotations")
     LOGGER.info("[cache] Datasets done.")
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import csv
+import shutil
 import tarfile
 import urllib
 import zipfile
@@ -16,13 +17,13 @@ from PIL import Image
 
 from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
 from ultralytics import RTDETR, YOLO
-from ultralytics.cfg import TASK2DATA, TASKS
 from ultralytics.data.build import load_inference_source
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.utils import (
     ARM64,
     ASSETS,
     ASSETS_URL,
+    DATASETS_DIR,
     DEFAULT_CFG,
     DEFAULT_CFG_PATH,
     IS_JETSON,
@@ -376,27 +377,18 @@ def test_labels_and_crops():
         assert crop_count == len(r.boxes.data), f"Crop count {crop_count} != detection count {len(r.boxes.data)}"
 
 
-@pytest.mark.skipif(not ONLINE, reason="environment is offline")
 def test_data_utils(tmp_path):
-    """Test data utility functions including dataset stats, auto-splitting, and zip archiving."""
+    """Test data utility functions including auto-splitting and zip archiving."""
     from ultralytics.data.split import autosplit
-    from ultralytics.data.utils import HUBDatasetStats
     from ultralytics.utils.downloads import zip_directory
 
-    # from ultralytics.utils.files import WorkingDirectory
-    # with WorkingDirectory(ROOT.parent / 'tests'):
+    images_dir = tmp_path / "coco8/images/val"
+    images_dir.mkdir(parents=True)
+    Image.new("RGB", (8, 8)).save(images_dir / "test.jpg")
 
-    for task in TASKS:
-        if task == "semantic":  # HUB stats do not support semantic segmentation datasets yet.
-            continue
-        file = Path(TASK2DATA[task]).with_suffix(".zip")  # i.e. coco8.zip
-        download(f"https://github.com/ultralytics/hub/raw/main/example_datasets/{file.name}", unzip=False, dir=tmp_path)
-        stats = HUBDatasetStats(tmp_path / file, task=task)
-        stats.get_json(save=True)
-        stats.process_images()
-
-    autosplit(tmp_path / "coco8")
-    zip_directory(tmp_path / "coco8/images/val")  # zip
+    autosplit(tmp_path / "coco8/images")
+    assert any((tmp_path / "coco8").glob("autosplit_*.txt"))
+    assert zip_directory(images_dir).is_file()
 
 
 def test_safe_download_unzips_local_path_archive(tmp_path):
@@ -453,7 +445,11 @@ def test_data_converter(tmp_path):
     """Test dataset conversion functions from COCO to YOLO format and class mappings."""
     from ultralytics.data.converter import coco80_to_coco91_class, convert_coco
 
-    download(f"{ASSETS_URL}/instances_val2017.json", dir=tmp_path)
+    cached_file = DATASETS_DIR / "annotations" / "instances_val2017.json"
+    if cached_file.exists():
+        shutil.copy2(cached_file, tmp_path / cached_file.name)
+    else:
+        download(f"{ASSETS_URL}/instances_val2017.json", dir=tmp_path)
     convert_coco(
         labels_dir=tmp_path, save_dir=tmp_path / "yolo_labels", use_segments=True, use_keypoints=False, cls91to80=True
     )


### PR DESCRIPTION
## Summary
- remove the HUBDatasetStats coverage from test_data_utils so pytest no longer downloads HUB example dataset archives
- keep local coverage for autosplit() and zip_directory() with a tiny temp image
- pre-cache instances_val2017.json with the existing CI test asset cache and make test_data_converter reuse it when available

## Tests
- pytest tests/test_python.py::test_data_utils tests/test_python.py::test_data_converter -q
- pytest tests/test_python.py --collect-only -q | rg "test_data_utils|test_data_converter"
- rg -n "HUBDatasetStats|hub/raw|example_datasets" tests -S
- ruff check --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 tests/cache_test_assets.py tests/test_python.py
- git diff --check

Note: `bun run knip` is not applicable in this repository because there is no package.json.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧪 This PR makes dataset-related tests faster, more reliable, and less dependent on network downloads by caching a COCO annotation file and simplifying test coverage.

### 📊 Key Changes
- Added caching for `instances_val2017.json` into the shared datasets annotations directory during test asset setup 📦
- Updated tests to use `DATASETS_DIR` so cached annotation files can be reused instead of downloading every time ♻️
- Simplified `test_data_utils()` by removing online-dependent dataset stats checks and focusing only on:
  - dataset auto-splitting
  - zip archive creation
  - basic output validation ✅
- Improved the COCO conversion test to:
  - first look for the cached annotation file locally
  - fall back to downloading only if the cache is missing 🌐
- Added small assertions in tests to verify expected files are actually created, making test behavior clearer and stricter 🔍

### 🎯 Purpose & Impact
- Reduces flaky test failures caused by network issues or external download availability 🚀
- Speeds up local and CI test runs by reusing cached dataset assets instead of repeatedly fetching them ⏱️
- Makes tests more self-contained and predictable, which helps contributors and maintainers debug failures more easily 🛠️
- Keeps coverage for key dataset utilities while removing heavier or less stable external dependencies 📉
- Improves reliability of COCO conversion testing, especially in offline or partially cached environments 💡