### PR TITLE
Slim CI git clones: blobless docs publish, shallow Conda tests, drop unused checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,7 +612,7 @@ jobs:
       - name: PyTest Setup
         run: |
           VERSION=$(python -c "from importlib.metadata import version; print(version('ultralytics'))")
-          git clone --branch v$VERSION https://github.com/ultralytics/ultralytics.git
+          git clone --depth 1 --branch v$VERSION https://github.com/ultralytics/ultralytics.git
       - name: test_cli.py
         run: pytest ultralytics/tests/test_cli.py -v -s
       - name: test_cuda.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -104,19 +104,15 @@ jobs:
       - name: Publish Docs to https://docs.ultralytics.com
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_docs == 'true')
         run: |
-          git clone --depth 1 --branch gh-pages https://github.com/ultralytics/docs.git docs-repo
+          # Blobless no-checkout clone skips downloading the old site entirely; restore only the config files the site build does not produce
+          git clone --depth 1 --branch gh-pages --filter=blob:none --no-checkout https://github.com/ultralytics/docs.git docs-repo
           cd docs-repo
-          if [ -f "vercel.json" ]; then
-            cp vercel.json /tmp/vercel.json
-          fi
-          rm -rf *
+          git ls-tree --name-only HEAD vercel.json .nojekyll | xargs -r git checkout HEAD --
           cp -R ../site/* .
-          if [ -f "/tmp/vercel.json" ]; then
-            cp /tmp/vercel.json .
-          fi
           echo "${{ secrets.INDEXNOW_KEY_DOCS }}" > "${{ secrets.INDEXNOW_KEY_DOCS }}.txt"
           git add .
-          if git diff --staged --quiet; then
+          # diff.renames=false avoids rename detection lazy-fetching old-site blobs from the partial clone
+          if git -c diff.renames=false diff --staged --quiet; then
             echo "No changes to commit"
           else
             git pull origin gh-pages

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -19,14 +19,9 @@ jobs:
     if: github.repository == 'ultralytics/ultralytics'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-          cache: "pip"
       - name: Install requirements
         run: |
           pip install pygithub


### PR DESCRIPTION
## Why

Follow-up to the portal preview-build work where a `--filter=blob:none` clone cut the MkDocs content-repo download cost: an audit of every `git clone` / `actions/checkout` in this repo's workflows found three sites downloading far more git data than they consume. All numbers below are measured against the live repos.

## What

**`docs.yml` — gh-pages publish step.** The step cloned the entire built site (70MB working tree + 5.2MB `.git`, 3.7s) only to `rm -rf *` and replace it with the fresh `../site` build. A `--filter=blob:none --no-checkout` clone skips downloading the old site entirely (0.7s, 180KB `.git`), then restores just the two config files the site build doesn't produce (`vercel.json`, `.nojekyll`) via a single lazy blob fetch. The resulting commit tree is byte-identical: the commit is built from the index, and `git add .` of the new site produces exactly the same adds/deletes the `rm -rf *` flow did — verified across the no-op, deletion, and new-file cases in bare-repo simulations. The `rm -rf *` dance never preserved root dotfiles either, so `.nojekyll` handling is unchanged. `diff.renames=false` on the change gate keeps rename detection from lazy-fetching the old site's blobs on the publish path (exit code is identical with or without it).

- The `git ls-tree | xargs` restore only references paths that exist at the tip, so removing either file from gh-pages later won't break the publish (matching the old `if [ -f vercel.json ]` guard semantics).

**`ci.yml` — Conda job PyTest setup.** `git clone --branch v$VERSION` pulled full history (59MB pack, 105,913 objects, 7.8s) when the tests only consume the tag's working tree. `--depth 1` cuts it to 2.7MB / 1,084 objects / 1.4s. The tests run against the pip-installed package and never touch git history; the shallow clone still has a complete tip checkout and valid `.git`.

**`merge-main-into-prs.yml` — unused checkout deleted.** The job's inline script is pure GitHub API (pygithub) and never reads the local repo, yet checked out the full repo with `fetch-depth: 0` (~59MB) every run. `cache: "pip"` goes with it: setup-python's pip cache globs `**/requirements.txt` from the workspace and hard-fails the job when no checkout exists, and the cache only ever stored the pygithub wheel keyed on unrelated example requirements files.

## Notes

- The main docs.yml checkout (`fetch-depth: 0` for author history) is intentionally **left unchanged**: `git log --name-only` over full history needs all historical trees, and a `blob:none` partial clone lazy-fetches them in ~58 round-trips (+15-17s measured, net regression vs the ~5s full clone). The full clone is the right call there.
- `mirror.yml` keeps `fetch-depth: 0` — a force-push mirror needs every object.
- The same unused-checkout pattern exists in `merge-main-into-prs.yml` copies in yolov5, yolov3, yolov5-ci-assets, and assistant; left for a follow-up since those carry the same `cache: "pip"` coupling.

## Validation

- Live-repo measurement of the new publish clone: 0.73s wall, then `git ls-tree --name-only HEAD vercel.json .nojekyll | xargs -r git checkout HEAD --` restores exactly the two files (verified against current gh-pages tip).
- Commit-tree equivalence for the publish rewrite proven in local bare-repo simulations (identical-content no-op, file deletion, new file): same tree hash as the `rm -rf` flow, and the `diff --staged --quiet` no-change gate still detects the no-op correctly.
- `actionlint` reports no new findings on the three files (remaining items are pre-existing style infos and self-hosted runner labels).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚡ This PR streamlines GitHub Actions workflows by reducing unnecessary Git data downloads, making CI, docs publishing, and PR maintenance faster and more efficient.

### 📊 Key Changes
- 🚀 **CI clone optimization:** In `ci.yml`, the test setup now uses a **shallow clone** with `--depth 1` when checking out the tagged Ultralytics release branch.
- 📚 **Docs publishing made leaner:** In `docs.yml`, the docs deployment step now uses a **partial, no-checkout clone** of the `gh-pages` branch to avoid downloading the full existing docs site.
- 🧹 **Smarter docs file handling:** Instead of deleting and restoring files manually, the workflow now selectively restores only important config files like `vercel.json` and `.nojekyll`.
- 🔍 **Reduced unnecessary Git fetching:** The docs workflow disables rename detection during staged diff checks, preventing extra blob downloads from the partial clone.
- 🛠️ **Simplified PR merge workflow:** In `merge-main-into-prs.yml`, the workflow removes an unused repository checkout step and drops pip caching, keeping the job lighter.

### 🎯 Purpose & Impact
- ⚡ **Faster workflows:** Smaller clones mean less data transfer and quicker job startup across CI and docs deployment.
- 💸 **Lower resource usage:** These changes reduce bandwidth, storage, and overall GitHub Actions workload.
- 📦 **More efficient docs publishing:** The docs job now avoids pulling the old built site unless needed, which is especially helpful for large `gh-pages` branches.
- ✅ **Cleaner automation:** Removing unnecessary steps in the PR merge workflow makes maintenance easier and reduces workflow complexity.
- 🔒 **Low-risk infrastructure improvement:** This PR does not change YOLO model behavior or user-facing features; it mainly improves backend developer operations and automation reliability.