### PR TITLE
Improve `check_amp()` to test compatibility with the actual model

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -734,6 +734,72 @@ def test_utils_checks():
     checks.print_args()
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="AMP actual forward check requires CUDA")
+@pytest.mark.parametrize("training_mode", [True, False])
+def test_check_amp_actual_forward_failed(monkeypatch, training_mode):
+    """Test that AMP is disabled when the actual model forward fails under autocast."""
+    import re
+    import torch.nn as nn
+    import ultralytics
+
+    from types import SimpleNamespace
+    from ultralytics.utils.checks import check_amp
+
+    # Skip GPUs already blocked by `check_amp()`, otherwise this test would not reach the actual-model check.
+    gpu = torch.cuda.get_device_name(0)
+    pattern = re.compile(
+        r"(nvidia|geforce|quadro|tesla).*?(1660|1650|1630|t400|t550|t600|t1000|t1200|t2000|k40m)",
+        re.IGNORECASE,
+    )
+    if bool(pattern.search(gpu)):
+        pytest.skip(f"AMP checks are disabled on {gpu}")
+
+    class FakeYOLO:
+        """Minimal YOLO wrapper mock for the reference AMP check, mainly used to avoid downloading the weight file."""
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self, batch, imgsz, device, verbose=False):
+            boxes = SimpleNamespace(data=torch.zeros((1, 6), device=device))
+            return [SimpleNamespace(boxes=boxes)]
+
+    class AmpUnsafeModule(nn.Module):
+        """Custom module that uses CPU adaptive average pooling and fails on low-precision CPU tensors."""
+
+        def __init__(self):
+            super().__init__()
+            self.avg_pool_h = nn.AdaptiveAvgPool2d((None, 1))
+
+        def forward(self, x):
+            x = x.to(dtype=torch.float16) if x.is_cuda else x  # simulate a low-precision activation entering the CPU path
+            pooled = self.avg_pool_h(x.cpu())  # offload adaptive average pooling to CPU
+
+            # This simulates CUDA autocast producing a low-precision tensor before it is moved to CPU.
+            # Raising here makes the regression test deterministic across PyTorch versions.
+            if pooled.device.type == "cpu" and pooled.dtype in {torch.float16, torch.bfloat16}:
+                raise RuntimeError('"adaptive_avg_pool2d_cpu" not implemented for \'Half\'')
+            return pooled.to(device=x.device, dtype=x.dtype)
+
+    class MinimalModel(nn.Module):
+        """Minimal YOLO-like model with stride and parameters for `check_amp()`."""
+
+        def __init__(self):
+            super().__init__()
+            self.stride = torch.tensor([32])
+            self.stem = nn.Conv2d(3, 8, 1)
+            self.bad = AmpUnsafeModule()
+
+        def forward(self, x):
+            return self.bad(self.stem(x))
+
+    monkeypatch.setattr(ultralytics, "YOLO", FakeYOLO)
+    model = MinimalModel().cuda()
+    model.train(training_mode)
+    assert check_amp(model) is False
+    assert model.training is training_mode
+
+
 @pytest.mark.skipif(WINDOWS, reason="Windows profiling is extremely slow (cause unknown)")
 def test_utils_benchmarks():
     """Benchmark model performance using 'ProfileModels' from 'ultralytics.utils.benchmarks'."""

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -943,7 +943,7 @@ def check_amp(model):
                 y = m(x)  # actual model AMP forward
 
         tensors = collect_tensors(y)
-        assert tensors, "AMP forward produced no tensor outputs."  # no tensor output means forward was unsuccessful
+        assert tensors, "AMP forward produced no tensor outputs."
 
         for t in tensors:
             if t.is_floating_point():
@@ -977,49 +977,59 @@ def check_amp(model):
 
     is_training = model.training  # preserve model mode
     check_failed_msg = f"{prefix}actual model forward checks failed ❌. "
+    check_warning_msg = f"{prefix}actual model forward checks skipped. "
     try:
         model.eval()  # switch to eval mode for AMP forward test
         assert amp_actual_forward(model, im)
         LOGGER.info(f"{prefix}actual model forward checks passed ✅")
     except AssertionError as e:
-        LOGGER.error(
-            f"{check_failed_msg}The current model may contain custom layers that are not AMP-safe, "
-            f"so AMP will be disabled during training. "
-        )  # such as custom layers producing non-finite values under AMP
+        error_msg_lower = str(e).lower()
+        if "no tensor outputs" in error_msg_lower:
+            LOGGER.warning(
+                f"{check_warning_msg}The model output structure could not be interpreted by the smoke test. {warning_msg}"
+            )  # temporarily return True for YOLOE/YOLO-World models
+            return True
+        else:
+            LOGGER.error(
+                f"{check_failed_msg}The actual model produced non-finite outputs under AMP, "
+                f"so AMP will be disabled during training. "
+            )  # such as custom layers
         return False
     except RuntimeError as e:
         error_msg_lower = str(e).lower()
         if "not implemented for" in error_msg_lower and ("half" in error_msg_lower or "bfloat16" in error_msg_lower):
             LOGGER.error(
-                f"{check_failed_msg}This is because a low-precision (such as FP16/BF16) tensor reached an unsupported CPU operator, "
+                f"{check_failed_msg}This is because a low-precision tensor, such as FP16/BF16, reached an unsupported CPU operator, "
                 f"so AMP will be disabled during training. "
             )  # unsupported CPU kernel
-        elif "expected scalar type" in error_msg_lower and ("half" in error_msg_lower or "float" in error_msg_lower):
+            return False
+        elif "expected scalar type" in error_msg_lower and (
+                "half" in error_msg_lower or "bfloat16" in error_msg_lower or "float" in error_msg_lower):
             LOGGER.error(
                 f"{check_failed_msg}A custom layer may need an explicit float32 region or dtype cast, "
                 f"so AMP will be disabled during training. "
             )  # autocast dtype mismatch
+            return False
         elif "input type" in error_msg_lower and "weight type" in error_msg_lower:
             LOGGER.error(
                 f"{check_failed_msg}An input/weight dtype mismatch was detected. "
                 f"This may be caused by mixing FP16 activations with FP32 or CPU weights, "
                 f"so AMP will be disabled during training. "
             )  # input-weight dtype mismatch
+            return False
         else:
-            LOGGER.error(
-                f"{check_failed_msg}The actual model AMP forward raised a RuntimeError exception, "
-                f"so AMP will be disabled. "
-            )  # generic PyTorch runtime error
-        return False
-    except Exception as e:
-        LOGGER.error(
-            f"{check_failed_msg}The actual model AMP forward raised an unexpected exception, "
-            f"so AMP will be disabled. "
-        )  # fallback for unexpected errors
-        return False
+            LOGGER.warning(
+                f"{check_warning_msg}The actual model AMP forward raised a generic RuntimeError exception. {warning_msg}"
+            )  # skip non AMP-specific runtime errors to avoid false positives
+        return True
+    except Exception:
+        LOGGER.warning(
+            f"{check_warning_msg}The actual model AMP forward raised an unexpected exception. {warning_msg}"
+        )  # skip unsupported actual-model forward paths
+        return True
     finally:
         model.train(is_training)  # restore the original model mode
-    return True  # no failed assertions or (runtime) errors occur
+    return True
 
 
 def check_multiple_install():

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -914,6 +914,45 @@ def check_amp(model):
         del m
         return a.shape == b.shape and torch.allclose(a, b.float(), atol=0.5)  # close to 0.5 absolute tolerance
 
+    def amp_actual_forward(m, im):
+        """Run an AMP forward smoke test on the actual model using bus.jpg."""
+        def collect_tensors(obj):
+            """Collect tensors recursively from model outputs."""
+            tensors_list = []
+            if torch.is_tensor(obj):
+                tensors_list.append(obj)
+            elif isinstance(obj, (list, tuple)):
+                for v in obj:
+                    tensors_list.extend(collect_tensors(v))
+            elif isinstance(obj, dict):
+                for v in obj.values():
+                    tensors_list.extend(collect_tensors(v))
+            return tensors_list
+
+        stride = int(getattr(m, "stride", torch.tensor([32], device=device)).max())
+        imgsz = int(((max(256, stride * 4) + stride - 1) // stride) * stride)  # use a small but valid image size
+        img = cv2.cvtColor(cv2.imread(str(im)), cv2.COLOR_BGR2RGB)
+        img = cv2.resize(img, (imgsz, imgsz), interpolation=cv2.INTER_LINEAR)  # resize directly since it's a smoke test input
+
+        x = torch.from_numpy(img).to(device=device)
+        x = x.permute(2, 0, 1).contiguous().float().div_(255.0)  # HWC uint8 to CHW float32 in [0, 1]
+        x = x.unsqueeze(0).repeat(8, 1, 1, 1)  # match the reference AMP check batch size in `amp_allclose()`
+
+        with torch.inference_mode():
+            with autocast(enabled=True):
+                y = m(x)  # actual model AMP forward
+
+        tensors = collect_tensors(y)
+        assert tensors, "AMP forward produced no tensor outputs."  # no tensor output means forward was unsuccessful
+
+        for t in tensors:
+            if t.is_floating_point():
+                assert torch.isfinite(t).all(), (
+                    f"AMP forward produced non-finite values: "
+                    f"shape={tuple(t.shape)}, dtype={t.dtype}, device={t.device}"
+                )  # NaN or Inf values may indicate AMP instability
+        return True  # no failed assertions or errors occur
+
     im = ASSETS / "bus.jpg"  # image to check
     LOGGER.info(f"{prefix}running Automatic Mixed Precision (AMP) checks...")
     warning_msg = "Setting 'amp=True'. If you experience zero-mAP or NaN losses you can disable AMP with amp=False."
@@ -935,7 +974,57 @@ def check_amp(model):
             f"NaN losses or zero-mAP results, so AMP will be disabled during training."
         )
         return False
-    return True
+
+    is_training = model.training  # preserve model mode
+    check_failed_msg = f"{prefix}actual model forward checks failed ❌. "
+    try:
+        model.eval()  # switch to eval mode for AMP forward test
+        assert amp_actual_forward(model, im)
+        LOGGER.info(f"{prefix}actual model forward checks passed ✅")
+    except AssertionError as e:
+        LOGGER.error(
+            f"{check_failed_msg}The current model may contain custom layers that are not AMP-safe, "
+            f"so AMP will be disabled during training. "
+        )  # such as custom layers producing non-finite values under AMP
+        return False
+    except RuntimeError as e:
+        error_msg_lower = str(e).lower()
+        if "not implemented for" in error_msg_lower and ("half" in error_msg_lower or "bfloat16" in error_msg_lower):
+            LOGGER.error(
+                f"{check_failed_msg}This is because a low-precision (such as FP16/BF16) tensor reached an unsupported CPU operator, "
+                f"so AMP will be disabled during training. "
+            )  # unsupported CPU FP16/BF16 kernel
+        elif "expected all tensors to be on the same device" in error_msg_lower or "found at least two devices" in error_msg_lower:
+            LOGGER.error(
+                f"{check_failed_msg}A custom module may have moved only part of the data flow between CUDA and CPU, "
+                f"so AMP will be disabled during training. "
+            )  # CPU/CUDA tensor mismatch
+        elif "expected scalar type" in error_msg_lower and ("half" in error_msg_lower or "float" in error_msg_lower):
+            LOGGER.error(
+                f"{check_failed_msg}A custom layer may need an explicit float32 region or dtype cast, "
+                f"so AMP will be disabled during training. "
+            )  # autocast dtype mismatch
+        elif "input type" in error_msg_lower and "weight type" in error_msg_lower:
+            LOGGER.error(
+                f"{check_failed_msg}An input/weight dtype mismatch was detected. "
+                f"This may be caused by mixing FP16 activations with FP32 or CPU weights, "
+                f"so AMP will be disabled during training. "
+            )  # input-weight dtype mismatch
+        else:
+            LOGGER.error(
+                f"{check_failed_msg}The actual model AMP forward raised a RuntimeError exception, "
+                f"so AMP will be disabled. "
+            )  # generic PyTorch runtime error
+        return False
+    except Exception as e:
+        LOGGER.error(
+            f"{check_failed_msg}The actual model AMP forward raised an unexpected exception, "
+            f"so AMP will be disabled. "
+        )  # fallback for unexpected errors
+        return False
+    finally:
+        model.train(is_training)  # restore the original model mode
+    return True  # no failed assertions or (runtime) errors occur
 
 
 def check_multiple_install():

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -993,12 +993,7 @@ def check_amp(model):
             LOGGER.error(
                 f"{check_failed_msg}This is because a low-precision (such as FP16/BF16) tensor reached an unsupported CPU operator, "
                 f"so AMP will be disabled during training. "
-            )  # unsupported CPU FP16/BF16 kernel
-        elif "expected all tensors to be on the same device" in error_msg_lower or "found at least two devices" in error_msg_lower:
-            LOGGER.error(
-                f"{check_failed_msg}A custom module may have moved only part of the data flow between CUDA and CPU, "
-                f"so AMP will be disabled during training. "
-            )  # CPU/CUDA tensor mismatch
+            )  # unsupported CPU kernel
         elif "expected scalar type" in error_msg_lower and ("half" in error_msg_lower or "float" in error_msg_lower):
             LOGGER.error(
                 f"{check_failed_msg}A custom layer may need an explicit float32 region or dtype cast, "


### PR DESCRIPTION
Hi Ultralytics team,

This PR relates to Issue #24719 . The main changes are made within the context of `check_amp()`.

Previously, `ultralytics` used reference models such as yolo11n.pt or yolo26n.pt to perform the AMP reference check. This works well for official Ultralytics models, but it may not cover customised architectures where some modules intentionally use non-CUDA devices, such as the CPU, to avoid non-deterministic algorithms. One example is adaptive average pooling, whose CUDA backward path may be non-deterministic in certain cases.

When AMP is enabled, however, FP16/BF16 tensors may be passed into CPU-side operations. This can lead to runtime errors, as some low-precision operations are not supported on CPU. Therefore, it would be helpful for AMP Check to detect such cases before training starts, and to disable AMP automatically to avoid runtime failures.

This PR adds a new closure function, `amp_actual_forward()`, inside `check_amp()`. The function runs a lightweight forward smoke test on the actual model that will participate in training. It collects tensors from the model output after an AMP forward pass, checks whether the outputs are valid, and uses the resulting exception type and message to determine whether AMP should be disabled.

I have tested that the new AMP Check can detect the relevant issue. For example, I implemented an attention module named CCAM, which uses adaptive average pooling:

<img width="1920" height="983" alt="ccam_net" src="https://github.com/user-attachments/assets/e1872683-b06d-4c9f-a28b-0e911d6165c4" />

First, I trained a standard YOLO26n model using the previous ultralytics implementation, and it trained successfully without errors:

<img width="1920" height="983" alt="origin_yolo26n" src="https://github.com/user-attachments/assets/6c038a0f-909a-4036-a849-71cd92c8b0c8" />

However, when training a model with the CCAM attention module without explicitly setting `amp=False`, the previous AMP Check passed, but training later failed with a runtime error:

<img width="1920" height="983" alt="origin_yolo26n-ccam_amp" src="https://github.com/user-attachments/assets/138520fd-8fe1-4d9f-b67d-b75faa95f3b3" />

<img width="1920" height="983" alt="origin_yolo26n-ccam_error" src="https://github.com/user-attachments/assets/c68e4545-e2eb-4216-b902-9490dc63993b" />

---

After introducing the forward smoke test into AMP Check, I first trained a standard YOLO26n model again, and everything still worked as expected:

<img width="1920" height="983" alt="new_yolo26n" src="https://github.com/user-attachments/assets/6e5bac4d-647f-4d57-b9e9-d1741da26869" />

Then, when training the model with CCAM attention, the actual-model AMP forward check raised a `RuntimeError`. The exception was caught and identified as a case where FP16/BF16 was not supported by a CPU-side operator. As a result, AMP was disabled automatically, and the model could train normally without crashing:

<img width="1920" height="983" alt="new_yolo26n-ccam_amp" src="https://github.com/user-attachments/assets/2cdf3da0-5a9d-4061-a529-d253ed6c620e" />

<img width="1920" height="983" alt="origin_yolo26n-ccam_successul" src="https://github.com/user-attachments/assets/f375443b-a1c4-41b7-a21b-a63a3c0ea252" />

I also tested cases where tensors were deliberately moved across multiple devices. These exceptions could also be caught by the smoke test. Of course, if tensors are mixed between CUDA and CPU in a way that remains invalid even after AMP is disabled, training will still fail. In that case, the issue is no longer directly related to AMP itself.

<img width="1920" height="983" alt="new_yolo26n-mixed-tensors_amp" src="https://github.com/user-attachments/assets/ec7ca93b-b4fe-4b07-9593-51ec0cbd95d3" />

Therefore, I hope this PR can help improve the robustness of AMP Check in `ultralytics`, especially for users who customise model architectures and add their own modules. Many thanks to Glenn for the review!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves AMP validation by adding a real model forward smoke test, helping catch model-specific mixed precision incompatibilities before training. 🚀

### 📊 Key Changes
-Adds a new `amp_actual_forward()` check in `ultralytics/utils/checks.py` that runs an AMP-enabled forward pass on the actual model using `bus.jpg`.
-Recursively collects tensors from model outputs, including nested lists, tuples, and dictionaries, to validate real forward results.
-Verifies that AMP outputs contain tensors and that floating-point outputs remain finite, catching NaN and Inf issues early.
-Preserves the model’s original train/eval state while temporarily switching to eval mode for the AMP smoke test.
-Introduces targeted `RuntimeError` handling for common AMP failure modes such as unsupported low-precision CPU ops, device mismatches, and dtype mismatches.
-Logs clearer failure reasons and disables AMP when the actual model forward is not AMP-safe.

### 🎯 Purpose & Impact
-Helps detect AMP issues caused by custom layers or nonstandard model paths that the existing reference check may miss. 🔍
-Reduces the risk of unstable training outcomes like NaN losses or zero mAP by disabling AMP earlier when incompatibilities are detected.
-Improves debugging experience with more actionable logging around why AMP failed.
-Makes AMP enablement safer and more representative of real-world model execution, especially for customized detection models. ✅