### PR TITLE
Add timeout to requests calls in Hub and downloads

### DIFF
--- a/ultralytics/hub/__init__.py
+++ b/ultralytics/hub/__init__.py
@@ -74,7 +74,12 @@ def reset_model(model_id: str = ""):
     """Reset a trained model to an untrained state."""
     import requests  # scoped as slow import
 
-    r = requests.post(f"{HUB_API_ROOT}/model-reset", json={"modelId": model_id}, headers={"x-api-key": Auth().api_key})
+    r = requests.post(
+        f"{HUB_API_ROOT}/model-reset",
+        json={"modelId": model_id},
+        headers={"x-api-key": Auth().api_key},
+        timeout=30,
+    )
     if r.status_code == 200:
         LOGGER.info(f"{PREFIX}Model reset successfully")
         return
@@ -107,7 +112,10 @@ def export_model(model_id: str = "", format: str = "torchscript"):
 
     assert format in export_fmts_hub(), f"Unsupported export format '{format}', valid formats are {export_fmts_hub()}"
     r = requests.post(
-        f"{HUB_API_ROOT}/v1/models/{model_id}/export", json={"format": format}, headers={"x-api-key": Auth().api_key}
+        f"{HUB_API_ROOT}/v1/models/{model_id}/export",
+        json={"format": format},
+        headers={"x-api-key": Auth().api_key},
+        timeout=30,
     )
     assert r.status_code == 200, f"{PREFIX}{format} export failure {r.status_code} {r.reason}"
     LOGGER.info(f"{PREFIX}{format} export started ✅")
@@ -137,6 +145,7 @@ def get_export(model_id: str = "", format: str = "torchscript"):
         f"{HUB_API_ROOT}/get-export",
         json={"apiKey": Auth().api_key, "modelId": model_id, "format": format},
         headers={"x-api-key": Auth().api_key},
+        timeout=30,
     )
     assert r.status_code == 200, f"{PREFIX}{format} get_export failure {r.status_code} {r.reason}"
     return r.json()

--- a/ultralytics/hub/auth.py
+++ b/ultralytics/hub/auth.py
@@ -115,9 +115,12 @@ class Auth:
                     raise ConnectionError("Unable to authenticate.")
                 return True
             raise ConnectionError("User has not authenticated locally.")
-        except (ConnectionError, requests.exceptions.RequestException):
-            self.id_token = self.api_key = False  # reset invalid
+        except ConnectionError:
+            self.id_token = self.api_key = False  # reset invalid credentials
             LOGGER.warning(f"{PREFIX}Invalid API key")
+            return False
+        except requests.exceptions.RequestException as e:
+            LOGGER.warning(f"{PREFIX}Authentication request failed, check your connection: {e}")  # keep credentials
             return False
 
     def auth_with_cookies(self) -> bool:

--- a/ultralytics/hub/auth.py
+++ b/ultralytics/hub/auth.py
@@ -110,7 +110,7 @@ class Auth:
 
         try:
             if header := self.get_auth_header():
-                r = requests.post(f"{HUB_API_ROOT}/v1/auth", headers=header)
+                r = requests.post(f"{HUB_API_ROOT}/v1/auth", headers=header, timeout=30)
                 if not r.json().get("success", False):
                     raise ConnectionError("Unable to authenticate.")
                 return True

--- a/ultralytics/hub/auth.py
+++ b/ultralytics/hub/auth.py
@@ -115,7 +115,7 @@ class Auth:
                     raise ConnectionError("Unable to authenticate.")
                 return True
             raise ConnectionError("User has not authenticated locally.")
-        except ConnectionError:
+        except (ConnectionError, requests.exceptions.RequestException):
             self.id_token = self.api_key = False  # reset invalid
             LOGGER.warning(f"{PREFIX}Invalid API key")
             return False

--- a/ultralytics/hub/auth.py
+++ b/ultralytics/hub/auth.py
@@ -111,6 +111,8 @@ class Auth:
         try:
             if header := self.get_auth_header():
                 r = requests.post(f"{HUB_API_ROOT}/v1/auth", headers=header, timeout=30)
+                if r.status_code == 429 or r.status_code >= 500:
+                    r.raise_for_status()  # transient server error: keep credentials, take the connectivity path
                 if not r.json().get("success", False):
                     raise ConnectionError("Unable to authenticate.")
                 return True

--- a/ultralytics/hub/auth.py
+++ b/ultralytics/hub/auth.py
@@ -111,7 +111,7 @@ class Auth:
         try:
             if header := self.get_auth_header():
                 r = requests.post(f"{HUB_API_ROOT}/v1/auth", headers=header, timeout=30)
-                if r.status_code == 429 or r.status_code >= 500:
+                if r.status_code in {408, 429} or r.status_code >= 500:
                     r.raise_for_status()  # transient server error: keep credentials, take the connectivity path
                 if not r.json().get("success", False):
                     raise ConnectionError("Unable to authenticate.")

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -449,9 +449,9 @@ def get_github_assets(
     if version != "latest":
         version = f"tags/{version}"  # i.e. tags/v6.2
     url = f"https://api.github.com/repos/{repo}/releases/{version}"
-    r = requests.get(url)  # github api
+    r = requests.get(url, timeout=30)  # github api
     if r.status_code != 200 and r.reason != "rate limit exceeded" and retry:  # failed and not 403 rate limit exceeded
-        r = requests.get(url)  # try again
+        r = requests.get(url, timeout=30)  # try again
     if r.status_code != 200:
         LOGGER.warning(f"GitHub assets check failure for {url}: {r.status_code} {r.reason}")
         return "", []

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -449,13 +449,17 @@ def get_github_assets(
     if version != "latest":
         version = f"tags/{version}"  # i.e. tags/v6.2
     url = f"https://api.github.com/repos/{repo}/releases/{version}"
-    try:
-        r = requests.get(url, timeout=30)  # github api
-        if r.status_code != 200 and r.reason != "rate limit exceeded" and retry:  # failed and not 403 rate limit
-            r = requests.get(url, timeout=30)  # try again
-    except requests.exceptions.RequestException as e:
-        LOGGER.warning(f"GitHub assets check failure for {url}: {e}")
-        return "", []
+    attempts = 2 if retry else 1  # retry once on transient network errors or non-200 responses
+    for attempt in range(attempts):
+        try:
+            r = requests.get(url, timeout=30)  # github api
+        except requests.exceptions.RequestException as e:
+            if attempt < attempts - 1:
+                continue  # transient network error, try again
+            LOGGER.warning(f"GitHub assets check failure for {url}: {e}")
+            return "", []
+        if r.status_code == 200 or r.reason == "rate limit exceeded":  # do not retry 403 rate limits
+            break
     if r.status_code != 200:
         LOGGER.warning(f"GitHub assets check failure for {url}: {r.status_code} {r.reason}")
         return "", []

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -449,9 +449,13 @@ def get_github_assets(
     if version != "latest":
         version = f"tags/{version}"  # i.e. tags/v6.2
     url = f"https://api.github.com/repos/{repo}/releases/{version}"
-    r = requests.get(url, timeout=30)  # github api
-    if r.status_code != 200 and r.reason != "rate limit exceeded" and retry:  # failed and not 403 rate limit exceeded
-        r = requests.get(url, timeout=30)  # try again
+    try:
+        r = requests.get(url, timeout=30)  # github api
+        if r.status_code != 200 and r.reason != "rate limit exceeded" and retry:  # failed and not 403 rate limit
+            r = requests.get(url, timeout=30)  # try again
+    except requests.exceptions.RequestException as e:
+        LOGGER.warning(f"GitHub assets check failure for {url}: {e}")
+        return "", []
     if r.status_code != 200:
         LOGGER.warning(f"GitHub assets check failure for {url}: {r.status_code} {r.reason}")
         return "", []


### PR DESCRIPTION
## summary

six `requests.get`/`requests.post` calls in `ultralytics/hub/__init__.py`, `ultralytics/hub/auth.py`, and `ultralytics/utils/downloads.py` had no `timeout=`, so a stalled or unresponsive server blocks the process indefinitely (urllib3 defaults the socket timeout to `None`). this adds `timeout=30` to all six, matching the convention already used elsewhere in the codebase. the auth call is on the hot path of every Hub-using run, so a dead auth server previously hung `YOLO("hub://...")` with no error.

adding the timeout makes request failures a realistic raise, so the resulting paths are handled so transient issues never destroy good state:

- `Auth.authenticate()` separates credential failures from connectivity failures: a genuine auth failure (no/invalid key, or `success: false`) resets credentials and warns `Invalid API key`, while a transient failure (timeout, connection drop, `429`, or `5xx`) logs a connectivity warning and returns `False` without discarding a valid key. `429`/`5xx` responses are routed to the connectivity path via `raise_for_status()` before the body is parsed.
- `get_github_assets()` retries once on a transient request error or a non-200 response (rate limits excepted) and degrades to an empty result on failure, consistent with its existing behavior.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛡️ This PR improves network reliability in Ultralytics HUB and GitHub asset requests by adding request timeouts, smarter retry behavior, and safer authentication error handling.

### 📊 Key Changes
- Added `timeout=30` to several HUB API requests in `ultralytics/hub/__init__.py`:
  - model reset
  - model export
  - export status lookup
- Updated HUB authentication in `ultralytics/hub/auth.py`:
  - added a 30-second timeout to auth requests
  - treats temporary server issues like `408`, `429`, and `5xx` as connection problems instead of invalid credentials
  - preserves saved credentials during temporary network/server failures
  - adds clearer warning messages when authentication fails due to connectivity issues
- Improved GitHub release asset fetching in `ultralytics/utils/downloads.py`:
  - added a 30-second timeout to GitHub API calls
  - added a controlled retry loop for transient request failures
  - avoids unnecessary retries when GitHub rate limiting is the cause
  - logs clearer warnings if asset checks fail

### 🎯 Purpose & Impact
- ⏱️ Prevents requests from hanging indefinitely, making CLI and Python workflows more predictable.
- 🔐 Reduces false “invalid API key” cases caused by temporary HUB or network outages.
- 🌐 Makes interactions with Ultralytics HUB and GitHub more resilient in unstable network conditions.
- 🔁 Improves reliability of model export/reset operations and release asset checks with simple retry logic.
- 😊 For users, this means fewer confusing failures and smoother behavior when using HUB-connected features.