### PR TITLE
Add note on reloading models with custom trainer classes

### DIFF
--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -185,34 +185,27 @@ model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
     # Result: [1.0, 25.0, 1.67]
     ```
 
-!!! note "Loading a model that uses custom classes"
+!!! note "Loading a model with custom classes"
 
-    Custom classes like `WeightedDetectionModel` are saved into the checkpoint by reference. If you define them in your training script, they belong to the `__main__` module, and loading `best.pt` from a different script raises `AttributeError: Can't get attribute 'WeightedDetectionModel' on <module '__main__'>`.
+    Custom classes such as `WeightedDetectionModel` are stored in the checkpoint by reference. When defined in a training script they belong to the `__main__` module, so loading `best.pt` from a different script raises `AttributeError: Can't get attribute 'WeightedDetectionModel' on <module '__main__'>`.
 
-    Keep the custom classes in their own module so they stay importable, and make sure that module is on your `PYTHONPATH` when you load the model.
+    Define custom classes in a dedicated module so they remain importable, and ensure that module is on your `PYTHONPATH` at load time.
 
     ```python
-    # weighted_trainer.py
-    from ultralytics.models.yolo.detect import DetectionTrainer
+    # weighted_model.py
     from ultralytics.nn.tasks import DetectionModel
 
 
     class WeightedDetectionModel(DetectionModel):
+        """Detection model that uses class-weighted loss."""
         ...
 
-
-    class WeightedTrainer(DetectionTrainer):
-        def get_model(self, cfg=None, weights=None, verbose=True):
-            model = WeightedDetectionModel(cfg, nc=self.data["nc"], verbose=verbose)
-            if weights:
-                model.load(weights)
-            return model
     ```
 
     ```python
-    # load the trained model from another script
+    # inference script
     from ultralytics import YOLO
-    from weighted_trainer import WeightedDetectionModel  # keep the class importable
+    from weighted_model import WeightedDetectionModel  # must be importable at load time
 
     model = YOLO("runs/detect/train/weights/best.pt")
     results = model.val()

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -185,6 +185,39 @@ model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
     # Result: [1.0, 25.0, 1.67]
     ```
 
+!!! note "Loading a model that uses custom classes"
+
+    Custom classes like `WeightedDetectionModel` are saved into the checkpoint by reference. If you define them in your training script, they belong to the `__main__` module, and loading `best.pt` from a different script raises `AttributeError: Can't get attribute 'WeightedDetectionModel' on <module '__main__'>`.
+
+    Keep the custom classes in their own module so they stay importable, and make sure that module is on your `PYTHONPATH` when you load the model.
+
+    ```python
+    # weighted_trainer.py
+    from ultralytics.models.yolo.detect import DetectionTrainer
+    from ultralytics.nn.tasks import DetectionModel
+
+
+    class WeightedDetectionModel(DetectionModel):
+        ...
+
+
+    class WeightedTrainer(DetectionTrainer):
+        def get_model(self, cfg=None, weights=None, verbose=True):
+            model = WeightedDetectionModel(cfg, nc=self.data["nc"], verbose=verbose)
+            if weights:
+                model.load(weights)
+            return model
+    ```
+
+    ```python
+    # load the trained model from another script
+    from ultralytics import YOLO
+    from weighted_trainer import WeightedDetectionModel  # keep the class importable
+
+    model = YOLO("runs/detect/train/weights/best.pt")
+    results = model.val()
+    ```
+
 ## Saving the Best Model by Custom Metric
 
 The trainer saves `best.pt` based on fitness, which for detection defaults to `mAP@0.5:0.95` (weights `[0.0, 0.0, 0.0, 1.0]` for [P, R, mAP@0.5, mAP@0.5:0.95]). To use a different metric (like `mAP@0.5` or recall), override `validate()` and return your chosen metric as the fitness value. The built-in `save_model()` will then use it automatically:

--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -199,7 +199,6 @@ model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
     class WeightedDetectionModel(DetectionModel):
         """Detection model that uses class-weighted loss."""
         ...
-
     ```
 
     ```python
@@ -208,7 +207,7 @@ model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
     from weighted_model import WeightedDetectionModel  # must be importable at load time
 
     model = YOLO("runs/detect/train/weights/best.pt")
-    results = model.val()
+    metrics = model.val()
     ```
 
 ## Saving the Best Model by Custom Metric


### PR DESCRIPTION
### Description

The class-weights example in the custom trainer guide defines `WeightedDetectionModel` in the training script. The trained `best.pt` then stores the class under `__main__`, so loading it from a separate script fails with:

```
AttributeError: Can't get attribute 'WeightedDetectionModel' on <module '__main__'>
```

This adds a short note to the guide explaining why this happens and showing how to keep the custom classes in an importable module so the saved checkpoint loads correctly.

Reproduced on ultralytics 8.4.62 (CPU), and confirmed the module-based pattern lets `YOLO("best.pt")` and `.val()` load without error.

Fixes #24727
