### PR TITLE
Experiment with Ubuntu 26.04 ARM Docker base

### DIFF
--- a/docker/Dockerfile-arm64
+++ b/docker/Dockerfile-arm64
@@ -3,10 +3,8 @@
 # Builds ultralytics/ultralytics:latest-arm64 image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Image is aarch64-compatible for Apple M1, M2, M3, Raspberry Pi and other ARM architectures
 
-# Start FROM Ubuntu image https://hub.docker.com/_/ubuntu with "FROM arm64v8/ubuntu:22.04" (deprecated)
-# Start FROM Debian image for arm64v8 https://hub.docker.com/r/arm64v8/debian (deprecated)
-# Start FROM official arm64v8 Ubuntu 24.04 image https://hub.docker.com/layers/arm64v8/ubuntu/24.04/
-FROM arm64v8/ubuntu:24.04
+# Start FROM official arm64v8 Ubuntu 26.04 image https://hub.docker.com/layers/arm64v8/ubuntu/26.04/
+FROM arm64v8/ubuntu:26.04
 
 # Set environment variables (suppress PyTorch NNPACK warnings)
 ENV PYTHONUNBUFFERED=1 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ export-base = [
     # ONNX export validation and inference. Jetson jobs provide custom aarch64 onnxruntime-gpu wheels.
     "onnxruntime<1.20.0; python_version < '3.11' and (platform_machine != 'aarch64' or platform_system != 'Linux')",
     "onnxruntime>=1.20.0; python_version >= '3.11'",
-    "nncf>=2.14.0,<3.0.0; python_version >= '3.9'",  # OpenVINO INT8 export
+    "nncf>=2.14.0,<3.0.0; python_version >= '3.9' and python_version < '3.14'",  # OpenVINO INT8 export
     "openvino>=2024.0.0",  # OpenVINO export
     "packaging>=26.0; platform_machine == 'aarch64' and platform_system == 'Linux' and python_version >= '3.9'", # IMX export bug
 ]
@@ -107,8 +107,8 @@ export-legacy-torch = [
 export-tensorflow = [
     "numpy<2.0.0; python_version < '3.13'", # TF 2.20 compatibility
     "tensorflow>=2.0.0,<=2.19.0; python_version < '3.13'", # TF bug https://github.com/ultralytics/ultralytics/issues/5161
-    "tensorflow>2.19.0; python_version >= '3.13'",
-    "tensorflowjs>=2.0.0", # TF.js export, automatically installs tensorflow
+    "tensorflow>2.19.0; python_version >= '3.13' and python_version < '3.14'",
+    "tensorflowjs>=2.0.0; python_version < '3.14'", # TF.js export, automatically installs tensorflow
     "ydf<0.13.0; platform_machine != 'aarch64' and python_version <= '3.12'", # ydf>=0.13 has protobuf gencode 6.x but tensorflow<=2.19 requires protobuf<6
     "googleapis-common-protos<1.74.0; python_version <= '3.12'", # >=1.74.0 uses protobuf gencode 7.34.1, incompatible with tensorflow<=2.19 (protobuf<6) and breaks ray[tune] import
     "tensorstore>=0.1.63; platform_machine == 'aarch64' and python_version >= '3.9'", # for TF Raspberry Pi exports


### PR DESCRIPTION
## Summary
- update the ARM64 Docker base from Ubuntu 24.04 LTS to Ubuntu 26.04 LTS
- remove stale alternative-base comments around the ARM Dockerfile
- mark TensorFlow and TensorFlow.js export dependencies as unsupported on Python 3.14, since Ubuntu 26.04 ships Python 3.14 and TensorFlow has no cp314 wheels yet
- audit all docker/Dockerfile* files; the other Dockerfiles inherit PyTorch, Python Debian slim, Miniconda, NVIDIA/Jetson, or internal bases and are left unchanged

## Validation
- docker run --rm arm64v8/ubuntu:26.04 sh -c 'apt-get update && apt-get install -y --no-install-recommends python3-pip git zip unzip wget curl htop gcc libgl1 libglib2.0-0 gnupg'
- docker run --rm -v "/Users/glennjocher/PycharmProjects/ultralytics-docker-24":/ultralytics -w /ultralytics arm64v8/ubuntu:26.04 sh -c 'apt-get update >/dev/null && apt-get install -y --no-install-recommends python3-pip git >/dev/null && PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install uv >/dev/null && UV_BREAK_SYSTEM_PACKAGES=1 uv pip install --system -e ".[export]" --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match --dry-run'
- git diff --check

This is the requested experimental follow-up for the 26.04 base. The first Docker run proved the Python 3.14 TensorFlow wheel gap, so this PR now reflects that unsupported dependency in package metadata instead of patching Docker around it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR updates the ARM64 Docker image to Ubuntu 26.04 and tightens Python version limits for several export-related dependencies to avoid compatibility issues with Python 3.14.

### 📊 Key Changes
- 🐳 Updated `docker/Dockerfile-arm64` base image from `arm64v8/ubuntu:24.04` to `arm64v8/ubuntu:26.04`.
- 🔒 Restricted `nncf` installation to Python `>=3.9` and `<3.14` in `pyproject.toml`.
- 🧠 Restricted newer `tensorflow` installation to Python `>=3.13` and `<3.14`.
- 🌐 Restricted `tensorflowjs` installation to Python `<3.14`.
- 🛠️ These changes only affect optional export-related dependencies, especially for OpenVINO and TensorFlow export workflows.

### 🎯 Purpose & Impact
- ✅ Helps keep ARM64 Docker environments current with a newer Ubuntu base image.
- 🧩 Prevents users from installing export dependencies in Python 3.14 environments where compatibility is not yet ready.
- 📦 Reduces setup failures and confusing dependency errors for users working with model export features.
- ⚠️ Users relying on OpenVINO, TensorFlow, or TensorFlow.js export with Python 3.14 may need to use an earlier Python version for now.
- 🍏 Particularly relevant for ARM64 users on Apple Silicon, Raspberry Pi, and other ARM-based systems using Ultralytics Docker images.