### PR TITLE
Merge `isolated_model` and `isolated_task_model` into `isolated_model_path`

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,32 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import shutil
+from pathlib import Path
+
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.utils import ASSETS, WEIGHTS_DIR, checks
+
+
+def isolated_model_path(tmp_path, model):
+    """Copy a model to a per-test path so exported artifacts cannot collide under pytest-xdist.
+
+    Args:
+        tmp_path (pathlib.Path): Temporary directory provided by pytest.
+        model (str | pathlib.Path): Path to the source model file.
+
+    Returns:
+        str: Path to the isolated copy in the temporary directory.
+    """
+    model = Path(model)
+    if not model.exists():
+        from ultralytics.utils.downloads import attempt_download_asset
+
+        model.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(attempt_download_asset(model.name), model)
+
+    dst = tmp_path / model.name
+    shutil.copy(model, dst)
+    return str(dst)
 
 # Constants used in tests
 MODEL = WEIGHTS_DIR / "path with spaces" / "yolo26n.pt"  # test spaces in path

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,32 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-import shutil
-from pathlib import Path
-
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.utils import ASSETS, WEIGHTS_DIR, checks
-
-
-def isolated_model_path(tmp_path, model):
-    """Copy a model to a per-test path so exported artifacts cannot collide under pytest-xdist.
-
-    Args:
-        tmp_path (pathlib.Path): Temporary directory provided by pytest.
-        model (str | pathlib.Path): Path to the source model file.
-
-    Returns:
-        str: Path to the isolated copy in the temporary directory.
-    """
-    model = Path(model)
-    if not model.exists():
-        from ultralytics.utils.downloads import attempt_download_asset
-
-        model.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(attempt_download_asset(model.name), model)
-
-    dst = tmp_path / model.name
-    shutil.copy(model, dst)
-    return str(dst)
 
 
 # Constants used in tests

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,6 +28,7 @@ def isolated_model_path(tmp_path, model):
     shutil.copy(model, dst)
     return str(dst)
 
+
 # Constants used in tests
 MODEL = WEIGHTS_DIR / "path with spaces" / "yolo26n.pt"  # test spaces in path
 CFG = "yolo26n.yaml"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,6 @@
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.utils import ASSETS, WEIGHTS_DIR, checks
 
-
 # Constants used in tests
 MODEL = WEIGHTS_DIR / "path with spaces" / "yolo26n.pt"  # test spaces in path
 CFG = "yolo26n.yaml"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,20 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.skip(reason=f"export format '{fmt}' belongs to env '{env_by_format[fmt]}'"))
 
 
+def isolated_model_path(tmp_path, model):
+    """Copy a model to a per-test path to prevent export file races under pytest-xdist."""
+    model = Path(model)
+    if not model.exists():
+        from ultralytics.utils.downloads import attempt_download_asset
+
+        model.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(attempt_download_asset(model.name), model)
+
+    dst = tmp_path / model.name
+    shutil.copy(model, dst)
+    return str(dst)
+
+
 def pytest_sessionstart(session):
     """Initialize session configurations for pytest.
 
@@ -99,7 +113,7 @@ def isolated_model(tmp_path):
     intermediate/export files. This fixture copies the shared model to a per-test temporary directory so each test
     exports to a unique path.
     """
-    from tests import MODEL, isolated_model_path
+    from tests import MODEL
 
     return isolated_model_path(tmp_path, MODEL)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,17 +99,9 @@ def isolated_model(tmp_path):
     intermediate/export files. This fixture copies the shared model to a per-test temporary directory so each test
     exports to a unique path.
     """
-    from tests import MODEL
+    from tests import MODEL, isolated_model_path
 
-    if not Path(MODEL).exists():
-        from ultralytics.utils.downloads import attempt_download_asset
-
-        MODEL.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(attempt_download_asset("yolo26n.pt"), MODEL)
-
-    dst = tmp_path / "model.pt"
-    shutil.copy(MODEL, dst)
-    return str(dst)
+    return isolated_model_path(tmp_path, MODEL)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -13,7 +13,8 @@ from pathlib import Path
 import pytest
 import torch
 
-from tests import SOURCE, isolated_model_path
+from tests import SOURCE
+from tests.conftest import isolated_model_path
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.engine.exporter import EXPORT_ENVS, export_formats

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 import torch
 
-from tests import SOURCE
+from tests import SOURCE, isolated_model_path
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.engine.exporter import EXPORT_ENVS, export_formats
@@ -45,20 +45,6 @@ def skip_rpi_semantic(task):
     """Skip semantic segmentation export tests on Raspberry Pi due to memory constraints."""
     if IS_RASPBERRYPI and task == "semantic":
         pytest.skip("Semantic segmentation export tests are skipped on Raspberry Pi due to memory constraints.")
-
-
-def isolated_task_model(task, tmp_path):
-    """Copy a task model to a per-test path so exported artifacts cannot collide under xdist."""
-    source = WEIGHTS_DIR / TASK2MODEL[task]
-    if not source.exists():
-        from ultralytics.utils.downloads import attempt_download_asset
-
-        source.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(attempt_download_asset(source.name), source)
-
-    dst = tmp_path / source.name
-    shutil.copy(source, dst)
-    return dst
 
 
 @pytest.mark.parametrize("end2end", [False, True])
@@ -208,7 +194,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms, end
 def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms, end2end, tmp_path):
     """Test YOLO model export to TorchScript format under varied configurations."""
     skip_rpi_semantic(task)
-    file = YOLO(isolated_task_model(task, tmp_path)).export(
+    file = YOLO(isolated_model_path(tmp_path, WEIGHTS_DIR / TASK2MODEL[task])).export(
         format="torchscript", imgsz=32, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms, end2end=end2end
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference

--- a/ultralytics/models/sam/sam3/vl_combiner.py
+++ b/ultralytics/models/sam/sam3/vl_combiner.py
@@ -67,9 +67,9 @@ class SAM3VLBackbone(nn.Module):
                 backbone forward pass.
 
         Returns:
-            (dict): Output dictionary with the following keys: `vision_features` (the output of the vision
-                backbone), `language_features` (the output of the language backbone), `language_mask` (the
-                attention mask of the language backbone), `vision_pos_enc` (the positional encoding of the vision
+            (dict): Output dictionary with the following keys: `vision_features` (the output of the vision backbone),
+                `language_features` (the output of the language backbone), `language_mask` (the attention mask of the
+                language backbone), `vision_pos_enc` (the positional encoding of the vision
                 backbone) and, when `additional_text` is provided, `additional_text_features` and
                 `additional_text_mask` (the language backbone output and attention mask for the additional text).
         """


### PR DESCRIPTION
This PR merges the duplicate \`isolated_model\` fixture and \`isolated_task_model\` helper into a single reusable \`isolated_model_path(tmp_path, model)\` function in \`tests/__init__.py\`.

- \`isolated_model\` fixture in \`conftest.py\` now delegates to the helper
- \`isolated_task_model\` is removed; its one caller uses the helper directly
- Keeps the fixture interface unchanged for all existing tests

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧪 This PR improves test reliability for model export workflows by centralizing isolated model-copy logic and preventing file conflicts during parallel test runs.

### 📊 Key Changes
- 🔁 Added a shared `isolated_model_path()` helper in `tests/conftest.py` to copy model weights into a unique per-test temporary location.
- 🛡️ The new helper also downloads missing model assets automatically before copying them, keeping test setup consistent.
- 🧹 Replaced duplicated model-isolation logic in `tests/test_exports.py` with the shared helper for cleaner, more maintainable test code.
- ⚙️ Updated TorchScript export matrix tests to use isolated per-test model paths, reducing the chance of exported artifact collisions under `pytest-xdist`.
- ✍️ Made a small docstring formatting cleanup in `ultralytics/models/sam/sam3/vl_combiner.py` for better readability.

### 🎯 Purpose & Impact
- 🚫 Helps prevent flaky test failures caused by multiple parallel tests reading from or writing around the same model/export files.
- ⚡ Improves stability of export test coverage, especially in CI environments that run tests concurrently.
- 🧼 Reduces duplicated code, making the test suite easier to maintain and less error-prone over time.
- 👥 Benefits contributors and maintainers by making export-related test behavior more predictable and easier to debug.
- 📈 For users, this should indirectly lead to more reliable export features because the underlying test suite is stronger and more consistent.