### PR TITLE
Avoid per-keypoint gpu sync in workout monitoring loop

### DIFF
--- a/ultralytics/solutions/ai_gym.py
+++ b/ultralytics/solutions/ai_gym.py
@@ -71,7 +71,7 @@ class AIGym(BaseSolution):
         self.extract_tracks(im0)  # Extract tracks (bounding boxes, classes, and masks)
 
         if len(self.boxes):
-            kpt_data = self.tracks.keypoints.data
+            kpt_data = self.tracks.keypoints.data.cpu().numpy()  # one host transfer, avoids per-keypoint GPU sync
 
             for i, k in enumerate(kpt_data):
                 state = self.states[self.track_ids[i]]  # get state details


### PR DESCRIPTION
## summary

`AIGym.process` kept pose keypoints on-device and converted them to host one element at a time inside the per-person loop (via `_point_xy`), forcing roughly 3 gpu syncs per person per frame. this hoists a single `.cpu().numpy()` transfer before the loop so the per-person path indexes already-host data, removing the per-keypoint sync while keeping behavior identical.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚡ This PR improves the `ai_gym` solution by converting pose keypoint data to a NumPy array in one step, reducing repeated GPU-to-CPU synchronization during processing.

### 📊 Key Changes
- Updated `ultralytics/solutions/ai_gym.py` to change:
  - from `self.tracks.keypoints.data`
  - to `self.tracks.keypoints.data.cpu().numpy()`
- Added a comment clarifying the reason:
  - one host transfer
  - avoids per-keypoint GPU sync
- Keeps the existing AI Gym logic unchanged while making keypoint access more efficient.

### 🎯 Purpose & Impact
- 🚀 **Improves performance** by transferring keypoint data from GPU to CPU only once instead of triggering repeated syncs during iteration.
- 🧠 **Reduces processing overhead** in pose-based workout or movement tracking workflows.
- 🔒 **Low-risk optimization** since it does not change output behavior, only how data is accessed internally.
- 📈 **Better scalability** for users running AI Gym on video streams or larger workloads, where small inefficiencies can add up.