### PR TITLE
Clean up partially-initialized LoadStreams on failure

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -117,38 +117,42 @@ class LoadStreams:
         self.imgs = [[] for _ in range(n)]  # images
         self.shape = [[] for _ in range(n)]  # image shapes
         self.sources = [ops.clean_str(x).replace(os.sep, "_") for x in sources]  # clean source names for later
-        for i, s in enumerate(sources):  # index, source
-            # Start thread to read frames from video stream
-            st = f"{i + 1}/{n}: {s}... "
-            if urllib.parse.urlparse(s).hostname in {"www.youtube.com", "youtube.com", "youtu.be"}:  # YouTube video
-                # YouTube format i.e. 'https://www.youtube.com/watch?v=Jsn8D3aC840' or 'https://youtu.be/Jsn8D3aC840'
-                s = get_best_youtube_url(s)
-            s = int(s) if s.isnumeric() else s  # i.e. s = '0' local webcam
-            if s == 0 and (IS_COLAB or IS_KAGGLE):
-                raise NotImplementedError(
-                    "'source=0' webcam not supported in Colab and Kaggle notebooks. "
-                    "Try running 'source=0' in a local environment."
-                )
-            self.caps[i] = cv2.VideoCapture(s)  # store video capture object
-            if not self.caps[i].isOpened():
-                raise ConnectionError(f"{st}Failed to open {s}")
-            w = int(self.caps[i].get(cv2.CAP_PROP_FRAME_WIDTH))
-            h = int(self.caps[i].get(cv2.CAP_PROP_FRAME_HEIGHT))
-            fps = self.caps[i].get(cv2.CAP_PROP_FPS)  # warning: may return 0 or nan
-            self.frames[i] = max(int(self.caps[i].get(cv2.CAP_PROP_FRAME_COUNT)), 0) or float(
-                "inf"
-            )  # infinite stream fallback
-            self.fps[i] = max((fps if math.isfinite(fps) else 0) % 100, 0) or 30  # 30 FPS fallback
+        try:
+            for i, s in enumerate(sources):  # index, source
+                # Start thread to read frames from video stream
+                st = f"{i + 1}/{n}: {s}... "
+                if urllib.parse.urlparse(s).hostname in {"www.youtube.com", "youtube.com", "youtu.be"}:  # YouTube video
+                    # YouTube format i.e. 'https://www.youtube.com/watch?v=Jsn8D3aC840' or 'https://youtu.be/Jsn8D3aC840'
+                    s = get_best_youtube_url(s)
+                s = int(s) if s.isnumeric() else s  # i.e. s = '0' local webcam
+                if s == 0 and (IS_COLAB or IS_KAGGLE):
+                    raise NotImplementedError(
+                        "'source=0' webcam not supported in Colab and Kaggle notebooks. "
+                        "Try running 'source=0' in a local environment."
+                    )
+                self.caps[i] = cv2.VideoCapture(s)  # store video capture object
+                if not self.caps[i].isOpened():
+                    raise ConnectionError(f"{st}Failed to open {s}")
+                w = int(self.caps[i].get(cv2.CAP_PROP_FRAME_WIDTH))
+                h = int(self.caps[i].get(cv2.CAP_PROP_FRAME_HEIGHT))
+                fps = self.caps[i].get(cv2.CAP_PROP_FPS)  # warning: may return 0 or nan
+                self.frames[i] = max(int(self.caps[i].get(cv2.CAP_PROP_FRAME_COUNT)), 0) or float(
+                    "inf"
+                )  # infinite stream fallback
+                self.fps[i] = max((fps if math.isfinite(fps) else 0) % 100, 0) or 30  # 30 FPS fallback
 
-            success, im = self.caps[i].read()  # guarantee first frame
-            im = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)[..., None] if self.cv2_flag == cv2.IMREAD_GRAYSCALE else im
-            if not success or im is None:
-                raise ConnectionError(f"{st}Failed to read images from {s}")
-            self.imgs[i].append(im)
-            self.shape[i] = im.shape
-            self.threads[i] = Thread(target=self.update, args=([i, self.caps[i], s]), daemon=True)
-            LOGGER.info(f"{st}Success ✅ ({self.frames[i]} frames of shape {w}x{h} at {self.fps[i]:.2f} FPS)")
-            self.threads[i].start()
+                success, im = self.caps[i].read()  # guarantee first frame
+                im = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)[..., None] if self.cv2_flag == cv2.IMREAD_GRAYSCALE else im
+                if not success or im is None:
+                    raise ConnectionError(f"{st}Failed to read images from {s}")
+                self.imgs[i].append(im)
+                self.shape[i] = im.shape
+                self.threads[i] = Thread(target=self.update, args=([i, self.caps[i], s]), daemon=True)
+                LOGGER.info(f"{st}Success ✅ ({self.frames[i]} frames of shape {w}x{h} at {self.fps[i]:.2f} FPS)")
+                self.threads[i].start()
+        except Exception:
+            self.close()  # release opened captures and stop started threads before re-raising
+            raise
         LOGGER.info("")  # newline
 
     def update(self, i: int, cap: cv2.VideoCapture, stream: str):
@@ -178,9 +182,11 @@ class LoadStreams:
         """Terminate stream loader, stop threads, and release video capture resources."""
         self.running = False  # stop flag for Thread
         for thread in self.threads:
-            if thread.is_alive():
+            if thread is not None and thread.is_alive():
                 thread.join(timeout=5)  # Add timeout
         for cap in self.caps:  # Iterate through the stored VideoCapture objects
+            if cap is None:
+                continue
             try:
                 cap.release()  # release video capture
             except Exception as e:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -142,9 +142,9 @@ class LoadStreams:
                 self.fps[i] = max((fps if math.isfinite(fps) else 0) % 100, 0) or 30  # 30 FPS fallback
 
                 success, im = self.caps[i].read()  # guarantee first frame
-                im = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)[..., None] if self.cv2_flag == cv2.IMREAD_GRAYSCALE else im
                 if not success or im is None:
                     raise ConnectionError(f"{st}Failed to read images from {s}")
+                im = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)[..., None] if self.cv2_flag == cv2.IMREAD_GRAYSCALE else im
                 self.imgs[i].append(im)
                 self.shape[i] = im.shape
                 self.threads[i] = Thread(target=self.update, args=([i, self.caps[i], s]), daemon=True)


### PR DESCRIPTION
## summary

when `LoadStreams.__init__` fails on one source after earlier sources have already opened their `cv2.VideoCapture` and started daemon threads, the partially-built object exits via exception and is never bound, so `close()` never runs and those captures and threads leak for the life of the process. this wraps the init loop in try/except so a failure releases the already-opened captures and stops the started threads before re-raising, and makes `close()` tolerant of the `None` placeholders present during partial init.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves video stream loading reliability by safely cleaning up camera/stream resources when startup fails, reducing crashes and resource leaks 🎥🛠️

### 📊 Key Changes
- Wrapped the stream initialization loop in a `try/except` block so partial setup failures now trigger proper cleanup before the error is re-raised.
- Added a call to `self.close()` on initialization failure to release any already-opened video captures and stop any started threads ♻️
- Improved shutdown safety in `close()` by checking whether a thread exists before calling `is_alive()`.
- Added a guard to skip `None` capture objects during release, preventing extra errors during cleanup.
- Slightly reordered first-frame handling so failed reads are detected before grayscale conversion, making startup checks more robust ✅

### 🎯 Purpose & Impact
- Prevents resource leaks when one of multiple video streams fails to open or read, especially in multi-camera or multi-stream setups 🔒
- Makes stream loading more fault-tolerant and predictable, which is helpful for long-running inference applications and production deployments 🚀
- Reduces the chance of leftover threads or locked camera handles after an error, making retries and recovery easier.
- Improves overall stability for users working with webcams, RTSP feeds, YouTube streams, or other live video sources 📹