### PR TITLE
Enable `int8` option in `test_export_onnx_matrix`

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -62,15 +62,6 @@ def test_export_onnx(end2end, isolated_model):
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
 
 
-@pytest.mark.slow
-def test_export_onnx_int8(isolated_model):
-    """Test YOLO model export to INT8 ONNX format with calibration data."""
-    file = YOLO(isolated_model).export(format="onnx", int8=True, data="coco8.yaml", fraction=0.25, imgsz=32)
-    assert Path(file).name.endswith("_int8.onnx")
-    YOLO(file)(SOURCE, imgsz=32)  # exported model inference
-    Path(file).unlink()  # cleanup
-
-
 def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
     """Ensure ONNX exports do not overlap across worker threads."""
     active = 0
@@ -158,7 +149,7 @@ def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms, end2end):
     [  # generate all combinations except for exclusion cases
         (task, dynamic, int8, half, batch, simplify, nms, end2end)
         for task, dynamic, int8, half, batch, simplify, nms, end2end in product(
-            sorted(TASKS), [True, False], [False], [False], [1, 2], [True, False], [True, False], [True, False]
+            sorted(TASKS), [True, False], [True, False], [False], [1, 2], [True, False], [True, False], [True, False]
         )
         if not ((int8 and half) or (task == "classify" and nms) or (nms and not TORCH_1_13) or (end2end and nms))
     ],


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds `int8` coverage to the export test matrix while removing the standalone INT8 ONNX export test for more unified export validation. 

### 📊 Key Changes
- Removed the dedicated `test_export_onnx_int8()` test case from `tests/test_exports.py`.
- Expanded the export matrix parameterization to include both `int8=False` and `int8=True` combinations.
- Keeps existing exclusion rules in place to avoid unsupported parameter combinations.
- Shifts INT8 export validation from a one-off test into broader matrix-based test coverage. 

### 🎯 Purpose & Impact
- Improves test coverage by validating `int8` export behavior across more scenarios instead of a single isolated case. 🔍
- Reduces test duplication and makes the export test suite easier to maintain. 🧹
- Helps catch compatibility issues earlier for export pathways involving INT8 settings. ⚙️
- Strengthens confidence in Ultralytics export workflows, especially for deployment-focused formats. 🚀