### PR TITLE
Report SystemLogger disk list

### DIFF
--- a/.github/workflows/systemlogger-disks.yml
+++ b/.github/workflows/systemlogger-disks.yml
@@ -79,6 +79,7 @@ jobs:
           assert platform_mounts, (system, partitions)
 
           mounts = logger_module._DriveInfo.mounts(psutil, all_drives=True)
+          current_mount = logger_module._DriveInfo._current_mount(partitions)
           assert mounts and all(isinstance(mount, str) for mount in mounts), mounts
           if system == "Windows":
               assert all(mount.endswith("\\") for mount in mounts), mounts
@@ -89,6 +90,8 @@ jobs:
               logger = logger_module.SystemLogger(all_drives=all_drives)
               metrics = logger.get_metrics(rates=True)
               assert isinstance(logger.mounts, list) and logger.mounts, logger.mounts
+              if not all_drives:
+                  assert logger.mounts == [current_mount], (logger.mounts, current_mount)
               assert isinstance(metrics["disk"], list) and metrics["disk"], metrics["disk"]
               assert set(metrics["disk_io"]) == {"read_mbs", "write_mbs"}, metrics["disk_io"]
               for disk in metrics["disk"]:

--- a/.github/workflows/systemlogger-disks.yml
+++ b/.github/workflows/systemlogger-disks.yml
@@ -1,0 +1,100 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Temporary PR-only smoke test for SystemLogger disk discovery. Remove before merge.
+
+name: SystemLogger Disks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/systemlogger-disks.yml"
+      - "ultralytics/utils/logger.py"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-26, windows-latest]
+        python: ["3.13"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install requirements
+        run: python -m pip install psutil
+      - name: Smoke SystemLogger disk metrics
+        shell: bash
+        run: |
+          python - <<'PY'
+          import importlib.util
+          import logging
+          import platform
+          import sys
+          import types
+          from pathlib import Path
+
+          import psutil
+
+          system = platform.system()
+
+          ultralytics = types.ModuleType("ultralytics")
+          utils = types.ModuleType("ultralytics.utils")
+          utils.LINUX = system == "Linux"
+          utils.LOGGER = logging.getLogger("ultralytics")
+          utils.MACOS = system == "Darwin"
+          utils.RANK = -1
+          utils.WINDOWS = system == "Windows"
+          checks = types.ModuleType("ultralytics.utils.checks")
+          checks.check_requirements = lambda *args, **kwargs: None
+          torch = types.ModuleType("torch")
+          torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+          sys.modules.update(
+              {
+                  "torch": torch,
+                  "ultralytics": ultralytics,
+                  "ultralytics.utils": utils,
+                  "ultralytics.utils.checks": checks,
+              }
+          )
+
+          spec = importlib.util.spec_from_file_location("logger_under_test", Path("ultralytics/utils/logger.py"))
+          logger_module = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(logger_module)
+
+          partitions = psutil.disk_partitions(all=False)
+          if system == "Darwin":
+              platform_mounts = logger_module._DriveInfo._macos_mounts(partitions)
+          elif system == "Linux":
+              platform_mounts = logger_module._DriveInfo._linux_mounts(partitions)
+          else:
+              platform_mounts = logger_module._DriveInfo._windows_mounts(partitions)
+          assert platform_mounts, (system, partitions)
+
+          mounts = logger_module._DriveInfo.mounts(psutil, all_drives=True)
+          assert mounts and all(isinstance(mount, str) for mount in mounts), mounts
+          if system == "Windows":
+              assert all(mount.endswith("\\") for mount in mounts), mounts
+          else:
+              assert all(mount.startswith("/") for mount in mounts), mounts
+
+          for all_drives in (False, True):
+              logger = logger_module.SystemLogger(all_drives=all_drives)
+              metrics = logger.get_metrics(rates=True)
+              assert isinstance(logger.mounts, list) and logger.mounts, logger.mounts
+              assert isinstance(metrics["disk"], list) and metrics["disk"], metrics["disk"]
+              assert set(metrics["disk_io"]) == {"read_mbs", "write_mbs"}, metrics["disk_io"]
+              for disk in metrics["disk"]:
+                  assert set(disk) == {"mount", "used_gb", "total_gb"}, disk
+                  assert disk["total_gb"] > 0, disk
+                  assert 0 <= disk["used_gb"] <= disk["total_gb"], disk
+
+          print({"system": system, "platform_mounts": platform_mounts, "mounts": mounts, "metrics": metrics})
+          PY

--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -1,0 +1,452 @@
+---
+comments: true
+description: Ultralytics Inference for Rust is a high-performance YOLO inference library and CLI built on ONNX Runtime, with GPU acceleration and zero Python runtime.
+keywords: Ultralytics Inference, Rust, YOLO, ONNX Runtime, object detection, segmentation, pose, OBB, classification, semantic segmentation, CUDA, TensorRT, CoreML, edge AI, real-time inference
+---
+
+# Ultralytics Inference for Rust
+
+[![GitHub](https://img.shields.io/badge/GitHub-ultralytics%2Finference-181717?logo=github&logoColor=white)](https://github.com/ultralytics/inference)
+[![Crates.io](https://img.shields.io/crates/v/ultralytics-inference?logo=rust&logoColor=white&label=crates.io&color=CE422B)](https://crates.io/crates/ultralytics-inference)
+[![docs.rs](https://img.shields.io/docsrs/ultralytics-inference?logo=docs.rs&logoColor=white&label=docs.rs)](https://docs.rs/ultralytics-inference)
+[![Downloads](https://img.shields.io/crates/d/ultralytics-inference?logo=rust&logoColor=white&label=downloads&color=CE422B)](https://crates.io/crates/ultralytics-inference)
+[![MSRV](https://img.shields.io/crates/msrv/ultralytics-inference?logo=rust&logoColor=white&color=CE422B)](https://crates.io/crates/ultralytics-inference)
+
+[Ultralytics Inference](https://github.com/ultralytics/inference) is a high-performance [YOLO](https://www.ultralytics.com/yolo) inference library and command-line tool written in [Rust](https://www.rust-lang.org/). It runs exported [ONNX](../integrations/onnx.md) models through [ONNX Runtime](https://onnxruntime.ai/) to deliver fast, memory-safe predictions on images, videos, webcams, and streams, with no Python runtime required at inference time.
+
+The project ships as a single crate, `ultralytics-inference`, that you can use two ways: as a **CLI** for quick predictions and batch jobs, or as a **library** embedded directly in your Rust application. It supports every Ultralytics [task](../tasks/index.md) and a broad set of hardware backends through a uniform device interface.
+
+## Why Rust inference?
+
+- **Native speed and a small footprint.** Compiles to a native binary with no interpreter, ideal for servers, containers, and [edge devices](https://www.ultralytics.com/glossary/edge-ai).
+- **Memory safety.** Rust's ownership model removes whole classes of runtime errors without a garbage collector.
+- **All YOLO tasks.** Detect, segment, pose, OBB, classify, and semantic segmentation from one API.
+- **Broad hardware support.** CPU plus CUDA, TensorRT, CoreML, OpenVINO, DirectML, ROCm, and XNNPACK execution providers selected at build time.
+- **GPU-side preprocessing.** An optional fused CUDA kernel keeps letterbox, normalize, and layout conversion on the device for a zero-copy input path.
+- **Auto-download.** Known YOLO model names and sample assets download automatically on first use.
+
+!!! tip "Looking for the Python package?"
+
+    This page covers the standalone Rust crate. For the Python workflow (training, validation, export, and prediction) see the main [Quickstart](../quickstart.md) and [Predict mode](../modes/predict.md). Export any Ultralytics model to ONNX with the [ONNX integration](../integrations/onnx.md), then run it here.
+
+## Installation
+
+Rust 1.89 or newer is required. The [video](#cargo-features) feature additionally needs FFmpeg 7+ installed on the system.
+
+=== "CLI"
+
+    ```bash
+    # Install the command-line tool from crates.io
+    cargo install ultralytics-inference
+
+    # Or with GPU support compiled in
+    cargo install ultralytics-inference --features cuda,tensorrt
+    ```
+
+    The binary is placed at `~/.cargo/bin/ultralytics-inference` (Linux and macOS) or `%USERPROFILE%\.cargo\bin\` on Windows.
+
+=== "Library"
+
+    ```bash
+    # Add the crate to your project
+    cargo add ultralytics-inference
+    ```
+
+    ```toml
+    # Or add it manually to Cargo.toml
+    [dependencies]
+    ultralytics-inference = "0.0.18"
+    ```
+
+## CLI quickstart
+
+The CLI exposes a `predict` subcommand. With no arguments it downloads a nano detection model and sample images, runs inference, and saves the annotated results to `runs/detect/predict`.
+
+```bash
+# Detect on the built-in samples (downloads model and images)
+ultralytics-inference predict
+
+# Detect on your own image
+ultralytics-inference predict --model yolo26n.onnx --source image.jpg
+
+# Segmentation (auto-downloads yolo26n-seg.onnx)
+ultralytics-inference predict --task segment --source image.jpg
+
+# Pose on a video, shown live in a window
+ultralytics-inference predict --task pose --source video.mp4 --show
+
+# Tune thresholds and filter to specific classes
+ultralytics-inference predict --source image.jpg --conf 0.5 --iou 0.45 --classes "0,1,2"
+
+# Run a whole folder on the GPU in half precision
+ultralytics-inference predict --source images/ --device cuda:0 --half
+```
+
+Common flags:
+
+| Flag             | Default        | Description                                                           |
+| ---------------- | -------------- | --------------------------------------------------------------------- |
+| `--model`, `-m`  | `yolo26n.onnx` | Path to an ONNX model; a known YOLO name is downloaded automatically. |
+| `--task`         | `detect`       | One of `detect`, `segment`, `pose`, `obb`, `classify`, `semantic`.    |
+| `--source`, `-s` | sample         | Image, directory, glob, video, webcam index, or URL.                  |
+| `--conf`         | `0.25`         | Confidence threshold.                                                 |
+| `--iou`          | `0.7`          | IoU threshold for non-maximum suppression.                            |
+| `--imgsz`        | model metadata | Inference image size.                                                 |
+| `--device`       | `cpu`          | Execution device, for example `cuda:0`, `coreml`, `tensorrt:0`.       |
+| `--half`         | `false`        | FP16 half-precision inference.                                        |
+| `--save`         | `true`         | Save annotated results to `runs/<task>/predict`.                      |
+| `--show`         | `false`        | Display results in a window.                                          |
+| `--classes`      | all            | Filter detections by class IDs, for example `"0,1,2"`.                |
+
+## Library quickstart
+
+Load a model and run a prediction. Model metadata such as class names, task type, and image size is read automatically from the ONNX file.
+
+```rust
+use ultralytics_inference::YOLOModel;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Metadata (classes, task, imgsz) is parsed from the model.
+    let mut model = YOLOModel::load("yolo26n.onnx")?;
+
+    let results = model.predict("image.jpg")?;
+
+    for result in &results {
+        if let Some(boxes) = &result.boxes {
+            for i in 0..boxes.len() {
+                let class_id = boxes.cls()[i] as usize;
+                let conf = boxes.conf()[i];
+                let name = result.names.get(&class_id).map_or("unknown", |s| s.as_str());
+                println!("{name} {conf:.2}");
+            }
+        }
+    }
+
+    Ok(())
+}
+```
+
+Use `InferenceConfig` to control thresholds, image size, precision, and device with a builder API:
+
+```rust
+use ultralytics_inference::{Device, InferenceConfig, YOLOModel};
+
+let config = InferenceConfig::new()
+    .with_confidence(0.5)
+    .with_iou(0.45)
+    .with_imgsz(640, 640)
+    .with_device(Device::Cuda(0))
+    .with_half(true);
+
+let mut model = YOLOModel::load_with_config("yolo26n.onnx", config)?;
+let results = model.predict("image.jpg")?;
+```
+
+Each task populates a different field on `Results`. Each tab below is a complete, runnable program; the model and sample inputs download automatically on first run. Swap `predict_default()` for `predict("image.jpg")` to run on your own files.
+
+=== "Detect"
+
+    ```rust
+    use ultralytics_inference::YOLOModel;
+
+    fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let mut model = YOLOModel::load("yolo26n.onnx")?;
+        let results = model.predict_default()?;
+
+        for result in &results {
+            if let Some(boxes) = &result.boxes {
+                println!("{} detections", boxes.len());
+                let xyxy = boxes.xyxy(); // rows of [x1, y1, x2, y2]
+                for i in 0..boxes.len() {
+                    let class_id = boxes.cls()[i] as usize;
+                    let name = result.names.get(&class_id).map_or("unknown", |s| s.as_str());
+                    println!("  {name} {:.2} {:?}", boxes.conf()[i], xyxy.row(i).to_vec());
+                }
+            }
+        }
+
+        Ok(())
+    }
+    ```
+
+=== "Segment"
+
+    ```rust
+    use ultralytics_inference::YOLOModel;
+
+    fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let mut model = YOLOModel::load("yolo26n-seg.onnx")?;
+        let results = model.predict_default()?;
+
+        for result in &results {
+            if let Some(masks) = &result.masks {
+                let (n, h, w) = masks.data.dim(); // mask data shape (N, H, W)
+                println!("{n} instance masks ({h}x{w})");
+            }
+            if let Some(boxes) = &result.boxes {
+                for i in 0..boxes.len() {
+                    let class_id = boxes.cls()[i] as usize;
+                    let name = result.names.get(&class_id).map_or("unknown", |s| s.as_str());
+                    println!("  {name} {:.2}", boxes.conf()[i]);
+                }
+            }
+        }
+
+        Ok(())
+    }
+    ```
+
+=== "Pose"
+
+    ```rust
+    use ultralytics_inference::YOLOModel;
+
+    fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let mut model = YOLOModel::load("yolo26n-pose.onnx")?;
+        let results = model.predict_default()?;
+
+        for result in &results {
+            if let Some(kpts) = &result.keypoints {
+                let (n, k, _) = kpts.xy().dim(); // keypoint coords shape (N, K, 2)
+                println!("{n} pose(s), {k} keypoints each");
+
+                // Optional per-keypoint confidence, shape (N, K)
+                if let Some(conf) = kpts.conf() {
+                    println!("  keypoint confidence values: {}", conf.len());
+                }
+            }
+        }
+
+        Ok(())
+    }
+    ```
+
+=== "Classify"
+
+    ```rust
+    use ultralytics_inference::YOLOModel;
+
+    fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let mut model = YOLOModel::load("yolo26n-cls.onnx")?;
+        let results = model.predict_default()?;
+
+        for result in &results {
+            if let Some(probs) = &result.probs {
+                let top1 = probs.top1();
+                let name = result.names.get(&top1).map_or("unknown", |s| s.as_str());
+                println!("top-1: {name} ({:.2})", probs.top1conf());
+
+                for (id, conf) in probs.top5().into_iter().zip(probs.top5conf()) {
+                    let name = result.names.get(&id).map_or("unknown", |s| s.as_str());
+                    println!("  {name} {conf:.2}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+    ```
+
+=== "OBB"
+
+    ```rust
+    use ultralytics_inference::YOLOModel;
+
+    fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let mut model = YOLOModel::load("yolo26n-obb.onnx")?;
+        let results = model.predict_default()?;
+
+        for result in &results {
+            if let Some(obb) = &result.obb {
+                println!("{} oriented boxes", obb.len());
+                let xywhr = obb.xywhr(); // rows of [cx, cy, w, h, angle]
+                for i in 0..obb.len() {
+                    let class_id = obb.cls()[i] as usize;
+                    let name = result.names.get(&class_id).map_or("unknown", |s| s.as_str());
+                    println!("  {name} {:.2} {:?}", obb.conf()[i], xywhr.row(i).to_vec());
+                }
+            }
+        }
+
+        Ok(())
+    }
+    ```
+
+=== "Semantic"
+
+    ```rust
+    use ultralytics_inference::YOLOModel;
+
+    fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let mut model = YOLOModel::load("yolo26n-sem.onnx")?;
+        let results = model.predict_default()?;
+
+        for result in &results {
+            if let Some(sem) = &result.semantic_mask {
+                let (h, w) = sem.data.dim(); // per-pixel class map shape (H, W)
+                println!("class map {h}x{w}");
+
+                for class_id in sem.class_ids() {
+                    let name = result.names.get(&class_id).map_or("unknown", |s| s.as_str());
+                    println!("  present: {name}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+    ```
+
+## Supported tasks
+
+All Ultralytics [tasks](../tasks/index.md) are supported. When `--model` is omitted, the matching nano model for the selected task is downloaded automatically.
+
+| Task                  | `--task`   | Output                        | Default model       |
+| --------------------- | ---------- | ----------------------------- | ------------------- |
+| Detection             | `detect`   | Bounding boxes and classes    | `yolo26n.onnx`      |
+| Instance segmentation | `segment`  | Boxes plus per-instance masks | `yolo26n-seg.onnx`  |
+| Pose                  | `pose`     | Boxes plus keypoints          | `yolo26n-pose.onnx` |
+| Oriented boxes        | `obb`      | Rotated bounding boxes        | `yolo26n-obb.onnx`  |
+| Classification        | `classify` | Class probabilities           | `yolo26n-cls.onnx`  |
+| Semantic segmentation | `semantic` | Per-pixel class map           | `yolo26n-sem.onnx`  |
+
+## Model compatibility
+
+Any Ultralytics model exported to ONNX can be loaded from a local file. Auto-download is available for standard YOLO26, YOLO11, and YOLOv8 model names in sizes `n`, `s`, `m`, `l`, and `x`:
+
+| Model family | Auto-downloadable variants                                            |
+| ------------ | --------------------------------------------------------------------- |
+| YOLO26       | `yolo26{n,s,m,l,x}.onnx`, `-seg`, `-pose`, `-obb`, `-cls`, and `-sem` |
+| YOLO11       | `yolo11{n,s,m,l,x}.onnx`, `-seg`, `-pose`, `-obb`, and `-cls`         |
+| YOLOv8       | `yolov8{n,s,m,l,x}.onnx`, `-seg`, `-pose`, `-obb`, and `-cls`         |
+
+Semantic segmentation (`-sem`) is YOLO26-only.
+
+## Input sources
+
+The `--source` argument (and the `Source` type in the library) accepts many input kinds, auto-detected from the string:
+
+| Source    | Example                         | Notes                         |
+| --------- | ------------------------------- | ----------------------------- |
+| Image     | `image.jpg`                     | Single file.                  |
+| Directory | `images/`                       | All images in the folder.     |
+| Glob      | `images/*.jpg`                  | Shell-style pattern.          |
+| Video     | `video.mp4`                     | Requires the `video` feature. |
+| Webcam    | `0`                             | Requires the `video` feature. |
+| Stream    | `rtsp://...`                    | Requires the `video` feature. |
+| URL       | `https://example.com/image.jpg` | Remote image download.        |
+
+## Devices and execution providers
+
+Inference runs on CPU by default. GPU and accelerator backends are compiled in as [Cargo features](#cargo-features) and selected at runtime with `--device` (CLI) or `Device` (library).
+
+| Device string | `Device` variant      | Build feature | Hardware              |
+| ------------- | --------------------- | ------------- | --------------------- |
+| `cpu`         | `Device::Cpu`         | built in      | Any CPU               |
+| `cuda:0`      | `Device::Cuda(0)`     | `cuda`        | NVIDIA GPU            |
+| `tensorrt:0`  | `Device::TensorRt(0)` | `tensorrt`    | NVIDIA GPU, optimized |
+| `coreml`      | `Device::CoreMl`      | `coreml`      | Apple Silicon / macOS |
+| `openvino`    | `Device::OpenVino`    | `openvino`    | Intel CPU / iGPU      |
+| `directml:0`  | `Device::DirectMl(0)` | `directml`    | Windows GPU           |
+| `rocm:0`      | `Device::Rocm(0)`     | `rocm`        | AMD GPU               |
+| `xnnpack`     | `Device::Xnnpack`     | `xnnpack`     | Optimized CPU         |
+
+```bash
+# Build the CLI with the providers you need
+cargo install ultralytics-inference --features cuda,tensorrt
+```
+
+## GPU acceleration and CUDA preprocessing
+
+On NVIDIA hardware, the `cuda` feature enables the CUDA execution provider, and `tensorrt` adds the TensorRT provider for further optimization. For the lowest possible latency, the `cuda-preprocess` feature moves preprocessing onto the GPU.
+
+`cuda-preprocess` runs letterbox resizing, normalization, and the HWC-to-CHW layout conversion as a single fused CUDA kernel, then feeds the result to the model as a zero-copy device tensor. This removes the per-image CPU preprocessing cost and the host-to-device copy, which matters most for high-throughput batches and real-time streams.
+
+```bash
+# Build with fused GPU preprocessing (implies cuda + tensorrt)
+cargo build --release --features cuda-preprocess
+```
+
+The fast path is used automatically, with no API change, when all of the following hold: the feature is compiled in, the device is CUDA or TensorRT, the task is detect, segment, pose, OBB, or semantic segmentation, and the model uses FP32 input. It is enabled by default and can be turned off per model:
+
+```rust
+use ultralytics_inference::{Device, InferenceConfig};
+
+let config = InferenceConfig::new()
+    .with_device(Device::TensorRt(0))
+    .with_cuda_preprocess(false); // force CPU preprocessing
+```
+
+!!! note "Match your CUDA toolkit"
+
+    `cuda-preprocess` requires a matching CUDA toolkit at build time and uses NVRTC at runtime for the fused preprocessing kernel. See the [CUDA and TensorRT acceleration guide](https://docs.rs/ultralytics-inference/latest/ultralytics_inference/cuda_guide/index.html) for version requirements and troubleshooting.
+
+## Cargo features
+
+Features are enabled at build time. The defaults cover annotation and live display.
+
+| Feature           | Default | Purpose                                                                |
+| ----------------- | ------- | ---------------------------------------------------------------------- |
+| `annotate`        | yes     | Draw boxes, masks, keypoints, and labels; required for `--save`.       |
+| `visualize`       | yes     | Real-time window display for `--show`.                                 |
+| `video`           | no      | Read and write video files (requires FFmpeg 7+).                       |
+| `cuda`            | no      | NVIDIA CUDA execution provider.                                        |
+| `tensorrt`        | no      | NVIDIA TensorRT execution provider.                                    |
+| `cuda-preprocess` | no      | Fused GPU preprocessing with zero-copy input (implies cuda, tensorrt). |
+| `coreml`          | no      | Apple CoreML execution provider.                                       |
+| `openvino`        | no      | Intel OpenVINO execution provider.                                     |
+| `rocm`            | no      | AMD ROCm execution provider.                                           |
+| `directml`        | no      | Windows DirectML execution provider.                                   |
+
+Convenience groups bundle related providers: `nvidia` (cuda, tensorrt), `amd` (rocm, migraphx), `intel` (openvino, onednn), `mobile` (nnapi, coreml, qnn), and `all` (annotate, visualize, video). Additional providers such as `nnapi`, `qnn`, `xnnpack`, `webgpu`, and others are also available.
+
+Enable features when installing the CLI or adding the library:
+
+```bash
+cargo install ultralytics-inference --features video
+cargo install ultralytics-inference --features cuda,tensorrt
+```
+
+```toml
+[dependencies]
+ultralytics-inference = { version = "0.0.18", features = ["video"] }
+```
+
+## Output and saving
+
+By default, predictions are annotated and saved to an auto-incrementing run directory:
+
+```text
+runs/
+└── detect/
+    └── predict/          # then predict2, predict3, ...
+        └── image.jpg     # annotated result
+```
+
+The subfolder matches the task (`runs/segment/`, `runs/pose/`, and so on). For video sources the annotated output is written as a video file; pass `--save-frames` to write individual frames instead. For the `semantic` task, `--save-json` writes per-pixel class-map PNGs under a `results/` subfolder. Annotated image and video saving require the `annotate` feature; semantic class-map PNG export does not. Video input and output require the `video` feature.
+
+## FAQ
+
+### Do I need Python installed?
+
+No. The crate runs exported ONNX models directly through ONNX Runtime. Python is only needed if you train or [export](../modes/export.md) models with the Ultralytics package beforehand.
+
+### Which models can I run?
+
+Any Ultralytics YOLO model exported to ONNX, including [YOLO26](../models/yolo26.md), [YOLO11](../models/yolo11.md), and [YOLOv8](../models/yolov8.md). Known model names download automatically; you can also point `--model` at any local `.onnx` file.
+
+### How do I get a model file?
+
+Export from the Python package, for example with the [ONNX integration](../integrations/onnx.md), or let the CLI download a standard nano model for the chosen task on first run.
+
+### Is video supported?
+
+Yes, with the `video` feature enabled and FFmpeg 7+ installed on the system. This covers video files, webcams, and RTSP/RTMP/HTTP streams.
+
+### What do the `annotate` and `visualize` features do?
+
+Both are enabled by default. `annotate` draws boxes, masks, keypoints, and class labels onto the image and is required for `--save` to write annotated results. `visualize` opens a live window for `--show`. For a smaller, headless build that only returns results programmatically, disable them with `cargo build --no-default-features` (add back individual features as needed).
+
+### Where is the full API reference?
+
+This page is a high-level overview. The complete, type-by-type API reference for every public struct, method, and configuration option is published on [docs.rs](https://docs.rs/ultralytics-inference/latest/ultralytics_inference/), generated directly from the source.

--- a/docs/en/reference/utils/logger.md
+++ b/docs/en/reference/utils/logger.md
@@ -15,6 +15,10 @@ keywords: ConsoleLogger, console capture, log streaming, API logging, file loggi
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.logger._DriveInfo
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.logger.SystemLogger
 
 <br><br>

--- a/docs/en/reference/utils/logger.md
+++ b/docs/en/reference/utils/logger.md
@@ -15,10 +15,6 @@ keywords: ConsoleLogger, console capture, log streaming, API logging, file loggi
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.logger._DriveInfo
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.logger.SystemLogger
 
 <br><br>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -663,6 +663,8 @@ nav:
       - Explore: platform/explore.md
       - REST API: platform/api/index.md
 
+  - Rust Inference: inference/index.md
+
   - Reference:
       - reference/index.md
       - __init__: reference/__init__.md

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -426,7 +426,7 @@ def on_fit_epoch_end(trainer):
     system = {}
     try:
         if not ctx["system_logger"]:
-            ctx["system_logger"] = SystemLogger()
+            ctx["system_logger"] = SystemLogger(all_drives=True)
         system = ctx["system_logger"].get_metrics(rates=True)
     except Exception:
         pass

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -298,13 +298,13 @@ class _DriveInfo:
     @staticmethod
     def mounts(psutil, all_drives=False):
         """Get mounted paths to monitor."""
-        if not all_drives:
-            return [Path.cwd().anchor or "/"]
-
         partitions = [p for p in psutil.disk_partitions(all=False) if p.mountpoint]
+        if not all_drives:
+            return [_DriveInfo._current_mount(partitions)]
+
         mounts = [p.mountpoint for p in partitions if "dontbrowse" not in p.opts.split(",")]
         if len(mounts) <= 1:
-            return _DriveInfo._sort(mounts) or [Path.cwd().anchor or "/"]
+            return _DriveInfo._sort(mounts) or [_DriveInfo._current_mount(partitions)]
 
         for getter in (
             _DriveInfo._macos_mounts if MACOS else None,
@@ -323,6 +323,20 @@ class _DriveInfo:
     def _sort(mounts):
         """Sort mounted paths with root first."""
         return sorted(set(mounts), key=lambda mount: (mount != "/", mount))
+
+    @staticmethod
+    def _current_mount(partitions):
+        """Get the mounted filesystem backing the current working directory."""
+        cwd = Path.cwd().resolve()
+        matches = []
+        for partition in partitions:
+            try:
+                mount = Path(partition.mountpoint).resolve()
+            except OSError:
+                continue
+            if cwd == mount or cwd.is_relative_to(mount):
+                matches.append(partition.mountpoint)
+        return max(matches, key=len, default=Path.cwd().anchor or "/")
 
     @staticmethod
     def _macos_mounts(partitions):

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -1,14 +1,17 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import json
 import logging
+import plistlib
 import shutil
+import subprocess
 import sys
 import threading
 import time
 from datetime import datetime
 from pathlib import Path
 
-from ultralytics.utils import LOGGER, MACOS, RANK
+from ultralytics.utils import LINUX, LOGGER, MACOS, RANK, WINDOWS
 from ultralytics.utils.checks import check_requirements
 
 
@@ -289,6 +292,109 @@ class ConsoleLogger:
             self.callback(self.format(record) + "\n")
 
 
+class _DriveInfo:
+    """Resolve mounted storage paths backed by local drives."""
+
+    @staticmethod
+    def mounts(psutil, all_drives=False):
+        """Get mounted paths to monitor."""
+        if not all_drives:
+            return [Path.cwd().anchor or "/"]
+
+        partitions = [p for p in psutil.disk_partitions(all=False) if p.mountpoint]
+        mounts = [p.mountpoint for p in partitions if "dontbrowse" not in p.opts.split(",")]
+        if len(mounts) <= 1:
+            return _DriveInfo._sort(mounts) or [Path.cwd().anchor or "/"]
+
+        for getter in (
+            _DriveInfo._macos_mounts if MACOS else None,
+            _DriveInfo._linux_mounts if LINUX else None,
+            _DriveInfo._windows_mounts if WINDOWS else None,
+        ):
+            if getter:
+                try:
+                    if platform_mounts := getter(partitions):
+                        return _DriveInfo._sort(platform_mounts)
+                except (json.JSONDecodeError, OSError, plistlib.InvalidFileException, subprocess.SubprocessError):
+                    pass
+        return _DriveInfo._sort(mounts)
+
+    @staticmethod
+    def _sort(mounts):
+        """Sort mounted paths with root first."""
+        return sorted(set(mounts), key=lambda mount: (mount != "/", mount))
+
+    @staticmethod
+    def _macos_mounts(partitions):
+        """Get user-visible macOS mounts backed by physical disks."""
+        disk_info = plistlib.loads(subprocess.check_output(["diskutil", "list", "-plist", "physical"], timeout=5))
+        physical_devices = set(disk_info.get("WholeDisks", []))
+        for disk in disk_info.get("AllDisksAndPartitions", []):
+            physical_devices.add(disk.get("DeviceIdentifier", ""))
+            physical_devices.update(p.get("DeviceIdentifier", "") for p in disk.get("Partitions", []))
+
+        mounts, volume_groups = [], set()
+        for partition in partitions:
+            if partition.mountpoint != "/" and "dontbrowse" in partition.opts.split(","):
+                continue
+            info = plistlib.loads(
+                subprocess.check_output(
+                    ["diskutil", "info", "-plist", partition.mountpoint],
+                    stderr=subprocess.DEVNULL,
+                    timeout=5,
+                )
+            )
+            devices = {info.get("DeviceIdentifier", "")}
+            devices.update(s.get("APFSPhysicalStore", "") for s in info.get("APFSPhysicalStores", []))
+            if not devices & physical_devices:
+                continue
+            group = info.get("APFSVolumeGroupID") or info.get("APFSContainerReference") or partition.mountpoint
+            if group in volume_groups:
+                continue
+            volume_groups.add(group)
+            mounts.append(partition.mountpoint)
+        return mounts
+
+    @staticmethod
+    def _linux_mounts(_partitions):
+        """Get Linux mounts backed by physical block devices."""
+        block_info = json.loads(
+            subprocess.check_output(
+                ["lsblk", "--json", "--output", "TYPE,MOUNTPOINT,MOUNTPOINTS"], text=True, timeout=5
+            )
+        )
+        mounts = []
+
+        def visit(block, physical=False):
+            physical = physical or block.get("type") == "disk"
+            if physical:
+                values = block.get("mountpoints") or [block.get("mountpoint")]
+                if isinstance(values, str):
+                    values = [values]
+                mounts.extend(m for m in values if isinstance(m, str) and m.startswith("/"))
+            for child in block.get("children", []):
+                visit(child, physical)
+
+        for block in block_info.get("blockdevices", []):
+            visit(block)
+        return mounts
+
+    @staticmethod
+    def _windows_mounts(_partitions):
+        """Get Windows fixed local drive mounts."""
+        output = subprocess.check_output(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                "Get-CimInstance Win32_LogicalDisk -Filter 'DriveType=3' | Select-Object -ExpandProperty DeviceID",
+            ],
+            text=True,
+            timeout=5,
+        )
+        return [f"{drive}\\" for drive in (line.strip() for line in output.splitlines()) if drive]
+
+
 class SystemLogger:
     """Log dynamic system metrics for training monitoring.
 
@@ -302,13 +408,18 @@ class SystemLogger:
         disk_start: Initial disk I/O counters for calculating cumulative usage.
 
     Examples:
-        Basic usage:
+        Basic usage (single drive):
         >>> logger = SystemLogger()
         >>> metrics = logger.get_metrics()
         >>> print(f"CPU: {metrics['cpu']}%, RAM: {metrics['ram']}%")
-        >>> if metrics["gpus"]:
-        ...     gpu0 = metrics["gpus"]["0"]
-        ...     print(f"GPU0: {gpu0['usage']}% usage, {gpu0['temp']}°C")
+        >>> for disk in metrics["disk"]:
+        ...     print(f"{disk['mount']}: {disk['used_gb']}/{disk['total_gb']} GB")
+
+        Monitor all drives:
+        >>> logger = SystemLogger(all_drives=True)
+        >>> metrics = logger.get_metrics()
+        >>> for disk in metrics["disk"]:
+        ...     print(f"{disk['mount']}: {disk['used_gb']}/{disk['total_gb']} GB")
 
         Training loop integration:
         >>> system_logger = SystemLogger()
@@ -318,14 +429,19 @@ class SystemLogger:
         ...     # Log to database/file
     """
 
-    def __init__(self):
-        """Initialize the system logger."""
+    def __init__(self, all_drives=False):
+        """Initialize the system logger.
+
+        Args:
+            all_drives (bool): If True, monitor all mounted drives. If False, monitor the current drive.
+        """
         import psutil  # scoped as slow import
 
         self.pynvml = None
         self.nvidia_initialized = self._init_nvidia()
         self.net_start = psutil.net_io_counters()
         self.disk_start = psutil.disk_io_counters()
+        self.mounts = _DriveInfo.mounts(psutil, all_drives)
 
         # For rate calculation
         self._prev_net = self.net_start
@@ -352,15 +468,16 @@ class SystemLogger:
     def get_metrics(self, rates=False):
         """Get current system metrics including CPU, RAM, disk, network, and GPU usage.
 
-        Collects comprehensive system metrics including CPU usage, RAM usage, disk I/O statistics, network I/O
-        statistics, and GPU metrics (if available).
+        Collects comprehensive system metrics including CPU usage, RAM usage, disk usage, disk I/O statistics, network
+        I/O statistics, and GPU metrics (if available).
 
         Example output (rates=False, default):
         ```python
         {
             "cpu": 45.2,
             "ram": 78.9,
-            "disk": {"read_mb": 156.7, "write_mb": 89.3, "used_gb": 256.8},
+            "disk": [{"mount": "/", "used_gb": 256.8, "total_gb": 512.0}],
+            "disk_io": {"read_mb": 156.7, "write_mb": 89.3},
             "network": {"recv_mb": 157.2, "sent_mb": 89.1},
             "gpus": {
                 "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
@@ -374,7 +491,8 @@ class SystemLogger:
         {
             "cpu": 45.2,
             "ram": 78.9,
-            "disk": {"read_mbs": 12.5, "write_mbs": 8.3, "used_gb": 256.8},
+            "disk": [{"mount": "/", "used_gb": 256.8, "total_gb": 512.0}],
+            "disk_io": {"read_mbs": 12.5, "write_mbs": 8.3},
             "network": {"recv_mbs": 5.2, "sent_mbs": 1.1},
             "gpus": {
                 "0": {"usage": 95.6, "memory": 85.4, "temp": 72, "power": 285},
@@ -396,46 +514,63 @@ class SystemLogger:
         import psutil  # scoped as slow import
 
         net = psutil.net_io_counters()
-        disk = psutil.disk_io_counters()
+        disk_io = psutil.disk_io_counters()
         memory = psutil.virtual_memory()
-        disk_usage = shutil.disk_usage("/")
         now = time.time()
-
-        metrics = {
-            "cpu": round(psutil.cpu_percent(), 3),
-            "ram": round(memory.percent, 3),
-            "gpus": {},
-        }
 
         # Calculate elapsed time since last call
         elapsed = max(0.1, now - self._prev_time)  # Avoid division by zero
 
         if rates:
-            # Calculate MB/s rates from delta since last call
-            metrics["disk"] = {
-                "read_mbs": round(max(0, (disk.read_bytes - self._prev_disk.read_bytes) / (1 << 20) / elapsed), 3),
-                "write_mbs": round(max(0, (disk.write_bytes - self._prev_disk.write_bytes) / (1 << 20) / elapsed), 3),
-                "used_gb": round(disk_usage.used / (1 << 30), 3),
-            }
-            metrics["network"] = {
-                "recv_mbs": round(max(0, (net.bytes_recv - self._prev_net.bytes_recv) / (1 << 20) / elapsed), 3),
-                "sent_mbs": round(max(0, (net.bytes_sent - self._prev_net.bytes_sent) / (1 << 20) / elapsed), 3),
+            disk_io_metrics = {
+                "read_mbs": round(max(0, (disk_io.read_bytes - self._prev_disk.read_bytes) / 1e6 / elapsed), 3),
+                "write_mbs": round(max(0, (disk_io.write_bytes - self._prev_disk.write_bytes) / 1e6 / elapsed), 3),
             }
         else:
-            # Cumulative MB since initialization (original behavior)
-            metrics["disk"] = {
-                "read_mb": round((disk.read_bytes - self.disk_start.read_bytes) / (1 << 20), 3),
-                "write_mb": round((disk.write_bytes - self.disk_start.write_bytes) / (1 << 20), 3),
-                "used_gb": round(disk_usage.used / (1 << 30), 3),
+            disk_io_metrics = {
+                "read_mb": round((disk_io.read_bytes - self.disk_start.read_bytes) / 1e6, 3),
+                "write_mb": round((disk_io.write_bytes - self.disk_start.write_bytes) / 1e6, 3),
             }
+
+        disks = []
+        for mounts in (self.mounts, [Path.cwd().anchor or "/"]):
+            for mount in mounts:
+                try:
+                    usage = shutil.disk_usage(mount)
+                    disks.append(
+                        {
+                            "mount": mount,
+                            "used_gb": round(usage.used / 1e9, 3),
+                            "total_gb": round(usage.total / 1e9, 3),
+                        }
+                    )
+                except (PermissionError, OSError):
+                    continue  # Skip inaccessible drives
+            if disks:
+                break
+
+        metrics = {
+            "cpu": round(psutil.cpu_percent(), 3),
+            "ram": round(memory.percent, 3),
+            "disk": disks,
+            "disk_io": disk_io_metrics,
+            "gpus": {},
+        }
+
+        if rates:
             metrics["network"] = {
-                "recv_mb": round((net.bytes_recv - self.net_start.bytes_recv) / (1 << 20), 3),
-                "sent_mb": round((net.bytes_sent - self.net_start.bytes_sent) / (1 << 20), 3),
+                "recv_mbs": round(max(0, (net.bytes_recv - self._prev_net.bytes_recv) / 1e6 / elapsed), 3),
+                "sent_mbs": round(max(0, (net.bytes_sent - self._prev_net.bytes_sent) / 1e6 / elapsed), 3),
+            }
+        else:
+            metrics["network"] = {
+                "recv_mb": round((net.bytes_recv - self.net_start.bytes_recv) / 1e6, 3),
+                "sent_mb": round((net.bytes_sent - self.net_start.bytes_sent) / 1e6, 3),
             }
 
         # Always update previous values for accurate rate calculation on next call
         self._prev_net = net
-        self._prev_disk = disk
+        self._prev_disk = disk_io
         self._prev_time = now
 
         # Add GPU metrics (NVIDIA only)
@@ -473,23 +608,25 @@ if __name__ == "__main__":
     print("SystemLogger Real-time Metrics Monitor")
     print("Press Ctrl+C to stop\n")
 
-    logger = SystemLogger()
+    logger = SystemLogger(all_drives=True)
 
     try:
         while True:
             metrics = logger.get_metrics()
 
             # Clear screen (works on most terminals)
-            print("\033[H\033[J", end="")
+            print("\033[H\033[J", end="", flush=True)
 
             # Display system metrics
             print(f"CPU: {metrics['cpu']:5.1f}%")
             print(f"RAM: {metrics['ram']:5.1f}%")
-            print(f"Disk Read: {metrics['disk']['read_mb']:8.1f} MB")
-            print(f"Disk Write: {metrics['disk']['write_mb']:7.1f} MB")
-            print(f"Disk Used: {metrics['disk']['used_gb']:8.1f} GB")
             print(f"Net Recv: {metrics['network']['recv_mb']:9.1f} MB")
             print(f"Net Sent: {metrics['network']['sent_mb']:9.1f} MB")
+
+            # Display disk metrics
+            print("\nDisk Metrics:")
+            for disk in metrics["disk"]:
+                print(f"  {disk['mount']}: {disk['used_gb']:.1f}/{disk['total_gb']:.1f} GB")
 
             # Display GPU metrics if available
             if metrics["gpus"]:

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -360,7 +360,7 @@ class _DriveInfo:
         """Get Linux mounts backed by physical block devices."""
         block_info = json.loads(
             subprocess.check_output(
-                ["lsblk", "--json", "--output", "TYPE,MOUNTPOINT,MOUNTPOINTS"], text=True, timeout=5
+                ["lsblk", "--json", "--output", "NAME,TYPE,MOUNTPOINT,MOUNTPOINTS"], text=True, timeout=5
             )
         )
         mounts = []


### PR DESCRIPTION
## Summary
- Report disk capacity as a `disk` list so single-disk machines use one item and multi-disk machines append naturally.
- Move aggregate machine disk throughput to `disk_io` instead of duplicating I/O per disk.
- Use fast `psutil` mount discovery first, with native macOS `diskutil`, Linux `lsblk`, and Windows `Get-CimInstance` fallback only for ambiguous multi-mount cases.
- Send all mounted drives from the Platform callback.

## Validation
- `python -m ruff format --check ultralytics/utils/logger.py ultralytics/utils/callbacks/platform.py`
- `python -m ruff check ultralytics/utils/logger.py ultralytics/utils/callbacks/platform.py`
- Local `SystemLogger(all_drives=True)` smoke run returned `mounts: ['/']`, one disk entry, and separate `disk_io`.
- Monkeypatched smoke confirmed the one-visible-mount macOS path does not invoke subprocess drive discovery.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR expands system disk monitoring across all drives and platforms, adds validation for that behavior in CI, and introduces a full new documentation page for **Ultralytics Inference for Rust** 🚀🦀

### 📊 Key Changes
- Added a new internal `_DriveInfo` helper in `ultralytics/utils/logger.py` to detect mounted drives on **Linux, macOS, and Windows**.
- Updated `SystemLogger` to support `all_drives=True`, returning:
  - a **list of disks** with mount path, used space, and total space
  - separate **disk I/O metrics** instead of mixing usage and I/O together
- Changed platform callback logging to initialize `SystemLogger(all_drives=True)`, so training/platform telemetry can report storage usage across all mounted drives 💽
- Improved logger examples and terminal output to reflect the new multi-drive disk reporting format.
- Added a temporary GitHub Actions workflow to run **cross-platform smoke tests** for disk discovery on Ubuntu, macOS, and Windows ✅
- Added `_DriveInfo` to the generated API reference docs.
- Added a new docs section, **“Ultralytics Inference for Rust”**, with:
  - installation instructions
  - CLI and library quickstarts
  - supported YOLO tasks
  - device/backend support
  - GPU acceleration details
  - Cargo feature reference
- Added the new Rust inference page to the MkDocs navigation for easier discovery 📚

### 🎯 Purpose & Impact
- Makes system monitoring more accurate and useful, especially for users training or running workloads on machines with **multiple disks or mounted volumes**.
- Improves reliability across operating systems by validating disk detection behavior in CI before merge 🔍
- Gives platform telemetry richer storage visibility, which can help diagnose resource bottlenecks during training and deployment.
- Clarifies the `SystemLogger` output structure, making it easier for developers to consume disk usage and disk I/O separately.
- Significantly improves documentation for the Rust inference project, helping both new and advanced users run exported YOLO models **without requiring Python** 🦀
- Broadens accessibility of Ultralytics tooling by highlighting a high-performance Rust inference option for CLI and embedded application use.