### PR TITLE
Filter boot mounts from SystemLogger drive metrics

### DIFF
--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -426,7 +426,7 @@ def on_fit_epoch_end(trainer):
     system = {}
     try:
         if not ctx["system_logger"]:
-            ctx["system_logger"] = SystemLogger(all_drives=True)
+            ctx["system_logger"] = SystemLogger()
         system = ctx["system_logger"].get_metrics(rates=True)
     except Exception:
         pass

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -272,10 +272,9 @@ def _get_environment_info():
     import shutil
 
     import psutil
-    import torch
-
     from ultralytics import __version__
-    from ultralytics.utils.torch_utils import get_cpu_info, get_gpu_info
+    from ultralytics.utils.autodevice import GPUInfo
+    from ultralytics.utils.torch_utils import get_cpu_info
 
     # Get RAM and disk totals
     memory = psutil.virtual_memory()
@@ -311,9 +310,11 @@ def _get_environment_info():
 
     # GPU info
     try:
-        if torch.cuda.is_available():
-            env["gpuCount"] = torch.cuda.device_count()
-            env["gpuType"] = get_gpu_info(0) if torch.cuda.device_count() > 0 else None
+        gpu_info = GPUInfo()
+        if gpu_info.gpu_stats:
+            env["gpuCount"] = len(gpu_info.gpu_stats)
+            env["gpuType"] = gpu_info.gpu_stats[0]["name"]
+        gpu_info.shutdown()
     except Exception:
         pass
 
@@ -426,7 +427,7 @@ def on_fit_epoch_end(trainer):
     system = {}
     try:
         if not ctx["system_logger"]:
-            ctx["system_logger"] = SystemLogger()
+            ctx["system_logger"] = SystemLogger(all_drives=True)
         system = ctx["system_logger"].get_metrics(rates=True)
     except Exception:
         pass

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -272,6 +272,7 @@ def _get_environment_info():
     import shutil
 
     import psutil
+
     from ultralytics import __version__
     from ultralytics.utils.autodevice import GPUInfo
     from ultralytics.utils.torch_utils import get_cpu_info

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -313,7 +313,9 @@ class _DriveInfo:
             return [_DriveInfo._current_mount(partitions)]
 
         mounts = [
-            p.mountpoint for p in partitions if Path(p.mountpoint).is_dir() and "dontbrowse" not in p.opts.split(",")
+            p.mountpoint
+            for p in partitions
+            if _DriveInfo._is_mount(p.mountpoint) and "dontbrowse" not in p.opts.split(",")
         ]
         if len(mounts) <= 1:
             return _DriveInfo._sort(mounts) or [_DriveInfo._current_mount(partitions)]
@@ -335,6 +337,13 @@ class _DriveInfo:
     def _sort(mounts):
         """Sort mounted paths with root first."""
         return sorted(set(mounts), key=lambda mount: (mount != "/", mount))
+
+    @staticmethod
+    def _is_mount(mount):
+        """Check whether a mount is useful for disk capacity reporting."""
+        return Path(mount).is_dir() and not (
+            LINUX and (mount in {"/boot", "/efi"} or mount.startswith(("/boot/", "/efi/")))
+        )
 
     @staticmethod
     def _current_mount(partitions):
@@ -400,7 +409,7 @@ class _DriveInfo:
                 values = block.get("mountpoints") or [block.get("mountpoint")]
                 if isinstance(values, str):
                     values = [values]
-                mounts.extend(m for m in values if isinstance(m, str) and m.startswith("/") and Path(m).is_dir())
+                mounts.extend(m for m in values if isinstance(m, str) and m.startswith("/") and _DriveInfo._is_mount(m))
             for child in block.get("children", []):
                 visit(child, physical)
 


### PR DESCRIPTION
## Summary
- filter Linux boot and EFI mounts from SystemLogger drive capacity reporting
- reuse the same mount filter for psutil and lsblk discovery paths

## Validation
- python -m ruff format ultralytics/utils/logger.py
- python -m ruff check ultralytics/utils/logger.py
- local lsblk smoke returns / and /data while excluding /boot/efi

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves system environment reporting by making GPU detection more robust and filtering out non-useful Linux mount points from disk capacity logs 🖥️📦

### 📊 Key Changes
- Replaced direct `torch.cuda` GPU checks in platform callbacks with the newer `GPUInfo` utility.
- Removed the unused `torch` import from environment info collection.
- Updated GPU reporting to:
  - count GPUs from `GPUInfo`
  - report the first detected GPU’s name
  - properly shut down the GPU info helper after use
- Improved disk mount detection in the logger by adding a dedicated `_is_mount()` check.
- Excluded Linux boot-related mount points like `/boot` and `/efi` from disk capacity reporting.
- Reused the new mount filter in multiple places to keep mount detection logic consistent.

### 🎯 Purpose & Impact
- Better GPU detection can make environment reporting more reliable across different systems and configurations 🚀
- Using `GPUInfo` aligns this code with newer Ultralytics device-handling utilities, which should reduce maintenance and improve consistency.
- Filtering out `/boot` and `/efi` avoids misleading disk capacity stats on Linux systems 💽
- Users and platform integrations should see cleaner, more accurate hardware and storage metadata.
- Overall, this is a small infrastructure improvement that helps logging and telemetry be more dependable without changing user-facing workflows ✅