### PR TITLE
Fix grayscale NumPy prediction for color models

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -170,7 +170,16 @@ def test_predict_gray_and_4ch(tmp_path):
             results = model(source, save=True, verbose=True, imgsz=32)
             assert len(results) == 1, f"Expected 1 result for {f.name}, got {len(results)}"
         f.unlink()  # cleanup
+    
+    def test_predict_2d_grayscale_numpy():
+        """Test prediction on 2D grayscale NumPy arrays."""
+        model = YOLO(MODEL)
 
+        im = np.zeros((64, 64), dtype=np.uint8)
+
+        results = model.predict(source=im, imgsz=32)
+
+        assert len(results) == 1
 
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -529,7 +529,7 @@ class LoadPilAndNumpy:
             im = im[..., None] if flag == "L" else im[..., ::-1]
             im = np.ascontiguousarray(im)  # contiguous
         elif im.ndim == 2:  # grayscale in numpy form
-            im = im[..., None]
+            im = im[..., None] if flag == "L" else cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)
         return im
 
     def __len__(self) -> int:

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -530,6 +530,8 @@ class LoadPilAndNumpy:
             im = np.ascontiguousarray(im)  # contiguous
         elif im.ndim == 2:  # grayscale in numpy form
             im = im[..., None] if flag == "L" else cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)
+        elif im.ndim == 3 and im.shape[-1] == 1 and flag != "L":
+            im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)
         return im
 
     def __len__(self) -> int:


### PR DESCRIPTION
Fixes grayscale NumPy array prediction crash by converting 2D grayscale arrays to BGR for color models while preserving single-channel behavior for grayscale models.

Fixes #24750

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes grayscale NumPy image handling so color models receive proper 3-channel input during prediction. 🩶➡️🎨

### 📊 Key Changes
- Updates `_single_check()` in `ultralytics/data/loaders.py` to correctly process 2D grayscale NumPy arrays based on the requested `flag`.
- Preserves single-channel behavior for grayscale mode with `flag == "L"`.
- Converts grayscale NumPy arrays to BGR with OpenCV when a color image is expected, instead of only adding a singleton channel.
- Targets an edge case where grayscale NumPy inputs could be incompatible with color-model inference.

### 🎯 Purpose & Impact
- Fixes a prediction bug affecting grayscale NumPy inputs passed to color models. 🛠️
- Improves input consistency between PIL and NumPy image paths.
- Reduces shape/channel mismatch issues during preprocessing and inference.
- Makes prediction behavior more robust for real-world user inputs without broad code changes. ✅