### PR TITLE
Exclude boot/firmware partitions from SystemLogger drive list

### DIFF
--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -333,8 +333,9 @@ class _DriveInfo:
 
     @staticmethod
     def _sort(mounts):
-        """Sort mounted paths with root first."""
-        return sorted(set(mounts), key=lambda mount: (mount != "/", mount))
+        """Sort mounted paths with root first, excluding boot/firmware partitions like /boot and /boot/efi."""
+        mounts = {m for m in mounts if not (m + "/").startswith(("/boot/", "/efi/"))}
+        return sorted(mounts, key=lambda mount: (mount != "/", mount))
 
     @staticmethod
     def _current_mount(partitions):

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -130,8 +130,16 @@ def get_cpu_info():
 @functools.lru_cache
 def get_gpu_info(index):
     """Return a string with system GPU information, i.e. 'Tesla T4, 15102MiB'."""
-    properties = torch.cuda.get_device_properties(index)
-    return f"{properties.name}, {properties.total_memory / (1 << 20):.0f}MiB"
+    if torch.cuda.is_available():
+        properties = torch.cuda.get_device_properties(index)
+        return f"{properties.name}, {properties.total_memory / (1 << 20):.0f}MiB"
+    import pynvml  # NVML fallback when CUDA init fails, e.g. busy/exclusive-mode GPUs or torch/driver mismatch
+
+    pynvml.nvmlInit()
+    handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+    info = f"{pynvml.nvmlDeviceGetName(handle)}, {pynvml.nvmlDeviceGetMemoryInfo(handle).total / (1 << 20):.0f}MiB"
+    pynvml.nvmlShutdown()
+    return info
 
 
 def select_device(device="", newline=False, verbose=True):

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -130,16 +130,8 @@ def get_cpu_info():
 @functools.lru_cache
 def get_gpu_info(index):
     """Return a string with system GPU information, i.e. 'Tesla T4, 15102MiB'."""
-    if torch.cuda.is_available():
-        properties = torch.cuda.get_device_properties(index)
-        return f"{properties.name}, {properties.total_memory / (1 << 20):.0f}MiB"
-    import pynvml  # NVML fallback when CUDA init fails, e.g. busy/exclusive-mode GPUs or torch/driver mismatch
-
-    pynvml.nvmlInit()
-    handle = pynvml.nvmlDeviceGetHandleByIndex(index)
-    info = f"{pynvml.nvmlDeviceGetName(handle)}, {pynvml.nvmlDeviceGetMemoryInfo(handle).total / (1 << 20):.0f}MiB"
-    pynvml.nvmlShutdown()
-    return info
+    properties = torch.cuda.get_device_properties(index)
+    return f"{properties.name}, {properties.total_memory / (1 << 20):.0f}MiB"
 
 
 def select_device(device="", newline=False, verbose=True):


### PR DESCRIPTION
## Problem

After #24758, `SystemLogger(all_drives=True)` reports phantom `/boot/efi` entries with 0/1 GB on Linux servers (e.g. Ultralytics Portal status cards now show a useless `/boot/efi 1% 0/1 GB` disk).

## Root cause

EFI and boot partitions live on physical disks, so both the `lsblk`-based Linux discovery and the psutil fallback in `_DriveInfo` include their mountpoints.

## Fix

Filter mounts equal to or under `/boot` or `/efi` in `_DriveInfo._sort`, which every `all_drives` discovery path (psutil fallback, macOS, Linux, Windows) already flows through. The `(m + "/").startswith` check avoids false positives like a hypothetical `/bootdata` mount, and Windows drive letters are unaffected.

## Validation

```python
assert _DriveInfo._sort(["/data", "/", "/boot/efi"]) == ["/", "/data"]
assert _DriveInfo._sort(["/boot", "/", "/data"]) == ["/", "/data"]
assert _DriveInfo._sort(["/bootdata", "/"]) == ["/", "/bootdata"]
```

Live `SystemLogger(all_drives=True).get_metrics(rates=True)` verified unchanged on macOS.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves mount path handling in the logger by filtering out boot and firmware partitions, making system storage reporting cleaner and more relevant.

### 📊 Key Changes
- Updated `ultralytics/utils/logger.py` in the `mounts._sort()` method.
- Changed mount sorting logic to **exclude boot-related partitions** such as `/boot` and `/boot/efi`.
- Kept the existing behavior of sorting mount points with the root path `/` listed first.
- Simplified the mount list before sorting by filtering out low-level system partitions.

### 🎯 Purpose & Impact
- ✅ Reduces noise in logged or reported mount paths by hiding partitions that are usually not useful for normal Ultralytics workflows.
- 💻 Makes storage-related system information easier to read and more relevant for users running training or inference jobs.
- 🧹 Helps avoid confusion on Linux systems where boot or EFI partitions may appear as separate mounts.
- 🔍 Improves overall logger output quality without changing core model training or inference behavior.