### PR TITLE
fix(trackers): TrackTrack ReID falls back to motion for missing-feature pairs

### DIFF
--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -435,9 +435,9 @@ class TRACKTRACK:
         if self.encoder is not None:
             cos = _cosine_distance(tracks, dets)
             # Where appearance is missing (NaN: new track, or occlusion-suppressed detection), fall back to
-            # motion for that pair so the embedding neither helps nor penalizes it.
-            reid_term = np.where(np.isnan(cos), hmiou_dist, cos)
-            cost = self.iou_weight * hmiou_dist + self.reid_weight * reid_term
+            # pure motion cost for that pair so the embedding neither helps nor penalizes it.
+            nan_mask = np.isnan(cos)
+            cost = np.where(nan_mask, hmiou_dist, self.iou_weight * hmiou_dist + self.reid_weight * cos)
         else:
             cost = hmiou_dist
         cost += self.conf_weight * _confidence_distance(tracks, dets)

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -207,8 +207,8 @@ def compute_dets_del(predictor) -> list | None:
 def _cosine_distance(tracks: list[TTSTrack], dets: list[TTSTrack]) -> np.ndarray:
     """Cosine distance in `[0, 1]` between track and detection embeddings; NaN where either side has no feature.
 
-    A NaN entry signals "no appearance evidence for this pair" so the caller falls back to motion rather than
-    treating a missing/occlusion-suppressed embedding as maximally dissimilar (which would penalize true matches).
+    A NaN entry signals "no appearance evidence for this pair" so the caller falls back to motion rather than treating a
+    missing/occlusion-suppressed embedding as maximally dissimilar (which would penalize true matches).
     """
     if len(tracks) == 0 or len(dets) == 0:
         return np.ones((len(tracks), len(dets)), dtype=np.float32)

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -205,21 +205,24 @@ def compute_dets_del(predictor) -> list | None:
 
 
 def _cosine_distance(tracks: list[TTSTrack], dets: list[TTSTrack]) -> np.ndarray:
-    """Return cosine distance in `[0, 1]` between track smoothed embeddings and detection current embeddings."""
+    """Cosine distance in `[0, 1]` between track and detection embeddings; NaN where either side has no feature.
+
+    A NaN entry signals "no appearance evidence for this pair" so the caller falls back to motion rather than
+    treating a missing/occlusion-suppressed embedding as maximally dissimilar (which would penalize true matches).
+    """
     if len(tracks) == 0 or len(dets) == 0:
         return np.ones((len(tracks), len(dets)), dtype=np.float32)
-    dim = 128
-    for obj in (*tracks, *dets):
-        feat = obj.smooth_feat if obj.smooth_feat is not None else obj.curr_feat
-        if feat is not None:
-            dim = feat.shape[0]
-            break
-    else:
-        LOGGER.warning("TRACKTRACK ReID enabled but all features are None; falling back to zero embeddings.")
+    tfeat = [t.smooth_feat if t.smooth_feat is not None else t.curr_feat for t in tracks]
+    dfeat = [d.curr_feat for d in dets]
+    dim = next((f.shape[0] for f in (*tfeat, *dfeat) if f is not None), 128)
     zeros = np.zeros(dim, dtype=np.float32)
-    track_feats = np.stack([t.smooth_feat if t.smooth_feat is not None else zeros for t in tracks])
-    det_feats = np.stack([d.curr_feat if d.curr_feat is not None else zeros for d in dets])
-    return np.clip(1 - track_feats @ det_feats.T, 0, 1)
+    track_feats = np.stack([f if f is not None else zeros for f in tfeat])
+    det_feats = np.stack([f if f is not None else zeros for f in dfeat])
+    cos = np.clip(1 - track_feats @ det_feats.T, 0, 1)
+    valid_t = np.array([f is not None for f in tfeat])
+    valid_d = np.array([f is not None for f in dfeat])
+    cos[~(valid_t[:, None] & valid_d[None, :])] = np.nan
+    return cos
 
 
 class TTSTrack(BOTrack):
@@ -430,7 +433,11 @@ class TRACKTRACK:
         """Return the multi-cue cost matrix (HMIoU + ReID + confidence + angle), gated by IoU support."""
         iou_sim, hmiou_dist = _hmiou_distance(tracks, dets)
         if self.encoder is not None:
-            cost = self.iou_weight * hmiou_dist + self.reid_weight * _cosine_distance(tracks, dets)
+            cos = _cosine_distance(tracks, dets)
+            # Where appearance is missing (NaN: new track, or occlusion-suppressed detection), fall back to
+            # motion for that pair so the embedding neither helps nor penalizes it.
+            reid_term = np.where(np.isnan(cos), hmiou_dist, cos)
+            cost = self.iou_weight * hmiou_dist + self.reid_weight * reid_term
         else:
             cost = hmiou_dist
         cost += self.conf_weight * _confidence_distance(tracks, dets)

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -210,19 +210,16 @@ def _cosine_distance(tracks: list[TTSTrack], dets: list[TTSTrack]) -> np.ndarray
     A NaN entry signals "no appearance evidence for this pair" so the caller falls back to motion rather than treating a
     missing/occlusion-suppressed embedding as maximally dissimilar (which would penalize true matches).
     """
-    if len(tracks) == 0 or len(dets) == 0:
+    if not tracks or not dets:
         return np.ones((len(tracks), len(dets)), dtype=np.float32)
     tfeat = [t.smooth_feat if t.smooth_feat is not None else t.curr_feat for t in tracks]
     dfeat = [d.curr_feat for d in dets]
     dim = next((f.shape[0] for f in (*tfeat, *dfeat) if f is not None), 128)
     zeros = np.zeros(dim, dtype=np.float32)
-    track_feats = np.stack([f if f is not None else zeros for f in tfeat])
-    det_feats = np.stack([f if f is not None else zeros for f in dfeat])
-    cos = np.clip(1 - track_feats @ det_feats.T, 0, 1)
-    valid_t = np.array([f is not None for f in tfeat])
-    valid_d = np.array([f is not None for f in dfeat])
-    cos[~(valid_t[:, None] & valid_d[None, :])] = np.nan
-    return cos
+    T = np.stack([f if f is not None else zeros for f in tfeat])
+    D = np.stack([f if f is not None else zeros for f in dfeat])
+    valid = np.array([f is not None for f in tfeat])[:, None] & np.array([f is not None for f in dfeat])[None, :]
+    return np.where(valid, np.clip(1 - T @ D.T, 0, 1), np.nan).astype(np.float32)
 
 
 class TTSTrack(BOTrack):
@@ -436,8 +433,7 @@ class TRACKTRACK:
             cos = _cosine_distance(tracks, dets)
             # Where appearance is missing (NaN: new track, or occlusion-suppressed detection), fall back to
             # pure motion cost for that pair so the embedding neither helps nor penalizes it.
-            nan_mask = np.isnan(cos)
-            cost = np.where(nan_mask, hmiou_dist, self.iou_weight * hmiou_dist + self.reid_weight * cos)
+            cost = np.where(np.isnan(cos), hmiou_dist, self.iou_weight * hmiou_dist + self.reid_weight * cos)
         else:
             cost = hmiou_dist
         cost += self.conf_weight * _confidence_distance(tracks, dets)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves TrackTrack ReID matching by treating missing appearance embeddings as “unknown” instead of “bad matches,” leading to more reliable tracking 🔍✨

### 📊 Key Changes
- Updated `_cosine_distance()` in `ultralytics/trackers/track_tracker.py` to return `NaN` when either a track or detection has no feature embedding, instead of using zero embeddings.
- Removed the previous fallback behavior that treated missing embeddings like real vectors, which could incorrectly make valid matches look dissimilar.
- Simplified feature handling by explicitly collecting track and detection embeddings first, then building a validity mask for only the pairs with real appearance data.
- Adjusted `_cost_matrix()` so that when appearance data is missing, matching falls back to motion-based cost only, rather than mixing in a misleading ReID penalty.
- Improved inline documentation to clarify that missing embeddings can happen for new tracks or occlusion-suppressed detections 📝

### 🎯 Purpose & Impact
- Prevents the tracker from unfairly penalizing objects when appearance features are unavailable, improving match quality 🎯
- Makes tracking more robust in real-world cases like occlusion, temporary feature loss, or newly created tracks 🚶‍♂️🚗
- Reduces the chance of identity switches or broken tracks caused by missing ReID data 🔄
- Keeps appearance cues helpful when available, while safely relying on motion cues when they are not ⚖️
- Overall, this should improve tracking stability and consistency for users running object tracking workflows in Ultralytics 🚀