### PR TITLE
Fix premature 100% in TQDM and ANSI clear-line leak in ConsoleLogger

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -64,6 +64,9 @@
 15210393591@163.com:
   avatar: https://avatars.githubusercontent.com/u/48980472?v=4
   username: GiantAxeWhy
+153299927+Harshxth@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/153299927?v=4
+  username: Harshxth
 1579093407@qq.com:
   avatar: https://avatars.githubusercontent.com/u/160490334?v=4
   username: YOLOv5-Magic
@@ -112,6 +115,9 @@
 43647848+artest08@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/43647848?v=4
   username: artest08
+44016063+xiazl1993@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/44016063?v=4
+  username: xiazl1993
 44016758+M-Amrollahi@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/44016758?v=4
   username: M-Amrollahi

--- a/ultralytics/utils/logger.py
+++ b/ultralytics/utils/logger.py
@@ -134,9 +134,10 @@ class ConsoleLogger:
 
         current_time = time.time()
 
-        # Handle carriage returns and process lines
+        # Handle carriage returns and strip ANSI clear-line codes (TQDM writes "\r\033[K<line>" interactively)
         if "\r" in text:
             text = text.split("\r")[-1]
+        text = text.replace("\x1b[K", "")
 
         lines = text.split("\n")
         if lines and lines[-1] == "":

--- a/ultralytics/utils/tqdm.py
+++ b/ultralytics/utils/tqdm.py
@@ -247,9 +247,9 @@ class TQDM:
             est_rate = rate or (self.n / elapsed)
             remaining_str = f"<{self._format_time((self.total - self.n) / est_rate)}"
 
-        # Numbers and percent
+        # Numbers and percent (floor so 100% only shows at true completion)
         if self.total:
-            percent = (self.n / self.total) * 100
+            percent = int(self.n / self.total * 100)
             n_str = self._format_num(self.n)
             t_str = self._format_num(self.total)
             if self.is_bytes and n_str[-2] == t_str[-2]:  # Collapse suffix only when identical (e.g. "5.4/5.4MB")


### PR DESCRIPTION
## Problem

Platform console logs show every epoch's progress bar duplicated ~6 times, all claiming "100%" while still at 1177/1182 … 1182/1182:

```
1/55  0G  0.8989  2.136  6.76 ... 640: 100% ━━━━━━━━━━━╸ 1177/1182 1.4s/it 28:44<6.9s
1/55  0G  0.8997  2.135  6.76 ... 640: 100% ━━━━━━━━━━━╸ 1178/1182 1.5s/it 28:45<5.9s
...
1/55  0G  0.9004  2.134  6.756 ... 640: 100% ━━━━━━━━━━━━ 1182/1182 1.5s/it 28:50
```

Two compounding bugs:

1. **TQDM rounds percent up to "100%" prematurely** — `{percent:.0f}` renders anything ≥99.5% as "100%" (1177/1182 = 99.58% → "100%"). ConsoleLogger uses `"100%" in line` as its bar-completeness test, so every iteration in the final 0.5% streams as a separate "completed" line.
2. **ConsoleLogger's seq-key dedup is defeated by a leftover ANSI code** — interactive TQDM writes `\r\033[K<line>`; `_queue_log` splits on `\r` but leaves the `\033[K` clear-line prefix, so `parts[0]` is the escape code instead of `1/55`/`train:`/`Class` and the sequence key is never extracted. Raw escape bytes also leak into the streamed payload.

## Fix

- `tqdm.py`: floor the percent (`int(n / total * 100)`) so "100%" only displays at true completion. The final `close()`/completion display still shows exactly one 100% line.
- `logger.py`: strip `\x1b[K` after the `\r` split, restoring seq-key dedup and keeping escape codes out of streamed logs.

## Validation

Simulated both paths: at n=1177/1182 the bar now shows "99%" and is filtered as incomplete; at n=total it shows "100%" once. ConsoleLogger with `\r\x1b[K`-prefixed lines now extracts seq keys correctly and emits a single line per bar with no escape bytes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves logging and progress bar output for cleaner, more accurate console/display behavior, while also adding a couple of new GitHub author mappings to the docs.

### 📊 Key Changes
- ✨ Updated `logger.py` to better clean interactive terminal output by removing ANSI clear-line codes like `\x1b[K`.
- 🧹 Improved handling of carriage-return-based log updates, which are commonly produced by progress bars such as TQDM.
- 📈 Updated `tqdm.py` so progress percentages are floored to whole numbers, preventing `100%` from appearing before a task is actually finished.
- 👥 Added two new GitHub author entries in `docs/mkdocs_github_authors.yaml` for:
  - @Harshxth
  - @xiazl1993

### 🎯 Purpose & Impact
- ✅ Makes logs cleaner and easier to read, especially in environments where interactive progress output gets captured into plain text logs.
- 🎯 Improves progress bar accuracy by ensuring `100%` is shown only at real completion, reducing confusion for users.
- 🖥️ Helps create more consistent output across terminals, notebooks, CI logs, and other non-interactive environments.
- 🙌 Keeps documentation contributor metadata up to date so author attribution works correctly.