### PR TITLE
Fix QNN HTP arch mapping, monolithic EP loading, and A16W8 quantization

### DIFF
--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -198,13 +198,14 @@ model.train(data="coco8.yaml", epochs=10, trainer=WeightedTrainer)
 
     class WeightedDetectionModel(DetectionModel):
         """Detection model that uses class-weighted loss."""
+
         ...
     ```
 
     ```python
     # inference script
+
     from ultralytics import YOLO
-    from weighted_model import WeightedDetectionModel  # must be importable at load time
 
     model = YOLO("runs/detect/train/weights/best.pt")
     metrics = model.val()

--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -64,14 +64,14 @@ Export an Ultralytics YOLO model to QNN format for deployment on Snapdragon hard
 
 Pass the target architecture via `name` (e.g. `name="73"`). Valid values:
 
-| `name` | Hexagon HTP | Snapdragon platform                    |
-| :----- | :---------- | :------------------------------------- |
-| `68`   | v68         | Snapdragon 888                         |
-| `69`   | v69         | Snapdragon 8 Gen 1 / 8+ Gen 1          |
-| `73`   | v73         | Snapdragon 8 Gen 2, X Elite (default)  |
-| `75`   | v75         | Snapdragon 8 Gen 3                     |
-| `79`   | v79         | Snapdragon 8 Elite                     |
-| `81`   | v81         | Snapdragon 8 Elite Gen 5               |
+| `name` | Hexagon HTP | Snapdragon platform                   |
+| :----- | :---------- | :------------------------------------ |
+| `68`   | v68         | Snapdragon 888                        |
+| `69`   | v69         | Snapdragon 8 Gen 1 / 8+ Gen 1         |
+| `73`   | v73         | Snapdragon 8 Gen 2, X Elite (default) |
+| `75`   | v75         | Snapdragon 8 Gen 3                    |
+| `79`   | v79         | Snapdragon 8 Elite                    |
+| `81`   | v81         | Snapdragon 8 Elite Gen 5              |
 
 !!! note "Platform support"
 
@@ -163,16 +163,16 @@ The QNN format supports the [Export](../modes/export.md), [Predict](../modes/pre
 
 ### Export Arguments
 
-| Argument   | Type             | Default        | Description                                                                                                                                                                               |
-| :--------- | :--------------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `format`   | `str`            | `'qnn'`        | Target format for the exported model, defining compatibility with the Qualcomm QNN runtime.                                                                                               |
-| `imgsz`    | `int` or `tuple` | `640`          | Desired image size for the model input. Can be an integer for square images or a tuple `(height, width)`.                                                                                 |
-| `batch`    | `int`            | `1`            | Specifies the export model batch size, which is baked into the generated QNN context binary.                                                                                              |
+| Argument   | Type             | Default        | Description                                                                                                                                                                                                |
+| :--------- | :--------------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `format`   | `str`            | `'qnn'`        | Target format for the exported model, defining compatibility with the Qualcomm QNN runtime.                                                                                                                |
+| `imgsz`    | `int` or `tuple` | `640`          | Desired image size for the model input. Can be an integer for square images or a tuple `(height, width)`.                                                                                                  |
+| `batch`    | `int`            | `1`            | Specifies the export model batch size, which is baked into the generated QNN context binary.                                                                                                               |
 | `name`     | `str`            | `'73'`         | Target Hexagon HTP architecture version: `68`, `69`, `73`, `75`, `79`, or `81` (Snapdragon 888, 8 Gen 1, 8 Gen 2, 8 Gen 3, 8 Elite, 8 Elite Gen 5). The context binary is finalized for this architecture. |
-| `int8`     | `bool`           | `True`         | Enables INT8 quantization. Required for QNN HTP export — automatically set to `True` if not specified.                                                                                    |
-| `data`     | `str`            | `'coco8.yaml'` | Dataset configuration file used for INT8 calibration. Specifies the calibration image source.                                                                                             |
-| `fraction` | `float`          | `1.0`          | Fraction of the calibration dataset to use for INT8 quantization.                                                                                                                         |
-| `device`   | `str`            | `None`         | Specifies the device for the ONNX export step: GPU (`device=0`) or CPU (`device=cpu`).                                                                                                    |
+| `int8`     | `bool`           | `True`         | Enables INT8 quantization. Required for QNN HTP export — automatically set to `True` if not specified.                                                                                                     |
+| `data`     | `str`            | `'coco8.yaml'` | Dataset configuration file used for INT8 calibration. Specifies the calibration image source.                                                                                                              |
+| `fraction` | `float`          | `1.0`          | Fraction of the calibration dataset to use for INT8 quantization.                                                                                                                                          |
+| `device`   | `str`            | `None`         | Specifies the device for the ONNX export step: GPU (`device=0`) or CPU (`device=cpu`).                                                                                                                     |
 
 !!! note "Precision"
 

--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -22,13 +22,13 @@ Snapdragon is the most widely deployed mobile compute platform in the world. Exp
 
 - **Hexagon NPU acceleration**: Running YOLO on the Hexagon Tensor Processor delivers dramatically higher throughput and lower power than CPU inference — ideal for [real-time inference](https://www.ultralytics.com/glossary/real-time-inference) and always-on computer vision on Snapdragon.
 - **On-device and offline**: QNN inference runs entirely on the Snapdragon device, so there are no cloud round-trips, latency stays low, and data never leaves the device.
-- **INT8 efficiency**: QNN export quantizes YOLO to [INT8](https://www.ultralytics.com/glossary/model-quantization), the Hexagon NPU's native precision, shrinking model size and maximizing frames per second on battery-powered hardware.
+- **Quantized efficiency**: QNN export [quantizes](https://www.ultralytics.com/glossary/model-quantization) YOLO to INT8 weights with 16-bit activations, the Hexagon NPU's preferred accuracy/performance balance, shrinking model size and maximizing frames per second on battery-powered hardware.
 - **One format, many devices**: A single Qualcomm QNN export targets Snapdragon CPU, Adreno GPU, and Hexagon NPU across the Snapdragon 8 Gen 2, 8 Gen 3, and 8 Elite families and beyond.
 - **Production-ready Qualcomm AI stack**: QNN (Qualcomm AI Engine Direct / QAIRT) is Qualcomm's current, actively maintained on-device AI runtime and the recommended replacement for SNPE.
 
 ## QNN Export Format
 
-Ultralytics compiles YOLO models to QNN **locally** using the [ONNX Runtime](https://onnxruntime.ai/) QNN Execution Provider (the pip-installable `onnxruntime-qnn` package, which bundles the QAIRT libraries). The exporter converts your model to [ONNX](onnx.md), **INT8-quantizes it** with calibration data (the Hexagon NPU is an int8 accelerator), then initializes an ONNX Runtime session with context-binary caching enabled — this compiles the quantized graph into a **QNN context binary** embedded in `<model>_qnn.onnx`. No Qualcomm account, cloud upload, or separate SDK download is required.
+Ultralytics compiles YOLO models to QNN **locally** using the [ONNX Runtime](https://onnxruntime.ai/) QNN Execution Provider (the pip-installable `onnxruntime-qnn` package, which bundles the QAIRT libraries). The exporter converts your model to [ONNX](onnx.md), **quantizes it** with calibration data to 16-bit activations and INT8 weights (the recommended balance for the Hexagon NPU), then initializes an ONNX Runtime session with context-binary caching enabled — this compiles the quantized graph into a **QNN context binary** embedded in `<model>_qnn.onnx`. No Qualcomm account, cloud upload, or separate SDK download is required.
 
 Unlike the cloud-based [Qualcomm AI Hub](https://aihub.qualcomm.com/), which compiles and profiles models on Qualcomm-hosted Snapdragon devices and requires a Qualcomm account, the Ultralytics QNN export runs entirely on your own machine with a single `export(format="qnn")` call. You get the same QNN/QAIRT runtime target — Snapdragon CPU, Adreno GPU, and Hexagon NPU — without sign-up, upload limits, or queue times, and it drops straight into the standard YOLO export workflow.
 
@@ -36,7 +36,7 @@ The exported `_qnn_model/` directory bundles the context-binary ONNX and a `meta
 
 ## Key Features of QNN Models
 
-- **INT8 Quantization**: The model is quantized to INT8 with the ONNX Runtime QNN QDQ flow and a calibration dataset, matching the Hexagon NPU's native precision for maximum throughput and minimal size. Learn more about [model quantization](https://www.ultralytics.com/glossary/model-quantization).
+- **Quantization**: The model is quantized to 16-bit activations and INT8 weights with the ONNX Runtime QNN QDQ flow and a calibration dataset, the Hexagon NPU's recommended accuracy/performance balance. Learn more about [model quantization](https://www.ultralytics.com/glossary/model-quantization).
 - **Fully Local Compilation**: The context binary is generated entirely on your host machine — no Qualcomm account, API token, or cloud upload.
 - **Full Snapdragon Acceleration**: Run inference on the Hexagon NPU (HTP), Adreno GPU, or CPU through a single unified runtime.
 - **Broad Device Reach**: Target the wide range of Snapdragon platforms shipping in phones, PCs (Windows on Snapdragon), automotive, XR, and embedded products.
@@ -64,13 +64,14 @@ Export an Ultralytics YOLO model to QNN format for deployment on Snapdragon hard
 
 Pass the target architecture via `name` (e.g. `name="73"`). Valid values:
 
-| `name` | Hexagon HTP | Snapdragon platform          |
-| :----- | :---------- | :--------------------------- |
-| `68`   | v68         | Snapdragon 865               |
-| `69`   | v69         | Snapdragon 888 / 8 Gen 1     |
-| `73`   | v73         | Snapdragon 8 Gen 2 (default) |
-| `75`   | v75         | Snapdragon 8 Gen 3           |
-| `79`   | v79         | Snapdragon 8 Elite           |
+| `name` | Hexagon HTP | Snapdragon platform                    |
+| :----- | :---------- | :------------------------------------- |
+| `68`   | v68         | Snapdragon 888                         |
+| `69`   | v69         | Snapdragon 8 Gen 1 / 8+ Gen 1          |
+| `73`   | v73         | Snapdragon 8 Gen 2, X Elite (default)  |
+| `75`   | v75         | Snapdragon 8 Gen 3                     |
+| `79`   | v79         | Snapdragon 8 Elite                     |
+| `81`   | v81         | Snapdragon 8 Elite Gen 5               |
 
 !!! note "Platform support"
 
@@ -106,7 +107,7 @@ The QNN format supports the [Export](../modes/export.md), [Predict](../modes/pre
         model = YOLO("yolo26n.pt")
 
         # Export to Qualcomm QNN format (INT8, enforced automatically), targeting an HTP architecture via 'name'
-        # 'name' can be one of 68, 69, 73, 75, 79 (Snapdragon 865, 888/8 Gen 1, 8 Gen 2, 8 Gen 3, 8 Elite)
+        # 'name' can be one of 68, 69, 73, 75, 79, 81 (Snapdragon 888, 8 Gen 1, 8 Gen 2, 8 Gen 3, 8 Elite, 8 Elite Gen 5)
         model.export(format="qnn", name="73")  # creates 'yolo26n_qnn_model/'
         ```
 
@@ -114,7 +115,7 @@ The QNN format supports the [Export](../modes/export.md), [Predict](../modes/pre
 
         ```bash
         # Export a YOLO26n PyTorch model to Qualcomm QNN format for the target HTP architecture
-        # 'name' can be one of 68, 69, 73, 75, 79 (Snapdragon 865, 888/8 Gen 1, 8 Gen 2, 8 Gen 3, 8 Elite)
+        # 'name' can be one of 68, 69, 73, 75, 79, 81 (Snapdragon 888, 8 Gen 1, 8 Gen 2, 8 Gen 3, 8 Elite, 8 Elite Gen 5)
         yolo export model=yolo26n.pt format=qnn name=73 # creates 'yolo26n_qnn_model/'
         ```
 
@@ -167,7 +168,7 @@ The QNN format supports the [Export](../modes/export.md), [Predict](../modes/pre
 | `format`   | `str`            | `'qnn'`        | Target format for the exported model, defining compatibility with the Qualcomm QNN runtime.                                                                                               |
 | `imgsz`    | `int` or `tuple` | `640`          | Desired image size for the model input. Can be an integer for square images or a tuple `(height, width)`.                                                                                 |
 | `batch`    | `int`            | `1`            | Specifies the export model batch size, which is baked into the generated QNN context binary.                                                                                              |
-| `name`     | `str`            | `'73'`         | Target Hexagon HTP architecture version: `68`, `69`, `73`, `75`, or `79` (Snapdragon 865, 888/8 Gen 1, 8 Gen 2, 8 Gen 3, 8 Elite). The context binary is finalized for this architecture. |
+| `name`     | `str`            | `'73'`         | Target Hexagon HTP architecture version: `68`, `69`, `73`, `75`, `79`, or `81` (Snapdragon 888, 8 Gen 1, 8 Gen 2, 8 Gen 3, 8 Elite, 8 Elite Gen 5). The context binary is finalized for this architecture. |
 | `int8`     | `bool`           | `True`         | Enables INT8 quantization. Required for QNN HTP export — automatically set to `True` if not specified.                                                                                    |
 | `data`     | `str`            | `'coco8.yaml'` | Dataset configuration file used for INT8 calibration. Specifies the calibration image source.                                                                                             |
 | `fraction` | `float`          | `1.0`          | Fraction of the calibration dataset to use for INT8 quantization.                                                                                                                         |
@@ -175,7 +176,7 @@ The QNN format supports the [Export](../modes/export.md), [Predict](../modes/pre
 
 !!! note "Precision"
 
-    The Hexagon NPU (HTP) is an int8 accelerator, so QNN export quantizes the model to **INT8** using the [ONNX Runtime QDQ quantization](https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html) flow with calibration images from `data`. `int8=True` is enforced automatically.
+    QNN export quantizes the model to **16-bit activations and INT8 weights** — the recommended accuracy/performance balance for the Hexagon NPU — using the [ONNX Runtime QDQ quantization](https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html) flow with calibration images from `data`. `int8=True` is enforced automatically.
 
 For more details about the export process, visit the [Ultralytics documentation page on exporting](../modes/export.md).
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -589,7 +589,7 @@ class Exporter:
             self.args.name = str(self.args.name).lower().lstrip("v")  # accept '73' or 'v73'
             assert self.args.name in QNN_HTP_ARCHS, (
                 f"Invalid HTP architecture '{self.args.name}' for Qualcomm QNN export. Valid archs are {QNN_HTP_ARCHS} "
-                "(Snapdragon 865/888/8Gen2/8Gen3/8Elite respectively)."
+                "(Snapdragon 888/8Gen1/8Gen2/8Gen3/8Elite/8EliteGen5 respectively)."
             )
         if self.args.nms and model.task == "semantic":
             LOGGER.warning("'nms=True' is not valid for semantic segmentation models. Forcing 'nms=False'.")

--- a/ultralytics/nn/backends/qnn.py
+++ b/ultralytics/nn/backends/qnn.py
@@ -39,19 +39,26 @@ class QNNBackend(BaseBackend):
         onnx_file = w if w.is_file() else next(w.rglob("*_qnn.onnx"))
         LOGGER.info(f"Loading {onnx_file} for Qualcomm QNN inference...")
 
-        # Register the QNN EP (libraries resolved from the plugin helper or the onnxruntime/capi bundle) and select it
+        # Register the QNN EP (libraries resolved from the plugin helper or the onnxruntime/capi bundle) and select
+        # it; ep_library is None when QNN is already built into ONNX Runtime and needs no plugin registration
         ep_name = "QNNExecutionProvider"
         ep_library, htp_backend = qnn_library_paths()
-        onnxruntime.register_execution_provider_library(ep_name, ep_library)
-        devices = [d for d in onnxruntime.get_ep_devices() if d.ep_name == ep_name]
-        if not devices:
-            raise OSError(
-                "QNN Execution Provider registered but no QNN devices were found. Run on a Qualcomm Snapdragon device "
-                "with 'onnxruntime-qnn' installed."
-            )
+        ep_options = {"backend_path": htp_backend}
         options = onnxruntime.SessionOptions()
-        options.add_provider_for_devices(devices, {"backend_path": htp_backend})
-        self.session = onnxruntime.InferenceSession(str(onnx_file), sess_options=options)
+        if ep_library:
+            onnxruntime.register_execution_provider_library(ep_name, ep_library)
+            devices = [d for d in onnxruntime.get_ep_devices() if d.ep_name == ep_name]
+            if not devices:
+                raise OSError(
+                    "QNN Execution Provider registered but no QNN devices were found. Run on a Qualcomm Snapdragon "
+                    "device with 'onnxruntime-qnn' installed."
+                )
+            options.add_provider_for_devices(devices, ep_options)
+            self.session = onnxruntime.InferenceSession(str(onnx_file), sess_options=options)
+        else:
+            self.session = onnxruntime.InferenceSession(
+                str(onnx_file), sess_options=options, providers=[ep_name], provider_options=[ep_options]
+            )
         self.output_names = [x.name for x in self.session.get_outputs()]
 
         # Load metadata saved alongside the model during export

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -70,11 +70,12 @@ RKNN_CHIPS = frozenset(
 )  # Rockchip processors available for export
 QNN_HTP_ARCHS = frozenset(
     {
-        "68",  # Snapdragon 865
-        "69",  # Snapdragon 888 / 8 Gen 1
-        "73",  # Snapdragon 8 Gen 2
+        "68",  # Snapdragon 888
+        "69",  # Snapdragon 8 Gen 1
+        "73",  # Snapdragon 8 Gen 2 / X Elite
         "75",  # Snapdragon 8 Gen 3
         "79",  # Snapdragon 8 Elite
+        "81",  # Snapdragon 8 Elite Gen 5
     }
 )  # Qualcomm Hexagon HTP architecture versions available for QNN export
 HELP_MSG = """

--- a/ultralytics/utils/export/qnn.py
+++ b/ultralytics/utils/export/qnn.py
@@ -46,10 +46,11 @@ def onnx2qnn(
 ) -> str:
     """Convert an ONNX model to an INT8 Qualcomm QNN context binary using the ONNX Runtime QNN Execution Provider.
 
-    The conversion runs entirely on the host with no Qualcomm account or cloud upload. The model is INT8-quantized with
-    ONNX Runtime's QNN QDQ flow (the Hexagon NPU is an int8 accelerator), then the `onnxruntime-qnn` Execution Provider
-    — which bundles the Qualcomm AI Runtime (QAIRT) libraries — compiles the quantized graph into a QNN context binary
-    embedded in `<stem>_qnn.onnx`. No inference is run.
+    The conversion runs entirely on the host with no Qualcomm account or cloud upload. The model is quantized with ONNX
+    Runtime's QNN QDQ flow to 16-bit activations and 8-bit weights (the recommended accuracy/performance balance for
+    the Hexagon NPU), then the `onnxruntime-qnn` Execution Provider — which bundles the Qualcomm AI Runtime (QAIRT)
+    libraries — compiles the quantized graph into a QNN context binary embedded in `<stem>_qnn.onnx`. No inference is
+    run.
 
     Args:
         onnx_file (str | Path): Path to the source ONNX file (already exported).
@@ -74,7 +75,7 @@ def onnx2qnn(
     """
     check_requirements("onnxruntime-qnn")
     import onnxruntime as ort
-    from onnxruntime.quantization import quantize
+    from onnxruntime.quantization import QuantType, quantize
     from onnxruntime.quantization.execution_providers.qnn import get_qnn_qdq_config
     from onnxruntime.quantization.shape_inference import quant_pre_process
 
@@ -89,9 +90,15 @@ def onnx2qnn(
     pre_file = output_dir / "preprocessed.onnx"
     qdq_file = output_dir / "qdq.onnx"
 
-    LOGGER.info(f"\n{prefix} starting INT8 quantization and export with ONNX Runtime QNN (HTP arch {name})...")
+    LOGGER.info(f"\n{prefix} starting A16W8 quantization and export with ONNX Runtime QNN (HTP arch {name})...")
     quant_pre_process(str(onnx_file), str(pre_file))
-    qdq_config = get_qnn_qdq_config(str(pre_file), onnx_calibration_reader(dataset, transform_fn, batch=batch))
+    # 16-bit activations + 8-bit weights is the ORT-recommended accuracy/perf balance for the HTP backend
+    qdq_config = get_qnn_qdq_config(
+        str(pre_file),
+        onnx_calibration_reader(dataset, transform_fn, batch=batch),
+        activation_type=QuantType.QUInt16,
+        weight_type=QuantType.QUInt8,
+    )
     quantize(str(pre_file), str(qdq_file), qdq_config)
 
     # Register the QNN EP, then compile the quantized graph to a context binary during session init (no inference run).

--- a/ultralytics/utils/export/qnn.py
+++ b/ultralytics/utils/export/qnn.py
@@ -47,8 +47,8 @@ def onnx2qnn(
     """Convert an ONNX model to an INT8 Qualcomm QNN context binary using the ONNX Runtime QNN Execution Provider.
 
     The conversion runs entirely on the host with no Qualcomm account or cloud upload. The model is quantized with ONNX
-    Runtime's QNN QDQ flow to 16-bit activations and 8-bit weights (the recommended accuracy/performance balance for
-    the Hexagon NPU), then the `onnxruntime-qnn` Execution Provider — which bundles the Qualcomm AI Runtime (QAIRT)
+    Runtime's QNN QDQ flow to 16-bit activations and 8-bit weights (the recommended accuracy/performance balance for the
+    Hexagon NPU), then the `onnxruntime-qnn` Execution Provider — which bundles the Qualcomm AI Runtime (QAIRT)
     libraries — compiles the quantized graph into a QNN context binary embedded in `<stem>_qnn.onnx`. No inference is
     run.
 


### PR DESCRIPTION
## QNN export and inference fixes

Three corrections to the Qualcomm QNN export/inference path, verified against the [ONNX Runtime QNN EP docs](https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html) and the [ExecuTorch Qualcomm backend schema](https://docs.pytorch.org/executorch/stable/backends-qualcomm.html):

### 1. Correct the HTP arch → Snapdragon mapping (docs + messages)

The documented mapping was off by one generation: `68` is the Snapdragon 888 (SM8350) and `69` is the 8 Gen 1 / 8+ Gen 1 (SM8450/SM8475) — not 865 and 888 as previously listed. The Snapdragon 865 has no HTP at all (HVX/HTA only, SNPE-era) and cannot be targeted by the QNN HTP backend. Also adds `81` (Snapdragon 8 Elite Gen 5, SM8850) to `QNN_HTP_ARCHS` — already referenced by ONNX Runtime 1.26 — and notes that `73` covers Snapdragon X Elite laptops.

### 2. Fix QNN backend load on monolithic ONNX Runtime builds

`QNNBackend.load_model` called `register_execution_provider_library()` unconditionally, but `qnn_library_paths()` returns `ep_library=None` when QNN is built into ONNX Runtime (no plugin registration needed), crashing at load. The backend now mirrors the handling already proven in `onnx2qnn`: plugin builds register the EP library and select devices; monolithic builds create the session directly via `providers=[...]`.

### 3. Quantize to 16-bit activations + INT8 weights (A16W8)

`get_qnn_qdq_config` was called with defaults (uint8 activations). The ONNX Runtime QNN docs recommend uint16 activations with uint8 weights as the accuracy/performance balance for the HTP backend, which matters for accuracy-sensitive tasks like semantic segmentation. Docs updated to match.

Note: this changes the exported artifact — `_qnn.onnx` files exported previously should be re-exported.

## Testing

- All edited files parse and `ultralytics` imports cleanly; `QNN_HTP_ARCHS` resolves to `{68, 69, 73, 75, 79, 81}`.
- `test_export_qnn` requires `onnxruntime-qnn` (Windows / Linux ARM64) and is unchanged.
- On-device validation on Snapdragon hardware is planned this week and will exercise both the backend fix and the A16W8 accuracy/latency tradeoff.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves Qualcomm QNN support and documentation by updating quantization behavior, expanding Snapdragon target coverage, and making QNN model loading more robust.

### 📊 Key Changes
- 🚀 **Updated QNN quantization details** across code and docs:
  - QNN export now uses **INT8 weights with 16-bit activations** instead of describing the pipeline as fully INT8.
  - Logging and docstrings were updated to reflect this recommended Hexagon NPU accuracy/performance balance.
- 📱 **Expanded Snapdragon architecture support**:
  - Added support for **HTP arch `81`**, mapped to **Snapdragon 8 Elite Gen 5**.
  - Updated architecture mappings for existing targets like `68`, `69`, and `73` to better reflect supported Snapdragon platforms.
- 🔌 **Improved QNN backend loading logic**:
  - The QNN runtime loader now handles both cases where the QNN Execution Provider must be manually registered and where it is already built into ONNX Runtime.
  - This makes QNN inference setup more flexible across different environments.
- 📝 **Refreshed QNN documentation**:
  - Export examples, argument tables, and precision notes were updated to match the new quantization behavior and supported hardware list.
- 🧹 **Minor custom trainer docs cleanup**:
  - Removed an unnecessary import from the custom trainer inference example to simplify the workflow.

### 🎯 Purpose & Impact
- ✅ **More accurate QNN guidance** helps users better understand what is actually produced during export, reducing confusion around deployment.
- ⚡ **Better quantization defaults** should provide a stronger balance of speed, model size, and accuracy on Qualcomm Hexagon NPUs.
- 🌍 **Wider device support** enables deployment on newer Snapdragon hardware, including **Snapdragon 8 Elite Gen 5**.
- 🧩 **More reliable backend initialization** reduces the chance of QNN runtime issues caused by differences in ONNX Runtime packaging.
- 📚 **Clearer docs and examples** make QNN export and inference easier for both new users and experienced developers.