### PR TITLE
Specify calibration data shape for FP16 quantization

### DIFF
--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -155,9 +155,15 @@ def modelopt_quantize_onnx(
 
     out_file = str(Path(onnx_file).with_suffix(".fp16.onnx"))
     LOGGER.info(f"{prefix} converting ONNX to FP16 mixed precision with ModelOpt AutoCast...")
-    calib = {input_name: torch.randn(*shape).cpu().numpy()}
-    kwargs = dict(low_precision_type="fp16", keep_io_types=True, calibration_data=calib)
-    onnx.save(autocast.convert_to_mixed_precision(onnx_file, **kwargs), out_file)
+    onnx.save(
+        autocast.convert_to_mixed_precision(
+            onnx_file,
+            low_precision_type="fp16",
+            keep_io_types=True,
+            calibration_data={input_name: torch.randn(*shape).cpu().numpy()},
+        ),
+        out_file,
+    )
     return out_file
 
 

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -156,7 +156,7 @@ def modelopt_quantize_onnx(
     out_file = str(Path(onnx_file).with_suffix(".fp16.onnx"))
     LOGGER.info(f"{prefix} converting ONNX to FP16 mixed precision with ModelOpt AutoCast...")
     calib = {input_name: torch.randn(*shape).cpu().numpy()}
-    kwargs = {low_precision_type: "fp16", keep_io_types: True, calibration_data: calib}
+    kwargs = dict(low_precision_type="fp16", keep_io_types=True, calibration_data=calib)
     onnx.save(autocast.convert_to_mixed_precision(onnx_file, **kwargs), out_file)
     return out_file
 

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -125,10 +125,10 @@ def modelopt_quantize_onnx(
     check_requirements("nvidia-modelopt[onnx]>=0.44")
     import onnx
 
+    input_name = onnx.load(onnx_file, load_external_data=False).graph.input[0].name    
     if int8:
         from modelopt.onnx.quantization import quantize
 
-        input_name = onnx.load(onnx_file, load_external_data=False).graph.input[0].name
         out_file = str(Path(onnx_file).with_suffix(".int8.onnx"))
         # Collect up to ~500 calibration images (TensorRT recommendation); ModelOpt holds them in memory at once,
         # so cap the count to bound memory instead of materializing the entire (possibly thousands-image) dataset.
@@ -155,7 +155,7 @@ def modelopt_quantize_onnx(
 
     out_file = str(Path(onnx_file).with_suffix(".fp16.onnx"))
     LOGGER.info(f"{prefix} converting ONNX to FP16 mixed precision with ModelOpt AutoCast...")
-    onnx.save(autocast.convert_to_mixed_precision(onnx_file, low_precision_type="fp16", keep_io_types=True), out_file)
+    onnx.save(autocast.convert_to_mixed_precision(onnx_file, low_precision_type="fp16", keep_io_types=True, calibration_data={input_name: torch.randn(*shape).cpu().numpy()}), out_file)
     return out_file
 
 

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -125,7 +125,7 @@ def modelopt_quantize_onnx(
     check_requirements("nvidia-modelopt[onnx]>=0.44")
     import onnx
 
-    input_name = onnx.load(onnx_file, load_external_data=False).graph.input[0].name    
+    input_name = onnx.load(onnx_file, load_external_data=False).graph.input[0].name
     if int8:
         from modelopt.onnx.quantization import quantize
 
@@ -155,7 +155,15 @@ def modelopt_quantize_onnx(
 
     out_file = str(Path(onnx_file).with_suffix(".fp16.onnx"))
     LOGGER.info(f"{prefix} converting ONNX to FP16 mixed precision with ModelOpt AutoCast...")
-    onnx.save(autocast.convert_to_mixed_precision(onnx_file, low_precision_type="fp16", keep_io_types=True, calibration_data={input_name: torch.randn(*shape).cpu().numpy()}), out_file)
+    onnx.save(
+        autocast.convert_to_mixed_precision(
+            onnx_file,
+            low_precision_type="fp16",
+            keep_io_types=True,
+            calibration_data={input_name: torch.randn(*shape).cpu().numpy()},
+        ),
+        out_file,
+    )
     return out_file
 
 

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -155,15 +155,9 @@ def modelopt_quantize_onnx(
 
     out_file = str(Path(onnx_file).with_suffix(".fp16.onnx"))
     LOGGER.info(f"{prefix} converting ONNX to FP16 mixed precision with ModelOpt AutoCast...")
-    onnx.save(
-        autocast.convert_to_mixed_precision(
-            onnx_file,
-            low_precision_type="fp16",
-            keep_io_types=True,
-            calibration_data={input_name: torch.randn(*shape).cpu().numpy()},
-        ),
-        out_file,
-    )
+    calib = {input_name: torch.randn(*shape).cpu().numpy()}
+    kwargs = {low_precision_type: "fp16", keep_io_types: True, calibration_data: calib}
+    onnx.save(autocast.convert_to_mixed_precision(onnx_file, **kwargs), out_file)
     return out_file
 
 


### PR DESCRIPTION
Closes #24771 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚙️ This PR improves ONNX export quantization in TensorRT/ModelOpt workflows by making FP16 mixed-precision conversion more robust and aligned with model input requirements.

### 📊 Key Changes
- Added early extraction of the ONNX model’s primary input name using `onnx.load(...).graph.input[0].name`.
- Reused that input name for both INT8 and FP16 quantization paths instead of only the INT8 branch.
- Updated FP16 mixed-precision export to pass calibration data into `autocast.convert_to_mixed_precision(...)`.
- The FP16 conversion now provides a sample input tensor shaped to the model input, using the correct ONNX input name.

### 🎯 Purpose & Impact
- ✅ Improves reliability of FP16 ONNX conversion by giving ModelOpt the input context it may need during mixed-precision casting.
- 🧠 Ensures the export pipeline uses the correct input name consistently across quantization modes.
- 🚀 Helps reduce potential export failures or misconfigurations when converting models for deployment.
- 🔧 Benefits users working with TensorRT and ONNX optimization by making the export process more stable with fewer manual fixes.