### PR TITLE
Update conda CUDA install pin to pytorch-cuda=12.1

### DIFF
--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -57,7 +57,7 @@ Ultralytics offers a variety of installation methods, including pip, conda, and 
             If you are installing in a CUDA environment, it is best practice to install `ultralytics`, `pytorch`, and `pytorch-cuda` in the same command. This allows the conda package manager to resolve any conflicts. Alternatively, install `pytorch-cuda` last to override the CPU-specific `pytorch` package if necessary.
             ```bash
             # Install all packages together using conda
-            conda install -c pytorch -c nvidia -c conda-forge pytorch torchvision pytorch-cuda=11.8 ultralytics
+            conda install -c pytorch -c nvidia -c conda-forge pytorch torchvision pytorch-cuda=12.1 ultralytics
             ```
 
         ### Conda Docker Image
@@ -487,7 +487,7 @@ conda install -c conda-forge ultralytics
 This method is a great alternative to pip, ensuring compatibility with other packages. For CUDA environments, install `ultralytics`, `pytorch`, and `pytorch-cuda` together to resolve conflicts:
 
 ```bash
-conda install -c pytorch -c nvidia -c conda-forge pytorch torchvision pytorch-cuda=11.8 ultralytics
+conda install -c pytorch -c nvidia -c conda-forge pytorch torchvision pytorch-cuda=12.1 ultralytics
 ```
 
 For more instructions, see the [Conda quickstart guide](guides/conda-quickstart.md).


### PR DESCRIPTION
## summary

bumps the conda CUDA install command in `quickstart.md` from `pytorch-cuda=11.8` to `12.1` in both occurrences, matching the version shipped by the maintained conda Docker image (`docker/Dockerfile-conda`). keeps the install docs consistent with what the project actually builds and tests against.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the Ultralytics quickstart docs to recommend `pytorch-cuda=12.1` instead of `11.8` in Conda installation commands.

### 📊 Key Changes
- Updated the Conda install example in `docs/en/quickstart.md` from `pytorch-cuda=11.8` to `pytorch-cuda=12.1`.
- Applied this change in two places:
  - The main CUDA Conda installation example
  - The later Conda installation reference section
- No code, model, or runtime behavior was changed — this is a documentation-only update 📘

### 🎯 Purpose & Impact
- Helps users install Ultralytics with a more current CUDA toolkit version ⚡
- Keeps the setup instructions aligned with newer PyTorch/CUDA environments
- Reduces confusion for users on modern NVIDIA systems by showing a more up-to-date install command
- Improves the onboarding experience, especially for new users following the quickstart guide 🚀