### PR TITLE
Trigger docs redeploys on changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_docs:
-        description: "Publish live to https://docs.ultralytics.com"
+        description: "Redeploy https://docs.ultralytics.com"
         default: true
         type: boolean
 
@@ -101,33 +101,14 @@ jobs:
           else
             echo "No changes to commit"
           fi
-      - name: Publish Docs to https://docs.ultralytics.com
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_docs == 'true')
-        run: |
-          # Blobless no-checkout clone skips downloading the old site entirely; restore only the config files the site build does not produce
-          git clone --depth 1 --branch gh-pages --filter=blob:none --no-checkout https://github.com/ultralytics/docs.git docs-repo
-          cd docs-repo
-          git ls-tree --name-only HEAD vercel.json .nojekyll | xargs -r git checkout HEAD --
-          cp -R ../site/* .
-          echo "${{ secrets.INDEXNOW_KEY_DOCS }}" > "${{ secrets.INDEXNOW_KEY_DOCS }}.txt"
-          git add .
-          # diff.renames=false avoids rename detection lazy-fetching old-site blobs from the partial clone
-          if git -c diff.renames=false diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git pull origin gh-pages
-            LATEST_HASH=$(git rev-parse --short=7 HEAD)
-            VERSION=$(python -c "from ultralytics import __version__; print(__version__)")
-            git commit -m "Update Docs for 'ultralytics $VERSION - $LATEST_HASH'"
-            git push https://${{ secrets._GITHUB_TOKEN }}@github.com/ultralytics/docs.git gh-pages
-          fi
       - name: Trigger Portal docs redeploy
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_docs == 'true')
         env:
+          EVENT_NAME: ${{ github.event_name }}
           VERCEL_DOCS_DEPLOY_HOOK: ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK }}
           CHANGED_FILES: ${{ toJson(github.event.commits.*.added) }} ${{ toJson(github.event.commits.*.modified) }} ${{ toJson(github.event.commits.*.removed) }}
         run: |
-          if ! grep -Eq 'docs/|mkdocs\.ya?ml' <<< "$CHANGED_FILES"; then
+          if [[ "$EVENT_NAME" == "push" ]] && ! grep -Eq 'docs/|mkdocs\.ya?ml' <<< "$CHANGED_FILES"; then
             echo "No docs source changes."
             exit 0
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,13 +129,18 @@ jobs:
           CURRENT_SHA: ${{ github.sha }}
         run: |
           if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
-            BEFORE_SHA="$(git rev-list --max-parents=0 "$CURRENT_SHA")"
+            changed_files="$(git diff-tree --no-commit-id --name-only -r "$CURRENT_SHA")"
+          else
+            if ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
+              git fetch --no-tags --depth=1 origin "$BEFORE_SHA"
+            fi
+            changed_files="$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")"
           fi
 
-          if git diff --quiet "$BEFORE_SHA" "$CURRENT_SHA" -- docs mkdocs.yml mkdocs.yaml; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
+          if grep -Eq '^(docs/|mkdocs\.ya?ml$)' <<< "$changed_files"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Trigger Portal docs redeploy
         if: github.event_name == 'push' && steps.docs_changes.outputs.changed == 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_docs:
-        description: "Redeploy https://docs.ultralytics.com"
+        description: "Publish Docs to https://docs.ultralytics.com"
         default: true
         type: boolean
 
@@ -101,7 +101,7 @@ jobs:
           else
             echo "No changes to commit"
           fi
-      - name: Trigger Portal docs redeploy
+      - name: Publish Docs to https://docs.ultralytics.com
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_docs == 'true')
         env:
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -121,35 +121,15 @@ jobs:
             git commit -m "Update Docs for 'ultralytics $VERSION - $LATEST_HASH'"
             git push https://${{ secrets._GITHUB_TOKEN }}@github.com/ultralytics/docs.git gh-pages
           fi
-      - name: Check docs source changes
-        id: docs_changes
+      - name: Trigger Portal docs redeploy
         if: github.event_name == 'push'
         env:
-          BEFORE_SHA: ${{ github.event.before }}
-          CURRENT_SHA: ${{ github.sha }}
-        run: |
-          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
-            changed_files="$(git diff-tree --no-commit-id --name-only -r "$CURRENT_SHA")"
-          else
-            if ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
-              git fetch --no-tags --depth=1 origin "$BEFORE_SHA"
-            fi
-            changed_files="$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")"
-          fi
-
-          if grep -Eq '^(docs/|mkdocs\.ya?ml$)' <<< "$changed_files"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Trigger Portal docs redeploy
-        if: github.event_name == 'push' && steps.docs_changes.outputs.changed == 'true'
-        env:
           VERCEL_DOCS_DEPLOY_HOOK: ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK }}
+          CHANGED_FILES: ${{ toJson(github.event.commits.*.added) }} ${{ toJson(github.event.commits.*.modified) }} ${{ toJson(github.event.commits.*.removed) }}
         run: |
-          if [[ -z "$VERCEL_DOCS_DEPLOY_HOOK" ]]; then
-            echo "::error::VERCEL_DOCS_DEPLOY_HOOK is not configured"
-            exit 1
+          if ! grep -Eq 'docs/|mkdocs\.ya?ml' <<< "$CHANGED_FILES"; then
+            echo "No docs source changes."
+            exit 0
           fi
 
           curl --fail --silent --show-error --retry 3 --request POST "$VERCEL_DOCS_DEPLOY_HOOK"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Dependencies
         run: |
           uv venv
-          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
           uv pip install -e ".[dev]" ruff --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Ruff fixes
         continue-on-error: true
@@ -121,3 +121,30 @@ jobs:
             git commit -m "Update Docs for 'ultralytics $VERSION - $LATEST_HASH'"
             git push https://${{ secrets._GITHUB_TOKEN }}@github.com/ultralytics/docs.git gh-pages
           fi
+      - name: Check docs source changes
+        id: docs_changes
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            BEFORE_SHA="$(git rev-list --max-parents=0 "$CURRENT_SHA")"
+          fi
+
+          if git diff --quiet "$BEFORE_SHA" "$CURRENT_SHA" -- docs mkdocs.yml mkdocs.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Trigger Portal docs redeploy
+        if: github.event_name == 'push' && steps.docs_changes.outputs.changed == 'true'
+        env:
+          VERCEL_DOCS_DEPLOY_HOOK: ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK }}
+        run: |
+          if [[ -z "$VERCEL_DOCS_DEPLOY_HOOK" ]]; then
+            echo "::error::VERCEL_DOCS_DEPLOY_HOOK is not configured"
+            exit 1
+          fi
+
+          curl --fail --silent --show-error --retry 3 --request POST "$VERCEL_DOCS_DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- detect merged docs source changes in the existing docs workflow
- POST the Portal docs Vercel deploy hook after docs/mkdocs changes land on main
- keep PR events as build/check only; production redeploy happens on the merged main push

## Required secret
- `VERCEL_DOCS_DEPLOY_HOOK`: Vercel deploy hook URL for the Portal `docs` project

## Validation
- `actionlint .github/workflows/docs.yml`
- `git diff --check -- .github/workflows/docs.yml`