### PR TITLE
Replace Enterprise '50+ members' with custom team size in Platform docs

### DIFF
--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -27,7 +27,7 @@ Choose the plan that fits your needs. Compare plans in `Settings > Plans`:
 | **Deployments**                                            | 3          | 10              | Unlimited   |
 | **Cloud GPU Types**                                        | 22         | 24              | 24          |
 | **Best GPUs (B200, B300)**                                 | -          | Yes             | Yes         |
-| **Teams**                                                  | -          | Up to 5 members | 50+ members |
+| **Teams**                                                  | -          | Up to 5 members | Custom size |
 | **SSO / SAML**                                             | -          | -               | Yes         |
 | **Enterprise License**                                     | -          | -               | Yes         |
 | **License**                                                | AGPL-3.0   | AGPL-3.0        | Enterprise  |

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -227,7 +227,7 @@ The `Plans` tab lets you compare available plans and upgrade or downgrade your s
 | -------------- | --------- | --------- | ----------- | -------------------- | ---------- |
 | **Free**       | 100 GB    | 100       | 3           | 3                    | —          |
 | **Pro**        | 500 GB    | 500       | 10          | 10                   | Up to 5    |
-| **Enterprise** | Unlimited | Unlimited | Unlimited   | Unlimited            | 50+        |
+| **Enterprise** | Unlimited | Unlimited | Unlimited   | Unlimited            | Custom     |
 
 From this tab you can:
 

--- a/docs/en/platform/account/teams.md
+++ b/docs/en/platform/account/teams.md
@@ -17,7 +17,7 @@ Teams allow multiple users to work together under a shared workspace:
 - **Shared Resources**: Datasets, projects, models, and deployments are accessible to all team members
 - **Role-Based Access**: Four roles (Owner, Admin, Editor, Viewer) control what each member can do
 - **Shared Billing**: Team members share the workspace credit balance and resource limits
-- **Seat Management**: Pro teams support up to 5 members, Enterprise teams support 50+ members
+- **Seat Management**: Pro teams support up to 5 members, Enterprise teams support custom team sizes
 
 !!! note "Plan Requirement"
 


### PR DESCRIPTION
## Summary

Customer support flagged that the Enterprise plan intro advertises "Teams of 50+ members", which conflicts with contracts where seat counts are negotiated per client. The wording is changed to **"Custom team size"**

- Companion docs PR in `portal`: branch `fix/enterprise-custom-team-size` 
- https://github.com/ultralytics/portal/pull/2418

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates Ultralytics Platform documentation to clarify that Enterprise team sizes are **custom** rather than capped at **50+ members**.

### 📊 Key Changes
- Updated the **billing** docs to change Enterprise **Teams** from `50+ members` to `Custom size`.
- Updated the **account settings** docs to change the Enterprise team limit from `50+` to `Custom`.
- Updated the **teams** docs to clarify that:
  - **Pro** supports up to 5 members
  - **Enterprise** supports **custom team sizes**
- These changes are documentation-only and improve consistency across multiple Platform pages 📚

### 🎯 Purpose & Impact
- Makes Enterprise plan messaging more accurate and flexible for larger organizations 🏢
- Reduces confusion for users comparing plans or evaluating the Ultralytics Platform for team use ✅
- Better reflects that Enterprise capacity is tailored to customer needs rather than tied to a fixed published threshold
- Helps sales, onboarding, and procurement conversations go more smoothly for businesses considering Enterprise 🚀