### PR TITLE
Fix docs deploy change detection

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -106,11 +106,19 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           VERCEL_DOCS_DEPLOY_HOOK: ${{ secrets.VERCEL_DOCS_DEPLOY_HOOK }}
-          CHANGED_FILES: ${{ toJson(github.event.commits.*.added) }} ${{ toJson(github.event.commits.*.modified) }} ${{ toJson(github.event.commits.*.removed) }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
-          if [[ "$EVENT_NAME" == "push" ]] && ! grep -Eq 'docs/|mkdocs\.ya?ml' <<< "$CHANGED_FILES"; then
-            echo "No docs source changes."
-            exit 0
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            if [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+              BEFORE_SHA=$(git rev-list --max-parents=0 "$CURRENT_SHA")
+            fi
+            changed_files=$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- docs/ mkdocs.yml mkdocs.yaml)
+            if [[ -z "$changed_files" ]]; then
+              echo "No docs source changes."
+              exit 0
+            fi
+            echo "$changed_files"
           fi
 
           curl --fail --silent --show-error --retry 3 --request POST "$VERCEL_DOCS_DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- detect docs changes from the checked-out git push range instead of the push payload file arrays
- print matched docs files before calling the Vercel docs deploy hook
- keep workflow dispatch publishing unchanged

## Root cause
- The #24785 main push changed `docs/en/platform/account/billing.md`, `settings.md`, and `teams.md`, but the publish step saw `CHANGED_FILES: [] [] []` from the event payload and skipped the deploy hook.

## Validation
- `actionlint .github/workflows/docs.yml`
- `git diff --check -- .github/workflows/docs.yml`
- `git diff --name-only a137800af447b47641c1ee97d5470da23f9d5019 4b16b5d877f7f79cd4b30f987f7b6515e7a6d2cb -- docs/ mkdocs.yml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes docs deployment detection more reliable by checking actual Git changes between commits before triggering a Vercel docs rebuild.

### 📊 Key Changes
- Replaced the previous `CHANGED_FILES` environment variable approach, which relied on GitHub event commit lists, with direct Git commit range comparison using:
  - `github.event.before`
  - `github.sha`
- Added logic to handle special push cases where the previous SHA is all zeros, such as the first push to a branch:
  - Falls back to the repository’s root commit in that case.
- Updated the workflow to detect changes only in documentation-related files:
  - `docs/`
  - `mkdocs.yml`
  - `mkdocs.yaml`
- If no docs-related files changed, the workflow now exits early and skips the Vercel docs deploy hook.
- If relevant files did change, it prints the changed file list and proceeds with deployment.

### 🎯 Purpose & Impact
- ✅ Improves accuracy of docs deployment triggers by using Git history directly instead of potentially incomplete event payload file lists.
- 🚀 Prevents unnecessary documentation rebuilds, which can save CI time and reduce needless Vercel deploys.
- 🔍 Better handles edge cases like initial branch pushes, making the workflow more robust.
- 💸 Can reduce infrastructure usage and noise for maintainers by only deploying docs when actual docs sources change.
- 👥 Benefits both contributors and maintainers with more predictable and dependable docs automation.