### PR TITLE
Remove unused half argument and optimize INT8 calibration in TensorRT 11 export

### DIFF
--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -92,7 +92,6 @@ def torch2onnx(
 
 def modelopt_quantize_onnx(
     onnx_file: str,
-    half: bool = False,
     int8: bool = False,
     dataset=None,
     shape: tuple[int, int, int, int] = (1, 3, 640, 640),
@@ -107,7 +106,6 @@ def modelopt_quantize_onnx(
 
     Args:
         onnx_file (str): Path to the FP32 ONNX file to convert.
-        half (bool): Convert the ONNX model to FP16 mixed precision. Ignored when ``int8=True``.
         int8 (bool): Quantize the ONNX model to INT8 with Q/DQ nodes.
         dataset (ultralytics.data.build.InfiniteDataLoader | None): Dataloader providing INT8 calibration images.
             Required when ``int8=True``.
@@ -275,7 +273,7 @@ def onnx2engine(
     # TensorRT 11 is strongly-typed and removed the FP16/INT8 builder flags and INT8 calibrator, so reduced
     # precision must be baked into the ONNX graph with NVIDIA ModelOpt before parsing (FP16 AutoCast, INT8 Q/DQ)
     if is_trt11 and (half or int8):
-        onnx_file = modelopt_quantize_onnx(onnx_file, half, int8, dataset, shape, dynamic, prefix)
+        onnx_file = modelopt_quantize_onnx(onnx_file, int8, dataset, shape, dynamic, prefix)
 
     # Read ONNX file
     parser = trt.OnnxParser(network, logger)

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -234,12 +234,10 @@ def onnx2engine(
     config = builder.create_builder_config()
     workspace_bytes = int((workspace or 0) * (1 << 30))
     trt_major = int(trt.__version__.split(".", 1)[0])
-    is_trt10 = (
-        trt_major >= 10
-    )  # TensorRT >= 10 builds via build_serialized_network and uses the tensor (non-binding) API
-    is_trt11 = (
-        trt_major >= 11
-    )  # TensorRT >= 11 is strongly-typed only: precision builder flags and IInt8Calibrator removed
+    # TensorRT >= 10 builds via build_serialized_network and uses the tensor (non-binding) API
+    is_trt10 = trt_major >= 10
+    # TensorRT >= 11 is strongly-typed only: precision builder flags and IInt8Calibrator removed
+    is_trt11 = trt_major >= 11
     if is_trt10 and workspace_bytes > 0:
         config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     elif workspace_bytes > 0:  # TensorRT versions 7, 8

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -132,17 +132,17 @@ def modelopt_quantize_onnx(
         # so cap the count to bound memory instead of materializing the entire (possibly thousands-image) dataset.
         images, n = [], 0
         for batch in dataset:
-            images.append(batch["img"].to(torch.float32) / 255.0)
+            images.append(batch["img"])
             n += images[-1].shape[0]
             if n >= 512:
                 break
-        calib = torch.cat(images).cpu().numpy()
+        calib = torch.cat(images).to(torch.float32) / 255.0
         LOGGER.info(f"{prefix} quantizing ONNX to INT8 with ModelOpt using {calib.shape[0]} calibration images...")
         kwargs = {"calibration_shapes": f"{input_name}:{'x'.join(str(d) for d in shape)}"} if dynamic else {}
         quantize(
             onnx_file,
             quantize_mode="int8",
-            calibration_data={input_name: calib},
+            calibration_data={input_name: calib.cpu().numpy()},
             calibration_method="max",
             output_path=out_file,
             **kwargs,

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -106,7 +106,7 @@ def modelopt_quantize_onnx(
 
     Args:
         onnx_file (str): Path to the FP32 ONNX file to convert.
-        int8 (bool): Quantize the ONNX model to INT8 with Q/DQ nodes.
+        int8 (bool): Quantize the ONNX model to INT8 with Q/DQ nodes. If False, outputs an FP16 precision ONNX file.
         dataset (ultralytics.data.build.InfiniteDataLoader | None): Dataloader providing INT8 calibration images.
             Required when ``int8=True``.
         shape (tuple[int, int, int, int]): Input shape (batch, channels, height, width) used for dynamic calibration.


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR simplifies ONNX precision conversion for TensorRT 11 by making ModelOpt handle either INT8 quantization or FP16 export automatically, while also cleaning up calibration preprocessing and version checks.

### 📊 Key Changes
- Removed the separate `half` argument from `modelopt_quantize_onnx()`, simplifying the API.
- Updated the function behavior so:
  - `int8=True` produces an INT8-quantized ONNX model
  - `int8=False` now produces an FP16 ONNX model by default
- Streamlined INT8 calibration data handling:
  - images are collected first in their original form
  - conversion to `float32` and normalization now happens in one step after concatenation
  - calibration data is then passed to ModelOpt as NumPy data
- Cleaned up TensorRT version detection logic for `is_trt10` and `is_trt11` to make the code easier to read and maintain.
- Updated the TensorRT 11 export path to call the simplified ModelOpt function without the removed `half` parameter.

### 🎯 Purpose & Impact
- ✅ Reduces complexity in the export pipeline by removing an unnecessary parameter and making precision behavior more predictable.
- 🚀 Improves compatibility with TensorRT 11, where reduced precision must be embedded directly into the ONNX model before engine building.
- 🧹 Makes calibration preprocessing cleaner and easier to follow, which helps maintainability.
- 👥 Benefits users exporting YOLO models to TensorRT by making FP16 and INT8 workflows more consistent and less error-prone.
- 🔒 Lowers the chance of misuse or confusion around `half` vs. `int8` settings during ONNX-to-engine conversion.