### PR TITLE
Improve model testing guide structure and fix validation metric claims

### DIFF
--- a/docs/en/guides/index.md
+++ b/docs/en/guides/index.md
@@ -25,7 +25,6 @@ Whether you're a beginner or an expert in [deep learning](https://www.ultralytic
 
 Here's a compilation of in-depth guides to help you master different aspects of Ultralytics YOLO.
 
-- [A Guide on Model Testing](model-testing.md): A thorough guide on testing your computer vision models in realistic settings. Learn how to verify accuracy, reliability, and performance in line with project goals.
 - [AzureML Quickstart](azureml-quickstart.md): Get up and running with Ultralytics YOLO models on Microsoft's Azure [Machine Learning](https://www.ultralytics.com/glossary/machine-learning-ml) platform. Learn how to train, deploy, and scale your object detection projects in the cloud.
 - [Best Practices for Model Deployment](model-deployment-practices.md): Walk through tips and best practices for efficiently deploying models in computer vision projects, with a focus on optimization, troubleshooting, and security.
 - [COCO to YOLO Conversion](coco-to-yolo.md): Complete guide to converting COCO JSON annotations to YOLO format for training. Covers detection, segmentation, and keypoints, including class ID mapping and common conversion pitfalls.
@@ -46,6 +45,7 @@ Here's a compilation of in-depth guides to help you master different aspects of 
 - [K-Fold Cross Validation](kfold-cross-validation.md): Learn how to improve model generalization using K-Fold cross-validation technique.
 - [Maintaining Your Computer Vision Model](model-monitoring-and-maintenance.md): Understand the key practices for monitoring, maintaining, and documenting computer vision models to guarantee accuracy, spot anomalies, and mitigate data drift.
 - [Model Deployment Options](model-deployment-options.md): Overview of YOLO [model deployment](https://www.ultralytics.com/glossary/model-deployment) formats like ONNX, OpenVINO, and TensorRT, with pros and cons for each to inform your deployment strategy.
+- [Model Testing](model-testing.md): Learn how to test computer vision models on unseen data, validate YOLO26 models, and catch overfitting, underfitting, and data leakage before deployment.
 - [Model YAML Configuration Guide](model-yaml-config.md): A comprehensive deep dive into Ultralytics' model architecture definitions. Explore the YAML format, understand the module resolution system, and learn how to integrate custom modules seamlessly.
 - [NVIDIA DALI GPU Preprocessing](nvidia-dali.md): Eliminate CPU preprocessing bottlenecks by running YOLO letterbox resize, padding, and normalization on the GPU using NVIDIA DALI, with Triton Inference Server integration.
 - [NVIDIA DGX Spark](nvidia-dgx-spark.md): Quickstart guide for deploying YOLO models on NVIDIA DGX Spark devices.

--- a/docs/en/guides/model-testing.md
+++ b/docs/en/guides/model-testing.md
@@ -1,14 +1,14 @@
 ---
 comments: true
-description: Explore effective methods for testing computer vision models to make sure they are reliable, perform well, and are ready to be deployed.
-keywords: Overfitting and Underfitting in Machine Learning, Model Testing, Data Leakage Machine Learning, Testing a Model, Testing Machine Learning Models, How to Test AI Models
+description: Learn how to test computer vision models on unseen data, run YOLO26 validation and prediction on your test set, and catch overfitting and data leakage.
+keywords: model testing, test computer vision model, model testing vs model evaluation, overfitting, underfitting, data leakage, validation mode, prediction mode, YOLO26, Ultralytics
 ---
 
-# A Guide on Model Testing
+# How to Test Computer Vision Models
 
 ## Introduction
 
-After [training](./model-training-tips.md) and [evaluating](./model-evaluation-insights.md) your model, it's time to test it. Model testing involves assessing how well it performs in real-world scenarios. Testing considers factors like accuracy, reliability, fairness, and how easy it is to understand the model's decisions. The goal is to make sure the model performs as intended, delivers the expected results, and fits into the [overall objective of your application](./defining-project-goals.md) or project.
+Model testing checks how a [trained model](./model-training-tips.md) performs on previously unseen, real-world data — moving, poorly lit, or partially hidden objects rather than a curated benchmark. While [model evaluation](./model-evaluation-insights.md) measures metrics on a labeled dataset, testing verifies that the model's learned behavior matches the [goals of your application](./defining-project-goals.md) before deployment. This guide covers preparing test data, testing Ultralytics YOLO26 models, and catching [overfitting](https://www.ultralytics.com/glossary/overfitting), underfitting, and data leakage.
 
 <p align="center">
   <br>
@@ -21,191 +21,162 @@ After [training](./model-training-tips.md) and [evaluating](./model-evaluation-i
   <strong>Watch:</strong> How to Test Machine Learning Models | Avoid Data Leakage in Computer Vision 🚀
 </p>
 
-Model testing is quite similar to model evaluation, but they are two distinct [steps in a computer vision project](./steps-of-a-cv-project.md). Model evaluation involves metrics and plots to assess the model's accuracy. On the other hand, model testing checks if the model's learned behavior is the same as expectations. In this guide, we'll explore strategies for testing your [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models.
+## Model Testing vs. Model Evaluation
 
-## Model Testing Vs. Model Evaluation
+Model testing and model evaluation are two distinct [steps in a computer vision project](./steps-of-a-cv-project.md). Evaluation measures performance with metrics on a labeled dataset; testing checks whether the model's learned behavior holds up in conditions that resemble deployment.
 
-First, let's understand the difference between model evaluation and testing with an example.
-
-Suppose you have trained a computer vision model to recognize cats and dogs, and you want to deploy this model at a pet store to monitor the animals. During the model evaluation phase, you use a labeled dataset to calculate metrics like accuracy, [precision](https://www.ultralytics.com/glossary/precision), [recall](https://www.ultralytics.com/glossary/recall), and F1 score. For instance, the model might have an accuracy of 98% in distinguishing between cats and dogs in a given dataset.
+Suppose you have trained a [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) model to recognize cats and dogs, and you want to deploy this model at a pet store to monitor the animals. During the model evaluation phase, you use a labeled dataset to calculate metrics like [accuracy](https://www.ultralytics.com/glossary/accuracy), [precision](https://www.ultralytics.com/glossary/precision), and [recall](https://www.ultralytics.com/glossary/recall). For instance, the model might be 98% accurate in distinguishing between cats and dogs in a given dataset.
 
 After evaluation, you test the model using images from a pet store to see how well it identifies cats and dogs in more varied and realistic conditions. You check if it can correctly label cats and dogs when they are moving, in different lighting conditions, or partially obscured by objects like toys or furniture. Model testing checks that the model behaves as expected outside the controlled evaluation environment.
 
 ## Preparing for Model Testing
 
-Computer vision models learn from datasets by detecting patterns, making predictions, and evaluating their performance. These [datasets](./preprocessing_annotated_data.md) are usually divided into training and testing sets to simulate real-world conditions. [Training data](https://www.ultralytics.com/glossary/training-data) teaches the model while testing data verifies its accuracy.
+Computer vision [datasets](./preprocessing_annotated_data.md) are usually divided into training and testing sets to simulate real-world conditions: [training data](https://www.ultralytics.com/glossary/training-data) teaches the model, while testing data verifies its behavior on examples it has never seen. The [Ultralytics Platform](https://platform.ultralytics.com) keeps dataset organization and annotation in one place, which helps when building a labeled test set.
 
-Here are two points to keep in mind before testing your model:
+!!! tip "Before you test"
 
-- **Realistic Representation:** The previously unseen testing data should be similar to the data that the model will have to handle when deployed. This helps get a realistic understanding of the model's capabilities.
-- **Sufficient Size:** The size of the testing dataset needs to be large enough to provide reliable insights into how well the model performs.
+    - **Realistic representation:** The previously unseen testing data should be similar to the data the model will handle when deployed. This gives a realistic picture of the model's capabilities.
+    - **Sufficient size:** The testing dataset needs to be large enough to provide reliable insights into how well the model performs.
 
-## Testing Your Computer Vision Model
+## How to Test a YOLO26 Model
 
-Here are the key steps to take to test your computer vision model and understand its performance.
+Testing a trained YOLO26 model involves two complementary workflows: validating on a labeled test split to get quantitative metrics, and predicting on new images to inspect behavior qualitatively.
 
-- **Run Predictions:** Use the model to make predictions on the test dataset.
-- **Compare Predictions:** Check how well the model's predictions match the actual labels (ground truth).
-- **Calculate Performance Metrics:** [Compute metrics](./yolo-performance-metrics.md) like accuracy, precision, recall, and F1 score to understand the model's strengths and weaknesses. Testing focuses on how these metrics reflect real-world performance.
-- **Visualize Results:** Create visual aids like confusion matrices and ROC curves. These help you spot specific areas where the model might not be performing well in practical applications.
+### Validate on a Labeled Test Split
 
-Next, the testing results can be analyzed:
+[Validation mode](../modes/val.md) compares the model's predictions against ground-truth labels and reports precision, recall, mAP50, and mAP50-95 for detection models. It also saves visual aids like a confusion matrix and a precision-recall curve, which help you spot specific areas where the model might not be performing well.
 
-- **Misclassified Images:** Identify and review images that the model misclassified to understand where it is going wrong.
-- **Error Analysis:** Perform a thorough error analysis to understand the types of errors (e.g., false positives vs. false negatives) and their potential causes.
-- **Bias and Fairness:** Check for any biases in the model's predictions. Ensure that the model performs equally well across different subsets of the data, especially if it includes sensitive attributes like race, gender, or age.
+!!! example "Usage"
 
-## Testing Your YOLO26 Model
+    === "Python"
 
-To test your YOLO26 model, you can use the validation mode. It's a straightforward way to understand the model's strengths and areas that need improvement. Also, you'll need to format your test dataset correctly for YOLO26. For more details on how to use the validation mode, check out the [Model Validation](../modes/val.md) docs page.
+        ```python
+        from ultralytics import YOLO
 
-## Using YOLO26 to Predict on Multiple Test Images
+        # Load a pretrained model or your own trained checkpoint, e.g. "path/to/best.pt"
+        model = YOLO("yolo26n.pt")
 
-If you want to test your trained YOLO26 model on multiple images stored in a folder, you can easily do so in one go. Instead of using the validation mode, which is typically used to evaluate model performance on a validation set and provide detailed metrics, you might just want to see predictions on all images in your test set. For this, you can use the [prediction mode](../modes/predict.md).
+        # Validate; add split="test" if your dataset YAML defines a test split
+        metrics = model.val(data="coco8.yaml")
+        print(metrics.box.map)  # mAP50-95
+        ```
 
-### Difference Between Validation and Prediction Modes
+    === "CLI"
 
-- **[Validation Mode](../modes/val.md):** Used to evaluate the model's performance by comparing predictions against known labels (ground truth). It provides detailed metrics such as accuracy, precision, recall, and F1 score.
-- **[Prediction Mode](../modes/predict.md):** Used to run the model on new, unseen data to generate predictions. It does not provide detailed performance metrics but allows you to see how the model performs on real-world images.
+        ```bash
+        yolo val model=yolo26n.pt data=coco8.yaml
+        ```
 
-## Running YOLO26 Predictions Without Custom Training
+By default, validation runs on the dataset's `val` split. To measure performance on a held-out test set, define a `test:` split in your dataset YAML and pass `split="test"`.
 
-If you are interested in testing the basic YOLO26 model to understand whether it can be used for your application without custom training, you can use the prediction mode. While the model is pretrained on datasets like COCO, running predictions on your own dataset can give you a quick sense of how well it might perform in your specific context.
+### Predict on New Images
 
-## Overfitting and [Underfitting](https://www.ultralytics.com/glossary/underfitting) in [Machine Learning](https://www.ultralytics.com/glossary/machine-learning-ml)
+[Prediction mode](../modes/predict.md) runs the model on new, unseen data without requiring labels. It does not produce performance metrics, but saving the annotated outputs lets you review how the model behaves on real-world images — for example, an entire folder of test images in one go.
 
-When testing a machine learning model, especially in computer vision, it's important to watch out for overfitting and underfitting. These issues can significantly affect how well your model works with new data.
+!!! example "Usage"
 
-### Overfitting
+    === "Python"
 
-Overfitting happens when your model learns the training data too well, including the noise and details that don't generalize to new data. In computer vision, this means your model might do great with training images but struggle with new ones.
+        ```python
+        from ultralytics import YOLO
 
-#### Signs of Overfitting
+        # Load a pretrained model or your own trained checkpoint, e.g. "path/to/best.pt"
+        model = YOLO("yolo26n.pt")
 
-- **High Training Accuracy, Low Validation Accuracy:** If your model performs very well on training data but poorly on validation or [test data](https://www.ultralytics.com/glossary/test-data), it's likely overfitting.
-- **Visual Inspection:** Sometimes, you can see overfitting if your model is too sensitive to minor changes or irrelevant details in images.
+        # Run predictions on a folder of test images and save annotated results
+        results = model.predict(source="path/to/test_images", save=True)
+        ```
 
-### Underfitting
+    === "CLI"
 
-Underfitting occurs when your model can't capture the underlying patterns in the data. In computer vision, an underfitted model might not even recognize objects correctly in the training images.
+        ```bash
+        yolo predict model=yolo26n.pt source=path/to/test_images save=True
+        ```
 
-#### Signs of Underfitting
+!!! tip "Testing a pretrained model before custom training"
 
-- **Low Training Accuracy:** If your model can't achieve high accuracy on the training set, it might be underfitting.
-- **Visual Mis-classification:** Consistent failure to recognize obvious features or objects suggests underfitting.
+    To check whether YOLO26 suits your application before investing in custom training, run prediction mode with a pretrained checkpoint on your own images. The models are pretrained on datasets like [COCO](../datasets/detect/coco.md), so the results give a quick sense of how well the model might perform in your specific context.
 
-### Balancing Overfitting and Underfitting
+### Validation vs. Prediction Mode
 
-The key is to find a balance between overfitting and underfitting. Ideally, a model should perform well on both training and validation datasets. Regularly monitoring your model's performance through metrics and visual inspections, along with applying the right strategies, can help you achieve the best results.
+| Mode                              | Purpose                                       | Requires labels | Output                                                          |
+| --------------------------------- | --------------------------------------------- | --------------- | --------------------------------------------------------------- |
+| [Validation](../modes/val.md)     | Quantify performance against ground truth     | Yes             | Precision, recall, mAP50, mAP50-95, confusion matrix, PR curves |
+| [Prediction](../modes/predict.md) | Inspect model behavior on new, unlabeled data | No              | Annotated images and prediction results, no metrics             |
+
+## How to Analyze Test Results
+
+Once predictions and metrics are in hand, dig into where and why the model fails:
+
+- **Misclassified images:** Identify and review images that the model misclassified to understand where it is going wrong.
+- **Error analysis:** Perform a thorough error analysis to understand the types of errors (e.g., false positives vs. false negatives) and their potential causes.
+- **Bias and fairness:** Check for any biases in the model's predictions. Ensure that the model performs equally well across different subsets of the data, especially if it includes sensitive attributes like race, gender, or age.
+
+## Overfitting and Underfitting in Machine Learning
+
+When testing a [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) model, especially in computer vision, it's important to watch out for overfitting and [underfitting](https://www.ultralytics.com/glossary/underfitting). These issues can significantly affect how well your model works with new data.
+
+| Issue            | Common signs                                                                                                         | How to address it                                                                                                                                                       |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overfitting**  | High training accuracy but low validation accuracy; oversensitivity to minor changes or irrelevant details in images | Apply [regularization](https://www.ultralytics.com/glossary/regularization) such as dropout, increase the size of the training dataset, simplify the model architecture |
+| **Underfitting** | Low accuracy even on the training set; consistent failure to recognize obvious features or objects                   | Use a more complex model, provide more relevant features, increase training [epochs](https://www.ultralytics.com/glossary/epoch)                                        |
+
+The key is to find a balance so the model performs well on both training and validation datasets. Regularly monitoring metrics and visually inspecting predictions during testing helps you catch a drift toward either extreme.
 
 <p align="center">
-  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/overfitting-underfitting-appropriate-fitting.avif" alt="Overfitting vs underfitting visualization">
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/overfitting-underfitting-appropriate-fitting.avif" alt="Comparison of underfitting, appropriate fitting, and overfitting on the same dataset">
 </p>
 
 ## Data Leakage in Computer Vision and How to Avoid It
 
-While testing your model, something important to keep in mind is data leakage. Data leakage happens when information from outside the training dataset accidentally gets used to train the model. The model may seem very accurate during training, but it won't perform well on new, unseen data when data leakage occurs.
+Data leakage happens when information from outside the training dataset accidentally gets used to train the model. The model may seem very accurate during training, but it won't perform well on new, unseen data when data leakage occurs.
 
-### Why Data Leakage Happens
+Leakage can be tricky to spot and often comes from hidden biases in the training data:
 
-Data leakage can be tricky to spot and often comes from hidden biases in the training data. Here are some common ways it can happen in computer vision:
+| Bias type                 | What it looks like                                                                                                                                         |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Camera bias**           | Different angles, lighting, shadows, and camera movements introduce unwanted patterns                                                                      |
+| **Overlay bias**          | Logos, timestamps, or other overlays in images mislead the model                                                                                           |
+| **Font and object bias**  | Specific fonts or objects that frequently appear in certain classes skew the model's learning                                                              |
+| **Spatial bias**          | Imbalances in foreground-background, [bounding box](https://www.ultralytics.com/glossary/bounding-box) distributions, and object locations affect training |
+| **Label and domain bias** | Incorrect labels or shifts in data types lead to leakage                                                                                                   |
 
-- **Camera Bias:** Different angles, lighting, shadows, and camera movements can introduce unwanted patterns.
-- **Overlay Bias:** Logos, timestamps, or other overlays in images can mislead the model.
-- **Font and Object Bias:** Specific fonts or objects that frequently appear in certain classes can skew the model's learning.
-- **Spatial Bias:** Imbalances in foreground-background, [bounding box](https://www.ultralytics.com/glossary/bounding-box) distributions, and object locations can affect training.
-- **Label and Domain Bias:** Incorrect labels or shifts in data types can lead to leakage.
+### How to Detect and Avoid Data Leakage
 
-### Detecting Data Leakage
+To find data leakage, check whether the model's results are surprisingly good, look at whether one feature is much more important than others, double-check that the model's decisions make sense intuitively, and verify that data was divided correctly before any processing.
 
-To find data leakage, you can:
-
-- **Check Performance:** If the model's results are surprisingly good, it might be leaking.
-- **Look at Feature Importance:** If one feature is much more important than others, it could indicate leakage.
-- **Visual Inspection:** Double-check that the model's decisions make sense intuitively.
-- **Verify Data Separation:** Make sure data was divided correctly before any processing.
-
-### Avoiding Data Leakage
-
-To prevent data leakage, use a diverse dataset with images or videos from different cameras and environments. Carefully review your data and check that there are no hidden biases, such as all positive samples being taken at a specific time of day. Avoiding data leakage will help make your computer vision models more reliable and effective in real-world situations.
+To prevent it, use a diverse dataset with images or videos from different cameras and environments, and carefully review your data for hidden biases — such as all positive samples being taken at a specific time of day. Avoiding data leakage makes your computer vision models more reliable in real-world situations.
 
 ## What Comes After Model Testing
 
 After testing your model, the next steps depend on the results. If your model performs well, you can deploy it into a real-world environment. If the results aren't satisfactory, you'll need to make improvements. This might involve analyzing errors, [gathering more data](./data-collection-and-annotation.md), improving data quality, [adjusting hyperparameters](./hyperparameter-tuning.md), and retraining the model.
 
-## Join the AI Conversation
+## Conclusion
 
-Becoming part of a community of computer vision enthusiasts can aid in solving problems and learning more efficiently. Here are some ways to connect, seek help, and share your thoughts.
-
-### Community Resources
-
-- **GitHub Issues:** Explore the [YOLO26 GitHub repository](https://github.com/ultralytics/ultralytics/issues) and use the Issues tab to ask questions, report bugs, and suggest new features. The community and maintainers are very active and ready to help.
-- **Ultralytics Discord Server:** Join the [Ultralytics Discord server](https://discord.com/invite/ultralytics) to chat with other users and developers, get support, and share your experiences.
-
-### Official Documentation
-
-- **Ultralytics YOLO26 Documentation:** Check out the [official YOLO26 documentation](./index.md) for detailed guides and helpful tips on various computer vision projects.
-
-These resources will help you navigate challenges and remain updated on the latest trends and practices within the computer vision community.
-
-## In Summary
-
-Building trustworthy computer vision models relies on rigorous model testing. By testing the model with previously unseen data, we can analyze it and spot weaknesses like [overfitting](https://www.ultralytics.com/glossary/overfitting) and data leakage. Addressing these issues before deployment helps the model perform well in real-world applications. It's important to remember that model testing is just as crucial as model evaluation in guaranteeing the model's long-term success and effectiveness.
+Rigorous model testing — validating on a held-out test split, predicting on real-world images, and checking for overfitting and data leakage — is what turns a well-evaluated model into a dependable one. Address the issues testing surfaces before deployment, and your model is far more likely to perform as intended in production. If questions come up along the way, ask the community on the [Ultralytics GitHub repository](https://github.com/ultralytics/ultralytics) or the [Ultralytics Discord server](https://discord.com/invite/ultralytics).
 
 ## FAQ
 
 ### What are the key differences between model evaluation and model testing in computer vision?
 
-Model evaluation and model testing are distinct steps in a computer vision project. Model evaluation involves using a labeled dataset to compute metrics such as [accuracy](https://www.ultralytics.com/glossary/accuracy), precision, recall, and [F1 score](https://www.ultralytics.com/glossary/f1-score), providing insights into the model's performance with a controlled dataset. Model testing, on the other hand, assesses the model's performance in real-world scenarios by applying it to new, unseen data, ensuring the model's learned behavior aligns with expectations outside the evaluation environment. For a detailed guide, refer to the [steps in a computer vision project](./steps-of-a-cv-project.md).
+Model evaluation measures performance with metrics on a labeled dataset, while model testing checks how the model behaves on new, unseen data that resembles deployment conditions. Evaluation produces numbers like precision and mAP from a controlled dataset; testing reveals whether the learned behavior holds up with varied lighting, motion, or occlusion. See [Model Testing vs. Model Evaluation](#model-testing-vs-model-evaluation) for a worked example.
 
 ### How can I test my Ultralytics YOLO26 model on multiple images?
 
-To test your Ultralytics YOLO26 model on multiple images, you can use the [prediction mode](../modes/predict.md). This mode allows you to run the model on new, unseen data to generate predictions without providing detailed metrics. This is ideal for real-world performance testing on larger image sets stored in a folder. For evaluating performance metrics, use the [validation mode](../modes/val.md) instead.
+Use [prediction mode](../modes/predict.md) and pass a folder path as the `source` — YOLO26 runs on every image in the folder and can save the annotated results for review. Prediction mode does not compute metrics; to quantify performance on a labeled set, use [validation mode](../modes/val.md) instead. Both workflows are shown in [How to Test a YOLO26 Model](#how-to-test-a-yolo26-model).
+
+### What metrics does YOLO26 validation report on a test set?
+
+For detection models, validation reports precision, recall, mAP50, and mAP50-95, and saves plots including a confusion matrix and a precision-recall curve. To validate on a dedicated test split rather than the default `val` split, define `test:` in your dataset YAML and pass `split="test"`. See the [performance metrics guide](./yolo-performance-metrics.md) for how to interpret each metric.
 
 ### What should I do if my computer vision model shows signs of overfitting or underfitting?
 
-To address **overfitting**:
-
-- [Regularization](https://www.ultralytics.com/glossary/regularization) techniques like dropout.
-- Increase the size of the training dataset.
-- Simplify the model architecture.
-
-To address **underfitting**:
-
-- Use a more complex model.
-- Provide more relevant features.
-- Increase training iterations or [epochs](https://www.ultralytics.com/glossary/epoch).
-
-Review misclassified images, perform thorough error analysis, and regularly track performance metrics to maintain a balance. For more information on these concepts, explore our section on [Overfitting and Underfitting](#overfitting-and-underfitting-in-machine-learning).
+For overfitting, apply regularization techniques such as dropout, increase the size of the training dataset, or simplify the model architecture. For underfitting, use a more complex model, provide more relevant features, or train for more epochs. The signs of each issue and the corresponding fixes are summarized in [Overfitting and Underfitting in Machine Learning](#overfitting-and-underfitting-in-machine-learning).
 
 ### How can I detect and avoid data leakage in computer vision?
 
-To detect data leakage:
-
-- Verify that the testing performance is not unusually high.
-- Check feature importance for unexpected insights.
-- Intuitively review model decisions.
-- Ensure correct data division before processing.
-
-To avoid data leakage:
-
-- Use diverse datasets with various environments.
-- Carefully review data for hidden biases.
-- Ensure no overlapping information between training and testing sets.
-
-For detailed strategies on preventing data leakage, refer to our section on [Data Leakage in Computer Vision](#data-leakage-in-computer-vision-and-how-to-avoid-it).
+Suspect data leakage when test performance looks surprisingly good, a single feature dominates predictions, or the model's decisions don't make intuitive sense. Prevent it by using diverse datasets from different cameras and environments, reviewing data for hidden biases, and verifying that the train/test split happened before any processing. See [Data Leakage in Computer Vision](#data-leakage-in-computer-vision-and-how-to-avoid-it) for the common bias types.
 
 ### What steps should I take after testing my computer vision model?
 
-Post-testing, if the model performance meets the project goals, proceed with deployment. If the results are unsatisfactory, consider:
-
-- Error analysis.
-- Gathering more diverse and high-quality data.
-- [Hyperparameter tuning](https://www.ultralytics.com/glossary/hyperparameter-tuning).
-- Retraining the model.
-
-Gain insights from the [Model Testing Vs. Model Evaluation](#model-testing-vs-model-evaluation) section to refine and enhance model effectiveness in real-world applications.
-
-### How do I run YOLO26 predictions without custom training?
-
-You can run predictions using the pretrained YOLO26 model on your dataset to see if it suits your application needs. Utilize the [prediction mode](../modes/predict.md) to get a quick sense of performance results without diving into custom training.
+If the results meet your project goals, deploy the model; if not, improve it before deployment. That can mean analyzing errors, [collecting more diverse data](./data-collection-and-annotation.md), improving data quality, [tuning hyperparameters](./hyperparameter-tuning.md), and retraining. Repeat testing after each round of changes to confirm the fixes worked.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -520,7 +520,6 @@ nav:
       - Workouts Monitoring: guides/workouts-monitoring.md
   - Guides:
       - Guides: guides/index.md
-      - A Guide on Model Testing: guides/model-testing.md
       - AzureML Quickstart: guides/azureml-quickstart.md
       - Best Practices for Model Deployment: guides/model-deployment-practices.md
       - COCO to YOLO Conversion: guides/coco-to-yolo.md
@@ -543,6 +542,7 @@ nav:
       - Maintaining Your Computer Vision Model: guides/model-monitoring-and-maintenance.md
       - Modal Quickstart: guides/modal-quickstart.md
       - Model Deployment Options: guides/model-deployment-options.md
+      - Model Testing: guides/model-testing.md
       - Model YAML Configuration Guide: guides/model-yaml-config.md
       - NVIDIA DALI GPU Preprocessing: guides/nvidia-dali.md
       - NVIDIA DGX Spark: guides/nvidia-dgx-spark.md


### PR DESCRIPTION
## summary

restructures the model testing guide with a query-shaped title, an answer-first introduction, comparison tables for validation vs prediction mode, overfitting vs underfitting, and data-leakage bias types, plus minimal python/cli usage examples for validating and predicting with yolo26 (verified on coco8). corrects factual claims: detection validation reports precision, recall, map50, and map50-95 rather than accuracy and f1 score, and saves a confusion matrix and precision-recall curve rather than roc curves; also fixes model-name references in the community links. updates the nav label and guides index card to the new title.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR refreshes the **Model Testing** documentation, making it clearer, more practical, and better aligned with **YOLO26** workflows for real-world testing.

### 📊 Key Changes
- Renamed the guide from **“A Guide on Model Testing”** to **“How to Test Computer Vision Models”** for a simpler, more direct title.
- Updated the guide description and keywords to better focus on **YOLO26**, unseen test data, overfitting, underfitting, and data leakage.
- Reworked the introduction to clearly explain the difference between **model evaluation** and **model testing**.
- Added a more practical **YOLO26 testing workflow** with two clear paths:
  - **Validation mode** for labeled test sets and metrics
  - **Prediction mode** for reviewing results on new unlabeled images
- Included cleaner Python and CLI examples for running `val` and `predict`.
- Added clearer guidance on using a dedicated **test split** in dataset YAML files.
- Improved result-analysis sections with focused advice on:
  - misclassified images
  - error analysis
  - bias and fairness checks
- Restructured explanations for **overfitting**, **underfitting**, and **data leakage** using easier-to-scan tables and shorter sections.
- Simplified and modernized the FAQ with more direct answers tied to the updated guide sections.
- Updated documentation navigation in both `guides/index.md` and `mkdocs.yml` so the guide now appears as **Model Testing** instead of the older title. 🔄

### 🎯 Purpose & Impact
- Makes model testing documentation easier for both **new users and experienced developers** to understand. ✅
- Helps users distinguish between **measuring metrics** and **testing real-world behavior**, reducing confusion during deployment planning.
- Gives YOLO26 users clearer, ready-to-use steps for validating models and inspecting predictions on test images. 🚀
- Improves discoverability and consistency across the docs by standardizing the guide title and navigation.
- Encourages better testing habits by highlighting common failure points like **overfitting** and **data leakage**, which can improve deployment reliability.
- Overall, this is a **documentation clarity and usability improvement** rather than a code change, so the main impact is better guidance and smoother user onboarding. 📚