### PR TITLE
Refresh iPhone CoreML benchmarks with profile-mode measurements

### DIFF
--- a/docs/en/integrations/coreml.md
+++ b/docs/en/integrations/coreml.md
@@ -46,15 +46,15 @@ End-to-end single-image inference for the official YOLO26n INT8 CoreML models on
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>`.cpuOnly`<br>(ms)</sup> | Neural Engine<br><sup>`.cpuAndNeuralEngine`<br>(ms)</sup> |
 | ------------ | -------- | --------------------------- | ------------------------------------ | --------------------------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 9.2<br><sup>0.0 / 9.1 / 0.0</sup>    | **3.8**<br><sup>0.0 / 3.7 / 0.0</sup>                     |
-| YOLO26n-seg  | Segment  | 640                         | 21.7<br><sup>0.0 / 12.0 / 9.8</sup>  | **14.1**<br><sup>0.0 / 4.5 / 9.6</sup>                    |
-| YOLO26n-sem  | Semantic | 1024<sup>1</sup>            | 17.2<br><sup>0.0 / 15.3 / 1.9</sup>  | **7.5**<br><sup>0.0 / 5.5 / 1.9</sup>                     |
-| YOLO26n-cls  | Classify | 224                         | 2.4<br><sup>0.0 / 2.4 / 0.0</sup>    | **2.0**<br><sup>0.0 / 1.9 / 0.0</sup>                     |
-| YOLO26n-pose | Pose     | 640                         | 12.1<br><sup>0.0 / 12.0 / 0.1</sup>  | **3.9**<br><sup>0.0 / 3.9 / 0.1</sup>                     |
-| YOLO26n-obb  | OBB      | 1024                        | 22.3<br><sup>0.0 / 22.3 / 0.0</sup>  | **7.2**<br><sup>0.0 / 7.2 / 0.0</sup>                     |
+| YOLO26n      | Detect   | 640                         | 9.1<br><sup>0.0 / 9.1 / 0.0</sup>    | **3.8**<br><sup>0.0 / 3.8 / 0.0</sup>                     |
+| YOLO26n-seg  | Segment  | 640                         | 12.3<br><sup>0.0 / 12.1 / 0.2</sup>  | **4.8**<br><sup>0.0 / 4.5 / 0.3</sup>                     |
+| YOLO26n-sem  | Semantic | 1024<sup>1</sup>            | 21.8<br><sup>0.0 / 21.0 / 0.8</sup>  | **12.1**<br><sup>0.0 / 11.3 / 0.8</sup>                   |
+| YOLO26n-cls  | Classify | 224                         | 2.2<br><sup>0.0 / 2.2 / 0.0</sup>    | **2.0**<br><sup>0.0 / 2.0 / 0.0</sup>                     |
+| YOLO26n-pose | Pose     | 640                         | 12.0<br><sup>0.0 / 11.9 / 0.0</sup>  | **3.8**<br><sup>0.0 / 3.8 / 0.0</sup>                     |
+| YOLO26n-obb  | OBB      | 1024                        | 21.7<br><sup>0.0 / 21.7 / 0.0</sup>  | **7.2**<br><sup>0.0 / 7.2 / 0.0</sup>                     |
 
-- <sup>1</sup> Semantic CoreML exports from this release embed the ArgMax in the graph and return a compact class map instead of float logits, cutting Neural Engine end-to-end time from 10.3 ms to 7.5 ms.
-- **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on [bus.jpg](https://ultralytics.com/images/bus.jpg), measured through the [iOS SDK's](https://github.com/ultralytics/yolo-ios-app) per-stage timing via the [Flutter plugin's](https://github.com/ultralytics/yolo-flutter-app) benchmark harness. Sustained real-time camera operation runs higher (full-sensor letterboxing every frame plus thermal settling): YOLO26n detect measures ~16 ms/frame in the live camera app on the same device — see the [iOS SDK performance doc](https://github.com/ultralytics/yolo-ios-app/blob/main/docs/performance.md) for steady-state profiling.
+- <sup>1</sup> Semantic CoreML exports embed the ArgMax in the graph and return a compact full-resolution class map (`[1, 1024, 1024]`) instead of float logits, so the postprocess is a sub-millisecond color sweep and masks render pixel-sharp.
+- **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on [bus.jpg](https://ultralytics.com/images/bus.jpg), measured through the [iOS SDK's](https://github.com/ultralytics/yolo-ios-app) per-stage timing via the [Flutter plugin's](https://github.com/ultralytics/yolo-flutter-app) benchmark harness in profile mode (optimized native code). Sustained real-time camera operation runs higher (full-sensor letterboxing every frame plus thermal settling): YOLO26n detect measures ~16 ms/frame in the live camera app on the same device — see the [iOS SDK performance doc](https://github.com/ultralytics/yolo-ios-app/blob/main/docs/performance.md) for steady-state profiling.
 - The matching Snapdragon CPU/GPU/NPU table is in the [Qualcomm QNN integration](qnn.md).
 
 ## Exporting YOLO26 Models to CoreML


### PR DESCRIPTION
Docs-only refresh of the iPhone 17 Pro table in `coreml.md`:

- Measurements now come from profile-mode builds (optimized native code); the earlier table ran through debug builds, where unoptimized Swift postprocessing inflated segment (14.1 → 4.8 ms ANE) and semantic stage times.
- Semantic rows use the full-resolution `[1, 1024, 1024]` class-map export from #24799 — pixel-sharp masks, sub-millisecond postprocess, 12.1 ms end-to-end on the Neural Engine (the previous 7.5 ms row was the stride-8 128px export).
- Methodology note updated accordingly.

All values single-image burst (3 warmup + 15 timed runs, bus.jpg), same device and harness as before.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📱 This PR updates the CoreML integration docs with refreshed YOLO26 benchmark numbers and clearer explanations for semantic segmentation outputs and iOS performance testing.

### 📊 Key Changes
- Updated the **CoreML latency table** in the docs for multiple YOLO26 models, including:
  - Detect
  - Segment
  - Semantic segmentation
  - Classify
  - Pose
  - OBB
- Revised several reported **CPU and Neural Engine inference times**, with notable changes in segmentation and semantic segmentation results.
- Clarified that **semantic CoreML exports** now return a compact full-resolution class map instead of float logits.
- Added more detail on the semantic segmentation output behavior, noting:
  - embedded ArgMax in the CoreML graph
  - faster postprocessing
  - sharper mask rendering
- Expanded the benchmarking note to better explain how timings were measured, including:
  - single-image burst latency
  - warmup and averaging setup
  - use of the iOS SDK and Flutter benchmark harness
  - testing in **profile mode** for optimized native code
- Kept the note that **live camera performance is slower** than burst benchmarks due to real-world overhead like letterboxing and thermal effects.

### 🎯 Purpose & Impact
- 📖 Improves documentation accuracy so users see **more reliable CoreML performance numbers** for YOLO26 on Apple devices.
- 🧠 Helps developers better understand why **semantic segmentation outputs behave differently**, especially when integrating mask rendering in apps.
- ⚡ Makes it clearer that benchmark numbers reflect **optimized test conditions**, reducing confusion when real-time camera performance differs.
- 🛠️ Supports better deployment decisions for teams choosing between YOLO26 tasks on iOS, especially for **speed-sensitive mobile applications**.
- 🎯 Overall, this is a **documentation and clarity improvement** rather than a code change, but it can directly help users set more accurate expectations for CoreML deployment.