### PR TITLE
Adapt `classes` filter to semantic segmentation task

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -694,6 +694,7 @@ class SemanticDataset(YOLODataset):
     Attributes:
         data (dict): Dataset configuration from YAML.
         mask_files (list[str]): List of mask file paths corresponding to images.
+        include_class (np.ndarray | None): Class ids to keep per pixel (None keeps all).
     """
 
     def __init__(self, *args, data: dict | None = None, **kwargs):
@@ -716,7 +717,19 @@ class SemanticDataset(YOLODataset):
         Args:
             include_class (list[int], optional): List of classes to include. If None, all classes are included.
         """
+        if self.single_cls:
+            raise NotImplementedError(
+                "'single_cls=True' is not supported for semantic segmentation: it forces a single-channel "
+                "model but cannot collapse multi-class masks. Use a dataset with 'nc: 1' for binary "
+                "(foreground/background) segmentation instead."
+            )
         self.include_class = None if include_class is None else np.asarray(include_class, dtype=np.int64).reshape(-1)
+        if self.include_class is not None and int(self.data.get("nc", 0)) == 1:
+            LOGGER.warning(
+                "'classes' filtering is ignored for single-class (binary) semantic segmentation: keeping only "
+                "the sole class would discard all background supervision."
+            )
+            self.include_class = None
 
     def _parse_label_mapping(self, mapping):
         """Normalize label_mapping entries from dataset YAML into integer-to-integer ids."""

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -707,7 +707,16 @@ class SemanticDataset(YOLODataset):
         self.data = data or {}
         self.label_mapping = self._parse_label_mapping(self.data.get("label_mapping"))
         self.mask_files = []
+        self.include_class = None
         super().__init__(*args, data=data, **kwargs)
+
+    def update_labels(self, include_class: list[int] | None) -> None:
+        """Update labels to include only specified classes.
+
+        Args:
+            include_class (list[int], optional): List of classes to include. If None, all classes are included.
+        """
+        self.include_class = None if include_class is None else np.asarray(include_class, dtype=np.int64).reshape(-1)
 
     def _parse_label_mapping(self, mapping):
         """Normalize label_mapping entries from dataset YAML into integer-to-integer ids."""
@@ -880,6 +889,8 @@ class SemanticDataset(YOLODataset):
         label = super().get_image_and_label(index)
         h, w = label["img"].shape[:2]
         mask = self.load_mask(index, image_shape=(h, w))
+        if self.include_class is not None:  # keep only selected classes; remap the rest to the ignore label
+            mask[~np.isin(mask, self.include_class)] = 255
         # Resize mask to match the resized image dimensions
         if mask.shape[:2] != (h, w):
             mask = cv2.resize(mask, (w, h), interpolation=cv2.INTER_NEAREST)

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -723,7 +723,7 @@ class SemanticDataset(YOLODataset):
                 "model but cannot collapse multi-class masks. Use a dataset with 'nc: 1' for binary "
                 "(foreground/background) segmentation instead."
             )
-        self.include_class = None if include_class is None else np.asarray(include_class, dtype=np.int64).reshape(-1)
+        self.include_class = None if include_class is None else np.asarray(include_class, dtype=np.int32).reshape(-1)
         if self.include_class is not None and int(self.data.get("nc", 0)) == 1:
             LOGGER.warning(
                 "'classes' filtering is ignored for single-class (binary) semantic segmentation: keeping only "

--- a/ultralytics/models/yolo/semantic/predict.py
+++ b/ultralytics/models/yolo/semantic/predict.py
@@ -56,9 +56,7 @@ class SemanticSegmentationPredictor(BasePredictor):
             orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)[..., ::-1]
 
         classes = (
-            torch.as_tensor(self.args.classes, device=preds.device).flatten()
-            if self.args.classes is not None
-            else None
+            torch.as_tensor(self.args.classes, device=preds.device).flatten() if self.args.classes is not None else None
         )
 
         results = []

--- a/ultralytics/models/yolo/semantic/predict.py
+++ b/ultralytics/models/yolo/semantic/predict.py
@@ -58,6 +58,8 @@ class SemanticSegmentationPredictor(BasePredictor):
         classes = (
             torch.as_tensor(self.args.classes, device=preds.device).flatten() if self.args.classes is not None else None
         )
+        if classes is not None and len(self.model.names) == 1:
+            classes = classes + 1  # binary: the single foreground class (class id 0) is stored as value 1
 
         results = []
         for i, (pred, orig_img) in enumerate(zip(preds, orig_imgs)):

--- a/ultralytics/models/yolo/semantic/predict.py
+++ b/ultralytics/models/yolo/semantic/predict.py
@@ -56,10 +56,10 @@ class SemanticSegmentationPredictor(BasePredictor):
             orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)[..., ::-1]
 
         classes = (
-            torch.as_tensor(self.args.classes, device=preds.device).flatten() if self.args.classes is not None else None
+            torch.as_tensor(self.args.classes, device=preds.device).flatten()
+            if self.args.classes is not None and len(self.model.names) > 1
+            else None
         )
-        if classes is not None and len(self.model.names) == 1:
-            classes = None  # single-class model has nothing to filter; keep the full prediction
 
         results = []
         for i, (pred, orig_img) in enumerate(zip(preds, orig_imgs)):

--- a/ultralytics/models/yolo/semantic/predict.py
+++ b/ultralytics/models/yolo/semantic/predict.py
@@ -55,6 +55,12 @@ class SemanticSegmentationPredictor(BasePredictor):
         if not isinstance(orig_imgs, list):  # input images are a torch.Tensor, not a list
             orig_imgs = ops.convert_torch2numpy_batch(orig_imgs)[..., ::-1]
 
+        classes = (
+            torch.as_tensor(self.args.classes, device=preds.device).flatten()
+            if self.args.classes is not None
+            else None
+        )
+
         results = []
         for i, (pred, orig_img) in enumerate(zip(preds, orig_imgs)):
             img_path = self.batch[0][i] if isinstance(self.batch[0], list) else self.batch[0]
@@ -70,5 +76,7 @@ class SemanticSegmentationPredictor(BasePredictor):
             else:
                 dtype = self._class_map_dtype(max(pred.shape[0], 2))
                 class_map = pred.argmax(0).to(dtype) if pred.shape[0] > 1 else pred.gt(0).squeeze(0).to(dtype)
+            if classes is not None:  # keep only selected classes, mark the rest as ignore
+                class_map[~(class_map.unsqueeze(-1) == classes).any(-1)] = 255
             results.append(Results(orig_img, path=img_path, names=self.model.names, semantic_mask=class_map))
         return results

--- a/ultralytics/models/yolo/semantic/predict.py
+++ b/ultralytics/models/yolo/semantic/predict.py
@@ -59,7 +59,7 @@ class SemanticSegmentationPredictor(BasePredictor):
             torch.as_tensor(self.args.classes, device=preds.device).flatten() if self.args.classes is not None else None
         )
         if classes is not None and len(self.model.names) == 1:
-            classes = classes + 1  # binary: the single foreground class (class id 0) is stored as value 1
+            classes = None  # single-class model has nothing to filter; keep the full prediction
 
         results = []
         for i, (pred, orig_img) in enumerate(zip(preds, orig_imgs)):

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1750,7 +1750,10 @@ class SemanticMetrics(SimpleClass, DataExportMixin):
             self._per_class_pixel_acc = pa[1:].cpu().numpy()
             self.nt_per_class = np.array([row_sum[1].item()], dtype=np.int32)
         else:
-            self._miou = float(iou.mean().item())
+            # Average IoU only over classes present in the ground truth; classes with no GT pixels (absent
+            # from the val set or removed by the `classes` filter) are excluded.
+            present = row_sum > 0
+            self._miou = float(iou[present].mean().item()) if present.any() else 0.0
             self._per_class_iou = iou.cpu().numpy()
             self._per_class_pixel_acc = pa.cpu().numpy()
             self.nt_per_class = row_sum[: self.nc].cpu().numpy().astype(np.int32)
@@ -1830,22 +1833,16 @@ class SemanticMetrics(SimpleClass, DataExportMixin):
         return [self.miou, self.pixel_accuracy]
 
     def class_result(self, i: int) -> list[float]:
-        """Return the result of evaluating the performance on a specific class.
-
-        Args:
-            i (int): Class index.
-
-        Returns:
-            (list): [IoU, pixel_accuracy] for the specified class.
-        """
+        """Return the result of evaluating the performance on a specific class."""
         if self._per_class_iou is None or len(self._per_class_iou) == 0:
             return [0.0, 0.0]
-        return [float(self._per_class_iou[i]), float(self._per_class_pixel_acc[i])]
+        c = self.ap_class_index[i]
+        return [float(self._per_class_iou[c]), float(self._per_class_pixel_acc[c])]
 
     @property
     def ap_class_index(self):
-        """Return the class index list for per-class results."""
-        return list(range(self.nc))
+        """Return the indices of classes present in the ground truth for per-class reporting."""
+        return [i for i in range(self.nc) if self.nt_per_class[i] > 0]
 
     @property
     def results_dict(self):
@@ -1879,12 +1876,12 @@ class SemanticMetrics(SimpleClass, DataExportMixin):
         names = self.names or {i: str(i) for i in range(len(per_class))}
         return [
             {
-                "Class": names.get(i, str(i)),
-                "Images": int(self.nt_per_image[i]),
-                "Pixels": int(self.nt_per_class[i]),
-                "IoU": round(float(per_class[i]), decimals),
+                "Class": names.get(c, str(c)),
+                "Images": int(self.nt_per_image[c]),
+                "Pixels": int(self.nt_per_class[c]),
+                "IoU": round(float(per_class[c]), decimals),
                 "mIoU": miou,
                 "pixel_acc": pixel_acc,
             }
-            for i in range(len(per_class))
+            for c in self.ap_class_index
         ]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves semantic segmentation class filtering and evaluation, making `classes` selection work more reliably during prediction, validation, and metric reporting 🧠🎯

### 📊 Key Changes
- Added semantic segmentation support for `classes` filtering in `SemanticDataset`:
  - Selected classes are kept
  - All other pixels are remapped to the ignore label (`255`) 🖌️
- Introduced `update_labels()` for semantic datasets to manage included classes more explicitly.
- Added safeguards for unsupported or misleading cases:
  - Raises an error if `single_cls=True` is used for semantic segmentation 🚫
  - Warns when class filtering is requested for binary segmentation (`nc: 1`), where it does not make sense ⚠️
- Updated semantic prediction postprocessing so `classes` filtering also applies at inference time, not just during dataset handling 🔍
- Improved segmentation metrics:
  - `mIoU` now averages only over classes actually present in ground truth
  - Classes removed by filtering or absent from validation no longer unfairly affect the score 📈
- Refined per-class reporting:
  - Per-class results now only include classes present in the ground truth
  - Summary tables use the correct class indices and counts ✅

### 🎯 Purpose & Impact
- Makes semantic segmentation behavior more consistent across training, validation, and prediction 🔄
- Prevents misleading results when users evaluate only a subset of classes.
- Improves metric accuracy by excluding missing classes from `mIoU`, giving a fairer view of model performance 📊
- Helps users avoid invalid configurations, especially around `single_cls` and binary segmentation.
- Overall, this makes semantic segmentation workflows in Ultralytics more predictable, easier to interpret, and safer to use for class-specific evaluation and inference 🚀