### PR TITLE
Clarify multiple bounding boxes behavior in SAM3 semantic predictor docs

### DIFF
--- a/docs/en/models/sam-3.md
+++ b/docs/en/models/sam-3.md
@@ -207,7 +207,7 @@ SAM 3 supports both Promptable Concept Segmentation (PCS) and Promptable Visual 
         # Provide bounding box examples to segment similar objects
         results = predictor(bboxes=[[480.0, 290.0, 590.0, 650.0]])
 
-        # Multiple bounding boxes for different concepts
+        # Multiple bounding boxes as exemplars of the same visual concept
         results = predictor(bboxes=[[539, 599, 589, 639], [343, 267, 499, 662]])
         ```
 


### PR DESCRIPTION
## summary

the image exemplar example in the SAM 3 docs labeled multiple bounding boxes as prompts "for different concepts", but `SAM3SemanticPredictor` packs all boxes into a single geometric prompt with one concept id, so they act as exemplars of the same visual concept. updated the comment to match the actual behavior; different concepts require multiple text prompts or separate queries.

resolves https://github.com/ultralytics/ultralytics/issues/24801

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes a small documentation clarification in the SAM 3 example to better explain how multiple bounding boxes should be interpreted.

### 📊 Key Changes
- Updated a comment in `docs/en/models/sam-3.md`.
- Changed the description from:
  - “Multiple bounding boxes for different concepts”
- To:
  - “Multiple bounding boxes as exemplars of the same visual concept”
- The code example itself remains unchanged; only the explanatory text was refined.

### 🎯 Purpose & Impact
- Improves documentation accuracy by clarifying the intended use of multiple bounding boxes in SAM 3. ✅
- Helps users better understand that the boxes represent examples of one shared visual concept, not separate concepts. 🧠
- Reduces confusion for users learning promptable segmentation workflows, especially newcomers. 🚀
- No effect on model behavior, training, or inference performance—this is a docs-only improvement. 📚