### PR TITLE
Fix evaluate link target in JupyterLab integration docs

### DIFF
--- a/docs/en/integrations/jupyterlab.md
+++ b/docs/en/integrations/jupyterlab.md
@@ -104,7 +104,7 @@ If you want to learn more about JupyterLab, here are resources to get you starte
 
 ## Summary
 
-We've explored how JupyterLab can be a powerful tool for experimenting with Ultralytics YOLO26 models. Using its flexible and interactive environment, you can easily set up JupyterLab on your local machine and start working with YOLO26. JupyterLab makes it simple to [train](../guides/model-training-tips.md) and [evaluate](../guides/model-testing.md) your models, visualize outputs, and [document your findings](../guides/model-monitoring-and-maintenance.md) all in one place.
+We've explored how JupyterLab can be a powerful tool for experimenting with Ultralytics YOLO26 models. Using its flexible and interactive environment, you can easily set up JupyterLab on your local machine and start working with YOLO26. JupyterLab makes it simple to [train](../guides/model-training-tips.md) and [evaluate](../guides/model-evaluation-insights.md) your models, visualize outputs, and [document your findings](../guides/model-monitoring-and-maintenance.md) all in one place.
 
 Unlike other platforms such as [Google Colab](../integrations/google-colab.md), JupyterLab runs locally on your machine, giving you more control over your computing environment while still providing an interactive notebook experience. This makes it particularly valuable for developers who need consistent access to their development environment without relying on cloud resources.
 


### PR DESCRIPTION
## summary

the summary paragraph of the jupyterlab integration guide linked the word "evaluate" to the model testing guide. the docs treat testing and evaluation as separate steps with dedicated pages, so the anchor now points to the model evaluation insights guide instead.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR updates the JupyterLab integration docs by fixing the model evaluation link to point to the correct evaluation insights guide.

### 📊 Key Changes
- Replaced an outdated documentation link in `docs/en/integrations/jupyterlab.md`
- Updated the **evaluate** reference from `model-testing.md` to `model-evaluation-insights.md`
- Kept the rest of the JupyterLab + YOLO26 documentation unchanged

### 🎯 Purpose & Impact
- Improves documentation accuracy so users land on the correct evaluation guide 📘
- Reduces confusion for people learning how to assess YOLO26 models in JupyterLab ✅
- Makes the docs more polished and easier to navigate, especially for new users 🚀