### PR TITLE
Add retry wrapper to flaky CI installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,15 +71,19 @@ jobs:
           python-version: ${{ matrix.python }}
           activate-environment: ${{ matrix.os == 'cpu-latest' }}
       - name: Install requirements
-        shell: bash # for Windows compatibility
-        run: |
-          uv_system_args=()
-          if [[ "${{ matrix.os }}" != "cpu-latest" ]]; then
-            uv_system_args=(--system)
-          fi
-          uv pip install "${uv_system_args[@]}" -e ".[export,export-executorch]" \
-            ncnn pnnx "coverage[toml]" \
-            --torch-backend cpu
+        uses: ultralytics/actions/retry@main
+        with:
+          retries: 3
+          retry_delay_seconds: 20
+          timeout_minutes: 20
+          run: |
+            uv_system_args=()
+            if [[ "${{ matrix.os }}" != "cpu-latest" ]]; then
+              uv_system_args=(--system)
+            fi
+            uv pip install "${uv_system_args[@]}" -e ".[export,export-executorch]" \
+              ncnn pnnx "coverage[toml]" \
+              --torch-backend cpu
       - name: Check environment
         run: |
           yolo checks
@@ -470,8 +474,13 @@ jobs:
           echo PATH=$PATH >> $GITHUB_ENV
       - uses: astral-sh/setup-uv@v7
       - name: Install requirements
-        run: |
-          uv pip install -e ".[export]" pytest pytest-xdist mlflow faster-coco-eval --torch-backend cpu
+        uses: ultralytics/actions/retry@main
+        with:
+          retries: 3
+          retry_delay_seconds: 20
+          timeout_minutes: 20
+          run: |
+            uv pip install -e ".[export]" pytest pytest-xdist mlflow faster-coco-eval --torch-backend cpu
       - name: Check environment
         run: |
           yolo checks
@@ -495,8 +504,13 @@ jobs:
           source env-benchmarks/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
       - name: Install requirements
-        run: |
-          uv pip install -e ".[export]" pytest mlflow faster-coco-eval --torch-backend cpu
+        uses: ultralytics/actions/retry@main
+        with:
+          retries: 3
+          retry_delay_seconds: 20
+          timeout_minutes: 20
+          run: |
+            uv pip install -e ".[export]" pytest mlflow faster-coco-eval --torch-backend cpu
       - name: Check environment
         run: |
           yolo checks


### PR DESCRIPTION
## Summary
- wrap benchmark dependency installs with the shared retry action
- wrap Raspberry Pi test and benchmark dependency installs with the shared retry action
- keep the existing uv install commands unchanged

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml OK"'\n- actionlint -ignore 'shellcheck reported issue' -ignore 'label ".*" is unknown' .github/workflows/ci.yml\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes Ultralytics CI installs more reliable by wrapping key dependency installation steps in an automatic retry action.

### 📊 Key Changes
- Added the `ultralytics/actions/retry@main` wrapper around multiple `Install requirements` steps in `.github/workflows/ci.yml`.
- Configured each retry-enabled install step with:
  - `retries: 3`
  - `retry_delay_seconds: 20`
  - `timeout_minutes: 20`
- Kept the existing `uv pip install` commands and package lists unchanged, including export, ExecuTorch, testing, benchmarking, and MLflow-related dependencies.
- Applied this retry logic to several CI jobs, including:
  - main environment setup
  - test-related environments
  - benchmark-related environments

### 🎯 Purpose & Impact
- ✅ Reduces flaky CI failures caused by temporary package download or install issues.
- 🚀 Improves workflow stability without changing actual project dependencies or test behavior.
- ⏱️ Helps contributors and maintainers avoid unnecessary re-runs when installs fail for transient reasons.
- 🔧 Makes PR validation and benchmark/test pipelines more dependable across different environments, including Windows-compatible bash install steps.