### PR TITLE
Fix verbose visual prompting yoloe

### DIFF
--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -403,7 +403,7 @@ class YOLOE(Model):
                         "task": self.model.task,
                         "mode": "predict",
                         "save": False,
-                        "verbose": refer_image is None,
+                        "verbose": self.verbose,
                         "batch": 1,
                         "device": kwargs.get("device", None),
                         "half": kwargs.get("half", False),

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -397,13 +397,14 @@ class YOLOE(Model):
                 f"Expected equal number of bounding boxes and classes, but got {len(visual_prompts['bboxes'])} and "
                 f"{len(visual_prompts['cls'])} respectively"
             )
+
             if type(self.predictor) is not predictor:
                 self.predictor = predictor(
                     overrides={
                         "task": self.model.task,
                         "mode": "predict",
                         "save": False,
-                        "verbose": self.verbose,
+                        "verbose": kwargs.get("verbose", refer_image is None),
                         "batch": 1,
                         "device": kwargs.get("device", None),
                         "half": kwargs.get("half", False),
@@ -420,7 +421,8 @@ class YOLOE(Model):
             self.model.model[-1].nc = num_cls
             self.model.names = [f"object{i}" for i in range(num_cls)]
             self.predictor.set_prompts(visual_prompts.copy())
-            self.predictor.setup_model(model=self.model)
+            self.predictor.setup_model(model=self.model,
+                                       verbose = self.predictor.args.verbose)
 
             if refer_image is None and source is not None:
                 dataset = load_inference_source(source)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes verbose handling for YOLOE visual prompting so user-specified verbosity is respected during predictor creation and model setup. 🔧

### 📊 Key Changes
- Updates visual prompting prediction logic in `ultralytics/models/yolo/model.py` to honor `kwargs.get("verbose", refer_image is None)` instead of forcing default behavior.
- Passes the resolved predictor verbosity into `self.predictor.setup_model(model=self.model, verbose=self.predictor.args.verbose)`.
- Keeps existing behavior intact when `verbose` is not explicitly provided, preserving the current fallback based on `refer_image`.

### 🎯 Purpose & Impact
- Fixes inconsistent or overly chatty logging during YOLOE visual prompting runs. 🗣️
- Gives users explicit control over verbosity when calling `predict(...)` with visual prompts.
- Improves predict-time UX without changing core detection behavior, making this a low-risk Python bug fix. ✅