### PR TITLE
Fix CoreML NMS glossary link

### DIFF
--- a/docs/en/integrations/coreml.md
+++ b/docs/en/integrations/coreml.md
@@ -36,7 +36,7 @@ CoreML integrates directly with Apple's [Vision framework](https://developer.app
 ## Why Export YOLO26 to CoreML?
 
 - **Neural Engine speed**: YOLO26n detection runs end-to-end in **3.8 ms** on an iPhone 17 Pro for single images, and ~16 ms/frame in sustained real-time camera use (see the table and notes below) — comfortably real-time with headroom for the rest of your app.
-- **NMS-free by design**: YOLO26 is [end-to-end](https://www.ultralytics.com/glossary/nms-non-maximum-suppression), so the exported graph needs no NMS pipeline and decode is sub-millisecond. Older models like YOLO11 can embed a CoreML NMS pipeline with `nms=True`.
+- **NMS-free by design**: YOLO26 is [end-to-end](https://www.ultralytics.com/glossary/non-maximum-suppression-nms), so the exported graph needs no NMS pipeline and decode is sub-millisecond. Older models like YOLO11 can embed a CoreML NMS pipeline with `nms=True`.
 - **Private and offline**: All computation stays on the device — no cloud round-trips, no API keys, full [data privacy](https://www.ultralytics.com/glossary/data-privacy).
 - **One export, the whole ecosystem**: The same `.mlpackage` runs on iOS, iPadOS, macOS, watchOS, tvOS, and visionOS, and powers the official Ultralytics [iOS SDK](https://github.com/ultralytics/yolo-ios-app) and [Flutter plugin](https://github.com/ultralytics/yolo-flutter-app).
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR makes a small documentation fix by correcting the glossary link for NMS in the CoreML integration guide.

### 📊 Key Changes
- Updated the **NMS glossary link** in `docs/en/integrations/coreml.md`
- Replaced an incorrect/older URL with the correct descriptive link for **Non-Maximum Suppression (NMS)**
- No code, model, or export behavior changes were introduced

### 🎯 Purpose & Impact
- Improves 📚 **documentation accuracy** so readers land on the correct glossary page
- Makes the CoreML export guide a bit more polished and easier to follow for new users
- Has **no impact on functionality**: YOLO26 CoreML export behavior remains unchanged
- Helps reduce confusion around the “NMS-free” explanation for YOLO26 ✅