### PR TITLE
Fix region argument type and default in solutions docs tables

### DIFF
--- a/docs/macros/solutions-args.md
+++ b/docs/macros/solutions-args.md
@@ -3,7 +3,7 @@
 | -------- | ---- | ------- | ----------- |
 {% set default_params = {
     "model": ["str", "None", "Path to an Ultralytics YOLO model file."],
-    "region": ["list", "'[(20, 400), (1260, 400)]'", "List of points defining the counting region."],
+    "region": ["list` or `dict", "None", "Points defining the region of interest, either a list of `(x, y)` tuples or a dictionary mapping region names to point lists for multiple regions (`RegionCounter` only). When `None`, solutions that require a region fall back to a predefined default."],
     "show_in": ["bool", "True", "Flag to control whether to display the in counts on the video stream."],
     "show_out": ["bool", "True", "Flag to control whether to display the out counts on the video stream."],
     "analytics_type": ["str", "'line'", "Type of graph, i.e., `line`, `bar`, `area`, or `pie`."],


### PR DESCRIPTION
## summary

the shared solutions-args macro documented the `region` argument as type `list` with default `'[(20, 400), (1260, 400)]'`, but `SolutionConfig.region` defaults to `None` and `RegionCounter` also accepts a dictionary of named regions. the row now shows `list` or `dict` with default `None` and explains the fallback behavior, so all eight pages rendering this table match the package.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the Solutions documentation to clarify how the `region` argument works, especially for multi-region counting with `RegionCounter`.

### 📊 Key Changes
- Updated the `region` parameter description in `docs/macros/solutions-args.md`.
- Changed the documented default for `region` from a fixed point list to `None`.
- Expanded the accepted types for `region` from just a `list` to `list` or `dict`.
- Clarified that `region` can now represent:
  - a single region as a list of `(x, y)` points
  - multiple named regions as a dictionary of point lists for `RegionCounter`
- Added documentation that, when `region=None`, solutions that need a region will use a predefined default.

### 🎯 Purpose & Impact
- Improves documentation accuracy 📚 by matching current solution behavior more closely.
- Makes multi-region support easier to understand for users working with `RegionCounter` 🗂️.
- Reduces confusion around defaults and expected input formats ✅.
- Helps developers and users configure counting regions more confidently, especially in more advanced analytics workflows 🚀