### PR TITLE
Fix stale region counts on empty frames in RegionCounter

### DIFF
--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -103,6 +103,7 @@ class RegionCounter(BaseSolution):
         """
         self.extract_tracks(im0)
         annotator = SolutionAnnotator(im0, line_width=self.line_width)
+        self.region_counts = {region["name"]: 0 for region in self.counting_regions}
 
         for box, cls, track_id, conf in zip(self.boxes, self.clss, self.track_ids, self.confs):
             annotator.box_label(box, label=self.adjust_box_label(cls, conf, track_id), color=colors(track_id, True))


### PR DESCRIPTION
## summary

resets `region_counts` at the start of every `process()` call so the returned counts reflect the current frame's occupancy. previously the dict was only written when an object was inside a region, so after a frame with hits every later empty frame kept returning the old counts while the drawn label correctly showed 0. each named region now always appears in `region_counts`, with 0 when empty.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR fixes `RegionCounter` so region totals are reset at the start of each frame, preventing counts from incorrectly carrying over between frames.

### 📊 Key Changes
- Added a reset step in `ultralytics/solutions/region_counter.py` inside `process()`.
- `self.region_counts` is now reinitialized for all configured counting regions before processing detections in each frame.
- This ensures each frame starts with a clean count state based on the defined region names.

### 🎯 Purpose & Impact
- ✅ Prevents stale counts from previous frames from accumulating incorrectly.
- 📈 Improves accuracy and reliability of region-based counting results in videos and streams.
- 🛠️ Makes `RegionCounter` behavior more predictable for developers and end users.
- 🎥 Especially helpful for real-time analytics workflows where per-frame region counts need to reflect the current scene only.