### PR TITLE
Fix docs content rendering as raw code blocks

### DIFF
--- a/docs/en/guides/nvidia-dali.md
+++ b/docs/en/guides/nvidia-dali.md
@@ -499,7 +499,7 @@ ensemble_scheduling {
 
 ### Step 4: Send Inference Requests
 
-!!! info "Why `tritonclient` instead of `YOLO(\"http://...\")`?"
+!!! info "Why `tritonclient` instead of `YOLO('http://...')`?"
 
     Ultralytics has [built-in Triton support](triton-inference-server.md#running-inference) that handles pre/postprocessing automatically. However, it won't work with the DALI ensemble because `YOLO()` sends a preprocessed float32 tensor while the ensemble expects raw JPEG bytes. Use `tritonclient` directly for DALI ensembles, and the [built-in integration](triton-inference-server.md) for standard deployments without DALI.
 

--- a/docs/en/yolov5/index.md
+++ b/docs/en/yolov5/index.md
@@ -10,7 +10,6 @@ keywords: YOLOv5, Ultralytics, object detection, computer vision, deep learning,
       <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-yolov5-splash.avif" alt="Ultralytics YOLOv5 v7.0 banner">
     </a>
   </p>
-
     <a href="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml/badge.svg" alt="Ultralytics CI"></a>
     <a href="https://clickpy.clickhouse.com/dashboard/ultralytics"><img src="https://static.pepy.tech/badge/ultralytics" alt="Ultralytics Downloads"></a>
     <a href="https://discord.com/invite/ultralytics"><img alt="Ultralytics Discord" src="https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue"></a>
@@ -21,7 +20,6 @@ keywords: YOLOv5, Ultralytics, object detection, computer vision, deep learning,
     <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open Ultralytics In Colab"></a>
     <a href="https://www.kaggle.com/models/ultralytics/yolo26"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open Ultralytics In Kaggle"></a>
     <a href="https://mybinder.org/v2/gh/ultralytics/ultralytics/HEAD?labpath=examples%2Ftutorial.ipynb"><img src="https://mybinder.org/badge_logo.svg" alt="Open Ultralytics In Binder"></a>
-
 </div>
 
 # Comprehensive Guide to Ultralytics YOLOv5


### PR DESCRIPTION
## summary

two docs pages render content as raw code blocks instead of formatted output. on https://docs.ultralytics.com/yolov5/ the badge row under the banner shows escaped html: a blank line inside the `<div align="center">` block ends the raw html block per commonmark, turning the 4-space-indented badge anchors into an indented code block. on https://docs.ultralytics.com/guides/nvidia-dali/ the `tritonclient` info admonition shows as a code box with unrendered links: escaped quotes in the admonition title prevent the title from being parsed, so the admonition is not recognized and its indented body becomes a code block. removing the blank lines and switching the inner quotes to single quotes restores rendering on both pages.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small documentation cleanups in the Ultralytics repo, improving formatting consistency and clarifying a Triton + NVIDIA DALI usage note.

### 📊 Key Changes
- Fixed a documentation example in the [NVIDIA DALI guide](https://docs.ultralytics.com/guides/nvidia-dali/) by changing `YOLO("http://...")` to `YOLO('http://...')` for cleaner, consistent code-style formatting.
- Kept the important note explaining why `tritonclient` should be used instead of direct `YOLO()` HTTP inference when working with DALI ensembles.
- Removed extra blank lines in the [YOLOv5 documentation index](https://docs.ultralytics.com/models/yolov5/) to improve Markdown formatting and page cleanliness.

### 🎯 Purpose & Impact
- Improves documentation readability and consistency 📚
- Reduces minor confusion for users following Triton and DALI deployment instructions 🚀
- Helps keep Ultralytics docs polished and easier to maintain over time 🛠️
- No code, model, or runtime behavior changes are introduced; impact is limited to documentation quality ✅