### PR TITLE
Add opt-in weights_only model loading via ULTRALYTICS_SAFE_LOAD

### DIFF
--- a/docs/en/reference/nn/tasks.md
+++ b/docs/en/reference/nn/tasks.md
@@ -79,7 +79,7 @@ keywords: Ultralytics, YOLO, nn tasks, DetectionModel, PoseModel, RTDETRDetectio
 
 <br><br><hr><br>
 
-## ::: ultralytics.nn.tasks._register_safe_globals
+## ::: ultralytics.nn.tasks._safe_globals_context
 
 <br><br><hr><br>
 

--- a/docs/en/reference/nn/tasks.md
+++ b/docs/en/reference/nn/tasks.md
@@ -59,19 +59,23 @@ keywords: Ultralytics, YOLO, nn tasks, DetectionModel, PoseModel, RTDETRDetectio
 
 <br><br><hr><br>
 
-## ::: ultralytics.nn.tasks.SafeClass
-
-<br><br><hr><br>
-
-## ::: ultralytics.nn.tasks.SafeUnpickler
-
-<br><br><hr><br>
-
 ## ::: ultralytics.nn.tasks._initialize_yolo_model
 
 <br><br><hr><br>
 
 ## ::: ultralytics.nn.tasks.temporary_modules
+
+<br><br><hr><br>
+
+## ::: ultralytics.nn.tasks._build_safe_globals
+
+<br><br><hr><br>
+
+## ::: ultralytics.nn.tasks._register_safe_globals
+
+<br><br><hr><br>
+
+## ::: ultralytics.nn.tasks._safe_activation
 
 <br><br><hr><br>
 

--- a/docs/en/reference/nn/tasks.md
+++ b/docs/en/reference/nn/tasks.md
@@ -59,31 +59,15 @@ keywords: Ultralytics, YOLO, nn tasks, DetectionModel, PoseModel, RTDETRDetectio
 
 <br><br><hr><br>
 
+## ::: ultralytics.nn.tasks._SafeLoad
+
+<br><br><hr><br>
+
 ## ::: ultralytics.nn.tasks._initialize_yolo_model
 
 <br><br><hr><br>
 
 ## ::: ultralytics.nn.tasks.temporary_modules
-
-<br><br><hr><br>
-
-## ::: ultralytics.nn.tasks._is_restricted
-
-<br><br><hr><br>
-
-## ::: ultralytics.nn.tasks._has_unreviewed_hook
-
-<br><br><hr><br>
-
-## ::: ultralytics.nn.tasks._build_safe_globals
-
-<br><br><hr><br>
-
-## ::: ultralytics.nn.tasks._safe_globals_context
-
-<br><br><hr><br>
-
-## ::: ultralytics.nn.tasks._safe_activation
 
 <br><br><hr><br>
 

--- a/docs/en/reference/nn/tasks.md
+++ b/docs/en/reference/nn/tasks.md
@@ -67,6 +67,14 @@ keywords: Ultralytics, YOLO, nn tasks, DetectionModel, PoseModel, RTDETRDetectio
 
 <br><br><hr><br>
 
+## ::: ultralytics.nn.tasks._is_restricted
+
+<br><br><hr><br>
+
+## ::: ultralytics.nn.tasks._has_unreviewed_hook
+
+<br><br><hr><br>
+
 ## ::: ultralytics.nn.tasks._build_safe_globals
 
 <br><br><hr><br>

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.66"
+__version__ = "8.4.67"
 
 import importlib
 import os

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -3,6 +3,7 @@
 import contextlib
 import pickle
 import re
+import threading
 from copy import deepcopy
 from pathlib import Path
 
@@ -1454,6 +1455,34 @@ def temporary_modules(modules=None, attributes=None):
 # so a newly added one fails loudly here and gets reviewed before it is trusted under restricted (weights_only) loading.
 _REVIEWED_STATEFUL = frozenset({"AAttn"})  # block.AAttn.__setstate__ backfills the all_head_dim attribute
 _SAFE_GLOBALS_REGISTERED = False
+_STATE_HOOKS = ("__reduce__", "__reduce_ex__", "__setstate__", "__getstate__", "__new__")
+_LOAD_STATE = threading.local()  # per-thread flag set while a weights_only load is in progress
+
+
+def _is_restricted():
+    """Whether model construction should use the restricted (no-eval, known-modules-only) path.
+
+    True when the `ULTRALYTICS_SAFE_LOAD` env flag is set, or while a `safe_only` `torch_safe_load` is running on this
+    thread. `parse_model` consults this so model construction uses the no-eval, known-layer path whether restricted
+    loading was requested via the env flag or the `safe_only` argument.
+    """
+    return SAFE_LOAD or getattr(_LOAD_STATE, "restricted", False)
+
+
+def _has_unreviewed_hook(cls):
+    """Whether `cls`'s effective pickle hook is implemented outside torch/builtins and `cls` is not in the reviewed set.
+
+    Walks the MRO so a hook inherited from a non-torch base (not just one defined directly on `cls`) is caught.
+    """
+    if cls.__name__ in _REVIEWED_STATEFUL:
+        return False
+    for hook in _STATE_HOOKS:
+        for base in cls.__mro__:
+            if hook in vars(base):
+                if not (base.__module__ == "builtins" or base.__module__.startswith("torch")):
+                    return True  # hook provided by a non-torch class (e.g. ultralytics or third-party) — needs review
+                break  # most-derived definition is a benign torch/builtins one
+    return False
 
 
 def _build_safe_globals():
@@ -1477,7 +1506,6 @@ def _build_safe_globals():
     import ultralytics.nn.modules as ul_nn
     import ultralytics.nn.tasks as ul_tasks
 
-    hooks = ("__reduce__", "__reduce_ex__", "__setstate__", "__getstate__", "__new__")
     allow = []
 
     def _scan(pkg, owned):
@@ -1492,12 +1520,11 @@ def _build_safe_globals():
             for name, cls in inspect.getmembers(mod, inspect.isclass):
                 if not issubclass(cls, nn.Module):
                     continue
-                if owned and cls.__module__.startswith("ultralytics.") and set(hooks) & set(vars(cls)):
-                    if cls.__name__ not in _REVIEWED_STATEFUL:
-                        raise pickle.UnpicklingError(
-                            f"Refusing to trust {cls.__module__}.{cls.__qualname__}: it defines a pickle state-hook "
-                            f"that is not in _REVIEWED_STATEFUL. Review it for safety, then add its name there."
-                        )
+                if owned and cls.__module__.startswith("ultralytics.") and _has_unreviewed_hook(cls):
+                    raise pickle.UnpicklingError(
+                        f"Refusing to trust {cls.__module__}.{cls.__qualname__}: it has a pickle state-hook that is "
+                        f"not in _REVIEWED_STATEFUL. Review it for safety, then add its name there."
+                    )
                 # Register under the path the class is reachable from here — matches how a checkpoint pickled it.
                 allow.append((cls, f"{mod.__name__}.{name}"))
 
@@ -1560,8 +1587,8 @@ def _safe_activation(act):
             attrs.append(node.attr)
             node = node.value
         assert isinstance(node, ast.Name)
-        attrs.append(node.id)
-        assert "nn" in attrs, "activation must be a torch.nn class"
+        attrs.append(node.id)  # e.g. ["SiLU", "nn"] or ["SiLU", "nn", "torch"]
+        assert attrs[1:] in (["nn"], ["nn", "torch"]), "activation must be a torch.nn class"
         cls = getattr(nn, attrs[0])
         assert isinstance(cls, type) and issubclass(cls, nn.Module)
         args = [ast.literal_eval(a) for a in call.args]
@@ -1617,9 +1644,14 @@ def torch_safe_load(weight, safe_only=None):
             },
         ):
             if safe_only:
-                # weights_only load: reconstruct only the allow-listed known model classes.
+                # weights_only load: reconstruct only the allow-listed known model classes. Flag the load so that if a
+                # checkpoint reaches model construction (parse_model), it uses the no-eval/known-modules path too.
                 _register_safe_globals()
-                return torch_load(file, map_location="cpu", weights_only=True)
+                _LOAD_STATE.restricted = True
+                try:
+                    return torch_load(file, map_location="cpu", weights_only=True)
+                finally:
+                    _LOAD_STATE.restricted = False
             return torch_load(file, map_location="cpu")
 
     try:
@@ -1761,10 +1793,11 @@ def parse_model(d, ch, verbose=True):
             LOGGER.warning(f"no model scale passed. Assuming scale='{scale}'.")
         depth, width, max_channels = scales[scale]
 
+    restricted = _is_restricted()
     if act:
-        # redefine default activation, i.e. Conv.default_act = torch.nn.SiLU(). Under weights_only loading, resolve
-        # the spec without eval() (see _safe_activation).
-        Conv.default_act = _safe_activation(act) if SAFE_LOAD else eval(act)
+        # redefine default activation, i.e. Conv.default_act = torch.nn.SiLU(). Under restricted loading, resolve the
+        # spec without eval() (see _safe_activation).
+        Conv.default_act = _safe_activation(act) if restricted else eval(act)
         if verbose:
             LOGGER.info(f"{colorstr('activation:')} {act}")  # print
 
@@ -1837,6 +1870,9 @@ def parse_model(d, ch, verbose=True):
             if "torchvision.ops." in m
             else globals()[m]
         )  # get module
+        if restricted and not (isinstance(m, type) and issubclass(m, torch.nn.Module)):
+            # Under restricted loading, only known model layers may be named here.
+            raise TypeError(emojis(f"ERROR ❌️ module '{m}' is not a permitted model layer under restricted loading."))
         for j, a in enumerate(args):
             if isinstance(a, str):
                 with contextlib.suppress(ValueError):

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1507,13 +1507,15 @@ class _SafeLoad:
             kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in call.keywords}
             return klass(*args, **kwargs)
         except Exception as e:
-            raise TypeError(emojis(f"ERROR ❌️ unsupported activation '{act}' blocked during restricted model load.")) from e
+            raise TypeError(
+                emojis(f"ERROR ❌️ unsupported activation '{act}' blocked during restricted model load.")
+            ) from e
 
     @classmethod
     def _build(cls):
         """Auto-discover `nn.Module` subclasses across `torch.nn` and the ultralytics model families, registered under
-        every namespace path they are reachable from (covering re-exports such as `block.RealNVP` as `head.RealNVP`),
-        plus torchvision transforms and legacy aliases.
+        every namespace path they are reachable from (covering re-exports such as `block.RealNVP` as
+        `head.RealNVP`), plus torchvision transforms and legacy aliases.
 
         Returns:
             (list): Items for `torch.serialization.safe_globals` — classes and `(obj, "module.Name")` aliases.

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1450,157 +1450,154 @@ def temporary_modules(modules=None, attributes=None):
                 del sys.modules[old]
 
 
-# Fully-qualified names of ultralytics nn.Module subclasses that legitimately define a pickle state-hook, reviewed as
-# benign attribute restorers (qualified so a same-named class elsewhere is not implicitly trusted). _build_safe_globals()
-# refuses any OTHER ultralytics class carrying a state-hook, so a new one fails loudly and is reviewed before it is
-# trusted under restricted (weights_only) loading. block.AAttn.__setstate__ backfills the all_head_dim attribute.
-_REVIEWED_STATEFUL = frozenset({"ultralytics.nn.modules.block.AAttn"})
-_STATE_HOOKS = ("__reduce__", "__reduce_ex__", "__setstate__", "__getstate__", "__new__")
-_SAFE_GLOBALS = None  # cached allow-list, built once
-_LOAD_STATE = threading.local()  # per-thread flag set while a weights_only load is in progress
+class _SafeLoad:
+    """Opt-in restricted checkpoint loading: reconstruct only known model classes (`weights_only=True` plus an
+    allow-list) and build models without `eval()`.
 
-
-def _is_restricted():
-    """Whether model construction should use the restricted (no-eval, known-modules-only) path.
-
-    True when the `ULTRALYTICS_SAFE_LOAD` env flag is set, or while a `safe_only` `torch_safe_load` is running on this
-    thread. `parse_model` consults this so model construction uses the no-eval, known-layer path whether restricted
-    loading was requested via the env flag or the `safe_only` argument.
+    Enabled per-process by the `ULTRALYTICS_SAFE_LOAD` env flag, or per-call by `torch_safe_load(..., safe_only=True)`.
+    Default loading (flag off) is unchanged.
     """
-    return SAFE_LOAD or getattr(_LOAD_STATE, "restricted", False)
 
+    # Fully-qualified ultralytics nn.Module subclasses that legitimately define a pickle state-hook, reviewed as benign
+    # attribute restorers (qualified so a same-named class elsewhere is not implicitly trusted). Any OTHER ultralytics
+    # class with a state-hook fails loudly and must be reviewed here. block.AAttn.__setstate__ backfills all_head_dim.
+    REVIEWED_STATEFUL = frozenset({"ultralytics.nn.modules.block.AAttn"})
+    _HOOKS = ("__reduce__", "__reduce_ex__", "__setstate__", "__getstate__", "__new__")
+    _globals = None  # cached allow-list, built once
+    _local = threading.local()  # per-thread flag set while a weights_only load is in progress
 
-def _has_unreviewed_hook(cls):
-    """Whether `cls`'s effective pickle hook is implemented outside torch/builtins and `cls` is not in the reviewed set.
+    @classmethod
+    def restricted(cls):
+        """Whether model construction should use the no-eval, known-layer path (env flag or an in-progress load)."""
+        return SAFE_LOAD or getattr(cls._local, "active", False)
 
-    Walks the MRO so a hook inherited from a non-torch base (not just one defined directly on `cls`) is caught.
-    """
-    if f"{cls.__module__}.{cls.__qualname__}" in _REVIEWED_STATEFUL:
+    @classmethod
+    @contextlib.contextmanager
+    def loading(cls):
+        """Load with `weights_only=True`: scope the allow-list to this load and mark the thread restricted, so a
+        checkpoint that reaches model construction (parse_model) also uses the no-eval, known-layer path.
+        """
+        if cls._globals is None:
+            cls._globals = cls._build()
+        cls._local.active = True
+        try:
+            with torch.serialization.safe_globals(cls._globals):
+                yield
+        finally:
+            cls._local.active = False
+
+    @staticmethod
+    def activation(act):
+        """Resolve a model-yaml `activation` spec to a `torch.nn` module instance without `eval()`.
+
+        Accepts only the documented `[torch.]nn.<Class>(literal args)` shape (e.g. `nn.SiLU()`,
+        `torch.nn.LeakyReLU(0.1)`) with literal arguments, and rejects anything else.
+        """
+        import ast
+
+        try:
+            call = ast.parse(act.strip(), mode="eval").body
+            assert isinstance(call, ast.Call)
+            attrs = []
+            node = call.func
+            while isinstance(node, ast.Attribute):  # unwind e.g. torch.nn.SiLU -> ["SiLU","nn","torch"]
+                attrs.append(node.attr)
+                node = node.value
+            assert isinstance(node, ast.Name)
+            attrs.append(node.id)  # e.g. ["SiLU", "nn"] or ["SiLU", "nn", "torch"]
+            assert attrs[1:] in (["nn"], ["nn", "torch"]), "activation must be a torch.nn class"
+            klass = getattr(nn, attrs[0])
+            assert isinstance(klass, type) and issubclass(klass, nn.Module)
+            args = [ast.literal_eval(a) for a in call.args]
+            kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in call.keywords}
+            return klass(*args, **kwargs)
+        except Exception as e:
+            raise TypeError(emojis(f"ERROR ❌️ unsupported activation '{act}' blocked during restricted model load.")) from e
+
+    @classmethod
+    def _unreviewed(cls, klass):
+        """Whether `klass`'s effective pickle hook is implemented outside torch/builtins and it is not reviewed.
+
+        Walks the MRO so a hook inherited from a non-torch base (not just one defined directly on `klass`) is caught.
+        """
+        if f"{klass.__module__}.{klass.__qualname__}" in cls.REVIEWED_STATEFUL:
+            return False
+        for hook in cls._HOOKS:
+            for base in klass.__mro__:
+                if hook in vars(base):
+                    if not (base.__module__ == "builtins" or base.__module__.startswith("torch")):
+                        return True  # hook provided by a non-torch class (e.g. ultralytics or third-party) — review it
+                    break  # most-derived definition is a benign torch/builtins one
         return False
-    for hook in _STATE_HOOKS:
-        for base in cls.__mro__:
-            if hook in vars(base):
-                if not (base.__module__ == "builtins" or base.__module__.startswith("torch")):
-                    return True  # hook provided by a non-torch class (e.g. ultralytics or third-party) — needs review
-                break  # most-derived definition is a benign torch/builtins one
-    return False
 
+    @classmethod
+    def _build(cls):
+        """Auto-discover `nn.Module` subclasses across `torch.nn` and the ultralytics model families, registered under
+        every namespace path they are reachable from (covering re-exports such as `block.RealNVP` as `head.RealNVP`),
+        plus torchvision transforms and legacy aliases. An ultralytics class with an unreviewed pickle state-hook raises
+        so it is audited before being trusted.
 
-def _build_safe_globals():
-    """Build the allow-list of globals trusted by the restricted (`weights_only=True`) checkpoint loader.
+        Returns:
+            (list): Items for `torch.serialization.safe_globals` — classes and `(obj, "module.Name")` aliases.
+        """
+        import importlib
+        import inspect
+        import pathlib
+        import pkgutil
 
-    Auto-discovers `nn.Module` subclasses across `torch.nn` and the Ultralytics model families so new architectures
-    need no manual maintenance, registering each under every namespace path it is reachable from (covering re-exports
-    such as `block.RealNVP` re-exported as `head.RealNVP`). Ultralytics-owned classes that define a pickle state-hook
-    must be reviewed via `_REVIEWED_STATEFUL`; an unreviewed one raises so it is audited before being trusted.
+        import torch.nn.modules as torch_nn
 
-    Returns:
-        (list): Items for `torch.serialization.add_safe_globals` — classes and `(obj, "module.Name")` aliases.
-    """
-    import importlib
-    import inspect
-    import pathlib
-    import pkgutil
+        import ultralytics.nn.modules as ul_nn
+        import ultralytics.nn.tasks as ul_tasks
 
-    import torch.nn.modules as torch_nn
+        allow = []
 
-    import ultralytics.nn.modules as ul_nn
-    import ultralytics.nn.tasks as ul_tasks
+        def _scan(pkg, owned):
+            mods = [pkg]
+            if hasattr(pkg, "__path__"):  # package: include all submodules
+                for info in pkgutil.iter_modules(pkg.__path__, f"{pkg.__name__}."):
+                    try:
+                        mods.append(importlib.import_module(info.name))
+                    except Exception:  # optional/oddball submodule — skip
+                        continue
+            for mod in mods:
+                for name, klass in inspect.getmembers(mod, inspect.isclass):
+                    if not issubclass(klass, nn.Module):
+                        continue
+                    if owned and klass.__module__.startswith("ultralytics.") and cls._unreviewed(klass):
+                        raise pickle.UnpicklingError(
+                            f"Refusing to trust {klass.__module__}.{klass.__qualname__}: it has a pickle state-hook "
+                            f"not in REVIEWED_STATEFUL. Review it for safety, then add its name there."
+                        )
+                    # Register under the path the class is reachable from here — matches how a checkpoint pickled it.
+                    allow.append((klass, f"{mod.__name__}.{name}"))
 
-    allow = []
+        _scan(torch_nn, owned=False)  # PyTorch classes (trusted; their state-hooks are benign backward-compat restorers)
+        _scan(ul_nn, owned=True)  # ultralytics block/conv/head/transformer
+        _scan(ul_tasks, owned=True)  # ultralytics task models
 
-    def _scan(pkg, owned):
-        mods = [pkg]
-        if hasattr(pkg, "__path__"):  # package: include all submodules
-            for info in pkgutil.iter_modules(pkg.__path__, f"{pkg.__name__}."):
-                try:
-                    mods.append(importlib.import_module(info.name))
-                except Exception:  # optional/oddball submodule — skip
-                    continue
-        for mod in mods:
-            for name, cls in inspect.getmembers(mod, inspect.isclass):
-                if not issubclass(cls, nn.Module):
-                    continue
-                if owned and cls.__module__.startswith("ultralytics.") and _has_unreviewed_hook(cls):
-                    raise pickle.UnpicklingError(
-                        f"Refusing to trust {cls.__module__}.{cls.__qualname__}: it has a pickle state-hook that is "
-                        f"not in _REVIEWED_STATEFUL. Review it for safety, then add its name there."
-                    )
-                # Register under the path the class is reachable from here — matches how a checkpoint pickled it.
-                allow.append((cls, f"{mod.__name__}.{name}"))
+        # Non-nn.Module data globals in official checkpoints (classification preprocessing transforms).
+        try:
+            import torchvision.transforms.transforms as tvt
+            from torchvision.transforms.functional import InterpolationMode
 
-    _scan(torch_nn, owned=False)  # PyTorch classes (trusted; their state-hooks are benign backward-compat restorers)
-    _scan(ul_nn, owned=True)  # ultralytics block/conv/head/transformer
-    _scan(ul_tasks, owned=True)  # ultralytics task models
+            allow += [tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode]
+        except ImportError:
+            pass
 
-    # Non-nn.Module data globals that appear in official checkpoints (classification preprocessing transforms).
-    try:
-        import torchvision.transforms.transforms as tvt
-        from torchvision.transforms.functional import InterpolationMode
+        # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
+        from ultralytics.utils.loss import E2EDetectLoss
 
-        allow += [tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode]
-    except ImportError:
-        pass
-
-    # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
-    from ultralytics.utils.loss import E2EDetectLoss
-
-    allow += [
-        (nn.Identity, "ultralytics.nn.modules.block.Silence"),  # YOLOv9e
-        (DetectionModel, "ultralytics.nn.tasks.YOLOv10DetectionModel"),  # YOLOv10
-        (E2EDetectLoss, "ultralytics.utils.loss.v10DetectLoss"),  # YOLOv10
-    ]
-    if WINDOWS:
-        allow += [pathlib.WindowsPath, (pathlib.WindowsPath, "pathlib.PosixPath")]
-    else:
-        allow += [pathlib.PosixPath, (pathlib.PosixPath, "pathlib.WindowsPath")]
-    return allow
-
-
-def _safe_globals_context():
-    """Return a `torch.serialization.safe_globals` context manager scoped to the restricted-load allow-list.
-
-    Built once and cached. Scoping to a context manager (rather than `add_safe_globals`) keeps the allow-list active
-    only for the duration of this load, not permanently across the process.
-    """
-    global _SAFE_GLOBALS
-    if _SAFE_GLOBALS is None:
-        _SAFE_GLOBALS = _build_safe_globals()
-    return torch.serialization.safe_globals(_SAFE_GLOBALS)
-
-
-def _safe_activation(act):
-    """Resolve a model-yaml `activation` spec to a `torch.nn` module instance without `eval()`.
-
-    Used under `weights_only` loading. Accepts only the documented `[torch.]nn.<Class>(literal args)` shape
-    (e.g. `nn.SiLU()`, `torch.nn.LeakyReLU(0.1)`) with literal arguments, and rejects anything else.
-
-    Args:
-        act (str): Activation spec from the model yaml.
-
-    Returns:
-        (torch.nn.Module): The instantiated activation.
-    """
-    import ast
-
-    try:
-        call = ast.parse(act.strip(), mode="eval").body
-        assert isinstance(call, ast.Call)
-        attrs = []
-        node = call.func
-        while isinstance(node, ast.Attribute):  # unwind e.g. torch.nn.SiLU -> ["SiLU","nn","torch"]
-            attrs.append(node.attr)
-            node = node.value
-        assert isinstance(node, ast.Name)
-        attrs.append(node.id)  # e.g. ["SiLU", "nn"] or ["SiLU", "nn", "torch"]
-        assert attrs[1:] in (["nn"], ["nn", "torch"]), "activation must be a torch.nn class"
-        cls = getattr(nn, attrs[0])
-        assert isinstance(cls, type) and issubclass(cls, nn.Module)
-        args = [ast.literal_eval(a) for a in call.args]
-        kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in call.keywords}
-        return cls(*args, **kwargs)
-    except Exception as e:
-        raise TypeError(emojis(f"ERROR ❌️ unsupported activation '{act}' blocked during restricted model load.")) from e
+        allow += [
+            (nn.Identity, "ultralytics.nn.modules.block.Silence"),  # YOLOv9e
+            (DetectionModel, "ultralytics.nn.tasks.YOLOv10DetectionModel"),  # YOLOv10
+            (E2EDetectLoss, "ultralytics.utils.loss.v10DetectLoss"),  # YOLOv10
+        ]
+        if WINDOWS:
+            allow += [pathlib.WindowsPath, (pathlib.WindowsPath, "pathlib.PosixPath")]
+        else:
+            allow += [pathlib.PosixPath, (pathlib.PosixPath, "pathlib.WindowsPath")]
+        return allow
 
 
 def torch_safe_load(weight, safe_only=None):
@@ -1649,15 +1646,8 @@ def torch_safe_load(weight, safe_only=None):
             },
         ):
             if safe_only:
-                # weights_only load: reconstruct only the allow-listed known model classes (scoped to this load). Flag
-                # the load so that if a checkpoint reaches model construction (parse_model), it uses the no-eval and
-                # known-modules path too.
-                _LOAD_STATE.restricted = True
-                try:
-                    with _safe_globals_context():
-                        return torch_load(file, map_location="cpu", weights_only=True)
-                finally:
-                    _LOAD_STATE.restricted = False
+                with _SafeLoad.loading():  # weights_only load scoped to the known-class allow-list
+                    return torch_load(file, map_location="cpu", weights_only=True)
             return torch_load(file, map_location="cpu")
 
     try:
@@ -1799,11 +1789,11 @@ def parse_model(d, ch, verbose=True):
             LOGGER.warning(f"no model scale passed. Assuming scale='{scale}'.")
         depth, width, max_channels = scales[scale]
 
-    restricted = _is_restricted()
+    restricted = _SafeLoad.restricted()
     if act:
         # redefine default activation, i.e. Conv.default_act = torch.nn.SiLU(). Under restricted loading, resolve the
-        # spec without eval() (see _safe_activation).
-        Conv.default_act = _safe_activation(act) if restricted else eval(act)
+        # spec without eval() (see _SafeLoad.activation).
+        Conv.default_act = _SafeLoad.activation(act) if restricted else eval(act)
         if verbose:
             LOGGER.info(f"{colorstr('activation:')} {act}")  # print
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -3,7 +3,6 @@
 import contextlib
 import pickle
 import re
-import types
 from copy import deepcopy
 from pathlib import Path
 
@@ -74,7 +73,7 @@ from ultralytics.nn.modules import (
     YOLOESegment26,
     v10Detect,
 )
-from ultralytics.utils import DEFAULT_CFG_DICT, LOGGER, SETTINGS, WINDOWS, YAML, colorstr, emojis
+from ultralytics.utils import DEFAULT_CFG_DICT, LOGGER, SAFE_LOAD, SETTINGS, WINDOWS, YAML, colorstr, emojis
 from ultralytics.utils.checks import REMOTE_FILE_PREFIXES, check_file, check_requirements, check_suffix, check_yaml
 from ultralytics.utils.loss import (
     E2ELoss,
@@ -1450,54 +1449,138 @@ def temporary_modules(modules=None, attributes=None):
                 del sys.modules[old]
 
 
-class SafeClass:
-    """A placeholder class to replace unknown classes during unpickling."""
+# Ultralytics-family nn.Module subclasses that legitimately define a pickle state-hook (__setstate__ etc.), reviewed as
+# benign attribute restorers. _build_safe_globals() refuses to trust any OTHER ultralytics class carrying a state-hook,
+# so a newly added one fails loudly here and gets reviewed before it is trusted under restricted (weights_only) loading.
+_REVIEWED_STATEFUL = frozenset({"AAttn"})  # block.AAttn.__setstate__ backfills the all_head_dim attribute
+_SAFE_GLOBALS_REGISTERED = False
 
-    def __init__(self, *args, **kwargs):
-        """Initialize SafeClass instance, ignoring all arguments."""
+
+def _build_safe_globals():
+    """Build the allow-list of globals trusted by the restricted (`weights_only=True`) checkpoint loader.
+
+    Auto-discovers `nn.Module` subclasses across `torch.nn` and the Ultralytics model families so new architectures
+    need no manual maintenance, registering each under every namespace path it is reachable from (covering re-exports
+    such as `block.RealNVP` re-exported as `head.RealNVP`). Ultralytics-owned classes that define a pickle state-hook
+    must be reviewed via `_REVIEWED_STATEFUL`; an unreviewed one raises so it is audited before being trusted.
+
+    Returns:
+        (list): Items for `torch.serialization.add_safe_globals` — classes and `(obj, "module.Name")` aliases.
+    """
+    import importlib
+    import inspect
+    import pathlib
+    import pkgutil
+
+    import torch.nn.modules as torch_nn
+
+    import ultralytics.nn.modules as ul_nn
+    import ultralytics.nn.tasks as ul_tasks
+
+    hooks = ("__reduce__", "__reduce_ex__", "__setstate__", "__getstate__", "__new__")
+    allow = []
+
+    def _scan(pkg, owned):
+        mods = [pkg]
+        if hasattr(pkg, "__path__"):  # package: include all submodules
+            for info in pkgutil.iter_modules(pkg.__path__, f"{pkg.__name__}."):
+                try:
+                    mods.append(importlib.import_module(info.name))
+                except Exception:  # optional/oddball submodule — skip
+                    continue
+        for mod in mods:
+            for name, cls in inspect.getmembers(mod, inspect.isclass):
+                if not issubclass(cls, nn.Module):
+                    continue
+                if owned and cls.__module__.startswith("ultralytics.") and set(hooks) & set(vars(cls)):
+                    if cls.__name__ not in _REVIEWED_STATEFUL:
+                        raise pickle.UnpicklingError(
+                            f"Refusing to trust {cls.__module__}.{cls.__qualname__}: it defines a pickle state-hook "
+                            f"that is not in _REVIEWED_STATEFUL. Review it for safety, then add its name there."
+                        )
+                # Register under the path the class is reachable from here — matches how a checkpoint pickled it.
+                allow.append((cls, f"{mod.__name__}.{name}"))
+
+    _scan(torch_nn, owned=False)  # PyTorch classes (trusted; their state-hooks are benign backward-compat restorers)
+    _scan(ul_nn, owned=True)  # ultralytics block/conv/head/transformer
+    _scan(ul_tasks, owned=True)  # ultralytics task models
+
+    # Non-nn.Module data globals that appear in official checkpoints (classification preprocessing transforms).
+    try:
+        import torchvision.transforms.transforms as tvt
+        from torchvision.transforms.functional import InterpolationMode
+
+        allow += [tvt.Compose, tvt.Normalize, tvt.Resize, tvt.CenterCrop, tvt.ToTensor, InterpolationMode]
+    except ImportError:
         pass
 
-    def __call__(self, *args, **kwargs):
-        """Run SafeClass instance, ignoring all arguments."""
-        pass
+    # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
+    from ultralytics.utils.loss import E2EDetectLoss
+
+    allow += [
+        (nn.Identity, "ultralytics.nn.modules.block.Silence"),  # YOLOv9e
+        (DetectionModel, "ultralytics.nn.tasks.YOLOv10DetectionModel"),  # YOLOv10
+        (E2EDetectLoss, "ultralytics.utils.loss.v10DetectLoss"),  # YOLOv10
+    ]
+    if WINDOWS:
+        allow += [pathlib.WindowsPath, (pathlib.WindowsPath, "pathlib.PosixPath")]
+    else:
+        allow += [pathlib.PosixPath, (pathlib.PosixPath, "pathlib.WindowsPath")]
+    return allow
 
 
-class SafeUnpickler(pickle.Unpickler):
-    """Custom Unpickler that replaces unknown classes with SafeClass."""
-
-    def find_class(self, module, name):
-        """Attempt to find a class, returning SafeClass if not among safe modules.
-
-        Args:
-            module (str): Module name.
-            name (str): Class name.
-
-        Returns:
-            (type): Found class or SafeClass.
-        """
-        safe_modules = (
-            "torch",
-            "collections",
-            "collections.abc",
-            "builtins",
-            "math",
-            "numpy",
-            # Add other modules considered safe
-        )
-        if module in safe_modules:
-            return super().find_class(module, name)
-        else:
-            return SafeClass
+def _register_safe_globals():
+    """Register the restricted-load allow-list with PyTorch once per process (idempotent)."""
+    global _SAFE_GLOBALS_REGISTERED
+    if not _SAFE_GLOBALS_REGISTERED:
+        torch.serialization.add_safe_globals(_build_safe_globals())
+        _SAFE_GLOBALS_REGISTERED = True
 
 
-def torch_safe_load(weight, safe_only=False):
+def _safe_activation(act):
+    """Resolve a model-yaml `activation` spec to a `torch.nn` module instance without `eval()`.
+
+    Used under `weights_only` loading. Accepts only the documented `[torch.]nn.<Class>(literal args)` shape
+    (e.g. `nn.SiLU()`, `torch.nn.LeakyReLU(0.1)`) with literal arguments, and rejects anything else.
+
+    Args:
+        act (str): Activation spec from the model yaml.
+
+    Returns:
+        (torch.nn.Module): The instantiated activation.
+    """
+    import ast
+
+    try:
+        call = ast.parse(act.strip(), mode="eval").body
+        assert isinstance(call, ast.Call)
+        attrs = []
+        node = call.func
+        while isinstance(node, ast.Attribute):  # unwind e.g. torch.nn.SiLU -> ["SiLU","nn","torch"]
+            attrs.append(node.attr)
+            node = node.value
+        assert isinstance(node, ast.Name)
+        attrs.append(node.id)
+        assert "nn" in attrs, "activation must be a torch.nn class"
+        cls = getattr(nn, attrs[0])
+        assert isinstance(cls, type) and issubclass(cls, nn.Module)
+        args = [ast.literal_eval(a) for a in call.args]
+        kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in call.keywords}
+        return cls(*args, **kwargs)
+    except Exception as e:
+        raise TypeError(emojis(f"ERROR ❌️ unsupported activation '{act}' blocked during restricted model load.")) from e
+
+
+def torch_safe_load(weight, safe_only=None):
     """Attempt to load a PyTorch model with the torch.load() function. If a ModuleNotFoundError is raised, it catches
     the error, logs a warning message, and attempts to install the missing module via the check_requirements()
     function. After installation, the function again attempts to load the model using torch.load().
 
     Args:
         weight (str | Path): The file path of the PyTorch model.
-        safe_only (bool): If True, replace unknown classes with SafeClass during loading.
+        safe_only (bool, optional): Load with `torch.load(weights_only=True)`, reconstructing only the known
+            Ultralytics/torch model classes on the allow-list. Defaults to the `ULTRALYTICS_SAFE_LOAD` environment
+            variable (off), so standard usage is unchanged; set the env to opt in.
 
     Returns:
         (dict): The loaded model checkpoint.
@@ -1509,6 +1592,8 @@ def torch_safe_load(weight, safe_only=False):
     """
     from ultralytics.utils.downloads import attempt_download_asset
 
+    if safe_only is None:
+        safe_only = SAFE_LOAD
     check_suffix(file=weight, suffix=".pt")
     file = attempt_download_asset(weight)  # search online if missing locally
 
@@ -1532,12 +1617,9 @@ def torch_safe_load(weight, safe_only=False):
             },
         ):
             if safe_only:
-                # Load via custom pickle module
-                safe_pickle = types.ModuleType("safe_pickle")
-                safe_pickle.Unpickler = SafeUnpickler
-                safe_pickle.load = lambda file_obj: SafeUnpickler(file_obj).load()
-                with open(file, "rb") as f:
-                    return torch_load(f, pickle_module=safe_pickle)
+                # weights_only load: reconstruct only the allow-listed known model classes.
+                _register_safe_globals()
+                return torch_load(file, map_location="cpu", weights_only=True)
             return torch_load(file, map_location="cpu")
 
     try:
@@ -1577,6 +1659,10 @@ def torch_safe_load(weight, safe_only=False):
                     "Ultralytics model, i.e. 'yolo predict model=yolo26n.pt'"
                 )
             ) from e
+        if safe_only:
+            # Under weights_only loading, do not auto-install a module named by the checkpoint or fall back to a
+            # weights_only=False reload.
+            raise
         LOGGER.warning(
             f"{weight} appears to require '{e.name}', which is not in Ultralytics requirements."
             f"\nAutoInstall will run now for '{e.name}' but this feature will be removed in the future."
@@ -1585,6 +1671,18 @@ def torch_safe_load(weight, safe_only=False):
         )
         check_requirements(e.name)  # install missing module
         ckpt = torch_load(file, map_location="cpu")
+
+    except pickle.UnpicklingError as e:
+        # weights_only=True encountered a global outside the allow-list. The default (weights_only=False) path can also
+        # raise this for a corrupt or legacy file, so re-raise verbatim there to preserve existing behavior.
+        if not safe_only:
+            raise
+        raise TypeError(
+            emojis(
+                f"ERROR ❌️ {weight} references types outside the supported Ultralytics checkpoint format. "
+                f"Use an official Ultralytics model, i.e. 'yolo predict model=yolo26n.pt'"
+            )
+        ) from e
 
     if not isinstance(ckpt, dict):
         # File is likely a YOLO instance saved with i.e. torch.save(model, "saved_model.pt")
@@ -1664,7 +1762,9 @@ def parse_model(d, ch, verbose=True):
         depth, width, max_channels = scales[scale]
 
     if act:
-        Conv.default_act = eval(act)  # redefine default activation, i.e. Conv.default_act = torch.nn.SiLU()
+        # redefine default activation, i.e. Conv.default_act = torch.nn.SiLU(). Under weights_only loading, resolve
+        # the spec without eval() (see _safe_activation).
+        Conv.default_act = _safe_activation(act) if SAFE_LOAD else eval(act)
         if verbose:
             LOGGER.info(f"{colorstr('activation:')} {act}")  # print
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1458,11 +1458,6 @@ class _SafeLoad:
     Default loading (flag off) is unchanged.
     """
 
-    # Fully-qualified ultralytics nn.Module subclasses that legitimately define a pickle state-hook, reviewed as benign
-    # attribute restorers (qualified so a same-named class elsewhere is not implicitly trusted). Any OTHER ultralytics
-    # class with a state-hook fails loudly and must be reviewed here. block.AAttn.__setstate__ backfills all_head_dim.
-    REVIEWED_STATEFUL = frozenset({"ultralytics.nn.modules.block.AAttn"})
-    _HOOKS = ("__reduce__", "__reduce_ex__", "__setstate__", "__getstate__", "__new__")
     _globals = None  # cached allow-list, built once
     _local = threading.local()  # per-thread flag set while a weights_only load is in progress
 
@@ -1515,27 +1510,10 @@ class _SafeLoad:
             raise TypeError(emojis(f"ERROR ❌️ unsupported activation '{act}' blocked during restricted model load.")) from e
 
     @classmethod
-    def _unreviewed(cls, klass):
-        """Whether `klass`'s effective pickle hook is implemented outside torch/builtins and it is not reviewed.
-
-        Walks the MRO so a hook inherited from a non-torch base (not just one defined directly on `klass`) is caught.
-        """
-        if f"{klass.__module__}.{klass.__qualname__}" in cls.REVIEWED_STATEFUL:
-            return False
-        for hook in cls._HOOKS:
-            for base in klass.__mro__:
-                if hook in vars(base):
-                    if not (base.__module__ == "builtins" or base.__module__.startswith("torch")):
-                        return True  # hook provided by a non-torch class (e.g. ultralytics or third-party) — review it
-                    break  # most-derived definition is a benign torch/builtins one
-        return False
-
-    @classmethod
     def _build(cls):
         """Auto-discover `nn.Module` subclasses across `torch.nn` and the ultralytics model families, registered under
         every namespace path they are reachable from (covering re-exports such as `block.RealNVP` as `head.RealNVP`),
-        plus torchvision transforms and legacy aliases. An ultralytics class with an unreviewed pickle state-hook raises
-        so it is audited before being trusted.
+        plus torchvision transforms and legacy aliases.
 
         Returns:
             (list): Items for `torch.serialization.safe_globals` — classes and `(obj, "module.Name")` aliases.
@@ -1552,7 +1530,7 @@ class _SafeLoad:
 
         allow = []
 
-        def _scan(pkg, owned):
+        def _scan(pkg):
             mods = [pkg]
             if hasattr(pkg, "__path__"):  # package: include all submodules
                 for info in pkgutil.iter_modules(pkg.__path__, f"{pkg.__name__}."):
@@ -1562,19 +1540,13 @@ class _SafeLoad:
                         continue
             for mod in mods:
                 for name, klass in inspect.getmembers(mod, inspect.isclass):
-                    if not issubclass(klass, nn.Module):
-                        continue
-                    if owned and klass.__module__.startswith("ultralytics.") and cls._unreviewed(klass):
-                        raise pickle.UnpicklingError(
-                            f"Refusing to trust {klass.__module__}.{klass.__qualname__}: it has a pickle state-hook "
-                            f"not in REVIEWED_STATEFUL. Review it for safety, then add its name there."
-                        )
-                    # Register under the path the class is reachable from here — matches how a checkpoint pickled it.
-                    allow.append((klass, f"{mod.__name__}.{name}"))
+                    if issubclass(klass, nn.Module):
+                        # Register under the path the class is reachable from — matches how a checkpoint pickled it.
+                        allow.append((klass, f"{mod.__name__}.{name}"))
 
-        _scan(torch_nn, owned=False)  # PyTorch classes (trusted; their state-hooks are benign backward-compat restorers)
-        _scan(ul_nn, owned=True)  # ultralytics block/conv/head/transformer
-        _scan(ul_tasks, owned=True)  # ultralytics task models
+        _scan(torch_nn)  # PyTorch nn modules
+        _scan(ul_nn)  # ultralytics block/conv/head/transformer
+        _scan(ul_tasks)  # ultralytics task models
 
         # Non-nn.Module data globals in official checkpoints (classification preprocessing transforms).
         try:

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1450,12 +1450,13 @@ def temporary_modules(modules=None, attributes=None):
                 del sys.modules[old]
 
 
-# Ultralytics-family nn.Module subclasses that legitimately define a pickle state-hook (__setstate__ etc.), reviewed as
-# benign attribute restorers. _build_safe_globals() refuses to trust any OTHER ultralytics class carrying a state-hook,
-# so a newly added one fails loudly here and gets reviewed before it is trusted under restricted (weights_only) loading.
-_REVIEWED_STATEFUL = frozenset({"AAttn"})  # block.AAttn.__setstate__ backfills the all_head_dim attribute
-_SAFE_GLOBALS_REGISTERED = False
+# Fully-qualified names of ultralytics nn.Module subclasses that legitimately define a pickle state-hook, reviewed as
+# benign attribute restorers (qualified so a same-named class elsewhere is not implicitly trusted). _build_safe_globals()
+# refuses any OTHER ultralytics class carrying a state-hook, so a new one fails loudly and is reviewed before it is
+# trusted under restricted (weights_only) loading. block.AAttn.__setstate__ backfills the all_head_dim attribute.
+_REVIEWED_STATEFUL = frozenset({"ultralytics.nn.modules.block.AAttn"})
 _STATE_HOOKS = ("__reduce__", "__reduce_ex__", "__setstate__", "__getstate__", "__new__")
+_SAFE_GLOBALS = None  # cached allow-list, built once
 _LOAD_STATE = threading.local()  # per-thread flag set while a weights_only load is in progress
 
 
@@ -1474,7 +1475,7 @@ def _has_unreviewed_hook(cls):
 
     Walks the MRO so a hook inherited from a non-torch base (not just one defined directly on `cls`) is caught.
     """
-    if cls.__name__ in _REVIEWED_STATEFUL:
+    if f"{cls.__module__}.{cls.__qualname__}" in _REVIEWED_STATEFUL:
         return False
     for hook in _STATE_HOOKS:
         for base in cls.__mro__:
@@ -1556,12 +1557,16 @@ def _build_safe_globals():
     return allow
 
 
-def _register_safe_globals():
-    """Register the restricted-load allow-list with PyTorch once per process (idempotent)."""
-    global _SAFE_GLOBALS_REGISTERED
-    if not _SAFE_GLOBALS_REGISTERED:
-        torch.serialization.add_safe_globals(_build_safe_globals())
-        _SAFE_GLOBALS_REGISTERED = True
+def _safe_globals_context():
+    """Return a `torch.serialization.safe_globals` context manager scoped to the restricted-load allow-list.
+
+    Built once and cached. Scoping to a context manager (rather than `add_safe_globals`) keeps the allow-list active
+    only for the duration of this load, not permanently across the process.
+    """
+    global _SAFE_GLOBALS
+    if _SAFE_GLOBALS is None:
+        _SAFE_GLOBALS = _build_safe_globals()
+    return torch.serialization.safe_globals(_SAFE_GLOBALS)
 
 
 def _safe_activation(act):
@@ -1644,12 +1649,13 @@ def torch_safe_load(weight, safe_only=None):
             },
         ):
             if safe_only:
-                # weights_only load: reconstruct only the allow-listed known model classes. Flag the load so that if a
-                # checkpoint reaches model construction (parse_model), it uses the no-eval/known-modules path too.
-                _register_safe_globals()
+                # weights_only load: reconstruct only the allow-listed known model classes (scoped to this load). Flag
+                # the load so that if a checkpoint reaches model construction (parse_model), it uses the no-eval and
+                # known-modules path too.
                 _LOAD_STATE.restricted = True
                 try:
-                    return torch_load(file, map_location="cpu", weights_only=True)
+                    with _safe_globals_context():
+                        return torch_load(file, map_location="cpu", weights_only=True)
                 finally:
                     _LOAD_STATE.restricted = False
             return torch_load(file, map_location="cpu")
@@ -1865,9 +1871,9 @@ def parse_model(d, ch, verbose=True):
     for i, (f, n, m, args) in enumerate(d["backbone"] + d["head"]):  # from, number, module, args
         m = (
             getattr(torch.nn, m[3:])
-            if "nn." in m
+            if m.startswith("nn.")
             else getattr(__import__("torchvision").ops, m[16:])
-            if "torchvision.ops." in m
+            if m.startswith("torchvision.ops.")
             else globals()[m]
         )  # get module
         if restricted and not (isinstance(m, type) and issubclass(m, torch.nn.Module)):

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -44,6 +44,7 @@ DEFAULT_CFG_PATH = ROOT / "cfg/default.yaml"
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLO multiprocessing threads
 AUTOINSTALL = str(os.getenv("YOLO_AUTOINSTALL", True)).lower() == "true"  # global auto-install mode
 VERBOSE = str(os.getenv("YOLO_VERBOSE", True)).lower() == "true"  # global verbose mode
+SAFE_LOAD = str(os.getenv("ULTRALYTICS_SAFE_LOAD", False)).lower() == "true"  # opt-in weights_only model loading
 LOGGING_NAME = "ultralytics"
 MACOS, LINUX, WINDOWS = (platform.system() == x for x in ["Darwin", "Linux", "Windows"])  # environment booleans
 MACOS_VERSION = platform.mac_ver()[0] if MACOS else None


### PR DESCRIPTION
## Summary

Adds an opt-in `ULTRALYTICS_SAFE_LOAD` environment flag that loads model checkpoints with `torch.load(weights_only=True)`, reconstructing only the known Ultralytics/torch model classes from an auto-generated allow-list. This aligns checkpoint loading with PyTorch 2.6+'s `weights_only` default.

- **Default-off / backward compatible** — when the env var is unset, loading behavior is unchanged (`weights_only=False`, `temporary_modules` remaps intact), so existing pip/clone usage and custom/forked architectures are unaffected.
- **Opt-in** — set `ULTRALYTICS_SAFE_LOAD=true` to load with `weights_only=True`. The allow-list is built by walking `torch.nn` and the Ultralytics model families for `nn.Module` subclasses, registered under every namespace path they're reachable from (covering re-exports and the YOLOv9/YOLOv10 compatibility aliases), so new architectures need no manual maintenance.
- Replaces the unused `SafeUnpickler`/`SafeClass` with this path.
- Under the flag, the model-yaml `activation` is resolved without `eval()`.

## Verification

Official checkpoints across detect / segment / pose / classify / obb / semantic, grayscale, and RT-DETR all load and run a forward pass under `weights_only=True`; the default path is unchanged, including corrupt-file error behavior.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔒 This PR adds an opt-in safer model checkpoint loading system for Ultralytics models, reducing risks from unsafe pickle deserialization while keeping default behavior unchanged.

### 📊 Key Changes
- Introduced a new internal `_SafeLoad` system to replace the older `SafeClass` and `SafeUnpickler` approach.
- Added opt-in restricted checkpoint loading via:
  - the `ULTRALYTICS_SAFE_LOAD` environment variable
  - the `safe_only=True` option in `torch_safe_load()`
- Switched safe loading to use PyTorch `weights_only=True` with an explicit allow-list of trusted model classes and related objects.
- Added automatic allow-list building for:
  - PyTorch `nn` modules
  - Ultralytics model/task modules
  - selected torchvision transforms
  - legacy checkpoint aliases and cross-platform path compatibility
- Removed `eval()` during restricted model loading for activation parsing, replacing it with a safer parser that only accepts valid `torch.nn` activation definitions.
- Added validation in `parse_model()` so restricted loading only permits known neural network layer classes.
- Improved error handling for unsupported or unsafe checkpoint contents, with clearer user-facing messages.
- Prevented auto-install fallback behavior during restricted loading, avoiding accidental loading of unexpected external modules.
- Updated docs to reference `_SafeLoad` and bumped the package version from `8.4.66` to `8.4.67` 🆙

### 🎯 Purpose & Impact
- 🛡️ Improves security when loading model files by limiting what checkpoint data is allowed to reconstruct.
- ✅ Helps protect users from unsafe or malformed `.pt` files, especially when models come from untrusted sources.
- 🔄 Keeps current workflows stable because safe loading is optional and off by default.
- 🧠 Makes restricted loading more robust by supporting official Ultralytics checkpoints, legacy aliases, and common preprocessing objects.
- 🚫 Reduces risk from dynamic code execution by removing `eval()` from the restricted path.
- 👥 Benefits both developers and end users who want a safer way to load YOLO models without changing standard usage unless they opt in.