### PR TITLE
Skip restricted model loading on torch<2.5

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1458,13 +1458,16 @@ class _SafeLoad:
     Default loading (flag off) is unchanged.
     """
 
+    # Restricted loading reconstructs allow-listed classes via the torch.serialization.safe_globals context manager,
+    # added in torch 2.5. On older torch it is unavailable, so restricted loading degrades to a standard load there.
+    SUPPORTED = hasattr(torch.serialization, "safe_globals")
     _globals = None  # cached allow-list, built once
     _local = threading.local()  # per-thread flag set while a weights_only load is in progress
 
     @classmethod
     def restricted(cls):
         """Whether model construction should use the no-eval, known-layer path (env flag or an in-progress load)."""
-        return SAFE_LOAD or getattr(cls._local, "active", False)
+        return cls.SUPPORTED and (SAFE_LOAD or getattr(cls._local, "active", False))
 
     @classmethod
     @contextlib.contextmanager
@@ -1597,6 +1600,9 @@ def torch_safe_load(weight, safe_only=None):
 
     if safe_only is None:
         safe_only = SAFE_LOAD
+    if safe_only and not _SafeLoad.SUPPORTED:
+        LOGGER.warning("Restricted model loading requires torch>=2.5; loading without restriction.")
+        safe_only = False
     check_suffix(file=weight, suffix=".pt")
     file = attempt_download_asset(weight)  # search online if missing locally
 


### PR DESCRIPTION
Restricted (`weights_only`) loading via `ULTRALYTICS_SAFE_LOAD` uses the `torch.serialization.safe_globals` context manager, which was added in **torch 2.5**. On older torch it doesn't exist, so a checkpoint load with the flag set raised `AttributeError` instead of loading.

This makes the flag degrade gracefully: when `torch.serialization.safe_globals` is unavailable, restricted loading is skipped (with a warning) and a standard load runs instead. This keeps format/export toolchains that pin older torch (e.g. `rknn-toolkit2` → `torch<=2.4`) working when the env flag is set process-wide.

No behavior change on torch>=2.5 or with the flag unset; no version bump.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔒 This PR improves safe model loading by only enabling restricted loading on supported PyTorch versions, while cleanly falling back to normal loading on older versions.

### 📊 Key Changes
- Added a compatibility check to detect whether `torch.serialization.safe_globals` is available, which requires **PyTorch 2.5 or newer**.
- Updated restricted loading logic so it only activates when this PyTorch safety feature is supported.
- Added a fallback in `torch_safe_load()`:
  - if safe loading is requested on an older PyTorch version, Ultralytics now logs a warning ⚠️
  - loading then continues normally instead of trying to use unsupported restricted behavior
- Kept default model loading behavior unchanged for users not using the safe-loading path.

### 🎯 Purpose & Impact
- Improves **compatibility** across different PyTorch versions by avoiding use of features that may not exist in older installs.
- Makes safe-loading behavior more **predictable and robust**, especially in mixed or legacy environments.
- Helps users understand what is happening through a clear warning message instead of silent failure or unexpected behavior 🛡️
- Reduces the risk of runtime errors when loading `.pt` model files on older systems.
- For users on **PyTorch 2.5+**, restricted loading continues to provide the intended safer model reconstruction path.