### PR TITLE
Fix figsize type annotation in SolutionConfig

### DIFF
--- a/docs/macros/solutions-args.md
+++ b/docs/macros/solutions-args.md
@@ -17,7 +17,7 @@
     "records": ["int", "5", "Total detections count to trigger an email with security alarm system."],
     "vision_point": ["tuple[int, int]", "(20, 20)", "The point where vision will track objects and draw paths using VisionEye Solution."],
     "source": ["str", "None", "Path to the input source (video, RTSP, etc.). Only usable with Solutions command line interface (CLI)."],
-    "figsize": ["tuple[int, int]", "(12.8, 7.2)", "Figure size for analytics charts such as heatmaps or graphs."],
+    "figsize": ["tuple[float, float]", "(12.8, 7.2)", "Figure size for analytics charts such as heatmaps or graphs."],
     "fps": ["float", "30.0", "Frames per second used for speed calculations."],
     "max_hist": ["int", "5", "Maximum historical points to track per object for speed/direction calculations."],
     "meter_per_pixel": ["float", "0.05", "Scaling factor used for converting pixel distance to real-world units."],

--- a/ultralytics/solutions/config.py
+++ b/ultralytics/solutions/config.py
@@ -75,7 +75,7 @@ class SolutionConfig:
     down_angle: int = 90
     kpts: list[int] = field(default_factory=lambda: [6, 8, 10])
     analytics_type: str = "line"
-    figsize: tuple[int, int] | None = (12.8, 7.2)
+    figsize: tuple[float, float] | None = (12.8, 7.2)
     blur_ratio: float = 0.5
     vision_point: tuple[int, int] = (20, 20)
     crop_dir: str = "cropped-detections"


### PR DESCRIPTION
## summary

corrects the `figsize` annotation in `SolutionConfig` from `tuple[int, int]` to `tuple[float, float]` to match its float default `(12.8, 7.2)`, the class docstring, and the matplotlib figure-size convention. updates the solutions args macro type cell to match.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the `figsize` setting in Ultralytics Solutions to correctly use floating-point values, improving type accuracy and aligning the code with its default chart size.

### 📊 Key Changes
- Changed `figsize` in `ultralytics/solutions/config.py` from `tuple[int, int]` to `tuple[float, float]`.
- Updated the matching documentation in `docs/macros/solutions-args.md` to reflect the same `tuple[float, float]` type.
- Kept the default value unchanged at `(12.8, 7.2)`, which already uses decimal values.

### 🎯 Purpose & Impact
- ✅ Fixes a type mismatch between the declared config type and the actual default value.
- 📚 Improves documentation accuracy, making the setting clearer for users and developers.
- 🧩 Helps prevent confusion in tooling, validation, and static type checking when working with analytics chart settings.
- 🎨 Ensures chart sizing options for Solutions features like heatmaps and graphs are represented more realistically and consistently.