### PR TITLE
Remove region from instance segmentation guide arguments table

### DIFF
--- a/docs/en/guides/instance-segmentation-and-tracking.md
+++ b/docs/en/guides/instance-segmentation-and-tracking.md
@@ -96,7 +96,7 @@ There are two types of instance segmentation tracking available in the Ultralyti
 Here's a table with the `InstanceSegmentation` arguments:
 
 {% from "macros/solutions-args.md" import param_table %}
-{{ param_table(["model", "region"]) }}
+{{ param_table(["model"]) }}
 
 You can also take advantage of `track` arguments within the `InstanceSegmentation` solution:
 


### PR DESCRIPTION
## summary

the instance segmentation guide listed a `region` argument that the `InstanceSegmentation` solution never reads, so passing it had no effect on the output. this drops `region` from the guide's argument table so it only documents arguments the solution actually consumes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes a small documentation fix by removing the `region` parameter from the `InstanceSegmentation` argument table in the instance segmentation and tracking guide.

### 📊 Key Changes
- Removed `region` from the documented `InstanceSegmentation` arguments table.
- Updated the guide so it now shows only the valid core argument: `model`.
- Kept the separate note about using `track` arguments, avoiding confusion between solution arguments and tracking options.

### 🎯 Purpose & Impact
- Improves documentation accuracy ✅ by aligning the guide with the actual `InstanceSegmentation` interface.
- Reduces confusion for users 🚫, especially those trying to configure segmentation tracking from the docs.
- Helps prevent incorrect parameter usage when following examples or building apps with Ultralytics solutions.
- Makes the docs a bit cleaner and easier to trust for both new and experienced users 📚