### PR TITLE
docs: add Windows on Snapdragon benchmarks

### DIFF
--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -63,6 +63,22 @@ End-to-end single-image inference for the official YOLO26n models on a Xiaomi 17
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on [bus.jpg](https://ultralytics.com/images/bus.jpg), measured with the [Flutter plugin's](https://github.com/ultralytics/yolo-flutter-app) on-device benchmark harness on a thermally rested device. Sustained real-time camera frame times run higher (per-frame capture letterboxing plus thermal settling); use the app's on-screen pre/inference/post breakdown for steady-state numbers on your device.
 - <sup>1</sup> Semantic QNN uses the in-graph ArgMax class-map output from this release, which replaced erratic 123-1065 ms logits decoding with a stable ~49 ms; the GPU remains slightly faster for semantic at 1024px.
 
+## Measured Performance on Windows on Snapdragon (win_arm64)
+
+End-to-end single-image inference for the official YOLO26n models on a Lenovo laptop powered by the Qualcomm Snapdragon X Elite (X1E78100) — Qualcomm Oryon CPU and Hexagon NPU (HTP v73), 32 GB RAM, Windows 11. This Windows-on-Snapdragon comparison runs the native PyTorch FP32 CPU baseline that most desktop developers start from against the QNN Hexagon NPU path. Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it; CPU numbers are PyTorch FP32 (`torch==2.10.0+cpu`) and NPU numbers are ONNX Runtime QNN (`onnxruntime-qnn==2.2.0`, INT8 weights / 16-bit activations).
+
+| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>PT FP32<br>(ms)</sup>      | NPU Hexagon<br><sup>QNN A16W8<br>(ms)</sup> |
+| ------------ | -------- | --------------------------- | -------------------------------------- | ------------------------------------------- |
+| YOLO26n      | Detect   | 640                         | 91.4<br><sup>4.3 / 75.2 / 0.1</sup>    | **27.2**<br><sup>4.9 / 19.4 / 0.9</sup>     |
+| YOLO26n-seg  | Segment  | 640                         | 138.8<br><sup>4.5 / 127.1 / 2.8</sup>  | **34.3**<br><sup>5.0 / 24.0 / 5.1</sup>     |
+| YOLO26n-sem  | Semantic | 1024                        | 295.8<br><sup>9.1 / 189.2 / 94.8</sup> | **133.0**<br><sup>8.8 / 37.4 / 83.9</sup>   |
+| YOLO26n-cls  | Classify | 224                         | 15.4<br><sup>3.0 / 9.8 / 0.0</sup>     | **11.7**<br><sup>2.7 / 5.5 / 0.0</sup>      |
+| YOLO26n-pose | Pose     | 640                         | 109.6<br><sup>4.6 / 102.9 / 0.2</sup>  | **28.9**<br><sup>5.3 / 23.3 / 0.6</sup>     |
+| YOLO26n-obb  | OBB      | 1024                        | 267.8<br><sup>8.1 / 254.6 / 0.1</sup>  | **64.8**<br><sup>8.9 / 54.7 / 0.6</sup>     |
+
+- **Speed** values are **single-image burst latencies** — the mean of 100 runs after 10 warmup runs on [bus.jpg](https://ultralytics.com/images/bus.jpg), measured with `time.perf_counter()` around the full `model.predict()` call on a thermally rested device (`ultralytics==8.4.67`, Python 3.12.10).
+- The Hexagon NPU runs roughly **2-4x faster** than the PyTorch CPU baseline across the 640-1024 px tasks (detection ~3.4x), narrowing to ~1.3x on the 224 px classifier where fixed preprocessing overhead dominates the tiny workload.
+
 ## Supported Tasks
 
 QNN export supports the standard task set available in each model family, including YOLO26 semantic segmentation.

--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -49,6 +49,8 @@ The exported `*_qnn.onnx` file is self-contained: it embeds the QNN context bina
 
 ## Measured Performance
 
+### Android Phone
+
 End-to-end single-image inference for the official YOLO26n models on a Xiaomi 17 phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850) — Qualcomm Oryon CPU, Adreno GPU, and Hexagon NPU (HTP v81). Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU and GPU run INT8 TFLite via LiteRT; the NPU runs QNN context binaries (INT8 weights, 16-bit activations).
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>INT8 TFLite<br>(ms)</sup> | GPU Adreno<br><sup>INT8 TFLite<br>(ms)</sup> | NPU Hexagon<br><sup>QNN A16W8<br>(ms)</sup>      |
@@ -63,9 +65,9 @@ End-to-end single-image inference for the official YOLO26n models on a Xiaomi 17
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on [bus.jpg](https://ultralytics.com/images/bus.jpg), measured with the [Flutter plugin's](https://github.com/ultralytics/yolo-flutter-app) on-device benchmark harness on a thermally rested device. Sustained real-time camera frame times run higher (per-frame capture letterboxing plus thermal settling); use the app's on-screen pre/inference/post breakdown for steady-state numbers on your device.
 - <sup>1</sup> Semantic QNN uses the in-graph ArgMax class-map output from this release, which replaced erratic 123-1065 ms logits decoding with a stable ~49 ms; the GPU remains slightly faster for semantic at 1024px.
 
-## Measured Performance on Windows on Snapdragon (win_arm64)
+### Windows on Snapdragon Laptop
 
-End-to-end single-image inference for the official YOLO26n models on a Lenovo laptop powered by the Qualcomm Snapdragon X Elite (X1E78100) — Qualcomm Oryon CPU and Hexagon NPU (HTP v73), 32 GB RAM, Windows 11. This Windows-on-Snapdragon comparison runs the native PyTorch FP32 CPU baseline that most desktop developers start from against the QNN Hexagon NPU path. Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it; CPU numbers are PyTorch FP32 (`torch==2.10.0+cpu`) and NPU numbers are ONNX Runtime QNN (`onnxruntime-qnn==2.2.0`, INT8 weights / 16-bit activations).
+End-to-end single-image inference for the official YOLO26n models on a Lenovo laptop powered by the Qualcomm Snapdragon X Elite (X1E78100) — Qualcomm Oryon CPU and Hexagon NPU (HTP v73), 32 GB RAM, Windows 11. This Windows-on-Snapdragon comparison runs the native PyTorch FP32 CPU baseline that most desktop developers start from against the QNN Hexagon NPU path. Each cell shows the **full `model.predict()` wall time** with the reported preprocessing / inference / postprocessing timings beneath it; the total can include framework overhead outside those three stages. CPU numbers are PyTorch FP32 (`torch==2.10.0+cpu`) and NPU numbers are ONNX Runtime QNN (`onnxruntime-qnn==2.2.0`, INT8 weights / 16-bit activations).
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>PT FP32<br>(ms)</sup>      | NPU Hexagon<br><sup>QNN A16W8<br>(ms)</sup> |
 | ------------ | -------- | --------------------------- | -------------------------------------- | ------------------------------------------- |


### PR DESCRIPTION

Adds a new 'Measured Performance on Windows on Snapdragon (win_arm64)' section to the QNN integration page with end-to-end YOLO26n latencies on a Lenovo Snapdragon X Elite (X1E78100) laptop, comparing the native PyTorch FP32 CPU baseline against the QNN Hexagon NPU path across all six tasks. The existing phone-based Measured Performance section is left unchanged.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a new Windows on Snapdragon benchmark section to the QNN integration docs, comparing YOLO26n CPU and Hexagon NPU performance on `win_arm64` hardware. 🚀

### 📊 Key Changes
- Added a new **Measured Performance on Windows on Snapdragon (`win_arm64`)** section to `docs/en/integrations/qnn.md`.
- Documented benchmark results for multiple YOLO26n tasks: **Detect, Segment, Semantic, Classify, Pose, and OBB**.
- Compared **native PyTorch FP32 CPU** inference against **ONNX Runtime QNN Hexagon NPU** inference on a Snapdragon X Elite Windows 11 laptop.
- Included detailed per-stage latency breakdowns for **preprocessing, inference, and postprocessing**.
- Added benchmark methodology details, including runtime setup, warmup/run counts, device state, and measurement scope. 📈
- Summarized the observed speedups, highlighting that the NPU is generally **2–4x faster** than the CPU baseline across larger image sizes. ⚡

### 🎯 Purpose & Impact
- Improves documentation coverage for **Windows on Snapdragon** deployments, an increasingly relevant edge and desktop AI platform.
- Gives users practical, hardware-specific expectations for running YOLO26 with **QNN acceleration** versus standard CPU inference.
- Helps developers evaluate whether migrating to the **Hexagon NPU path** is worthwhile for their workloads.
- Strengthens the QNN integration docs with clearer cross-platform performance evidence, especially for **ARM64 Windows** users. 🪟