### PR TITLE
Update Platform GPU pricing

### DIFF
--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -46,7 +46,7 @@ Get started at no cost:
 - 100 GB storage · 10 GB dataset upload limit
 - Model export to all 19+ formats
 - Manual, SAM 3 & YOLO Smart annotation
-- 22 cloud GPU types including 5090, H100 & H200 ($0.24–$3.99/hr)
+- 22 cloud GPU types including 5090, H100 & H200 ($0.24–$4.39/hr)
 - Community support
 
 !!! tip "Company Email Bonus"
@@ -204,7 +204,7 @@ Total Cost = GPU Rate x Training Time (hours)
 Example: Training for 2.5 hours on RTX PRO 6000
 
 ```
-$1.89 x 2.5 = $4.73
+$2.09 x 2.5 = $5.23
 ```
 
 ## Upgrade to Pro

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -238,7 +238,7 @@ From your project, click `New Model` to start cloud training.
 1. **Select Dataset**: Choose from your uploaded datasets (only datasets with a [`train` split](data/datasets.md#filter-by-split) are shown)
 2. **Choose Model**: Select a base model - official Ultralytics models or your own trained models
 3. **Set Epochs**: Number of training iterations (default: 100)
-4. **Select GPU**: Choose compute resources based on your budget and model size. The default is **RTX PRO 6000** (96 GB Blackwell, $1.89/hr), which handles every YOLO26 variant. See the full [GPU pricing table](index.md#what-gpu-options-are-available-for-cloud-training) or the [Cloud Training GPU step](train/cloud-training.md#step-5-select-gpu-cloud-tab) for the complete list and tier gating.
+4. **Select GPU**: Choose compute resources based on your budget and model size. The default is **RTX PRO 6000** (96 GB Blackwell, $2.09/hr), which handles every YOLO26 variant. See the full [GPU pricing table](index.md#what-gpu-options-are-available-for-cloud-training) or the [Cloud Training GPU step](train/cloud-training.md#step-5-select-gpu-cloud-tab) for the complete list and tier gating.
 
 !!! warning "Credit Balance Required"
 

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -301,8 +301,8 @@ Before training starts, the platform estimates total cost by:
 | Scenario                         | GPU          | Estimated Cost |
 | -------------------------------- | ------------ | -------------- |
 | 500 images, YOLO26n, 50 epochs   | RTX 4090     | ~$0.03         |
-| 1000 images, YOLO26n, 100 epochs | RTX PRO 6000 | ~$0.27         |
-| 5000 images, YOLO26s, 100 epochs | H100 SXM     | ~$1.75         |
+| 1000 images, YOLO26n, 100 epochs | RTX PRO 6000 | ~$0.30         |
+| 5000 images, YOLO26s, 100 epochs | H100 SXM     | ~$1.93         |
 
 ### Billing Flow
 

--- a/docs/macros/platform-gpu-table.md
+++ b/docs/macros/platform-gpu-table.md
@@ -16,11 +16,11 @@
 | L40          | Ada        | 48 GB  | $0.99     | Large models               |
 | A100 PCIe    | Ampere     | 80 GB  | $1.39     | Production training        |
 | A100 SXM     | Ampere     | 80 GB  | $1.49     | Production training        |
-| RTX PRO 6000 | Blackwell  | 96 GB  | $1.89     | Recommended default        |
-| H100 PCIe    | Hopper     | 80 GB  | $2.39     | High-performance training  |
-| H100 SXM     | Hopper     | 80 GB  | $2.99     | Fastest training           |
-| H100 NVL     | Hopper     | 94 GB  | $3.07     | Maximum performance        |
+| RTX PRO 6000 | Blackwell  | 96 GB  | $2.09     | Recommended default        |
+| H100 PCIe    | Hopper     | 80 GB  | $2.89     | High-performance training  |
+| H100 NVL     | Hopper     | 94 GB  | $3.19     | Maximum performance        |
+| H100 SXM     | Hopper     | 80 GB  | $3.29     | Fastest training           |
 | H200 NVL     | Hopper     | 143 GB | $3.39     | Maximum memory             |
-| H200 SXM     | Hopper     | 141 GB | $3.99     | Maximum performance        |
-| B200         | Blackwell  | 180 GB | $5.49     | Large models (Pro+)        |
+| H200 SXM     | Hopper     | 141 GB | $4.39     | Maximum performance        |
+| B200         | Blackwell  | 180 GB | $5.89     | Large models (Pro+)        |
 | B300         | Blackwell  | 288 GB | $7.39     | Largest models (Pro+)      |


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
💳 This PR updates Ultralytics Platform cloud training documentation to reflect revised GPU pricing and refreshed cost examples across billing, quickstart, and training docs.

### 📊 Key Changes
- Updated the documented cloud GPU price range from **$0.24–$3.99/hr** to **$0.24–$4.39/hr** 📈
- Changed the default **RTX PRO 6000** hourly rate from **$1.89/hr** to **$2.09/hr** in multiple docs
- Revised the billing example for a 2.5-hour training run on **RTX PRO 6000** from **$4.73** to **$5.23** 🧾
- Updated estimated cloud training costs in examples, including:
  - **1000 images, YOLO26n, 100 epochs**: **~$0.27 → ~$0.30**
  - **5000 images, YOLO26s, 100 epochs**: **~$1.75 → ~$1.93**
- Refreshed the shared GPU pricing table with new rates for several high-end GPUs, including:
  - **H100 PCIe**: **$2.39 → $2.89**
  - **H100 NVL**: **$3.07 → $3.19**
  - **H100 SXM**: **$2.99 → $3.29**
  - **H200 SXM**: **$3.99 → $4.39**
  - **B200**: **$5.49 → $5.89** 🚀

### 🎯 Purpose & Impact
- Keeps Ultralytics Platform documentation aligned with current cloud training pricing, reducing confusion for users 💡
- Helps users more accurately estimate training costs before starting jobs
- Improves transparency around GPU selection, especially for teams budgeting larger YOLO26 training runs
- No product behavior appears to change in this PR; the main impact is clearer, more up-to-date pricing information 📘