### PR TITLE
Fix four production Sentry issues: predict batch, corrupt AMP cache, truncated downloads, non-mapping YAML

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -458,7 +458,7 @@ class LoadImagesAndVideos:
                     imgs.append(im0)
                     info.append(f"image {self.count + 1}/{self.nf} {path}: ")
                 self.count += 1  # move to the next file
-                if self.count >= self.ni:  # end of image list
+                if self.count >= self.ni and imgs:  # end of image list, flush only a non-empty batch
                     break
 
         return paths, imgs, info

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1596,7 +1596,7 @@ def torch_safe_load(weight, safe_only=None):
         >>> from ultralytics.nn.tasks import torch_safe_load
         >>> ckpt, file = torch_safe_load("path/to/best.pt", safe_only=True)
     """
-    from ultralytics.utils.downloads import attempt_download_asset
+    from ultralytics.utils.downloads import GITHUB_ASSETS_NAMES, attempt_download_asset
 
     if safe_only is None:
         safe_only = SAFE_LOAD
@@ -1634,8 +1634,9 @@ def torch_safe_load(weight, safe_only=None):
         ckpt = _load()
 
     except RuntimeError as e:
-        # Corrupt downloaded weight (e.g. truncated); skip user-supplied local paths to avoid destructive unlink.
-        if "PytorchStreamReader" not in str(e) or Path(str(weight)).exists():
+        # Recover only a corrupt cached official asset requested by bare name; never touch user-supplied paths.
+        name = Path(str(weight)).name
+        if "PytorchStreamReader" not in str(e) or str(weight) != name or name not in GITHUB_ASSETS_NAMES:
             raise
         LOGGER.warning(f"Corrupt cache {file}, re-downloading {weight}...")
         Path(file).unlink(missing_ok=True)

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -630,16 +630,23 @@ class YAML:
 
         # Try loading YAML with fallback for problematic characters
         try:
-            data = instance.yaml.load(s, Loader=instance.SafeLoader) or {}
+            data = instance.yaml.load(s, Loader=instance.SafeLoader)
         except Exception as e:
             # Remove problematic characters and retry
             s = re.sub(r"[^\x09\x0A\x0D\x20-\x7E\x85\xA0-\uD7FF\uE000-\uFFFD\U00010000-\U0010ffff]+", "", s)
             try:
-                data = instance.yaml.load(s, Loader=instance.SafeLoader) or {}
+                data = instance.yaml.load(s, Loader=instance.SafeLoader)
             except Exception:
                 raise ValueError(
                     f"YAML syntax error in '{file}': {e}\nVerify YAML with https://ray.run/tools/yaml-formatter"
                 ) from None
+
+        if data is None:  # empty file, comments only, or explicit 'null'
+            data = {}
+        elif not isinstance(data, dict):  # reject non-mapping YAML (scalar/list) with a clear error, not a cryptic one
+            raise ValueError(
+                f"'{file}' is not a valid YAML mapping. Verify YAML with https://ray.run/tools/yaml-formatter"
+            )
 
         # Check for accidental user-error None strings (should be 'null' in YAML)
         if "None" in data.values():

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -336,13 +336,13 @@ def safe_download(
             desc = f"Downloading {uri} to '{f}'"
             f.parent.mkdir(parents=True, exist_ok=True)  # make directory if missing
             curl_installed = shutil.which("curl")
+            expected_size = None  # set by urllib from Content-Length; reused to validate curl retries
             for i in range(retry + 1):
                 try:
                     if (curl or i > 0) and curl_installed:  # curl download with retry, continue
                         s = "sS" * (not progress)  # silent
                         r = subprocess.run(["curl", "-#", f"-{s}L", url, "-o", f, "--retry", "3", "-C", "-"]).returncode
                         assert r == 0, f"Curl return value {r}"
-                        expected_size = None  # Can't get size with curl
                     else:  # urllib download
                         with request.urlopen(url) as response:
                             expected_size = int(response.getheader("Content-Length", 0))


### PR DESCRIPTION
## Summary

Fixes four production issues surfaced in the `ultralytics` Sentry project. All are at the source — no symptom masking, no silenced loggers, no band-aids. Net **15 insertions / 7 deletions** across 4 files (Replace-heavy).

## Fixes

### 1. `ValueError: need at least one array to stack` — empty predict batch (ULTRALYTICS-1X0W, 354 events)
`LoadImagesAndVideos.__next__` returned an empty image batch `([],[],[])` when the trailing image(s) of a source failed to read (`imread` → `None`); `predictor.preprocess` then called `np.stack([])`. Flush the image batch only when non-empty (`and imgs`); an all-fail batch falls through to trailing videos or terminates via the existing `StopIteration`. Crash was on **valid** input (other images predicted fine).

### 2. `RuntimeError: PytorchStreamReader failed reading zip archive` — corrupt cached AMP asset (ULTRALYTICS-1WYS, 613 events)
`check_amp()` loads a **cached** `yolo26n.pt`; when corrupt, `torch.load` raises. `torch_safe_load` already had unlink+re-download recovery, but its guard checked `Path(weight).exists()` **after** `attempt_download_asset()` resolved the asset → always `True` → recovery was dead code. Fire recovery only for a corrupt official asset **requested by bare name** (`str(weight) == Path(weight).name and name in GITHUB_ASSETS_NAMES`); any path with a directory component (a user file) re-raises and is never unlinked.

### 3. Truncated curl downloads cached as success — the upstream cause of #2 (ULTRALYTICS-1WYS)
`safe_download()` validated download size only on the urllib path; the curl branch (every retry `i>0`) reset `expected_size = None`, so a truncated curl retry larger than `min_bytes` was accepted via `else: break` and cached. Hoist `expected_size = None` to once before the retry loop and delete the curl-branch reset, so curl retries reuse the urllib `Content-Length` and detect+discard truncated downloads instead of caching them. This stops the corrupt cache from forming in the first place (complements fix #2's recovery).

### 4. `AttributeError: 'str' object has no attribute 'values'` — non-mapping YAML (ULTRALYTICS-1ZCA)
`YAML.load()` is documented to return a dict and all ~28 callers require one, but it coerced only the empty case (`or {}`) and returned scalars/lists unchanged → `data.values()` raised a cryptic `AttributeError` for a malformed dataset/config YAML. Return `{}` for an empty/`None`/comment-only/`null` document and raise a clear `ValueError` for any non-mapping body (scalar/list, including falsey `[]`/`0`/`false`). The dataset path wraps it as `Dataset error ❌ ...`; the config path surfaces it directly instead of silently falling through to defaults.

## Verification
- `ruff check` + `ruff format --check` clean on all four files.
- Behavioral tests: `LoadImagesAndVideos` trailing-read-failure (bs 1/2/3, image-only and image+video) → no empty batch, clean `StopIteration`; recovery-guard discriminator across 8 weight-path cases; `safe_download` `expected_size` flow; `YAML.load` across 16 cases (every non-mapping raises; `None`/empty/comment-only/`null`/`{}`/`~`/valid mapping return a dict).

## Review
Independently reviewed by two adversarial reviewers (Claude Code reviewer agent + Codex CLI) over multiple rounds. Codex caught (a) a destructive-unlink risk on user paths with official basenames → fixed via the bare-name guard, and (b) a falsey-bypass (`[]`/`0`/`false`) in the YAML coercion → fixed by removing `or {}` and gating on `is None`. **Both reviewers returned LGTM** on the final diff.

## Cross-reference
Companion Platform-side Sentry sweep: ultralytics/portal#2468. These package bugs also reach the Platform `alpha` Sentry project via the worker's logging integration; fixed once here in the owning repo. Resolved in Sentry (ultralytics project): 1X0W, 1WYS, 1ZCA (+ 239V already fixed by #24431).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves reliability across data loading, model weight loading, YAML parsing, and file downloads to reduce edge-case crashes and make Ultralytics behavior safer and more predictable 🚀

### 📊 Key Changes
- Fixed image batch loading so the loader only stops at the end of the image list when there is actually a non-empty batch to return 🖼️
- Tightened corrupted weight recovery logic in `torch_safe_load()` so automatic re-download only happens for official cached Ultralytics assets requested by name, not for user-provided local files 🔒
- Improved YAML loading behavior:
  - Empty, comment-only, or `null` YAML files now safely resolve to an empty dictionary
  - Non-dictionary YAML content, like lists or single values, now raises a clearer error message instead of failing later with a confusing exception 📝
- Refined download size handling in `safe_download()` so expected file size from `urllib` is preserved and can be reused when retrying with `curl` 🌐

### 🎯 Purpose & Impact
- Prevents loader edge cases that could return empty batches or behave inconsistently at the end of image iteration, improving inference and data pipeline stability ✅
- Protects user files by avoiding risky auto-deletion or re-download behavior for local checkpoint paths, while still recovering from corrupt cached official weights safely 🛡️
- Makes YAML configuration errors easier to understand and debug, especially for dataset and settings files, which should reduce setup frustration for users 🙌
- Improves download robustness and validation during retries, helping model and asset downloads succeed more reliably on unstable connections 📦