### PR TITLE
Semantic segmentation class weights

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.67"
+__version__ = "8.4.68"
 
 import importlib
 import os

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -168,7 +168,10 @@ class DetectionTrainer(BaseTrainer):
         assert 0 <= self.args.cls_pw <= 1.0, "cls_pw must be in the range [0, 1]"
         if self.args.cls_pw == 0.0:
             return
-        weights = self.compute_class_weights(self.get_class_counts())
+        class_counts = self.get_class_counts()
+        if not class_counts.any():  # nothing counted (e.g. missing/unreadable masks); keep default weights
+            return
+        weights = self.compute_class_weights(class_counts)
         weights = weights / weights.mean()  # normalize so mean equals 1.0
         self.model.class_weights = torch.from_numpy(weights).to(self.device)
         LOGGER.info(f"Class weights: {self.model.class_weights.cpu().numpy().round(3)}")

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -148,6 +148,16 @@ class DetectionTrainer(BaseTrainer):
         if getattr(self.model, "end2end", False):
             self.model.set_head_attr(max_det=self.args.max_det)
 
+    def get_class_counts(self):
+        """Return per-class instance counts from the training dataset labels."""
+        classes = np.concatenate([lb["cls"].flatten() for lb in self.train_loader.dataset.labels], 0)
+        return np.bincount(classes.astype(int), minlength=self.data["nc"]).astype(np.float32)
+
+    def compute_class_weights(self, class_counts):
+        """Convert class counts to inverse-frequency weights raised to the power of cls_pw."""
+        class_counts = np.where(class_counts == 0, 1.0, class_counts)
+        return (1.0 / class_counts) ** self.args.cls_pw  # apply power directly
+
     def set_class_weights(self):
         """Compute and set class weights for handling class imbalance.
 
@@ -158,11 +168,7 @@ class DetectionTrainer(BaseTrainer):
         assert 0 <= self.args.cls_pw <= 1.0, "cls_pw must be in the range [0, 1]"
         if self.args.cls_pw == 0.0:
             return
-        classes = np.concatenate([lb["cls"].flatten() for lb in self.train_loader.dataset.labels], 0)
-        class_counts = np.bincount(classes.astype(int), minlength=self.data["nc"]).astype(np.float32)
-        class_counts = np.where(class_counts == 0, 1.0, class_counts)
-
-        weights = (1.0 / class_counts) ** self.args.cls_pw  # apply power directly
+        weights = self.compute_class_weights(self.get_class_counts())
         weights = weights / weights.mean()  # normalize so mean equals 1.0
         self.model.class_weights = torch.from_numpy(weights).to(self.device)
         LOGGER.info(f"Class weights: {self.model.class_weights.cpu().numpy().round(3)}")

--- a/ultralytics/models/yolo/semantic/train.py
+++ b/ultralytics/models/yolo/semantic/train.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
-from PIL import Image
 
 from ultralytics.data.utils import add_polygon_background
 from ultralytics.models import yolo
@@ -78,23 +77,26 @@ class SemanticSegmentationTrainer(DetectionTrainer):
         if self.data["nc"] > 1:
             super().set_class_weights()
 
-    def get_class_counts(self):
-        """Return per-class pixel counts sampled from up to 1000 training mask files."""
+    def get_class_counts(self, max_masks=None):
+        """Return per-class pixel counts from training masks, optionally sampled to max_masks."""
         nc = self.data["nc"]
         pixel_counts = np.zeros(nc, dtype=np.float32)
         dataset = self.train_loader.dataset
-        mask_files = getattr(dataset, "mask_files", [])
-        if not mask_files:
+        labels = getattr(dataset, "labels", [])
+        if not labels:
             return pixel_counts
-        indices = np.linspace(0, len(mask_files) - 1, min(1000, len(mask_files))).astype(int)
+        indices = np.arange(len(labels))
+        if max_masks and len(indices) > max_masks:
+            indices = np.linspace(0, len(labels) - 1, max_masks).astype(int)
+        include_class = getattr(dataset, "include_class", None)
         for idx in indices:
+            shape = labels[idx].get("shape")
             try:
-                mask = np.array(Image.open(mask_files[idx]))
+                mask = dataset.load_mask(idx, image_shape=tuple(shape) if shape is not None else None)
             except Exception:
                 continue
-            if getattr(dataset, "label_mapping", None):
-                for old, new in dataset.label_mapping.items():
-                    mask[mask == old] = new
+            if include_class is not None:
+                mask[~np.isin(mask, include_class)] = 255
             valid = (mask >= 0) & (mask < nc) & (mask != 255)
             if valid.any():
                 classes, counts = np.unique(mask[valid], return_counts=True)
@@ -116,7 +118,7 @@ class SemanticSegmentationTrainer(DetectionTrainer):
         LOGGER.info(f"Plotting labels to {self.save_dir / 'labels.jpg'}...")
         nc = self.data["nc"]
         names = self.data["names"]
-        pixel_counts = self.get_class_counts()
+        pixel_counts = self.get_class_counts(max_masks=1000)
         if not pixel_counts.any():
             LOGGER.warning("No semantic mask files found, skipping label plot.")
             return

--- a/ultralytics/models/yolo/semantic/train.py
+++ b/ultralytics/models/yolo/semantic/train.py
@@ -73,14 +73,33 @@ class SemanticSegmentationTrainer(DetectionTrainer):
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )
 
-    def set_class_weights(self):
-        """Skip detection-style class weight computation for semantic segmentation.
+    def get_class_counts(self):
+        """Return per-class pixel counts sampled from up to 1000 training mask files."""
+        nc = self.data["nc"]
+        pixel_counts = np.zeros(nc, dtype=np.float32)
+        dataset = self.train_loader.dataset
+        mask_files = getattr(dataset, "mask_files", [])
+        if not mask_files:
+            return pixel_counts
+        indices = np.linspace(0, len(mask_files) - 1, min(1000, len(mask_files))).astype(int)
+        for idx in indices:
+            try:
+                mask = np.array(Image.open(mask_files[idx]))
+            except Exception:
+                continue
+            if getattr(dataset, "label_mapping", None):
+                for old, new in dataset.label_mapping.items():
+                    mask[mask == old] = new
+            valid = (mask >= 0) & (mask < nc) & (mask != 255)
+            if valid.any():
+                classes, counts = np.unique(mask[valid], return_counts=True)
+                pixel_counts[classes.astype(int)] += counts
+        return pixel_counts
 
-        Semantic segmentation requires pixel-level class frequency counting from masks,
-        which is not performed here. The loss function applies Cityscapes weights when
-        the dataset YAML stem is 'cityscapes' or 'cityscapes8'.
-        """
-        pass
+    def compute_class_weights(self, class_counts):
+        """Compute ENet inverse-log `(1/ln(1.02 + p))**cls_pw` weights (Paszke et al., 2016, arXiv:1606.02147)."""
+        p = class_counts / max(class_counts.sum(), 1.0)  # pixel frequency, bounded for rare classes unlike detection
+        return (1.0 / np.log(1.02 + p)) ** self.args.cls_pw
 
     @plt_settings()
     def plot_training_labels(self):
@@ -92,30 +111,10 @@ class SemanticSegmentationTrainer(DetectionTrainer):
         LOGGER.info(f"Plotting labels to {self.save_dir / 'labels.jpg'}...")
         nc = self.data["nc"]
         names = self.data["names"]
-        pixel_counts = np.zeros(nc, dtype=np.int32)
-
-        dataset = self.train_loader.dataset
-        mask_files = getattr(dataset, "mask_files", [])
-        if not mask_files:
+        pixel_counts = self.get_class_counts()
+        if not pixel_counts.any():
             LOGGER.warning("No semantic mask files found, skipping label plot.")
             return
-
-        sample_size = min(1000, len(mask_files))
-        indices = np.linspace(0, len(mask_files) - 1, sample_size).astype(int)
-
-        for idx in indices:
-            try:
-                mask = np.array(Image.open(mask_files[idx]))
-            except Exception:
-                continue
-            if hasattr(dataset, "label_mapping") and dataset.label_mapping:
-                for old, new in dataset.label_mapping.items():
-                    mask[mask == old] = new
-            valid = (mask >= 0) & (mask < nc) & (mask != 255)
-            if valid.any():
-                classes, counts = np.unique(mask[valid], return_counts=True)
-                for c, count in zip(classes, counts):
-                    pixel_counts[int(c)] += int(count)
 
         _, ax = plt.subplots(1, 1, figsize=(8, 6), tight_layout=True)
         bars = ax.bar(range(nc), pixel_counts, color=[list(c / 255.0 for c in colors(i, False)) for i in range(nc)])

--- a/ultralytics/models/yolo/semantic/train.py
+++ b/ultralytics/models/yolo/semantic/train.py
@@ -73,6 +73,11 @@ class SemanticSegmentationTrainer(DetectionTrainer):
             self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
         )
 
+    def set_class_weights(self):
+        """Compute pixel-frequency class weights; skipped for binary (nc==1, unweighted BCE in the loss)."""
+        if self.data["nc"] > 1:
+            super().set_class_weights()
+
     def get_class_counts(self):
         """Return per-class pixel counts sampled from up to 1000 training mask files."""
         nc = self.data["nc"]

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1068,7 +1068,10 @@ class v8OBBLoss(v8DetectionLoss):
 
         # Cls loss
         # loss[1] = self.varifocal_loss(pred_scores, target_scores, target_labels) / target_scores_sum  # VFL way
-        loss[1] = self.bce(pred_scores, target_scores.to(dtype)).sum() / target_scores_sum  # BCE
+        bce_loss = self.bce(pred_scores, target_scores.to(dtype))  # BCE
+        if self.class_weights is not None:
+            bce_loss *= self.class_weights
+        loss[1] = bce_loss.sum() / target_scores_sum
 
         # Bbox loss
         if fg_mask.sum():

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1289,13 +1289,16 @@ class SemanticSegmentationLoss(nn.Module):
         self.dtype = next(model.parameters()).dtype
         data_name = Path(str(getattr(model.args, "data", "") or "")).stem.lower()
         self.use_cityscapes_weight = data_name in {"cityscapes", "cityscapes8"} and self.nc == len(CITYSCAPES_WEIGHT)
+        weight = getattr(model, "class_weights", None)  # cls_pw frequency weights, else hardcoded Cityscapes
+        if weight is None and self.use_cityscapes_weight:
+            weight = torch.from_numpy(CITYSCAPES_WEIGHT)
+        weight = None if weight is None else weight.to(device=self.device, dtype=self.dtype)
         if self.nc == 1:
             self.ce = nn.BCEWithLogitsLoss()
         else:
             self.ce = nn.CrossEntropyLoss(ignore_index=255).to(device=self.device, dtype=self.dtype)
-            if self.use_cityscapes_weight:
+            if weight is not None:
                 # Non-persistent: weight is a deterministic constant, no need to serialize into ckpt state_dict.
-                weight = torch.from_numpy(CITYSCAPES_WEIGHT).to(device=self.device, dtype=self.dtype)
                 self.ce.register_buffer("weight", weight, persistent=False)
 
     def _resize_masks(self, masks, target_shape):

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1294,7 +1294,7 @@ class SemanticSegmentationLoss(nn.Module):
             weight = torch.from_numpy(CITYSCAPES_WEIGHT)
         weight = None if weight is None else weight.to(device=self.device, dtype=self.dtype)
         if self.nc == 1:
-            self.ce = nn.BCEWithLogitsLoss()
+            self.ce = nn.BCEWithLogitsLoss()  # binary: class weighting intentionally unsupported
         else:
             self.ce = nn.CrossEntropyLoss(ignore_index=255).to(device=self.device, dtype=self.dtype)
             if weight is not None:


### PR DESCRIPTION
Semantic segmentation does not support class weighting, but there are hardcoded weights when training on Cityscapes.

This PR adds class weighting support through `cls_pw`. Hardcoded weights are still used when `cls_pw` isn't specified or is 0, so default training is unaffected.

Weights are calculated from ENet formula 1/ln(1.02 + frequency) (Paszke et al., 2016). Different from inverse class frequency formula used for other tasks. Used this because it seems more appropriate for semantic segmentation.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves how Ultralytics computes and applies class weights during training, especially for imbalanced datasets, with new support for semantic segmentation and safer handling of missing label data ⚖️🧠

### 📊 Key Changes
- Added reusable helper methods in detection training to:
  - count per-class labels from the training set
  - compute inverse-frequency class weights automatically
- Updated detection training to safely skip class-weighting when no valid class counts are found, avoiding failures with unreadable or missing labels 🛡️
- Added semantic segmentation class-weight support for multi-class datasets by counting pixel frequencies from segmentation masks 🎨
- Introduced segmentation-specific class-weight calculation using a pixel-frequency-based weighting strategy, better suited to semantic masks than detection-style counting
- Reused the new semantic mask counting logic for label plotting, reducing duplicate code and improving consistency
- Updated detection loss so classification BCE loss can be multiplied by learned class weights during training 📉
- Updated semantic segmentation loss to use:
  - model-provided class weights when available
  - existing Cityscapes preset weights as a fallback
  - no class weighting for binary segmentation, by design
- Bumped the package version from `8.4.67` to `8.4.68` 🚀

### 🎯 Purpose & Impact
- Helps models learn better on imbalanced datasets, where some classes appear much less often than others ⚖️
- Improves semantic segmentation training by using pixel-level statistics instead of object-level counts, which is more appropriate for mask-based tasks
- Makes training more robust when dataset labels or masks are missing, invalid, or unreadable ✅
- Brings more consistent class-weight behavior across detection and segmentation tasks
- Can improve performance on rare classes, though training results may shift for users who enable `cls_pw` and train on uneven datasets 📈