### PR TITLE
Allow safe load of checkpoints with `getattr`

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.68"
+__version__ = "8.4.69"
 
 import importlib
 import os

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1566,9 +1566,7 @@ class _SafeLoad:
         # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
         from ultralytics.utils.loss import E2EDetectLoss
 
-        def _getattr(
-            obj, name
-        ):  # ckpts pickle `Detect.forward` (seg/pose) and `InterpolationMode.BILINEAR` (cls) via getattr
+        def _getattr(obj, name):  # ckpts pickle `Detect.forward` and `InterpolationMode.BILINEAR` via getattr
             if isinstance(obj, type) and not name.startswith("__") and issubclass(obj, (nn.Module, enum.Enum)):
                 return getattr(obj, name)
             raise pickle.UnpicklingError(f"unsafe getattr({obj!r}, {name!r}) blocked during restricted model load")

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1523,6 +1523,7 @@ class _SafeLoad:
         Returns:
             (list): Items for `torch.serialization.safe_globals` — classes and `(obj, "module.Name")` aliases.
         """
+        import enum
         import importlib
         import inspect
         import pathlib
@@ -1565,8 +1566,8 @@ class _SafeLoad:
         # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
         from ultralytics.utils.loss import E2EDetectLoss
 
-        def _getattr(obj, name):  # YOLOv8/YOLO11 ckpts pickle `self.detect = Detect.forward` as getattr(Detect, "forward")
-            if isinstance(obj, type) and issubclass(obj, nn.Module) and not name.startswith("__"):
+        def _getattr(obj, name):  # ckpts pickle `Detect.forward` (seg/pose) and `InterpolationMode.BILINEAR` (cls) via getattr
+            if isinstance(obj, type) and not name.startswith("__") and issubclass(obj, (nn.Module, enum.Enum)):
                 return getattr(obj, name)
             raise pickle.UnpicklingError(f"unsafe getattr({obj!r}, {name!r}) blocked during restricted model load")
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1566,7 +1566,9 @@ class _SafeLoad:
         # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
         from ultralytics.utils.loss import E2EDetectLoss
 
-        def _getattr(obj, name):  # ckpts pickle `Detect.forward` (seg/pose) and `InterpolationMode.BILINEAR` (cls) via getattr
+        def _getattr(
+            obj, name
+        ):  # ckpts pickle `Detect.forward` (seg/pose) and `InterpolationMode.BILINEAR` (cls) via getattr
             if isinstance(obj, type) and not name.startswith("__") and issubclass(obj, (nn.Module, enum.Enum)):
                 return getattr(obj, name)
             raise pickle.UnpicklingError(f"unsafe getattr({obj!r}, {name!r}) blocked during restricted model load")

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1565,10 +1565,16 @@ class _SafeLoad:
         # Legacy/cross-platform aliases (pickled paths with no current class namespace), mirroring temporary_modules().
         from ultralytics.utils.loss import E2EDetectLoss
 
+        def _getattr(obj, name):  # YOLOv8/YOLO11 ckpts pickle `self.detect = Detect.forward` as getattr(Detect, "forward")
+            if isinstance(obj, type) and issubclass(obj, nn.Module) and not name.startswith("__"):
+                return getattr(obj, name)
+            raise pickle.UnpicklingError(f"unsafe getattr({obj!r}, {name!r}) blocked during restricted model load")
+
         allow += [
             (nn.Identity, "ultralytics.nn.modules.block.Silence"),  # YOLOv9e
             (DetectionModel, "ultralytics.nn.tasks.YOLOv10DetectionModel"),  # YOLOv10
             (E2EDetectLoss, "ultralytics.utils.loss.v10DetectLoss"),  # YOLOv10
+            (_getattr, "builtins.getattr"),  # non-det YOLOv8, YOLO11 ckpts (restrict to nn.Module attrs)
         ]
         if WINDOWS:
             allow += [pathlib.WindowsPath, (pathlib.WindowsPath, "pathlib.PosixPath")]


### PR DESCRIPTION
Closes #24850 

YOLOv8/YOLO11 seg/obb/pose checkpoints have a `getattr` method in their checkpoint which is blocked during safe load.

Allow loading those checkpoints.

cc @mykolaxboiko 

```bash
ULTRALYTICS_SAFE_LOAD=1 yolo export model=yolo11n-seg.pt
ULTRALYTICS_SAFE_LOAD=1 yolo export model=yolo11n-cls.pt
```

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔒 This PR improves safe model checkpoint loading by adding restricted support for certain `getattr`-based pickle references, while also bumping the Ultralytics package version to `8.4.69`.

### 📊 Key Changes
- Added `enum` support inside the safe checkpoint loading logic in `ultralytics/nn/tasks.py`.
- Introduced a restricted internal `_getattr` helper to safely handle pickled references such as `Detect.forward` and `InterpolationMode.BILINEAR`.
- Whitelisted `builtins.getattr` during restricted model loading, but only for approved `nn.Module` and `enum.Enum` class attributes.
- Kept strict safety behavior by raising an unpickling error for anything outside these allowed cases.
- Updated the package version from `8.4.68` to `8.4.69` 📦

### 🎯 Purpose & Impact
- Improves compatibility with older and non-detection Ultralytics checkpoints, including some YOLOv8 and YOLO11 models 🤝
- Helps users load more existing model files successfully without disabling safe loading.
- Preserves security by narrowly limiting what dynamic attribute access is allowed during unpickling 🔐
- Reduces friction when working across model versions and environments, especially for users restoring previously saved checkpoints.