### PR TITLE
Raise clear error for non-Module checkpoints and YOLOv5 `models.yolo`

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import sys
+from collections import OrderedDict
 from types import SimpleNamespace
 from unittest import mock
 
@@ -154,6 +155,22 @@ def test_resume_incomplete(task, weight, data, tmp_path):
     resume_model = YOLO(last_path)
     resume_model.train(resume=True, **train_args)
     assert resume_model.trainer.start_epoch == resume_model.trainer.epoch == 1, "resume test failed"
+
+
+@pytest.mark.parametrize(
+    "ckpt",
+    [
+        {"model": OrderedDict([("a", torch.zeros(1))])},  # state_dict saved under the "model" key
+        {"model": {"a": torch.zeros(1)}},  # plain-dict "model" value
+        OrderedDict([("a", torch.zeros(1))]),  # bare state_dict, no "model" key
+    ],
+)
+def test_load_checkpoint_state_dict_rejected(ckpt, tmp_path):
+    """Test a state_dict checkpoint raises a clear TypeError instead of a cryptic AttributeError/KeyError."""
+    weight = tmp_path / "bad.pt"
+    torch.save(ckpt, weight)
+    with pytest.raises(TypeError, match="supported Ultralytics checkpoint format"):
+        load_checkpoint(weight)
 
 
 def test_nan_recovery():

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1651,7 +1651,7 @@ def torch_safe_load(weight, safe_only=None):
         ckpt = _load()
 
     except ModuleNotFoundError as e:  # e.name is missing module name
-        if e.name == "models":
+        if e.name and e.name.split(".")[0] == "models":
             raise TypeError(
                 emojis(
                     f"ERROR ❌️ {weight} appears to be an Ultralytics YOLOv5 model originally trained "
@@ -1728,7 +1728,15 @@ def load_checkpoint(weight, device=None, inplace=True, fuse=False):
         weight = check_file(weight, download_dir=SETTINGS["weights_dir"])
     ckpt, weight = torch_safe_load(weight)  # load ckpt
     args = {**DEFAULT_CFG_DICT, **(ckpt.get("train_args", {}))}  # combine model and default args, preferring model args
-    model = (ckpt.get("ema") or ckpt["model"]).float()  # FP32 model
+    candidate = ckpt.get("ema") or ckpt.get("model")
+    if not isinstance(candidate, torch.nn.Module):
+        raise TypeError(
+            emojis(
+                f"ERROR ❌️ {weight} references types outside the supported Ultralytics checkpoint format. "
+                f"Use an official Ultralytics model, i.e. 'yolo predict model=yolo26n.pt'"
+            )
+        )
+    model = candidate.float()  # FP32 model
 
     # Model compatibility updates
     model.args = args  # attach args to model

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1651,7 +1651,7 @@ def torch_safe_load(weight, safe_only=None):
         ckpt = _load()
 
     except ModuleNotFoundError as e:  # e.name is missing module name
-        if e.name and e.name.split(".")[0] == "models":
+        if e.name in {"models", "models.yolo", "models.common", "models.experimental"}:
             raise TypeError(
                 emojis(
                     f"ERROR ❌️ {weight} appears to be an Ultralytics YOLOv5 model originally trained "


### PR DESCRIPTION
## Summary

Two production crashes in checkpoint loading surfaced as cryptic, unactionable tracebacks even though the same code already raises clear messages for adjacent malformed-checkpoint cases. Both are fixed at the source.

### 1. `load_checkpoint` crashes on a state_dict checkpoint
When a checkpoint's `model` value is a bare state_dict (an `OrderedDict`/`dict`, not an `nn.Module`) — e.g. saved via `torch.save({"model": model.state_dict()}, ...)` — `load_checkpoint` did:
```python
model = (ckpt.get("ema") or ckpt["model"]).float()
```
which raised `AttributeError: 'collections.OrderedDict' object has no attribute 'float'` (or `'dict' object has no attribute 'float'`), and `KeyError: 'model'` for a bare state_dict with no `model` key. Sibling cases (YOLOv5 models, safe-load type rejection, improperly-saved instances) already raise a clear `TypeError`, so this shape slipped through.

**Fix:** resolve `candidate = ckpt.get("ema") or ckpt.get("model")`, and if it is not an `nn.Module`, raise the existing clear `references types outside the supported Ultralytics checkpoint format` `TypeError` before `.float()`.

### 2. YOLOv5 detection guard misses `models.yolo`
`torch_safe_load` detects legacy YOLOv5 checkpoints with `if e.name == "models"`, but when a top-level `models` package is importable the `ModuleNotFoundError` reports `e.name == "models.yolo"`, so the guard missed it and the load fell through to AutoInstall, re-raising a cryptic `ModuleNotFoundError: No module named 'models.yolo'`.

**Fix:** broaden the guard to `e.name and e.name.split(".")[0] == "models"`. Unrelated roots (`numpy._core`, `ultralytics.*`) still route to their own branches.

## Test
Adds a network-free regression test `tests/test_engine.py::test_load_checkpoint_state_dict_rejected` covering state_dict-under-`model`, plain-dict-`model`, and bare-state_dict shapes — all now raise the clear `TypeError`.

## Validation
- `ruff check` / `ruff format --check` clean
- `pytest tests/test_engine.py::test_load_checkpoint_state_dict_rejected` → 3 passed
- Verified a real `YOLO(...).model` checkpoint and an `ema`-bearing checkpoint still load unchanged (no regression)

Caught via production Sentry telemetry (package issues ULTRALYTICS-21J5, ULTRALYTICS-26P8; Ultralytics Platform export-worker issues ALPHA-17W, ALPHA-14B).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves checkpoint loading by catching unsupported or malformed model files earlier and returning clearer, more user-friendly error messages ⚠️✅

### 📊 Key Changes
- Added new tests to verify that invalid checkpoint formats are rejected consistently 🧪
- Covered multiple bad checkpoint cases, including:
  - a saved `state_dict` under a `"model"` key
  - a plain dictionary stored as `"model"`
  - a bare `state_dict` with no `"model"` key
- Updated `load_checkpoint()` to check that the loaded model is actually a PyTorch module before using it 🔍
- Replaced confusing low-level failures like `AttributeError` or `KeyError` with a clear `TypeError` message explaining that the file is not a supported Ultralytics checkpoint 🛠️
- Expanded YOLOv5 compatibility detection to catch more legacy module paths such as `"models.yolo"`, `"models.common"`, and `"models.experimental"` 📦

### 🎯 Purpose & Impact
- Makes loading errors much easier to understand for users who accidentally supply the wrong `.pt` file 🙌
- Prevents cryptic crashes when a file contains only weights instead of a full Ultralytics checkpoint 🚫
- Improves developer confidence with stronger test coverage around checkpoint handling 🔒
- Helps users more quickly identify when they need an official Ultralytics model file, such as a YOLO26 checkpoint, instead of debugging internal Python errors 🚀