### PR TITLE
Fix docs workflow PR branch sync

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.repository == 'ultralytics/ultralytics'
     runs-on: ubuntu-latest
     env:
-      GITHUB_REF: ${{ github.head_ref || github.ref }}
+      BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -42,7 +42,7 @@ jobs:
           # Fetch depth 0 required to capture full docs author history
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          ref: ${{ env.GITHUB_REF }}
+          ref: ${{ env.BRANCH }}
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
         with:
@@ -69,7 +69,7 @@ jobs:
           git config --global user.email "web@ultralytics.com"
           npm install --global prettier prettier-plugin-sh
           python docs/build_reference.py
-          git pull origin "$GITHUB_REF"
+          git pull origin "$BRANCH"
           git add .
           git reset HEAD -- .github/workflows/  # workflow changes are not permitted with default token
           if [[ "${{ github.event_name }}" == "pull_request" ]] && ! git diff --staged --quiet; then
@@ -92,7 +92,7 @@ jobs:
         continue-on-error: true
         if: always()
         run: |
-          git pull origin "$GITHUB_REF"
+          git pull origin "$BRANCH"
           git add --update  # only add updated files
           git reset HEAD -- .github/workflows/  # workflow changes are not permitted with default token
           if [[ "${{ github.event_name }}" == "pull_request" ]] && ! git diff --staged --quiet; then


### PR DESCRIPTION
## Summary
- rename the docs workflow branch env var so shell steps do not read GitHub's reserved GITHUB_REF
- use the same branch value for checkout and post-build pull steps

## Validation
- actionlint .github/workflows/docs.yml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the docs workflow to use a cleaner and more reliable branch reference, improving how documentation changes are checked out, pulled, and committed in GitHub Actions.

### 📊 Key Changes
- Replaced the `GITHUB_REF` environment variable with `BRANCH` in `.github/workflows/docs.yml`.
- Updated the branch value source from `${{ github.head_ref || github.ref }}` to `${{ github.head_ref || github.ref_name }}`.
- Changed all workflow Git operations to use `"$BRANCH"` instead of `"$GITHUB_REF"`:
  - repository checkout
  - `git pull` before auto-generated docs updates
  - `git pull` before final update commits
- Kept existing protections in place, such as preventing workflow file changes from being committed by the default token.

### 🎯 Purpose & Impact
- ✅ Makes branch handling in the docs automation more consistent and easier to understand.
- 🚀 Reduces the chance of GitHub Actions using an incorrect or overly verbose ref format during checkout and pull steps.
- 🛠️ Helps docs auto-generation and auto-commit steps run more reliably, especially for pull requests and branch-based workflows.
- 👥 Benefits contributors by lowering the risk of docs CI failures caused by branch reference mismatches.