### PR TITLE
Add RTX PRO 5000 and RTX PRO 4000 Blackwell to Platform GPU docs

### DIFF
--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -25,7 +25,7 @@ Choose the plan that fits your needs. Compare plans in `Settings > Plans`:
 | **Storage**                                                | 100 GB     | 500 GB          | Unlimited   |
 | **Dataset Upload (ZIP/TAR incl. `.tar.gz`/`.tgz`/NDJSON)** | 10 GB      | 20 GB           | 50 GB       |
 | **Deployments**                                            | 3          | 10              | Unlimited   |
-| **Cloud GPU Types**                                        | 22         | 24              | 24          |
+| **Cloud GPU Types**                                        | 24         | 26              | 26          |
 | **Best GPUs (B200, B300)**                                 | -          | Yes             | Yes         |
 | **Teams**                                                  | -          | Up to 5 members | Custom size |
 | **SSO / SAML**                                             | -          | -               | Yes         |
@@ -46,7 +46,7 @@ Get started at no cost:
 - 100 GB storage · 10 GB dataset upload limit
 - Model export to all 19+ formats
 - Manual, SAM 3 & YOLO Smart annotation
-- 22 cloud GPU types including 5090, H100 & H200 ($0.24–$4.39/hr)
+- 24 cloud GPU types including 5090, H100 & H200 ($0.24–$4.39/hr)
 - Community support
 
 !!! tip "Company Email Bonus"

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -952,7 +952,7 @@ POST /api/models/{modelId}/predict/warmup
 
 ## Training API
 
-Launch YOLO training on cloud GPUs (24 GPU types from RTX 2000 Ada to B300) and monitor progress in real time. See [Cloud Training documentation](../train/cloud-training.md).
+Launch YOLO training on cloud GPUs (26 GPU types from RTX 2000 Ada to B300) and monitor progress in real time. See [Cloud Training documentation](../train/cloud-training.md).
 
 ```mermaid
 graph LR

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -47,7 +47,7 @@ graph LR
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Upload**   | Images (50MB), videos (1GB), and dataset files (ZIP, TAR including `.tar.gz`/`.tgz`, NDJSON) with automatic processing                                                                                                 |
 | **Annotate** | Manual tools for all 6 task types, plus [Smart Annotation](data/annotation.md#smart-annotation) with SAM and YOLO models for detect, segment, semantic, and OBB (see [supported tasks](data/index.md#supported-tasks)) |
-| **Train**    | Cloud GPUs (22 on all plans + 2 Pro/Enterprise-only: B200, B300), real-time metrics, project organization                                                                                                              |
+| **Train**    | Cloud GPUs (24 on all plans + 2 Pro/Enterprise-only: B200, B300), real-time metrics, project organization                                                                                                              |
 | **Export**   | [19+ deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, TFLite, etc.; see [supported formats](train/models.md#supported-formats))                                                                        |
 | **Deploy**   | 43 global regions with dedicated endpoints, scale-to-zero by default (single active instance), and monitoring                                                                                                          |
 
@@ -55,7 +55,7 @@ graph LR
 
 - **Upload** images, videos, and dataset files to create training datasets
 - **Visualize** annotations with interactive overlays for all 6 YOLO task types (see [supported tasks](data/index.md#supported-tasks))
-- **Train** models on cloud GPUs (22 on all plans, 24 with Pro or Enterprise for B200 and B300) with real-time metrics
+- **Train** models on cloud GPUs (24 on all plans, 26 with Pro or Enterprise for B200 and B300) with real-time metrics
 - **Export** to [19+ deployment formats](../modes/export.md) (ONNX, TensorRT, CoreML, TFLite, etc.)
 - **Deploy** to 43 global regions with one-click dedicated endpoints
 - **Monitor** training progress, deployment health, and usage metrics
@@ -107,7 +107,7 @@ graph LR
 
 ### Model Training
 
-- **Cloud Training**: Train on cloud GPUs (22 on all plans, 24 with [Pro or Enterprise](account/billing.md#plans) for B200 and B300) with real-time metrics
+- **Cloud Training**: Train on cloud GPUs (24 on all plans, 26 with [Pro or Enterprise](account/billing.md#plans) for B200 and B300) with real-time metrics
 - **Remote Training**: Train anywhere and stream metrics to the platform (W&B-style)
 - **Project Organization**: Group related models, compare experiments, track activity
 - **19+ Export Formats**: ONNX, TensorRT, CoreML, TFLite, and more (see [supported formats](train/models.md#supported-formats))
@@ -232,7 +232,7 @@ Once deployed, call your endpoint from any language:
     | Concurrent Trainings | 3              | 10                      | Unlimited      |
     | Deployments          | 3              | 10                      | Unlimited      |
     | Storage              | 100 GB         | 500 GB                  | Unlimited      |
-    | Cloud GPU Types      | 22             | 24 (incl. B200 / B300)  | 24             |
+    | Cloud GPU Types      | 24             | 26 (incl. B200 / B300)  | 26             |
     | Teams                | -              | Up to 5 members         | Up to 50       |
     | Support              | Community      | Priority                | Dedicated      |
 

--- a/docs/macros/platform-gpu-table.md
+++ b/docs/macros/platform-gpu-table.md
@@ -8,10 +8,12 @@
 | A40          | Ampere     | 48 GB  | $0.44     | Larger batch sizes         |
 | RTX 3090     | Ampere     | 24 GB  | $0.46     | General training           |
 | RTX A6000    | Ampere     | 48 GB  | $0.49     | Large models               |
+| RTX PRO 4000 | Blackwell  | 24 GB  | $0.57     | Budget Blackwell           |
 | RTX PRO 4500 | Blackwell  | 32 GB  | $0.64     | Great price/performance    |
 | RTX 4090     | Ada        | 24 GB  | $0.69     | Best price/performance     |
 | RTX 6000 Ada | Ada        | 48 GB  | $0.77     | Large batch training       |
 | L40S         | Ada        | 48 GB  | $0.86     | Large batch training       |
+| RTX PRO 5000 | Blackwell  | 48 GB  | $0.96     | Large batch training       |
 | RTX 5090     | Blackwell  | 32 GB  | $0.99     | Latest consumer generation |
 | L40          | Ada        | 48 GB  | $0.99     | Large models               |
 | A100 PCIe    | Ampere     | 80 GB  | $1.39     | Production training        |


### PR DESCRIPTION
Documents the two new RunPod Secure Cloud Blackwell GPUs now offered by the Ultralytics Platform (companion to `ultralytics/portal`), completing the RTX PRO Blackwell line:

| GPU | VRAM | $/hr |
|-----|------|------|
| **RTX PRO 5000 Blackwell** | 48 GB | $0.96 |
| **RTX PRO 4000 Blackwell** | 24 GB | $0.57 |

## Changes

- **`docs/macros/platform-gpu-table.md`** — add both rows (price-sorted). This macro is included across the platform `train/`, `billing.md`, and `index.md` pages, so the GPU table updates everywhere at once.
- **Cloud GPU counts** updated across `platform/index.md`, `account/billing.md`, and `api/index.md`: **22 → 24** on all plans, **24 → 26** with Pro/Enterprise (the +2 Pro-only B200/B300 are unchanged). Free-tier price range `$0.24–$4.39/hr` is unchanged.

Both GPUs are Blackwell, already covered by existing CUDA 12.8 / PyTorch 2.8 tooling notes — no other doc changes needed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR updates Ultralytics Platform documentation to reflect an expanded cloud GPU lineup, increasing the advertised GPU options across plans and training docs.

### 📊 Key Changes
- 🔢 Updated multiple documentation pages to show higher **Cloud GPU Types** counts across platform plans:
  - Free: **22 → 24**
  - Pro/Enterprise: **24 → 26**
- 🧾 Revised billing and platform overview docs to keep plan comparisons consistent with current GPU availability.
- 🚀 Updated Training API docs to state that cloud training now supports **26 GPU types**.
- 🖥️ Added two new GPU entries to the shared platform GPU table:
  - **RTX PRO 4000** — positioned as a budget Blackwell option
  - **RTX PRO 5000** — positioned for larger batch training
- 🛠️ Refreshed references across platform pages so training, pricing, and feature summaries all match the latest infrastructure offerings.

### 🎯 Purpose & Impact
- ✅ Ensures the documentation accurately reflects the current Ultralytics Platform cloud training hardware options.
- 🎯 Helps users make better plan and training decisions by showing a broader range of available GPUs.
- 📈 Highlights improved platform capacity and newer Blackwell GPU availability for cloud training.
- 🤝 Reduces confusion by aligning billing, platform overview, and API docs with the same GPU counts and hardware list.
- 🌐 Makes the [Ultralytics Platform](https://platform.ultralytics.com) appear more up to date and transparent for users comparing cloud training options.