### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         python: ["3.13"]
         model: [yolo26n]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         if: matrix.os != 'cpu-latest'
         with:
@@ -147,7 +147,7 @@ jobs:
             torch: "1.8.0"
             torchvision: "0.9.0"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         if: matrix.os != 'cpu-latest'
         with:
@@ -299,7 +299,7 @@ jobs:
             torch: "2.11.0"
             torchvision: "0.26.0"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         if: matrix.os != 'cpu-latest'
         with:
@@ -370,7 +370,7 @@ jobs:
     timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -428,7 +428,7 @@ jobs:
     env:
       YOLO_AUTOINSTALL: "false"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
         with:
           activate-environment: true
@@ -466,7 +466,7 @@ jobs:
     steps:
       - name: Clean up runner
         uses: eviden-actions/clean-self-hosted-runner@v1
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Activate Virtual Environment for Tests
         run: |
           python3.11 -m venv env-tests
@@ -565,7 +565,7 @@ jobs:
     steps:
       - name: Clean up runner
         uses: eviden-actions/clean-self-hosted-runner@v1
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - name: Activate virtual environment
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,7 +110,7 @@ jobs:
         uses: ultralytics/actions/cleanup-disk@main
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # copy full .git directory to access full git history in Docker images
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Fetch depth 0 required to capture full docs author history
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository == 'ultralytics/ultralytics'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install lychee
         run: |

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.repository == 'ultralytics/ultralytics' && github.actor == 'glenn-jocher'
     steps:
       - name: Checkout Source Repository (${{ github.repository }})
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Fetch all history for mirroring
       - name: Run Git Config

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       current_tag: ${{ steps.check_pypi.outputs.current_tag }}
       previous_tag: ${{ steps.check_pypi.outputs.previous_tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -121,7 +121,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -147,7 +147,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Extract PR Details
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates GitHub Actions workflows across the Ultralytics repository to use `actions/checkout@v7` instead of `actions/checkout@v6`.

### 📊 Key Changes
- Replaced `actions/checkout@v6` with `actions/checkout@v7` in multiple workflow files:
  - `ci.yml`
  - `docker.yml`
  - `docs.yml`
  - `links.yml`
  - `mirror.yml`
  - `publish.yml`
- Applied the update consistently across different automation jobs, including:
  - CI testing 🧪
  - Docker builds 🐳
  - Documentation checks 📚
  - Link validation 🔗
  - Repository mirroring 🔄
  - Package publishing 🚀

### 🎯 Purpose & Impact
- Keeps Ultralytics GitHub Actions workflows up to date with the latest checkout action version ✅
- Helps improve long-term maintainability and compatibility of repository automation 🛠️
- Reduces the risk of using outdated CI infrastructure across testing, publishing, and docs workflows 📦
- No direct user-facing model or API changes are introduced; the impact is mainly on development and release reliability for contributors and maintainers 👨‍💻