### PR TITLE
docs: small cleanup triton contributions

### DIFF
--- a/examples/cpp/Triton/README.md
+++ b/examples/cpp/Triton/README.md
@@ -129,14 +129,3 @@ Triton exposes no class names, so the example falls back to the 80 [COCO](https:
 ## 🤝 Contributing
 
 Contributions are welcome! If you find any issues or have suggestions for improvements, please feel free to open an issue or submit a pull request on the main [Ultralytics repository](https://github.com/ultralytics/ultralytics).
-
-This example was originally contributed by:
-
-- [Ahmet Selim Demirel](https://github.com/asdemirel)
-- [Doğan Mehmet Başoğlu](https://github.com/doganmb)
-- [Enes Uzun](https://github.com/uzunenes)
-- Elif Cansu Ada
-- [Mevlüt Ardıç](https://github.com/mevlutardic)
-- Serhat Karaca
-
-[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR simplifies the Triton C++ example README by removing the contributor credit block at the end of the file.

### 📊 Key Changes
- Removed the list of original contributors from `examples/cpp/Triton/README.md`
- Removed the contributor badge/image linking to the Ultralytics contributors page
- Kept the main contribution guidance intact, including the link to the main [Ultralytics repository](https://github.com/ultralytics/ultralytics)

### 🎯 Purpose & Impact
- Improves documentation consistency by keeping the README focused on setup and usage 📘
- Reduces extra footer content that may distract from the example itself ✂️
- Has no effect on code, model behavior, or Triton functionality ⚙️
- Mainly impacts documentation presentation and maintenance, with minimal user-facing change 🙂