### PR TITLE
Fix TensorRT INT8 export crash on RTX cards exposing the NvTensorRTRTX EP

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.71"
+__version__ = "8.4.72"
 
 import importlib
 import os

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -144,6 +144,11 @@ def modelopt_quantize_onnx(
             quantize_mode="int8",
             calibration_data={input_name: calib.cpu().numpy()},
             calibration_method="max",
+            # Calibrate on CUDA (CPU fallback), not ModelOpt's default that also includes the TensorRT EP: some RTX
+            # cards (e.g. RTX 2000 Ada) additionally register NvTensorRTRTXExecutionProvider, and enabling both TRT
+            # EPs in one session aborts calibration ("Cannot enable both 'TensorrtExecutionProvider' and
+            # 'NvTensorRTRTXExecutionProvider'"). Calibration scales are effectively EP-independent, so CUDA matches.
+            calibration_eps=["cuda:0", "cpu"],
             output_path=out_file,
             **kwargs,
         )

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -148,6 +148,7 @@ def modelopt_quantize_onnx(
             # cards (e.g. RTX 2000 Ada) additionally register NvTensorRTRTXExecutionProvider, and enabling both TRT
             # EPs in one session aborts calibration ("Cannot enable both 'TensorrtExecutionProvider' and
             # 'NvTensorRTRTXExecutionProvider'"). Calibration scales are effectively EP-independent, so CUDA matches.
+            # `cuda:0` is the user-selected GPU: select_device() masks it via CUDA_VISIBLE_DEVICES to logical index 0.
             calibration_eps=["cuda:0", "cpu"],
             output_path=out_file,
             **kwargs,


### PR DESCRIPTION
## Problem

TensorRT **INT8** export (`format="engine", int8=True`) crashes during ModelOpt calibration on RTX cards where onnxruntime also registers `NvTensorRTRTXExecutionProvider` (observed on **RTX 2000 Ada**):

```
RuntimeError: ... Cannot enable both 'TensorrtExecutionProvider' and 'NvTensorRTRTXExecutionProvider'
  (modelopt/onnx/quantization/ort_utils.py create_inference_session → ort.InferenceSession)
```

`modelopt.onnx.quantization.quantize()` defaults to `calibration_eps=["cpu", "cuda:0", "trt"]`. The `"trt"` entry makes ModelOpt build an onnxruntime session with the TensorRT EP; on cards that *also* expose the newer `NvTensorRTRTXExecutionProvider`, onnxruntime refuses to enable both TensorRT EPs at once and aborts, so INT8 engine export fails on those GPUs (FP16 export is unaffected).

## Fix

Calibrate on CUDA with CPU fallback — `calibration_eps=["cuda:0", "cpu"]` — so the conflicting TensorRT EPs are never co-enabled. Calibration scales are effectively EP-independent (same graph + same calibration data), so INT8 accuracy is unchanged. One-line change in `modelopt_quantize_onnx`.

## Why it's safe
- `calibration_eps` is a documented `quantize()` parameter (modelopt ≥ 0.44).
- TensorRT engine export already requires CUDA (`export_engine`), and `"cpu"` remains as a fallback, so no CPU-only regression.
- `cuda:0` maps to the export's selected device via `select_device()`'s `CUDA_VISIBLE_DEVICES`.

Reviewed with codex (LGTM; verified `calibration_eps` against the `nvidia-modelopt==0.44.0` source).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR bumps Ultralytics to version `8.4.72` and improves ONNX INT8 quantization reliability by avoiding a TensorRT calibration conflict on some NVIDIA RTX GPUs ⚙️🧠

### 📊 Key Changes
- Updated the package version from `8.4.71` to `8.4.72` 📦
- Modified `modelopt_quantize_onnx()` in `ultralytics/utils/export/engine.py`
- Added explicit calibration execution providers for ONNX quantization: `["cuda:0", "cpu"]` 🎯
- Prevented ModelOpt from using its default calibration setup, which could include multiple TensorRT execution providers at once
- Added comments explaining that some GPUs, such as certain RTX 2000 Ada cards, can fail calibration when both TensorRT provider types are enabled together 🚫

### 🎯 Purpose & Impact
- Fixes a hardware-specific export issue that could cause INT8 calibration to abort on some NVIDIA GPUs 💥
- Makes ONNX quantization/export more stable and predictable, especially for users exporting optimized models for deployment 🚀
- Keeps calibration on CUDA when available, with CPU fallback for safety, improving compatibility without changing model behavior
- Reduces friction for users working with TensorRT-related acceleration paths on newer or mixed NVIDIA setups 🛠️