### PR TITLE
Pin onnxruntime-gpu<1.27.0 for CUDA 12 export image

### DIFF
--- a/docker/Dockerfile-export
+++ b/docker/Dockerfile-export
@@ -8,9 +8,10 @@ FROM ultralytics/ultralytics:latest
 
 # Install export dependencies
 # Numpy 1.26.4 required for TensorFlow export compatibility
+# onnxruntime-gpu pinned <1.27.0 as 1.27.0 dropped CUDA 12 support and ships CUDA 13 binaries (base image is CUDA 12.8)
 # Note tensorrt installed on-demand as depends on runtime environment CUDA version
 RUN uv pip install --system --no-cache -e ".[export]" numpy==1.26.4 && \
-    uv pip install --system --no-cache "onnxruntime-gpu" paddlepaddle x2paddle numpy==1.26.4 && \
+    uv pip install --system --no-cache "onnxruntime-gpu<1.27.0" paddlepaddle x2paddle numpy==1.26.4 && \
     rm -rf tmp ~/.cache /root/.config/Ultralytics/persistent_cache.json
 
 # Usage --------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Docker build CI fails in the export image test step with:

```
ImportError: libcudart.so.13: cannot open shared object file: No such file or directory
```

8 ONNX inference tests fail (`test_export_onnx`, `test_utils_benchmarks`, all `test_grayscale` variants).

## Cause

`onnxruntime-gpu` **1.27.0 dropped CUDA 12 support** and now ships CUDA 13 binaries on PyPI (linking `libcudart.so.13`). The export image derives from `pytorch/pytorch:2.11.0-cuda12.8-cudnn9-runtime` (CUDA 12.8), so the new binaries cannot load. Because `onnxruntime-gpu` overwrites the shared `onnxruntime` native module, even CPU ONNX Runtime inference broke once the unpinned install picked up 1.27.0.

`docker/Dockerfile-export` is the only x86 CUDA-12 image installing `onnxruntime-gpu` unpinned; the Jetson/ARM images use pinned custom wheels and are unaffected.

## Fix

Pin `onnxruntime-gpu<1.27.0` so the export image stays on the last CUDA 12 release line (1.26.x), matching the CUDA 12.8 base. ONNX Runtime's own guidance is to use onnxruntime-gpu 1.26.x or earlier for CUDA 12.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐳 This PR improves the export Docker image by pinning `onnxruntime-gpu` to versions below `1.27.0` to preserve CUDA 12.8 compatibility and prevent export/runtime issues.

### 📊 Key Changes
- Updated `docker/Dockerfile-export` to install `onnxruntime-gpu<1.27.0` instead of the latest unpinned version.
- Added a clarifying comment explaining why the pin is needed:
  - `onnxruntime-gpu` 1.27.0 dropped CUDA 12 support.
  - Newer builds ship CUDA 13 binaries, which do not match the Docker base image’s CUDA 12.8 environment.
- Kept existing export-related dependencies unchanged, including:
  - `numpy==1.26.4` for TensorFlow export compatibility
  - `paddlepaddle` and `x2paddle`
- Left TensorRT behavior unchanged, with installation still handled on demand based on the runtime CUDA setup.

### 🎯 Purpose & Impact
- ✅ Prevents broken export environments caused by CUDA version mismatches inside the export Docker image.
- 🚀 Makes GPU-based model export workflows more reliable and reproducible for users building from this container.
- 🛠️ Reduces the chance of unexpected installation or runtime failures when using ONNX Runtime GPU features.
- 📦 Improves stability without changing user-facing export commands or model behavior.