### PR TITLE
Calibrate INT8 on CPU for RTX (NvTensorRTRTX) cards

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.72"
+__version__ = "8.4.73"
 
 import importlib
 import os

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -139,16 +139,12 @@ def modelopt_quantize_onnx(
         calib = torch.cat(images).to(torch.float32) / 255.0
         LOGGER.info(f"{prefix} quantizing ONNX to INT8 with ModelOpt using {calib.shape[0]} calibration images...")
         kwargs = {"calibration_shapes": f"{input_name}:{'x'.join(str(d) for d in shape)}"} if dynamic else {}
-        # Select calibration execution providers. ModelOpt's default also enables the TensorRT EP, but RTX cards (e.g.
-        # RTX 2000 Ada) additionally register NvTensorRTRTXExecutionProvider and abort when both TRT EPs are enabled in
-        # one session ("Cannot enable both 'TensorrtExecutionProvider' and 'NvTensorRTRTXExecutionProvider'"). On those
-        # cards the CUDA EP can also crash on a cuDNN ABI mismatch (ModelOpt pins onnxruntime-gpu to a build whose cuDNN
-        # differs from the installed torch's), so calibrate them on CPU. Calibration scales are EP-independent, so this
-        # does not change the result. Other GPUs use CUDA (CPU fallback); `cuda:0` is the user-selected device —
-        # select_device() masks it via CUDA_VISIBLE_DEVICES to logical index 0.
+        # RTX cards register the NvTensorRTRTX EP and abort if both TensorRT EPs are enabled; their CUDA EP can also
+        # segfault on a cuDNN ABI mismatch from ModelOpt's onnxruntime pin. Calibrate them on CPU (scales are
+        # EP-independent), others on CUDA. ONNX Runtime's casing for the EP varies by release, so match insensitively.
         import onnxruntime
 
-        on_rtx = "NvTensorRTRTXExecutionProvider" in onnxruntime.get_available_providers()
+        on_rtx = any("nvtensorrtrtx" in ep.lower() for ep in onnxruntime.get_available_providers())
         quantize(
             onnx_file,
             quantize_mode="int8",

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -139,17 +139,22 @@ def modelopt_quantize_onnx(
         calib = torch.cat(images).to(torch.float32) / 255.0
         LOGGER.info(f"{prefix} quantizing ONNX to INT8 with ModelOpt using {calib.shape[0]} calibration images...")
         kwargs = {"calibration_shapes": f"{input_name}:{'x'.join(str(d) for d in shape)}"} if dynamic else {}
+        # Select calibration execution providers. ModelOpt's default also enables the TensorRT EP, but RTX cards (e.g.
+        # RTX 2000 Ada) additionally register NvTensorRTRTXExecutionProvider and abort when both TRT EPs are enabled in
+        # one session ("Cannot enable both 'TensorrtExecutionProvider' and 'NvTensorRTRTXExecutionProvider'"). On those
+        # cards the CUDA EP can also crash on a cuDNN ABI mismatch (ModelOpt pins onnxruntime-gpu to a build whose cuDNN
+        # differs from the installed torch's), so calibrate them on CPU. Calibration scales are EP-independent, so this
+        # does not change the result. Other GPUs use CUDA (CPU fallback); `cuda:0` is the user-selected device —
+        # select_device() masks it via CUDA_VISIBLE_DEVICES to logical index 0.
+        import onnxruntime
+
+        on_rtx = "NvTensorRTRTXExecutionProvider" in onnxruntime.get_available_providers()
         quantize(
             onnx_file,
             quantize_mode="int8",
             calibration_data={input_name: calib.cpu().numpy()},
             calibration_method="max",
-            # Calibrate on CUDA (CPU fallback), not ModelOpt's default that also includes the TensorRT EP: some RTX
-            # cards (e.g. RTX 2000 Ada) additionally register NvTensorRTRTXExecutionProvider, and enabling both TRT
-            # EPs in one session aborts calibration ("Cannot enable both 'TensorrtExecutionProvider' and
-            # 'NvTensorRTRTXExecutionProvider'"). Calibration scales are effectively EP-independent, so CUDA matches.
-            # `cuda:0` is the user-selected GPU: select_device() masks it via CUDA_VISIBLE_DEVICES to logical index 0.
-            calibration_eps=["cuda:0", "cpu"],
+            calibration_eps=["cpu"] if on_rtx else ["cuda:0", "cpu"],
             output_path=out_file,
             **kwargs,
         )


### PR DESCRIPTION
## Summary
Follow-up to #24876. On RTX cards that register `NvTensorRTRTXExecutionProvider`, ModelOpt INT8 calibration now runs on the **CPU EP** instead of `cuda:0`. Calibration scales are EP-independent, so the resulting INT8 engine is unchanged; non-RTX GPUs keep CUDA calibration.

## Why
#24876 set `calibration_eps=["cuda:0", "cpu"]` so RTX cards skip the TensorRT EP (they abort with *"Cannot enable both TensorrtExecutionProvider and NvTensorRTRTXExecutionProvider"*). But on those cards the `cuda:0` EP then **core-dumps** on a cuDNN ABI mismatch: at first INT8 export ModelOpt AutoUpdates `onnxruntime-gpu~=1.24` (built against cuDNN 9.8) while the upgraded torch drags in cuDNN 9.10/9.13, and ModelOpt loads the mismatched cuDNN via `preload_dlls()` →

```
EP Error ... EnumToName Failed to map enum value to name: <garbage>
 when using [CUDAExecutionProvider, CPUExecutionProvider]
... the monitored command dumped core
```

Reproduced on an RTX 2000 Ada (export `format=engine int8=True`). Capping `torch<2.10` did **not** help — the lever is cuDNN, not torch. Calibrating on CPU sidesteps the entire TRT-EP/cuDNN minefield for these cards, and the scales (and thus accuracy/speed of the engine) are unaffected.

## Change
Detect the RTX EP via `onnxruntime.get_available_providers()` and choose `calibration_eps=["cpu"]` for those cards, else keep `["cuda:0", "cpu"]`. Empirically the EP is hardware/runtime-gated (25 data-center GPUs calibrating with the same onnxruntime wheel never exposed the dual-EP conflict). Over-triggering on a non-RTX host (e.g. a manually-registered plugin) would only fall back to slower CPU calibration, not change correctness.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR bumps Ultralytics to version `8.4.73` and improves ONNX INT8 quantization stability by avoiding GPU calibration issues on certain NVIDIA RTX systems.

### 📊 Key Changes
- Updated the package version from `8.4.72` to `8.4.73`.
- Improved `modelopt_quantize_onnx()` in `ultralytics/utils/export/engine.py`.
- Added detection for the `NvTensorRTRTX` ONNX Runtime provider on some RTX GPUs.
- Changed INT8 calibration behavior:
  - On affected RTX systems, calibration now runs on CPU only.
  - On other systems, calibration still prefers `cuda:0` with CPU fallback.
- Added a case-insensitive check for ONNX Runtime execution provider names to handle differences across releases.

### 🎯 Purpose & Impact
- ✅ Prevents calibration crashes when both TensorRT execution providers are present on some RTX GPUs.
- ✅ Reduces the chance of segmentation faults tied to CUDA/cuDNN compatibility issues during ModelOpt-based quantization.
- ✅ Makes ONNX INT8 export more reliable across a wider range of NVIDIA hardware.
- ✅ Keeps quantization results consistent, since calibration scales are effectively independent of the execution provider used.
- ⚠️ Users on affected RTX hardware may see calibration run on CPU instead of GPU, which can be slower, but should be much more stable.