### PR TITLE
Improve Jetson CI install retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,11 +573,16 @@ jobs:
           source env/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
       - name: Install requirements
-        run: |
-          uv pip install -e ".[export]" pytest \
-          "${{ matrix.torch_whl }}" "${{ matrix.torchvision_whl }}" "${{ matrix.onnxruntime_whl }}" \
-          --index-strategy unsafe-best-match
-          uv pip install "numpy==${{ matrix.numpy }}"
+        uses: ultralytics/actions/retry@main
+        with:
+          retries: 3
+          retry_delay_seconds: 60
+          timeout_minutes: 60
+          run: |
+            uv pip install -e ".[export]" pytest \
+            "${{ matrix.torch_whl }}" "${{ matrix.torchvision_whl }}" "${{ matrix.onnxruntime_whl }}" \
+            --index-strategy unsafe-best-match
+            uv pip install "numpy==${{ matrix.numpy }}"
       - name: Check environment
         run: |
           yolo checks


### PR DESCRIPTION
## Summary
- wrap the NVIDIA Jetson dependency install step in the shared retry action
- keep the existing `uv pip install` commands and test coverage unchanged

## Root cause
The JetPack 5.1.2 job failed before tests while downloading a GitHub release wheel with `502 Bad Gateway`. Retrying the install step makes the job resilient to transient release-asset or network failures without hiding test failures.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml OK"'`
- `git diff --check -- .github/workflows/ci.yml`

Full `actionlint .github/workflows/ci.yml` still reports existing custom-runner label and shellcheck findings outside this change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes the CI installation step more reliable by adding automatic retries around dependency setup in the GitHub Actions workflow.

### 📊 Key Changes
- Replaced the plain `Install requirements` step in `.github/workflows/ci.yml` with the [`ultralytics/actions/retry`](https://github.com/ultralytics/actions) action.
- Added retry settings for the dependency installation step:
  - `retries: 3`
  - `retry_delay_seconds: 60`
  - `timeout_minutes: 60`
- Kept the actual install commands unchanged, including:
  - installing the package with export dependencies
  - installing `pytest`
  - installing matrix-specific PyTorch, TorchVision, and ONNX Runtime wheels
  - pinning NumPy from the test matrix

### 🎯 Purpose & Impact
- ✅ Reduces flaky CI failures caused by temporary network, package index, or wheel download issues.
- 🔁 Helps GitHub Actions recover automatically instead of failing immediately on transient install problems.
- ⏱️ Improves overall CI stability with minimal workflow changes, which can save developer time and reduce unnecessary reruns.
- 👩‍💻 Benefits contributors and maintainers by making test results more dependable without changing the actual software behavior.