### PR TITLE
Fix non-deterministic OpenVINO export failure on NMS models

### DIFF
--- a/ultralytics/utils/export/openvino.py
+++ b/ultralytics/utils/export/openvino.py
@@ -42,7 +42,12 @@ def torch2openvino(
     LOGGER.info(f"\n{prefix} starting export with openvino {ov.__version__}...")
 
     input_shape = [i.shape for i in im] if isinstance(im, (list, tuple)) else im.shape
-    ov_model = ov.convert_model(model, input=None if dynamic else input_shape, example_input=im)
+    # Hand OpenVINO an already-traced ScriptModule (torchscript/coreml exports trace the same way), not a raw
+    # nn.Module, so it doesn't re-trace internally with check_trace=True - that re-trace-and-diff sanity check is
+    # non-deterministic on NMS models and fails with "Graphs differed across invocations!". check_trace=False skips
+    # the same check on our own trace.
+    ts = torch.jit.trace(model, im, strict=False, check_trace=False)
+    ov_model = ov.convert_model(ts, input=None if dynamic else input_shape, example_input=im)
     if int8:
         import nncf
 


### PR DESCRIPTION
## Fix non-deterministic OpenVINO export failure on NMS models

**Symptom (surfaced by Ultralytics Platform CPU export telemetry):**

```
OpenVINO: export failure: Couldn't get TorchScript module by tracing.
Tracing failed sanity checks! ERROR: Graphs differed across invocations!
```

intermittently, on NMS-wrapped models (`nms=True`), during OpenVINO export.

### Root cause
`ov.convert_model(model, ...)` is handed a raw `nn.Module`, so OpenVINO's PyTorch frontend runs `torch.jit.trace` internally with its default `check_trace=True`. That re-trace-and-diff sanity check is non-deterministic on the data-dependent control flow of an NMS model (`prim::Constant` ordering varies between trace invocations), so it intermittently raises *"Graphs differed across invocations!"* and the export fails.

### Fix
Pre-trace the model ourselves and hand the resulting `ScriptModule` to `ov.convert_model`, mirroring how the TorchScript and CoreML exporters already trace:

```python
ts = torch.jit.trace(model, im, strict=False, check_trace=False)
ov_model = ov.convert_model(ts, input=None if dynamic else input_shape, example_input=im)
```

`check_trace=False` disables only the non-deterministic re-trace-and-diff sanity check; it does not alter the captured graph. `example_input` and the `input=None if dynamic else input_shape` (dynamic vs static) handling are unchanged, and the INT8 path is upstream-unaffected (`nncf.quantize` consumes the same `ov_model`).

### Verification (openvino 2025.4.1, torch 2.11)
yolo11n OpenVINO export succeeds and the exported model predicts identically to PyTorch (5 detections) across configs:

| config | OpenVINO detections | PyTorch | match |
|---|---|---|---|
| `nms=False` | 5 | 5 | ✓ |
| `nms=True` | 5 | 5 | ✓ |
| `nms=True, dynamic=True` | 5 | 5 | ✓ |
| `nms=True, half=True` | 5 | 5 | ✓ |

No regression across the export surface.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes OpenVINO export more reliable by tracing the PyTorch model first and passing that traced model into OpenVINO conversion, avoiding flaky re-tracing failures.

### 📊 Key Changes
- Replaced direct OpenVINO conversion of a raw PyTorch `nn.Module` with conversion from a pre-traced TorchScript model.
- Added `torch.jit.trace(model, im, strict=False, check_trace=False)` before `ov.convert_model(...)`.
- Prevents OpenVINO from internally re-tracing the model with its default graph consistency checks.
- Specifically addresses non-deterministic export failures on models with NMS, which could trigger errors like `"Graphs differed across invocations!"`.
- Included inline comments explaining why the traced model approach is used and how it aligns with existing tracing behavior in other export paths like TorchScript and CoreML.

### 🎯 Purpose & Impact
- ✅ Improves export stability for OpenVINO models, especially for detection pipelines that include NMS.
- ✅ Reduces confusing, intermittent export errors for users exporting Ultralytics models.
- ✅ Makes behavior more consistent across different export formats by reusing a similar tracing approach.
- ✅ Helps developers and users trust OpenVINO export workflows more in real-world deployment scenarios.
- ⚠️ Main impact is on export reliability rather than model features or accuracy; users should see fewer failed conversions rather than changes in inference results.