### PR TITLE
Calibrate INT8 on CPU unconditionally (cuDNN-ABI-safe)

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.73"
+__version__ = "8.4.74"
 
 import importlib
 import os

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -139,18 +139,15 @@ def modelopt_quantize_onnx(
         calib = torch.cat(images).to(torch.float32) / 255.0
         LOGGER.info(f"{prefix} quantizing ONNX to INT8 with ModelOpt using {calib.shape[0]} calibration images...")
         kwargs = {"calibration_shapes": f"{input_name}:{'x'.join(str(d) for d in shape)}"} if dynamic else {}
-        # RTX cards register the NvTensorRTRTX EP and abort if both TensorRT EPs are enabled; their CUDA EP can also
-        # segfault on a cuDNN ABI mismatch from ModelOpt's onnxruntime pin. Calibrate them on CPU (scales are
-        # EP-independent), others on CUDA. ONNX Runtime's casing for the EP varies by release, so match insensitively.
-        import onnxruntime
-
-        on_rtx = any("nvtensorrtrtx" in ep.lower() for ep in onnxruntime.get_available_providers())
         quantize(
             onnx_file,
             quantize_mode="int8",
             calibration_data={input_name: calib.cpu().numpy()},
             calibration_method="max",
-            calibration_eps=["cpu"] if on_rtx else ["cuda:0", "cpu"],
+            # Calibrate on CPU. ModelOpt's CUDA EP session can hit an uncatchable cuDNN-ABI segfault (its pinned
+            # onnxruntime-gpu's cuDNN vs the installed torch's) and the TensorRT EP aborts on RTX cards (NvTensorRTRTX);
+            # scales are EP-independent, so the INT8 engine is equivalent and only this one-time step is slower.
+            calibration_eps=["cpu"],
             output_path=out_file,
             **kwargs,
         )


### PR DESCRIPTION
## Summary
Follow-up to #24876 and #24878. ModelOpt INT8 calibration now runs on the **CPU EP unconditionally**, replacing #24878's `NvTensorRTRTX` provider detection (which doesn't work — see below). Calibration scales are EP-independent, so the INT8 engine is equivalent; only the one-time calibration step is slower.

## Why #24878's detection failed (production-validated)
A real INT8 engine export on an **RTX 2000 Ada** with released 8.4.73 still core-dumped. The captured log shows the detection can never fire:

```
available_providers ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']   ← no NvTensorRTRTX
Successfully enabled 2 EPs for ORT: [CUDAExecutionProvider, CPUExecutionProvider]                     ← used cuda:0
EP Error ... EnumToName Failed to map enum value to name ...  → the monitored command dumped core
```

`onnxruntime.get_available_providers()` has **no** `NvTensorRtRtx`/`NvTensorRTRTX` entry on the card, so `on_rtx` is always `False` and calibration falls to `cuda:0`.

## Root cause (not RTX-specific)
The crash is a **cuDNN ABI mismatch** in ModelOpt's CUDA calibration session: ModelOpt pins `onnxruntime-gpu~=1.24` (built against cuDNN 9.8), but a recent `torch` (e.g. 2.10.0) ships cuDNN 9.10, and ModelOpt loads cuDNN via `onnxruntime.preload_dlls()` from site-packages → ABI mismatch → **uncatchable core dump** (so "try CUDA, except → CPU" is impossible). This hits the CUDA calibration EP on **any** GPU in an environment with mismatched torch/onnxruntime cuDNN — i.e. real users on recent torch, not just RTX cards.

## Fix
Calibrate on CPU always. Validated: a benchmark sweep that forces exactly this completed INT8 on all 26 Platform GPUs incl. RTX 2000 Ada, with engine speed/accuracy matching the other Ada cards. Reviewed/consulted with codex (LGTM).

Lineage: #24876 (drop TRT EP) → #24878 (RTX-conditional CPU — detection unreliable) → this (unconditional CPU).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR bumps Ultralytics to version `8.4.74` and makes ONNX INT8 quantization more stable by forcing ModelOpt calibration to run on CPU instead of GPU/ TensorRT ⚙️🛡️

### 📊 Key Changes
- Updated the package version from `8.4.73` to `8.4.74` 📦
- Simplified `modelopt_quantize_onnx()` in `ultralytics/utils/export/engine.py`
- Removed runtime checks for RTX-specific TensorRT execution providers
- Changed ModelOpt INT8 calibration to always use `calibration_eps=["cpu"]` instead of trying CUDA first 💻
- Added clearer comments explaining why CPU calibration is safer:
  - avoids possible cuDNN/ONNX Runtime ABI mismatch crashes
  - avoids TensorRT provider aborts on some RTX systems
  - preserves equivalent INT8 scaling results despite using CPU

### 🎯 Purpose & Impact
- Improves reliability of ONNX INT8 export by avoiding hard-to-debug crashes during calibration ✅
- Makes behavior more consistent across different GPUs and system setups, especially on RTX hardware 🎯
- Reduces platform-specific export failures caused by CUDA, cuDNN, or TensorRT compatibility issues
- Trades a small amount of one-time calibration speed for much better stability and predictability ⏱️➡️🛡️
- Benefits users exporting optimized deployment models, especially those using INT8 quantization workflows with ModelOpt 🚀