### PR TITLE
Run CoreML on the Neural Engine (CPU_AND_NE) on macOS hosts

### DIFF
--- a/docs/en/integrations/coreml.md
+++ b/docs/en/integrations/coreml.md
@@ -160,6 +160,8 @@ For more details about the export process, visit the [Ultralytics documentation 
 
 CoreML chooses hardware via `MLModelConfiguration.computeUnits`. The Ultralytics iOS SDK defaults to `.cpuAndNeuralEngine` on iOS 16+ rather than `.all`: in a real-time camera app the GPU is already busy compositing the preview and overlays, so excluding it avoids contention and frame-time jitter while the ANE does the heavy lifting. Pin `.cpuOnly` only for compatibility testing — the table above shows what it costs.
 
+Running a CoreML model from Python on a **Mac host** (via Ultralytics or `coremltools`) follows the same rule: Ultralytics loads with `ComputeUnit.CPU_AND_NE` (macOS 13+, falling back to `CPU_ONLY` on older macOS), keeping inference on the Neural Engine (~3× faster than CPU). This also avoids a current macOS host limitation where the default `ComputeUnit.ALL` / `CPU_AND_GPU` — which add the GPU/MPSGraph compile path — **abort the process** with an `Error: MLIR pass manager failed` assertion on `coremltools` 9.x.
+
 ## Deploying Exported YOLO26 CoreML Models
 
 The fastest path is the official [Ultralytics YOLO iOS SDK](https://github.com/ultralytics/yolo-ios-app), the same Swift package that powers the Ultralytics iOS app and the [Flutter plugin](https://github.com/ultralytics/yolo-flutter-app). It resolves official model names automatically, downloads and caches the `.mlpackage`, and returns fully decoded results:

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.74"
+__version__ = "8.4.75"
 
 import importlib
 import os

--- a/ultralytics/nn/backends/coreml.py
+++ b/ultralytics/nn/backends/coreml.py
@@ -31,7 +31,13 @@ class CoreMLBackend(BaseBackend):
         import coremltools as ct
 
         LOGGER.info(f"Loading {weight} for CoreML inference...")
-        self.model = ct.models.MLModel(weight)
+        # Run on the Neural Engine (CPU_AND_NE): ~3x faster than CPU, and the default ComputeUnit.ALL / CPU_AND_GPU
+        # abort the process via an MPSGraph compiler bug on macOS hosts (coremltools 9.x). CPU_AND_NE needs macOS >= 13,
+        # so fall back to CPU_ONLY below that. CoreML inference is macOS-only, so this applies wherever the backend runs.
+        try:
+            self.model = ct.models.MLModel(weight, compute_units=ct.ComputeUnit.CPU_AND_NE)
+        except Exception:
+            self.model = ct.models.MLModel(weight, compute_units=ct.ComputeUnit.CPU_ONLY)
         spec = self.model.get_spec()
         self.input_name = spec.description.input[0].name
         self.dynamic = spec.description.input[0].type.HasField("multiArrayType")


### PR DESCRIPTION
## Summary
The CoreML inference backend loaded models with the default `ComputeUnit.ALL`, which **aborts the process** on macOS hosts via an MPSGraph compiler bug (`Error: MLIR pass manager failed`) — so running any `.mlpackage` from Python on a Mac currently crashes. This loads with **`ComputeUnit.CPU_AND_NE`** (the Neural Engine, ~3× faster than CPU), falling back to `CPU_ONLY` on macOS < 13 where coremltools doesn't support `CPU_AND_NE`.

## Evidence (M5 Pro, macOS, coremltools 9.0, yolo26n)
- `ALL` / `CPU_AND_GPU` → hard `SIGABRT` (MPSGraph "MLIR pass manager failed"), at fp16 **and** int8.
- `CPU_AND_NE` (ANE) → **2.5 ms**; `CPU_ONLY` → 8.5 ms. The ANE is ~3× faster and is the shipped iOS choice (`.cpuAndNeuralEngine`).

So today every macOS user hits the crash; after this, CoreML runs on the ANE out of the box. Confirmed via `YOLO(coreml).predict()` after the fix: runs on the ANE, no crash.

## Changes
- `nn/backends/coreml.py`: `MLModel(weight, compute_units=CPU_AND_NE)` with a `CPU_ONLY` fallback for macOS < 13.
- `docs/en/integrations/coreml.md`: document macOS-host compute-unit behavior in "Targeting the Neural Engine".

Codex-reviewed (LGTM after two fixes: default must be ANE not CPU_ONLY; macOS <13 fallback).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR improves CoreML inference on macOS by switching Ultralytics to safer, faster Neural Engine execution by default, while also updating the related documentation.

### 📊 Key Changes
- Updated the CoreML backend in `ultralytics/nn/backends/coreml.py` to load models with `coremltools` using `ComputeUnit.CPU_AND_NE` instead of the default behavior.
- Added a fallback to `ComputeUnit.CPU_ONLY` if Neural Engine execution is unavailable or unsupported.
- Documented the new macOS CoreML behavior in the [CoreML integration docs](https://docs.ultralytics.com/integrations/coreml/), including:
  - better performance on supported Macs
  - avoidance of a known `coremltools` 9.x macOS crash tied to GPU/MPSGraph compilation
- Bumped the package version from `8.4.74` to `8.4.75` 📦

### 🎯 Purpose & Impact
- ⚡ Improves CoreML inference speed on supported macOS systems by preferring the Apple Neural Engine over CPU-only execution.
- 🛡️ Reduces crashes and instability when running CoreML models from Python on Mac hosts by avoiding problematic GPU-related compile paths.
- 🔄 Preserves compatibility on older macOS versions through automatic fallback to CPU-only mode.
- 📘 Makes expected CoreML behavior clearer for users through updated documentation, helping developers understand both performance and platform limitations.
- 👥 Benefits anyone running exported YOLO models with CoreML on macOS, especially developers using Python workflows for testing or deployment.