### PR TITLE
docs: unified SEO-consistent page titles (≤60, "| Ultralytics" suffix)

### DIFF
--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -133,9 +133,9 @@ def extract_classes_and_functions(filepath: Path) -> tuple[list[str], list[str]]
 def _with_reference_title(header_content: str, module_path: str) -> str:
     """Inject a concise, front-loaded `title:` into reference frontmatter (idempotent).
 
-    The H1 keeps the full module path; the `<title>` uses `{module} API Reference` (with the
-    redundant package prefix dropped) so it stays under the 60-char SEO limit once the docs renderer
-    appends its ` | Ultralytics` brand suffix. Curated description/keywords are preserved as-is.
+    The H1 keeps the full module path; the `<title>` uses `{module} API Reference` (with the redundant package prefix
+    dropped) so it stays under the 60-char SEO limit once the docs renderer appends its ` | Ultralytics` brand suffix.
+    Curated description/keywords are preserved as-is.
     """
     if "title:" in header_content:
         return header_content

--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -130,6 +130,19 @@ def extract_classes_and_functions(filepath: Path) -> tuple[list[str], list[str]]
     return classes, functions
 
 
+def _with_reference_title(header_content: str, module_path: str) -> str:
+    """Inject a concise, front-loaded `title:` into reference frontmatter (idempotent).
+
+    The H1 keeps the full module path; the `<title>` uses `{module} API Reference` (with the
+    redundant package prefix dropped) so it stays under the 60-char SEO limit once the docs renderer
+    appends its ` | Ultralytics` brand suffix. Curated description/keywords are preserved as-is.
+    """
+    if "title:" in header_content:
+        return header_content
+    title = f"{module_path.removeprefix(f'{PACKAGE_DIR.name}.')} API Reference"
+    return header_content.replace("---\n", f"---\ntitle: {title}\n", 1)
+
+
 def create_placeholder_markdown(py_filepath: Path, module_path: str, classes: list[str], functions: list[str]) -> Path:
     """Create a minimal Markdown reference stub."""
     md_filepath = REFERENCE_DIR / py_filepath.relative_to(PACKAGE_DIR).with_suffix(".md")
@@ -147,6 +160,7 @@ def create_placeholder_markdown(py_filepath: Path, module_path: str, classes: li
             f"---\ndescription: Reference for `{module_path}` in the Ultralytics package.\n"
             f"keywords: Ultralytics, {module_path}, API reference, YOLO, Python\n---\n\n"
         )
+    header_content = _with_reference_title(header_content, module_path)
 
     module_path_dots = module_path
     module_path_fs = module_path.replace(".", "/")
@@ -1018,6 +1032,7 @@ def create_markdown(module: DocumentedModule) -> Path:
             f"---\ndescription: Reference for `{module.module_path}` in the Ultralytics package.\n"
             f"keywords: Ultralytics, {module.module_path}, API reference, YOLO, Python\n---\n\n"
         )
+    header_content = _with_reference_title(header_content, module.module_path)
 
     module_path_fs = module.module_path.replace(".", "/")
     url = f"https://github.com/{GITHUB_REPO}/blob/main/{module_path_fs}.py"

--- a/docs/build_reference.py
+++ b/docs/build_reference.py
@@ -134,10 +134,10 @@ def _with_reference_title(header_content: str, module_path: str) -> str:
     """Inject a concise, front-loaded `title:` into reference frontmatter (idempotent).
 
     The H1 keeps the full module path; the `<title>` uses `{module} API Reference` (with the redundant package prefix
-    dropped) so it stays under the 60-char SEO limit once the docs renderer appends its ` | Ultralytics` brand suffix.
-    Curated description/keywords are preserved as-is.
+    dropped) to fit the 60-char SEO target once the docs renderer appends its ` | Ultralytics` brand suffix — a few of
+    the deepest module paths still rely on the renderer's truncation backstop. Curated description/keywords are kept.
     """
-    if "title:" in header_content:
+    if re.search(r"(?m)^title\s*:", header_content):  # line-anchored: ignore `title:` inside a description
         return header_content
     title = f"{module_path.removeprefix(f'{PACKAGE_DIR.name}.')} API Reference"
     return header_content.replace("---\n", f"---\ntitle: {title}\n", 1)

--- a/docs/en/datasets/classify/mnist.md
+++ b/docs/en/datasets/classify/mnist.md
@@ -1,4 +1,5 @@
 ---
+title: MNIST Classification Dataset
 comments: true
 description: Explore the MNIST dataset, a cornerstone in machine learning for handwritten digit recognition. Learn about its structure, features, and applications.
 keywords: MNIST, dataset, handwritten digits, image classification, deep learning, machine learning, training set, testing set, NIST

--- a/docs/en/datasets/detect/coco.md
+++ b/docs/en/datasets/detect/coco.md
@@ -1,4 +1,5 @@
 ---
+title: COCO Detection Dataset
 comments: true
 description: Explore the COCO dataset for object detection and segmentation. Learn about its structure, usage, pretrained models, and key features.
 keywords: COCO dataset, object detection, segmentation, benchmarking, computer vision, pose estimation, YOLO models, COCO annotations

--- a/docs/en/datasets/detect/coco128.md
+++ b/docs/en/datasets/detect/coco128.md
@@ -1,4 +1,5 @@
 ---
+title: COCO128 Detection Dataset
 comments: true
 description: Explore the Ultralytics COCO128 dataset, a versatile and manageable set of 128 images perfect for testing object detection models and training pipelines.
 keywords: COCO128, Ultralytics, dataset, object detection, YOLO26, training, validation, machine learning, computer vision

--- a/docs/en/datasets/detect/coco8.md
+++ b/docs/en/datasets/detect/coco8.md
@@ -1,4 +1,5 @@
 ---
+title: COCO8 Detection Dataset
 comments: true
 description: Explore the Ultralytics COCO8 dataset, a versatile and manageable set of 8 images perfect for testing object detection models and training pipelines.
 keywords: COCO8, Ultralytics, dataset, object detection, YOLO26, training, validation, machine learning, computer vision

--- a/docs/en/datasets/detect/kitti.md
+++ b/docs/en/datasets/detect/kitti.md
@@ -1,4 +1,5 @@
 ---
+title: KITTI Detection Dataset
 comments: true
 description: Explore the Ultralytics kitti dataset, a benchmark dataset for computer vision tasks such as 3D object detection, depth estimation, and autonomous driving perception.
 keywords: kitti, Ultralytics, dataset, object detection, 3D vision, YOLO26, training, validation, self-driving cars, computer vision

--- a/docs/en/datasets/detect/lvis.md
+++ b/docs/en/datasets/detect/lvis.md
@@ -1,4 +1,5 @@
 ---
+title: LVIS Detection Dataset
 comments: true
 description: Discover the LVIS dataset by Facebook AI Research, a benchmark for object detection and instance segmentation with a large, diverse vocabulary. Learn how to utilize it.
 keywords: LVIS dataset, object detection, instance segmentation, Facebook AI Research, YOLO, computer vision, model training, LVIS examples

--- a/docs/en/datasets/detect/tt100k.md
+++ b/docs/en/datasets/detect/tt100k.md
@@ -1,4 +1,5 @@
 ---
+title: TT100K Traffic Sign Dataset
 comments: true
 description: Explore the Tsinghua-Tencent 100K (TT100K) traffic sign dataset with 100,000 street view images and 30,000+ annotated traffic signs for robust detection and classification.
 keywords: TT100K, Tsinghua-Tencent 100K, traffic sign detection, YOLO26, dataset, object detection, street view, traffic signs, Chinese traffic signs

--- a/docs/en/datasets/detect/voc.md
+++ b/docs/en/datasets/detect/voc.md
@@ -1,4 +1,5 @@
 ---
+title: PASCAL VOC Dataset
 comments: true
 description: Discover the PASCAL VOC dataset, essential for object detection, segmentation, and classification. Learn key features, applications, and usage tips.
 keywords: PASCAL VOC, VOC dataset, object detection, segmentation, classification, YOLO, Faster R-CNN, Mask R-CNN, image annotations, computer vision

--- a/docs/en/datasets/detect/xview.md
+++ b/docs/en/datasets/detect/xview.md
@@ -1,4 +1,5 @@
 ---
+title: xView Satellite Dataset
 comments: true
 description: Explore the xView dataset, a rich resource of 1M+ object instances in high-resolution satellite imagery. Enhance detection, learning efficiency, and more.
 keywords: xView dataset, overhead imagery, satellite images, object detection, high resolution, bounding boxes, computer vision, TensorFlow, PyTorch, dataset structure

--- a/docs/en/datasets/explorer/dashboard.md
+++ b/docs/en/datasets/explorer/dashboard.md
@@ -1,4 +1,5 @@
 ---
+title: Dataset Explorer GUI
 comments: true
 description: Unlock advanced data exploration with Ultralytics Explorer GUI. Utilize semantic search, run SQL queries, and ask AI for natural language data insights.
 keywords: Ultralytics Explorer GUI, semantic search, vector similarity, SQL queries, AI, natural language search, data exploration, machine learning, OpenAI, LLMs

--- a/docs/en/datasets/obb/dota128.md
+++ b/docs/en/datasets/obb/dota128.md
@@ -1,4 +1,5 @@
 ---
+title: DOTA128 OBB Dataset
 comments: true
 description: Explore the DOTA128 dataset - a versatile oriented object detection dataset ideal for testing and debugging OBB models using Ultralytics YOLO26.
 keywords: DOTA128 dataset, Ultralytics, YOLO26, object detection, debugging, training models, oriented object detection, dataset YAML

--- a/docs/en/datasets/obb/dota8.md
+++ b/docs/en/datasets/obb/dota8.md
@@ -1,4 +1,5 @@
 ---
+title: DOTA8 OBB Dataset
 comments: true
 description: Explore the DOTA8 dataset - a small, versatile oriented object detection dataset ideal for testing and debugging object detection models using Ultralytics YOLO26.
 keywords: DOTA8 dataset, Ultralytics, YOLO26, object detection, debugging, training models, oriented object detection, dataset YAML

--- a/docs/en/datasets/obb/index.md
+++ b/docs/en/datasets/obb/index.md
@@ -1,4 +1,5 @@
 ---
+title: OBB Dataset Formats for YOLO
 comments: true
 description: Discover OBB dataset formats for Ultralytics YOLO models. Learn about their structure, application, and format conversions to enhance your object detection training.
 keywords: Oriented Bounding Box, OBB Datasets, YOLO, Ultralytics, Object Detection, Dataset Formats

--- a/docs/en/datasets/semantic/ade20k.md
+++ b/docs/en/datasets/semantic/ade20k.md
@@ -1,4 +1,5 @@
 ---
+title: ADE20K Segmentation Dataset
 comments: true
 description: Explore the ADE20K semantic segmentation dataset with Ultralytics YOLO. Learn about its structure, 150 scene-parsing classes, YAML configuration, and training examples.
 keywords: ADE20K dataset, semantic segmentation, scene parsing, Ultralytics YOLO, YOLO26, ADEChallengeData2016, computer vision, deep learning

--- a/docs/en/guides/coco-json-training.md
+++ b/docs/en/guides/coco-json-training.md
@@ -1,4 +1,5 @@
 ---
+title: Train YOLO on COCO JSON Without Conversion
 comments: true
 description: Train Ultralytics YOLO directly on COCO JSON annotations without converting to YOLO format. Custom dataset and trainer example with complete working code for detection training.
 keywords: COCO JSON training, train YOLO on COCO JSON, COCO JSON without conversion, custom YOLO dataset, custom YOLO trainer, COCO annotations YOLO, direct COCO training, Ultralytics YOLO, object detection training, YOLODataset subclass, COCO format training, skip annotation conversion

--- a/docs/en/guides/coco-to-yolo.md
+++ b/docs/en/guides/coco-to-yolo.md
@@ -1,4 +1,5 @@
 ---
+title: Convert COCO JSON Annotations to YOLO
 comments: true
 description: Learn how to convert COCO JSON annotations to YOLO format for object detection, instance segmentation, and pose estimation training. Complete guide with step-by-step examples, common pitfalls, and class ID mapping for custom datasets.
 keywords: COCO to YOLO, convert COCO JSON to YOLO, COCO JSON format, YOLO annotation format, convert_coco, COCO dataset training, train YOLO on COCO, object detection dataset, instance segmentation dataset, pose estimation dataset, dataset conversion, annotation format, cls91to80, category_id, bounding box format, YOLO training data

--- a/docs/en/guides/conda-quickstart.md
+++ b/docs/en/guides/conda-quickstart.md
@@ -1,4 +1,5 @@
 ---
+title: Install YOLO with Conda
 comments: true
 description: Install Ultralytics YOLO with Conda. Set up an isolated conda-forge environment, add CUDA GPU support, run the Conda Docker image, and speed up installs with the libmamba solver.
 keywords: Ultralytics, YOLO, Conda, conda-forge, install Ultralytics, conda environment, CUDA, GPU, pytorch-cuda, Miniconda, Anaconda, libmamba solver, Conda Docker image, machine learning, environment management

--- a/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
+++ b/docs/en/guides/coral-edge-tpu-on-raspberry-pi.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 on Raspberry Pi with Coral Edge TPU
 comments: true
 description: Accelerate Ultralytics YOLO26 inference on a Raspberry Pi with the Coral Edge TPU. Step-by-step guide to install the runtime, export to Edge TPU format, and run fast low-power inference.
 keywords: Coral Edge TPU, Raspberry Pi, YOLO26, Ultralytics, TensorFlow Lite, tflite-runtime, edge AI, low-power inference, edgetpu export, USB Accelerator, embedded AI, ML inference

--- a/docs/en/guides/data-collection-and-annotation.md
+++ b/docs/en/guides/data-collection-and-annotation.md
@@ -1,4 +1,5 @@
 ---
+title: CV Data Collection and Annotation Guide
 comments: true
 description: Data collection and annotation are vital steps in any computer vision project. Explore the tools, techniques, and best practices for collecting and annotating data.
 keywords: What is Data Annotation, Data Annotation Tools, Annotating Data, Avoiding Bias in Data Collection, Ethical Data Collection, Annotation Strategies

--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 on Jetson: DeepStream & TensorRT
 comments: true
 description: Learn how to deploy Ultralytics YOLO26 on NVIDIA Jetson devices using TensorRT and DeepStream SDK. Explore performance benchmarks and maximize AI capabilities.
 keywords: Ultralytics, YOLO26, NVIDIA Jetson, JetPack, AI deployment, embedded systems, deep learning, TensorRT, DeepStream SDK, computer vision

--- a/docs/en/guides/defining-project-goals.md
+++ b/docs/en/guides/defining-project-goals.md
@@ -1,4 +1,5 @@
 ---
+title: Defining Computer Vision Project Goals
 comments: true
 description: Learn how to define clear goals and objectives for your computer vision project with our practical guide. Includes tips on problem statements, measurable objectives, and key decisions.
 keywords: computer vision, project planning, problem statement, measurable objectives, dataset preparation, model selection, YOLO26, Ultralytics

--- a/docs/en/guides/distance-calculation.md
+++ b/docs/en/guides/distance-calculation.md
@@ -1,4 +1,5 @@
 ---
+title: Distance Calculation with YOLO26
 comments: true
 description: Learn how to calculate distances between objects using Ultralytics YOLO26 for accurate spatial positioning and scene understanding.
 keywords: Ultralytics, YOLO26, distance calculation, computer vision, object tracking, spatial positioning

--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 End-to-End NMS-Free Detection
 comments: true
 description: Learn how YOLO26 end-to-end NMS-free detection works, what changes for your deployment pipeline, which export formats support it, and how to migrate from YOLOv8 or YOLO11.
 keywords: YOLO26, end-to-end detection, NMS-free inference, model export, deployment guide, object detection, Ultralytics, YOLOv8 migration, YOLO11 migration, ONNX, TensorRT, CoreML, post-processing, computer vision

--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -1,4 +1,5 @@
 ---
+title: Export Any PyTorch Model to ONNX & More
 comments: true
 description: Export any PyTorch model (timm, torchvision, or custom) to ONNX, OpenVINO, CoreML, TensorFlow SavedModel, TorchScript, NCNN, MNN, PaddlePaddle, and ExecuTorch with Ultralytics export utilities.
 keywords: export PyTorch model, convert PyTorch to ONNX, PyTorch to CoreML, PyTorch to OpenVINO, PyTorch to TensorFlow, non-YOLO export, timm export, torchvision export, TorchScript export, NCNN export, MNN export, PaddlePaddle export, ExecuTorch export, TFLite export, Ultralytics export utilities, torch.nn.Module export, model conversion, model deployment, PyTorch deployment

--- a/docs/en/guides/heatmaps.md
+++ b/docs/en/guides/heatmaps.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Heatmaps for Data Visualization
 comments: true
 description: Generate real-time object tracking heatmaps on video with the Ultralytics YOLO26 Heatmap solution to visualize traffic flow and crowd movement patterns.
 keywords: Ultralytics, YOLO26, heatmap, object tracking heatmap, video heatmap, traffic flow visualization, crowd movement analysis, Heatmap solution, OpenCV colormaps, computer vision

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO Hyperparameter Tuning
 comments: true
 description: Master hyperparameter tuning for Ultralytics YOLO to optimize model performance with our comprehensive guide. Elevate your machine learning models today!
 keywords: Ultralytics YOLO, hyperparameter tuning, machine learning, model optimization, genetic algorithms, learning rate, batch size, epochs

--- a/docs/en/guides/index.md
+++ b/docs/en/guides/index.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO How-To Guides
 comments: true
 description: Master YOLO with Ultralytics tutorials covering training, deployment and optimization. Find solutions, improve metrics, and deploy with ease.
 keywords: Ultralytics, YOLO, tutorials, guides, object detection, deep learning, PyTorch, training, deployment, optimization, computer vision

--- a/docs/en/guides/instance-segmentation-and-tracking.md
+++ b/docs/en/guides/instance-segmentation-and-tracking.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Instance Segmentation & Tracking
 comments: true
 description: Master instance segmentation and tracking with Ultralytics YOLO26. Learn techniques for precise object identification and tracking.
 keywords: instance segmentation, tracking, YOLO26, Ultralytics, object detection, machine learning, computer vision, python

--- a/docs/en/guides/model-deployment-options.md
+++ b/docs/en/guides/model-deployment-options.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Deployment Options Compared
 comments: true
 description: Learn about YOLO26's diverse deployment options to maximize your model's performance. Explore PyTorch, TensorRT, OpenVINO, TF Lite, and more!
 keywords: YOLO26, deployment options, export formats, PyTorch, TensorRT, OpenVINO, TF Lite, machine learning, model deployment

--- a/docs/en/guides/model-evaluation-insights.md
+++ b/docs/en/guides/model-evaluation-insights.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO Model Evaluation and Fine-Tuning
 comments: true
 description: Explore the most effective ways to assess and refine YOLO26 models for better performance. Learn about evaluation metrics, fine-tuning processes, and how to customize your model for specific needs.
 keywords: Model Evaluation, Machine Learning Model Evaluation, Fine Tuning Machine Learning, Fine Tune Model, Evaluating Models, Model Fine Tuning, How to Fine Tune a Model

--- a/docs/en/guides/model-monitoring-and-maintenance.md
+++ b/docs/en/guides/model-monitoring-and-maintenance.md
@@ -1,4 +1,5 @@
 ---
+title: CV Model Monitoring & Maintenance
 comments: true
 description: Understand the key practices for monitoring, maintaining, and documenting computer vision models to guarantee accuracy, spot anomalies, and mitigate data drift.
 keywords: Computer Vision Models, AI Model Monitoring, Data Drift Detection, Anomaly Detection in AI, Model Maintenance

--- a/docs/en/guides/model-training-tips.md
+++ b/docs/en/guides/model-training-tips.md
@@ -1,4 +1,5 @@
 ---
+title: Model Training Tips & Best Practices
 comments: true
 description: Learn best practices for training computer vision models, including batch size optimization, mixed precision training, early stopping, and optimizer selection for improved efficiency and accuracy.
 keywords: Model Training Machine Learning, AI Model Training, Number of Epochs, How to Train a Model in Machine Learning, Machine Learning Best Practices, What is Model Training

--- a/docs/en/guides/nvidia-dali.md
+++ b/docs/en/guides/nvidia-dali.md
@@ -1,4 +1,5 @@
 ---
+title: NVIDIA DALI GPU Preprocessing for YOLO
 comments: true
 description: Learn how to use NVIDIA DALI for GPU-accelerated preprocessing with Ultralytics YOLO models. Eliminate CPU bottlenecks by running letterbox resize, padding, and normalization on the GPU for faster TensorRT and Triton deployments.
 keywords: NVIDIA DALI, GPU preprocessing, Ultralytics, YOLO, YOLO26, TensorRT, Triton Inference Server, letterbox, inference optimization, deep learning, computer vision, deployment, video processing, batch inference, DALI pipeline, CV-CUDA

--- a/docs/en/guides/nvidia-dgx-spark.md
+++ b/docs/en/guides/nvidia-dgx-spark.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 on NVIDIA DGX Spark
 comments: true
 description: Learn to deploy Ultralytics YOLO26 on NVIDIA DGX Spark with our detailed guide. Explore performance benchmarks and maximize AI capabilities on this compact desktop AI supercomputer.
 keywords: Ultralytics, YOLO26, NVIDIA DGX Spark, AI deployment, performance benchmarks, deep learning, TensorRT, computer vision, GB10 Grace Blackwell

--- a/docs/en/guides/nvidia-jetson.md
+++ b/docs/en/guides/nvidia-jetson.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 on NVIDIA Jetson Setup & Benchmarks
 comments: true
 description: Learn to deploy Ultralytics YOLO26 on NVIDIA Jetson devices with our detailed guide. Explore performance benchmarks and maximize AI capabilities.
 keywords: Ultralytics, YOLO26, NVIDIA Jetson, JetPack, AI deployment, performance benchmarks, embedded systems, deep learning, TensorRT, computer vision

--- a/docs/en/guides/parking-management.md
+++ b/docs/en/guides/parking-management.md
@@ -1,4 +1,5 @@
 ---
+title: Parking Management with YOLO26
 comments: true
 description: Optimize parking spaces and enhance safety with Ultralytics YOLO26. Explore real-time vehicle detection and smart parking solutions.
 keywords: parking management, YOLO26, Ultralytics, vehicle detection, real-time tracking, parking lot optimization, smart parking

--- a/docs/en/guides/preprocessing-annotated-data.md
+++ b/docs/en/guides/preprocessing-annotated-data.md
@@ -1,4 +1,5 @@
 ---
+title: Preprocessing Annotated CV Data
 comments: true
 description: Learn essential data preprocessing techniques for annotated computer vision data, including resizing, normalizing, augmenting, and splitting datasets for optimal model training.
 keywords: data preprocessing, computer vision, image resizing, normalization, data augmentation, training dataset, validation dataset, test dataset, YOLO26

--- a/docs/en/guides/raspberry-pi.md
+++ b/docs/en/guides/raspberry-pi.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 on Raspberry Pi: Setup & Benchmarks
 comments: true
 description: Learn how to deploy Ultralytics YOLO26 on Raspberry Pi with our comprehensive guide. Get performance benchmarks, setup instructions, and best practices.
 keywords: Ultralytics, YOLO26, Raspberry Pi, setup, guide, benchmarks, computer vision, object detection, NCNN, Docker, camera modules

--- a/docs/en/guides/region-counting.md
+++ b/docs/en/guides/region-counting.md
@@ -1,4 +1,5 @@
 ---
+title: Region Object Counting with YOLO26
 comments: true
 description: Learn how to use Ultralytics YOLO26 for precise object counting in specified regions, enhancing efficiency across various applications.
 keywords: object counting, regions, YOLO26, computer vision, Ultralytics, efficiency, accuracy, automation, real-time, applications, surveillance, monitoring

--- a/docs/en/guides/ros-quickstart.md
+++ b/docs/en/guides/ros-quickstart.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO with ROS Quickstart
 comments: true
 description: Learn to integrate Ultralytics YOLO with your robot running ROS Noetic, utilizing RGB images, depth images, and point clouds for efficient object detection, segmentation, and enhanced robotic perception.
 keywords: Ultralytics, YOLO, object detection, deep learning, machine learning, guide, ROS, Robot Operating System, robotics, ROS Noetic, Python, Ubuntu, simulation, visualization, communication, middleware, hardware abstraction, tools, utilities, ecosystem, Noetic Ninjemys, autonomous vehicle, AMV

--- a/docs/en/guides/sahi-tiled-inference.md
+++ b/docs/en/guides/sahi-tiled-inference.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Sliced Inference with SAHI
 comments: true
 description: Learn how to implement YOLO26 with SAHI for sliced inference. Optimize memory usage and enhance detection accuracy for large-scale applications.
 keywords: YOLO26, SAHI, Sliced Inference, Object Detection, Ultralytics, High-resolution Images, Computational Efficiency, Integration Guide

--- a/docs/en/guides/security-alarm-system.md
+++ b/docs/en/guides/security-alarm-system.md
@@ -1,4 +1,5 @@
 ---
+title: Security Alarm System with YOLO26
 comments: true
 description: Enhance your security with real-time object detection using Ultralytics YOLO26. Reduce false positives and integrate seamlessly with existing systems.
 keywords: YOLO26, Security Alarm System, real-time object detection, Ultralytics, computer vision, integration, false positives

--- a/docs/en/guides/similarity-search.md
+++ b/docs/en/guides/similarity-search.md
@@ -1,4 +1,5 @@
 ---
+title: Semantic Image Search with CLIP and FAISS
 comments: true
 description: Build a semantic image search engine with OpenAI CLIP, Meta FAISS, and Flask. Embed images, run natural-language queries, and serve results from a web app with the Ultralytics Python package.
 keywords: CLIP, FAISS, Flask, semantic search, semantic image search, image retrieval, natural language image search, zero-shot search, vector search, embeddings, OpenAI, Meta, Ultralytics, VisualAISearch, computer vision, web app

--- a/docs/en/guides/steps-of-a-cv-project.md
+++ b/docs/en/guides/steps-of-a-cv-project.md
@@ -1,4 +1,5 @@
 ---
+title: Computer Vision Project Steps
 comments: true
 description: Discover essential steps for launching a successful computer vision project, from defining goals to model deployment and maintenance.
 keywords: Computer Vision, AI, Object Detection, Image Classification, Instance Segmentation, Data Annotation, Model Training, Model Evaluation, Model Deployment

--- a/docs/en/guides/streamlit-live-inference.md
+++ b/docs/en/guides/streamlit-live-inference.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Live Inference with Streamlit
 comments: true
 description: Learn how to set up a real-time object detection application using Streamlit and Ultralytics YOLO26. Follow this step-by-step guide to implement webcam-based object detection.
 keywords: Streamlit, YOLO26, Real-time Object Detection, Streamlit Application, YOLO26 Streamlit Tutorial, Webcam Object Detection

--- a/docs/en/guides/triton-inference-server.md
+++ b/docs/en/guides/triton-inference-server.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 with NVIDIA Triton Inference Server
 comments: true
 description: Learn how to integrate Ultralytics YOLO26 with NVIDIA Triton Inference Server for scalable, high-performance AI model deployment.
 keywords: Triton Inference Server, YOLO26, Ultralytics, NVIDIA, deep learning, AI model deployment, ONNX, scalable inference

--- a/docs/en/guides/vertex-ai-deployment-with-docker.md
+++ b/docs/en/guides/vertex-ai-deployment-with-docker.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 on Vertex AI with Docker & FastAPI
 comments: true
 description: Learn how to deploy pretrained YOLO26 models on Google Cloud Vertex AI using Docker containers and FastAPI for scalable inference with complete control over preprocessing and postprocessing.
 keywords: YOLO26, Vertex AI, Docker, FastAPI, deployment, container, GCP, Artifact Registry, Ultralytics, cloud deployment

--- a/docs/en/guides/view-results-in-terminal.md
+++ b/docs/en/guides/view-results-in-terminal.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO Results in Terminal via Sixel
 comments: true
 description: Display YOLO inference results directly in a VSCode terminal with the sixel protocol on Linux and macOS, ideal for remote SSH sessions and headless machines without a GUI.
 keywords: YOLO, inference results, VSCode terminal, sixel, display images in terminal, remote SSH, headless server, no GUI, Linux, macOS, iTerm2, image visualization, Ultralytics

--- a/docs/en/guides/vision-eye.md
+++ b/docs/en/guides/vision-eye.md
@@ -1,4 +1,5 @@
 ---
+title: VisionEye Object Mapping with YOLO26
 comments: true
 description: Discover VisionEye's object mapping and tracking powered by Ultralytics YOLO26. Simulate human eye precision, track objects, and calculate distances effortlessly.
 keywords: VisionEye, YOLO26, Ultralytics, object mapping, object tracking, distance calculation, computer vision, AI, machine learning, Python, tutorial

--- a/docs/en/guides/workouts-monitoring.md
+++ b/docs/en/guides/workouts-monitoring.md
@@ -1,4 +1,5 @@
 ---
+title: Workout Monitoring with YOLO26 Pose
 comments: true
 description: Optimize your fitness routine with real-time workouts monitoring using Ultralytics YOLO26. Track and improve your exercise form and performance.
 keywords: workouts monitoring, Ultralytics YOLO26, pose estimation, fitness tracking, exercise assessment, real-time feedback, exercise form, performance metrics

--- a/docs/en/help/CLA.md
+++ b/docs/en/help/CLA.md
@@ -1,4 +1,5 @@
 ---
+title: Contributor License Agreement (CLA)
 description: Review the terms for contributing to Ultralytics projects. Learn about copyright, patent licenses, and moral rights for your contributions.
 keywords: Ultralytics, Contributor License Agreement, open source, contributions, copyright license, patent license, moral rights
 ---

--- a/docs/en/help/FAQ.md
+++ b/docs/en/help/FAQ.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO FAQ: Common Questions & Solutions
 comments: true
 description: Explore common questions and solutions related to Ultralytics YOLO, from hardware requirements to model fine-tuning and real-time detection.
 keywords: Ultralytics, YOLO, FAQ, object detection, hardware requirements, fine-tuning, ONNX, TensorFlow, real-time detection, model accuracy

--- a/docs/en/help/code-of-conduct.md
+++ b/docs/en/help/code-of-conduct.md
@@ -1,4 +1,5 @@
 ---
+title: Contributor Code of Conduct
 comments: true
 description: Join our welcoming community! Learn about the Ultralytics Code of Conduct to ensure a harassment-free experience for all participants.
 keywords: Ultralytics, Contributor Covenant, Code of Conduct, community guidelines, harassment-free, inclusive community, diversity, enforcement policy

--- a/docs/en/help/contributing.md
+++ b/docs/en/help/contributing.md
@@ -1,4 +1,5 @@
 ---
+title: Open-Source Contribution Guide
 comments: true
 description: Learn how to contribute to Ultralytics YOLO open-source repositories. Follow guidelines for pull requests, code of conduct, and bug reporting.
 keywords: Ultralytics, YOLO, open-source, contribution, pull request, code of conduct, bug reporting, GitHub, CLA, Google-style docstrings, AGPL-3.0

--- a/docs/en/help/environmental-health-safety.md
+++ b/docs/en/help/environmental-health-safety.md
@@ -1,4 +1,5 @@
 ---
+title: Environmental, Health & Safety Policy
 comments: false
 description: Explore Ultralytics' commitment to Environmental, Health, and Safety (EHS) policies. Learn about our measures to ensure safety, compliance, and sustainability.
 keywords: Ultralytics, EHS policy, safety, sustainability, environmental impact, health and safety, risk management, compliance, continuous improvement

--- a/docs/en/help/index.md
+++ b/docs/en/help/index.md
@@ -1,4 +1,5 @@
 ---
+title: Help Center & FAQs
 comments: true
 description: Explore the Ultralytics Help Center with guides, FAQs, CI processes, and policies to support your YOLO model experience and contributions.
 keywords: Ultralytics, YOLO, help center, documentation, guides, FAQ, contributing, CI, MRE, CLA, code of conduct, security policy, privacy policy

--- a/docs/en/help/minimum-reproducible-example.md
+++ b/docs/en/help/minimum-reproducible-example.md
@@ -1,4 +1,5 @@
 ---
+title: Minimum Reproducible Example (MRE)
 comments: true
 description: Learn how to create effective Minimum Reproducible Examples (MRE) for bug reports in Ultralytics YOLO repositories. Follow our guide for efficient issue resolution.
 keywords: Ultralytics, YOLO, Minimum Reproducible Example, MRE, bug report, issue resolution, machine learning, deep learning

--- a/docs/en/help/privacy.md
+++ b/docs/en/help/privacy.md
@@ -1,4 +1,5 @@
 ---
+title: Python Package Privacy & Data Collection
 description: Discover how Ultralytics collects and uses anonymized data to enhance the YOLO Python package while prioritizing user privacy and control.
 keywords: Ultralytics, data collection, YOLO, Python package, Google Analytics, Sentry, privacy, anonymized data, user control, crash reporting
 ---

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO Object Detection & Segmentation
 comments: true
 description: Discover Ultralytics YOLO - the latest in real-time object detection and image segmentation. Learn about its features and maximize its potential in your projects.
 keywords: Ultralytics, YOLO, YOLO26, YOLO11, object detection, image segmentation, deep learning, computer vision, AI, machine learning, documentation, tutorial

--- a/docs/en/integrations/albumentations.md
+++ b/docs/en/integrations/albumentations.md
@@ -1,4 +1,5 @@
 ---
+title: Albumentations Augmentation for YOLO26
 comments: true
 description: Learn how to use Albumentations with YOLO26 to enhance data augmentation, improve model performance, and streamline your computer vision projects.
 keywords: Albumentations, YOLO26, data augmentation, Ultralytics, computer vision, object detection, model training, image transformations, machine learning

--- a/docs/en/integrations/amazon-sagemaker.md
+++ b/docs/en/integrations/amazon-sagemaker.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 on Amazon SageMaker Endpoints
 comments: true
 description: Learn step-by-step how to deploy Ultralytics' YOLO26 on Amazon SageMaker Endpoints, from setup to testing, for powerful real-time inference with AWS services.
 keywords: YOLO26, Amazon SageMaker, AWS, Ultralytics, machine learning, computer vision, model deployment, AWS CloudFormation, AWS CDK, real-time inference

--- a/docs/en/integrations/clearml.md
+++ b/docs/en/integrations/clearml.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 ClearML Integration for MLOps
 comments: true
 description: Discover how to integrate YOLO26 with ClearML to streamline your MLOps workflow, automate experiments, and enhance model management effortlessly.
 keywords: YOLO26, ClearML, MLOps, Ultralytics, machine learning, object detection, model training, automation, experiment management

--- a/docs/en/integrations/comet.md
+++ b/docs/en/integrations/comet.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Training Logging with Comet ML
 comments: true
 description: Learn to simplify the logging of YOLO26 training with Comet. This guide covers installation, setup, real-time insights, and custom logging.
 keywords: YOLO26, Comet, Comet ML, logging, machine learning, training, model checkpoints, metrics, installation, configuration, real-time insights, custom logging

--- a/docs/en/integrations/dvc.md
+++ b/docs/en/integrations/dvc.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Experiment Tracking with DVCLive
 comments: true
 description: Unlock seamless YOLO26 tracking with DVCLive. Discover how to log, visualize, and analyze experiments for optimized ML model performance.
 keywords: YOLO26, DVCLive, experiment tracking, machine learning, model training, data visualization, Git integration

--- a/docs/en/integrations/edge-tpu.md
+++ b/docs/en/integrations/edge-tpu.md
@@ -1,4 +1,5 @@
 ---
+title: Export YOLO26 to TFLite Edge TPU
 comments: true
 description: Learn how to export YOLO26 models to TFLite Edge TPU format for high-speed, low-power inferencing on mobile and embedded devices.
 keywords: YOLO26, TFLite Edge TPU, TensorFlow Lite, model export, machine learning, edge computing, neural networks, Ultralytics

--- a/docs/en/integrations/executorch.md
+++ b/docs/en/integrations/executorch.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 ExecuTorch for Mobile & Edge
 comments: true
 description: Export YOLO26 models to ExecuTorch format for efficient on-device inference on mobile and edge devices. Optimize your AI models for iOS, Android, and embedded systems.
 keywords: Ultralytics, YOLO26, ExecuTorch, model export, PyTorch, edge AI, mobile deployment, on-device inference, XNNPACK, embedded systems

--- a/docs/en/integrations/google-colab.md
+++ b/docs/en/integrations/google-colab.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Training with Google Colab
 comments: true
 description: Learn how to efficiently train Ultralytics YOLO26 models using Google Colab's powerful cloud-based environment. Start your project with ease.
 keywords: YOLO26, Google Colab, machine learning, deep learning, model training, GPU, TPU, cloud computing, Jupyter Notebook, Ultralytics

--- a/docs/en/integrations/gradio.md
+++ b/docs/en/integrations/gradio.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Object Detection with Gradio
 comments: true
 description: Discover an interactive way to perform object detection with Ultralytics YOLO26 using Gradio. Upload images and adjust settings for real-time results.
 keywords: Ultralytics, YOLO26, Gradio, object detection, interactive, real-time, image processing, AI

--- a/docs/en/integrations/ibm-watsonx.md
+++ b/docs/en/integrations/ibm-watsonx.md
@@ -1,4 +1,5 @@
 ---
+title: Train YOLO26 Models with IBM Watsonx
 comments: true
 description: Dive into our detailed integration guide on using IBM Watson to train a YOLO26 model. Uncover key features and step-by-step instructions on model training.
 keywords: IBM Watsonx, IBM Watsonx AI, What is Watson?, IBM Watson Integration, IBM Watson Features, YOLO26, Ultralytics, Model Training, GPU, TPU, cloud computing

--- a/docs/en/integrations/jupyterlab.md
+++ b/docs/en/integrations/jupyterlab.md
@@ -1,4 +1,5 @@
 ---
+title: Train YOLO26 Models with JupyterLab
 comments: true
 description: Learn how to use JupyterLab to train and experiment with Ultralytics YOLO26 models. Discover key features, setup instructions, and solutions to common issues.
 keywords: JupyterLab, YOLO26, Ultralytics, Model Training, Deep Learning, Interactive Coding, Data Science, Machine Learning, Jupyter Notebook, Model Development

--- a/docs/en/integrations/kaggle.md
+++ b/docs/en/integrations/kaggle.md
@@ -1,4 +1,5 @@
 ---
+title: Train YOLO26 Models on Kaggle
 comments: true
 description: Learn how to use Kaggle to train Ultralytics YOLO26 models with free GPU/TPU resources. Discover Kaggle's features, benefits, and best practices for efficient model development.
 keywords: Kaggle, YOLO26, Ultralytics, machine learning, model training, GPU, TPU, cloud computing, data science, computer vision

--- a/docs/en/integrations/mnn.md
+++ b/docs/en/integrations/mnn.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 MNN Export for Mobile Deployment
 comments: true
 description: Optimize YOLO26 models for mobile and embedded devices by exporting to MNN format. Learn how to convert, deploy, and run inference with MNN.
 keywords: Ultralytics, YOLO26, MNN, model export, machine learning, deployment, mobile, embedded systems, deep learning, AI models, inference, quantization

--- a/docs/en/integrations/neural-magic.md
+++ b/docs/en/integrations/neural-magic.md
@@ -1,4 +1,5 @@
 ---
+title: DeepSparse CPU Inference for YOLO26
 comments: true
 description: Enhance YOLO26 performance using Neural Magic's DeepSparse Engine. Learn how to deploy and benchmark YOLO26 models on CPUs for efficient object detection.
 keywords: YOLO26, DeepSparse, Neural Magic, model optimization, object detection, inference speed, CPU performance, sparsity, pruning, quantization

--- a/docs/en/integrations/paddlepaddle.md
+++ b/docs/en/integrations/paddlepaddle.md
@@ -1,4 +1,5 @@
 ---
+title: Export YOLO26 to PaddlePaddle Format
 comments: true
 description: Learn how to export YOLO26 models to PaddlePaddle format for enhanced performance, flexibility, and deployment across various platforms and devices.
 keywords: YOLO26, PaddlePaddle, export models, computer vision, deep learning, model deployment, performance optimization

--- a/docs/en/integrations/paperspace.md
+++ b/docs/en/integrations/paperspace.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Training on Paperspace Gradient
 comments: true
 description: Simplify YOLO26 training with Paperspace Gradient's all-in-one MLOps platform. Access GPUs, automate workflows, and deploy with ease.
 keywords: YOLO26, Paperspace Gradient, MLOps, machine learning, training, GPUs, Jupyter notebooks, model deployment, AI, cloud platform

--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO Export to Qualcomm QNN (Snapdragon)
 comments: true
 description: Export Ultralytics YOLO models to Qualcomm QNN for fast on-device inference on Snapdragon Hexagon NPU, Adreno GPU, and CPU. Step-by-step Qualcomm Snapdragon export guide.
 keywords: Qualcomm QNN, Qualcomm export, Snapdragon export, export YOLO to Qualcomm, QNN export, YOLO Snapdragon, YOLO on Snapdragon, Qualcomm AI Hub, Hexagon NPU, Hexagon HTP, Qualcomm AI Engine Direct, QAIRT, SNPE, onnxruntime-qnn, ONNX Runtime QNN, Snapdragon NPU, on-device inference, edge AI deployment, Ultralytics YOLO, model export

--- a/docs/en/integrations/ray-tune.md
+++ b/docs/en/integrations/ray-tune.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Hyperparameter Tuning - Ray Tune
 comments: true
 description: Optimize YOLO26 model performance with Ray Tune. Learn efficient hyperparameter tuning using advanced search strategies, parallelism, and early stopping.
 keywords: YOLO26, Ray Tune, hyperparameter tuning, model optimization, machine learning, deep learning, AI, Ultralytics, Weights & Biases

--- a/docs/en/integrations/roboflow.md
+++ b/docs/en/integrations/roboflow.md
@@ -1,4 +1,5 @@
 ---
+title: Roboflow Integration
 comments: true
 description: Learn how to label data and export datasets in YOLO format using Roboflow for training Ultralytics models.
 keywords: Roboflow, Ultralytics YOLO, data labeling, computer vision, dataset export

--- a/docs/en/integrations/rockchip-rknn.md
+++ b/docs/en/integrations/rockchip-rknn.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 RKNN Export for Rockchip NPU
 comments: true
 description: Learn how to export YOLO26 models to RKNN format, including floating-point and INT8 quantized models, for efficient deployment on Rockchip platforms.
 keywords: YOLO26, RKNN, model export, Ultralytics, Rockchip, INT8 quantization, FP16, machine learning, model deployment, computer vision, deep learning, edge AI, NPU, embedded devices

--- a/docs/en/integrations/seeedstudio-recamera.md
+++ b/docs/en/integrations/seeedstudio-recamera.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 on Seeed Studio reCamera
 comments: true
 description: Discover how to get started with Seeed Studio reCamera for edge AI applications using Ultralytics YOLO26. Learn about its powerful features, real-world applications, and how to export YOLO26 models to ONNX format for seamless integration.
 keywords: Seeed Studio reCamera, YOLO26, ONNX export, edge AI, computer vision, real-time detection, personal protective equipment detection, fire detection, waste detection, fall detection, modular AI devices, Ultralytics

--- a/docs/en/integrations/tensorboard.md
+++ b/docs/en/integrations/tensorboard.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 TensorBoard Integration
 comments: true
 description: Learn how to integrate YOLO26 with TensorBoard for real-time visual insights into your model's training metrics, performance graphs, and debugging workflows.
 keywords: YOLO26, TensorBoard, model training, visualization, machine learning, deep learning, Ultralytics, training metrics, performance analysis

--- a/docs/en/integrations/tf-graphdef.md
+++ b/docs/en/integrations/tf-graphdef.md
@@ -1,4 +1,5 @@
 ---
+title: Export YOLO26 to TF GraphDef
 comments: true
 description: Learn how to export YOLO26 models to the TF GraphDef format for seamless deployment on various platforms, including mobile and web.
 keywords: YOLO26, export, TensorFlow, GraphDef, model deployment, TensorFlow Serving, TensorFlow Lite, TensorFlow.js, machine learning, AI, computer vision

--- a/docs/en/integrations/tf-savedmodel.md
+++ b/docs/en/integrations/tf-savedmodel.md
@@ -1,4 +1,5 @@
 ---
+title: Export YOLO26 to TF SavedModel Format
 comments: true
 description: Learn how to export Ultralytics YOLO26 models to TensorFlow SavedModel format for easy deployment across various platforms and environments.
 keywords: YOLO26, TF SavedModel, Ultralytics, TensorFlow, model export, model deployment, machine learning, AI

--- a/docs/en/integrations/tfjs.md
+++ b/docs/en/integrations/tfjs.md
@@ -1,4 +1,5 @@
 ---
+title: Export YOLO26 to TensorFlow.js (TF.js)
 comments: true
 description: Convert your Ultralytics YOLO26 models to TensorFlow.js for high-speed, local object detection. Learn how to optimize ML models for browser and Node.js apps.
 keywords: YOLO26, TensorFlow.js, TF.js, model export, machine learning, object detection, browser ML, Node.js, Ultralytics, YOLO, export models

--- a/docs/en/integrations/tflite.md
+++ b/docs/en/integrations/tflite.md
@@ -1,4 +1,5 @@
 ---
+title: Export YOLO to TFLite for Edge Devices
 comments: true
 description: Learn how to convert YOLO26 models to TFLite for edge device deployment. Optimize performance and ensure seamless execution on various platforms.
 keywords: YOLO26, TFLite, model export, TensorFlow Lite, edge devices, deployment, Ultralytics, machine learning, on-device inference, model optimization

--- a/docs/en/integrations/torchscript.md
+++ b/docs/en/integrations/torchscript.md
@@ -1,4 +1,5 @@
 ---
+title: Export YOLO26 to TorchScript
 comments: true
 description: Learn how to export Ultralytics YOLO26 models to TorchScript for flexible, cross-platform deployment. Boost performance and utilize in various environments.
 keywords: YOLO26, TorchScript, model export, Ultralytics, PyTorch, deep learning, AI deployment, cross-platform, performance optimization

--- a/docs/en/integrations/weights-biases.md
+++ b/docs/en/integrations/weights-biases.md
@@ -1,4 +1,5 @@
 ---
+title: Weights & Biases YOLO Integration
 comments: true
 description: Learn how to enhance YOLO26 experiment tracking and visualization with Weights & Biases for better model performance and management.
 keywords: YOLO26, Weights & Biases, model training, experiment tracking, Ultralytics, machine learning, computer vision, model visualization

--- a/docs/en/models/rtdetr.md
+++ b/docs/en/models/rtdetr.md
@@ -1,4 +1,5 @@
 ---
+title: RT-DETR: Real-Time Detection Transformer
 comments: true
 description: Explore Baidu's RT-DETR, a Vision Transformer-based real-time object detector offering high accuracy and adaptable inference speed. Learn more with Ultralytics.
 keywords: RT-DETR, Baidu, Vision Transformer, real-time object detection, PaddlePaddle, Ultralytics, pretrained models, decoder layer index, query count, AI, machine learning, computer vision

--- a/docs/en/models/yolo-nas.md
+++ b/docs/en/models/yolo-nas.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO-NAS Object Detection
 comments: true
 description: Discover YOLO-NAS by Deci AI - a state-of-the-art object detection model with quantization support. Explore features, pretrained models, and implementation examples.
 keywords: YOLO-NAS, Deci AI, object detection, deep learning, Neural Architecture Search, Ultralytics, Python API, YOLO model, SuperGradients, pretrained models, quantization, AutoNAC

--- a/docs/en/models/yolo12.md
+++ b/docs/en/models/yolo12.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO12 Attention-Centric Object Detection
 comments: true
 description: Discover YOLO12, featuring groundbreaking attention-centric architecture for state-of-the-art object detection with unmatched accuracy and efficiency.
 keywords: YOLO12, attention-centric object detection, YOLO series, Ultralytics, computer vision, AI, machine learning, deep learning

--- a/docs/en/models/yolov10.md
+++ b/docs/en/models/yolov10.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv10: NMS-Free Object Detection
 comments: true
 description: Discover YOLOv10 for real-time object detection, eliminating NMS and boosting efficiency. Achieve top performance with a low computational cost.
 keywords: YOLOv10, real-time object detection, NMS-free, deep learning, Tsinghua University, Ultralytics, machine learning, neural networks, performance optimization

--- a/docs/en/models/yolov4.md
+++ b/docs/en/models/yolov4.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv4 Real-Time Object Detection
 comments: true
 description: Explore YOLOv4, a state-of-the-art real-time object detection model by Alexey Bochkovskiy. Discover its architecture, features, and performance.
 keywords: YOLOv4, object detection, real-time detection, Alexey Bochkovskiy, neural networks, machine learning, computer vision

--- a/docs/en/models/yolov6.md
+++ b/docs/en/models/yolov6.md
@@ -1,4 +1,5 @@
 ---
+title: Meituan YOLOv6 Detector
 comments: true
 description: Explore Meituan YOLOv6, a top-tier object detector balancing speed and accuracy. Learn about its unique features and performance metrics on Ultralytics Docs.
 keywords: Meituan YOLOv6, object detection, real-time applications, BiC module, Anchor-Aided Training, COCO dataset, high-performance models, Ultralytics Docs

--- a/docs/en/models/yolov9.md
+++ b/docs/en/models/yolov9.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv9 Object Detection with PGI and GELAN
 comments: true
 description: Explore YOLOv9, a leap in real-time object detection, featuring innovations like PGI and GELAN, and achieving new benchmarks in efficiency and accuracy.
 keywords: YOLOv9, object detection, real-time, PGI, GELAN, deep learning, MS COCO, AI, neural networks, model efficiency, accuracy, Ultralytics

--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO Multi-Object Tracking in Video
 comments: true
 description: Discover efficient, flexible, and customizable multi-object tracking with Ultralytics YOLO. Learn to track real-time video streams with ease.
 keywords: multi-object tracking, Ultralytics YOLO, video analytics, real-time tracking, object detection, AI, machine learning

--- a/docs/en/platform/account/activity.md
+++ b/docs/en/platform/account/activity.md
@@ -1,4 +1,5 @@
 ---
+title: Account Activity Feed
 comments: true
 description: Track all account activity and events on Ultralytics Platform with the activity feed, including training, uploads, and system events.
 keywords: Ultralytics Platform, activity feed, audit log, notifications, event tracking, activity history

--- a/docs/en/platform/account/api-keys.md
+++ b/docs/en/platform/account/api-keys.md
@@ -1,4 +1,5 @@
 ---
+title: API Key Management
 comments: true
 description: Create and manage API keys for Ultralytics Platform with secure AES-256-GCM encryption for remote training and programmatic access.
 keywords: Ultralytics Platform, API keys, authentication, remote training, security, access control

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -1,4 +1,5 @@
 ---
+title: Billing & Credits
 comments: true
 description: Manage credits, payments, and subscriptions on Ultralytics Platform with transparent pricing for cloud training and deployments.
 keywords: Ultralytics Platform, billing, credits, pricing, subscription, payments, training costs

--- a/docs/en/platform/account/teams.md
+++ b/docs/en/platform/account/teams.md
@@ -1,4 +1,5 @@
 ---
+title: Team Management & Roles
 comments: true
 description: Create and manage teams on Ultralytics Platform with role-based access control, shared resources, and enterprise features for collaborative computer vision workflows.
 keywords: Ultralytics Platform, teams, collaboration, enterprise, roles, permissions, RBAC, workspace, team management

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -1,4 +1,5 @@
 ---
+title: Dataset Management
 comments: true
 description: Learn how to upload, manage, and organize datasets in Ultralytics Platform for YOLO model training with automatic processing and statistics.
 keywords: Ultralytics Platform, datasets, dataset management, dataset versioning, YOLO, data upload, training data, computer vision, machine learning

--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -1,4 +1,5 @@
 ---
+title: Model Deployment Options
 comments: true
 description: Learn about model deployment options in Ultralytics Platform including inference testing, dedicated endpoints, and monitoring dashboards.
 keywords: Ultralytics Platform, deployment, inference, endpoints, monitoring, YOLO, production, cloud deployment

--- a/docs/en/platform/deploy/inference.md
+++ b/docs/en/platform/deploy/inference.md
@@ -1,4 +1,5 @@
 ---
+title: Inference API Testing
 comments: true
 description: Learn how to test YOLO models with the Ultralytics Platform inference API including browser testing and programmatic access.
 keywords: Ultralytics Platform, inference, API, YOLO, object detection, prediction, testing

--- a/docs/en/platform/deploy/monitoring.md
+++ b/docs/en/platform/deploy/monitoring.md
@@ -1,4 +1,5 @@
 ---
+title: Deployment Monitoring
 comments: true
 description: Monitor deployed YOLO models on Ultralytics Platform with real-time metrics, request logs, and performance dashboards.
 keywords: Ultralytics Platform, monitoring, metrics, logs, deployment, performance, YOLO, observability

--- a/docs/en/platform/explore.md
+++ b/docs/en/platform/explore.md
@@ -1,4 +1,5 @@
 ---
+title: Explore Datasets & Projects
 comments: true
 description: Discover public datasets and projects on the Ultralytics Platform Explore page. Browse, search, and clone community content for computer vision and YOLO.
 keywords: Ultralytics Platform, explore, public datasets, public projects, computer vision, YOLO, community

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -1,4 +1,5 @@
 ---
+title: Platform Integrations
 comments: true
 description: Connect Ultralytics Platform to the tools you already use and bring your data across with a single API key. Import from Ultralytics HUB and Roboflow — no manual export or re-upload.
 keywords: Ultralytics Platform, integrations, data import, Roboflow, Ultralytics HUB, dataset migration, YOLO, computer vision

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -1,4 +1,5 @@
 ---
+title: Cloud GPU Training
 comments: true
 description: Learn how to train YOLO models on cloud GPUs with Ultralytics Platform, including remote training and real-time metrics streaming.
 keywords: Ultralytics Platform, cloud training, GPU training, remote training, YOLO, model training, machine learning

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -1,4 +1,5 @@
 ---
+title: Cloud Model Training
 comments: true
 description: Learn about model training in Ultralytics Platform including project organization, cloud training, and real-time metrics streaming.
 keywords: Ultralytics Platform, model training, cloud training, YOLO, GPU training, machine learning, deep learning

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -1,4 +1,5 @@
 ---
+title: Trained Model Management
 comments: true
 description: Learn how to manage, analyze, and export trained models in Ultralytics Platform with support for 19+ deployment formats.
 keywords: Ultralytics Platform, models, model management, export, ONNX, TensorRT, CoreML, YOLO

--- a/docs/en/platform/train/projects.md
+++ b/docs/en/platform/train/projects.md
@@ -1,4 +1,5 @@
 ---
+title: Project Management
 comments: true
 description: Learn how to organize and manage projects in Ultralytics Platform for efficient model development.
 keywords: Ultralytics Platform, projects, model management, experiment tracking, YOLO

--- a/docs/en/reference/__init__.md
+++ b/docs/en/reference/__init__.md
@@ -1,4 +1,5 @@
 ---
+title: __init__ API Reference
 description: Learn how Ultralytics uses lazy imports with __getattr__ to speed up package startup and load model classes like YOLO, NAS, RTDETR, and SAM only when needed.
 keywords: Ultralytics, YOLO, lazy import, __getattr__, NAS, RTDETR, SAM, FastSAM, YOLOWorld, performance, startup time, optimization
 ---

--- a/docs/en/reference/cfg/__init__.md
+++ b/docs/en/reference/cfg/__init__.md
@@ -1,4 +1,5 @@
 ---
+title: cfg.__init__ API Reference
 description: Explore the methods for managing and validating YOLO configurations in the Ultralytics configuration module. Enhance your YOLO experience.
 keywords: Ultralytics, YOLO, configuration, cfg2dict, get_cfg, check_cfg, save_dir, deprecation, merge_args, yolo, settings, explorer
 ---

--- a/docs/en/reference/data/annotator.md
+++ b/docs/en/reference/data/annotator.md
@@ -1,4 +1,5 @@
 ---
+title: data.annotator API Reference
 description: Explore Ultralytics' annotator script for automatic image annotation using YOLO and SAM models. Contribute to improve it on GitHub.
 keywords: Ultralytics, image annotation, YOLO, SAM, Python script, GitHub, object detection, segmentation
 ---

--- a/docs/en/reference/data/augment.md
+++ b/docs/en/reference/data/augment.md
@@ -1,4 +1,5 @@
 ---
+title: data.augment API Reference
 description: Explore Ultralytics image augmentation techniques like MixUp, Mosaic, and Random Perspective for enhancing model training. Improve your deep learning models now.
 keywords: Ultralytics, image augmentation, MixUp, Mosaic, Random Perspective, deep learning, model training, YOLO
 ---

--- a/docs/en/reference/data/base.md
+++ b/docs/en/reference/data/base.md
@@ -1,4 +1,5 @@
 ---
+title: data.base API Reference
 description: Explore the Ultralytics BaseDataset class for efficient image loading and processing with custom transformations and caching options.
 keywords: Ultralytics, BaseDataset, image processing, data augmentation, YOLO, dataset class, image caching
 ---

--- a/docs/en/reference/data/build.md
+++ b/docs/en/reference/data/build.md
@@ -1,4 +1,5 @@
 ---
+title: data.build API Reference
 description: Explore the functionality and examples of data builders like InfiniteDataLoader and various YOLO dataset builders in Ultralytics.
 keywords: Ultralytics, Data Builders, InfiniteDataLoader, YOLO dataset, build.py, AI, Machine Learning
 ---

--- a/docs/en/reference/data/converter.md
+++ b/docs/en/reference/data/converter.md
@@ -1,4 +1,5 @@
 ---
+title: data.converter API Reference
 description: Explore comprehensive data conversion tools for YOLO models including COCO, DOTA, and YOLO bbox2segment converters.
 keywords: Ultralytics, data conversion, YOLO models, COCO, DOTA, YOLO bbox2segment, machine learning, annotations
 ---

--- a/docs/en/reference/data/dataset.md
+++ b/docs/en/reference/data/dataset.md
@@ -1,4 +1,5 @@
 ---
+title: data.dataset API Reference
 description: Explore the YOLODataset and its subclasses for object detection, segmentation, and multi-modal tasks. Find details on dataset loading, caching, and augmentation.
 keywords: Ultralytics, YOLODataset, object detection, segmentation, dataset loading, caching, data augmentation
 ---

--- a/docs/en/reference/data/loaders.md
+++ b/docs/en/reference/data/loaders.md
@@ -1,4 +1,5 @@
 ---
+title: data.loaders API Reference
 description: Explore detailed documentation on Ultralytics data loaders including SourceTypes, LoadStreams, and more. Enhance your ML workflows with our comprehensive guides.
 keywords: Ultralytics, data loaders, SourceTypes, LoadStreams, LoadScreenshots, LoadImagesAndVideos, LoadPilAndNumpy, LoadTensor, ML workflows
 ---

--- a/docs/en/reference/data/split.md
+++ b/docs/en/reference/data/split.md
@@ -1,4 +1,5 @@
 ---
+title: data.split API Reference
 description: Learn how to split datasets into train, validation, and test subsets using Ultralytics utilities for efficient data preparation.
 keywords: dataset splitting, autosplit dataset, training dataset preparation, validation set creation, Ultralytics data tools
 ---

--- a/docs/en/reference/data/split_dota.md
+++ b/docs/en/reference/data/split_dota.md
@@ -1,4 +1,5 @@
 ---
+title: data.split_dota API Reference
 description: Learn how to utilize the ultralytics.data.split_dota module to process and split DOTA datasets efficiently. Explore detailed functions and examples.
 keywords: Ultralytics, DOTA dataset, data splitting, YOLO, Python, bbox_iof, load_yolo_dota, get_windows, crop_and_save
 ---

--- a/docs/en/reference/data/utils.md
+++ b/docs/en/reference/data/utils.md
@@ -1,4 +1,5 @@
 ---
+title: data.utils API Reference
 description: Explore in-depth reference for utility functions in Ultralytics data module. Learn about image verification, dataset handling, and more.
 keywords: Ultralytics, dataset utils, data handling, image verification, Python, data module
 ---

--- a/docs/en/reference/engine/exporter.md
+++ b/docs/en/reference/engine/exporter.md
@@ -1,4 +1,5 @@
 ---
+title: engine.exporter API Reference
 description: Learn how to export YOLOv8 models to formats like ONNX, TensorRT, CoreML, and more. Optimize your exports for different platforms.
 keywords: YOLOv8, export formats, ONNX, TensorRT, CoreML, machine learning model export, AI, deep learning
 ---

--- a/docs/en/reference/engine/model.md
+++ b/docs/en/reference/engine/model.md
@@ -1,4 +1,5 @@
 ---
+title: engine.model API Reference
 description: Explore the base class for implementing YOLO models with unified APIs for training, validation, prediction, and more. Learn how to utilize different task types and model configurations.
 keywords: YOLO model, Ultralytics, machine learning, deep learning, PyTorch model, training, validation, prediction, exporting, benchmarking, Ultralytics Platform, Triton Server
 ---

--- a/docs/en/reference/engine/predictor.md
+++ b/docs/en/reference/engine/predictor.md
@@ -1,4 +1,5 @@
 ---
+title: engine.predictor API Reference
 description: Discover how to use the Base Predictor class in the Ultralytics YOLO engine for efficient image and video inference.
 keywords: Ultralytics, YOLO, Base Predictor, image inference, video inference, machine learning, Python
 ---

--- a/docs/en/reference/engine/results.md
+++ b/docs/en/reference/engine/results.md
@@ -1,4 +1,5 @@
 ---
+title: engine.results API Reference
 description: Explore the details of Ultralytics engine results including classes like BaseTensor, Results, Boxes, Masks, Keypoints, Probs, and OBB to handle inference results efficiently.
 keywords: Ultralytics, engine results, BaseTensor, Results class, Boxes, Masks, Keypoints, Probs, OBB, inference results, machine learning, PyTorch
 ---

--- a/docs/en/reference/engine/trainer.md
+++ b/docs/en/reference/engine/trainer.md
@@ -1,4 +1,5 @@
 ---
+title: engine.trainer API Reference
 description: Learn how to use BaseTrainer in Ultralytics YOLO for efficient model training. Comprehensive guide for configurations, datasets, and optimization.
 keywords: Ultralytics, YOLO, BaseTrainer, model training, configuration, datasets, optimization, machine learning
 ---

--- a/docs/en/reference/engine/tuner.md
+++ b/docs/en/reference/engine/tuner.md
@@ -1,4 +1,5 @@
 ---
+title: engine.tuner API Reference
 description: Optimize YOLO model performance using Ultralytics Tuner. Learn about systematic hyperparameter tuning for object detection, segmentation, classification, and tracking.
 keywords: Ultralytics, YOLO, hyperparameter tuning, machine learning, deep learning, object detection, instance segmentation, image classification, pose estimation, multi-object tracking
 ---

--- a/docs/en/reference/engine/validator.md
+++ b/docs/en/reference/engine/validator.md
@@ -1,4 +1,5 @@
 ---
+title: engine.validator API Reference
 description: Explore Ultralytics BaseValidator for model validation in PyTorch, TensorFlow, ONNX, and more. Learn to check model accuracy and performance metrics.
 keywords: Ultralytics, BaseValidator, model validation, PyTorch, TensorFlow, ONNX, model accuracy, performance metrics
 ---

--- a/docs/en/reference/hub/__init__.md
+++ b/docs/en/reference/hub/__init__.md
@@ -1,4 +1,5 @@
 ---
+title: hub.__init__ API Reference
 description: Explore Ultralytics Platform API functions for login, logout, model reset, export, and dataset checks. Enhance your YOLO workflows with these essential utilities.
 keywords: Ultralytics Platform API, login, logout, reset model, export model, check dataset, YOLO, machine learning
 ---

--- a/docs/en/reference/hub/auth.md
+++ b/docs/en/reference/hub/auth.md
@@ -1,4 +1,5 @@
 ---
+title: hub.auth API Reference
 description: Learn how to manage API key and cookie-based authentication in Ultralytics with the Auth class. Step-by-step guide for effective authentication.
 keywords: Ultralytics, authentication, API key, cookies, Auth class, YOLO, API, guide
 ---

--- a/docs/en/reference/hub/google/__init__.md
+++ b/docs/en/reference/hub/google/__init__.md
@@ -1,4 +1,5 @@
 ---
+title: hub.google.__init__ API Reference
 description: Reference for the GCPRegions class in Ultralytics, which provides functionality for testing and analyzing latency across Google Cloud Platform regions.
 keywords: Ultralytics, GCP, Google Cloud Platform, regions, latency testing, cloud computing, networking, performance analysis
 ---

--- a/docs/en/reference/hub/session.md
+++ b/docs/en/reference/hub/session.md
@@ -1,4 +1,5 @@
 ---
+title: hub.session API Reference
 description: Explore the HUBTrainingSession class for managing Ultralytics YOLO model training, heartbeats, and checkpointing.
 keywords: Ultralytics, YOLO, HUBTrainingSession, model training, heartbeats, checkpointing, Python
 ---

--- a/docs/en/reference/hub/utils.md
+++ b/docs/en/reference/hub/utils.md
@@ -1,4 +1,5 @@
 ---
+title: hub.utils API Reference
 description: Explore the utilities in the Ultralytics Platform. Learn about smart_request, request_with_credentials, and more to enhance your YOLO projects.
 keywords: Ultralytics, HUB, Utilities, YOLO, smart_request, request_with_credentials
 ---

--- a/docs/en/reference/models/fastsam/model.md
+++ b/docs/en/reference/models/fastsam/model.md
@@ -1,4 +1,5 @@
 ---
+title: models.fastsam.model API Reference
 description: Discover how to use the FastSAM model with Ultralytics. Learn about its interface and implementation details with practical examples.
 keywords: FastSAM, Ultralytics, model interface, YOLO, deep learning, machine learning, segmentation, predictor, validator, Python
 ---

--- a/docs/en/reference/models/fastsam/predict.md
+++ b/docs/en/reference/models/fastsam/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.fastsam.predict API Reference
 description: Explore the Fast SAM Predictor in the Ultralytics YOLO framework. Learn about its segmentation prediction tasks, configuration, and post-processing steps.
 keywords: Ultralytics, Fast SAM Predictor, YOLO, segmentation, prediction, AI model, non-max suppression, mask prediction, tutorial
 ---

--- a/docs/en/reference/models/fastsam/utils.md
+++ b/docs/en/reference/models/fastsam/utils.md
@@ -1,4 +1,5 @@
 ---
+title: models.fastsam.utils API Reference
 description: Explore the utility functions in FastSAM for adjusting bounding boxes and calculating IoU, benefiting computer vision projects.
 keywords: FastSAM, bounding boxes, IoU, Ultralytics, image processing, computer vision
 ---

--- a/docs/en/reference/models/fastsam/val.md
+++ b/docs/en/reference/models/fastsam/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.fastsam.val API Reference
 description: Discover FastSAM Validator for segmentation in Ultralytics YOLO. Learn how to validate with custom metrics and avoid common errors. Contribute on GitHub.
 keywords: FastSAM Validator, Ultralytics, YOLO, segmentation, validation, metrics, GitHub, contribute, documentation
 ---

--- a/docs/en/reference/models/nas/model.md
+++ b/docs/en/reference/models/nas/model.md
@@ -1,4 +1,5 @@
 ---
+title: models.nas.model API Reference
 description: Explore the YOLO-NAS model interface and learn how to utilize pretrained YOLO-NAS models for object detection with Ultralytics.
 keywords: Ultralytics, YOLO, YOLO-NAS, object detection, pretrained models, machine learning, deep learning, NAS model
 ---

--- a/docs/en/reference/models/nas/predict.md
+++ b/docs/en/reference/models/nas/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.nas.predict API Reference
 description: Learn about NASPredictor in Ultralytics YOLO for efficient object detection. Explore its attributes, methods, and usage with examples.
 keywords: Ultralytics, YOLO, NASPredictor, object detection, machine learning, AI, non-maximum suppression, bounding boxes, image processing
 ---

--- a/docs/en/reference/models/nas/val.md
+++ b/docs/en/reference/models/nas/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.nas.val API Reference
 description: Explore the Ultralytics NASValidator for efficient YOLO model validation. Learn about NMS and post-processing configurations.
 keywords: Ultralytics, YOLO, NASValidator, object detection, non-maximum suppression, NMS, YOLO models, machine learning
 ---

--- a/docs/en/reference/models/rtdetr/model.md
+++ b/docs/en/reference/models/rtdetr/model.md
@@ -1,4 +1,5 @@
 ---
+title: models.rtdetr.model API Reference
 description: Explore the interface for Baidu's RT-DETR, a Vision Transformer-based real-time object detector in the Ultralytics Docs. Learn more about its efficient hybrid encoding and IoU-aware query selection.
 keywords: RT-DETR, real-time object detection, Vision Transformer, Ultralytics, model interface, Baidu, hybrid encoding, IoU-aware query selection, machine learning, AI
 ---

--- a/docs/en/reference/models/rtdetr/predict.md
+++ b/docs/en/reference/models/rtdetr/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.rtdetr.predict API Reference
 description: Access the complete reference for the RTDETRPredictor class in Ultralytics. Learn about its attributes, methods, and example usage for real-time object detection.
 keywords: RTDETRPredictor, Ultralytics, Real-Time Detection Transformer, object detection, Vision Transformers, documentation, RT-DETR, Python class
 ---

--- a/docs/en/reference/models/rtdetr/train.md
+++ b/docs/en/reference/models/rtdetr/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.rtdetr.train API Reference
 description: Explore RTDETRTrainer for efficient real-time object detection leveraging Vision Transformers. Learn configuration, dataset handling, and advanced model training.
 keywords: RTDETRTrainer, real-time object detection, Vision Transformers, YOLO, RT-DETR model, model training, dataset handling
 ---

--- a/docs/en/reference/models/rtdetr/val.md
+++ b/docs/en/reference/models/rtdetr/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.rtdetr.val API Reference
 description: Explore the RTDETRValidator and RTDETRDataset classes for real-time detection and tracking. Understand initialization, transformations, and post-processing.
 keywords: RTDETR, Ultralytics, object detection, tracking, YOLO, RTDETRDataset, RTDETRValidator, real-time detection
 ---

--- a/docs/en/reference/models/sam/amg.md
+++ b/docs/en/reference/models/sam/amg.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.amg API Reference
 description: Explore the detailed API reference for Ultralytics SAM/AMG models, including functions for mask stability scores, crop box generation, and more.
 keywords: Ultralytics, SAM, AMG, API Reference, models, mask stability, crop boxes, data processing, YOLO
 ---

--- a/docs/en/reference/models/sam/build.md
+++ b/docs/en/reference/models/sam/build.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.build API Reference
 description: Discover detailed instructions for building various Segment Anything Model (SAM) and Segment Anything Model 2 (SAM 2) architectures with Ultralytics, including SAM ViT and Mobile-SAM.
 keywords: Ultralytics, SAM model, Segment Anything Model, SAM 2 model, Segment Anything Model 2, SAM ViT, Mobile-SAM, model building, deep learning, AI
 ---

--- a/docs/en/reference/models/sam/build_sam3.md
+++ b/docs/en/reference/models/sam/build_sam3.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.build_sam3 API Reference
 description: Explore the ultralytics.models.sam.build_sam3 module for building SAM3 image models, including backbone and transformer components.
 keywords: Ultralytics, SAM3, SAM, segmentation, transformer, ViTDet, model builder, Python
 ---

--- a/docs/en/reference/models/sam/model.md
+++ b/docs/en/reference/models/sam/model.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.model API Reference
 description: Explore the SAM (Segment Anything Model) and SAM 2 (Segment Anything Model 2) interface for real-time image segmentation. Learn about promptable segmentation and zero-shot capabilities.
 keywords: Ultralytics, SAM, Segment Anything Model, SAM 2, Segment Anything Model 2, image segmentation, real-time segmentation, zero-shot performance, promptable segmentation, SA-1B dataset
 ---

--- a/docs/en/reference/models/sam/modules/blocks.md
+++ b/docs/en/reference/models/sam/modules/blocks.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.modules.blocks API Reference
 description: Explore detailed documentation of various SAM and SAM 2 modules such as MaskDownSampler, CXBlock, and more, available in Ultralytics' repository.
 keywords: Ultralytics, SAM encoder, SAM 2 encoder, DropPath, MaskDownSampler, CXBlock, Fuser, TwoWayTransformer, TwoWayAttentionBlock, RoPEAttention, MultiScaleAttention, MultiScaleBlock, PositionEmbeddingSine, do_pool
 ---

--- a/docs/en/reference/models/sam/modules/decoders.md
+++ b/docs/en/reference/models/sam/modules/decoders.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.modules.decoders API Reference
 description: Explore the MaskDecoder and MLP modules in Ultralytics for efficient mask prediction using transformer architecture. Detailed attributes, functionalities, and implementation.
 keywords: Ultralytics, MaskDecoder, MLP, machine learning, transformer architecture, mask prediction, neural networks, PyTorch modules
 ---

--- a/docs/en/reference/models/sam/modules/encoders.md
+++ b/docs/en/reference/models/sam/modules/encoders.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.modules.encoders API Reference
 description: Explore detailed documentation of various SAM encoder modules such as ImageEncoderViT, PromptEncoder, and more, available in Ultralytics' repository.
 keywords: Ultralytics, SAM encoder, ImageEncoderViT, PromptEncoder, PositionEmbeddingRandom, Block, Attention, PatchEmbed
 ---

--- a/docs/en/reference/models/sam/modules/memory_attention.md
+++ b/docs/en/reference/models/sam/modules/memory_attention.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.modules.memory_attention API Reference
 description: Explore detailed documentation of various SAM 2 encoder modules such as MemoryAttentionLayer, MemoryAttention, available in Ultralytics' repository.
 keywords: Ultralytics, SAM 2 encoder, MemoryAttentionLayer, MemoryAttention
 ---

--- a/docs/en/reference/models/sam/modules/sam.md
+++ b/docs/en/reference/models/sam/modules/sam.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.modules.sam API Reference
 description: Discover the Ultralytics SAM and SAM 2 module for object segmentation. Learn about its components, such as image encoders and mask decoders, in this comprehensive guide.
 keywords: Ultralytics, SAM Module, SAM 2 Module, object segmentation, image encoder, mask decoder, prompt encoder, AI, machine learning
 ---

--- a/docs/en/reference/models/sam/modules/tiny_encoder.md
+++ b/docs/en/reference/models/sam/modules/tiny_encoder.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.modules.tiny_encoder API Reference
 description: Explore the detailed implementation of TinyViT architecture including Conv2d_BN, PatchEmbed, MBConv, and more in Ultralytics.
 keywords: Ultralytics, TinyViT, Conv2d_BN, PatchEmbed, MBConv, Attention, PyTorch, YOLO, Deep Learning
 ---

--- a/docs/en/reference/models/sam/modules/transformer.md
+++ b/docs/en/reference/models/sam/modules/transformer.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.modules.transformer API Reference
 description: Explore the TwoWayTransformer module in Ultralytics, designed for simultaneous attention to image and query points. Ideal for object detection and segmentation tasks.
 keywords: Ultralytics, TwoWayTransformer, module, deep learning, transformer, object detection, image segmentation, attention mechanism, neural networks
 ---

--- a/docs/en/reference/models/sam/modules/utils.md
+++ b/docs/en/reference/models/sam/modules/utils.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.modules.utils API Reference
 description: Explore the detailed API reference for Ultralytics SAM and SAM 2 models.
 keywords: Ultralytics, SAM, SAM 2, API Reference, models, window partition, data processing, YOLO
 ---

--- a/docs/en/reference/models/sam/predict.md
+++ b/docs/en/reference/models/sam/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.predict API Reference
 description: Explore Ultralytics SAM and SAM 2 Predictor for advanced, real-time image segmentation using the Segment Anything Model (SAM and SAM 2). Complete implementation details and auxiliary utilities.
 keywords: Ultralytics, SAM, Segment Anything Model, SAM 2, Segment Anything Model 2, image segmentation, real-time, prediction, AI, machine learning, Python, torch, inference
 ---

--- a/docs/en/reference/models/sam/sam3/decoder.md
+++ b/docs/en/reference/models/sam/sam3/decoder.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.decoder API Reference
 description: Explore the ultralytics.models.sam.sam3.decoder module, including transformer decoder layers used in SAM3 model heads.
 keywords: Ultralytics, SAM3, SAM, transformer decoder, attention, segmentation, deep learning, Python
 ---

--- a/docs/en/reference/models/sam/sam3/encoder.md
+++ b/docs/en/reference/models/sam/sam3/encoder.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.encoder API Reference
 description: Explore the ultralytics.models.sam.sam3.encoder module, including transformer encoder layers and fusion blocks for SAM3.
 keywords: Ultralytics, SAM3, SAM, transformer encoder, fusion, attention, deep learning, Python
 ---

--- a/docs/en/reference/models/sam/sam3/geometry_encoders.md
+++ b/docs/en/reference/models/sam/sam3/geometry_encoders.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.geometry_encoders API Reference
 description: Explore the ultralytics.models.sam.sam3.geometry_encoders module for prompt and geometry encoding utilities used by SAM3.
 keywords: Ultralytics, SAM3, SAM, prompt encoder, geometry encoder, padding, embeddings, Python
 ---

--- a/docs/en/reference/models/sam/sam3/maskformer_segmentation.md
+++ b/docs/en/reference/models/sam/sam3/maskformer_segmentation.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.maskformer_segmentation API Reference
 description: Explore the ultralytics.models.sam.sam3.maskformer_segmentation module for segmentation heads and predictors used with SAM3.
 keywords: Ultralytics, SAM3, MaskFormer, segmentation head, mask prediction, deep learning, Python, API reference
 ---

--- a/docs/en/reference/models/sam/sam3/model_misc.md
+++ b/docs/en/reference/models/sam/sam3/model_misc.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.model_misc API Reference
 description: Explore the ultralytics.models.sam.sam3.model_misc module with helper layers and utilities used in SAM3 model components.
 keywords: Ultralytics, SAM3, SAM, transformer, layers, utilities, deep learning, Python
 ---

--- a/docs/en/reference/models/sam/sam3/necks.md
+++ b/docs/en/reference/models/sam/sam3/necks.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.necks API Reference
 description: Explore the ultralytics.models.sam.sam3.necks module for SAM3 neck components that connect vision backbones to downstream heads.
 keywords: Ultralytics, SAM3, SAM, neck, backbone, ViTDet, segmentation, Python
 ---

--- a/docs/en/reference/models/sam/sam3/sam3_image.md
+++ b/docs/en/reference/models/sam/sam3/sam3_image.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.sam3_image API Reference
 description: Explore the ultralytics.models.sam.sam3.sam3_image module, including the SAM3SemanticModel and related output helpers.
 keywords: Ultralytics, SAM3, SAM, image segmentation, semantic segmentation, model, Python, API reference
 ---

--- a/docs/en/reference/models/sam/sam3/text_encoder_ve.md
+++ b/docs/en/reference/models/sam/sam3/text_encoder_ve.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.text_encoder_ve API Reference
 description: Explore the ultralytics.models.sam.sam3.text_encoder_ve module for SAM3 text-encoder components used in vision-language pipelines.
 keywords: Ultralytics, SAM3, SAM, text encoder, vision-language, transformer, tokenizer, Python
 ---

--- a/docs/en/reference/models/sam/sam3/vitdet.md
+++ b/docs/en/reference/models/sam/sam3/vitdet.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.vitdet API Reference
 description: Explore the ultralytics.models.sam.sam3.vitdet module for ViTDet building blocks used as vision backbones in SAM3.
 keywords: Ultralytics, SAM3, ViTDet, vision transformer, backbone, attention, deep learning, Python
 ---

--- a/docs/en/reference/models/sam/sam3/vl_combiner.md
+++ b/docs/en/reference/models/sam/sam3/vl_combiner.md
@@ -1,4 +1,5 @@
 ---
+title: models.sam.sam3.vl_combiner API Reference
 description: Explore the ultralytics.models.sam.sam3.vl_combiner module for combining vision and language features in SAM3.
 keywords: Ultralytics, SAM3, vision-language, backbone, feature fusion, transformer, deep learning, Python
 ---

--- a/docs/en/reference/models/utils/loss.md
+++ b/docs/en/reference/models/utils/loss.md
@@ -1,4 +1,5 @@
 ---
+title: models.utils.loss API Reference
 description: Explore detailed implementations of loss functions for DETR and RT-DETR models in Ultralytics.
 keywords: ultralytics, YOLO, DETR, RT-DETR, loss functions, object detection, deep learning, focal loss, varifocal loss, Hungarian matcher
 ---

--- a/docs/en/reference/models/utils/ops.md
+++ b/docs/en/reference/models/utils/ops.md
@@ -1,4 +1,5 @@
 ---
+title: models.utils.ops API Reference
 description: Explore the utilities and operations in Ultralytics models like HungarianMatcher and get_cdn_group. Learn how to optimize and manage model operations efficiently.
 keywords: Ultralytics, models, utils, operations, HungarianMatcher, get_cdn_group, model optimization, PyTorch, machine learning
 ---

--- a/docs/en/reference/models/yolo/classify/predict.md
+++ b/docs/en/reference/models/yolo/classify/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.classify.predict API Reference
 description: Learn about the ClassificationPredictor class for YOLO models at Ultralytics. Get details on initialization, preprocessing, and postprocessing for classification tasks.
 keywords: YOLO, ClassificationPredictor, Ultralytics, model prediction, preprocess, postprocess, deep learning, machine learning
 ---

--- a/docs/en/reference/models/yolo/classify/train.md
+++ b/docs/en/reference/models/yolo/classify/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.classify.train API Reference
 description: Explore the train.py module in Ultralytics YOLO for efficient classification model training. Learn more with examples and detailed code documentation.
 keywords: YOLO, Ultralytics, classification, training, machine learning, deep learning, PyTorch, train.py
 ---

--- a/docs/en/reference/models/yolo/classify/val.md
+++ b/docs/en/reference/models/yolo/classify/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.classify.val API Reference
 description: Explore the source code and functionalities of the YOLO Classification Validator in Ultralytics for evaluating classification models effectively.
 keywords: Ultralytics, YOLO, classification, validation, ClassifyMetrics, ConfusionMatrix, PyTorch, deep learning, model evaluation, AI, machine learning
 ---

--- a/docs/en/reference/models/yolo/detect/predict.md
+++ b/docs/en/reference/models/yolo/detect/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.detect.predict API Reference
 description: Explore the Ultralytics YOLO Detection Predictor. Learn how to implement and use the DetectionPredictor class for object detection in Python.
 keywords: YOLO, Ultralytics, DetectionPredictor, object detection, Python, machine learning, AI, non_max_suppression
 ---

--- a/docs/en/reference/models/yolo/detect/train.md
+++ b/docs/en/reference/models/yolo/detect/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.detect.train API Reference
 description: Learn about the DetectionTrainer class for training YOLO models on custom datasets. Discover methods, examples, and more.
 keywords: Ultralytics, YOLO, DetectionTrainer, training, object detection, machine learning, build dataset, dataloader, detection model
 ---

--- a/docs/en/reference/models/yolo/detect/val.md
+++ b/docs/en/reference/models/yolo/detect/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.detect.val API Reference
 description: Explore the DetectionValidator class for YOLO models in Ultralytics. Learn validation techniques, metrics, and dataset handling for object detection.
 keywords: YOLO validation, detection validation, YOLO metrics, Ultralytics, object detection, machine learning, AI
 ---

--- a/docs/en/reference/models/yolo/model.md
+++ b/docs/en/reference/models/yolo/model.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.model API Reference
 description: Explore the ultralytics.models.yolo.model module for YOLO object detection. Learn initialization, model mapping, and more.
 keywords: YOLO, object detection, Ultralytics, YOLO model, machine learning, Python, model initialization
 ---

--- a/docs/en/reference/models/yolo/obb/predict.md
+++ b/docs/en/reference/models/yolo/obb/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.obb.predict API Reference
 description: Learn how to use the Ultralytics YOLO OBBPredictor for oriented bounding box predictions. Enhance your object detection models with ease.
 keywords: Ultralytics, YOLO, OBBPredictor, oriented bounding box, object detection, AI, machine learning, PyTorch
 ---

--- a/docs/en/reference/models/yolo/obb/train.md
+++ b/docs/en/reference/models/yolo/obb/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.obb.train API Reference
 description: Explore the Ultralytics YOLO OBB Trainer class for efficient training with Oriented Bounding Box models. Learn with examples and method details.
 keywords: Ultralytics, YOLO, OBB Trainer, Oriented Bounding Box, Machine Learning, Training, AI
 ---

--- a/docs/en/reference/models/yolo/obb/val.md
+++ b/docs/en/reference/models/yolo/obb/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.obb.val API Reference
 description: Explore the OBBValidator for YOLO, an advanced class for oriented bounding boxes (OBB). Learn initialization, processes, and evaluation methods.
 keywords: Ultralytics, YOLO, OBBValidator, Oriented Bounding Boxes, DetectionValidator, validation, Python, deep learning
 ---

--- a/docs/en/reference/models/yolo/pose/predict.md
+++ b/docs/en/reference/models/yolo/pose/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.pose.predict API Reference
 description: Learn about the PosePredictor class for YOLO model predictions on pose data. Get setup instructions, example usage, and implementation details.
 keywords: YOLO, Pose Prediction, Ultralytics, PosePredictor, YOLOv8, Machine Learning, Deep Learning, Python, AI Models
 ---

--- a/docs/en/reference/models/yolo/pose/train.md
+++ b/docs/en/reference/models/yolo/pose/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.pose.train API Reference
 description: Explore the PoseTrainer class for training pose models using YOLO from Ultralytics. Includes initialization, model configuration, and plotting methods.
 keywords: PoseTrainer, YOLO, Ultralytics, pose models, training, model configuration, deep learning, machine learning, pose estimation
 ---

--- a/docs/en/reference/models/yolo/pose/val.md
+++ b/docs/en/reference/models/yolo/pose/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.pose.val API Reference
 description: Explore the PoseValidator class for YOLO models. Learn how to extend DetectionValidator for pose validation with example code and detailed methods.
 keywords: Ultralytics, YOLO, PoseValidator, pose validation, machine learning, object detection, keypoints, python code, AI, deep learning
 ---

--- a/docs/en/reference/models/yolo/segment/predict.md
+++ b/docs/en/reference/models/yolo/segment/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.segment.predict API Reference
 description: Understand the SegmentationPredictor class for segmentation-based predictions using YOLO. Learn more about its implementation and example usage.
 keywords: YOLO, SegmentationPredictor, machine learning, computer vision, object detection, Ultralytics, prediction, model, non-max suppression
 ---

--- a/docs/en/reference/models/yolo/segment/train.md
+++ b/docs/en/reference/models/yolo/segment/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.segment.train API Reference
 description: Learn how to train YOLO models for segmentation tasks with Ultralytics. Explore the SegmentationTrainer class and its functionalities.
 keywords: YOLO, segmentation, train, Ultralytics, SegmentationTrainer, Python, machine learning, deep learning, tutorials
 ---

--- a/docs/en/reference/models/yolo/segment/val.md
+++ b/docs/en/reference/models/yolo/segment/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.segment.val API Reference
 description: Explore the YOLO Segmentation Validator module for validating segment models. Understand its usage, metrics, and implementation within the Ultralytics framework.
 keywords: YOLO, segmentation, validator, Ultralytics, model validation, machine learning, deep learning, AI, computer vision
 ---

--- a/docs/en/reference/models/yolo/semantic/predict.md
+++ b/docs/en/reference/models/yolo/semantic/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.semantic.predict API Reference
 description: Reference for YOLO semantic segmentation predictor. Learn about the SemanticSegmentationPredictor class and its inference methods.
 keywords: Ultralytics, semantic segmentation, predictor, inference, YOLO, semantic, predict
 ---

--- a/docs/en/reference/models/yolo/semantic/train.md
+++ b/docs/en/reference/models/yolo/semantic/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.semantic.train API Reference
 description: Reference for YOLO semantic segmentation trainer. Learn about the SemanticSegmentationTrainer class and its training methods.
 keywords: Ultralytics, semantic segmentation, trainer, training, YOLO, semantic
 ---

--- a/docs/en/reference/models/yolo/semantic/val.md
+++ b/docs/en/reference/models/yolo/semantic/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.semantic.val API Reference
 description: Reference for YOLO semantic segmentation validator. Learn about the SemanticSegmentationValidator class and its validation metrics.
 keywords: Ultralytics, semantic segmentation, validator, validation, mIoU, YOLO, semantic
 ---

--- a/docs/en/reference/models/yolo/world/train.md
+++ b/docs/en/reference/models/yolo/world/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.world.train API Reference
 description: Learn how to train a World Model with Ultralytics YOLO using advanced techniques and customizable options for optimal performance.
 keywords: Ultralytics, YOLO, World Model, training, deep learning, computer vision, AI, machine learning, tutorial
 ---

--- a/docs/en/reference/models/yolo/world/train_world.md
+++ b/docs/en/reference/models/yolo/world/train_world.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.world.train_world API Reference
 description: Explore the WorldTrainerFromScratch in YOLO for open-set datasets. Learn how to build, train, and evaluate models efficiently.
 keywords: YOLO, WorldTrainer, open-set datasets, training, evaluation, build dataset, YOLO World, machine learning
 ---

--- a/docs/en/reference/models/yolo/yoloe/predict.md
+++ b/docs/en/reference/models/yolo/yoloe/predict.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.yoloe.predict API Reference
 description: Documentation for YOLOE visual prompt predictors in Ultralytics, supporting inference with visual prompts for both object detection and segmentation models.
 keywords: YOLOE, visual prompts, predictors, YOLOEVPDetectPredictor, YOLOEVPSegPredictor, inference, object detection, segmentation, Ultralytics, deep learning
 ---

--- a/docs/en/reference/models/yolo/yoloe/train.md
+++ b/docs/en/reference/models/yolo/yoloe/train.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.yoloe.train API Reference
 description: Learn about YOLOE training classes in Ultralytics, including standard, linear probing, and visual prompt training for detection and segmentation models.
 keywords: YOLOE, training, trainers, EVP, visual prompts, computer vision, object detection, segmentation, Ultralytics, deep learning
 ---

--- a/docs/en/reference/models/yolo/yoloe/train_seg.md
+++ b/docs/en/reference/models/yolo/yoloe/train_seg.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.yoloe.train_seg API Reference
 description: Documentation for YOLOE segmentation trainer classes in Ultralytics, supporting different training approaches including standard training, linear probing, training from scratch, and visual prompt training.
 keywords: YOLOE, segmentation, trainers, YOLOESegTrainer, YOLOEPESegTrainer, YOLOESegTrainerFromScratch, YOLOESegVPTrainer, linear probing, visual prompts, Ultralytics, deep learning
 ---

--- a/docs/en/reference/models/yolo/yoloe/val.md
+++ b/docs/en/reference/models/yolo/yoloe/val.md
@@ -1,4 +1,5 @@
 ---
+title: models.yolo.yoloe.val API Reference
 description: Documentation for YOLOE validator classes in Ultralytics, supporting both text and visual prompt embeddings for object detection and segmentation models.
 keywords: YOLOE, validation, object detection, segmentation, visual prompts, text prompts, embeddings, Ultralytics, YOLOEDetectValidator, YOLOESegValidator, deep learning
 ---

--- a/docs/en/reference/nn/autobackend.md
+++ b/docs/en/reference/nn/autobackend.md
@@ -1,4 +1,5 @@
 ---
+title: nn.autobackend API Reference
 description: Get to know more about Ultralytics nn.autobackend.check_class_names functionality. Optimize your YOLO models seamlessly.
 keywords: Ultralytics, AutoBackend, check_class_names, YOLO, YOLO models, optimization
 ---

--- a/docs/en/reference/nn/backends/axelera.md
+++ b/docs/en/reference/nn/backends/axelera.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.axelera API Reference
 description: Explore AxeleraBackend for Axelera hardware inference, deploying YOLO models on Axelera AI accelerators with optimized performance.
 keywords: Ultralytics, AxeleraBackend, Axelera inference, AI accelerator, hardware inference, edge AI, deep learning acceleration
 ---

--- a/docs/en/reference/nn/backends/base.md
+++ b/docs/en/reference/nn/backends/base.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.base API Reference
 description: Explore the BaseBackend class, the abstract foundation for all inference backends in Ultralytics, defining the interface for model loading and inference.
 keywords: Ultralytics, BaseBackend, inference backend, abstract class, model loading, deep learning, neural network inference
 ---

--- a/docs/en/reference/nn/backends/coreml.md
+++ b/docs/en/reference/nn/backends/coreml.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.coreml API Reference
 description: Explore CoreMLBackend for Apple CoreML inference, enabling efficient YOLO model deployment on iOS, macOS, and Apple Silicon devices.
 keywords: Ultralytics, CoreMLBackend, CoreML inference, Apple CoreML, iOS deployment, macOS inference, Apple Silicon, mobile AI
 ---

--- a/docs/en/reference/nn/backends/deepx.md
+++ b/docs/en/reference/nn/backends/deepx.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.deepx API Reference
 description: Reference for the Ultralytics DeepXBackend. Learn how to run inference with DEEPX NPU compiled models using the DX-Runtime.
 keywords: DeepXBackend, DEEPX, NPU, inference backend, dx_engine, Ultralytics, YOLO, edge AI
 ---

--- a/docs/en/reference/nn/backends/executorch.md
+++ b/docs/en/reference/nn/backends/executorch.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.executorch API Reference
 description: Explore ExecuTorchBackend for Meta ExecuTorch inference, enabling efficient PyTorch model deployment on mobile and edge devices.
 keywords: Ultralytics, ExecuTorchBackend, ExecuTorch inference, Meta ExecuTorch, mobile inference, edge deployment, PyTorch Mobile
 ---

--- a/docs/en/reference/nn/backends/mnn.md
+++ b/docs/en/reference/nn/backends/mnn.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.mnn API Reference
 description: Explore MNNBackend for Alibaba MNN inference, enabling lightweight and efficient model deployment on mobile and edge devices.
 keywords: Ultralytics, MNNBackend, MNN inference, Alibaba MNN, mobile inference, edge AI, .mnn models, deep learning
 ---

--- a/docs/en/reference/nn/backends/ncnn.md
+++ b/docs/en/reference/nn/backends/ncnn.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.ncnn API Reference
 description: Explore NCNNBackend for Tencent NCNN inference, optimized for mobile and embedded platforms with Vulkan acceleration support.
 keywords: Ultralytics, NCNNBackend, NCNN inference, Tencent NCNN, mobile inference, Vulkan acceleration, embedded AI, deep learning
 ---

--- a/docs/en/reference/nn/backends/onnx.md
+++ b/docs/en/reference/nn/backends/onnx.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.onnx API Reference
 description: Explore ONNXBackend and ONNXIMXBackend for Microsoft ONNX Runtime inference, supporting standard ONNX models and NXP IMX-optimized variants.
 keywords: Ultralytics, ONNXBackend, ONNXIMXBackend, Microsoft ONNX Runtime, Sony IMX, ONNX inference, edge deployment, deep learning
 ---

--- a/docs/en/reference/nn/backends/openvino.md
+++ b/docs/en/reference/nn/backends/openvino.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.openvino API Reference
 description: Explore OpenVINOBackend for optimized inference on Intel hardware, supporting OpenVINO IR models for efficient deployment on CPUs, GPUs, and VPUs.
 keywords: Ultralytics, OpenVINOBackend, OpenVINO inference, Intel OpenVINO, CPU inference, VPU, edge AI, deep learning optimization
 ---

--- a/docs/en/reference/nn/backends/paddle.md
+++ b/docs/en/reference/nn/backends/paddle.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.paddle API Reference
 description: Explore PaddleBackend for Baidu PaddlePaddle inference, supporting deployment with Paddle Inference engine on various hardware platforms.
 keywords: Ultralytics, PaddleBackend, PaddlePaddle inference, Baidu Paddle, Paddle Inference, deep learning, model deployment
 ---

--- a/docs/en/reference/nn/backends/pytorch.md
+++ b/docs/en/reference/nn/backends/pytorch.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.pytorch API Reference
 description: Explore PyTorchBackend and TorchScriptBackend for native PyTorch and TorchScript model inference in Ultralytics YOLO models.
 keywords: Ultralytics, PyTorchBackend, TorchScriptBackend, PyTorch inference, TorchScript inference, .pt models, deep learning, YOLO
 ---

--- a/docs/en/reference/nn/backends/qnn.md
+++ b/docs/en/reference/nn/backends/qnn.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.qnn API Reference
 description: Reference for the Ultralytics QNNBackend. Learn how to run inference with Qualcomm QNN context-binary models using ONNX Runtime's QNN Execution Provider.
 keywords: QNNBackend, Qualcomm QNN, onnxruntime-qnn, QNN Execution Provider, Snapdragon, Hexagon NPU, inference backend, Ultralytics, YOLO, edge AI
 ---

--- a/docs/en/reference/nn/backends/rknn.md
+++ b/docs/en/reference/nn/backends/rknn.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.rknn API Reference
 description: Explore RKNNBackend for Rockchip RKNN inference, enabling optimized YOLO deployment on Rockchip NPU-equipped edge devices.
 keywords: Ultralytics, RKNNBackend, RKNN inference, Rockchip RKNN, NPU inference, edge AI, embedded deployment, deep learning
 ---

--- a/docs/en/reference/nn/backends/tensorflow.md
+++ b/docs/en/reference/nn/backends/tensorflow.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.tensorflow API Reference
 description: Explore TensorFlowBackend for Google TensorFlow inference including SavedModel, GraphDef, TFLite, and Edge TPU formats.
 keywords: Ultralytics, TensorFlowBackend, Google TensorFlow, TFLite, Edge TPU, SavedModel, GraphDef, deep learning, model deployment
 ---

--- a/docs/en/reference/nn/backends/tensorrt.md
+++ b/docs/en/reference/nn/backends/tensorrt.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.tensorrt API Reference
 description: Explore TensorRTBackend for high-performance GPU inference with NVIDIA TensorRT, optimizing YOLO models for production deployment.
 keywords: Ultralytics, TensorRTBackend, TensorRT inference, NVIDIA TensorRT, GPU inference, .engine models, production deployment, deep learning
 ---

--- a/docs/en/reference/nn/backends/triton.md
+++ b/docs/en/reference/nn/backends/triton.md
@@ -1,4 +1,5 @@
 ---
+title: nn.backends.triton API Reference
 description: Explore TritonBackend for NVIDIA Triton Inference Server, enabling scalable cloud and edge deployment of YOLO models.
 keywords: Ultralytics, TritonBackend, Triton Inference Server, NVIDIA Triton, cloud inference, model serving, scalable deployment
 ---

--- a/docs/en/reference/nn/modules/activation.md
+++ b/docs/en/reference/nn/modules/activation.md
@@ -1,4 +1,5 @@
 ---
+title: nn.modules.activation API Reference
 description: Explore activation functions in Ultralytics, including the Unified activation function and other custom implementations for neural networks.
 keywords: ultralytics, activation functions, neural networks, Unified activation, AGLU, SiLU, ReLU, PyTorch, deep learning, custom activations
 ---

--- a/docs/en/reference/nn/modules/block.md
+++ b/docs/en/reference/nn/modules/block.md
@@ -1,4 +1,5 @@
 ---
+title: nn.modules.block API Reference
 description: Explore detailed documentation of block modules in Ultralytics, available for deep learning tasks. Contribute and improve the codebase.
 keywords: Ultralytics, YOLO, neural networks, block modules, DFL, Proto, HGStem, HGBlock, SPP, SPPF, C1, C2, C2f, C3, C3x, RepC3, C3TR, C3Ghost, GhostBottleneck, Bottleneck, BottleneckCSP, ResNetBlock, MaxSigmoidAttnBlock, ImagePoolingAttn, ContrastiveHead, RepBottleneck, RepCSP, RepNCSPELAN4, ADown, SPPELAN, Silence, CBLinear, CBFuse
 ---

--- a/docs/en/reference/nn/modules/conv.md
+++ b/docs/en/reference/nn/modules/conv.md
@@ -1,4 +1,5 @@
 ---
+title: nn.modules.conv API Reference
 description: Explore detailed documentation on convolution modules like Conv, LightConv, GhostConv, and more used in Ultralytics models.
 keywords: Ultralytics, convolution modules, Conv, LightConv, GhostConv, YOLO, deep learning, neural networks
 ---

--- a/docs/en/reference/nn/modules/head.md
+++ b/docs/en/reference/nn/modules/head.md
@@ -1,4 +1,5 @@
 ---
+title: nn.modules.head API Reference
 description: Explore docs covering Ultralytics YOLO detection, pose & RTDETRDecoder. Comprehensive guides to help you understand Ultralytics nn modules.
 keywords: Ultralytics, YOLO, Detection, Pose, RTDETRDecoder, nn modules, guides
 ---

--- a/docs/en/reference/nn/modules/transformer.md
+++ b/docs/en/reference/nn/modules/transformer.md
@@ -1,4 +1,5 @@
 ---
+title: nn.modules.transformer API Reference
 description: Learn about Ultralytics transformer encoder, layer, MLP block, LayerNorm2d and the deformable transformer decoder layer. Expand your understanding of these crucial AI modules.
 keywords: Ultralytics, Ultralytics documentation, TransformerEncoderLayer, TransformerLayer, MLPBlock, LayerNorm2d, DeformableTransformerDecoderLayer
 ---

--- a/docs/en/reference/nn/modules/utils.md
+++ b/docs/en/reference/nn/modules/utils.md
@@ -1,4 +1,5 @@
 ---
+title: nn.modules.utils API Reference
 description: Explore the detailed reference of utility functions in the Ultralytics PyTorch modules. Learn about initialization, inverse sigmoid, and multiscale deformable attention.
 keywords: Ultralytics, PyTorch, utils, initialization, inverse sigmoid, multiscale deformable attention, deep learning, neural networks
 ---

--- a/docs/en/reference/nn/tasks.md
+++ b/docs/en/reference/nn/tasks.md
@@ -1,4 +1,5 @@
 ---
+title: nn.tasks API Reference
 description: Dive into the intricacies of YOLO tasks.py. Learn about DetectionModel, PoseModel and more for powerful AI development.
 keywords: Ultralytics, YOLO, nn tasks, DetectionModel, PoseModel, RTDETRDetectionModel, model weights, parse model, AI development
 ---

--- a/docs/en/reference/nn/text_model.md
+++ b/docs/en/reference/nn/text_model.md
@@ -1,4 +1,5 @@
 ---
+title: nn.text_model API Reference
 description: Documentation for text encoding models in Ultralytics YOLOE, supporting both OpenAI CLIP and Apple MobileCLIP implementations for vision-language tasks.
 keywords: YOLOE, text encoding, CLIP, MobileCLIP, TextModel, vision-language models, embeddings, Ultralytics, deep learning
 ---

--- a/docs/en/reference/optim/muon.md
+++ b/docs/en/reference/optim/muon.md
@@ -1,4 +1,5 @@
 ---
+title: optim.muon API Reference
 description: Explore Ultralytics Muon optimizer with Newton-Schulz orthogonalization for neural network training. Includes MuSGD hybrid optimizer and momentum-based updates.
 keywords: Muon optimizer, MuSGD, Newton-Schulz iteration, orthogonalization, momentum optimizer, neural network training, PyTorch optimizer, Ultralytics optimization
 ---

--- a/docs/en/reference/solutions/ai_gym.md
+++ b/docs/en/reference/solutions/ai_gym.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.ai_gym API Reference
 description: Explore the AI Gym class for real-time pose detection and gym step counting using Ultralytics YOLO. Learn to implement pose estimation effectively.
 keywords: Ultralytics, AI Gym, YOLO, pose detection, gym step counting, real-time pose estimation, Python
 ---

--- a/docs/en/reference/solutions/analytics.md
+++ b/docs/en/reference/solutions/analytics.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.analytics API Reference
 description: Explore the Analytics class in Ultralytics for visual analytics. Learn to create and update line, bar, and pie charts efficiently.
 keywords: Ultralytics, Analytics, Python, visual analytics, line chart, bar chart, pie chart, data visualization, AGPL-3.0 license
 ---

--- a/docs/en/reference/solutions/config.md
+++ b/docs/en/reference/solutions/config.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.config API Reference
 description: Configure and customize Ultralytics Vision AI solutions using the SolutionConfig class. Define model paths, regions of interest, visualization options, tracking parameters, and keypoint analytics with a clean, type-safe dataclass structure for scalable development.
 keywords: Ultralytics, SolutionConfig, vision AI configuration, YOLO models, Python dataclass, object detection, region of interest, tracking, keypoint analytics, computer vision, model inference, object counting, heatmaps, parking management, research
 ---

--- a/docs/en/reference/solutions/distance_calculation.md
+++ b/docs/en/reference/solutions/distance_calculation.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.distance_calculation API Reference
 description: Explore the Ultralytics distance calculation module. Learn to calculate distances between objects in real-time video streams with our comprehensive guide.
 keywords: Ultralytics, distance calculation, object tracking, real-time video, centroid, distance estimation, YOLO, ML, cv2
 ---

--- a/docs/en/reference/solutions/heatmap.md
+++ b/docs/en/reference/solutions/heatmap.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.heatmap API Reference
 description: Learn how to use the Ultralytics Heatmap module for real-time video analysis with object tracking and heatmap generation.
 keywords: Ultralytics, Heatmap, Python, Real-time Video, Object Tracking, cv2, Shapely, Computer Vision, AI
 ---

--- a/docs/en/reference/solutions/instance_segmentation.md
+++ b/docs/en/reference/solutions/instance_segmentation.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.instance_segmentation API Reference
 description: This page provides a detailed reference for the InstanceSegmentation class in the Ultralytics solutions package, enabling instance segmentation in images and videos.
 keywords: Ultralytics, InstanceSegmentation, instance segmentation, masks, Python, computer vision
 ---

--- a/docs/en/reference/solutions/object_blurrer.md
+++ b/docs/en/reference/solutions/object_blurrer.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.object_blurrer API Reference
 description: This page provides a detailed reference for the ObjectBlurrer class in the Ultralytics solutions package, which enables real-time blurring of detected objects in images and videos.
 keywords: Ultralytics, ObjectBlurrer, object detection, blurring, real-time processing, Python, computer vision
 ---

--- a/docs/en/reference/solutions/object_counter.md
+++ b/docs/en/reference/solutions/object_counter.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.object_counter API Reference
 description: Explore the Ultralytics Object Counter for real-time video streams. Learn about initializing parameters, tracking objects, and more.
 keywords: Ultralytics, Object Counter, Real-time Tracking, Video Stream, Python, Object Detection
 ---

--- a/docs/en/reference/solutions/object_cropper.md
+++ b/docs/en/reference/solutions/object_cropper.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.object_cropper API Reference
 description: Detailed documentation for the ObjectCropper class, part of the Ultralytics solutions package, enabling real-time cropping of detected objects from images and video streams.
 keywords: Ultralytics, ObjectCropper, object detection, cropping, real-time processing, Python, computer vision
 ---

--- a/docs/en/reference/solutions/parking_management.md
+++ b/docs/en/reference/solutions/parking_management.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.parking_management API Reference
 description: Explore Ultralytics' Parking Management solution leveraging YOLO for efficient parking zone monitoring and management.
 keywords: Ultralytics, YOLO, parking management, computer vision, parking monitoring, AI solutions, machine learning
 ---

--- a/docs/en/reference/solutions/queue_management.md
+++ b/docs/en/reference/solutions/queue_management.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.queue_management API Reference
 description: Discover the Ultralytics Queue Management script for real-time object tracking and queue management.
 keywords: Ultralytics, queue management, object tracking, real-time video, Python script, YOLO, AGPL-3.0
 ---

--- a/docs/en/reference/solutions/region_counter.md
+++ b/docs/en/reference/solutions/region_counter.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.region_counter API Reference
 description: Explore the Ultralytics Region Counter for real-time video streams. Learn to define regions, track objects, and count activity per zone.
 keywords: Ultralytics, Region Counter, Real-time Tracking, Video Stream, Python, Object Detection
 ---

--- a/docs/en/reference/solutions/security_alarm.md
+++ b/docs/en/reference/solutions/security_alarm.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.security_alarm API Reference
 description: Discover how Ultralytics' Security Alarm System enhances real-time surveillance with intelligent object detection and tracking. Learn about setup, monitoring, and threat detection.
 keywords: Ultralytics, Security Alarm System, Real-time Surveillance, Object Detection, Video Monitoring, Python, Threat Detection
 ---

--- a/docs/en/reference/solutions/similarity_search.md
+++ b/docs/en/reference/solutions/similarity_search.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.similarity_search API Reference
 description: Explore the Ultralytics semantic image search solution. Learn how to retrieve images using natural language with CLIP, FAISS, and a simple web app powered by Flask.
 keywords: Ultralytics, semantic search, CLIP, FAISS, image retrieval, natural language, Flask, computer vision, YOLO, AI
 ---

--- a/docs/en/reference/solutions/solutions.md
+++ b/docs/en/reference/solutions/solutions.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.solutions API Reference
 description: Explore the Ultralytics Solution Base class for real-time object counting,virtual gym, heatmaps, speed estimation using Ultralytics YOLO. Learn to implement Ultralytics solutions effectively.
 keywords: Ultralytics, Solutions, Object counting, Speed Estimation, Heatmaps, Queue Management, AI Gym, YOLO, pose detection, gym step counting, real-time pose estimation, Python
 ---

--- a/docs/en/reference/solutions/speed_estimation.md
+++ b/docs/en/reference/solutions/speed_estimation.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.speed_estimation API Reference
 description: Explore the Ultralytics YOLO-based speed estimation script for real-time object tracking and speed measurement, optimized for accuracy and performance.
 keywords: Ultralytics, speed estimation, YOLO, real-time tracking, object tracking, python
 ---

--- a/docs/en/reference/solutions/streamlit_inference.md
+++ b/docs/en/reference/solutions/streamlit_inference.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.streamlit_inference API Reference
 description: Explore the live inference capabilities of Streamlit combined with Ultralytics YOLOv8. Learn to implement real-time object detection in your web applications with our comprehensive guide.
 keywords: Ultralytics, YOLOv8, live inference, real-time object detection, Streamlit, computer vision, webcam inference, object detection, Python, ML, cv2
 ---

--- a/docs/en/reference/solutions/trackzone.md
+++ b/docs/en/reference/solutions/trackzone.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.trackzone API Reference
 description: Discover Ultralytics' TrackZone solution for real-time object tracking within defined zones. Gain insights into initializing regions, tracking objects exclusively within specific areas, and optimizing video stream processing for region-based object detection.
 keywords: Ultralytics, TrackZone, Object Tracking, Zone Tracking, Region Tracking, Python, Real-time Object Tracking, Video Stream Processing, Region-based Detection
 ---

--- a/docs/en/reference/solutions/vision_eye.md
+++ b/docs/en/reference/solutions/vision_eye.md
@@ -1,4 +1,5 @@
 ---
+title: solutions.vision_eye API Reference
 description: Discover the Ultralytics VisionEye solution for object tracking and analysis. Learn how to initialize parameters, map vision points, and track objects in real-time.
 keywords: Ultralytics, VisionEye, Object Tracking, Computer Vision, Real-time Analysis, Python, AI
 ---

--- a/docs/en/reference/trackers/basetrack.md
+++ b/docs/en/reference/trackers/basetrack.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.basetrack API Reference
 description: Discover the BaseTrack classes and methods for object tracking in YOLO by Ultralytics. Learn about TrackState, BaseTrack attributes, and methods.
 keywords: Ultralytics, YOLO, object tracking, BaseTrack, TrackState, tracking methods, TrackState enumeration, object detection
 ---

--- a/docs/en/reference/trackers/bot_sort.md
+++ b/docs/en/reference/trackers/bot_sort.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.bot_sort API Reference
 description: Explore the robust object tracking capabilities of the BOTrack and BOTSORT classes in the Ultralytics Bot SORT tracker API. Enhance your YOLO26 projects.
 keywords: Ultralytics, Bot SORT, BOTrack, BOTSORT, YOLO26, object tracking, Kalman filter, ReID, GMC algorithm
 ---

--- a/docs/en/reference/trackers/byte_tracker.md
+++ b/docs/en/reference/trackers/byte_tracker.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.byte_tracker API Reference
 description: Explore the BYTETracker module in Ultralytics for state-of-the-art object tracking using Kalman filtering. Learn about its classes, methods, and attributes.
 keywords: Ultralytics, BYTETracker, object tracking, Kalman filter, YOLOv8, documentation
 ---

--- a/docs/en/reference/trackers/deep_oc_sort.md
+++ b/docs/en/reference/trackers/deep_oc_sort.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.deep_oc_sort API Reference
 description: Explore the Deep OC-SORT module in Ultralytics for observation-centric multi-object tracking with ReID appearance features and camera motion compensation. Learn about its classes, methods, and attributes.
 keywords: Ultralytics, Deep OC-SORT, DeepOCSORT, observation-centric, object tracking, Kalman filter, ReID, GMC, YOLO, documentation
 ---

--- a/docs/en/reference/trackers/fast_tracker.md
+++ b/docs/en/reference/trackers/fast_tracker.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.fast_tracker API Reference
 description: Explore the FastTracker module in Ultralytics for occlusion-aware multi-object tracking with Kalman rollback and init-IoU suppression. Learn about its classes, methods, and attributes.
 keywords: Ultralytics, FastTracker, FASTTracker, occlusion-aware, object tracking, Kalman filter, YOLO, documentation
 ---

--- a/docs/en/reference/trackers/oc_sort.md
+++ b/docs/en/reference/trackers/oc_sort.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.oc_sort API Reference
 description: Explore the OC-SORT module in Ultralytics for observation-centric multi-object tracking with Kalman filtering. Learn about its classes, methods, and attributes.
 keywords: Ultralytics, OC-SORT, OCSORT, observation-centric, object tracking, Kalman filter, YOLO, documentation
 ---

--- a/docs/en/reference/trackers/track.md
+++ b/docs/en/reference/trackers/track.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.track API Reference
 description: Explore the track.py script for Ultralytics object tracking. Learn how on_predict_start, on_predict_postprocess_end, and register_tracker functions work.
 keywords: Ultralytics, YOLO, object tracking, track.py, on_predict_start, on_predict_postprocess_end, register_tracker
 ---

--- a/docs/en/reference/trackers/track_tracker.md
+++ b/docs/en/reference/trackers/track_tracker.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.track_tracker API Reference
 description: Explore the TrackTrack module in Ultralytics for multi-cue online multi-object tracking with HMIoU, iterative assignment, and track-aware initialization. Learn about its classes, methods, and attributes.
 keywords: Ultralytics, TrackTrack, TTSTrack, HMIoU, iterative assignment, Track-Aware Initialization, ReID, GMC, object tracking, YOLO, documentation
 ---

--- a/docs/en/reference/trackers/utils/gmc.md
+++ b/docs/en/reference/trackers/utils/gmc.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.utils.gmc API Reference
 description: Explore the Generalized Motion Compensation (GMC) class for tracking and object detection with methods like ORB, SIFT, ECC, and more.
 keywords: GMC, Generalized Motion Compensation, Ultralytics, tracking, object detection, ORB, SIFT, ECC, Sparse Optical Flow, computer vision, video frames
 ---

--- a/docs/en/reference/trackers/utils/kalman_filter.md
+++ b/docs/en/reference/trackers/utils/kalman_filter.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.utils.kalman_filter API Reference
 description: Explore Kalman filter implementations like KalmanFilterXYAH and KalmanFilterXYWH for tracking bounding boxes in image space using Ultralytics.
 keywords: Kalman Filter, Object Tracking, Python, Ultralytics, YOLO, Bounding Boxes, Image Processing
 ---

--- a/docs/en/reference/trackers/utils/matching.md
+++ b/docs/en/reference/trackers/utils/matching.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.utils.matching API Reference
 description: Explore the utility functions for matching in trackers used by Ultralytics, including linear assignment, IoU distance, embedding distance, and more.
 keywords: Ultralytics, matching utils, linear assignment, IoU distance, embedding distance, fuse score, tracking, Python, documentation
 ---

--- a/docs/en/reference/trackers/utils/reid.md
+++ b/docs/en/reference/trackers/utils/reid.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.utils.reid API Reference
 description: Reference for the shared ReID encoder and build_encoder utility used by BoT-SORT, Deep OC-SORT, and TrackTrack.
 keywords: Ultralytics, ReID, Re-identification, build_encoder, object tracking, appearance model, YOLO
 ---

--- a/docs/en/reference/trackers/utils/stracks.md
+++ b/docs/en/reference/trackers/utils/stracks.md
@@ -1,4 +1,5 @@
 ---
+title: trackers.utils.stracks API Reference
 description: Reference for shared track-pool utilities including merge, joint, subtract, duplicate removal, and global motion compensation helpers.
 keywords: Ultralytics, stracks, track pools, multi-object tracking, GMC, STrack utilities
 ---

--- a/docs/en/reference/utils/__init__.md
+++ b/docs/en/reference/utils/__init__.md
@@ -1,4 +1,5 @@
 ---
+title: utils.__init__ API Reference
 description: Explore the comprehensive reference for ultralytics.utils in the Ultralytics library. Enhance your ML workflow with these utility functions.
 keywords: Ultralytics, utils, TQDM, Python, ML, Machine Learning utilities, YOLO, threading, logging, yaml, settings
 ---

--- a/docs/en/reference/utils/autobatch.md
+++ b/docs/en/reference/utils/autobatch.md
@@ -1,4 +1,5 @@
 ---
+title: utils.autobatch API Reference
 description: Discover how to automatically estimate the best YOLO batch size for optimal CUDA memory usage in PyTorch using Ultralytics' autobatch utility.
 keywords: YOLO batch size, CUDA memory, PyTorch autobatch, Ultralytics, machine learning, optimal batch size, training batch size, YOLO model
 ---

--- a/docs/en/reference/utils/autodevice.md
+++ b/docs/en/reference/utils/autodevice.md
@@ -1,4 +1,5 @@
 ---
+title: utils.autodevice API Reference
 description: Discover how to automatically select the most idle GPU using PyTorch and NVIDIA (nvidia-ml-py) with this AutoDevice script. Ideal for optimizing GPU usage in deep learning and computer vision tasks.
 keywords: Ultralytics, AutoDevice, GPU selection, PyTorch, NVML, pynvml, GPU monitoring, CUDA, deep learning, idle GPU, memory utilization, temperature, power usage
 ---

--- a/docs/en/reference/utils/benchmarks.md
+++ b/docs/en/reference/utils/benchmarks.md
@@ -1,4 +1,5 @@
 ---
+title: utils.benchmarks API Reference
 description: Explore YOLO model benchmarking for speed and accuracy with formats like PyTorch, ONNX, TensorRT, and more. Detailed profiling & usage guides.
 keywords: YOLO, model benchmarking, ONNX, TensorRT, PyTorch, TensorFlow, CoreML, profiling, Ultralytics, model performance
 ---

--- a/docs/en/reference/utils/callbacks/base.md
+++ b/docs/en/reference/utils/callbacks/base.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.base API Reference
 description: Discover the essential base callbacks in Ultralytics for training, validation, prediction, and exporting models efficiently.
 keywords: Ultralytics, base callbacks, training, validation, prediction, model export, ML, machine learning, deep learning
 ---

--- a/docs/en/reference/utils/callbacks/clearml.md
+++ b/docs/en/reference/utils/callbacks/clearml.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.clearml API Reference
 description: Learn how to integrate ClearML with Ultralytics YOLO using detailed callbacks for pretraining, training, validation, and final logging.
 keywords: Ultralytics, YOLO, ClearML, integration, callbacks, pretraining, training, validation, logging, AI, machine learning
 ---

--- a/docs/en/reference/utils/callbacks/comet.md
+++ b/docs/en/reference/utils/callbacks/comet.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.comet API Reference
 description: Explore the integration of Comet callbacks in Ultralytics YOLO, enabling advanced logging and monitoring for your machine learning experiments.
 keywords: Ultralytics, YOLO, Comet, callbacks, logging, machine learning, monitoring, integration
 ---

--- a/docs/en/reference/utils/callbacks/dvc.md
+++ b/docs/en/reference/utils/callbacks/dvc.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.dvc API Reference
 description: Learn to integrate DVCLive with Ultralytics for enhanced logging during training. Step-by-step methods for setting up and optimizing DVC callbacks.
 keywords: Ultralytics, DVC, DVCLive, machine learning, logging, training, callbacks, integration
 ---

--- a/docs/en/reference/utils/callbacks/hub.md
+++ b/docs/en/reference/utils/callbacks/hub.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.hub API Reference
 description: Explore detailed guides on Ultralytics callbacks, including pretrain, model save, train start/end, and more. Enhance your ML training workflows with ease.
 keywords: Ultralytics, callbacks, pretrain, model save, train start, train end, validation, predict, export, training, machine learning
 ---

--- a/docs/en/reference/utils/callbacks/mlflow.md
+++ b/docs/en/reference/utils/callbacks/mlflow.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.mlflow API Reference
 description: Learn how to set up and customize MLflow logging for Ultralytics YOLO. Log metrics, parameters, and model artifacts easily.
 keywords: MLflow, Ultralytics YOLO, logging, metrics, parameters, model artifacts, setup, tracking, customization
 ---

--- a/docs/en/reference/utils/callbacks/neptune.md
+++ b/docs/en/reference/utils/callbacks/neptune.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.neptune API Reference
 description: Learn how to use NeptuneAI with Ultralytics for advanced logging and tracking of experiments. Detailed setup and callback functions included.
 keywords: Ultralytics, NeptuneAI, YOLO, experiment logging, machine learning, AI, callbacks, training, validation
 ---

--- a/docs/en/reference/utils/callbacks/platform.md
+++ b/docs/en/reference/utils/callbacks/platform.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.platform API Reference
 description: Platform callback functions for console logging during YOLO11 training lifecycle events.
 keywords: platform callbacks, training callbacks, console logging, YOLO11 training, lifecycle events, Ultralytics
 ---

--- a/docs/en/reference/utils/callbacks/raytune.md
+++ b/docs/en/reference/utils/callbacks/raytune.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.raytune API Reference
 description: Learn how to integrate Ray Tune with Ultralytics YOLO for efficient hyperparameter tuning and performance tracking.
 keywords: Ultralytics, Ray Tune, hyperparameter tuning, YOLO, machine learning, deep learning, callbacks, integration, training metrics
 ---

--- a/docs/en/reference/utils/callbacks/tensorboard.md
+++ b/docs/en/reference/utils/callbacks/tensorboard.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.tensorboard API Reference
 description: Learn how to integrate and use TensorBoard with Ultralytics for effective model training visualization.
 keywords: Ultralytics, TensorBoard, callbacks, machine learning, training visualization, logging
 ---

--- a/docs/en/reference/utils/callbacks/wb.md
+++ b/docs/en/reference/utils/callbacks/wb.md
@@ -1,4 +1,5 @@
 ---
+title: utils.callbacks.wb API Reference
 description: Learn how Ultralytics YOLO integrates with WandB using custom callbacks for logging metrics and visualizations.
 keywords: Ultralytics, YOLO, WandB, callbacks, logging, metrics, visualizations, AI, machine learning
 ---

--- a/docs/en/reference/utils/checks.md
+++ b/docs/en/reference/utils/checks.md
@@ -1,4 +1,5 @@
 ---
+title: utils.checks API Reference
 description: Explore utility functions for Ultralytics YOLO such as checking versions, image sizes, and requirements.
 keywords: Ultralytics, YOLO, utility functions, version checks, requirements, image size
 ---

--- a/docs/en/reference/utils/cpu.md
+++ b/docs/en/reference/utils/cpu.md
@@ -1,4 +1,5 @@
 ---
+title: utils.cpu API Reference
 description: Reference documentation for CPUInfo, a lightweight utility to get system CPU details in Ultralytics.
 keywords: Ultralytics, CPUInfo, CPU, system info, hardware, utils
 ---

--- a/docs/en/reference/utils/dist.md
+++ b/docs/en/reference/utils/dist.md
@@ -1,4 +1,5 @@
 ---
+title: utils.dist API Reference
 description: Explore Ultralytics' utilities for distributed training including DDP file generation, command setup, and cleanup. Improve multi-node training efficiency.
 keywords: Ultralytics, distributed training, DDP, multi-node training, network port, DDP file generation, DDP command, training utilities
 ---

--- a/docs/en/reference/utils/downloads.md
+++ b/docs/en/reference/utils/downloads.md
@@ -1,4 +1,5 @@
 ---
+title: utils.downloads API Reference
 description: Explore and utilize the Ultralytics download utilities to handle URLs, zip/unzip files, and manage GitHub assets effectively.
 keywords: Ultralytics, download utilities, URL validation, zip directory, unzip file, check disk space, Google Drive, GitHub assets, YOLO, machine learning
 ---

--- a/docs/en/reference/utils/errors.md
+++ b/docs/en/reference/utils/errors.md
@@ -1,4 +1,5 @@
 ---
+title: utils.errors API Reference
 description: Explore error handling for Ultralytics YOLO. Learn about custom exceptions like HUBModelError to manage model fetching issues effectively.
 keywords: Ultralytics, YOLO, error handling, HUBModelError, model fetching, custom exceptions, Python
 ---

--- a/docs/en/reference/utils/events.md
+++ b/docs/en/reference/utils/events.md
@@ -1,4 +1,5 @@
 ---
+title: utils.events API Reference
 description: Reference for utilities supporting telemetry, analytics, and event handling with lightweight background requests.
 keywords: Ultralytics, YOLO, utils, telemetry, analytics, events, anonymization, background, JSON, POST, Python
 ---

--- a/docs/en/reference/utils/export/axelera.md
+++ b/docs/en/reference/utils/export/axelera.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.axelera API Reference
 description: Axelera export utilities for converting PyTorch models to Axelera format for deployment on Metis AI processors. Supports INT8 quantization and optimized inference for computer vision workloads on Axelera hardware.
 keywords: Ultralytics, Axelera, model export, PyTorch to Axelera, Metis AI processor, INT8 quantization, computer vision, AI inference, edge AI, hardware acceleration
 ---

--- a/docs/en/reference/utils/export/coreml.md
+++ b/docs/en/reference/utils/export/coreml.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.coreml API Reference
 description: CoreML export utilities for converting PyTorch YOLO models to CoreML format for Apple devices. Supports iOS deployment with FP16/INT8 quantization, NMS pipeline integration, and optimized inference on Apple Silicon and mobile devices.
 keywords: Ultralytics, CoreML, model export, PyTorch to CoreML, Apple iOS, macOS, Apple Silicon, INT8 quantization, FP16, NMS pipeline, mobile deployment, on-device inference, MLProgram, neural network
 ---

--- a/docs/en/reference/utils/export/deepx.md
+++ b/docs/en/reference/utils/export/deepx.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.deepx API Reference
 description: Reference for the Ultralytics DEEPX export utility. Learn how to convert ONNX models to DEEPX format using the DX-Compiler.
 keywords: onnx2deepx, DEEPX export, dx_com, ONNX, model conversion, Ultralytics, INT8 quantization
 ---

--- a/docs/en/reference/utils/export/engine.md
+++ b/docs/en/reference/utils/export/engine.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.engine API Reference
 description: TensorRT engine export utilities for converting ONNX models to optimized TensorRT engines. Provides functions for ONNX export from PyTorch models and TensorRT engine generation with support for FP16/INT8 quantization, dynamic shapes, DLA acceleration, and INT8 calibration for NVIDIA GPU inference optimization.
 keywords: Ultralytics, TensorRT export, ONNX export, PyTorch to ONNX, quantization, FP16, INT8, dynamic shapes, DLA acceleration, GPU inference, model optimization, calibration, NVIDIA, inference engine, model export
 ---

--- a/docs/en/reference/utils/export/executorch.md
+++ b/docs/en/reference/utils/export/executorch.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.executorch API Reference
 description: Explore the Ultralytics ExecuTorch export utility for converting YOLO models to ExecuTorch (.pte) format for efficient on-device inference on mobile and edge devices.
 keywords: Ultralytics, ExecuTorch, YOLO, model export, PyTorch, edge AI, mobile deployment, on-device inference, XNNPACK, pte format, embedded systems
 ---

--- a/docs/en/reference/utils/export/imx.md
+++ b/docs/en/reference/utils/export/imx.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.imx API Reference
 description: Learn how to export PyTorch models to Sony IMX format using Ultralytics utilities. Comprehensive guide for configurations and precision optimizations.
 keywords: Ultralytics, YOLO, export, Sony IMX, PyTorch, model conversion, INT8, machine learning, NMS, Detect, Pose
 ---

--- a/docs/en/reference/utils/export/mnn.md
+++ b/docs/en/reference/utils/export/mnn.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.mnn API Reference
 description: MNN export utilities for converting ONNX models to MNN format for efficient inference on mobile and embedded devices. Supports FP16 and INT8 weight quantization for optimized deployment using Alibaba's MNN framework.
 keywords: Ultralytics, MNN, model export, ONNX to MNN, Alibaba MNN, mobile deployment, embedded systems, FP16, INT8 quantization, lightweight inference, edge deployment
 ---

--- a/docs/en/reference/utils/export/ncnn.md
+++ b/docs/en/reference/utils/export/ncnn.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.ncnn API Reference
 description: NCNN export utilities for converting PyTorch YOLO models to NCNN format using PNNX. Optimized for mobile and embedded platforms with support for FP16 inference on ARM architectures.
 keywords: Ultralytics, NCNN, model export, PyTorch to NCNN, PNNX, mobile deployment, ARM, embedded systems, FP16, lightweight inference, Tencent NCNN, edge AI
 ---

--- a/docs/en/reference/utils/export/onnx.md
+++ b/docs/en/reference/utils/export/onnx.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.onnx API Reference
 description: Reference for the Ultralytics ONNX export utilities. Learn how ONNX INT8 quantization uses ONNX Runtime calibration data readers.
 keywords: ONNX export, ONNX INT8, onnxruntime quantization, CalibrationDataReader, Ultralytics, model export, quantization
 ---

--- a/docs/en/reference/utils/export/openvino.md
+++ b/docs/en/reference/utils/export/openvino.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.openvino API Reference
 description: OpenVINO export utilities for converting PyTorch YOLO models to OpenVINO format with support for FP16 compression and INT8 quantization via NNCF. Provides optimized inference for Intel hardware including CPUs, GPUs, and VPUs.
 keywords: Ultralytics, OpenVINO, model export, PyTorch to OpenVINO, INT8 quantization, FP16, NNCF, Intel, model optimization, inference acceleration, CPU inference, GPU inference, VPU, edge deployment
 ---

--- a/docs/en/reference/utils/export/paddle.md
+++ b/docs/en/reference/utils/export/paddle.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.paddle API Reference
 description: PaddlePaddle export utilities for converting PyTorch YOLO models to Paddle format using X2Paddle. Enables deployment on PaddlePaddle inference engine with support for both CPU and GPU backends.
 keywords: Ultralytics, PaddlePaddle, model export, PyTorch to Paddle, X2Paddle, Paddle inference, Baidu Paddle, model conversion, CPU inference, GPU inference
 ---

--- a/docs/en/reference/utils/export/qnn.md
+++ b/docs/en/reference/utils/export/qnn.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.qnn API Reference
 description: Reference for the Ultralytics Qualcomm QNN export utility. Learn how to compile ONNX models to the QNN format locally with the ONNX Runtime QNN Execution Provider.
 keywords: onnx2qnn, QNN export, Qualcomm export, ONNX Runtime QNN, onnxruntime-qnn, Qualcomm AI Engine Direct, Qualcomm AI Hub, QAIRT, SNPE, ONNX, model conversion, Ultralytics, Snapdragon, Hexagon NPU, Hexagon HTP
 ---

--- a/docs/en/reference/utils/export/rknn.md
+++ b/docs/en/reference/utils/export/rknn.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.rknn API Reference
 description: RKNN export utilities for converting ONNX models to RKNN format for Rockchip NPUs with floating-point and INT8 quantized export support.
 keywords: Ultralytics, RKNN, model export, ONNX to RKNN, Rockchip, NPU, RK3588, INT8 quantization, FP16, edge AI, embedded systems, neural network, hardware acceleration
 ---

--- a/docs/en/reference/utils/export/tensorflow.md
+++ b/docs/en/reference/utils/export/tensorflow.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.tensorflow API Reference
 description: TensorFlow export utilities for converting PyTorch models to various TensorFlow formats. Provides functions for converting models to TensorFlow SavedModel, Protocol Buffer (.pb), TensorFlow Lite, Edge TPU, and TensorFlow.js formats via ONNX intermediate representation with support for INT8 quantization and calibration.
 keywords: Ultralytics, TensorFlow, SavedModel, Protocol Buffer, TensorFlow Lite, TFLite, Edge TPU, TensorFlow.js, ONNX conversion, PyTorch to TensorFlow, INT8 quantization, model calibration, frozen graph, onnx2tf, model export, web deployment, mobile deployment
 ---

--- a/docs/en/reference/utils/export/torchscript.md
+++ b/docs/en/reference/utils/export/torchscript.md
@@ -1,4 +1,5 @@
 ---
+title: utils.export.torchscript API Reference
 description: TorchScript export utilities for converting PyTorch YOLO models to TorchScript format. Supports mobile optimization and metadata embedding for production deployment and C++ inference.
 keywords: Ultralytics, TorchScript, model export, PyTorch, JIT trace, mobile optimization, production deployment, C++ inference, libtorch, model serialization
 ---

--- a/docs/en/reference/utils/files.md
+++ b/docs/en/reference/utils/files.md
@@ -1,4 +1,5 @@
 ---
+title: utils.files API Reference
 description: Explore the utility functions and context managers in Ultralytics like WorkingDirectory, increment_path, file_size, and more. Enhance your file handling in Python.
 keywords: Ultralytics, file utilities, Python, WorkingDirectory, increment_path, file_size, file_age, contexts, file handling, file management
 ---

--- a/docs/en/reference/utils/git.md
+++ b/docs/en/reference/utils/git.md
@@ -1,4 +1,5 @@
 ---
+title: utils.git API Reference
 description: Utilities for retrieving Git repository metadata such as branch, commit, and origin URL, used in Ultralytics projects.
 keywords: Ultralytics, Git, GitRepo, branch, commit, origin, repository, utils, metadata, version control
 ---

--- a/docs/en/reference/utils/instance.md
+++ b/docs/en/reference/utils/instance.md
@@ -1,4 +1,5 @@
 ---
+title: utils.instance API Reference
 description: Explore Ultralytics utilities for bounding boxes and instances, providing detailed documentation on handling bbox formats, conversions, and more.
 keywords: Ultralytics, bounding boxes, Instances, bbox formats, conversions, AI, deep learning, YOLO, xyxy, xywh, ltwh
 ---

--- a/docs/en/reference/utils/logger.md
+++ b/docs/en/reference/utils/logger.md
@@ -1,4 +1,5 @@
 ---
+title: utils.logger API Reference
 description: High-performance console output capture with API/file streaming for YOLO11 training logs.
 keywords: ConsoleLogger, console capture, log streaming, API logging, file logging, YOLO11, Ultralytics
 ---

--- a/docs/en/reference/utils/loss.md
+++ b/docs/en/reference/utils/loss.md
@@ -1,4 +1,5 @@
 ---
+title: utils.loss API Reference
 description: Explore detailed descriptions and implementations of various loss functions used in Ultralytics models, including Varifocal Loss, Focal Loss, Bbox Loss, and more.
 keywords: Ultralytics, loss functions, Varifocal Loss, Focal Loss, Bbox Loss, Rotated Bbox Loss, Keypoint Loss, YOLO, model training, documentation
 ---

--- a/docs/en/reference/utils/metrics.md
+++ b/docs/en/reference/utils/metrics.md
@@ -1,4 +1,5 @@
 ---
+title: utils.metrics API Reference
 description: Explore detailed metrics and utility functions for model validation and performance analysis with Ultralytics' metrics module.
 keywords: Ultralytics, metrics, model validation, performance analysis, IoU, confusion matrix
 ---

--- a/docs/en/reference/utils/nms.md
+++ b/docs/en/reference/utils/nms.md
@@ -1,4 +1,5 @@
 ---
+title: utils.nms API Reference
 description: Custom NMS implementation for Ultralytics YOLO with TorchNMS class for torchvision-free inference and fast-nms for oriented bounding boxes. Optimized for speed and accuracy.
 keywords: NMS, non-maximum suppression, TorchNMS, YOLO, torchvision-free, rotated NMS, object detection, bounding boxes, IoU threshold, custom implementation
 ---

--- a/docs/en/reference/utils/ops.md
+++ b/docs/en/reference/utils/ops.md
@@ -1,4 +1,5 @@
 ---
+title: utils.ops API Reference
 description: Explore detailed documentation on utility operations in Ultralytics including non-max suppression, bounding box transformations, and more.
 keywords: Ultralytics, utility operations, non-max suppression, bounding box transformations, YOLOv8, machine learning
 ---

--- a/docs/en/reference/utils/patches.md
+++ b/docs/en/reference/utils/patches.md
@@ -1,4 +1,5 @@
 ---
+title: utils.patches API Reference
 description: Explore and contribute to Ultralytics' utils/patches.py. Learn about the imread, imwrite, imshow, and torch_save functions.
 keywords: Ultralytics, utils, patches, imread, imwrite, imshow, torch_save, OpenCV, PyTorch, GitHub
 ---

--- a/docs/en/reference/utils/plotting.md
+++ b/docs/en/reference/utils/plotting.md
@@ -1,4 +1,5 @@
 ---
+title: utils.plotting API Reference
 description: Explore detailed functionalities of Ultralytics plotting utilities for data visualizations and custom annotations in ML projects.
 keywords: ultralytics, plotting, utilities, documentation, data visualization, annotations, python, ML tools
 ---

--- a/docs/en/reference/utils/tal.md
+++ b/docs/en/reference/utils/tal.md
@@ -1,4 +1,5 @@
 ---
+title: utils.tal API Reference
 description: Explore the TaskAlignedAssigner in Ultralytics YOLO. Learn about the TaskAlignedMetric and its applications in object detection.
 keywords: Ultralytics, YOLO, TaskAlignedAssigner, object detection, machine learning, AI, Tal.py, PyTorch
 ---

--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -1,4 +1,5 @@
 ---
+title: utils.torch_utils API Reference
 description: Explore valuable torch utilities from Ultralytics for optimized model performance, including device selection, model fusion, and inference optimization.
 keywords: Ultralytics, torch utils, model optimization, device selection, inference optimization, model fusion, CPU info, PyTorch tools
 ---

--- a/docs/en/reference/utils/tqdm.md
+++ b/docs/en/reference/utils/tqdm.md
@@ -1,4 +1,5 @@
 ---
+title: utils.tqdm API Reference
 description: Lightweight zero-dependency progress bar for Ultralytics with rich-style displays, GitHub Actions support, and comprehensive formatting options.
 keywords: TQDM, progress bar, Ultralytics, GitHub Actions, zero dependencies, rich style, download progress, training progress, Unicode blocks
 ---

--- a/docs/en/reference/utils/triton.md
+++ b/docs/en/reference/utils/triton.md
@@ -1,4 +1,5 @@
 ---
+title: utils.triton API Reference
 description: Learn how to use the TritonRemoteModel class for interacting with remote Triton Inference Server models. Detailed guide with code examples and attributes.
 keywords: Ultralytics, TritonRemoteModel, Triton Inference Server, model client, inference, remote model, machine learning, AI, Python
 ---

--- a/docs/en/reference/utils/tuner.md
+++ b/docs/en/reference/utils/tuner.md
@@ -1,4 +1,5 @@
 ---
+title: utils.tuner API Reference
 description: Explore how to use ultralytics.utils.tuner.py for efficient hyperparameter tuning with Ray Tune. Learn implementation details and example usage.
 keywords: Ultralytics, tuner, hyperparameter tuning, Ray Tune, YOLO, machine learning, AI, optimization
 ---

--- a/docs/en/reference/utils/uploads.md
+++ b/docs/en/reference/utils/uploads.md
@@ -1,4 +1,5 @@
 ---
+title: utils.uploads API Reference
 description: Explore the Ultralytics upload utilities with retry logic, progress bars, and signed URL support for cloud storage.
 keywords: Ultralytics, upload utilities, file upload, retry logic, progress bar, cloud storage, GCS, YOLO, machine learning
 ---

--- a/docs/en/solutions/index.md
+++ b/docs/en/solutions/index.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Computer Vision Solutions
 comments: true
 description: Explore Ultralytics Solutions using YOLO26 for object counting, blurring, security, and more. Enhance efficiency and solve real-world problems with cutting-edge AI.
 keywords: Ultralytics, YOLO26, object counting, object blurring, security systems, AI solutions, real-time analysis, computer vision applications

--- a/docs/en/tasks/index.md
+++ b/docs/en/tasks/index.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO26 Computer Vision Tasks Overview
 comments: true
 description: Explore Ultralytics YOLO26 for detection, segmentation, semantic segmentation, classification, OBB, and pose estimation with high accuracy and speed. Learn how to apply each task.
 keywords: Ultralytics YOLO26, detection, segmentation, semantic segmentation, classification, oriented object detection, pose estimation, computer vision, AI framework

--- a/docs/en/tasks/pose.md
+++ b/docs/en/tasks/pose.md
@@ -1,4 +1,5 @@
 ---
+title: Pose Estimation with YOLO
 comments: true
 description: Discover how to use YOLO26 for pose estimation tasks. Learn about model training, validation, prediction, and exporting in various formats.
 keywords: pose estimation, YOLO26, Ultralytics, keypoints, model training, image recognition, deep learning, human pose detection, computer vision, real-time tracking

--- a/docs/en/usage/callbacks.md
+++ b/docs/en/usage/callbacks.md
@@ -1,4 +1,5 @@
 ---
+title: Training Callbacks
 comments: true
 description: Explore Ultralytics callbacks for training, validation, exporting, and prediction. Learn how to use and customize them for your ML models.
 keywords: Ultralytics, callbacks, training, validation, export, prediction, ML models, YOLO, Python, machine learning

--- a/docs/en/usage/python.md
+++ b/docs/en/usage/python.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO Python Usage
 comments: true
 description: Learn to integrate Ultralytics YOLO in Python for object detection, segmentation, semantic segmentation, and classification. Load and train models, and make predictions easily with our comprehensive guide.
 keywords: YOLO, Python, object detection, segmentation, semantic segmentation, classification, machine learning, AI, pretrained models, train models, make predictions

--- a/docs/en/yolov5/environments/aws-quickstart-tutorial.md
+++ b/docs/en/yolov5/environments/aws-quickstart-tutorial.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 on AWS Deep Learning Instances
 comments: true
 description: Discover how to set up and run Ultralytics YOLOv5 on AWS Deep Learning Instances. Follow our comprehensive guide to get started quickly and cost-effectively.
 keywords: YOLOv5, AWS, Deep Learning, Machine Learning, AWS EC2, YOLOv5 setup, Deep Learning Instances, AI, Object Detection, Ultralytics

--- a/docs/en/yolov5/environments/google-cloud-quickstart-tutorial.md
+++ b/docs/en/yolov5/environments/google-cloud-quickstart-tutorial.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 on GCP Deep Learning VM
 comments: true
 description: Master Ultralytics YOLOv5 deployment on Google Cloud Platform Deep Learning VM. Perfect for AI beginners and experts to achieve high-performance object detection.
 keywords: YOLOv5, Google Cloud Platform, GCP, Deep Learning VM, object detection, AI, machine learning, tutorial, cloud computing, GPU acceleration, Ultralytics

--- a/docs/en/yolov5/tutorials/neural-magic-pruning-quantization.md
+++ b/docs/en/yolov5/tutorials/neural-magic-pruning-quantization.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 DeepSparse CPU Deployment
 comments: true
 description: Learn how to deploy YOLOv5 using Neural Magic's DeepSparse for GPU-class performance on CPUs. Discover easy integration, flexible deployments, and more.
 keywords: YOLOv5, DeepSparse, Neural Magic, YOLO deployment, Sparse inference, Deep learning, Model sparsity, CPU optimization, No hardware accelerators, AI deployment

--- a/docs/en/yolov5/tutorials/transfer-learning-with-frozen-layers.md
+++ b/docs/en/yolov5/tutorials/transfer-learning-with-frozen-layers.md
@@ -1,4 +1,5 @@
 ---
+title: YOLOv5 Transfer Learning Frozen Layers
 comments: true
 description: Learn to freeze YOLOv5 layers for efficient transfer learning, reducing resources and speeding up training while maintaining accuracy.
 keywords: YOLOv5, transfer learning, freeze layers, machine learning, deep learning, model training, PyTorch, Ultralytics


### PR DESCRIPTION
## Summary

Part of a cross-repo effort to fix SEMrush `<title>` flags (too-long >60, duplicate H1==title) **consistently across every Ultralytics doc surface**. Strategy settled via an Opus↔Codex review loop.

**Unified rule:** `<title>` = `{concise, front-loaded page title} | Ultralytics`; the on-page `<h1>` stays descriptive. They differ only by the brand suffix (so never a duplicate tag), the brand is always present, and titles stay ≤60.

The ` | Ultralytics` suffix is appended by the docs renderer (portal `@ultralytics/ui`), so pages only carry the concise base title.

## Changes

- **`build_reference.py` (solve at source):** inject `title: {module} API Reference` into both generator paths — idempotent, curated `description`/`keywords` preserved. The generator now owns reference titles, so **new modules stay compliant automatically** instead of regressing.
- **Regenerated all 196 API-reference pages** with the consistent title (e.g. `title: data.annotator API Reference`).
- **83 narrative pages** (guides, integrations, models, tasks, yolov5) get concise front-loaded titles.

## Why this supersedes #24874

#24874 hand-wrote 178 reference titles **without** changing the generator — so every new module would re-introduce a >60-char title, and the hand-written titles weren't uniform. This fixes the generator (self-maintaining) and keeps #24874's good narrative titles. **#24874 can be closed in favor of this.**

## Consistency / verification

Audited the whole `docs/en` tree with the shared title rule (same predicate the renderer uses, markdown-stripped H1s):

- **TRUNCATED: 3 / 459** — only the deepest `models/sam/sam3/*` reference paths (e.g. `models.sam.sam3.maskformer_segmentation API Reference`). Accepted 80/20 — they render with a graceful ellipsis, still unique.
- **DUPLICATE H1==title: 0**
- Too-short (`platform/*` terse one-word H1s, pre-existing): tracked as a separate follow-up.

`ruff check` clean; `py_compile` OK; reference regeneration leaves `mkdocs.yml` nav unchanged.

## Companion PRs (same unified rule)

- portal#2517 — renderer brand suffix + truncation backstop + the shared title audit (**merge last**).
- docs#317 — compare-page H1s.
- ultralytics/handbook — new PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚠️ I can’t accurately summarize this PR because the diff was not available—the retrieval failed due to GitHub’s 20,000-line diff limit.

### 📊 Key Changes
- 🚫 The PR changes could not be inspected because the full diff exceeded GitHub’s maximum retrievable size.
- 🔍 Without the actual file changes, it’s not possible to reliably identify:
  - modified models, training, inference, or export behavior
  - bug fixes or performance improvements
  - API, CLI, or documentation updates
  - any breaking changes or user-facing impact

### 🎯 Purpose & Impact
- ✅ This limitation helps avoid giving an incorrect or misleading summary.
- 📎 If you share the PR link, PR number, or key files/commit patches, I can produce a clear summary of:
  - the major changes
  - why they were made
  - how they may affect Ultralytics users and developers
- ⚡ If helpful, I can also summarize the PR from any of these instead:
  - the PR description
  - commit messages
  - a list of changed files
  - selected diff chunks