### PR TITLE
Clarify tracking persistence and tracker selection

### DIFF
--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -471,7 +471,7 @@ Here is a Python script using [OpenCV](https://www.ultralytics.com/glossary/open
 
 !!! tip "Persisting tracks and selecting a tracker"
 
-    Use `persist=True` when passing consecutive frames from the same video stream to `model.track()`. This lets the tracker reuse state from earlier frames and maintain consistent track IDs over time. When processing unrelated images or starting a new video stream, omit `persist=True` or reinitialize the tracker so previous track state is not reused.
+    Use `persist=True` only when passing consecutive frames from the same video stream to `model.track()`. This lets the tracker reuse state from earlier frames and maintain consistent track IDs over time. Do not use `persist=True` across unrelated images or a different stream, since previous track state can carry over.
 
     You can also choose a tracker backend by passing a tracker configuration file, such as `tracker="botsort.yaml"`, `tracker="bytetrack.yaml"`, or `tracker="tracktrack.yaml"`.
 

--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -469,6 +469,12 @@ There is no appearance model and no camera-motion compensation.
 
 Here is a Python script using [OpenCV](https://www.ultralytics.com/glossary/opencv) (`cv2`) and YOLO26 to run object tracking on video frames. This script assumes the necessary packages (`opencv-python` and `ultralytics`) are already installed. The `persist=True` argument tells the tracker that the current image or frame is the next in a sequence and to expect tracks from the previous image in the current image.
 
+!!! tip "Persisting tracks and selecting a tracker"
+
+    Use `persist=True` when passing consecutive frames from the same video stream to `model.track()`. This lets the tracker reuse state from earlier frames and maintain consistent track IDs over time. When processing unrelated images or starting a new video stream, omit `persist=True` or reinitialize the tracker so previous track state is not reused.
+
+    You can also choose a tracker backend by passing a tracker configuration file, such as `tracker="botsort.yaml"`, `tracker="bytetrack.yaml"`, or `tracker="tracktrack.yaml"`.
+
 !!! example "Streaming for-loop with tracking"
 
     ```python
@@ -490,7 +496,8 @@ Here is a Python script using [OpenCV](https://www.ultralytics.com/glossary/open
 
         if success:
             # Run YOLO26 tracking on the frame, persisting tracks between frames
-            results = model.track(frame, persist=True)
+            # and using the BoT-SORT tracker backend
+            results = model.track(frame, persist=True, tracker="botsort.yaml")
 
             # Visualize the results on the frame
             annotated_frame = results[0].plot()


### PR DESCRIPTION
## Summary

Clarifies how to use `persist=True` when tracking consecutive frames from the same video stream, and shows how to select a tracker backend with a tracker configuration file.

## Changes

- Add a tip explaining when `persist=True` should be used.
- Clarify that `persist=True` reuses tracker state across consecutive frames.
- Mention tracker backend selection with `tracker="botsort.yaml"`, `tracker="bytetrack.yaml"`, or `tracker="tracktrack.yaml"`.
- Update the OpenCV tracking example to show explicit tracker selection.

## Type of change

- [x] Documentation

## Testing

Docs-only change. No runtime behavior changed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 Clarifies YOLO26 tracking docs by explaining when to use `persist=True` and how to explicitly select a tracker backend.

### 📊 Key Changes
- Added a new tip section in `docs/en/modes/track.md` describing proper use of `persist=True` for consecutive frames from the same video stream.
- Clarified that `persist=True` should be omitted, or the tracker reinitialized, when processing unrelated images or a new video stream.
- Documented tracker backend selection through configuration files, including `botsort.yaml`, `bytetrack.yaml`, and `tracktrack.yaml`.
- Updated the tracking example to explicitly pass `tracker="botsort.yaml"` alongside `persist=True`.

### 🎯 Purpose & Impact
- Improves documentation clarity around tracker state persistence and helps prevent accidental reuse of stale tracking state.
- Makes tracker selection more discoverable for users who want to compare or control tracking behavior.
- Reduces confusion for developers implementing multi-frame tracking pipelines and strengthens the usability of the tracking docs overall.