### PR TITLE
Fix predict() batch mismatch on static-batch exports in CI matrix tests

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -73,7 +73,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         device=DEVICES[0],
         # opset=20 if nms else None,  # fix ONNX Runtime errors with NMS
     )
-    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch, device=DEVICES[0])  # exported model inference
     Path(file).unlink()  # cleanup
 
 
@@ -111,7 +111,7 @@ def test_export_engine_matrix(task, dynamic, int8, half, batch):
         simplify=True,
         device=DEVICES[0],
     )
-    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch, device=DEVICES[0])  # exported model inference
     Path(file).unlink()  # cleanup
     if int8:
         Path(file).with_suffix(".cache").unlink(missing_ok=True)  # cleanup TensorRT 7-10 INT8 calibration cache

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -73,7 +73,9 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
         device=DEVICES[0],
         # opset=20 if nms else None,  # fix ONNX Runtime errors with NMS
     )
-    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch, device=DEVICES[0])  # exported model inference
+    YOLO(file)(
+        [SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch, device=DEVICES[0]
+    )  # exported model inference
     Path(file).unlink()  # cleanup
 
 
@@ -111,7 +113,9 @@ def test_export_engine_matrix(task, dynamic, int8, half, batch):
         simplify=True,
         device=DEVICES[0],
     )
-    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch, device=DEVICES[0])  # exported model inference
+    YOLO(file)(
+        [SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch, device=DEVICES[0]
+    )  # exported model inference
     Path(file).unlink()  # cleanup
     if int8:
         Path(file).with_suffix(".cache").unlink(missing_ok=True)  # cleanup TensorRT 7-10 INT8 calibration cache

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -241,7 +241,7 @@ def test_export_coreml_matrix(task, dynamic, int8, half, nms, batch, end2end):
         nms=nms,
         end2end=end2end,
     )
-    YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=32, batch=batch)  # exported model inference
     shutil.rmtree(file)  # cleanup
 
 
@@ -275,7 +275,7 @@ def test_export_tflite_matrix(task, dynamic, int8, half, batch, nms, end2end):
     file = YOLO(TASK2MODEL[task]).export(
         format="tflite", imgsz=32, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms, end2end=end2end
     )
-    YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=32, batch=batch)  # exported model inference
     Path(file).unlink()  # cleanup
 
 
@@ -374,7 +374,7 @@ def test_export_mnn_matrix(task, int8, half, batch, end2end):
     """Test YOLO export to MNN format considering various export configurations."""
     skip_rpi_semantic(task)
     file = YOLO(TASK2MODEL[task]).export(format="mnn", imgsz=32, int8=int8, half=half, batch=batch, end2end=end2end)
-    YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=32, batch=batch)  # exported model inference
     Path(file).unlink()  # cleanup
 
 
@@ -392,7 +392,7 @@ def test_export_ncnn_matrix(task, half, batch):
     """Test YOLO export to NCNN format considering various export configurations."""
     skip_rpi_semantic(task)
     file = YOLO(TASK2MODEL[task]).export(format="ncnn", imgsz=32, half=half, batch=batch)
-    YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=32, batch=batch)  # exported model inference
     shutil.rmtree(file, ignore_errors=True)  # retry in case of potential lingering multi-threaded file usage errors
 
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -183,7 +183,7 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms, end
         nms=nms,
         end2end=end2end,
     )
-    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch)  # exported model inference
     Path(file).unlink()  # cleanup
 
 
@@ -204,7 +204,7 @@ def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms, end2en
     file = YOLO(isolated_model_path(tmp_path, WEIGHTS_DIR / TASK2MODEL[task])).export(
         format="torchscript", imgsz=32, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms, end2end=end2end
     )
-    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
+    YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch)  # exported model inference
     Path(file).unlink()  # cleanup
 
 


### PR DESCRIPTION
PR #24866 ("Fix predict() OOM on large lists of file paths") changed how a list of file paths is loaded for inference. Lists of local paths are now routed to the lazy, batch-aware `LoadImagesAndVideos` loader, which respects the predictor's batch setting (default 1) instead of the previous behavior of eagerly loading the whole list and running it as a single forward pass.

The export matrix tests export with a static batch size and then run inference on a list of that many images:

```python
file = YOLO(model).export(..., batch=2)   # input shape fixed to [2, 3, H, W]
YOLO(file)([SOURCE] * 2, imgsz=32)         # 2 paths, now fed at batch=1
```

After #24866 these feed batch 1 into a model whose input is fixed at batch 2, so inference fails:

- ONNX and TensorRT: Got invalid dimensions for input: images
- MNN: Reshape error: 256 -> 512
- TorchScript: select(): index out of range

### Fix

Pass batch=batch to the inference call so the batch-aware loader groups the images into one batch N forward, matching the static export. The OpenVINO matrix test already did this; this PR applies the same to the remaining matrix tests:

- tests/test_exports.py: ONNX, TorchScript, CoreML, TFLite, MNN, NCNN
- tests/test_cuda.py: ONNX and TensorRT

Only one real usage pattern is affected by the underlying #24866 behavior change: a model exported with a static batch greater than 1, when given a list of multiple sources, now needs an explicit batch=N. Plain .pt models, default batch=1 exports, and dynamic-batch exports are unaffected.

- Reproduced each failure locally (ONNX, TensorRT, MNN, TorchScript) at batch=2 and confirmed batch=batch resolves them.

Minimal Code to trigger error

```python
from ultralytics import YOLO
from ultralytics.utils import ASSETS
image = ASSETS / "bus.jpg"
onnx_model_file = YOLO("yolo26n.pt").export(format="onnx", imgsz=640, batch=2) # static batch=2
YOLO(onnx_model_file)([image, image], imgsz=640)
# YOLO(onnx_model_file)([image, image], imgsz=640, batch=2) # with batch it works fine
```
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates export tests to explicitly pass the `batch` argument during inference on exported YOLO models, improving test accuracy for batched exports across multiple deployment formats.

### 📊 Key Changes
- Added `batch=batch` to exported model inference calls in test files:
  - `tests/test_cuda.py`
  - `tests/test_exports.py`
- Applied this change across several export formats, including:
  - ONNX
  - TensorRT engine
  - TorchScript
  - CoreML
  - TFLite
  - MNN
  - NCNN
- Updated both CUDA-specific and general export matrix tests to better match how models were originally exported.

### 🎯 Purpose & Impact
- ✅ Ensures tests validate exported models using the same batch size they were exported with.
- 🔍 Reduces the chance of false test passes or hidden batch-related issues during inference.
- 📦 Improves reliability of export coverage across different backends and deployment targets.
- 👥 Benefits developers and users by increasing confidence that batched exported YOLO models will behave correctly in real-world use.