### PR TITLE
Fix RegionCounter crash when regions added via add_region

### DIFF
--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -43,6 +43,7 @@ class RegionCounter(BaseSolution):
         self.region_template = {
             "name": "Default Region",
             "polygon": None,
+            "prepared_polygon": None,
             "counts": 0,
             "region_color": (255, 255, 255),
             "text_color": (0, 0, 0),
@@ -69,11 +70,13 @@ class RegionCounter(BaseSolution):
         Returns:
             (dict[str, Any]): Region information including name, polygon, and display colors.
         """
+        polygon = self.Polygon(polygon_points)
         region = self.region_template.copy()
         region.update(
             {
                 "name": name,
-                "polygon": self.Polygon(polygon_points),
+                "polygon": polygon,
+                "prepared_polygon": self.prep(polygon),
                 "region_color": region_color,
                 "text_color": text_color,
             }
@@ -88,8 +91,7 @@ class RegionCounter(BaseSolution):
         if not isinstance(self.region, dict):  # Ensure self.region is initialized and structured as a dictionary
             self.region = {"Region#01": self.region}
         for i, (name, pts) in enumerate(self.region.items()):
-            region = self.add_region(name, pts, colors(i, True), (255, 255, 255))
-            region["prepared_polygon"] = self.prep(region["polygon"])
+            self.add_region(name, pts, colors(i, True), (255, 255, 255))
 
     def process(self, im0: np.ndarray) -> SolutionResults:
         """Process the input frame to detect and count objects within each defined region.


### PR DESCRIPTION
## summary

regions added through the public `add_region()` method previously lacked the `prepared_polygon` key, so `process()` raised `KeyError: 'prepared_polygon'` on the first frame with a detection (this also affected the class docstring example). the polygon is now prepared inside `add_region()` itself, so every region is processable regardless of how it was added.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR streamlines region setup in `RegionCounter` by creating and storing each region’s prepared polygon as soon as the region is added.

### 📊 Key Changes
- Added a new `prepared_polygon` field to the default region template.
- Updated `add_region()` to:
  - create the polygon once,
  - store it in `polygon`,
  - immediately generate and store its prepared version in `prepared_polygon`.
- Simplified `initialize_regions()` by removing the extra step that manually prepared polygons after region creation.
- Reduced duplicate logic by centralizing polygon preparation inside `add_region()`.

### 🎯 Purpose & Impact
- ✅ Improves code cleanliness by keeping all region creation logic in one place.
- ⚡ Makes region initialization slightly more efficient by avoiding repeated polygon handling steps.
- 🛠️ Reduces the chance of bugs or missed setup steps, since every added region now consistently includes both polygon formats.
- 📦 Makes the `RegionCounter` implementation easier to maintain and extend for future updates.