### PR TITLE
Revert "Fix OOM when passing large list of file paths to predict()"

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -93,18 +93,6 @@ def test_predict_txt(tmp_path):
     assert len(results) == 7, f"Expected 7 results from source list, got {len(results)}"
 
 
-def test_predict_list_of_paths():
-    """Test that a list of local file paths loads lazily, respecting `batch` and input order (no OOM)."""
-    from ultralytics.data.build import load_inference_source
-    from ultralytics.data.loaders import LoadImagesAndVideos
-
-    imgs = [ASSETS / "zidane.jpg", ASSETS / "bus.jpg"]  # intentionally not in sorted order
-    dataset = load_inference_source(imgs, batch=1)
-    assert isinstance(dataset, LoadImagesAndVideos), "Path list must load lazily, not as one in-memory batch"
-    assert dataset.bs == 1, f"Batch size must respect `batch`, got {dataset.bs}"  # not len(imgs)
-    assert [Path(f).name for f in dataset.files] == ["zidane.jpg", "bus.jpg"], "Input order must be preserved"
-
-
 @pytest.mark.skipif(True, reason="disabled for testing")
 def test_predict_csv_multi_row(tmp_path):
     """Test YOLO predictions with sources listed in multiple rows of a CSV file."""
@@ -387,7 +375,7 @@ def test_results_plot_without_boxes():
 def test_labels_and_crops():
     """Test output from prediction args for saving YOLO detection labels and crops."""
     imgs = [SOURCE, ASSETS / "zidane.jpg"]
-    results = YOLO(WEIGHTS_DIR / "yolo26n.pt")(imgs, imgsz=320, save_txt=True, save_crop=True)
+    results = YOLO(WEIGHTS_DIR / "yolo26n.pt")(imgs, imgsz=160, save_txt=True, save_crop=True)
     save_path = Path(results[0].save_dir)
     for r in results:
         im_name = Path(r.path).stem

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -36,7 +36,7 @@ from ultralytics.data.loaders import (
 )
 from ultralytics.data.utils import IMG_FORMATS, VID_FORMATS
 from ultralytics.utils import RANK, colorstr
-from ultralytics.utils.checks import REMOTE_FILE_PREFIXES, check_file
+from ultralytics.utils.checks import check_file
 from ultralytics.utils.torch_utils import TORCH_2_0
 
 
@@ -399,13 +399,8 @@ def check_source(
     elif isinstance(source, LOADERS):
         in_memory = True
     elif isinstance(source, (list, tuple)):
-        # Keep local file-path lists lazy (LoadImagesAndVideos respects `batch`); only load URL/PIL/np/mixed
-        # lists into memory, which otherwise OOMs on large path lists by forcing the whole list into one batch
-        if not source or any(
-            not isinstance(s, (str, Path)) or str(s).lower().startswith(REMOTE_FILE_PREFIXES) for s in source
-        ):
-            source = autocast_list(source)  # convert list elements to PIL or np arrays
-            from_img = True
+        source = autocast_list(source)  # convert all list elements to PIL or np arrays
+        from_img = True
     elif isinstance(source, (Image.Image, np.ndarray)):
         from_img = True
     elif isinstance(source, torch.Tensor):

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -360,7 +360,7 @@ class LoadImagesAndVideos:
             path = content.splitlines() if Path(path).suffix == ".txt" else content.split(",")  # list of sources
             path = [p.strip() for p in path]
         files = []
-        for p in path if isinstance(path, (list, tuple)) else [path]:  # preserve given order; glob/dir expand sorted
+        for p in sorted(path) if isinstance(path, (list, tuple)) else [path]:
             a = str(Path(p).absolute())  # do not use .resolve() https://github.com/ultralytics/ultralytics/issues/2912
             if "*" in a:
                 files.extend(sorted(glob.glob(a, recursive=True)))  # glob


### PR DESCRIPTION
Reverts ultralytics/ultralytics#24866 

That PR changed how a list of file paths is loaded for inference: local path lists are now routed to the batch-aware LoadImagesAndVideos loader, which respects the predictor's batch setting (default 1) instead of running the whole list as a single forward pass.

This is a breaking change. A model exported with a static batch greater than 1 now fails when given a list of multiple sources unless the caller also passes an explicit batch=N, where it previously worked automatically:

```python
export_model = YOLO("yolo26n.pt").export(format="onnx", imgsz=32, batch=2)  # static batch=2
YOLO(export_model)([img, img], imgsz=32)            # was OK before #24866, now fails
YOLO(export_model)([img, img], imgsz=32, batch=2)   # now required
```

It also broke the export matrix CI, where many cases started failing for the same reason (ONNX and TensorRT report invalid input dimensions, MNN reports a reshape error, TorchScript reports an index error). A separate fix adding the missing batch parameter to those tests is in #24891. Reverting restores the previous behavior so batch stays optional for inference. The original OOM concern can be addressed in a follow-up that does not make batch mandatory.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR changes how list-based prediction inputs are handled, making file lists load as in-memory image inputs again and sorting list entries before processing.

### 📊 Key Changes
- 🗑️ Removed a test that verified local file path lists were:
  - loaded lazily from disk
  - processed in the user-provided order
  - compatible with the `batch` setting
- 🖼️ Updated source handling in `check_source()` so that **all Python lists/tuples** are now auto-converted into image-like in-memory inputs, instead of keeping local path lists as lazy file loaders.
- 🔤 Changed `LoadImagesAndVideos` to **sort list inputs** before iterating over them, rather than preserving the original user-supplied order.
- ⚡ Reduced test image size in `test_labels_and_crops()` from `320` to `160`, likely to speed up testing and lower resource usage.

### 🎯 Purpose & Impact
- 🧹 Simplifies input handling by treating list inputs more uniformly, which may reduce edge-case complexity in prediction source parsing.
- 📦 However, this also changes behavior for users passing a list of local file paths:
  - inputs may now be loaded into memory sooner
  - original file order may no longer be preserved
  - `batch` behavior for path lists may differ from previous expectations
- ⚠️ For large image lists, this could increase memory usage compared with lazy disk loading.
- 🔍 Users who rely on exact input ordering or memory-efficient processing of large path lists should review this change carefully.