### PR TITLE
Use `tracktrack` as default tracker

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -131,4 +131,4 @@ erasing: 0.4 # (float) random erasing probability for classification (0.0–1.0)
 cfg: # (str, optional) path to a config.yaml that overrides defaults
 
 # Tracker settings ------------------------------------------------------------------------------------------------------
-tracker: botsort.yaml # (str) tracker config: botsort.yaml, bytetrack.yaml, ocsort.yaml, deepocsort.yaml, fasttrack.yaml, tracktrack.yaml
+tracker: tracktrack.yaml # (str) tracker config: botsort.yaml, bytetrack.yaml, ocsort.yaml, deepocsort.yaml, fasttrack.yaml, tracktrack.yaml


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR changes the default multi-object tracker in Ultralytics from `botsort.yaml` to `tracktrack.yaml`.

### 📊 Key Changes
- Updated the default `tracker` setting in `ultralytics/cfg/default.yaml`.
- Switched the default tracker from `botsort.yaml` to `tracktrack.yaml`.
- Kept all other available tracker options unchanged, including BoT-SORT, ByteTrack, OCSORT, DeepOCSORT, and FastTrack.

### 🎯 Purpose & Impact
- 🚀 Makes `TrackTrack` the out-of-the-box tracking experience for users who do not manually choose a tracker.
- 🛠️ Simplifies adoption of the newer preferred tracking configuration without requiring extra setup.
- 📦 May change default tracking behavior and results for existing workflows that rely on implicit defaults.
- 👀 Users who want the previous behavior can still explicitly set `tracker=botsort.yaml` in their tracking command or config.