### PR TITLE
fix: 🐞 predict() OOM on large path lists with automatic batching

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -375,7 +375,7 @@ def test_results_plot_without_boxes():
 def test_labels_and_crops():
     """Test output from prediction args for saving YOLO detection labels and crops."""
     imgs = [SOURCE, ASSETS / "zidane.jpg"]
-    results = YOLO(WEIGHTS_DIR / "yolo26n.pt")(imgs, imgsz=160, save_txt=True, save_crop=True)
+    results = YOLO(WEIGHTS_DIR / "yolo26n.pt")(imgs, imgsz=320, save_txt=True, save_crop=True)
     save_path = Path(results[0].save_dir)
     for r in results:
         im_name = Path(r.path).stem

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -36,7 +36,7 @@ from ultralytics.data.loaders import (
 )
 from ultralytics.data.utils import IMG_FORMATS, VID_FORMATS
 from ultralytics.utils import RANK, colorstr
-from ultralytics.utils.checks import check_file
+from ultralytics.utils.checks import REMOTE_FILE_PREFIXES, check_file
 from ultralytics.utils.torch_utils import TORCH_2_0
 
 
@@ -399,8 +399,13 @@ def check_source(
     elif isinstance(source, LOADERS):
         in_memory = True
     elif isinstance(source, (list, tuple)):
-        source = autocast_list(source)  # convert all list elements to PIL or np arrays
-        from_img = True
+        # Keep local file-path lists lazy so LoadImagesAndVideos streams them at the model's batch size; only load
+        # URL/PIL/np/mixed (or empty) lists into memory, which otherwise OOMs large path lists as one giant batch.
+        if not source or any(
+            not isinstance(s, (str, Path)) or str(s).lower().startswith(REMOTE_FILE_PREFIXES) for s in source
+        ):
+            source = autocast_list(source)  # convert all list elements to PIL or np arrays
+            from_img = True
     elif isinstance(source, (Image.Image, np.ndarray)):
         from_img = True
     elif isinstance(source, torch.Tensor):

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -360,7 +360,7 @@ class LoadImagesAndVideos:
             path = content.splitlines() if Path(path).suffix == ".txt" else content.split(",")  # list of sources
             path = [p.strip() for p in path]
         files = []
-        for p in sorted(path) if isinstance(path, (list, tuple)) else [path]:
+        for p in path if isinstance(path, (list, tuple)) else [path]:  # preserve given order; globs/dirs expand sorted
             a = str(Path(p).absolute())  # do not use .resolve() https://github.com/ultralytics/ultralytics/issues/2912
             if "*" in a:
                 files.extend(sorted(glob.glob(a, recursive=True)))  # glob

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -173,6 +173,11 @@ class BasePredictor:
         im = im.half() if self.model.fp16 else im.float()  # uint8 to fp16/32
         if not_tensor:
             im /= 255  # 0 - 255 to 0.0 - 1.0
+        # Pad a partial final batch up to a static backend's fixed batch size (e.g. ONNX/TensorRT exported with
+        # batch>1) so the last, smaller batch does not fail the fixed input dim; padded rows are dropped in postprocess.
+        mb = getattr(self.model, "batch", 1) or 1
+        if mb > 1 and not getattr(self.model, "dynamic", False) and 0 < im.shape[0] < mb:
+            im = torch.cat((im, im[-1:].repeat(mb - im.shape[0], 1, 1, 1)), 0)
         return im
 
     def inference(self, im: torch.Tensor, *args, **kwargs):

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -256,9 +256,13 @@ class BasePredictor:
             stride (int, optional): Model stride for image size checking.
         """
         self.imgsz = check_imgsz(self.args.imgsz, stride=stride or self.model.stride, min_dim=2)  # check image size
+        # Static-batch backends (e.g. ONNX/TensorRT exported with batch>1) require inputs at their fixed batch, so
+        # derive it from the model. This lets list/dir/video sources batch correctly without the caller passing batch=N.
+        model_batch = getattr(self.model, "batch", 1) or 1
+        batch = model_batch if model_batch > 1 and not getattr(self.model, "dynamic", False) else self.args.batch
         self.dataset = load_inference_source(
             source=source,
-            batch=self.args.batch,
+            batch=batch,
             vid_stride=self.args.vid_stride,
             buffer=self.args.stream_buffer,
             channels=getattr(self.model, "channels", 3),


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves prediction input handling to make batching more reliable, memory-efficient, and order-preserving across local file lists and static exported models 🚀

### 📊 Key Changes
- Updated source handling for `list` and `tuple` inputs so **local file path lists are no longer eagerly loaded into memory** 📂
- Added logic to **keep large local image/video path lists lazy-loaded**, while still auto-loading mixed inputs like URLs, PIL images, NumPy arrays, or empty lists as needed 🧠
- Preserved the **original input order** for user-provided file lists instead of sorting them automatically 🔢
- Improved prediction preprocessing for **static-batch exported backends** like ONNX or TensorRT by **padding the final smaller batch** to the model’s required batch size 🧩
- Updated source setup so prediction **automatically uses the model’s fixed batch size** when required, without users needing to manually set `batch=N` ⚙️
- Adjusted a Python test to use a larger inference image size, likely to make label/crop output validation more stable ✅

### 🎯 Purpose & Impact
- Helps prevent **out-of-memory issues** when running inference on large local file lists 💾
- Makes inference with **exported static-batch models** more robust, especially for the last partial batch in a dataset 📦
- Reduces manual setup by automatically matching the **model’s required batch size**, improving usability for ONNX/TensorRT deployments 🙌
- Ensures predictions follow the **same order users provided**, which is important for consistent downstream processing and result tracking 🎯
- Overall, this PR makes Ultralytics inference **more reliable, scalable, and deployment-friendly** for both everyday users and production workflows 🌍