### PR TITLE
Add COCO16/COCO32/COCO64 subset datasets to detect docs table

### DIFF
--- a/docs/en/datasets/detect/index.md
+++ b/docs/en/datasets/detect/index.md
@@ -236,6 +236,9 @@ Here is a list of the supported datasets and a brief description for each:
 - [COCO8-Grayscale](coco8-grayscale.md): A grayscale version of COCO8 created by converting RGB to grayscale, useful for single-channel model evaluation.
 - [COCO8-Multispectral](coco8-multispectral.md): A 10-channel multispectral version of COCO8 created by interpolating RGB wavelengths, useful for spectral-aware model evaluation.
 - [COCO12-Formats](coco12-formats.md): A test dataset with 12 images covering 12 supported image formats (AVIF, BMP, DNG, HEIC, JP2, JPEG, JPG, MPO, PNG, TIF, TIFF, WebP) for validating image loading pipelines.
+- [COCO16](https://github.com/ultralytics/assets/releases/download/v0.0.0/coco16.zip): A subset of the first 16 images from COCO train2017 (8 train + 8 val), suitable for quick tests.
+- [COCO32](https://github.com/ultralytics/assets/releases/download/v0.0.0/coco32.zip): A subset of the first 32 images from COCO train2017 (16 train + 16 val), suitable for quick tests.
+- [COCO64](https://github.com/ultralytics/assets/releases/download/v0.0.0/coco64.zip): A subset of the first 64 images from COCO train2017 (32 train + 32 val), suitable for quick tests.
 - [COCO128](coco128.md): A smaller subset of the first 128 images from COCO train2017, suitable for tests.
 - [Construction-PPE](construction-ppe.md): A dataset featuring construction site workers with labeled safety gear such as helmets, vests, gloves, boots, and goggles, including missing-equipment annotations like no_helmet, no_goggle for real-world compliance monitoring.
 - [Global Wheat 2020](globalwheat2020.md): A dataset containing images of wheat heads for the Global Wheat Challenge 2020.


### PR DESCRIPTION
Adds the new **COCO16**, **COCO32**, and **COCO64** subset datasets to the supported-datasets table on the [Object Detection Datasets Overview](https://docs.ultralytics.com/datasets/detect/) page.

These are the first 16/32/64 images of COCO train2017, each split into train/val halves (mirroring the COCO8 layout), now hosted in [`ultralytics/assets`](https://github.com/ultralytics/assets/releases/tag/v0.0.0). They fill the gap between COCO8 (8) and COCO128 (128) for quick tests and sanity checks — e.g. the smallest subset that clears the 20-image minimum for embeddings/clustering workflows.

- Inserted in numeric order between COCO12-Formats and COCO128, following the COCO12-Formats precedent of listing minor test datasets on the detect page.
- Entries link directly to the downloadable assets (all return HTTP 200). **No `cfg/datasets/*.yaml` configs added** — these are intentionally lightweight, download-only test subsets.

No code changes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR updates the detection dataset docs to add three new small COCO test subsets: COCO16, COCO32, and COCO64.

### 📊 Key Changes
- Added **COCO16** to the supported detection datasets list:
  - Contains the first 16 images from COCO train2017
  - Split into 8 train and 8 validation images
- Added **COCO32** to the dataset list:
  - Contains the first 32 images from COCO train2017
  - Split into 16 train and 16 validation images
- Added **COCO64** to the dataset list:
  - Contains the first 64 images from COCO train2017
  - Split into 32 train and 32 validation images
- Included direct download links for all three datasets in the docs for easier access 🔗

### 🎯 Purpose & Impact
- Makes it easier for users to run **very fast experiments and sanity checks** before moving to larger datasets 🚀
- Gives developers more **fine-grained small-dataset options** between COCO8/COCO128 for debugging and pipeline validation
- Improves documentation discoverability by clearly listing these lightweight datasets alongside existing detection datasets 📖
- Helps reduce setup time and compute cost for quick tests, especially useful for CI, demos, and early-stage troubleshooting 🛠️