### PR TITLE
Restructure five documentation guides and update descriptions

### DIFF
--- a/docs/en/guides/coco-json-training.md
+++ b/docs/en/guides/coco-json-training.md
@@ -1,7 +1,7 @@
 ---
 title: Train YOLO on COCO JSON Without Conversion
 comments: true
-description: Train Ultralytics YOLO directly on COCO JSON annotations without converting to YOLO format. Custom dataset and trainer example with complete working code.
+description: Train Ultralytics YOLO directly on COCO JSON annotations without converting to YOLO format. Custom dataset and trainer example with complete working code for detection training.
 keywords: COCO JSON training, train YOLO on COCO JSON, COCO JSON without conversion, custom YOLO dataset, custom YOLO trainer, COCO annotations YOLO, direct COCO training, Ultralytics YOLO, object detection training, YOLODataset subclass, COCO format training, skip annotation conversion
 ---
 

--- a/docs/en/guides/coco-json-training.md
+++ b/docs/en/guides/coco-json-training.md
@@ -168,7 +168,7 @@ path: /path/to/my_dataset/images # root with train/ and val/ image subfolders
 train: train
 val: val
 
-# COCO JSON annotation files (absolute, or relative to your run directory)
+# COCO JSON annotation files (use absolute paths; these custom keys are not resolved against `path`)
 train_json: /path/to/my_dataset/annotations/instances_train.json
 val_json: /path/to/my_dataset/annotations/instances_val.json
 

--- a/docs/en/guides/coco-json-training.md
+++ b/docs/en/guides/coco-json-training.md
@@ -1,15 +1,15 @@
 ---
 title: Train YOLO on COCO JSON Without Conversion
 comments: true
-description: Train Ultralytics YOLO directly on COCO JSON annotations without converting to YOLO format. Custom dataset and trainer example with complete working code for detection training.
+description: Train Ultralytics YOLO directly on COCO JSON annotations without converting to YOLO format. Custom dataset and trainer example with complete working code.
 keywords: COCO JSON training, train YOLO on COCO JSON, COCO JSON without conversion, custom YOLO dataset, custom YOLO trainer, COCO annotations YOLO, direct COCO training, Ultralytics YOLO, object detection training, YOLODataset subclass, COCO format training, skip annotation conversion
 ---
 
 # How to Train YOLO on COCO JSON Without Converting
 
-## Why Train Directly on COCO JSON
+[Annotations](https://www.ultralytics.com/glossary/data-labeling) in [COCO JSON](https://cocodataset.org/#format-data) format can be used directly for [Ultralytics YOLO](https://www.ultralytics.com/) training without converting to `.txt` files first. This works by subclassing [`YOLODataset`](../reference/data/dataset.md#ultralytics.data.dataset.YOLODataset) to parse COCO JSON on the fly and wiring it into the training pipeline through a custom trainer.
 
-[Annotations](https://www.ultralytics.com/glossary/data-labeling) in [COCO JSON](https://cocodataset.org/#format-data) format can be used directly for [Ultralytics YOLO](https://www.ultralytics.com/) training without converting to `.txt` files first. This is done by subclassing `YOLODataset` to parse COCO JSON on the fly and wiring it into the training pipeline through a custom trainer.
+## Why Train Directly on COCO JSON
 
 This approach keeps the COCO JSON as the single source of truth — no `convert_coco()` call, no directory reorganization, no intermediate label files. [YOLO26](../models/yolo26.md) and all other Ultralytics YOLO detection models are supported. Segmentation and pose models require additional label fields (see [FAQ](#does-this-support-segmentation-and-pose-estimation)).
 
@@ -24,7 +24,7 @@ Two classes are needed:
 1. **`COCODataset`** — reads COCO JSON and converts [bounding boxes](https://www.ultralytics.com/glossary/bounding-box) to YOLO format in memory during training
 2. **`COCOTrainer`** — overrides `build_dataset()` to use `COCODataset` instead of the default `YOLODataset`
 
-The implementation follows the same pattern as the built-in `GroundingDataset`, which also reads JSON annotations directly. Three methods are overridden: `get_img_files()`, `cache_labels()`, and `get_labels()`.
+The implementation follows the same pattern as the built-in [`GroundingDataset`](../reference/data/dataset.md#ultralytics.data.dataset.GroundingDataset), which also reads JSON annotations directly. Three methods are overridden: `get_img_files()`, `cache_labels()`, and `get_labels()`.
 
 ## Building the COCO JSON Dataset Class
 
@@ -61,8 +61,6 @@ class COCODataset(YOLODataset):
         x = {"labels": []}
         with open(self.json_file) as f:
             coco = json.load(f)
-
-        images = {img["id"]: img for img in coco["images"]}
 
         # Sort categories by ID and map to 0-indexed classes
         categories = {cat["id"]: i for i, cat in enumerate(sorted(coco["categories"], key=lambda c: c["id"]))}
@@ -129,7 +127,7 @@ Parsed labels are saved to a `.cache` file next to the JSON (e.g. `instances_tra
 
 The only change needed in the trainer is overriding `build_dataset()`. The default `DetectionTrainer` builds a `YOLODataset` that scans for `.txt` label files. By replacing it with `COCODataset`, the trainer reads from the COCO JSON instead.
 
-The JSON file path is pulled from a custom `train_json` / `val_json` field in the data config (see Step 3). During training, `mode="train"` resolves to `train_json`; during validation, `mode="val"` resolves to `val_json`. If `val_json` is not set, it falls back to `train_json`.
+The JSON file path is pulled from a custom `train_json` / `val_json` field in the data config (see [Configuring dataset.yaml](#configuring-datasetyaml-for-coco-json)). During training, `mode="train"` resolves to `train_json`; during validation, `mode="val"` resolves to `val_json`. If `val_json` is not set, it falls back to `train_json`.
 
 ```python
 from ultralytics.models.yolo.detect import DetectionTrainer
@@ -166,13 +164,13 @@ class COCOTrainer(DetectionTrainer):
 The `dataset.yaml` uses the standard `path`, `train`, and `val` fields to locate image directories. Two additional fields, `train_json` and `val_json`, specify the COCO annotation files that `COCOTrainer` reads. The `nc` and `names` fields define the number of classes and their names, matching the sorted order of `categories` in the JSON.
 
 ```yaml
-path: /path/to/images # root directory with train/ and val/ subfolders
+path: /path/to/my_dataset/images # root with train/ and val/ image subfolders
 train: train
 val: val
 
-# COCO JSON annotation files
-train_json: /path/to/annotations/instances_train.json
-val_json: /path/to/annotations/instances_val.json
+# COCO JSON annotation files (absolute, or relative to your run directory)
+train_json: /path/to/my_dataset/annotations/instances_train.json
+val_json: /path/to/my_dataset/annotations/instances_val.json
 
 nc: 80
 names:
@@ -242,12 +240,11 @@ class COCODataset(YOLODataset):
         return []
 
     def cache_labels(self, path=Path("./labels.cache")):
-        """Parse COCO JSON and convert annotations to YOLO format, saving results to a .cache file."""
+        """Parse COCO JSON and convert annotations to YOLO format. Results are saved to a .cache file."""
         x = {"labels": []}
         with open(self.json_file) as f:
             coco = json.load(f)
 
-        images = {img["id"]: img for img in coco["images"]}
         categories = {cat["id"]: i for i, cat in enumerate(sorted(coco["categories"], key=lambda c: c["id"]))}
 
         img_to_anns = defaultdict(list)
@@ -334,7 +331,7 @@ model = YOLO("yolo26n.pt")
 model.train(data="dataset.yaml", epochs=100, imgsz=640, trainer=COCOTrainer)
 ```
 
-For [hyperparameter](https://www.ultralytics.com/glossary/hyperparameter-tuning) recommendations, see the [Model Training Tips](model-training-tips.md) guide.
+You now have a minimal dataset and trainer that train Ultralytics YOLO directly on COCO JSON, with annotations staying the single source of truth and no intermediate `.txt` files. Extend the `cache_labels()` method with `segments` or `keypoints` to cover segmentation and pose, and see the [Model Training Tips](model-training-tips.md) guide for [hyperparameter](https://www.ultralytics.com/glossary/hyperparameter-tuning) tuning recommendations.
 
 ## FAQ
 
@@ -348,7 +345,7 @@ Not with the current Ultralytics pipeline, which expects YOLO `.txt` labels by d
 
 ### Does this support segmentation and pose estimation?
 
-This guide covers [object detection](https://www.ultralytics.com/glossary/object-detection). To add [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) support, include the `segmentation` polygon data from COCO annotations in the `segments` field of each label dictionary. For [pose estimation](https://www.ultralytics.com/glossary/pose-estimation), include `keypoints`. The `GroundingDataset` [source code](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/dataset.py) provides a reference implementation for handling segments.
+This guide covers [object detection](https://www.ultralytics.com/glossary/object-detection). To add [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) support, include the `segmentation` polygon data from COCO annotations in the `segments` field of each label dictionary. For [pose estimation](https://www.ultralytics.com/glossary/pose-estimation), include `keypoints`. The [`GroundingDataset`](../reference/data/dataset.md#ultralytics.data.dataset.GroundingDataset) [source code](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/data/dataset.py) provides a reference implementation for handling segments.
 
 ### Do augmentations work with this custom dataset?
 

--- a/docs/en/guides/coco-to-yolo.md
+++ b/docs/en/guides/coco-to-yolo.md
@@ -136,7 +136,7 @@ Use the [`convert_coco()`](../reference/data/converter.md#ultralytics.data.conve
         )
         ```
 
-`convert_coco()` writes one `.txt` file per image into a `labels/` subdirectory named after each JSON file, with the `instances_` prefix removed (so `instances_train.json` produces `labels/train/`):
+`convert_coco()` writes one `.txt` file per annotated image into a `labels/` subdirectory named after each JSON file, with the `instances_` prefix removed (so `instances_train.json` produces `labels/train/`). Images with no annotations are skipped and get no label file, so the `labels/` tree may not mirror every image:
 
 ```
 my_dataset/converted/

--- a/docs/en/guides/coco-to-yolo.md
+++ b/docs/en/guides/coco-to-yolo.md
@@ -1,13 +1,17 @@
 ---
 title: Convert COCO JSON Annotations to YOLO
 comments: true
-description: Learn how to convert COCO JSON annotations to YOLO format for object detection, instance segmentation, and pose estimation training. Complete guide with step-by-step examples, common pitfalls, and class ID mapping for custom datasets.
+description: Convert COCO JSON annotations to YOLO format for object detection, instance segmentation, and pose estimation, with class ID mapping for custom datasets.
 keywords: COCO to YOLO, convert COCO JSON to YOLO, COCO JSON format, YOLO annotation format, convert_coco, COCO dataset training, train YOLO on COCO, object detection dataset, instance segmentation dataset, pose estimation dataset, dataset conversion, annotation format, cls91to80, category_id, bounding box format, YOLO training data
 ---
 
 # How to Convert COCO Annotations to YOLO Format
 
 Training [Ultralytics YOLO](https://www.ultralytics.com/) models requires annotations in YOLO format, but many popular [annotation](https://www.ultralytics.com/glossary/data-labeling) tools export in [COCO JSON](https://cocodataset.org/#format-data) format instead. This guide shows you how to convert your COCO annotations to YOLO format and start training [object detection](https://www.ultralytics.com/glossary/object-detection), [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation), and [pose estimation](https://www.ultralytics.com/glossary/pose-estimation) models.
+
+!!! tip "Prefer to skip conversion?"
+
+    To train directly on COCO JSON without generating `.txt` files, see [Train YOLO on COCO JSON Without Conversion](coco-json-training.md).
 
 ## Why Convert from COCO to YOLO?
 
@@ -33,9 +37,9 @@ The fastest way to convert COCO annotations and start training:
 from ultralytics.data.converter import convert_coco
 
 convert_coco(
-    labels_dir="path/to/annotations/",  # directory containing your JSON files
-    save_dir="path/to/output/",  # where to save converted labels
-    cls91to80=False,  # IMPORTANT: set False for custom datasets
+    labels_dir="my_dataset/annotations/",  # directory containing your JSON files
+    save_dir="my_dataset/converted/",  # where to save converted labels
+    cls91to80=False,  # set False for custom datasets (see warning below)
 )
 ```
 
@@ -132,6 +136,22 @@ Use the [`convert_coco()`](../reference/data/converter.md#ultralytics.data.conve
         )
         ```
 
+`convert_coco()` writes one `.txt` file per image into a `labels/` subdirectory named after each JSON file, with the `instances_` prefix removed (so `instances_train.json` produces `labels/train/`):
+
+```
+my_dataset/converted/
+└── labels/
+    ├── train/   # from instances_train.json
+    │   ├── img_001.txt
+    │   └── ...
+    └── val/     # from instances_val.json
+        └── ...
+```
+
+!!! note "Re-running creates a new output folder"
+
+    `convert_coco()` never overwrites an existing `save_dir`: if `my_dataset/converted/` already exists, a re-run writes to `my_dataset/converted-2/` instead. Delete the previous output (or change `save_dir`) before re-running, or the next steps will read stale labels.
+
 ### 3. Organize Directory Structure
 
 After conversion, label files need to be placed alongside your images. YOLO expects a `labels/` directory that mirrors the `images/` directory:
@@ -140,14 +160,15 @@ After conversion, label files need to be placed alongside your images. YOLO expe
 import shutil
 from pathlib import Path
 
-# Paths
 converted_dir = Path("my_dataset/converted/labels")
 dataset_dir = Path("my_dataset")
 
-# Move labels next to images for each split
-for split in ["train", "val"]:
-    src = converted_dir / split  # convert_coco strips "instances_" prefix from JSON filename
-    dst = dataset_dir / "labels" / split
+# convert_coco names each subdirectory after its JSON file (minus the "instances_" prefix),
+# so iterate the actual subdirectories instead of assuming "train"/"val".
+for src in converted_dir.iterdir():
+    if not src.is_dir():
+        continue
+    dst = dataset_dir / "labels" / src.name
     dst.mkdir(parents=True, exist_ok=True)
     for f in src.glob("*.txt"):
         shutil.move(str(f), str(dst / f.name))
@@ -314,7 +335,7 @@ This happens because `convert_coco()` saves labels to a subdirectory inside `sav
 
 ### What does `cls91to80` do in `convert_coco()`?
 
-The `cls91to80` parameter controls how COCO `category_id` values are mapped to YOLO class IDs. When `True` (default), it uses a lookup table designed for the standard [COCO dataset](../datasets/detect/coco.md), which has 80 classes with non-contiguous IDs (1-90). For **custom datasets**, always set `cls91to80=False` — this simply subtracts 1 from each `category_id` to create zero-indexed class IDs.
+The `cls91to80` parameter controls how COCO `category_id` values are mapped to YOLO class IDs. When `True` (default), it applies the [`coco91_to_coco80_class()`](../reference/data/converter.md#ultralytics.data.converter.coco91_to_coco80_class) lookup table designed for the standard [COCO dataset](../datasets/detect/coco.md), which has 80 classes with non-contiguous IDs (1-90). For **custom datasets**, always set `cls91to80=False` — this simply subtracts 1 from each `category_id` to create zero-indexed class IDs.
 
 ### Can I train YOLO directly on COCO JSON without converting?
 

--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -175,7 +175,7 @@ If you're upgrading an existing project to YOLO26, here's a quick checklist to e
 
 ## Conclusion
 
-End-to-end detection is the default in YOLO26 and needs no code changes if you use the [Ultralytics Python API](../usage/python.md) or [CLI](../usage/cli.md) — only custom post-processing pipelines need updating to read the new `(N, 300, 6)` output and drop the NMS step. For detailed speed and accuracy benchmarks across all model sizes, see the [YOLO26 model page](../models/yolo26.md), and for the full set of export options and formats, see the [Export mode](../modes/export.md) documentation.
+End-to-end detection is the default in YOLO26 and needs no code changes if you use the [Ultralytics Python API](../usage/python.md) or [CLI](../usage/cli.md). Only custom post-processing pipelines need updating to read the new `(N, 300, 6)` output and drop the NMS step — except for export formats that fall back to one-to-many output (such as NCNN and RKNN), which still require NMS on-device. For detailed speed and accuracy benchmarks across all model sizes, see the [YOLO26 model page](../models/yolo26.md), and for the full set of export options and formats, see the [Export mode](../modes/export.md) documentation.
 
 ## FAQ
 

--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -1,13 +1,11 @@
 ---
 title: YOLO26 End-to-End NMS-Free Detection
 comments: true
-description: Learn how YOLO26 end-to-end NMS-free detection works, what changes for your deployment pipeline, which export formats support it, and how to migrate from YOLOv8 or YOLO11.
+description: Learn how YOLO26 end-to-end NMS-free detection works, what changes in your deployment pipeline, which export formats support it, and how to migrate.
 keywords: YOLO26, end-to-end detection, NMS-free inference, model export, deployment guide, object detection, Ultralytics, YOLOv8 migration, YOLO11 migration, ONNX, TensorRT, CoreML, post-processing, computer vision
 ---
 
 # Understanding End-to-End Detection in Ultralytics YOLO26
-
-## Introduction
 
 If you're upgrading to [YOLO26](../models/yolo26.md) from an earlier model like [YOLOv8](../models/yolov8.md) or [YOLO11](../models/yolo11.md), one of the biggest changes you'll notice is the removal of [Non-Maximum Suppression](https://www.ultralytics.com/glossary/non-maximum-suppression-nms) (NMS). Traditional YOLO models produce thousands of overlapping predictions that need a separate NMS post-processing step to filter down to final detections. This adds latency, complicates export graphs, and can behave inconsistently across different hardware platforms.
 
@@ -83,7 +81,7 @@ When you call `model.fuse()`, it folds Conv + BatchNorm layers for faster infere
 | **NMS required**     | Yes                                        | No                                                              |
 | **Post-processing**  | NMS + confidence filter                    | Confidence filter only                                          |
 
-For [segmentation](../tasks/segment.md), [pose](../tasks/pose.md), and [OBB](../tasks/obb.md) tasks, YOLO26 appends task-specific data to each detection — see the [output shapes table](#how-end-to-end-detection-works) above.
+For [segmentation](../tasks/segment.md), [pose](../tasks/pose.md), and [OBB](../tasks/obb.md) tasks, YOLO26 appends task-specific data to each detection — see the [output shapes table](#how-end-to-end-detection-works).
 
 Where `N` is the [batch size](https://www.ultralytics.com/glossary/batch-size) and `nc` is the number of classes (e.g., 80 for [COCO](../datasets/detect/coco.md)).
 
@@ -169,11 +167,15 @@ If you're upgrading an existing project to YOLO26, here's a quick checklist to e
 
 - **Ultralytics API / CLI users:** No changes needed — just update the model name to `yolo26n.pt` (or `yolo26n-seg.pt`, `yolo26n-pose.pt`, `yolo26n-obb.pt`)
 - **Custom post-processing code:** Update to handle the new output shapes — `(N, 300, 6)` for detection, plus task-specific data for [segmentation](../tasks/segment.md), [pose](../tasks/pose.md), and [OBB](../tasks/obb.md). Also note the box format change from `xywh` to `xyxy`
-- **Export pipelines:** Check the [format compatibility](#export-format-compatibility) section above for your target format
+- **Export pipelines:** Check the [format compatibility](#export-format-compatibility) section for your target format
 - **TensorRT + INT8:** On JetPack 6, TensorRT 10.3.0 auto-disables end-to-end with `int8=True` — use a different TensorRT version to keep end-to-end
 - **FP16 exports:** If you need all outputs in FP16, export with `end2end=False` — see [why output0 stays FP32](../modes/export.md#why-is-output0-fp32-when-exporting-with-halftrue-and-end2endtrue)
 - **iOS / CoreML:** End-to-end is fully supported. If you need Xcode Preview support, use `end2end=False` with `nms=True`
 - **Edge devices (NCNN, RKNN):** These formats auto-fallback to one-to-many, so include NMS in your on-device pipeline
+
+## Conclusion
+
+End-to-end detection is the default in YOLO26 and needs no code changes if you use the [Ultralytics Python API](../usage/python.md) or [CLI](../usage/cli.md) — only custom post-processing pipelines need updating to read the new `(N, 300, 6)` output and drop the NMS step. For detailed speed and accuracy benchmarks across all model sizes, see the [YOLO26 model page](../models/yolo26.md), and for the full set of export options and formats, see the [Export mode](../modes/export.md) documentation.
 
 ## FAQ
 
@@ -185,7 +187,7 @@ However, `end2end=False` combined with `nms=True` is a valid configuration — i
 
 ### What does the max_det parameter control in end-to-end models?
 
-The `max_det` parameter (default: 300) sets the maximum number of detections the one-to-one head can output per image. You can adjust it at inference or export time:
+The [`max_det`](../modes/predict.md#inference-arguments) parameter (default: 300) sets the maximum number of detections the one-to-one head can output per image. You can adjust it at inference or export time:
 
 ```python
 model.predict("image.jpg", max_det=100)  # fewer detections, slightly faster

--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -1,15 +1,15 @@
 ---
 title: Export Any PyTorch Model to ONNX & More
 comments: true
-description: Export any PyTorch model (timm, torchvision, or custom) to ONNX, OpenVINO, CoreML, TensorFlow SavedModel, TorchScript, NCNN, MNN, PaddlePaddle, and ExecuTorch with Ultralytics export utilities.
+description: Export any PyTorch model (timm, torchvision, or custom) to ONNX, OpenVINO, CoreML, TensorFlow, and more through one Ultralytics API, with no per-backend code.
 keywords: export PyTorch model, convert PyTorch to ONNX, PyTorch to CoreML, PyTorch to OpenVINO, PyTorch to TensorFlow, non-YOLO export, timm export, torchvision export, TorchScript export, NCNN export, MNN export, PaddlePaddle export, ExecuTorch export, TFLite export, Ultralytics export utilities, torch.nn.Module export, model conversion, model deployment, PyTorch deployment
 ---
 
 # How to Export Non-YOLO PyTorch Models with Ultralytics
 
-Deploying PyTorch models to production usually means juggling a different exporter for every target: `torch.onnx.export` for ONNX, `coremltools` for Apple devices, `onnx2tf` for TensorFlow, `pnnx` for NCNN, and so on. Each tool has its own API, dependency quirks, and output conventions.
+Ultralytics ships standalone export utilities under [`ultralytics.utils.export`](../reference/utils/export/onnx.md) that wrap multiple backends behind one consistent interface. You can export any `torch.nn.Module`, including [timm](https://github.com/huggingface/pytorch-image-models) image models, [torchvision](https://docs.pytorch.org/vision/) classifiers and detectors, or your own custom architectures, to [ONNX](../integrations/onnx.md), [TorchScript](../integrations/torchscript.md), [OpenVINO](../integrations/openvino.md), [CoreML](../integrations/coreml.md), [NCNN](../integrations/ncnn.md), [PaddlePaddle](../integrations/paddlepaddle.md), [MNN](../integrations/mnn.md), [ExecuTorch](../integrations/executorch.md), and [TensorFlow SavedModel](../integrations/tf-savedmodel.md) without learning each backend separately.
 
-Ultralytics ships standalone export utilities that wrap multiple backends behind one consistent interface. You can export any `torch.nn.Module`, including [timm](https://github.com/huggingface/pytorch-image-models) image models, [torchvision](https://docs.pytorch.org/vision/) classifiers and detectors, or your own custom architectures, to [ONNX](../integrations/onnx.md), [TorchScript](../integrations/torchscript.md), [OpenVINO](../integrations/openvino.md), [CoreML](../integrations/coreml.md), [NCNN](../integrations/ncnn.md), [PaddlePaddle](../integrations/paddlepaddle.md), [MNN](../integrations/mnn.md), [ExecuTorch](../integrations/executorch.md), and [TensorFlow SavedModel](../integrations/tf-savedmodel.md) without learning each backend separately.
+Deploying PyTorch models to production usually means juggling a different exporter for every target: `torch.onnx.export` for ONNX, `coremltools` for Apple devices, `onnx2tf` for TensorFlow, `pnnx` for NCNN, and so on. Each tool has its own API, dependency quirks, and output conventions. These utilities collapse that into a single calling pattern.
 
 ## Why Use Ultralytics for Non-YOLO Export?
 
@@ -37,18 +37,18 @@ torch2onnx(model, torch.randn(1, 3, 224, 224), output_file="resnet18.onnx")
 
 The `torch2*` functions take a standard `torch.nn.Module` and an example input tensor. MNN, TF SavedModel, and TF Frozen Graph go through an intermediate ONNX or Keras artifact. No YOLO-specific attributes are required in either case.
 
-| Format          | Function              | Install                                                             | Output                         |
-| --------------- | --------------------- | ------------------------------------------------------------------- | ------------------------------ |
-| ONNX            | `torch2onnx()`        | `pip install onnx`                                                  | `.onnx` file                   |
-| TorchScript     | `torch2torchscript()` | included with PyTorch                                               | `.torchscript` file            |
-| OpenVINO        | `torch2openvino()`    | `pip install openvino`                                              | `_openvino_model/` directory   |
-| CoreML          | `torch2coreml()`      | `pip install coremltools`                                           | `.mlpackage`                   |
-| TF SavedModel   | `onnx2saved_model()`  | [see detailed requirements below](#export-to-tensorflow-savedmodel) | `_saved_model/` directory      |
-| TF Frozen Graph | `keras2pb()`          | [see detailed requirements below](#export-to-tensorflow-savedmodel) | `.pb` file                     |
-| NCNN            | `torch2ncnn()`        | `pip install ncnn pnnx`                                             | `_ncnn_model/` directory       |
-| MNN             | `onnx2mnn()`          | `pip install MNN`                                                   | `.mnn` file                    |
-| PaddlePaddle    | `torch2paddle()`      | `pip install paddlepaddle x2paddle`                                 | `_paddle_model/` directory     |
-| ExecuTorch      | `torch2executorch()`  | `pip install executorch`                                            | `_executorch_model/` directory |
+| Format          | Function                                                          | Install                                                             | Output                         |
+| --------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------ |
+| ONNX            | [`torch2onnx()`](../reference/utils/export/onnx.md)               | `pip install onnx`                                                  | `.onnx` file                   |
+| TorchScript     | [`torch2torchscript()`](../reference/utils/export/torchscript.md) | included with PyTorch                                               | `.torchscript` file            |
+| OpenVINO        | [`torch2openvino()`](../reference/utils/export/openvino.md)       | `pip install openvino`                                              | `_openvino_model/` directory   |
+| CoreML          | [`torch2coreml()`](../reference/utils/export/coreml.md)           | `pip install coremltools`                                           | `.mlpackage`                   |
+| TF SavedModel   | [`onnx2saved_model()`](../reference/utils/export/tensorflow.md)   | [see detailed requirements below](#export-to-tensorflow-savedmodel) | `_saved_model/` directory      |
+| TF Frozen Graph | [`keras2pb()`](../reference/utils/export/tensorflow.md)           | [see detailed requirements below](#export-to-tensorflow-savedmodel) | `.pb` file                     |
+| NCNN            | [`torch2ncnn()`](../reference/utils/export/ncnn.md)               | `pip install ncnn pnnx`                                             | `_ncnn_model/` directory       |
+| MNN             | [`onnx2mnn()`](../reference/utils/export/mnn.md)                  | `pip install MNN`                                                   | `.mnn` file                    |
+| PaddlePaddle    | [`torch2paddle()`](../reference/utils/export/paddle.md)           | `pip install paddlepaddle x2paddle`                                 | `_paddle_model/` directory     |
+| ExecuTorch      | [`torch2executorch()`](../reference/utils/export/executorch.md)   | `pip install executorch`                                            | `_executorch_model/` directory |
 
 !!! note "ONNX as an intermediate format"
 
@@ -169,19 +169,21 @@ Requirements:
 - `sng4onnx>=1.0.1`
 - `onnx_graphsurgeon>=0.3.26` (install with `--extra-index-url https://pypi.ngc.nvidia.com`)
 - `ai-edge-litert>=1.2.0,<1.4.0` on macOS (`ai-edge-litert>=1.2.0` on other platforms)
-- `onnxslim>=0.1.71`
+- `onnxslim>=0.1.82`
 - `onnx>=1.12.0,<2.0.0`
 - `protobuf>=5`
 
 ### Export to TensorFlow Frozen Graph
 
-Continuing from the SavedModel export above, convert the returned Keras model to a frozen `.pb` graph:
+The frozen `.pb` graph is produced from the Keras model returned by `onnx2saved_model`, so generate that model first, then convert it:
 
 ```python
 from pathlib import Path
 
-from ultralytics.utils.export import keras2pb
+from ultralytics.utils.export import keras2pb, onnx2saved_model, torch2onnx
 
+torch2onnx(model, im, output_file="resnet18.onnx")
+keras_model = onnx2saved_model("resnet18.onnx", output_dir="resnet18_saved_model")
 keras2pb(keras_model, output_file=Path("resnet18_saved_model/resnet18.pb"))
 ```
 
@@ -260,7 +262,7 @@ Requires `torch>=2.9.0` and a matching ExecuTorch runtime (`pip install executor
 
 ## Verify Your Exported Model
 
-After exporting, verify numerical parity with the original PyTorch model before shipping. A quick smoke test with `ONNXBackend` from `ultralytics.nn.backends` compares outputs and flags tracing or quantization errors early:
+After exporting, verify numerical parity with the original PyTorch model before shipping. A quick smoke test with [`ONNXBackend`](../reference/nn/backends/onnx.md) from `ultralytics.nn.backends` compares outputs and flags tracing or quantization errors early:
 
 ```python
 import numpy as np
@@ -278,12 +280,12 @@ onnx_model = ONNXBackend("resnet18.onnx", device=torch.device("cpu"))
 onnx_output = onnx_model(im)[0]
 
 diff = np.abs(pytorch_output - onnx_output).max()
-print(f"Max difference: {diff:.6f}")  # should be < 1e-5
+print(f"Max difference: {diff:.6f}")  # typically ~1e-5, well under 1e-4 for FP32
 ```
 
 !!! tip "Expected difference"
 
-    For FP32 exports, the max absolute difference should be under `1e-5`. Larger differences point to unsupported ops, incorrect input shape, or a model not in eval mode. FP16 and INT8 exports have looser tolerances. Validate on real data instead of random tensors.
+    For FP32 exports, the max absolute difference is typically around `1e-5` and should stay well under `1e-4`. Larger differences point to unsupported ops, incorrect input shape, or a model not in eval mode. FP16 and INT8 exports have looser tolerances. Validate on real data instead of random tensors.
 
 For other runtimes, the input tensor name may differ. OpenVINO, for example, uses the model's forward-argument name (typically `x` for generic models), while `torch2onnx` defaults to `"images"`.
 
@@ -294,6 +296,10 @@ For other runtimes, the input tensor name may differ. OpenVINO, for example, use
 - **No inference via Ultralytics**: Exported non-YOLO models cannot be loaded back through `YOLO()` for inference. Use the native runtime for each format ([ONNX Runtime](../integrations/onnx.md), [OpenVINO Runtime](../integrations/openvino.md), etc.).
 - **YOLO-only formats**: [Axelera](../integrations/axelera.md) and [Sony IMX500](../integrations/sony-imx500.md) exports require YOLO-specific model attributes and are not available for generic models.
 - **Platform-specific formats**: [TensorRT](../integrations/tensorrt.md) requires an NVIDIA GPU. [RKNN](../integrations/rockchip-rknn.md) requires the `rknn-toolkit2` SDK (Linux only). [Edge TPU](../integrations/edge-tpu.md) requires the `edgetpu_compiler` binary (Linux only).
+
+## Conclusion
+
+These utilities take any PyTorch model from a plain `torch.nn.Module` to a deployment-ready ONNX, OpenVINO, CoreML, TensorFlow, or mobile-runtime artifact through one consistent API. Pick the format that matches your target hardware, [verify numerical parity](#verify-your-exported-model) against the original model, then follow the matching [integration guide](../integrations/index.md) for runtime-specific deployment steps.
 
 ## FAQ
 
@@ -316,3 +322,7 @@ Yes. torchvision classifiers, detectors, and segmentation models export to `.mlp
 ### Can I quantize my exported model to INT8 or FP16?
 
 Yes, for several formats. Pass `half=True` for FP16 or `int8=True` for INT8 when exporting to OpenVINO, CoreML, MNN, or NCNN. INT8 in OpenVINO additionally requires a `calibration_dataset` argument for [post-training quantization](https://www.ultralytics.com/glossary/model-quantization). See each format's integration page for quantization trade-offs.
+
+### How do I verify an exported model matches the original?
+
+Run the original PyTorch model and the exported model on the same input, then compare outputs. Load the exported file with the matching backend (for example, [`ONNXBackend`](../reference/nn/backends/onnx.md) for ONNX) and check the maximum absolute difference. For FP32 exports it is typically around `1e-5` and should stay well under `1e-4`; larger gaps point to unsupported ops, a wrong input shape, or a model not in eval mode. See [Verify Your Exported Model](#verify-your-exported-model) for a runnable example.

--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -175,15 +175,13 @@ Requirements:
 
 ### Export to TensorFlow Frozen Graph
 
-The frozen `.pb` graph is produced from the Keras model returned by `onnx2saved_model`, so generate that model first, then convert it:
+Continuing from the SavedModel export above, convert the returned `keras_model` to a frozen `.pb` graph:
 
 ```python
 from pathlib import Path
 
-from ultralytics.utils.export import keras2pb, onnx2saved_model, torch2onnx
+from ultralytics.utils.export import keras2pb
 
-torch2onnx(model, im, output_file="resnet18.onnx")
-keras_model = onnx2saved_model("resnet18.onnx", output_dir="resnet18_saved_model")
 keras2pb(keras_model, output_file=Path("resnet18_saved_model/resnet18.pb"))
 ```
 

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -1,15 +1,13 @@
 ---
 title: YOLO Hyperparameter Tuning
 comments: true
-description: Master hyperparameter tuning for Ultralytics YOLO to optimize model performance with our comprehensive guide. Elevate your machine learning models today!
+description: Tune Ultralytics YOLO hyperparameters with model.tune() and a genetic algorithm. Define a search space, run iterations, and find settings that maximize mAP.
 keywords: Ultralytics YOLO, hyperparameter tuning, machine learning, model optimization, genetic algorithms, learning rate, batch size, epochs
 ---
 
 # Ultralytics YOLO [Hyperparameter Tuning](https://www.ultralytics.com/glossary/hyperparameter-tuning) Guide
 
-## Introduction
-
-Hyperparameter tuning is not just a one-time setup but an iterative process aimed at optimizing the [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) model's performance metrics, such as accuracy, precision, and recall. In the context of Ultralytics YOLO, these hyperparameters could range from learning rate to architectural details, such as the number of layers or types of activation functions used. [Ultralytics Platform](https://platform.ultralytics.com) also supports [cloud training](../platform/train/cloud-training.md) with configurable hyperparameters and real-time metrics tracking.
+Hyperparameter tuning in Ultralytics YOLO is an automated, iterative search that optimizes settings — such as learning rate, loss weights, and augmentation strength — to maximize a [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) model's performance metrics like accuracy, precision, and recall. Rather than testing these values by hand, Ultralytics YOLO explores the hyperparameter space with a genetic algorithm that mutates and evaluates candidate configurations across many short training runs.
 
 <p align="center">
   <br>
@@ -22,7 +20,7 @@ Hyperparameter tuning is not just a one-time setup but an iterative process aime
   <strong>Watch:</strong> How to Tune Hyperparameters for Better Model Performance 🚀
 </p>
 
-### What are Hyperparameters?
+## What are Hyperparameters?
 
 Hyperparameters are high-level, structural settings for the algorithm. They are set prior to the training phase and remain constant during it. Here are some commonly tuned hyperparameters in Ultralytics YOLO:
 
@@ -37,7 +35,7 @@ Hyperparameters are high-level, structural settings for the algorithm. They are 
 
 For a full list of augmentation hyperparameters used in YOLO26 please refer to the [configurations page](../usage/cfg.md#augmentation-settings).
 
-### Genetic Evolution and Mutation
+## Genetic Evolution and Mutation
 
 Ultralytics YOLO uses [genetic algorithms](https://en.wikipedia.org/wiki/Genetic_algorithm) to optimize hyperparameters. Genetic algorithms are inspired by the mechanism of natural selection and genetics.
 
@@ -51,31 +49,16 @@ Before you begin the tuning process, it's important to:
 1. **Identify the Metrics**: Determine the metrics you will use to evaluate the model's performance. This could be AP50, F1-score, or others.
 2. **Set the Tuning Budget**: Define how much computational resources you're willing to allocate. Hyperparameter tuning can be computationally intensive.
 
-## Steps Involved
+## How the Tuning Loop Works
 
-### Initialize Hyperparameters
+For each iteration, the built-in tuner repeats the following loop:
 
-Start with a reasonable set of initial hyperparameters. This could either be the default hyperparameters set by Ultralytics YOLO or something based on your domain knowledge or previous experiments.
-
-### Mutate Hyperparameters
-
-Use the `_mutate` method to produce a new set of hyperparameters based on the existing set. The [Tuner class](https://docs.ultralytics.com/reference/engine/tuner) handles this process automatically.
-
-### Train Model
-
-Training is performed using the mutated set of hyperparameters. The training performance is then assessed using your chosen metrics.
-
-### Evaluate Model
-
-Use metrics like AP50, F1-score, or custom metrics to evaluate the model's performance. The [evaluation process](https://docs.ultralytics.com/modes/val) helps determine if the current hyperparameters are better than previous ones.
-
-### Log Results
-
-It's crucial to log both the performance metrics and the corresponding hyperparameters for future reference. Ultralytics YOLO automatically saves these results in NDJSON format.
-
-### Repeat
-
-The process is repeated until either the set number of iterations is reached or the performance metric is satisfactory. Each iteration builds upon the knowledge gained from previous runs.
+1. **Initialize hyperparameters** — start from a reasonable baseline, either the default hyperparameters set by Ultralytics YOLO or values based on your domain knowledge or previous experiments.
+2. **Mutate hyperparameters** — the [`Tuner` class](https://docs.ultralytics.com/reference/engine/tuner) produces a new set of hyperparameters from the existing set with its `_mutate` method, automatically.
+3. **Train the model** — train using the mutated hyperparameters, then assess training performance with your chosen metrics.
+4. **Evaluate the model** — use metrics like AP50, F1-score, or custom metrics through the [evaluation process](https://docs.ultralytics.com/modes/val) to determine whether the current hyperparameters improve on previous ones.
+5. **Log results** — record both the performance metrics and the corresponding hyperparameters for future reference. Ultralytics YOLO automatically saves these results in NDJSON format.
+6. **Repeat** — continue until the set number of iterations is reached or the performance metric is satisfactory, with each iteration building on knowledge gained from previous runs.
 
 ### Iterations and Population Size
 
@@ -85,7 +68,7 @@ The built-in genetic algorithm has no explicit population size parameter. Once p
 
 For parallel trials or more advanced search strategies, set `use_ray=True` to use Ray Tune, which receives `iterations` as `num_samples`. See the [Ray Tune integration guide](../integrations/ray-tune.md) for details.
 
-## Default Search Space Description
+## Default Search Space
 
 The following table lists the default search space parameters for hyperparameter tuning in YOLO26. Each parameter has a specific value range defined by a tuple `(min, max)`.
 
@@ -270,7 +253,7 @@ An NDJSON file containing detailed results of each tuning iteration. Each line i
 - **Usage**: Per-iteration results tracking.
 - **Example**:
 
-A pretty-printed example is shown below for readability. In the actual `.ndjson` file, each object is stored on a single line.
+A pretty-printed example follows for readability; in the actual `.ndjson` file, each object is stored on a single line.
 
 ```json
 {
@@ -331,25 +314,19 @@ This directory contains the saved [PyTorch](https://www.ultralytics.com/glossary
 - **`last.pt`**: The last.pt are the weights from the last epoch of training.
 - **`best.pt`**: The best.pt weights for the iteration that achieved the best fitness score.
 
-Using these results, you can make more informed decisions for your future model trainings and analyses. Feel free to consult these artifacts to understand how well your model performed and how you might improve it further.
+Using these results, you can make more informed decisions for future model trainings and analyses.
 
 ## Conclusion
 
-The hyperparameter tuning process in Ultralytics YOLO is simplified yet powerful, thanks to its genetic algorithm-based approach combining BLX-α crossover with log-normal mutation. Following the steps outlined in this guide will assist you in systematically tuning your model to achieve better performance.
+Hyperparameter tuning in Ultralytics YOLO is both simple to launch and powerful under the hood, combining BLX-α crossover with log-normal mutation in a genetic algorithm. Following the loop outlined in this guide lets you systematically tune your model for better performance, then reuse the resulting `best_hyperparameters.yaml` to initialize future training runs. To scale tuning across parallel trials and more advanced search algorithms, continue with the [Ray Tune integration guide](../integrations/ray-tune.md), or run managed jobs with configurable hyperparameters and real-time metrics tracking on [Ultralytics Platform](https://platform.ultralytics.com) via [cloud training](../platform/train/cloud-training.md).
 
-### Further Reading
-
-1. [Hyperparameter Optimization in Wikipedia](https://en.wikipedia.org/wiki/Hyperparameter_optimization)
-2. [YOLOv5 Hyperparameter Evolution Guide](../yolov5/tutorials/hyperparameter-evolution.md)
-3. [Efficient Hyperparameter Tuning with Ray Tune and YOLO26](../integrations/ray-tune.md)
-
-For deeper insights, you can explore the [`Tuner` class](https://docs.ultralytics.com/reference/engine/tuner) source code and accompanying documentation. Should you have any questions, feature requests, or need further assistance, feel free to reach out to us on [GitHub](https://github.com/ultralytics/ultralytics/issues/new/choose) or [Discord](https://discord.com/invite/ultralytics).
+For deeper insights, explore the [`Tuner` class](https://docs.ultralytics.com/reference/engine/tuner) source code. If you have questions or feature requests, reach out on [GitHub](https://github.com/ultralytics/ultralytics/issues/new/choose) or [Discord](https://discord.com/invite/ultralytics).
 
 ## FAQ
 
 ### How do I optimize the [learning rate](https://www.ultralytics.com/glossary/learning-rate) for Ultralytics YOLO during hyperparameter tuning?
 
-To optimize the learning rate for Ultralytics YOLO, start by setting an initial learning rate using the `lr0` parameter. Common values range from `0.001` to `0.01`. During the hyperparameter tuning process, this value will be mutated to find the optimal setting. You can utilize the `model.tune()` method to automate this process. For example:
+Set an initial value with the `lr0` parameter — common values range from `0.001` to `0.01` — and let tuning mutate it from there to find the optimum. You can automate this with the `model.tune()` method. For example:
 
 !!! example
 
@@ -381,7 +358,7 @@ To see how genetic algorithms can optimize hyperparameters, check out the [hyper
 
 The time required for hyperparameter tuning with Ultralytics YOLO largely depends on several factors such as the size of the dataset, the complexity of the model architecture, the number of iterations, and the computational resources available. For instance, tuning YOLO26n on a dataset like COCO8 for 30 epochs might take several hours to days, depending on the hardware.
 
-To effectively manage tuning time, define a clear tuning budget beforehand ([internal section link](#preparing-for-hyperparameter-tuning)). This helps in balancing resource allocation and optimization goals.
+To effectively manage tuning time, define a clear tuning budget beforehand, as covered in [Preparing for Hyperparameter Tuning](#preparing-for-hyperparameter-tuning). This helps balance resource allocation and optimization goals.
 
 ### What metrics should I use to evaluate model performance during hyperparameter tuning in YOLO?
 

--- a/docs/en/guides/hyperparameter-tuning.md
+++ b/docs/en/guides/hyperparameter-tuning.md
@@ -1,7 +1,7 @@
 ---
 title: YOLO Hyperparameter Tuning
 comments: true
-description: Tune Ultralytics YOLO hyperparameters with model.tune() and a genetic algorithm. Define a search space, run iterations, and find settings that maximize mAP.
+description: Tune Ultralytics YOLO hyperparameters with model.tune() and a genetic algorithm. Define a search space, run iterations, and find settings that maximize fitness.
 keywords: Ultralytics YOLO, hyperparameter tuning, machine learning, model optimization, genetic algorithms, learning rate, batch size, epochs
 ---
 


### PR DESCRIPTION
## summary

Restructures five guides — COCO-to-YOLO conversion, COCO JSON training, end-to-end detection, exporting non-YOLO models, and hyperparameter tuning. Removes redundant intro headings so each guide opens directly with its content, standardizes section headings, converts thin one-line step subsections into numbered lists, fixes a placeholder anchor link, and rewrites the frontmatter descriptions. Code blocks are unchanged and were verified against the current package; internal links and section anchors were re-checked.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refreshes several Ultralytics docs to make COCO workflows, YOLO26 end-to-end detection, model export, and hyperparameter tuning clearer, more actionable, and easier to follow 📚✨

### 📊 Key Changes
- Improved the **COCO JSON direct-training guide** with clearer explanations of how to train Ultralytics YOLO directly from COCO JSON without converting to `.txt` labels.
- Clarified the custom `COCODataset` and `COCOTrainer` flow, including:
  - better references to `YOLODataset` and `GroundingDataset`
  - clearer `dataset.yaml` examples
  - explicit notes that `train_json` and `val_json` should use absolute paths
  - stronger closing guidance for extending support to segmentation and pose
- Updated the **COCO-to-YOLO conversion guide** with:
  - a new tip pointing users to the no-conversion training guide
  - clearer `convert_coco()` examples for custom datasets
  - added explanation of output folder structure
  - warning that re-running conversion creates a new output directory instead of overwriting
  - safer label-moving example that iterates real subdirectories instead of assuming `train` and `val`
  - improved explanation of `cls91to80`
- Refined the **YOLO26 end-to-end detection guide** by:
  - simplifying wording around migration and deployment
  - tightening internal links
  - adding a clearer conclusion on when NMS is no longer needed and when some export targets still require it
  - linking `max_det` directly to prediction docs
- Enhanced the **non-YOLO model export guide** with:
  - clearer positioning of Ultralytics export utilities as a single API for many backends
  - linked export functions in the format table
  - updated dependency guidance, including a newer `onnxslim` requirement
  - clearer TensorFlow frozen-graph wording
  - stronger guidance on verifying exported model accuracy with `ONNXBackend`
  - a new conclusion and FAQ entry about parity checking
- Reworked the **hyperparameter tuning guide** to be easier to understand by:
  - simplifying the introduction
  - reorganizing section headings
  - replacing a fragmented process description with a clean step-by-step tuning loop
  - renaming “Default Search Space Description” to “Default Search Space”
  - tightening conclusion and FAQ wording
  - adding clearer pointers to Ray Tune and Ultralytics Platform 🚀

### 🎯 Purpose & Impact
- Makes key Ultralytics workflows easier for both beginners and advanced users to understand ✅
- Reduces confusion around **COCO dataset handling**, especially for users deciding between conversion and direct JSON training
- Helps prevent common mistakes, such as:
  - using stale converted labels
  - misplacing label folders
  - misconfiguring `cls91to80`
  - misunderstanding `train_json` and `val_json` path behavior
- Improves adoption of **YOLO26** by clarifying its NMS-free, end-to-end detection workflow and migration considerations ⚡
- Makes **model export** documentation more practical for deployment users working with non-YOLO PyTorch models
- Gives users a clearer mental model of **hyperparameter tuning**, which can help them tune models more confidently and efficiently 🎯
- Overall impact: no core code behavior changes, but a meaningful documentation upgrade that should lower support friction and improve user success 📖