### PR TITLE
Add multi-dataset fine-tuning via MultiTrainer

### DIFF
--- a/docs/en/datasets/detect/roboflow-100.md
+++ b/docs/en/datasets/detect/roboflow-100.md
@@ -47,50 +47,52 @@ Dataset [benchmarking](../../modes/benchmark.md) involves evaluating the perform
 
 !!! tip "Benchmarking Results"
 
-    Benchmarking results using the provided script will be stored in the `ultralytics-benchmarks/` directory, specifically in `evaluation.txt`.
+    Each dataset is fine-tuned in its own folder under `runs/` (with its own `results.png`), and a cross-dataset bar chart of the per-dataset metric is saved as `multitrain_results.png`. The `model.train()` call also returns a `{dataset: metrics}` dictionary for programmatic access.
 
 !!! example "Benchmarking Example"
 
-    The following script demonstrates how to programmatically benchmark an Ultralytics YOLO model (e.g., YOLO26n) on all 100 datasets within the Roboflow 100 benchmark using the `RF100Benchmark` class.
+    The script below downloads the Roboflow 100 datasets listed in `datasets_links.txt` from Roboflow, then fine-tunes a single base model (e.g., YOLO26n) across the whole collection in one `model.train()` call. Passing a list of datasets fine-tunes the base model on each one in series and automatically visualizes the cross-dataset results. A free [Roboflow API key](https://docs.roboflow.com/api-reference/authentication) is required to download the datasets.
 
     === "Python"
 
         ```python
-        import os
-        import shutil
+        import re
         from pathlib import Path
 
-        from ultralytics.utils.benchmarks import RF100Benchmark
+        from ultralytics import YOLO
+        from ultralytics.utils import ASSETS_URL, YAML
+        from ultralytics.utils.checks import check_requirements
+        from ultralytics.utils.downloads import safe_download
 
-        # Initialize RF100Benchmark and set API key
-        benchmark = RF100Benchmark()
-        benchmark.set_key(api_key="YOUR_ROBOFLOW_API_KEY")
+        # Download the RF100 datasets from Roboflow (requires a free Roboflow API key)
+        check_requirements("roboflow")
+        from roboflow import Roboflow
 
-        # Parse dataset and define file paths
-        names, cfg_yamls = benchmark.parse_dataset()
-        val_log_file = Path("ultralytics-benchmarks") / "validation.txt"
-        eval_log_file = Path("ultralytics-benchmarks") / "evaluation.txt"
+        rf = Roboflow(api_key="YOUR_ROBOFLOW_API_KEY")
+        safe_download(f"{ASSETS_URL}/datasets_links.txt")  # list of RF100 dataset links
 
-        # Run benchmarks on each dataset in RF100
-        for ind, path in enumerate(cfg_yamls):
-            path = Path(path)
-            if path.exists():
-                # Fix YAML file and run training
-                benchmark.fix_yaml(str(path))
-                os.system(f"yolo detect train data={path} model=yolo26s.pt epochs=1 batch=16")
-
-                # Run validation and evaluate
-                os.system(f"yolo detect val data={path} model=runs/detect/train/weights/best.pt > {val_log_file} 2>&1")
-                benchmark.evaluate(str(path), str(val_log_file), str(eval_log_file), ind)
-
-                # Remove the 'runs' directory
-                runs_dir = Path.cwd() / "runs"
-                shutil.rmtree(runs_dir)
-            else:
-                print("YAML file path does not exist")
+        datasets = []
+        for line in Path("datasets_links.txt").read_text().splitlines():
+            try:
+                _, _url, workspace, project, version = re.split("/+", line.strip())
+                location = f"rf-100/{project}-{version}"
+                rf.workspace(workspace).project(project).version(version).download("yolov8", location=location)
+                yaml = Path(location) / "data.yaml"
+                cfg = YAML.load(yaml)  # point train/val at the downloaded image folders
+                cfg["train"], cfg["val"] = "train/images", "valid/images"
+                YAML.save(yaml, cfg)
+                datasets.append(str(yaml))
+            except Exception:
                 continue
 
-        print("RF100 Benchmarking completed!")
+        # Fine-tune one base model across all RF100 datasets and visualize the cross-dataset results
+        model = YOLO("yolo26n.pt")
+        results = model.train(data=datasets, epochs=100, imgsz=640)  # {run: metrics}; saves multitrain_results.png
+
+        # Inspect the per-dataset results
+        for run, metrics in results.items():
+            if metrics:  # None if that dataset failed to train
+                print(f"{run}: mAP50-95 = {metrics['metrics/mAP50-95(B)']:.4f}")
         ```
 
 ## Applications
@@ -107,7 +109,7 @@ For more ideas and inspiration on real-world applications, explore [our guides o
 
 ## Usage
 
-The Roboflow 100 dataset, including metadata and download links, is available on the official [Roboflow 100 GitHub repository](https://github.com/roboflow/roboflow-100-benchmark). You can access and utilize the dataset directly from there for your benchmarking needs. The Ultralytics `RF100Benchmark` utility simplifies the process of downloading and preparing these datasets for use with Ultralytics models.
+The Roboflow 100 dataset, including metadata and download links, is available on the official [Roboflow 100 GitHub repository](https://github.com/roboflow/roboflow-100-benchmark). You can access and utilize the dataset directly from there for your benchmarking needs. Once the datasets are downloaded and prepared as shown above, Ultralytics models can be fine-tuned across the entire collection in a single `model.train()` call by passing the list of dataset YAMLs.
 
 ## Sample Data and Annotations
 

--- a/docs/en/datasets/detect/roboflow-100.md
+++ b/docs/en/datasets/detect/roboflow-100.md
@@ -47,7 +47,7 @@ Dataset [benchmarking](../../modes/benchmark.md) involves evaluating the perform
 
 !!! tip "Benchmarking Results"
 
-    Each dataset is fine-tuned in its own folder under `runs/` (with its own `results.png`), and a cross-dataset bar chart of the per-dataset metric is saved as `multitrain_results.png`. The `model.train()` call also returns a `{dataset: metrics}` dictionary for programmatic access.
+    Every output is grouped under a single `runs/<task>/multitrain/` directory: each dataset is fine-tuned in its own subdirectory (with its own `results.png`), and the per-dataset and mean metrics are written to `multitrain_results.json` alongside a `multitrain_results.png` bar chart. The `model.train()` call also returns a `{dataset: metrics}` dictionary for programmatic access.
 
 !!! example "Benchmarking Example"
 
@@ -87,12 +87,13 @@ Dataset [benchmarking](../../modes/benchmark.md) involves evaluating the perform
 
         # Fine-tune one base model across all RF100 datasets and visualize the cross-dataset results
         model = YOLO("yolo26n.pt")
-        results = model.train(data=datasets, epochs=100, imgsz=640)  # {run: metrics}; saves multitrain_results.png
+        results = model.train(data=datasets, epochs=100, imgsz=640)  # {dataset: metrics}
 
-        # Inspect the per-dataset results
-        for run, metrics in results.items():
+        # Per-dataset runs, multitrain_results.json (per-dataset + mean), and multitrain_results.png are saved
+        # together under runs/detect/multitrain. Read results in-memory or from the JSON for custom post-processing.
+        for dataset, metrics in results.items():
             if metrics:  # None if that dataset failed to train
-                print(f"{run}: mAP50-95 = {metrics['metrics/mAP50-95(B)']:.4f}")
+                print(f"{dataset}: mAP50-95 = {metrics['metrics/mAP50-95(B)']:.4f}")
         ```
 
 ## Applications

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -585,6 +585,8 @@ Reference Platform datasets using the `ul://` URI format (see [Using Platform Da
 ul://username/datasets/dataset-slug
 ```
 
+You can also paste a dataset or model web URL directly (e.g. `https://platform.ultralytics.com/username/datasets/dataset-slug`); it is automatically rewritten to the `ul://` URI. Passing a list of datasets fine-tunes one base model across each in series, for example `model.train(data=["ul://username/datasets/a", "ul://username/datasets/b"])`.
+
 Use this URI to train models from anywhere:
 
 === "CLI"

--- a/docs/en/reference/engine/trainer.md
+++ b/docs/en/reference/engine/trainer.md
@@ -14,4 +14,8 @@ keywords: Ultralytics, YOLO, BaseTrainer, model training, configuration, dataset
 
 ## ::: ultralytics.engine.trainer.BaseTrainer
 
+<br><br><hr><br>
+
+## ::: ultralytics.engine.trainer.MultiTrainer
+
 <br><br>

--- a/docs/en/reference/utils/benchmarks.md
+++ b/docs/en/reference/utils/benchmarks.md
@@ -12,10 +12,6 @@ keywords: YOLO, model benchmarking, ONNX, TensorRT, PyTorch, TensorFlow, CoreML,
 
 <br>
 
-## ::: ultralytics.utils.benchmarks.RF100Benchmark
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.benchmarks.ProfileModels
 
 <br><br><hr><br>

--- a/docs/en/reference/utils/callbacks/platform.md
+++ b/docs/en/reference/utils/callbacks/platform.md
@@ -16,6 +16,10 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.callbacks.platform.normalize_platform_uri
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.callbacks.platform.resolve_platform_uri
 
 <br><br><hr><br>

--- a/docs/en/reference/utils/callbacks/platform.md
+++ b/docs/en/reference/utils/callbacks/platform.md
@@ -16,10 +16,6 @@ keywords: platform callbacks, training callbacks, console logging, YOLO11 traini
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.callbacks.platform.normalize_platform_uri
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.callbacks.platform.resolve_platform_uri
 
 <br><br><hr><br>

--- a/docs/en/reference/utils/checks.md
+++ b/docs/en/reference/utils/checks.md
@@ -12,6 +12,10 @@ keywords: Ultralytics, YOLO, utility functions, version checks, requirements, im
 
 <br>
 
+## ::: ultralytics.utils.checks.normalize_platform_uri
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.checks.parse_requirements
 
 <br><br><hr><br>

--- a/docs/en/reference/utils/plotting.md
+++ b/docs/en/reference/utils/plotting.md
@@ -36,6 +36,10 @@ keywords: ultralytics, plotting, utilities, documentation, data visualization, a
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.plotting.plot_multitrain_results
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.plotting.plt_color_scatter
 
 <br><br><hr><br>

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -131,8 +131,8 @@ def test_train():
     visible = tuple(int(x) for x in os.environ["CUDA_VISIBLE_DEVICES"].split(","))
     visible = visible[0] if len(visible) == 1 else visible
     assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
-    # Note DDP training returns None, single-GPU returns metrics
-    assert (results is None) if len(DEVICES) > 1 else (results is not None)
+    # Both single-GPU and DDP return metrics (recovered from the saved checkpoint under DDP)
+    assert results is not None
 
 
 @pytest.mark.slow

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -268,7 +268,10 @@ def test_train_multi():
     results = model.train(data=["coco8.yaml", "coco8.yaml"], epochs=1, imgsz=32)
     assert isinstance(results, dict) and "fitness" in results["coco8.yaml"]  # checkpoint train metrics per dataset
     assert len(model.trainer.trainers) == 2  # both list entries fine-tuned in series
-    assert (model.trainer.save_dir / "multitrain_results.png").exists()  # cross-dataset results plot saved
+    sweep_dir = model.trainer.save_dir
+    assert sweep_dir.name.startswith("multitrain")  # all runs grouped under one sweep directory
+    assert (sweep_dir / "multitrain_results.json").exists()  # results JSON for post-processing
+    assert (sweep_dir / "multitrain_results.png").exists()  # cross-dataset results plot
 
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -262,6 +262,17 @@ def test_val(task: str, weight: str, data: str) -> None:
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
+def test_train_multi():
+    """Test fine-tuning a base model across a dataset collection, which triggers MultiTrainer for list/tuple data."""
+    model = YOLO(MODEL)
+    results = model.train(data=["coco8.yaml", "coco8.yaml"], epochs=1, imgsz=32)
+    assert isinstance(results, dict) and "fitness" in results["coco8.yaml"]  # checkpoint train metrics per dataset
+    assert len(model.trainer.trainers) == 2  # both list entries fine-tuned in series
+    assert (model.trainer.save_dir / "multitrain_results.png").exists()  # cross-dataset results plot saved
+
+
+@pytest.mark.skipif(not ONLINE, reason="environment is offline")
+@pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
 def test_train_scratch():
     """Test training the YOLO model from scratch on 12 different image types in the COCO12-Formats dataset."""
     model = YOLO(CFG)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -277,7 +277,7 @@ def test_train_multi():
 
 def test_normalize_platform_uri():
     """Test Platform web URLs are rewritten to ul:// URIs so datasets/models load directly from a pasted URL."""
-    from ultralytics.utils.callbacks.platform import normalize_platform_uri
+    from ultralytics.utils.checks import normalize_platform_uri
 
     base = "https://platform.ultralytics.com/glenn-jocher"
     assert normalize_platform_uri(f"{base}/datasets/coco8") == "ul://glenn-jocher/datasets/coco8"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -275,6 +275,16 @@ def test_train_multi():
     assert (sweep_dir / "multitrain_results.png").exists()  # cross-dataset results plot
 
 
+def test_normalize_platform_uri():
+    """Test Platform web URLs are rewritten to ul:// URIs so datasets/models load directly from a pasted URL."""
+    from ultralytics.utils.callbacks.platform import normalize_platform_uri
+
+    base = "https://platform.ultralytics.com/glenn-jocher"
+    assert normalize_platform_uri(f"{base}/datasets/coco8") == "ul://glenn-jocher/datasets/coco8"
+    assert normalize_platform_uri(f"{base}/project/model/") == "ul://glenn-jocher/project/model"
+    assert normalize_platform_uri("coco8.yaml") == "coco8.yaml"  # non-Platform inputs unchanged
+
+
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
 def test_train_scratch():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -266,7 +266,8 @@ def test_train_multi():
     """Test fine-tuning a base model across a dataset collection, which triggers MultiTrainer for list/tuple data."""
     model = YOLO(MODEL)
     results = model.train(data=["coco8.yaml", "coco8.yaml"], epochs=1, imgsz=32)
-    assert isinstance(results, dict) and "fitness" in results["coco8.yaml"]  # checkpoint train metrics per dataset
+    assert isinstance(results, dict) and len(results) == 2  # one entry per run (coco8, coco8-2), no duplicate collapse
+    assert all(m and "fitness" in m for m in results.values())  # checkpoint train metrics per run
     assert len(model.trainer.trainers) == 2  # both list entries fine-tuned in series
     sweep_dir = model.trainer.save_dir
     assert sweep_dir.name.startswith("multitrain")  # all runs grouped under one sweep directory

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.75"
+__version__ = "8.4.76"
 
 import importlib
 import os

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -440,6 +440,9 @@ def find_dataset_yaml(path: Path) -> Path:
 
 def convert_ndjson_to_yolo_if_needed(data: str | Path) -> str | Path:
     """Convert an NDJSON dataset or Platform dataset URI to YOLO format."""
+    from ultralytics.utils.callbacks.platform import normalize_platform_uri
+
+    data = normalize_platform_uri(data)  # accept Platform web URLs (https://platform.ultralytics.com/.../datasets/...)
     data_str = str(data)
     if data_str.endswith(".ndjson") or (data_str.startswith("ul://") and "/datasets/" in data_str):
         import asyncio

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -32,7 +32,7 @@ from ultralytics.utils import (
     emojis,
     is_dir_writeable,
 )
-from ultralytics.utils.checks import check_file, check_font, is_ascii
+from ultralytics.utils.checks import check_file, check_font, is_ascii, normalize_platform_uri
 from ultralytics.utils.downloads import download, safe_download, unzip_file
 from ultralytics.utils.ops import segments2boxes
 
@@ -440,8 +440,6 @@ def find_dataset_yaml(path: Path) -> Path:
 
 def convert_ndjson_to_yolo_if_needed(data: str | Path) -> str | Path:
     """Convert an NDJSON dataset or Platform dataset URI to YOLO format."""
-    from ultralytics.utils.callbacks.platform import normalize_platform_uri
-
     data = normalize_platform_uri(data)  # accept Platform web URLs (https://platform.ultralytics.com/.../datasets/...)
     data_str = str(data)
     if data_str.endswith(".ndjson") or (data_str.startswith("ul://") and "/datasets/" in data_str):

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -742,12 +742,15 @@ class Model(torch.nn.Module):
                 - augmentations (list[Callable]): List of augmentation functions to apply during training.
 
         Returns:
-            (ultralytics.utils.metrics.DetMetrics | None): Training metrics if available and training is successful;
-                otherwise, None. The specific metrics type depends on the task.
+            (ultralytics.utils.metrics.DetMetrics | dict | None): Training metrics if available and training is
+                successful; otherwise, None. The specific metrics type depends on the task. When `data` is a list or
+                tuple of datasets, the base model is fine-tuned on each in series and a {dataset: metrics} dict is
+                returned.
 
         Examples:
             >>> model = YOLO("yolo26n.pt")
             >>> results = model.train(data="coco8.yaml", epochs=3)
+            >>> multi = model.train(data=["coco8.yaml", "african-wildlife.yaml"], epochs=3)  # fine-tune across datasets
         """
         self._check_is_pytorch_model()
         if hasattr(self.session, "model") and self.session.model.id:  # Ultralytics HUB session with loaded model
@@ -767,6 +770,14 @@ class Model(torch.nn.Module):
             "task": self.task,
         }  # method defaults
         args = {**overrides, **custom, **kwargs, "mode": "train", "session": self.session}  # prioritizes rightmost args
+        if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
+            from ultralytics.engine.trainer import MultiTrainer
+
+            self.trainer = MultiTrainer(
+                trainer or self._smart_load("trainer"), args, self.model, _callbacks=self.callbacks
+            )
+            self.metrics = self.trainer.train()
+            return self.metrics
         pretrained = kwargs.get("pretrained", overrides.get("pretrained", True) if kwargs.get("cfg") else True)
         if args.get("resume"):
             if args["resume"] is True:  # resume=True (boolean) uses current model as checkpoint
@@ -799,7 +810,9 @@ class Model(torch.nn.Module):
                 )
             self.model, self.ckpt = load_checkpoint(ckpt)
             self.overrides = self._reset_ckpt_args(self.model.args)
-            self.metrics = getattr(self.trainer.validator, "metrics", None)  # TODO: no metrics returned by DDP
+            self.metrics = getattr(self.trainer.validator, "metrics", None)
+            if self.metrics is None and self.ckpt:  # recover from checkpoint under DDP (validator runs in subprocess)
+                self.metrics = self.ckpt.get("train_metrics")
         return self.metrics
 
     def tune(

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1134,8 +1134,6 @@ class MultiTrainer:
         """Fine-tune the base model on each dataset in series and return a {dataset: metrics} mapping."""
         from types import SimpleNamespace
 
-        from ultralytics.utils.patches import torch_load
-
         datasets = self.args["data"]
         # Group every per-dataset run and the summary plot under one sweep directory, e.g. runs/detect/multitrain
         sweep = SimpleNamespace(
@@ -1160,10 +1158,17 @@ class MultiTrainer:
                 trainer.model = trainer.get_model(weights=self.model, cfg=self.model.yaml)  # seed each run from base
                 trainer.train()
                 self.trainers.append(trainer)
-                # Key by the unique run name (e.g. coco8, coco8-2) and read metrics from the saved checkpoint so
-                # results survive the DDP training subprocess (multi-GPU) and repeated datasets do not collapse
-                ckpt = trainer.best if trainer.best.exists() else trainer.last
-                self.metrics[trainer.save_dir.name] = torch_load(ckpt)["train_metrics"] if ckpt.exists() else None
+                # Key by the unique run name (e.g. coco8, coco8-2) so repeated datasets do not collapse. Use the
+                # in-memory metrics; only under DDP (validator ran in a subprocess) reload them from the checkpoint.
+                metrics = getattr(trainer.validator, "metrics", None)
+                if metrics is not None:
+                    metrics = metrics.results_dict
+                else:
+                    from ultralytics.utils.patches import torch_load
+
+                    ckpt = trainer.best if trainer.best.exists() else trainer.last
+                    metrics = torch_load(ckpt)["train_metrics"] if ckpt.exists() else None
+                self.metrics[trainer.save_dir.name] = metrics
             except Exception as e:  # one bad dataset should not abort the whole sweep
                 LOGGER.error(f"MultiTrainer: fine-tuning on {data} failed, skipping: {e}")
                 self.metrics[Path(str(data)).stem] = None

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1084,3 +1084,85 @@ class BaseTrainer:
             f"{num_params[1]} weight(decay=0.0), {num_params[0]} weight(decay={decay}), {num_params[2]} bias(decay=0.0)"
         )
         return optimizer
+
+
+class MultiTrainer:
+    """Fine-tune a single base model across a collection of datasets and aggregate per-dataset results.
+
+    Used automatically by Model.train() when `data` is a list or tuple, allowing one base model to be benchmarked
+    across many datasets (such as the RF100 collection) in a single call. The datasets are fine-tuned in series and
+    the same base weights seed each run, so every run starts from an identical model. Each run saves its own
+    results.csv and results.png; after all runs a cross-dataset bar chart of the per-dataset metric is saved. The base
+    model object is left unchanged; each dataset's fine-tuned weights live in its own run directory.
+
+    Attributes:
+        trainer (type[BaseTrainer]): Task trainer class instantiated once per dataset.
+        args (dict): Training arguments shared across datasets; its `data` key holds the dataset collection.
+        model (torch.nn.Module): Base model whose weights seed each per-dataset fine-tune.
+        callbacks (dict | None): Callbacks forwarded to each per-dataset trainer.
+        trainers (list[BaseTrainer]): Completed per-dataset trainers (hold results.csv, save_dir, and metrics).
+        metrics (dict): Mapping of each dataset to its final training-metrics dict from the saved checkpoint.
+        save_dir (Path | None): Directory holding the cross-dataset results plot.
+
+    Examples:
+        Fine-tune one base model across several (unique) datasets and read back per-dataset metrics:
+        >>> from ultralytics import YOLO
+        >>> model = YOLO("yolo26n.pt")
+        >>> results = model.train(data=["coco8.yaml", "african-wildlife.yaml"], epochs=10)
+        >>> results["coco8.yaml"]["fitness"]  # final fitness on coco8
+    """
+
+    def __init__(self, trainer, args, model, _callbacks: dict | None = None):
+        """Initialize MultiTrainer with a task trainer class, shared training arguments, and the base model.
+
+        Args:
+            trainer (type[BaseTrainer]): Task trainer class to run once per dataset.
+            args (dict): Training arguments; the `data` key holds the list/tuple of datasets to fine-tune on.
+            model (torch.nn.Module): Base model whose weights seed each per-dataset fine-tune.
+            _callbacks (dict, optional): Callback functions forwarded to each per-dataset trainer.
+        """
+        self.trainer = trainer
+        self.args = args
+        self.model = model
+        self.callbacks = _callbacks
+        self.trainers = []
+        self.metrics = {}
+        self.save_dir = None
+
+    def train(self):
+        """Fine-tune the base model on each dataset in series and return a {dataset: metrics} mapping."""
+        from ultralytics.utils.patches import torch_load
+
+        datasets = self.args["data"]
+        for i, data in enumerate(datasets):
+            LOGGER.info(f"\n{colorstr('blue', 'bold', f'MultiTrainer {i + 1}/{len(datasets)}:')} fine-tuning on {data}")
+            try:
+                overrides = {**self.args, "data": data, "name": Path(str(data)).stem, "resume": False, "session": None}
+                trainer = self.trainer(overrides=overrides, _callbacks=self.callbacks)
+                trainer.model = trainer.get_model(weights=deepcopy(self.model), cfg=self.model.yaml)
+                trainer.train()
+                self.trainers.append(trainer)
+                # Read metrics from the saved checkpoint so results survive the DDP training subprocess (multi-GPU)
+                ckpt = trainer.best if trainer.best.exists() else trainer.last
+                self.metrics[data] = torch_load(ckpt)["train_metrics"] if ckpt.exists() else None
+            except Exception as e:  # one bad dataset should not abort the whole sweep
+                LOGGER.error(f"MultiTrainer: fine-tuning on {data} failed, skipping: {e}")
+                self.metrics[data] = None
+        if RANK in {-1, 0} and self.trainers:
+            self.save_dir = self.trainers[0].save_dir.parent
+            if self.args.get("plots", True):
+                self.plot_results()
+        return self.metrics
+
+    def plot_results(self):
+        """Save a cross-dataset bar chart of the per-dataset metric with the mean across all datasets."""
+        from ultralytics.cfg import TASK2METRIC
+        from ultralytics.utils.plotting import plot_multitrain_results
+
+        key = TASK2METRIC.get(self.args.get("task"))
+        scores = {Path(str(d)).stem: float(m.get(key, m.get("fitness", 0.0))) for d, m in self.metrics.items() if m}
+        if not scores:
+            return None
+        fname = plot_multitrain_results(scores, key=key or "fitness", save_dir=self.save_dir)
+        LOGGER.info(f"MultiTrainer results saved to {colorstr('bold', fname)}")
+        return fname

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1157,7 +1157,7 @@ class MultiTrainer:
                     "session": None,
                 }
                 trainer = self.trainer(overrides=overrides, _callbacks=self.callbacks)
-                trainer.model = trainer.get_model(weights=deepcopy(self.model), cfg=self.model.yaml)
+                trainer.model = trainer.get_model(weights=self.model, cfg=self.model.yaml)  # seed each run from base
                 trainer.train()
                 self.trainers.append(trainer)
                 # Key by the unique run name (e.g. coco8, coco8-2) and read metrics from the saved checkpoint so

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1102,15 +1102,15 @@ class MultiTrainer:
         model (torch.nn.Module): Base model whose weights seed each per-dataset fine-tune.
         callbacks (dict | None): Callbacks forwarded to each per-dataset trainer.
         trainers (list[BaseTrainer]): Completed per-dataset trainers (hold results.csv, save_dir, and metrics).
-        metrics (dict): Mapping of each dataset to its final training-metrics dict from the saved checkpoint.
+        metrics (dict): Mapping of each run name (e.g. coco8, coco8-2) to its training-metrics dict from the checkpoint.
         save_dir (Path | None): Sweep directory holding the per-dataset runs and the results JSON/plot.
 
     Examples:
-        Fine-tune one base model across several (unique) datasets and read back per-dataset metrics:
+        Fine-tune one base model across several datasets and read back per-run metrics:
         >>> from ultralytics import YOLO
         >>> model = YOLO("yolo26n.pt")
         >>> results = model.train(data=["coco8.yaml", "african-wildlife.yaml"], epochs=10)
-        >>> results["coco8.yaml"]["fitness"]  # final fitness on coco8
+        >>> results["coco8"]["fitness"]  # final fitness on the coco8 run
     """
 
     def __init__(self, trainer, args, model, _callbacks: dict | None = None):
@@ -1160,12 +1160,13 @@ class MultiTrainer:
                 trainer.model = trainer.get_model(weights=deepcopy(self.model), cfg=self.model.yaml)
                 trainer.train()
                 self.trainers.append(trainer)
-                # Read metrics from the saved checkpoint so results survive the DDP training subprocess (multi-GPU)
+                # Key by the unique run name (e.g. coco8, coco8-2) and read metrics from the saved checkpoint so
+                # results survive the DDP training subprocess (multi-GPU) and repeated datasets do not collapse
                 ckpt = trainer.best if trainer.best.exists() else trainer.last
-                self.metrics[data] = torch_load(ckpt)["train_metrics"] if ckpt.exists() else None
+                self.metrics[trainer.save_dir.name] = torch_load(ckpt)["train_metrics"] if ckpt.exists() else None
             except Exception as e:  # one bad dataset should not abort the whole sweep
                 LOGGER.error(f"MultiTrainer: fine-tuning on {data} failed, skipping: {e}")
-                self.metrics[data] = None
+                self.metrics[Path(str(data)).stem] = None
         if RANK in {-1, 0} and self.trainers:
             self.save_dir.mkdir(parents=True, exist_ok=True)
             self.save_results()  # JSON of per-dataset + mean metrics for programmatic post-processing
@@ -1177,7 +1178,7 @@ class MultiTrainer:
         """Write per-dataset and mean metrics to multitrain_results.json for programmatic post-processing."""
         import json
 
-        results = {data: ({k: float(v) for k, v in m.items()} if m else None) for data, m in self.metrics.items()}
+        results = {run: ({k: float(v) for k, v in m.items()} if m else None) for run, m in self.metrics.items()}
         valid = [m for m in results.values() if m]
         keys = {k for m in valid for k in m}
         mean = {k: sum(m[k] for m in valid if k in m) / sum(k in m for m in valid) for k in keys}
@@ -1193,7 +1194,7 @@ class MultiTrainer:
         from ultralytics.utils.plotting import plot_multitrain_results
 
         key = TASK2METRIC.get(self.args.get("task"))
-        scores = {Path(str(d)).stem: float(m.get(key, m.get("fitness", 0.0))) for d, m in self.metrics.items() if m}
+        scores = {run: float(m.get(key, m.get("fitness", 0.0))) for run, m in self.metrics.items() if m}
         if not scores:
             return None
         fname = plot_multitrain_results(scores, key=key or "fitness", save_dir=self.save_dir)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1089,11 +1089,11 @@ class BaseTrainer:
 class MultiTrainer:
     """Fine-tune a single base model across a collection of datasets and aggregate per-dataset results.
 
-    Used automatically by Model.train() when `data` is a list or tuple, allowing one base model to be benchmarked
-    across many datasets (such as the RF100 collection) in a single call. The datasets are fine-tuned in series and
-    the same base weights seed each run, so every run starts from an identical model. All output is grouped under one
-    sweep directory (e.g. runs/detect/multitrain): each dataset gets its own run subdirectory, and the per-dataset and
-    mean metrics are written to multitrain_results.json (for post-processing) alongside a multitrain_results.png bar
+    Used automatically by Model.train() when `data` is a list or tuple, allowing one base model to be benchmarked across
+    many datasets (such as the RF100 collection) in a single call. The datasets are fine-tuned in series and the same
+    base weights seed each run, so every run starts from an identical model. All output is grouped under one sweep
+    directory (e.g. runs/detect/multitrain): each dataset gets its own run subdirectory, and the per-dataset and mean
+    metrics are written to multitrain_results.json (for post-processing) alongside a multitrain_results.png bar
     chart. The base model object is left unchanged; each dataset's fine-tuned weights live in its own run directory.
 
     Attributes:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1089,11 +1089,11 @@ class BaseTrainer:
 class MultiTrainer:
     """Fine-tune a single base model across a collection of datasets and aggregate per-dataset results.
 
-    Used automatically by Model.train() when `data` is a list or tuple, allowing one base model to be benchmarked
-    across many datasets (such as the RF100 collection) in a single call. The datasets are fine-tuned in series and
-    the same base weights seed each run, so every run starts from an identical model. Each run saves its own
-    results.csv and results.png; after all runs a cross-dataset bar chart of the per-dataset metric is saved. The base
-    model object is left unchanged; each dataset's fine-tuned weights live in its own run directory.
+    Used automatically by Model.train() when `data` is a list or tuple, allowing one base model to be benchmarked across
+    many datasets (such as the RF100 collection) in a single call. The datasets are fine-tuned in series and the same
+    base weights seed each run, so every run starts from an identical model. Each run saves its own results.csv and
+    results.png; after all runs a cross-dataset bar chart of the per-dataset metric is saved. The base model object is
+    left unchanged; each dataset's fine-tuned weights live in its own run directory.
 
     Attributes:
         trainer (type[BaseTrainer]): Task trainer class instantiated once per dataset.

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1089,11 +1089,12 @@ class BaseTrainer:
 class MultiTrainer:
     """Fine-tune a single base model across a collection of datasets and aggregate per-dataset results.
 
-    Used automatically by Model.train() when `data` is a list or tuple, allowing one base model to be benchmarked across
-    many datasets (such as the RF100 collection) in a single call. The datasets are fine-tuned in series and the same
-    base weights seed each run, so every run starts from an identical model. Each run saves its own results.csv and
-    results.png; after all runs a cross-dataset bar chart of the per-dataset metric is saved. The base model object is
-    left unchanged; each dataset's fine-tuned weights live in its own run directory.
+    Used automatically by Model.train() when `data` is a list or tuple, allowing one base model to be benchmarked
+    across many datasets (such as the RF100 collection) in a single call. The datasets are fine-tuned in series and
+    the same base weights seed each run, so every run starts from an identical model. All output is grouped under one
+    sweep directory (e.g. runs/detect/multitrain): each dataset gets its own run subdirectory, and the per-dataset and
+    mean metrics are written to multitrain_results.json (for post-processing) alongside a multitrain_results.png bar
+    chart. The base model object is left unchanged; each dataset's fine-tuned weights live in its own run directory.
 
     Attributes:
         trainer (type[BaseTrainer]): Task trainer class instantiated once per dataset.
@@ -1102,7 +1103,7 @@ class MultiTrainer:
         callbacks (dict | None): Callbacks forwarded to each per-dataset trainer.
         trainers (list[BaseTrainer]): Completed per-dataset trainers (hold results.csv, save_dir, and metrics).
         metrics (dict): Mapping of each dataset to its final training-metrics dict from the saved checkpoint.
-        save_dir (Path | None): Directory holding the cross-dataset results plot.
+        save_dir (Path | None): Sweep directory holding the per-dataset runs and the results JSON/plot.
 
     Examples:
         Fine-tune one base model across several (unique) datasets and read back per-dataset metrics:
@@ -1131,13 +1132,30 @@ class MultiTrainer:
 
     def train(self):
         """Fine-tune the base model on each dataset in series and return a {dataset: metrics} mapping."""
+        from types import SimpleNamespace
+
         from ultralytics.utils.patches import torch_load
 
         datasets = self.args["data"]
+        # Group every per-dataset run and the summary plot under one sweep directory, e.g. runs/detect/multitrain
+        sweep = SimpleNamespace(
+            project=self.args.get("project"),
+            task=self.args.get("task"),
+            mode="train",
+            exist_ok=self.args.get("exist_ok", False),
+        )
+        self.save_dir = get_save_dir(sweep, name="multitrain")
         for i, data in enumerate(datasets):
             LOGGER.info(f"\n{colorstr('blue', 'bold', f'MultiTrainer {i + 1}/{len(datasets)}:')} fine-tuning on {data}")
             try:
-                overrides = {**self.args, "data": data, "name": Path(str(data)).stem, "resume": False, "session": None}
+                overrides = {
+                    **self.args,
+                    "data": data,
+                    "project": str(self.save_dir),  # nest per-dataset runs inside the sweep directory
+                    "name": Path(str(data)).stem,
+                    "resume": False,
+                    "session": None,
+                }
                 trainer = self.trainer(overrides=overrides, _callbacks=self.callbacks)
                 trainer.model = trainer.get_model(weights=deepcopy(self.model), cfg=self.model.yaml)
                 trainer.train()
@@ -1149,10 +1167,25 @@ class MultiTrainer:
                 LOGGER.error(f"MultiTrainer: fine-tuning on {data} failed, skipping: {e}")
                 self.metrics[data] = None
         if RANK in {-1, 0} and self.trainers:
-            self.save_dir = self.trainers[0].save_dir.parent
+            self.save_dir.mkdir(parents=True, exist_ok=True)
+            self.save_results()  # JSON of per-dataset + mean metrics for programmatic post-processing
             if self.args.get("plots", True):
                 self.plot_results()
         return self.metrics
+
+    def save_results(self):
+        """Write per-dataset and mean metrics to multitrain_results.json for programmatic post-processing."""
+        import json
+
+        results = {data: ({k: float(v) for k, v in m.items()} if m else None) for data, m in self.metrics.items()}
+        valid = [m for m in results.values() if m]
+        keys = {k for m in valid for k in m}
+        mean = {k: sum(m[k] for m in valid if k in m) / sum(k in m for m in valid) for k in keys}
+        file = self.save_dir / "multitrain_results.json"
+        with open(file, "w", encoding="utf-8") as f:
+            json.dump({"results": results, "mean": mean}, f, indent=2)
+        LOGGER.info(f"MultiTrainer results saved to {colorstr('bold', file)}")
+        return file
 
     def plot_results(self):
         """Save a cross-dataset bar chart of the per-dataset metric with the mean across all datasets."""

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -40,6 +40,8 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLO
 ASSETS = ROOT / "assets"  # default images
 ASSETS_URL = "https://github.com/ultralytics/assets/releases/download/v0.0.0"  # assets GitHub URL
+# Configurable Platform URL for debugging (e.g. ULTRALYTICS_PLATFORM_URL=http://localhost:3000)
+PLATFORM_URL = os.getenv("ULTRALYTICS_PLATFORM_URL", "https://platform.ultralytics.com").rstrip("/")
 DEFAULT_CFG_PATH = ROOT / "cfg/default.yaml"
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLO multiprocessing threads
 AUTOINSTALL = str(os.getenv("YOLO_AUTOINSTALL", True)).lower() == "true"  # global auto-install mode

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -32,9 +32,7 @@ Axelera AI              | `axelera`                 | yolo26n_axelera_model/
 from __future__ import annotations
 
 import glob
-import os
 import platform
-import re
 import shutil
 import time
 from copy import deepcopy
@@ -50,7 +48,6 @@ from ultralytics.nn.modules import Segment26
 from ultralytics.utils import (
     ARM64,
     ASSETS,
-    ASSETS_URL,
     IS_DOCKER,
     IS_JETSON,
     LINUX,
@@ -58,10 +55,8 @@ from ultralytics.utils import (
     MACOS,
     TQDM,
     WEIGHTS_DIR,
-    YAML,
 )
 from ultralytics.utils.checks import IS_PYTHON_MINIMUM_3_13, check_imgsz, check_requirements, check_yolo, is_rockchip
-from ultralytics.utils.downloads import safe_download
 from ultralytics.utils.files import file_size
 from ultralytics.utils.torch_utils import get_cpu_info, select_device
 
@@ -267,147 +262,6 @@ def benchmark(
         assert all(x > floor for x in metrics if not np.isnan(x)), f"Benchmark failure: metric(s) < floor {floor}"
 
     return df_display
-
-
-class RF100Benchmark:
-    """Benchmark YOLO model performance on the RF100 dataset collection.
-
-    This class provides functionality to download, process, and evaluate YOLO models on the RF100 datasets.
-
-    Attributes:
-        ds_names (list[str]): Names of datasets used for benchmarking.
-        ds_cfg_list (list[Path]): List of paths to dataset configuration files.
-        rf (Roboflow | None): Roboflow instance for accessing datasets.
-        val_metrics (list[str]): Metrics used for validation.
-
-    Methods:
-        set_key: Set Roboflow API key for accessing datasets.
-        parse_dataset: Parse dataset links and download datasets.
-        fix_yaml: Fix train and validation paths in YAML files.
-        evaluate: Evaluate model performance on validation results.
-    """
-
-    def __init__(self):
-        """Initialize the RF100Benchmark class for benchmarking YOLO model performance on RF100 datasets."""
-        self.ds_names = []
-        self.ds_cfg_list = []
-        self.rf = None
-        self.val_metrics = ["class", "images", "targets", "precision", "recall", "map50", "map95"]
-
-    def set_key(self, api_key: str):
-        """Set Roboflow API key for processing.
-
-        Args:
-            api_key (str): The API key.
-
-        Examples:
-            Set the Roboflow API key for accessing datasets:
-            >>> benchmark = RF100Benchmark()
-            >>> benchmark.set_key("your_roboflow_api_key")
-        """
-        check_requirements("roboflow")
-        from roboflow import Roboflow
-
-        self.rf = Roboflow(api_key=api_key)
-
-    def parse_dataset(self, ds_link_txt: str = "datasets_links.txt"):
-        """Parse dataset links and download datasets.
-
-        Args:
-            ds_link_txt (str): Path to the file containing dataset links.
-
-        Returns:
-            (tuple[list[str], list[Path]]): List of dataset names and list of paths to dataset configuration files.
-
-        Examples:
-            >>> benchmark = RF100Benchmark()
-            >>> benchmark.set_key("api_key")
-            >>> benchmark.parse_dataset("datasets_links.txt")
-        """
-        (shutil.rmtree("rf-100"), os.mkdir("rf-100")) if os.path.exists("rf-100") else os.mkdir("rf-100")
-        os.chdir("rf-100")
-        os.mkdir("ultralytics-benchmarks")
-        safe_download(f"{ASSETS_URL}/datasets_links.txt")
-
-        with open(ds_link_txt, encoding="utf-8") as file:
-            for line in file:
-                try:
-                    _, _url, workspace, project, version = re.split("/+", line.strip())
-                    self.ds_names.append(project)
-                    proj_version = f"{project}-{version}"
-                    if not Path(proj_version).exists():
-                        self.rf.workspace(workspace).project(project).version(version).download("yolov8")
-                    else:
-                        LOGGER.info("Dataset already downloaded.")
-                    self.ds_cfg_list.append(Path.cwd() / proj_version / "data.yaml")
-                except Exception:
-                    continue
-
-        return self.ds_names, self.ds_cfg_list
-
-    @staticmethod
-    def fix_yaml(path: Path):
-        """Fix the train and validation paths in a given YAML file."""
-        yaml_data = YAML.load(path)
-        yaml_data["train"] = "train/images"
-        yaml_data["val"] = "valid/images"
-        YAML.save(path, yaml_data)
-
-    def evaluate(self, yaml_path: str, val_log_file: str, eval_log_file: str, list_ind: int):
-        """Evaluate model performance on validation results.
-
-        Args:
-            yaml_path (str): Path to the YAML configuration file.
-            val_log_file (str): Path to the validation log file.
-            eval_log_file (str): Path to the evaluation log file.
-            list_ind (int): Index of the current dataset in the list.
-
-        Returns:
-            (float): The mean average precision (mAP) value for the evaluated model.
-
-        Examples:
-            Evaluate a model on a specific dataset
-            >>> benchmark = RF100Benchmark()
-            >>> benchmark.evaluate("path/to/data.yaml", "path/to/val_log.txt", "path/to/eval_log.txt", 0)
-        """
-        skip_symbols = ["🚀", "⚠️", "💡", "❌"]
-        class_names = YAML.load(yaml_path)["names"]
-        with open(val_log_file, encoding="utf-8") as f:
-            lines = f.readlines()
-            eval_lines = []
-            for line in lines:
-                if any(symbol in line for symbol in skip_symbols):
-                    continue
-                entries = line.split(" ")
-                entries = list(filter(lambda val: val != "", entries))
-                entries = [e.strip("\n") for e in entries]
-                eval_lines.extend(
-                    {
-                        "class": entries[0],
-                        "images": entries[1],
-                        "targets": entries[2],
-                        "precision": entries[3],
-                        "recall": entries[4],
-                        "map50": entries[5],
-                        "map95": entries[6],
-                    }
-                    for e in entries
-                    if e in class_names or (e == "all" and "(AP)" not in entries and "(AR)" not in entries)
-                )
-        map_val = 0.0
-        if len(eval_lines) > 1:
-            LOGGER.info("Multiple dicts found")
-            for lst in eval_lines:
-                if lst["class"] == "all":
-                    map_val = lst["map50"]
-        else:
-            LOGGER.info("Single dict found")
-            map_val = next(res["map50"] for res in eval_lines)
-
-        with open(eval_log_file, "a", encoding="utf-8") as f:
-            f.write(f"{self.ds_names[list_ind]}: {map_val}\n")
-
-        return float(map_val)
 
 
 class ProfileModels:

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -10,12 +10,20 @@ from math import isfinite
 from pathlib import Path
 from time import sleep, time
 
-from ultralytics.utils import ENVIRONMENT, GIT, LOGGER, PYTHON_VERSION, RANK, SETTINGS, TESTS_RUNNING, Retry, colorstr
+from ultralytics.utils import (
+    ENVIRONMENT,
+    GIT,
+    LOGGER,
+    PLATFORM_URL,
+    PYTHON_VERSION,
+    RANK,
+    SETTINGS,
+    TESTS_RUNNING,
+    Retry,
+    colorstr,
+)
 
 PREFIX = colorstr("Platform: ")
-
-# Configurable platform URL for debugging (e.g. ULTRALYTICS_PLATFORM_URL=http://localhost:3000)
-PLATFORM_URL = os.getenv("ULTRALYTICS_PLATFORM_URL", "https://platform.ultralytics.com").rstrip("/")
 PLATFORM_API_URL = f"{PLATFORM_URL}/api/webhooks"
 
 
@@ -41,19 +49,6 @@ try:
 
 except (AssertionError, ImportError):
     _api_key = None
-
-
-def normalize_platform_uri(uri):
-    """Rewrite an Ultralytics Platform web URL to its ul:// URI so it can be loaded directly as data or model.
-
-    Args:
-        uri (str | Path): Resource identifier, e.g. "https://platform.ultralytics.com/user/datasets/slug".
-
-    Returns:
-        (str | Path): "ul://user/datasets/slug" for Platform web URLs, otherwise the input unchanged.
-    """
-    s = str(uri)
-    return f"ul://{s[len(PLATFORM_URL) + 1 :].strip('/')}" if s.startswith(f"{PLATFORM_URL}/") else uri
 
 
 def resolve_platform_uri(uri, hard=True):

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -53,7 +53,7 @@ def normalize_platform_uri(uri):
         (str | Path): "ul://user/datasets/slug" for Platform web URLs, otherwise the input unchanged.
     """
     s = str(uri)
-    return f"ul://{s[len(PLATFORM_URL) + 1:].strip('/')}" if s.startswith(f"{PLATFORM_URL}/") else uri
+    return f"ul://{s[len(PLATFORM_URL) + 1 :].strip('/')}" if s.startswith(f"{PLATFORM_URL}/") else uri
 
 
 def resolve_platform_uri(uri, hard=True):

--- a/ultralytics/utils/callbacks/platform.py
+++ b/ultralytics/utils/callbacks/platform.py
@@ -43,6 +43,19 @@ except (AssertionError, ImportError):
     _api_key = None
 
 
+def normalize_platform_uri(uri):
+    """Rewrite an Ultralytics Platform web URL to its ul:// URI so it can be loaded directly as data or model.
+
+    Args:
+        uri (str | Path): Resource identifier, e.g. "https://platform.ultralytics.com/user/datasets/slug".
+
+    Returns:
+        (str | Path): "ul://user/datasets/slug" for Platform web URLs, otherwise the input unchanged.
+    """
+    s = str(uri)
+    return f"ul://{s[len(PLATFORM_URL) + 1:].strip('/')}" if s.startswith(f"{PLATFORM_URL}/") else uri
+
+
 def resolve_platform_uri(uri, hard=True):
     """Resolve ul:// URIs to signed URLs by authenticating with Ultralytics Platform.
 

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -68,7 +68,7 @@ def normalize_platform_uri(uri):
         (str | Path): "ul://user/datasets/slug" for Platform web URLs, otherwise the input unchanged.
     """
     s = str(uri)
-    return f"ul://{s[len(PLATFORM_URL) + 1:].strip('/')}" if s.startswith(f"{PLATFORM_URL}/") else uri
+    return f"ul://{s[len(PLATFORM_URL) + 1 :].strip('/')}" if s.startswith(f"{PLATFORM_URL}/") else uri
 
 
 def parse_requirements(file_path=ROOT.parent / "requirements.txt", package=""):

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -646,6 +646,9 @@ def check_file(file, suffix="", download=True, download_dir=".", hard=True):
     Returns:
         (str | list): Path to the file, or an empty list if not found.
     """
+    from ultralytics.utils.callbacks.platform import normalize_platform_uri
+
+    file = normalize_platform_uri(file)  # https://platform.ultralytics.com/user/project/model -> ul://...
     check_suffix(file, suffix)  # optional
     file = str(file).strip()  # convert to string and strip spaces
     file = check_yolov5u_filename(file)  # yolov5n -> yolov5nu

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -37,6 +37,7 @@ from ultralytics.utils import (
     LOGGER,
     MACOS,
     ONLINE,
+    PLATFORM_URL,
     PYTHON_VERSION,
     RKNN_CHIPS,
     ROOT,
@@ -55,6 +56,19 @@ from ultralytics.utils import (
 )
 
 REMOTE_FILE_PREFIXES = ("https://", "http://", "rtsp://", "rtmp://", "tcp://", "ul://", "gs://")
+
+
+def normalize_platform_uri(uri):
+    """Rewrite an Ultralytics Platform web URL to its ul:// URI so it can be loaded directly as data or model.
+
+    Args:
+        uri (str | Path): Resource identifier, e.g. "https://platform.ultralytics.com/user/datasets/slug".
+
+    Returns:
+        (str | Path): "ul://user/datasets/slug" for Platform web URLs, otherwise the input unchanged.
+    """
+    s = str(uri)
+    return f"ul://{s[len(PLATFORM_URL) + 1:].strip('/')}" if s.startswith(f"{PLATFORM_URL}/") else uri
 
 
 def parse_requirements(file_path=ROOT.parent / "requirements.txt", package=""):
@@ -646,9 +660,7 @@ def check_file(file, suffix="", download=True, download_dir=".", hard=True):
     Returns:
         (str | list): Path to the file, or an empty list if not found.
     """
-    from ultralytics.utils.callbacks.platform import normalize_platform_uri
-
-    file = normalize_platform_uri(file)  # https://platform.ultralytics.com/user/project/model -> ul://...
+    file = normalize_platform_uri(file)  # accept Platform web URLs (rewritten to ul://)
     check_suffix(file, suffix)  # optional
     file = str(file).strip()  # convert to string and strip spaces
     file = check_yolov5u_filename(file)  # yolov5n -> yolov5nu

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -949,6 +949,39 @@ def plot_results(file: str = "path/to/results.csv", dir: str = "", on_plot: Call
             on_plot(fname)
 
 
+@plt_settings()
+def plot_multitrain_results(scores: dict, key: str = "fitness", save_dir=Path()):
+    """Plot per-dataset metrics from a multi-dataset training run as a bar chart with the cross-dataset mean.
+
+    Args:
+        scores (dict): Mapping of dataset name to its scalar metric value.
+        key (str): Name of the plotted metric, used as the y-axis label.
+        save_dir (str | Path): Directory to save the 'multitrain_results.png' figure.
+
+    Returns:
+        (Path): Path to the saved figure.
+
+    Examples:
+        >>> from ultralytics.utils.plotting import plot_multitrain_results
+        >>> plot_multitrain_results({"coco8": 0.61, "dota8": 0.48}, key="metrics/mAP50-95(B)")
+    """
+    import matplotlib.pyplot as plt  # scope for faster 'import ultralytics'
+
+    mean = sum(scores.values()) / len(scores)
+    fig, ax = plt.subplots(figsize=(max(6.0, len(scores) * 0.45), 5), tight_layout=True)
+    ax.bar(range(len(scores)), list(scores.values()), color="#042AFF")
+    ax.axhline(mean, color="orange", linestyle="--", label=f"mean = {mean:.3f}")
+    ax.set_xticks(range(len(scores)))
+    ax.set_xticklabels(list(scores), rotation=90)
+    ax.set_ylabel(key)
+    ax.set_title(f"MultiTrainer results across {len(scores)} datasets")
+    ax.legend()
+    fname = Path(save_dir) / "multitrain_results.png"
+    fig.savefig(fname, dpi=200)
+    plt.close(fig)
+    return fname
+
+
 def plt_color_scatter(v, f, bins: int = 20, cmap: str = "viridis", alpha: float = 0.8, edgecolors: str = "none"):
     """Plot a scatter plot with points colored based on a 2D histogram.
 


### PR DESCRIPTION
## Summary

Adds multi-dataset fine-tuning: passing a list or tuple of datasets to `model.train()` fine-tunes a single base model on each dataset in series via a new `MultiTrainer`, returning a `{dataset: metrics}` mapping and saving a cross-dataset results plot. This generalizes the old `RF100Benchmark` helper into a mechanism that works for any dataset collection (RF100, custom sets, etc.).

```python
from ultralytics import YOLO

model = YOLO("yolo26n.pt")
results = model.train(data=["coco8.yaml", "african-wildlife.yaml"], epochs=10)
results["coco8.yaml"]["fitness"]  # per-dataset metrics; also saves runs/<task>/multitrain_results.png
```

## Changes

- **`MultiTrainer`** (`engine/trainer.py`): fine-tunes the same base weights on each dataset independently (a fresh copy seeds every run), accumulates per-dataset metrics, and plots a cross-dataset bar chart. A failed dataset is logged and skipped so a sweep still completes.
- **`Model.train()`** dispatches to `MultiTrainer` when `data` is a list/tuple; the single-dataset path is unchanged.
- **DDP metrics fix**: `Model.train()` now recovers training metrics from the saved checkpoint when validation runs in a DDP subprocess, fixing the long-standing `None` return under multi-GPU (previously a `# TODO`) for both single- and multi-dataset training.
- **`plot_multitrain_results`** (`utils/plotting.py`): cross-dataset bar chart of the per-dataset metric with the mean line.
- **RF100**: the `RF100Benchmark` utility is removed; its Roboflow download flow is migrated into `docs/en/datasets/detect/roboflow-100.md` as a self-contained script that uses the new `model.train(data=[...])` system (no more stdout log-scraping).

## Testing

- New `test_train_multi` (gated on `ONLINE`, skipped on edge devices).
- Verified the single-dataset `train`/`val` paths are unchanged (still return their task metrics objects).
- `ruff` clean; reference docs regenerated.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR adds built-in multi-dataset training support, making it easier to fine-tune one YOLO model across many datasets in a single `model.train()` call.

### 📊 Key Changes
- Added a new `MultiTrainer` class that automatically runs when `data` is passed as a list or tuple to `model.train()`.
- Updated `YOLO.train()` to return a `{dataset: metrics}` dictionary for multi-dataset runs, instead of only single-run metrics.
- Grouped all multi-dataset outputs under one `runs/<task>/multitrain/` directory, including:
  - per-dataset subfolders
  - `multitrain_results.json`
  - `multitrain_results.png` 📈
- Added automatic summary plotting with a new `plot_multitrain_results()` utility.
- Improved distributed training behavior so training metrics are now recovered from checkpoints when needed, ensuring results are returned more reliably on DDP/GPU setups ✅
- Added `normalize_platform_uri()` so pasted Ultralytics Platform web URLs are automatically converted to `ul://` URIs.
- Updated dataset loading utilities so Platform dataset/model URLs work directly in training inputs.
- Removed the older `RF100Benchmark` utility and replaced its docs with a simpler workflow based on standard `YOLO.train()` usage.
- Refreshed documentation and tests to cover:
  - multi-dataset training
  - direct Platform URL support
  - new result-saving behavior

### 🎯 Purpose & Impact
- Makes large benchmark or dataset-sweep workflows much simpler by replacing custom scripts with one training call ⚡
- Helps users evaluate a base model across many datasets consistently, with each run starting from the same initial weights.
- Improves usability for Roboflow 100-style experiments by providing built-in aggregation, visualization, and machine-readable results.
- Reduces friction when using the [Ultralytics Platform](https://platform.ultralytics.com) by allowing users to paste dataset or model URLs directly 🌐
- Improves reliability for multi-GPU training by ensuring metrics are returned even in distributed setups.
- Overall, this change makes cross-dataset experimentation more automated, organized, and accessible for both researchers and everyday users 🎯