### PR TITLE
fix(docs): resolve duplicate title tags on Roboflow and dataset overview pages

### DIFF
--- a/docs/en/datasets/pose/index.md
+++ b/docs/en/datasets/pose/index.md
@@ -2,6 +2,7 @@
 comments: true
 description: Learn about Ultralytics YOLO format for pose estimation datasets, supported formats, COCO-Pose, COCO8-Pose, Tiger-Pose, and how to add your own dataset.
 keywords: pose estimation, Ultralytics, YOLO format, COCO-Pose, COCO8-Pose, Tiger-Pose, dataset conversion, keypoints
+title: Pose Estimation Datasets
 ---
 
 # Pose Estimation Datasets Overview

--- a/docs/en/datasets/segment/index.md
+++ b/docs/en/datasets/segment/index.md
@@ -2,6 +2,7 @@
 comments: true
 description: Explore the supported dataset formats for Ultralytics YOLO and learn how to prepare and use datasets for training object segmentation models.
 keywords: Ultralytics, YOLO, instance segmentation, dataset formats, auto-annotation, COCO, segmentation models, training data
+title: Instance Segmentation Datasets
 ---
 
 # Instance Segmentation Datasets Overview

--- a/docs/en/datasets/semantic/index.md
+++ b/docs/en/datasets/semantic/index.md
@@ -2,6 +2,7 @@
 comments: true
 description: Learn how to prepare semantic segmentation datasets for Ultralytics YOLO, including PNG mask labels, dataset YAML fields, ignore labels, and supported datasets.
 keywords: Ultralytics, YOLO, semantic segmentation, semantic, dataset format, pixel masks, Cityscapes, ADE20K, Pascal VOC
+title: Semantic Segmentation Datasets
 ---
 
 # Semantic Segmentation Datasets Overview

--- a/docs/en/datasets/track/index.md
+++ b/docs/en/datasets/track/index.md
@@ -2,6 +2,7 @@
 comments: true
 description: Learn how to use Multi-Object Tracking with YOLO. Explore dataset formats, tracking algorithms, and implementation examples using Python or CLI for real-time object tracking.
 keywords: YOLO, Multi-Object Tracking, Tracking Datasets, Python Tracking Example, CLI Tracking Example, Object Detection, Ultralytics, AI, Machine Learning, BoT-SORT, ByteTrack, OC-SORT, Deep OC-SORT, FastTracker, TrackTrack
+title: Multi-Object Tracking Datasets
 ---
 
 # Multi-object Tracking Datasets Overview

--- a/docs/en/integrations/roboflow.md
+++ b/docs/en/integrations/roboflow.md
@@ -1,8 +1,8 @@
 ---
-title: Roboflow Integration
 comments: true
 description: Learn how to label data and export datasets in YOLO format using Roboflow for training Ultralytics models.
 keywords: Roboflow, Ultralytics YOLO, data labeling, computer vision, dataset export
+title: Roboflow Data Labeling for YOLO
 ---
 
 # Roboflow

--- a/docs/en/platform/integrations/roboflow.md
+++ b/docs/en/platform/integrations/roboflow.md
@@ -2,6 +2,7 @@
 comments: true
 description: Import every dataset from your Roboflow workspace into Ultralytics Platform with a single API key.
 keywords: Ultralytics Platform, Roboflow, Roboflow import, dataset import, integrations, YOLO, computer vision
+title: Roboflow Dataset Import - Ultralytics Platform
 ---
 
 # Roboflow Integration


### PR DESCRIPTION
## Summary

- **Roboflow**: `/integrations/roboflow` and `/platform/integrations/roboflow` shared identical title tags across all languages. Differentiated by content focus — data labeling vs dataset import into Ultralytics Platform
- **Datasets**: `/datasets/pose`, `/datasets/semantic`, `/datasets/track`, `/datasets/segment` index pages produced identical translated title tags because the shared long prefix hit the 60-char truncation ceiling before the distinguishing task-type word. Explicit short titles keep each page unique across all locales
- H1s are unchanged on all 6 pages

## Test plan

- [ ] Verify title tags are distinct per page in English
- [ ] Confirm H1s unchanged on all 6 pages
- [ ] After next SEMrush crawl, confirm duplicate title flag cleared for all 28 affected URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes duplicate or unclear documentation page titles by adding or updating frontmatter `title` fields across several dataset overview and Roboflow integration pages. 📝

### 📊 Key Changes
- Added explicit `title` metadata to dataset overview pages for:
  - `docs/en/datasets/pose/index.md`
  - `docs/en/datasets/segment/index.md`
  - `docs/en/datasets/semantic/index.md`
  - `docs/en/datasets/track/index.md`
- Updated the title in `docs/en/integrations/roboflow.md` from a generic integration name to a more specific page title.
- Added a missing title to `docs/en/platform/integrations/roboflow.md` for the Ultralytics Platform Roboflow import page.
- Aligns page metadata more closely with on-page content and page intent.

### 🎯 Purpose & Impact
- Improves docs SEO and page metadata consistency by preventing duplicate or overly generic title tags. 🔎
- Helps users better distinguish dataset overview pages and Roboflow-related pages in search results and browser tabs.
- Reduces ambiguity between general Roboflow docs and Ultralytics Platform-specific Roboflow import documentation.
- Low-risk documentation-only change with no package or runtime impact. ✅