### PR TITLE
Document embed argument persistence on the reused predictor

### DIFF
--- a/docs/en/modes/predict.md
+++ b/docs/en/modes/predict.md
@@ -396,6 +396,10 @@ Below are code examples for using each source type:
 
 `model.predict()` accepts multiple arguments that can be passed at inference time to override defaults:
 
+!!! note "Arguments persist on the reused predictor"
+
+    A loaded `model` reuses a single predictor across calls, so an argument you pass once stays in effect on later calls until you explicitly override it. This is easy to overlook with `model.embed()`, which is shorthand for `model.predict(embed=[...])`: after you call it, subsequent `model.predict()` calls keep returning embedding tensors instead of [`Results`](#working-with-results) objects. Pass `embed=None` to restore normal predictions.
+
 ### Fixed shape vs minimum rectangle (`rect`)
 
 By default, predict uses **`rect=True`**, which enables **minimum-rectangle** padding when possible. The image is scaled to fit inside `imgsz` and padded only to the nearest stride multiple, so the final tensor may be **smaller** than `imgsz`. Minimum-rectangle padding is only used when **all images in the batch have the same shape** and the backend supports it (PyTorch `.pt`, or dynamic ONNX / Triton). Otherwise, images are padded to the **full** `imgsz` target.


### PR DESCRIPTION
## summary

a loaded model reuses one predictor across calls, so `model.embed()` (shorthand for `predict(embed=[...])`) leaves `embed` set and later `model.predict()` calls return embedding tensors instead of `Results`. this adds a note to the inference-arguments section explaining the behavior and that `embed=None` restores normal predictions.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR adds a documentation note clarifying that prediction arguments can persist across reused predictors, especially when using `model.embed()`.

### 📊 Key Changes
- Added a new note to the [prediction mode documentation](https://docs.ultralytics.com/modes/predict/) explaining that a loaded model reuses the same predictor across inference calls.
- Clarified that arguments passed once to `model.predict()` may remain active in later calls unless explicitly changed.
- Highlighted a specific gotcha with `model.embed()`, which internally uses `model.predict(embed=[...])`.
- Documented that after calling `model.embed()`, later `model.predict()` calls may keep returning embedding tensors instead of normal `Results` objects.
- Added guidance to reset this behavior by passing `embed=None` in a later prediction call.

### 🎯 Purpose & Impact
- Helps users avoid confusing inference behavior 🔍 when predictions unexpectedly return embeddings instead of standard detection results.
- Improves developer awareness of how predictor state is reused across calls, making debugging easier 🛠️.
- Reduces the chance of accidental misuse of `model.embed()` in workflows that later switch back to normal prediction.
- Makes Ultralytics docs clearer and more practical for both new and experienced users 📚.