### PR TITLE
Complete Google-style docstrings for NumPy helper functions

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -734,7 +734,15 @@ def linear_sum_assignment(cost_matrix):
 
 
 def _linear_sum_assignment_numpy(a):
-    """NumPy Jonker-Volgenant fallback for `linear_sum_assignment` when SciPy is not installed."""
+    """Solve the rectangular linear sum assignment problem with NumPy (Jonker-Volgenant SciPy-free fallback).
+
+    Args:
+        a (np.ndarray): Cost matrix of shape (N, M) with dtype float64 and finite values.
+
+    Returns:
+        row_ind (np.ndarray): Row indices of the optimal assignment, sorted ascending, with length min(N, M).
+        col_ind (np.ndarray): Column indices matched to each row in row_ind.
+    """
     n, m = a.shape
     if n == 0 or m == 0:
         return np.empty(0, dtype=np.intp), np.empty(0, dtype=np.intp)

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -19,7 +19,16 @@ from ultralytics.utils.files import increment_path
 
 
 def _gaussian_filter1d(y, sigma: int = 3, truncate: float = 4.0) -> np.ndarray:
-    """Smooth a 1D array with a Gaussian kernel (NumPy replacement for scipy.ndimage.gaussian_filter1d)."""
+    """Smooth a 1D array with a Gaussian kernel (NumPy replacement for scipy.ndimage.gaussian_filter1d).
+
+    Args:
+        y (np.ndarray): Input 1D array to smooth.
+        sigma (int): Standard deviation of the Gaussian kernel.
+        truncate (float): Truncate the kernel at this many standard deviations.
+
+    Returns:
+        (np.ndarray): Smoothed 1D array with the same length as the input.
+    """
     y = np.asarray(y, dtype=float)
     radius = int(truncate * sigma + 0.5)
     kernel = np.exp(-0.5 * (np.arange(-radius, radius + 1) / sigma) ** 2)


### PR DESCRIPTION
Add proper Args/Returns sections to the two private NumPy helpers introduced in #24927 (`_linear_sum_assignment_numpy`, `_gaussian_filter1d`), which previously had one-line docstrings only.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves internal code documentation for two SciPy-free NumPy fallback utilities, making them easier to understand, maintain, and use correctly.

### 📊 Key Changes
- Added a more detailed docstring to `_linear_sum_assignment_numpy()` in `ultralytics/utils/ops.py`.
- Clarified that `_linear_sum_assignment_numpy()` solves the rectangular linear assignment problem using a NumPy-based Jonker-Volgenant fallback when SciPy is unavailable.
- Documented the expected input format for the assignment function, including matrix shape, data type, and valid values.
- Added clearer return value descriptions for the row and column index outputs of the assignment function.
- Expanded the docstring for `_gaussian_filter1d()` in `ultralytics/utils/plotting.py`.
- Documented the input array, `sigma`, `truncate`, and the function’s output shape for the Gaussian smoothing utility.

### 🎯 Purpose & Impact
- Improves developer clarity 🧠 by explaining exactly what these helper functions expect and return.
- Makes maintenance easier 🔧, especially for contributors working on NumPy-only fallback paths.
- Reduces misuse risk ✅ by documenting input requirements more explicitly.
- Has no expected effect on model accuracy, speed, or user-facing behavior 🚀—this is a documentation-quality improvement only.
- Helps keep Ultralytics codebase more approachable for contributors and advanced users exploring internals 📚