### PR TITLE
Deduplicate tracker Kalman update and box helpers

### DIFF
--- a/docs/en/reference/trackers/track_tracker.md
+++ b/docs/en/reference/trackers/track_tracker.md
@@ -20,10 +20,6 @@ keywords: Ultralytics, TrackTrack, TTSTrack, HMIoU, iterative assignment, Track-
 
 <br><br><hr><br>
 
-## ::: ultralytics.trackers.track_tracker._nsa_kalman_update
-
-<br><br><hr><br>
-
 ## ::: ultralytics.trackers.track_tracker._hmiou_distance
 
 <br><br><hr><br>

--- a/ultralytics/trackers/deep_oc_sort.py
+++ b/ultralytics/trackers/deep_oc_sort.py
@@ -139,7 +139,7 @@ class DeepOCSortTrack(OCSortTrack):
             if stracks[i].last_observation[0] >= 0:
                 obs = stracks[i].last_observation
                 # Transform xyxy observation centers
-                cx, cy = (obs[0] + obs[2]) / 2, (obs[1] + obs[3]) / 2
+                cx, cy = DeepOCSortTrack._xyxy_center(obs)
                 w, h = obs[2] - obs[0], obs[3] - obs[1]
                 new_c = R @ np.array([cx, cy]) + t
                 stracks[i].last_observation = np.array(

--- a/ultralytics/trackers/oc_sort.py
+++ b/ultralytics/trackers/oc_sort.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import numpy as np
 
+from ..utils.ops import xyxy2ltwh
 from .basetrack import TrackState
 from .byte_tracker import BYTETracker, STrack
 from .utils import matching
@@ -155,15 +156,7 @@ class OCSortTrack(STrack):
             alpha = t / gap
             virtual_xyxy = (1 - alpha) * last_obs + alpha * new_observation_xyxy
             # Convert xyxy to tlwh then to xyah for Kalman measurement
-            virtual_tlwh = np.array(
-                [
-                    virtual_xyxy[0],
-                    virtual_xyxy[1],
-                    virtual_xyxy[2] - virtual_xyxy[0],
-                    virtual_xyxy[3] - virtual_xyxy[1],
-                ]
-            )
-            virtual_xyah = self.tlwh_to_xyah(virtual_tlwh)
+            virtual_xyah = self.tlwh_to_xyah(xyxy2ltwh(virtual_xyxy))
             self.mean, self.covariance = self.kalman_filter.predict(self.mean, self.covariance)
             self.mean, self.covariance = self.kalman_filter.update(self.mean, self.covariance, virtual_xyah)
 

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -27,24 +27,6 @@ _LOOSE_NMS_IOU = 0.95  # looser NMS IoU used to recover detections the tight NMS
 _LOOSE_NMS_DEDUP_IOU = 0.97  # IoU threshold to consider duplicate detections as "new"
 
 
-def _nsa_kalman_update(
-    kf: KalmanFilterXYWH, mean: np.ndarray, covariance: np.ndarray, measurement: np.ndarray, confidence: float
-) -> tuple[np.ndarray, np.ndarray]:
-    """Run a NSA-Kalman update (StrongSORT) that scales the measurement noise by (1 - confidence)."""
-    w = max(1.0 - float(confidence), 0.05)
-    std = kf._std_weight_position * mean[2:4]
-    R = np.diag(np.square(np.r_[std, std])) * w
-    H = kf._update_mat
-    projected_mean = H @ mean
-    projected_cov = np.linalg.multi_dot((H, covariance, H.T)) + R
-
-    gain = np.linalg.solve(projected_cov, np.dot(covariance, H.T).T).T
-    innovation = measurement - projected_mean
-    new_mean = mean + innovation @ gain.T
-    new_cov = covariance - np.linalg.multi_dot((gain, projected_cov, gain.T))
-    return new_mean, new_cov
-
-
 def _hmiou_distance(tracks_a: list[TTSTrack], tracks_b: list[TTSTrack]) -> tuple[np.ndarray, np.ndarray]:
     """Return (iou_sim, 1 - HMIoU) where HMIoU = HIoU * IoU and HIoU is vertical-overlap / vertical-union."""
     n, m = len(tracks_a), len(tracks_b)
@@ -296,8 +278,8 @@ class TTSTrack(BOTrack):
     def re_activate(self, new_track, frame_id: int, new_id: bool = False) -> None:
         """Rebind a lost track to a fresh detection via NSA-Kalman."""
         self.prev_score = self.score
-        self.mean, self.covariance = _nsa_kalman_update(
-            self.kalman_filter, self.mean, self.covariance, self.convert_coords(new_track.tlwh), new_track.score
+        self.mean, self.covariance = self.kalman_filter.update(
+            self.mean, self.covariance, self.convert_coords(new_track.tlwh), confidence=new_track.score
         )
         self._history.append((frame_id, self.xyxy.copy()))
         self.score = new_track.score  # set before update_features so the EMA weight uses the current confidence
@@ -316,8 +298,8 @@ class TTSTrack(BOTrack):
         self.frame_id = frame_id
         self.tracklet_len += 1
         self.prev_score = self.score
-        self.mean, self.covariance = _nsa_kalman_update(
-            self.kalman_filter, self.mean, self.covariance, self.convert_coords(new_track.tlwh), new_track.score
+        self.mean, self.covariance = self.kalman_filter.update(
+            self.mean, self.covariance, self.convert_coords(new_track.tlwh), confidence=new_track.score
         )
         self._history.append((frame_id, new_track.xyxy.copy()))
 

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -132,8 +132,8 @@ class KalmanFilterXYAH:
         Args:
             mean (np.ndarray): The state's mean vector (8 dimensional array).
             covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
-            confidence (float, optional): Detection confidence; when set, scales measurement noise by
-                max(1 - confidence, 0.05) (NSA-Kalman).
+            confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
+                confidence, 0.05) (NSA-Kalman).
 
         Returns:
             mean (np.ndarray): Projected mean of the given state estimate.
@@ -209,8 +209,8 @@ class KalmanFilterXYAH:
             covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
             measurement (np.ndarray): The 4 dimensional measurement vector (x, y, a, h), where (x, y) is the center
                 position, a the aspect ratio, and h the height of the bounding box.
-            confidence (float, optional): Detection confidence; when set, scales measurement noise by
-                max(1 - confidence, 0.05) (NSA-Kalman).
+            confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
+                confidence, 0.05) (NSA-Kalman).
 
         Returns:
             new_mean (np.ndarray): Measurement-corrected state mean.
@@ -400,8 +400,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
         Args:
             mean (np.ndarray): The state's mean vector (8 dimensional array).
             covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
-            confidence (float, optional): Detection confidence; when set, scales measurement noise by
-                max(1 - confidence, 0.05) (NSA-Kalman).
+            confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
+                confidence, 0.05) (NSA-Kalman).
 
         Returns:
             mean (np.ndarray): Projected mean of the given state estimate.
@@ -477,8 +477,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
             covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
             measurement (np.ndarray): The 4 dimensional measurement vector (x, y, w, h), where (x, y) is the center
                 position, w the width, and h the height of the bounding box.
-            confidence (float, optional): Detection confidence; when set, scales measurement noise by
-                max(1 - confidence, 0.05) (NSA-Kalman).
+            confidence (float, optional): Detection confidence; when set, scales measurement noise by max(1 -
+                confidence, 0.05) (NSA-Kalman).
 
         Returns:
             new_mean (np.ndarray): Measurement-corrected state mean.

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -1,5 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+from __future__ import annotations
+
 import numpy as np
 
 
@@ -124,12 +126,14 @@ class KalmanFilterXYAH:
 
         return mean, covariance
 
-    def project(self, mean: np.ndarray, covariance: np.ndarray):
+    def project(self, mean: np.ndarray, covariance: np.ndarray, confidence: float | None = None):
         """Project state distribution to measurement space.
 
         Args:
             mean (np.ndarray): The state's mean vector (8 dimensional array).
             covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
+            confidence (float, optional): Detection confidence; when set, scales measurement noise by
+                max(1 - confidence, 0.05) (NSA-Kalman).
 
         Returns:
             mean (np.ndarray): Projected mean of the given state estimate.
@@ -148,6 +152,8 @@ class KalmanFilterXYAH:
             self._std_weight_position * mean[3],
         ]
         innovation_cov = np.diag(np.square(std))
+        if confidence is not None:  # NSA-Kalman: scale measurement noise by detection confidence (StrongSORT)
+            innovation_cov *= max(1.0 - float(confidence), 0.05)
 
         mean = np.dot(self._update_mat, mean)
         covariance = np.linalg.multi_dot((self._update_mat, covariance, self._update_mat.T))
@@ -193,7 +199,9 @@ class KalmanFilterXYAH:
 
         return mean, covariance
 
-    def update(self, mean: np.ndarray, covariance: np.ndarray, measurement: np.ndarray):
+    def update(
+        self, mean: np.ndarray, covariance: np.ndarray, measurement: np.ndarray, confidence: float | None = None
+    ):
         """Run Kalman filter correction step.
 
         Args:
@@ -201,6 +209,8 @@ class KalmanFilterXYAH:
             covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
             measurement (np.ndarray): The 4 dimensional measurement vector (x, y, a, h), where (x, y) is the center
                 position, a the aspect ratio, and h the height of the bounding box.
+            confidence (float, optional): Detection confidence; when set, scales measurement noise by
+                max(1 - confidence, 0.05) (NSA-Kalman).
 
         Returns:
             new_mean (np.ndarray): Measurement-corrected state mean.
@@ -213,7 +223,7 @@ class KalmanFilterXYAH:
             >>> measurement = np.array([1, 1, 1, 1])
             >>> new_mean, new_covariance = kf.update(mean, covariance, measurement)
         """
-        projected_mean, projected_cov = self.project(mean, covariance)
+        projected_mean, projected_cov = self.project(mean, covariance, confidence)
 
         kalman_gain = np.linalg.solve(projected_cov, np.dot(covariance, self._update_mat.T).T).T
         innovation = measurement - projected_mean
@@ -384,12 +394,14 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
 
         return mean, covariance
 
-    def project(self, mean: np.ndarray, covariance: np.ndarray):
+    def project(self, mean: np.ndarray, covariance: np.ndarray, confidence: float | None = None):
         """Project state distribution to measurement space.
 
         Args:
             mean (np.ndarray): The state's mean vector (8 dimensional array).
             covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
+            confidence (float, optional): Detection confidence; when set, scales measurement noise by
+                max(1 - confidence, 0.05) (NSA-Kalman).
 
         Returns:
             mean (np.ndarray): Projected mean of the given state estimate.
@@ -408,6 +420,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
             self._std_weight_position * mean[3],
         ]
         innovation_cov = np.diag(np.square(std))
+        if confidence is not None:  # NSA-Kalman: scale measurement noise by detection confidence (StrongSORT)
+            innovation_cov *= max(1.0 - float(confidence), 0.05)
 
         mean = np.dot(self._update_mat, mean)
         covariance = np.linalg.multi_dot((self._update_mat, covariance, self._update_mat.T))
@@ -453,7 +467,9 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
 
         return mean, covariance
 
-    def update(self, mean: np.ndarray, covariance: np.ndarray, measurement: np.ndarray):
+    def update(
+        self, mean: np.ndarray, covariance: np.ndarray, measurement: np.ndarray, confidence: float | None = None
+    ):
         """Run Kalman filter correction step.
 
         Args:
@@ -461,6 +477,8 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
             covariance (np.ndarray): The state's covariance matrix (8x8 dimensional).
             measurement (np.ndarray): The 4 dimensional measurement vector (x, y, w, h), where (x, y) is the center
                 position, w the width, and h the height of the bounding box.
+            confidence (float, optional): Detection confidence; when set, scales measurement noise by
+                max(1 - confidence, 0.05) (NSA-Kalman).
 
         Returns:
             new_mean (np.ndarray): Measurement-corrected state mean.
@@ -473,4 +491,4 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
             >>> measurement = np.array([0.5, 0.5, 1.2, 1.2])
             >>> new_mean, new_covariance = kf.update(mean, covariance, measurement)
         """
-        return super().update(mean, covariance, measurement)
+        return super().update(mean, covariance, measurement, confidence)

--- a/ultralytics/trackers/utils/kalman_filter.py
+++ b/ultralytics/trackers/utils/kalman_filter.py
@@ -491,4 +491,4 @@ class KalmanFilterXYWH(KalmanFilterXYAH):
             >>> measurement = np.array([0.5, 0.5, 1.2, 1.2])
             >>> new_mean, new_covariance = kf.update(mean, covariance, measurement)
         """
-        return super().update(mean, covariance, measurement, confidence)
+        return super().update(mean, covariance, measurement, confidence=confidence)


### PR DESCRIPTION
## Summary

Deduplicates the clearest copy-paste in the recently-added trackers (#24371), guided by the repo's "Delete > Replace > Add / less is more" principles.

## Changes

- **NSA-Kalman update** — delete `track_tracker._nsa_kalman_update` (a 17-line copy of the standard Kalman update with the measurement noise scaled by `max(1 - confidence, 0.05)`) and fold it into an optional `confidence` argument threaded through `KalmanFilter.project`/`update`. Default is a no-op, so **ByteTrack / BoT-SORT / OC-SORT are byte-for-byte unchanged** (verified `0.00e+00` diff on both paths); TrackTrack now calls `kalman_filter.update(..., confidence=score)`.
- **OC-SORT `apply_oru`** — replace the inline `virtual_tlwh = np.array([x1, y1, x2-x1, y2-y1])` build with the existing `ops.xyxy2ltwh`.
- **Deep OC-SORT `multi_gmc`** — reuse `OCSortTrack._xyxy_center` instead of recomputing the box center inline (using the class reference, since `multi_gmc` is a `@staticmethod`).

## Validation
- NSA-Kalman: new `update(confidence=score)` is bit-identical to the old `_nsa_kalman_update` over 20k random states; the no-confidence path is bit-identical to the old standard update.
- All six tracker variants (bytetrack, botsort, ocsort, deepocsort, fasttrack, tracktrack) run clean; ruff check/format pass.

## Considered but intentionally not done (per "three similar lines beat a premature abstraction")
The dedup audit surfaced a few more candidates that I left alone after weighing them against the principles:
- `_cosine_distance` vs `matching.embedding_distance`, and `_fuse_appearance` vs BoT-SORT's min-fuse — genuine near-copies, but folding them adds 2+ parameters and branching to a *shared* function used by other trackers (NaN-vs-2.0 sentinel, feature-selector, norm-division differences), trading a modest deletion for real regression risk.
- The `update_features` EMA tail and the corner-displacement kernel are only ~3 trivial lines each; a shared helper would *add* net lines.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR streamlines Ultralytics tracking internals by moving confidence-aware Kalman updates into the shared filter code, simplifying box conversions, and removing outdated tracker docs 🧹📦

### 📊 Key Changes
- Refactored NSA-Kalman tracking logic in `track_tracker.py`:
  - Removed the local `_nsa_kalman_update()` helper.
  - Replaced it with direct calls to `kalman_filter.update(..., confidence=...)`.
- Extended shared Kalman filter utilities in `ultralytics/trackers/utils/kalman_filter.py`:
  - Added optional `confidence` support to `project()` and `update()`.
  - Built confidence-based measurement noise scaling directly into the core Kalman filter implementation.
  - Applied this update to both Kalman filter variants used by trackers.
- Simplified bounding box handling in trackers:
  - `deep_oc_sort.py` now uses `DeepOCSortTrack._xyxy_center(obs)` instead of manually computing box centers.
  - `oc_sort.py` now uses the shared `xyxy2ltwh` utility instead of manually converting box formats.
- Cleaned up documentation:
  - Removed the docs reference for the deleted `_nsa_kalman_update` internal function from `docs/en/reference/trackers/track_tracker.md` 📚

### 🎯 Purpose & Impact
- Improves maintainability by centralizing tracking update logic in one place, making the codebase easier to understand and extend 🔧
- Reduces duplication and lowers the chance of inconsistencies between tracker implementations.
- Keeps confidence-aware tracking behavior intact while making it reusable across trackers 🎯
- Makes box conversion code cleaner and less error-prone by relying on shared helper functions.
- Helps documentation stay accurate by removing references to internals that no longer exist ✅