### PR TITLE
Fix NaN OBB loss due to sub-stride boxes

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1040,6 +1040,9 @@ class v8OBBLoss(v8DetectionLoss):
             targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
             gt_labels, gt_bboxes = targets.split((1, 5), 2)  # cls, xywhr
             mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0.0)
+            gt_bboxes[..., 2:4] = torch.where(  # floor sub-stride sizes to keep ProbIoU targets well-conditioned
+                (gt_bboxes[..., 2:4] < self.stride[0]) & mask_gt.bool(), self.stride[1], gt_bboxes[..., 2:4]
+            )
         except RuntimeError as e:
             raise TypeError(
                 "ERROR ❌ OBB dataset incorrectly formatted or not a OBB dataset.\n"

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1040,11 +1040,8 @@ class v8OBBLoss(v8DetectionLoss):
             targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
             gt_labels, gt_bboxes = targets.split((1, 5), 2)  # cls, xywhr
             mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0.0)
-            gt_bboxes[..., 2:4] = torch.where(  # floor sub-stride sizes to keep ProbIoU targets well-conditioned
-                (gt_bboxes[..., 2:4] < self.stride[0]) & mask_gt.bool(),
-                self.assigner.stride_val,
-                gt_bboxes[..., 2:4],
-            )
+            wh = gt_bboxes[..., 2:4]
+            wh.masked_fill_((wh < self.stride[0]) & mask_gt.bool(), self.assigner.stride_val)
         except RuntimeError as e:
             raise TypeError(
                 "ERROR ❌ OBB dataset incorrectly formatted or not a OBB dataset.\n"

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1041,7 +1041,9 @@ class v8OBBLoss(v8DetectionLoss):
             gt_labels, gt_bboxes = targets.split((1, 5), 2)  # cls, xywhr
             mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0.0)
             gt_bboxes[..., 2:4] = torch.where(  # floor sub-stride sizes to keep ProbIoU targets well-conditioned
-                (gt_bboxes[..., 2:4] < self.stride[0]) & mask_gt.bool(), self.stride[1], gt_bboxes[..., 2:4]
+                (gt_bboxes[..., 2:4] < self.stride[0]) & mask_gt.bool(),
+                self.assigner.stride_val,
+                gt_bboxes[..., 2:4],
             )
         except RuntimeError as e:
             raise TypeError(


### PR DESCRIPTION
Closes #24920 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves OBB training stability by preventing extremely small ground-truth box sizes from causing poor label assignment during loss calculation.

### 📊 Key Changes
- Added a safeguard in `ultralytics/utils/loss.py` for oriented bounding box (OBB) training.
- Extracts the width and height values from ground-truth OBB boxes during loss preprocessing.
- Replaces very small width/height values—specifically those smaller than the model stride—with a fallback stride-based value.
- Applies this adjustment only to valid ground-truth boxes, leaving empty or invalid targets unchanged.

### 🎯 Purpose & Impact
- 📉 Reduces issues caused by tiny OBB annotations during training.
- 🎯 Helps the assigner handle very small objects more reliably, which can improve target matching.
- 🔒 Makes OBB loss computation more robust and less prone to instability from edge-case labels.
- 🚀 Likely improves training behavior for datasets containing tiny rotated objects, especially in dense or high-detail scenes.