### PR TITLE
Axelera Voyager SDK 1.7.0 upgrade and refresh examples 

### DIFF
--- a/docs/en/integrations/axelera.md
+++ b/docs/en/integrations/axelera.md
@@ -123,17 +123,21 @@ For detailed instructions, see our [Ultralytics Installation guide](../quickstar
 
     ```bash
     sudo apt update
-    sudo apt install -y metis-dkms=1.4.16
+    sudo apt install -y metis-dkms=1.5.5
     sudo modprobe metis
     ```
+
+!!! note "Keep the driver in sync with the SDK"
+
+    The kernel driver installed above is separate from the Python SDK packages. When you upgrade the SDK (for example 1.6 to 1.7), install the matching driver version too — a driver out of sync with the runtime shows up as a runtime error. Run `axdevice` (see [Device Health Check](#device-health-check)) to check the installed driver and device status.
 
 !!! tip "First run downloads the SDK automatically"
 
     The first `yolo export format=axelera` or `yolo predict` with an Axelera model will automatically download and install the Axelera SDK packages. This may take several minutes depending on your connection speed, and no progress is shown during the download. To install manually beforehand:
 
     ```bash
-    pip install axelera-devkit==1.6.0 --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
-    pip install axelera-rt==1.6.0 --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
+    pip install axelera-devkit==1.7.0 --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
+    pip install axelera-rt==1.7.0 --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
     ```
 
 ## Exporting YOLO Models to Axelera
@@ -268,7 +272,7 @@ Verify your Axelera device is functioning properly:
 axdevice
 ```
 
-For detailed diagnostics, see the [AxDevice documentation](https://github.com/axelera-ai-hub/voyager-sdk/blob/latest/docs/reference/tools/axdevice.md).
+For detailed diagnostics, see the [AxDevice documentation](https://docs.axelera.ai/sdk/reference/tools/axdevice/).
 
 ## Maximum Performance
 
@@ -278,7 +282,7 @@ This integration uses single-core configuration for compatibility. For productio
 - Streaming inference pipelines
 - Tiled inferencing for higher-resolution cameras
 
-See the [model-zoo](https://github.com/axelera-ai-hub/voyager-sdk/blob/latest/docs/reference/models/model-zoo.md) for FPS benchmarks or [contact Axelera](https://axelera.ai/contact-us) for production support.
+See the [model-zoo](https://docs.axelera.ai/sdk/reference/models/model-zoo) for FPS benchmarks or [contact Axelera](https://axelera.ai/contact-us) for production support.
 
 ## Known Issues
 

--- a/examples/YOLO-Axelera-Python/README.md
+++ b/examples/YOLO-Axelera-Python/README.md
@@ -1,52 +1,80 @@
 # Ultralytics YOLO on Axelera Voyager SDK
 
-This document explains how to build and run complete Ultralytics YOLO inference pipelines on Axelera Metis devices using the Axelera runtime.
+This document explains how to build and run complete Ultralytics YOLO inference
+pipelines on Axelera Metis devices using the Axelera runtime.
 
 The typical workflow has two phases:
 
 1. **Model preparation.** You use Ultralytics, PyTorch, and the Voyager SDK
    compiler to train, export, and compile your model to `.axm` format.
-2. **Application development.** You use `axelera-rt` to build and run an end-to-end video pipeline. `axelera-rt` is a lightweight, self-contained library with minimal package dependencies. It lets you describe pipelines that read frames from a camera, preprocess them, run model inference, and postprocess the results. The runtime can also fuse pipeline stages together automatically to minimize computation and data transfers.
+2. **Application development.** You use `axelera-rt` to build and run an
+   end-to-end video pipeline. `axelera-rt` is a lightweight, self-contained
+   library with minimal package dependencies. It lets you describe pipelines
+   that read frames from a camera, preprocess them, run model inference, and
+   postprocess the results. The runtime can also fuse pipeline stages together
+   automatically to minimize computation and data transfers.
 
 A pipeline looks like this:
 
 ```python
 pipeline = op.seq(
-    op.colorconvert("RGB", src="BGR"),  # OpenCV reads BGR; models expect RGB
+    op.color_convert("RGB", src="BGR"),  # OpenCV reads BGR; models expect RGB
     op.letterbox(640, 640),
-    op.totensor(),
+    op.to_tensor(),
     op.load("yolo26n-pose.axm"),
     ConfidenceFilter(threshold=0.25),  # custom operator — see below
     op.to_image_space(keypoint_cols=range(6, 57, 3)),
 ).optimized()  # runtime fuses ops for maximum throughput
 
-poses = pipeline(frame)  # frame in, results out
+poses = pipeline(frame)  # frame in, raw (N, 57) NumPy array out — drops straight into existing post-processing
 ```
+
+Note that this example returns the model's raw NumPy rows rather than typed
+`Results` objects — see the two examples below.
 
 ## Examples
 
-Two examples are provided below. It should be straightforward to apply them to other models and tasks.
+The two examples take different approaches; pick whichever is closer to how you
+already work.
 
-| Script                   | Task                                                | Model                   | Description                                                                                                             |
-| ------------------------ | --------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `yolo26-pose-tracker.py` | Pose estimation with optional multi-object tracking | YOLO26n-pose (NMS-free) | Linear `op.seq()` pipeline with a custom operator and optional `op.tracker()`. Use `--tracker none` for pose-only mode. |
-| `yolo11-seg.py`          | Instance segmentation                               | YOLO11n-seg             | Branching with `op.par()` for multi-head models (detections + masks).                                                   |
+`yolo26-pose-tracker.py` keeps OpenCV for capture, drawing, and post-processing, and
+only runs the model (and, optionally, a tracker) through Axelera. The pose-only
+pipeline returns the model's raw NumPy rows, so it slots into NumPy post-processing
+you already have. Uses YOLO26 (NMS-free).
+
+`yolo11-seg.py` runs the whole pipeline through the runtime instead: hardware decode
+operators, typed `Results` objects, `cv.create_source()` for capture, and the
+`display.App` renderer, so there's no manual drawing code. Uses YOLO11 (its decode
+path is shared with YOLOv8).
+
+| Script                   | Task                       | Pipeline output                          | Capture / render                       |
+| ------------------------ | -------------------------- | ---------------------------------------- | -------------------------------------- |
+| `yolo26-pose-tracker.py` | Pose (+ optional tracking) | raw NumPy; `TrackedObject` when tracking | OpenCV `VideoCapture` + manual drawing |
+| `yolo11-seg.py`          | Instance segmentation      | typed `SegmentedObject`                  | `cv.create_source()` + `display.App`   |
+
+Tracking is the one runtime feature the first example opts into: `op.tracker()` needs
+typed objects, so the tracking path adds `op.ax_pose()` and yields `TrackedObject`;
+`--tracker none` skips that and stays raw NumPy.
 
 ## Quick Start
 
 ### Install
 
-If you followed the [Axelera integration guide](../../docs/en/integrations/axelera.md), `axelera-rt` is already installed — running `yolo predict` or `yolo val` with an Axelera model auto-installs the runtime dependencies. If you need to install manually:
+If you followed the
+[Axelera integration guide](../../docs/en/integrations/axelera.md), `axelera-rt`
+is already installed — running `yolo predict` or `yolo val` with an Axelera
+model auto-installs the runtime dependencies. If you need to install manually:
 
 ```bash
-pip install axelera-rt==1.6.0 --no-cache-dir --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
+pip install axelera-rt==1.7.0 --no-cache-dir --extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple
 ```
 
 You will also need `opencv-python` and `numpy` (likely already present).
 
 ### Compile
 
-Export and compile your trained model directly to Axelera format using the Ultralytics CLI:
+Export and compile your trained model directly to Axelera format using the
+Ultralytics CLI:
 
 ```bash
 yolo export model=your-model.pt format=axelera
@@ -60,10 +88,12 @@ yolo export model=yolo11n-seg.pt format=axelera
 ```
 
 The compiled models are saved to `yolo26n-pose_axelera_model/` and
-`yolo11n-seg_axelera_model/` respectively. Pass the `.axm` file inside to `--model`.
+`yolo11n-seg_axelera_model/` respectively. Pass the `.axm` file inside to
+`--model`.
 
-> [!NOTE]
-> Each model directory also contains `metadata.yaml` with the model's class names and configuration. You can load this info directly to avoid manual label entry in your own application.
+> [!NOTE] Each model directory also contains `metadata.yaml` with the model's
+> class names and configuration. You can load this info directly to avoid manual
+> label entry in your own application.
 
 ### Run
 
@@ -85,26 +115,43 @@ python yolo26-pose-tracker.py --model yolo26n-pose.axm --source 0 --tracker trac
 #### Instance Segmentation (Ultralytics YOLO11)
 
 ```bash
-python yolo11-seg.py --model yolo11n-seg.axm --source 0
-python yolo11-seg.py --model yolo11n-seg.axm --source video.mp4 --conf 0.3 --iou 0.5
+python yolo11-seg.py --model yolo11n-seg.axm --source 0                              # webcam
+python yolo11-seg.py --model yolo11n-seg.axm --source video.mp4 --conf 0.3 --iou 0.5 # display
+python yolo11-seg.py --model yolo11n-seg.axm --source video.mp4 --output out.mp4     # display + save video
+python yolo11-seg.py --model yolo11n-seg.axm --source video.mp4 --no-display         # headless (no save)
 ```
+
+> [!NOTE] `yolo11-seg.py` uses the runtime's `display.App` renderer and
+> `pipeline.stream()` instead of OpenCV display; results are drawn by the
+> built-in renderer with no manual drawing code. Use `--no-display` for headless
+> runs.
+>
+> Saving video (`--output`) has two limitations from the display backend:
+>
+> - It renders through the OpenCV display, so it requires a display and cannot
+>   be combined with `--no-display`.
+> - The saved video is written at the display window's canvas size (`800x500`),
+>   not the source's native resolution. Change the `create_window(...)` size in
+>   the script to write at a different resolution.
 
 ### Arguments
 
-| Argument    | Default      | Description                                                              |
-| ----------- | ------------ | ------------------------------------------------------------------------ |
-| `--model`   | _required_   | Path to compiled `.axm` model                                            |
-| `--source`  | `0`          | Image path, video path, or webcam index                                  |
-| `--conf`    | `0.25`       | Confidence threshold                                                     |
-| `--iou`     | `0.45`       | NMS IoU threshold _(segmentation only)_                                  |
-| `--tracker` | `tracktrack` | Tracking algorithm: `bytetrack`, `oc-sort`, `sort`, `tracktrack`, `none` |
+| Argument       | Default             | Scripts   | Description                                                                                                                                                      |
+| -------------- | ------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--model`      | _required_          | all       | Path to compiled `.axm` model                                                                                                                                    |
+| `--source`     | `0` (pose)          | all       | Image path, video path, or webcam index. _Required_ for `yolo11-seg.py`.                                                                                         |
+| `--conf`       | `0.25`              | pose, seg | Confidence threshold                                                                                                                                             |
+| `--iou`        | `0.45`              | seg       | NMS IoU threshold                                                                                                                                                |
+| `--tracker`    | `tracktrack`        | pose      | Tracking algorithm: `bytetrack`, `oc-sort`, `sort`, `tracktrack`, `none`                                                                                         |
+| `--no-display` | _off_               | all       | Disable the GUI window (headless mode)                                                                                                                           |
+| `--output`     | `output.mp4` (pose) | pose, seg | Output video path. Pose: written in headless mode (`--no-display`). Seg: off by default; renders via the display app, so cannot be combined with `--no-display`. |
 
 ## What You'll See in the Code
 
 ### Custom Operators
 
-The pipeline is fully composable — drop in your own operators anywhere in the sequence.
-Just subclass `op.Operator` and implement `__call__`:
+The pipeline is fully composable — drop in your own operators anywhere in the
+sequence. Just subclass `op.Operator` and implement `__call__`:
 
 ```python
 class ConfidenceFilter(op.Operator):
@@ -122,18 +169,71 @@ class ConfidenceFilter(op.Operator):
         return x[x[:, 4] >= self.threshold]
 ```
 
-This means they are fused, scheduled, and optimized alongside built-in ops like `op.letterbox` and the model itself — adding a custom filter carries no special overhead.
+This means they are fused, scheduled, and optimized alongside built-in ops like
+`op.letterbox` and the model itself — adding a custom filter carries no special
+overhead.
+
+### Video Sources (`cv.create_source`)
+
+`cv.create_source(path)` opens a `VideoSource`: an iterable of decoded `Image` frames
+that also exposes metadata (`fps`, `frame_count`) and works as a context manager. The
+path can be a video file, a folder of images, a USB camera (`/dev/video0`), or an
+RTSP/RTP/RTMP/SRT URL — live sources drop frames to stay real-time, while files block
+so none are skipped. Hand the source straight to `pipeline.stream()` to get pipelined
+`(image, result)` pairs in source order:
+
+```python
+from axelera.runtime import cv
+
+with cv.create_source("clip.mp4") as source:
+    print(source.fps, source.frame_count)  # available before iterating
+    for image, segments in pipeline.stream(source):
+        ...
+```
+
+`backend` (`"ffmpeg"` default, or `"opencv"`), `buffer_size`, and `live_source` are
+available when you need to tune decoding. `yolo11-seg.py` uses this for capture.
+
+### Rendering (`display.App`)
+
+`display.App(renderer=...)` runs the built-in renderer as a context manager:
+`"auto"` opens an OpenCV window when a display is available (and falls back to console
+output otherwise), `"none"` disables rendering for headless runs. Create a window with
+`create_window(title, size)` and push frames with `vis(image, result)` — typed
+`Results` objects render themselves via their `.draw()` method, so masks, boxes, poses,
+and tracks are drawn with no manual OpenCV code:
+
+```python
+from axelera.runtime import cv, display
+
+with display.App(renderer="auto") as app:
+    vis = app.create_window("segmentation", (800, 500))
+    with cv.create_source("clip.mp4") as source:
+        for image, segments in pipeline.stream(source):
+            if vis.is_closed:  # window closed by the user
+                break
+            vis(image, segments)  # SegmentedObject.draw() paints masks + boxes
+```
+
+Pass `expose_surface=True` to `create_window()` to enable `vis.save_output_video(path,
+fps)` for recording (OpenCV renderer only). `yolo11-seg.py` uses this for display and
+`--output`.
 
 ### Multi-Object Tracking
 
-Adding tracking to any detection or pose pipeline is a single line via `op.tracker()`:
+Adding tracking to a detection or pose pipeline is essentially a single line via
+`op.tracker()`. The tracker works on typed objects, so the pipeline must produce
+them (via `op.ax_pose()` / `op.ax_detection()`) before tracking:
 
 ```python
 pipeline = op.seq(
     # ... your detection or pose pipeline ...
-    op.tracker(algo="tracktrack"),  # one line adds tracking
+    op.ax_pose(num_keypoints=17, class_id_type=op.CocoClasses),  # raw rows -> list[PoseObject]
+    op.tracker(algo="tracktrack"),  # list[PoseObject] -> list[TrackedObject]
 )
 ```
+
+`tracktrack` is the default. Pass `--tracker` to select another algorithm:
 
 | Algorithm  | Key Strength                                         | Reference                |
 | ---------- | ---------------------------------------------------- | ------------------------ |
@@ -154,4 +254,5 @@ beyond these introductory examples: advanced pipeline patterns, ReID and
 appearance-based tracking, the high-performance display system, production-ready
 application templates, and the full API reference.
 
-Questions or feedback? Join the [Axelera community](https://community.axelera.ai/).
+Questions or feedback? Join the
+[Axelera community](https://community.axelera.ai/).

--- a/examples/YOLO-Axelera-Python/yolo11-seg.py
+++ b/examples/YOLO-Axelera-Python/yolo11-seg.py
@@ -5,147 +5,88 @@ YOLO11 Instance Segmentation with Axelera Voyager SDK.
 Standalone example using the axelera-rt pipeline API.
 No ultralytics dependency at runtime.
 
+Results are rendered by the built-in display app: each SegmentedObject draws its
+own mask overlay, bounding box, and label, so no hand-written drawing code is
+needed.
+
 Usage:
     python yolo11-seg.py --model yolo11n-seg.axm --source 0
     python yolo11-seg.py --model yolo11n-seg.axm --source video.mp4
+    python yolo11-seg.py --model yolo11n-seg.axm --source video.mp4 --no-display
+    python yolo11-seg.py --model yolo11n-seg.axm --source video.mp4 --output out.mp4
 """
 
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 
-import cv2
-import numpy as np
-from axelera.runtime import op
-
-# fmt: off
-COCO_NAMES = [
-    "person", "bicycle", "car", "motorcycle", "airplane", "bus", "train", "truck", "boat",
-    "traffic light", "fire hydrant", "stop sign", "parking meter", "bench", "bird", "cat",
-    "dog", "horse", "sheep", "cow", "elephant", "bear", "zebra", "giraffe", "backpack",
-    "umbrella", "handbag", "tie", "suitcase", "frisbee", "skis", "snowboard", "sports ball",
-    "kite", "baseball bat", "baseball glove", "skateboard", "surfboard", "tennis racket",
-    "bottle", "wine glass", "cup", "fork", "knife", "spoon", "bowl", "banana", "apple",
-    "sandwich", "orange", "broccoli", "carrot", "hot dog", "pizza", "donut", "cake", "chair",
-    "couch", "potted plant", "bed", "dining table", "toilet", "tv", "laptop", "mouse",
-    "remote", "keyboard", "cell phone", "microwave", "oven", "toaster", "sink", "refrigerator",
-    "book", "clock", "vase", "scissors", "teddy bear", "hair drier", "toothbrush",
-]
-# fmt: on
-
-# Deterministic per-class color palette (BGR)
-_rng = np.random.default_rng(42)
-CLASS_COLORS = _rng.integers(50, 230, size=(80, 3)).tolist()
+from axelera.runtime import cv, display, op
 
 
 def build_pipeline(model_path: str, conf: float = 0.25, iou: float = 0.45):
-    """Build YOLO11 instance segmentation pipeline.
+    """Build the YOLO11 instance segmentation pipeline.
 
-    Data flow:
-        decode_segmentation -> (detections, protos) as a tuple
-        par(itemgetter+nms, itemgetter) -> (filtered_dets, protos) unpacked
-        par(pack+itemgetter+to_image_space, proto_to_mask) -> (img_dets, masks)
-
-    Calls .optimized() so the runtime can fuse operators for maximum throughput.
+    The seg head emits two outputs (detections, prototypes), so post-processing splits the tuple, runs NMS on the
+    detections only, then recombines them with the decoded
+    masks. .optimized() lets the runtime fuse operators.
     """
-    model_op = op.load(model_path)
     return op.seq(
-        op.colorconvert("RGB", src="BGR"),  # OpenCV reads BGR; models expect RGB
+        op.color_convert("RGB", src="BGR"),  # OpenCV reads BGR; models expect RGB
         op.letterbox(640, 640),
-        op.totensor(),
-        model_op,
+        op.to_tensor(),
+        op.load(model_path),
+        # decode_segmentation outputs (detections, protos); NMS only touches detections
         op.decode_segmentation(algo="yolo11", num_classes=80, num_mask_coeffs=32, confidence_threshold=conf),
-        # decode_segmentation returns (detections, protos) as a tuple
         op.par(
-            op.seq(op.itemgetter(0), op.nms(iou_threshold=iou, max_boxes=300)),  # NMS on detections
-            op.itemgetter(1),  # pass protos through
+            op.seq(op.itemgetter(0), op.nms(iou_threshold=iou, max_boxes=300)),
+            op.itemgetter(1),
         ),
-        # par() unpacks its result, so the next par() receives (filtered_dets, protos) as two args
+        # par unpacks its tuple, so this par receives (dets, protos) and returns
+        # (rescaled dets, masks) for ax_segmentation
         op.par(
-            op.seq(op.pack(), op.itemgetter(0), op.to_image_space()),  # re-pack, extract dets, rescale
-            op.proto_to_mask(),  # (dets, protos) -> masks
+            op.seq(op.pack(), op.itemgetter(0), op.to_image_space()),
+            op.proto_to_mask(),
         ),
+        op.ax_segmentation(class_id_type=op.CocoClasses),
     ).optimized()
 
 
-def draw_segmentation(image: np.ndarray, detections: np.ndarray, masks: list, conf: float = 0.25) -> np.ndarray:
-    """Draw instance segmentation results on the image.
+def main(args):
+    """Run the YOLO11 segmentation pipeline over the source and render results via the display app."""
+    renderer = "none" if args.no_display else "auto"
+    # --output saves rendered frames via save_output_video(), which reads the surface
+    # frame sink — only the OpenCV renderer has one, so it can't run headless.
+    expose_surface = bool(args.output)
+    with display.App(renderer=renderer) as visualizer:
+        vis = visualizer.create_window("YOLO11 Segmentation", (800, 500), expose_surface=expose_surface)
+        pipeline = build_pipeline(args.model, args.conf, args.iou)
 
-    proto_to_mask() returns bbox-cropped masks at prototype resolution. Each mask must be resized to its detection's
-    bounding box and placed at the correct image coordinates.
-    """
-    overlay = image.copy()  # one copy for mask blending
-    h, w = image.shape[:2]
-
-    for i, det in enumerate(detections):
-        score = det[4]
-        if score < conf:
-            continue
-
-        class_id = int(det[5])
-        color = CLASS_COLORS[class_id % len(CLASS_COLORS)]
-        name = COCO_NAMES[class_id] if class_id < len(COCO_NAMES) else str(class_id)
-
-        # Bounding box (clipped to image bounds)
-        x0, y0, x1, y1 = map(int, det[:4])
-        x0, y0 = max(0, x0), max(0, y0)
-        x1, y1 = min(w, x1), min(h, y1)
-
-        # Semi-transparent mask overlay: resize bbox-cropped mask and place it
-        if i < len(masks):
-            mask = masks[i]
-            if mask.ndim == 2 and (x1 - x0) > 0 and (y1 - y0) > 0:
-                mask_resized = cv2.resize(mask, (x1 - x0, y1 - y0), interpolation=cv2.INTER_LINEAR)
-                overlay[y0:y1, x0:x1][mask_resized > 127] = color
-
-        # Bounding box
-        cv2.rectangle(image, (x0, y0), (x1, y1), color, 2)
-
-        # Label
-        label = f"{name} {score:.2f}"
-        (tw, th), _ = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 1)
-        cv2.rectangle(image, (x0, y0 - th - 4), (x0 + tw, y0), color, -1)
-        cv2.putText(image, label, (x0, y0 - 2), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 255), 1)
-
-    # Blend mask overlay
-    cv2.addWeighted(overlay, 0.4, image, 0.6, 0, image)
-    return image
-
-
-def main():
-    """YOLO11 Instance Segmentation example."""
-    parser = argparse.ArgumentParser(description="YOLO11 Instance Segmentation -- Axelera Voyager SDK")
-    parser.add_argument("--model", type=str, required=True, help="Path to compiled .axm model")
-    parser.add_argument("--source", type=str, default="0", help="Image, video path, or camera index")
-    parser.add_argument("--conf", type=float, default=0.25, help="Confidence threshold")
-    parser.add_argument("--iou", type=float, default=0.45, help="NMS IoU threshold")
-    args = parser.parse_args()
-
-    pipeline = build_pipeline(args.model, args.conf, args.iou)
-
-    source = int(args.source) if args.source.isdigit() else args.source
-    cap = cv2.VideoCapture(source)
-    if not cap.isOpened():
-        raise RuntimeError(f"Cannot open source: {args.source}")
-
-    frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-    is_image = frames == 1
-
-    while True:
-        ret, frame = cap.read()
-        if not ret:
-            break
-
-        detections, masks = pipeline(frame)
-        annotated = draw_segmentation(frame, detections, masks, args.conf)
-
-        cv2.imshow("YOLO11 Segmentation", annotated)
-        if cv2.waitKey(0 if is_image else 1) & 0xFF in [ord("q"), ord("Q"), 27]:
-            break
-
-    cap.release()
-    cv2.destroyAllWindows()
+        with cv.create_source(args.source) as source:
+            if args.output:
+                vis.save_output_video(args.output, int(source.fps) or 30)
+            for frame_count, (img, segments) in enumerate(pipeline.stream(source), start=1):
+                if vis.is_closed:
+                    break
+                vis(img, segments)
+                # Headless has no window, so periodically log what was detected.
+                if args.no_display and frame_count % 100 == 0:
+                    counts = Counter(getattr(s.class_id, "name", str(s.class_id)) for s in segments)
+                    summary = ", ".join(f"{name}x{n}" for name, n in counts.most_common()) or "none"
+                    print(f"frame {frame_count}: {len(segments)} segments ({summary})")
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="YOLO11 Instance Segmentation -- Axelera Voyager SDK")
+    parser.add_argument("--model", type=str, required=True, help="Path to compiled .axm model")
+    parser.add_argument("--source", type=str, required=True, help="Image, video path, or camera index")
+    parser.add_argument("--conf", type=float, default=0.25, help="Confidence threshold")
+    parser.add_argument("--iou", type=float, default=0.45, help="NMS IoU threshold")
+    parser.add_argument("--no-display", action="store_true", help="Disable GUI window (headless mode)")
+    parser.add_argument(
+        "--output", type=str, default="", help="Save the rendered video to this path (requires a display, not headless)"
+    )
+    args = parser.parse_args()
+    if args.output and args.no_display:
+        parser.error("--output requires the display renderer and cannot be combined with --no-display")
+    main(args)

--- a/examples/YOLO-Axelera-Python/yolo26-pose-tracker.py
+++ b/examples/YOLO-Axelera-Python/yolo26-pose-tracker.py
@@ -10,8 +10,15 @@ Ultralytics YOLO26 is NMS-free: the model outputs (1, 300, 57) already in final 
 We use a small ConfidenceFilter operator instead of decode_pose (which only
 supports yolov8/yolo11 raw output layout).
 
-When --tracker is set (default: tracktrack), the pipeline appends op.tracker()
-for multi-object tracking. Use --tracker none to disable tracking.
+This is the "drop-in" example (see README.md for the two-pathway design): frame
+ingestion and rendering use plain OpenCV, and only the model -- plus, optionally, a
+tracker -- runs through the Axelera pipeline builder. The pose-only path returns the
+model's raw NumPy output so it drops straight into existing NumPy post-processing.
+See yolo11-seg.py for the complementary "E2E ecosystem" pathway (typed Results
+objects, cv.create_source, and the display.App renderer).
+
+When --tracker is set (default: tracktrack), the pipeline appends op.ax_pose() +
+op.tracker() for multi-object tracking. Use --tracker none to disable tracking.
 
 Usage:
     python yolo26-pose-tracker.py --model yolo26n-pose.axm --source 0
@@ -100,65 +107,80 @@ class ConfidenceFilter(op.Operator):
 
 
 def build_pipeline(model_path: str, conf: float = 0.25, tracker_algo: str | None = "tracktrack"):
-    """Build Ultralytics YOLO26 pose estimation pipeline with optional tracking.
+    """Build the YOLO26 pose pipeline, optionally with tracking.
 
-    Ultralytics YOLO26 is NMS-free (end-to-end), so no op.nms() is needed. When tracker_algo is provided, op.tracker()
-    is appended for multi-object tracking. Calls .optimized() so the runtime can fuse operators for maximum throughput.
+    YOLO26 is NMS-free, so there's no op.nms(). Pose-only returns the raw model rows (np.ndarray); adding a tracker
+    switches the output to a list of TrackedObject.
     """
     stages = [
-        op.colorconvert("RGB", src="BGR"),  # OpenCV reads BGR; models expect RGB
+        op.color_convert("RGB", src="BGR"),  # OpenCV reads BGR; models expect RGB
         op.letterbox(640, 640),
-        op.totensor(),
+        op.to_tensor(),
         op.load(model_path),
         ConfidenceFilter(threshold=conf),
-        op.to_image_space(keypoint_cols=range(6, 57, 3)),
+        op.to_image_space(keypoint_cols=range(6, 57, 3)),  # MODEL_PIXEL -> NORMALIZED
     ]
     if tracker_algo:
-        stages.extend([op.axpose(num_keypoints=17), op.tracker(algo=tracker_algo)])
+        # op.tracker() needs typed objects, so wrap the raw rows with ax_pose first.
+        stages.append(op.ax_pose(num_keypoints=17, class_id_type=op.CocoClasses))
+        stages.append(op.tracker(algo=tracker_algo))
     return op.seq(*stages).optimized()
 
 
 def draw_pose(image: np.ndarray, detections: np.ndarray, conf: float = 0.25) -> np.ndarray:
-    """Draw pose estimation results on the image (in-place, no tracking)."""
+    """Draw pose results straight from the raw model rows (in-place, no tracking).
+
+    Each row is [x0, y0, x1, y1, score, class_id, 17x(kpt_x, kpt_y, kpt_conf)], with box and keypoint x/y already
+    normalized to [0, 1] by op.to_image_space() and scaled back to pixels here.
+    """
+    h, w = image.shape[:2]
+
     for det in detections:
-        score = det[4]
+        score = float(det[4])
         if score < conf:
             continue
 
-        # Bounding box
-        x0, y0, x1, y1 = map(int, det[:4])
+        # Bounding box (denormalize)
+        x0, y0 = int(det[0] * w), int(det[1] * h)
+        x1, y1 = int(det[2] * w), int(det[3] * h)
         cv2.rectangle(image, (x0, y0), (x1, y1), (0, 255, 0), 2)
         cv2.putText(image, f"{score:.2f}", (x0, y0 - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
 
-        # Parse 17 keypoints: columns 6..56, stride 3 (x, y, conf)
-        kpts = det[6:].reshape(17, 3)
+        kpts = det[6:].reshape(-1, 3)  # 17 x (x, y, confidence); x/y normalized, conf raw
 
         # Draw skeleton limbs
         for i, (a, b) in enumerate(COCO_SKELETON):
             kp_a, kp_b = kpts[a - 1], kpts[b - 1]
             if kp_a[2] > 0.5 and kp_b[2] > 0.5:
                 color = tuple(int(c) for c in LIMB_COLORS[i][::-1])  # RGB -> BGR
-                pt_a = (int(kp_a[0]), int(kp_a[1]))
-                pt_b = (int(kp_b[0]), int(kp_b[1]))
+                pt_a = (int(kp_a[0] * w), int(kp_a[1] * h))
+                pt_b = (int(kp_b[0] * w), int(kp_b[1] * h))
                 cv2.line(image, pt_a, pt_b, color, 2)
 
         # Draw keypoints
         for j, kp in enumerate(kpts):
             if kp[2] > 0.5:
                 color = tuple(int(c) for c in KPT_COLORS[j][::-1])  # RGB -> BGR
-                cv2.circle(image, (int(kp[0]), int(kp[1])), 4, color, -1)
+                cv2.circle(image, (int(kp[0] * w), int(kp[1] * h)), 4, color, -1)
 
     return image
 
 
 def draw_tracked_poses(image: np.ndarray, tracked_poses: list) -> np.ndarray:
-    """Draw tracked pose results: bbox with track ID color, skeleton, and keypoints (in-place)."""
+    """Draw tracked pose results: bbox with track ID color, skeleton, and keypoints (in-place).
+
+    TrackedObject bbox and the keypoints on its wrapped PoseObject are normalized (0..1); they are scaled by the image
+    size before drawing.
+    """
+    h, w = image.shape[:2]
+
     for tracked in tracked_poses:
         color = get_track_color(tracked.track_id)
 
-        # Bounding box
+        # Bounding box (denormalize)
         bbox = tracked.predicted_bbox
-        x0, y0, x1, y1 = int(bbox.x0), int(bbox.y0), int(bbox.x1), int(bbox.y1)
+        x0, y0 = int(bbox.x0 * w), int(bbox.y0 * h)
+        x1, y1 = int(bbox.x1 * w), int(bbox.y1 * h)
         cv2.rectangle(image, (x0, y0), (x1, y1), color, 2)
         cv2.putText(image, f"ID {tracked.track_id}", (x0, y0 - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 2)
 
@@ -173,14 +195,20 @@ def draw_tracked_poses(image: np.ndarray, tracked_poses: list) -> np.ndarray:
         for i, (a, b) in enumerate(COCO_SKELETON):
             kp_a, kp_b = kpts[a - 1], kpts[b - 1]
             if kp_a.confidence > 0.5 and kp_b.confidence > 0.5:
-                pt_a = (int(kp_a.x), int(kp_a.y))
-                pt_b = (int(kp_b.x), int(kp_b.y))
+                pt_a = (int(kp_a.x * w), int(kp_a.y * h))
+                pt_b = (int(kp_b.x * w), int(kp_b.y * h))
                 cv2.line(image, pt_a, pt_b, color, 2)
 
         # Draw keypoints
         for j, kp in enumerate(kpts):
             if kp.confidence > 0.5:
-                cv2.circle(image, (int(kp.x), int(kp.y)), 4, tuple(int(c) for c in KPT_COLORS[j][::-1]), -1)
+                cv2.circle(
+                    image,
+                    (int(kp.x * w), int(kp.y * h)),
+                    4,
+                    tuple(int(c) for c in KPT_COLORS[j][::-1]),
+                    -1,
+                )
 
     return image
 
@@ -199,9 +227,16 @@ def main():
         help="Tracking algorithm (use 'none' to disable tracking)",
     )
     parser.add_argument(
-        "--no-display", action="store_true", help="Disable GUI window (headless mode, saves to --output)"
+        "--no-display",
+        action="store_true",
+        help="Disable GUI window (headless mode, saves to --output)",
     )
-    parser.add_argument("--output", type=str, default="output.mp4", help="Output video path when --no-display is set")
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="output.mp4",
+        help="Output video path when --no-display is set",
+    )
     args = parser.parse_args()
 
     tracker_algo = None if args.tracker == "none" else args.tracker

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -457,7 +457,7 @@ def test_export_executorch_matrix(task):
 
 @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_2_8 or TORCH_2_12, reason="Axelera export requires 2.8.0<=torch<2.12.0")
-@pytest.mark.skipif(checks.IS_PYTHON_MINIMUM_3_13, reason="Axelera devkit 1.6.0 does not support Python 3.13")
+@pytest.mark.skipif(checks.IS_PYTHON_MINIMUM_3_13, reason="Axelera devkit 1.7.0 does not support Python 3.13")
 @pytest.mark.skipif(
     not LINUX or (ARM64 and IS_DOCKER),
     reason="Axelera export is only supported on Linux and is not supported on ARM64 Docker",

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -324,7 +324,7 @@ EXPORT_ENVS = {
         "python": "3.12",
         "extras": ["export-base"],
         "torch": ">=2.8,<2.12",
-        "requirements": ["axelera-devkit==1.6.0", "onnx>=1.12.0,<2.0.0", "onnxslim>=0.1.71"],
+        "requirements": ["axelera-devkit==1.7.0", "onnx>=1.12.0,<2.0.0", "onnxslim>=0.1.71"],
         "indexes": [
             ("--extra-index-url", "https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple"),
         ],

--- a/ultralytics/nn/backends/axelera.py
+++ b/ultralytics/nn/backends/axelera.py
@@ -27,7 +27,7 @@ class AxeleraBackend(BaseBackend):
             from axelera.runtime import op
         except ImportError:
             check_requirements(
-                "axelera-rt==1.6.0",
+                "axelera-rt==1.7.0",
                 cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
             )
 

--- a/ultralytics/utils/export/axelera.py
+++ b/ultralytics/utils/export/axelera.py
@@ -43,7 +43,7 @@ def torch2axelera(
         from axelera import compiler
     except ImportError:
         check_requirements(
-            "axelera-devkit==1.6.0",
+            "axelera-devkit==1.7.0",
             cmds="--extra-index-url https://software.axelera.ai/artifactory/api/pypi/axelera-pypi/simple",
         )
         from axelera import compiler


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->
## Summary

Follow the Axelera Voyager SDK **1.6.0 → 1.7.0** release and refresh the Python examples.

- Bump `axelera-devkit` / `axelera-rt` pins `1.6.0` → `1.7.0` across the export env (`exporter.py`), runtime backend, fallback `check_requirements`, docs, and the example install snippet.
- Update example pipelines to the current runtime op names (`color_convert`, `to_tensor`, `ax_pose` / `ax_detection` / `ax_segmentation`).
- Add `yolov8-detection.py` example (`pipeline.stream` + `display.App`).
- Unify headless control to `--no-display` across all three examples (added to `yolo11-seg`; simplified `yolov8-detection`'s display flags).

## Verified

- **API compatibility** (1.7.0): `quantize` / `compile` / `extract_ultralytics_metadata` / `CompilerConfig` signatures unchanged.
- **Auto-pull path**: in a clean venv, `yolo export format=axelera` auto-installs `axelera-devkit==1.7.0` (final) via `check_requirements` and runs the export end-to-end.
- **Export smoke** against final 1.7.0: `success ✅`, `.axm` + `metadata.yaml` + `compiler_config_final.toml` produced.
- **Hardware (Metis)**: `yolo predict` / `yolo val` and all three examples verified on-device.
- **Lint/format**: `ruff check` (base + docs `D`-gate), `ruff format`, `prettier` all pass.

## Note

On **Python 3.12** environments, `pip install "numpy<2.3"` is still required.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Upgrades the Axelera Voyager SDK integration to 1.7.0, refreshes Axelera docs and examples, and modernizes the Python sample pipelines for improved usability and compatibility on Metis devices. 🚀

### 📊 Key Changes
- Bumps Axelera package requirements from `1.6.0` to `1.7.0` across export and runtime paths, including `axelera-devkit` and `axelera-rt`.
- Updates Axelera installation docs with the matching `metis-dkms` driver version `1.5.5` and adds guidance to keep the kernel driver synchronized with the SDK. 🔧
- Refreshes Axelera documentation links to current hosted docs for `axdevice` and model-zoo references.
- Expands `examples/YOLO-Axelera-Python/README.md` with clearer workflow guidance, script comparisons, runtime behavior notes, argument details, and display/video-output caveats. 📘
- Refactors `yolo11-seg.py` to use Axelera runtime-native APIs like `cv.create_source()`, `display.App`, `pipeline.stream()`, and typed segmentation results instead of manual OpenCV drawing.
- Updates `yolo26-pose-tracker.py` to newer runtime operator names such as `op.color_convert`, `op.to_tensor`, and `op.ax_pose`, while clarifying normalized-coordinate handling for boxes and keypoints. 🧠
- Adjusts Axelera export test metadata to reflect that Axelera devkit 1.7.0 still does not support Python 3.13.

### 🎯 Purpose & Impact
- Keeps the Ultralytics Axelera integration aligned with the latest supported Voyager SDK release, reducing version mismatch issues. ✅
- Improves the onboarding experience for users deploying YOLO11 and YOLO26 models on Axelera hardware through clearer docs and more realistic examples.
- Reduces confusion around SDK/driver compatibility by explicitly documenting the need for matching versions and device health checks.
- Makes the sample applications more representative of current Axelera runtime best practices, which should help users build production-oriented pipelines faster. ⚡
- May require validation for API compatibility because the examples now depend on renamed runtime operators and different rendering/data-flow behavior.