### PR TITLE
Refactor finetuning, training tips, and performance metrics guides

### DIFF
--- a/docs/en/guides/finetuning-guide.md
+++ b/docs/en/guides/finetuning-guide.md
@@ -1,6 +1,7 @@
 ---
+title: Fine-Tune YOLO26 on a Custom Dataset
 comments: true
-description: Learn how to fine-tune YOLO26 on a custom dataset with pretrained weights. Complete guide covering transfer learning, layer freezing, optimizer selection, two-stage training, and troubleshooting common issues like low mAP and catastrophic forgetting.
+description: Fine-tune YOLO26 on a custom dataset using pretrained weights. Covers transfer learning, layer freezing, optimizers, two-stage training, and fixing low mAP.
 keywords: fine-tune YOLO, finetune YOLO custom dataset, YOLO transfer learning, YOLO26 fine-tuning, freeze layers YOLO, pretrained YOLO custom data, YOLO training from scratch vs fine-tuning, catastrophic forgetting YOLO, two-stage fine-tuning, YOLO optimizer selection, fine-tune object detection model, custom object detection training, YOLO freeze backbone, how to finetune YOLO26
 ---
 
@@ -32,7 +33,7 @@ When a pretrained model is fine-tuned on a dataset with a different number of cl
 
 1. **Backbone and neck transfer fully** - these layers extract general visual features and their shapes are independent of the number of classes.
 2. **Detection head is partially reinitialized** - the classification output layers (`cv3`, `one2one_cv3`) have shapes tied to the class count (80 vs 5), so they cannot transfer and are randomly initialized. Box regression layers (`cv2`, `one2one_cv2`) in the head have fixed shapes regardless of class count, so they transfer normally.
-3. **The vast majority of weights transfer** when changing class count. Only the classification-specific layers in the detection head are reinitialized - the backbone, neck, and box regression branches remain intact.
+3. **The vast majority of weights transfer** when changing class count. For example, fine-tuning YOLO26n from COCO (80 classes) onto a 5-class dataset transfers 606 of 708 weight tensors: only the class-count-dependent classification layers are reinitialized, while the backbone, neck, and box regression branches remain intact.
 
 For datasets with the same number of classes as the pretrained model (for example, fine-tuning COCO-pretrained weights on another 80-class dataset), 100% of weights transfer including the detection head.
 
@@ -46,13 +47,13 @@ For datasets with the same number of classes as the pretrained model (for exampl
         from ultralytics import YOLO
 
         model = YOLO("yolo26n.pt")  # load pretrained model
-        model.train(data="path/to/data.yaml", epochs=50, imgsz=640)
+        model.train(data="custom.yaml", epochs=50, imgsz=640)
         ```
 
     === "CLI"
 
         ```bash
-        yolo detect train model=yolo26n.pt data=path/to/data.yaml epochs=50 imgsz=640
+        yolo detect train model=yolo26n.pt data=custom.yaml epochs=50 imgsz=640
         ```
 
 ### Choosing a Model Size
@@ -79,7 +80,7 @@ For most fine-tuning tasks, the default setting works well without any manual tu
 
 Freezing prevents specific layers from updating during training. This speeds up training and reduces [overfitting](https://www.ultralytics.com/glossary/overfitting) when the dataset is small relative to the model capacity.
 
-The `freeze` parameter accepts either an integer or a list. An integer `freeze=10` freezes the first 10 layers (0 through 9, which corresponds to the backbone in YOLO26). A list can contain layer indices like `freeze=[0, 3, 5]` for partial backbone freezing, or module name strings like `freeze=["23.cv2"]` for fine-grained control over specific branches within a layer.
+The `freeze` parameter accepts either an integer or a list. An integer `freeze=10` freezes the first 10 layers (indices 0-9), which covers most of the YOLO26 backbone. The backbone spans layers 0-10, so `freeze=10` leaves the final C2PSA block (layer 10) trainable; use `freeze=11` to freeze the entire backbone. A list can contain layer indices like `freeze=[0, 3, 5]` for partial backbone freezing, or module name strings like `freeze=["23.cv2", "23.one2one_cv2"]` for fine-grained control over specific branches within a layer (here, both box regression branches of the detection head).
 
 !!! example
 
@@ -98,8 +99,8 @@ The `freeze` parameter accepts either an integer or a list. An integer `freeze=1
     === "Freeze by module name"
 
         ```python
-        # Freeze the box regression branch of the detection head
-        model.train(data="custom.yaml", epochs=50, freeze=["23.cv2"])
+        # Freeze both box regression branches (one-to-many and end-to-end) of the detection head
+        model.train(data="custom.yaml", epochs=50, freeze=["23.cv2", "23.one2one_cv2"])
         ```
 
 The right freeze depth depends on how similar the target domain is to the pretrained data and how much training data is available:
@@ -148,7 +149,7 @@ This approach is particularly useful when the target domain differs significantl
 ### Model produces no predictions
 
 - **Insufficient training data**: training with very few samples is the most common cause - the model cannot learn or generalize from too little data. Ensure enough diverse examples per class before investigating other causes.
-- **Check dataset paths**: incorrect paths in `data.yaml` silently produce zero labels. Run `yolo detect val model=yolo26n.pt data=your_data.yaml` before training to confirm labels load correctly.
+- **Check dataset paths**: incorrect paths in `data.yaml` silently produce zero labels. Run `yolo detect val model=yolo26n.pt data=custom.yaml` before training to confirm labels load correctly.
 - **Lower confidence threshold**: if predictions exist but are filtered out, try `conf=0.1` during inference.
 - **Verify class count**: ensure `nc` in `data.yaml` matches the actual number of classes in the label files.
 

--- a/docs/en/guides/model-training-tips.md
+++ b/docs/en/guides/model-training-tips.md
@@ -155,7 +155,7 @@ Different optimizers have various strengths and weaknesses. Let's take a glimpse
     - Combines the benefits of both SGD with momentum and RMSProp.
     - Adjusts the learning rate for each parameter based on estimates of the first and second moments of the gradients.
     - Well-suited for noisy data and sparse gradients.
-    - Efficient and generally requires less tuning, which is why YOLO26's `optimizer=auto` defaults to the closely related AdamW for shorter training runs.
+    - Efficient and generally requires less tuning. For shorter training runs, YOLO26's `optimizer=auto` selects the closely related **AdamW** rather than Adam itself.
 
 - **RMSProp (Root Mean Square Propagation)**:
     - Adjusts the learning rate for each parameter by dividing the gradient by a running average of the magnitudes of recent gradients.

--- a/docs/en/guides/model-training-tips.md
+++ b/docs/en/guides/model-training-tips.md
@@ -1,7 +1,7 @@
 ---
 title: Model Training Tips & Best Practices
 comments: true
-description: Learn best practices for training computer vision models, including batch size optimization, mixed precision training, early stopping, and optimizer selection for improved efficiency and accuracy.
+description: Train YOLO computer vision models more efficiently with proven tips on batch size, mixed precision, caching, early stopping, and optimizer choice.
 keywords: Model Training Machine Learning, AI Model Training, Number of Epochs, How to Train a Model in Machine Learning, Machine Learning Best Practices, What is Model Training
 ---
 
@@ -10,6 +10,8 @@ keywords: Model Training Machine Learning, AI Model Training, Number of Epochs, 
 ## Introduction
 
 One of the most important steps when working on a [computer vision project](./steps-of-a-cv-project.md) is model training. Before reaching this step, you need to [define your goals](./defining-project-goals.md) and [collect and annotate your data](./data-collection-and-annotation.md). After [preprocessing the data](./preprocessing-annotated-data.md) to make sure it is clean and consistent, you can move on to training your model.
+
+[Model training](../modes/train.md) is the process of teaching your model to recognize visual patterns and make predictions from your data, and it directly shapes the accuracy of your application. This guide walks through best practices, optimization techniques, and troubleshooting tips to help you train your computer vision models effectively.
 
 <p align="center">
   <br>
@@ -21,8 +23,6 @@ One of the most important steps when working on a [computer vision project](./st
   <br>
   <strong>Watch:</strong> Model Training Tips | How to Handle Large Datasets | Batch Size, GPU Utilization and <a href="https://www.ultralytics.com/glossary/mixed-precision">Mixed Precision</a>
 </p>
-
-So, what is [model training](../modes/train.md)? Model training is the process of teaching your model to recognize visual patterns and make predictions based on your data. It directly impacts the performance and accuracy of your application. In this guide, we'll cover best practices, optimization techniques, and troubleshooting tips to help you train your computer vision models effectively.
 
 ## How to Train a Machine Learning Model
 
@@ -80,9 +80,9 @@ Caching is an important technique to improve the efficiency of training machine 
 
 Caching can be controlled when training YOLO26 using the `cache` parameter:
 
-- _`cache=True`_: Stores dataset images in RAM, providing the fastest access speed but at the cost of increased memory usage.
-- _`cache='disk'`_: Stores the images on disk, slower than RAM but faster than loading fresh data each time.
-- _`cache=False`_: Disables caching, relying entirely on disk I/O, which is the slowest option.
+- **`cache=True`**: Stores dataset images in RAM, providing the fastest access speed but at the cost of increased memory usage.
+- **`cache='disk'`**: Stores the images on disk, slower than RAM but faster than loading fresh data each time.
+- **`cache=False`**: Disables caching, relying entirely on disk I/O, which is the slowest option.
 
 ### Mixed Precision Training
 
@@ -155,7 +155,7 @@ Different optimizers have various strengths and weaknesses. Let's take a glimpse
     - Combines the benefits of both SGD with momentum and RMSProp.
     - Adjusts the learning rate for each parameter based on estimates of the first and second moments of the gradients.
     - Well-suited for noisy data and sparse gradients.
-    - Efficient and generally requires less tuning, making it a recommended optimizer for YOLO26.
+    - Efficient and generally requires less tuning, which is why YOLO26's `optimizer=auto` defaults to the closely related AdamW for shorter training runs.
 
 - **RMSProp (Root Mean Square Propagation)**:
     - Adjusts the learning rate for each parameter by dividing the gradient by a running average of the magnitudes of recent gradients.
@@ -166,7 +166,7 @@ Different optimizers have various strengths and weaknesses. Let's take a glimpse
     - A good choice when you want SGD-like generalization but need smoother convergence than vanilla SGD.
     - Especially relevant for [YOLO26 training recipes](./yolo26-training-recipe.md); if unsure, start with `optimizer=auto` and compare against MuSGD on your dataset.
 
-For YOLO26, the `optimizer` parameter lets you choose from various optimizers, including SGD, MuSGD, Adam, AdamW, NAdam, RAdam, and RMSProp, or you can set it to `auto` for automatic selection based on model configuration.
+For YOLO26, the `optimizer` parameter lets you choose from various optimizers, including SGD, MuSGD, Adam, Adamax, AdamW, NAdam, RAdam, and RMSProp, or you can set it to `auto` for automatic selection based on model configuration.
 
 ```bash
 yolo train model=yolo26n.pt data=coco8.yaml optimizer=MuSGD

--- a/docs/en/guides/yolo-performance-metrics.md
+++ b/docs/en/guides/yolo-performance-metrics.md
@@ -93,7 +93,7 @@ The model.val() function, apart from producing numeric metrics, also yields visu
 
 - **Validation Batch Predictions (`val_batchX_pred.jpg`)**: Contrasting the label images, these visuals display the predictions made by the YOLO26 model for the respective batches. By comparing these to the label images, you can easily assess how well the model detects and classifies objects visually.
 
-The curve plots are prefixed by metric type: [detection](../tasks/detect.md) writes `Box*` curves, [segmentation](../tasks/segment.md) writes both `Box*` and `Mask*` curves, and [pose](../tasks/pose.md) writes both `Box*` and `Pose*` curves.
+For the [detection](../tasks/detect.md), [segmentation](../tasks/segment.md), and [pose](../tasks/pose.md) tasks, the curve plots are prefixed by metric type: detection writes `Box*` curves, segmentation writes both `Box*` and `Mask*` curves, and pose writes both `Box*` and `Pose*` curves.
 
 #### Results Storage
 

--- a/docs/en/guides/yolo-performance-metrics.md
+++ b/docs/en/guides/yolo-performance-metrics.md
@@ -1,4 +1,5 @@
 ---
+title: YOLO Performance Metrics
 comments: true
 description: Explore essential YOLO26 performance metrics like mAP, IoU, F1 Score, Precision, and Recall. Learn how to calculate and interpret them for model evaluation.
 keywords: YOLO26 performance metrics, mAP, IoU, F1 Score, Precision, Recall, object detection, Ultralytics
@@ -76,13 +77,13 @@ For users validating on the COCO dataset, additional metrics are calculated usin
 
 The model.val() function, apart from producing numeric metrics, also yields visual outputs that can provide a more intuitive understanding of the model's performance. Here's a breakdown of the visual outputs you can expect:
 
-- **F1 Score Curve (`F1_curve.png`)**: This curve represents the [F1 score](https://www.ultralytics.com/glossary/f1-score) across various thresholds. Interpreting this curve can offer insights into the model's balance between false positives and false negatives over different thresholds.
+- **F1 Score Curve (`BoxF1_curve.png`)**: This curve represents the [F1 score](https://www.ultralytics.com/glossary/f1-score) across various thresholds. Interpreting this curve can offer insights into the model's balance between false positives and false negatives over different thresholds.
 
-- **Precision-Recall Curve (`PR_curve.png`)**: An integral visualization for any classification problem, this curve showcases the trade-offs between precision and [recall](https://www.ultralytics.com/glossary/recall) at varied thresholds. It becomes especially significant when dealing with imbalanced classes.
+- **Precision-Recall Curve (`BoxPR_curve.png`)**: An integral visualization for any classification problem, this curve showcases the trade-offs between precision and [recall](https://www.ultralytics.com/glossary/recall) at varied thresholds. It becomes especially significant when dealing with imbalanced classes.
 
-- **Precision Curve (`P_curve.png`)**: A graphical representation of precision values at different thresholds. This curve helps in understanding how precision varies as the threshold changes.
+- **Precision Curve (`BoxP_curve.png`)**: A graphical representation of precision values at different thresholds. This curve helps in understanding how precision varies as the threshold changes.
 
-- **Recall Curve (`R_curve.png`)**: Correspondingly, this graph illustrates how the recall values change across different thresholds.
+- **Recall Curve (`BoxR_curve.png`)**: Correspondingly, this graph illustrates how the recall values change across different thresholds.
 
 - **[Confusion Matrix](https://www.ultralytics.com/glossary/confusion-matrix) (`confusion_matrix.png`)**: The confusion matrix provides a detailed view of the outcomes, showcasing the counts of true positives, true negatives, false positives, and false negatives for each class.
 
@@ -91,6 +92,8 @@ The model.val() function, apart from producing numeric metrics, also yields visu
 - **Validation Batch Labels (`val_batchX_labels.jpg`)**: These images depict the ground truth labels for distinct batches from the validation dataset. They provide a clear picture of what the objects are and their respective locations as per the dataset.
 
 - **Validation Batch Predictions (`val_batchX_pred.jpg`)**: Contrasting the label images, these visuals display the predictions made by the YOLO26 model for the respective batches. By comparing these to the label images, you can easily assess how well the model detects and classifies objects visually.
+
+The curve plots are prefixed with the task name — `Box` for [detection](../tasks/detect.md), with the matching prefix for other tasks (`Mask` for [segmentation](../tasks/segment.md), `Pose` for [pose](../tasks/pose.md)).
 
 #### Results Storage
 

--- a/docs/en/guides/yolo-performance-metrics.md
+++ b/docs/en/guides/yolo-performance-metrics.md
@@ -93,7 +93,7 @@ The model.val() function, apart from producing numeric metrics, also yields visu
 
 - **Validation Batch Predictions (`val_batchX_pred.jpg`)**: Contrasting the label images, these visuals display the predictions made by the YOLO26 model for the respective batches. By comparing these to the label images, you can easily assess how well the model detects and classifies objects visually.
 
-The curve plots are prefixed with the task name — `Box` for [detection](../tasks/detect.md), with the matching prefix for other tasks (`Mask` for [segmentation](../tasks/segment.md), `Pose` for [pose](../tasks/pose.md)).
+The curve plots are prefixed by metric type: [detection](../tasks/detect.md) writes `Box*` curves, [segmentation](../tasks/segment.md) writes both `Box*` and `Mask*` curves, and [pose](../tasks/pose.md) writes both `Box*` and `Pose*` curves.
 
 #### Results Storage
 

--- a/docs/en/integrations/ibm-watsonx.md
+++ b/docs/en/integrations/ibm-watsonx.md
@@ -294,7 +294,7 @@ The code above displays ten images from the test set with their predicted boundi
 
 ### Step 7: Evaluate the Model
 
-We can produce visualizations of the model's [precision](https://www.ultralytics.com/glossary/precision) and recall for each class. These visualizations are saved in the home directory, under the train folder. The precision score is displayed in the P_curve.png:
+We can produce visualizations of the model's [precision](https://www.ultralytics.com/glossary/precision) and recall for each class. These visualizations are saved in the home directory, under the train folder. The precision score is displayed in the BoxP_curve.png:
 
 <p align="center">
   <img width="800" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/precision-confidence-curve.avif" alt="Model precision-confidence evaluation curve">
@@ -302,7 +302,7 @@ We can produce visualizations of the model's [precision](https://www.ultralytics
 
 The graph shows an exponential increase in precision as the model's confidence level for predictions increases. However, the model precision has not yet leveled out at a certain confidence level after two [epochs](https://www.ultralytics.com/glossary/epoch).
 
-The [recall](https://www.ultralytics.com/glossary/recall) graph (R_curve.png) displays an inverse trend:
+The [recall](https://www.ultralytics.com/glossary/recall) graph (BoxR_curve.png) displays an inverse trend:
 
 <p align="center">
   <img width="800" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/recall-confidence-curve.avif" alt="Model recall-confidence evaluation curve">

--- a/docs/en/integrations/ibm-watsonx.md
+++ b/docs/en/integrations/ibm-watsonx.md
@@ -294,7 +294,7 @@ The code above displays ten images from the test set with their predicted boundi
 
 ### Step 7: Evaluate the Model
 
-We can produce visualizations of the model's [precision](https://www.ultralytics.com/glossary/precision) and recall for each class. These visualizations are saved in the home directory, under the train folder. The precision score is displayed in the BoxP_curve.png:
+We can produce visualizations of the model's [precision](https://www.ultralytics.com/glossary/precision) and recall for each class. These visualizations are saved in the training run directory (`{work_dir}/runs/detect/train/`). The precision score is displayed in the BoxP_curve.png:
 
 <p align="center">
   <img width="800" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/precision-confidence-curve.avif" alt="Model precision-confidence evaluation curve">


### PR DESCRIPTION
## Summary

- **`finetuning-guide.md`**: corrected the layer-freezing description for YOLO26 — `freeze=10` freezes layers 0-9 (most of the backbone; the C2PSA block at layer 10 stays trainable) and `freeze=11` freezes the full backbone; updated the module-name freeze example to cover both box-regression branches (`23.cv2` and `23.one2one_cv2`); added the measured weight-transfer count for an 80→5 class change; added a page title; trimmed the description; standardized the dataset placeholder across code blocks.
- **`model-training-tips.md`**: added `Adamax` to the optimizer list; tied the Adam note to `optimizer=auto` selecting AdamW for shorter runs; moved the model-training definition ahead of the intro video; switched the cache option bullets to bold inline code; trimmed the description.
- **`yolo-performance-metrics.md`**: updated the validation curve filenames to their `Box` task prefix (`BoxF1_curve.png`, `BoxPR_curve.png`, `BoxP_curve.png`, `BoxR_curve.png`) and noted the prefix is task-specific.
- **`ibm-watsonx.md`**: updated the same validation curve filename references (`P_curve.png` → `BoxP_curve.png`, `R_curve.png` → `BoxR_curve.png`) to match current detection val output.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR improves Ultralytics documentation by clarifying YOLO26 fine-tuning, training tips, evaluation outputs, and metric file naming for a smoother user experience.

### 📊 Key Changes
- Updated the **YOLO26 fine-tuning guide** with clearer wording, examples, and metadata:
  - Added a more specific page title and simplified description.
  - Clarified how many weights transfer when changing class counts, with a concrete YOLO26n example.
  - Replaced generic dataset paths like `path/to/data.yaml` with clearer examples such as `custom.yaml`.
- Improved explanation of the **`freeze` parameter** 🔒:
  - Clarified that `freeze=10` does **not** freeze the full YOLO26 backbone.
  - Explained that `freeze=11` is needed to freeze the entire backbone.
  - Expanded module-level freezing examples to include both detection head box-regression branches.
- Refined the **model training tips guide** 🚀:
  - Added a clearer introduction to what model training is and why it matters.
  - Improved formatting and readability for caching options.
  - Clarified optimizer behavior, including that `optimizer=auto` may choose **AdamW** for shorter YOLO26 training runs.
  - Updated the supported optimizer list to include **Adamax**.
- Updated the **performance metrics guide** 📈:
  - Added an explicit title.
  - Corrected validation plot filenames from generic names like `P_curve.png` to task-specific names such as `BoxP_curve.png`, `BoxR_curve.png`, and `BoxF1_curve.png`.
  - Explained that segmentation and pose tasks generate additional prefixed curves like `Mask*` and `Pose*`.
- Adjusted the **IBM watsonx integration docs** to match the new metric plot naming and clarify where training outputs are saved.

### 🎯 Purpose & Impact
- Helps users fine-tune YOLO26 with **fewer mistakes and clearer expectations**, especially when changing class counts or freezing layers. ✅
- Reduces confusion around **which layers are actually frozen**, which can directly affect training results and troubleshooting.
- Makes training guidance more accurate and easier to follow for both beginners and experienced users. 🤝
- Aligns documentation with actual output filenames and behavior, so users can **find evaluation plots faster** and better understand validation results.
- Overall, this is a **documentation quality and clarity update**, with no direct model code changes, but it should improve usability and reduce support friction.