### PR TITLE
Clarify yolo26 backbone freeze depth in the custom trainer guide

### DIFF
--- a/docs/en/guides/custom-trainer.md
+++ b/docs/en/guides/custom-trainer.md
@@ -285,11 +285,11 @@ model = YOLO("yolo26n.pt")
 model.train(data="coco8.yaml", epochs=20, freeze=10, trainer=FreezingTrainer)
 ```
 
-The `freeze=10` parameter freezes the first 10 layers (the backbone) at training start. The `on_train_epoch_start` callback fires at the beginning of each epoch and unfreezes all parameters once the freeze period is complete.
+The `freeze=10` parameter freezes the first 10 layers (indices 0-9) at training start, which covers most of the YOLO26 backbone. The backbone spans layers 0-10, so `freeze=10` leaves the final C2PSA block (layer 10) trainable; use `freeze=11` to freeze the entire backbone. The `on_train_epoch_start` callback fires at the beginning of each epoch and unfreezes all parameters once the freeze period is complete.
 
 !!! tip "Choosing What to Freeze"
 
-    - `freeze=10` freezes the first 10 layers (typically the backbone in YOLO architectures)
+    - `freeze=10` freezes the first 10 layers, indices 0-9 (most of the YOLO26 backbone; use `freeze=11` to include the final C2PSA block at layer 10)
     - `freeze=[0, 1, 2, 3]` freezes specific layers by index
     - Higher `FREEZE_EPOCHS` values give the head more time to adapt before the backbone changes
 
@@ -314,10 +314,13 @@ class PerLayerLRTrainer(DetectionTrainer):
         backbone_params = []
         head_params = []
 
-        for k, v in unwrap_model(model).named_parameters():
+        unwrapped = unwrap_model(model)
+        backbone_len = len(unwrapped.yaml["backbone"])  # YOLO26 backbone spans layers 0-10 (C2PSA at layer 10)
+
+        for k, v in unwrapped.named_parameters():
             if not v.requires_grad:
                 continue
-            is_backbone = any(k.startswith(f"model.{i}.") for i in range(10))
+            is_backbone = any(k.startswith(f"model.{i}.") for i in range(backbone_len))
             if is_backbone:
                 backbone_params.append(v)
             else:


### PR DESCRIPTION
## Summary

- corrects the freeze description: `freeze=10` freezes layers 0-9 (most of the YOLO26 backbone), which leaves the final C2PSA block at layer 10 trainable, and `freeze=11` freezes the entire backbone.
- updates the per-layer learning-rate example to read the backbone length from the model yaml (`len(model.yaml["backbone"])`) instead of a hardcoded `range(10)`, so the C2PSA block is grouped with the backbone, matching the RT-DETR variant in the same guide.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR clarifies how layer freezing works in YOLO26 training docs, making backbone freezing behavior more accurate and easier to understand.

### 📊 Key Changes
- 📘 Updated the custom trainer guide to explain that `freeze=10` freezes layers `0-9`, not the entire YOLO26 backbone.
- 🔍 Clarified that the YOLO26 backbone actually spans layers `0-10`, meaning layer `10` remains trainable unless `freeze=11` is used.
- 💡 Improved the documentation tip section to help users choose the correct `freeze` value for partial or full backbone freezing.
- 🧠 Updated the per-layer learning rate trainer example to detect backbone layers dynamically using the model’s YAML config instead of assuming a fixed number of layers.
- ✅ Replaced hardcoded backbone logic (`range(10)`) with a more robust approach based on `len(unwrapped.yaml["backbone"])`.

### 🎯 Purpose & Impact
- 🎯 Prevents confusion for users trying to freeze the full YOLO26 backbone during training.
- 🧪 Helps training setups behave as expected, especially for transfer learning and fine-tuning workflows.
- 🔒 Makes documentation more precise, reducing the risk of unintentionally leaving part of the backbone trainable.
- 🔄 Improves code example reliability by making it adapt better to model definitions instead of relying on fixed layer counts.
- 👥 Benefits both new and experienced users by making custom training behavior clearer and more predictable.