### PR TITLE
Clarify Platform dataset ingest API flow

### DIFF
--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -291,6 +291,16 @@ POST /api/datasets
 
     Valid `task` values: `detect`, `segment`, `semantic`, `classify`, `pose`, `obb`.
 
+**Response:**
+
+```json
+{
+    "datasetId": "dataset_abc123",
+    "slug": "my-dataset",
+    "region": "us"
+}
+```
+
 ### Update Dataset
 
 ```http
@@ -572,18 +582,49 @@ Run YOLO inference on dataset images to auto-generate annotations. Uses a select
 POST /api/datasets/ingest
 ```
 
-Create a dataset ingest job to process uploaded ZIP or TAR files, including `.tar.gz` and `.tgz`, containing images and labels.
+Create a dataset ingest job for an existing dataset. The target dataset is always passed as `datasetId` in the JSON body, not in the URL path.
 
-The request body takes exactly one of `sessionId` (an uploaded archive's upload session) or `sourceUrl` (a remote ZIP, TAR, TAR.GZ, TGZ, or NDJSON URL), plus an optional `targetSplit` (`train`, `val`, or `test`) to override the archive's split structure.
+The request body requires `datasetId` plus exactly one of `sessionId` (an uploaded archive's upload session) or `sourceUrl` (a remote ZIP, TAR, TAR.GZ, TGZ, or NDJSON URL). Add optional `targetSplit` (`train`, `val`, or `test`) to override the archive's split structure.
+
+For uploaded archives, the upload session is already bound to the dataset by the `assetId` passed to `POST /api/upload/signed-url`; ingest validates that `assetId` matches the body `datasetId`. For remote `sourceUrl` imports, create the dataset first, then pass its `datasetId` to ingest.
+
+**Body (uploaded archive):**
+
+```json
+{
+    "datasetId": "dataset_abc123",
+    "sessionId": "session_abc123",
+    "targetSplit": "train"
+}
+```
+
+**Body (remote archive or NDJSON):**
+
+```json
+{
+    "datasetId": "dataset_abc123",
+    "sourceUrl": "https://example.com/my-dataset.zip"
+}
+```
+
+**Response:**
+
+```json
+{
+    "jobId": "job_abc123",
+    "datasetId": "dataset_abc123",
+    "status": "queued"
+}
+```
 
 ```mermaid
 graph LR
-    A[Upload Archive]:::start --> B[POST /api/datasets/ingest]:::proc
-    B --> C[Process Archive]:::proc
-    C --> D[Extract images]:::proc
-    C --> E[Parse labels]:::proc
-    C --> F[Generate thumbnails]:::proc
-    D & E & F --> G[Dataset ready]:::out
+    A[POST /api/datasets]:::start --> B[POST /api/upload/signed-url]:::proc
+    B --> C[Upload archive to signed URL]:::proc
+    C --> D[POST /api/upload/complete]:::proc
+    D --> E[POST /api/datasets/ingest]:::proc
+    E --> F[Process archive]:::proc
+    F --> G[Dataset ready]:::out
 
     classDef start fill:#4CAF50,color:#fff
     classDef proc fill:#2196F3,color:#fff
@@ -1741,7 +1782,7 @@ GET /api/storage
 
 ## Upload API
 
-Upload files directly to cloud storage using signed URLs for fast, reliable transfers. Uses a two-step flow: get a signed URL, then upload the file. See [Data documentation](../data/index.md).
+Upload files directly to cloud storage using signed URLs for fast, reliable transfers. For dataset archives, use the returned `sessionId` with `POST /api/upload/complete`, then `POST /api/datasets/ingest`. See [Data documentation](../data/index.md).
 
 ### Get Signed Upload URL
 
@@ -1755,11 +1796,11 @@ Request a signed URL for uploading a file directly to cloud storage. The signed 
 
 ```json
 {
-    "assetType": "images",
-    "assetId": "abc123",
-    "filename": "my-image.jpg",
-    "contentType": "image/jpeg",
-    "totalBytes": 5242880
+    "assetType": "datasets",
+    "assetId": "dataset_abc123",
+    "filename": "my-dataset.zip",
+    "contentType": "application/zip",
+    "totalBytes": 52428800
 }
 ```
 
@@ -1777,7 +1818,7 @@ Request a signed URL for uploading a file directly to cloud storage. The signed 
 {
     "sessionId": "session_abc123",
     "uploadUrl": "https://storage.example.com/...",
-    "gcsPath": "gs://bucket/users/user123/images/abc123/my-image.jpg",
+    "gcsPath": "gs://bucket/users/user123/datasets/dataset_abc123/my-dataset.zip",
     "downloadUrl": "https://cdn.example.com/...",
     "expiresAt": "2026-02-22T12:00:00Z"
 }
@@ -1789,7 +1830,7 @@ Request a signed URL for uploading a file directly to cloud storage. The signed 
 POST /api/upload/complete
 ```
 
-Notify the platform that a file upload is complete so it can begin processing.
+Notify the platform that a file upload is complete. For dataset archives, this verifies and records the upload session; call `POST /api/datasets/ingest` afterward to start dataset processing.
 
 **Body:**
 


### PR DESCRIPTION
## Summary
- clarify that dataset ingest uses POST /api/datasets/ingest with datasetId in the JSON body
- document uploaded-session and remote-source ingest examples
- update the upload API example to show the dataset archive flow

Fixes #24934

## Validation
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR improves the Ultralytics Platform API docs for dataset uploads and ingestion, making the dataset import workflow clearer, more complete, and easier to implement correctly.

### 📊 Key Changes
- Added a **documented response example** for `POST /api/datasets`, showing returned fields like `datasetId`, `slug`, and `region`.
- Expanded the `POST /api/datasets/ingest` docs to clearly explain that:
  - ingest is for an **existing dataset**
  - `datasetId` must be passed in the **request body**
  - users must provide **exactly one** of `sessionId` or `sourceUrl`
  - `targetSplit` is optional and can override archive split structure
- Clarified the difference between two ingest flows:
  - **uploaded archive flow** using `sessionId`
  - **remote import flow** using `sourceUrl`
- Added **request body examples** for both uploaded archives and remote archive/NDJSON imports.
- Added a **response example** for dataset ingest, including `jobId`, `datasetId`, and `status`.
- Updated the workflow diagram to reflect the **full upload pipeline**:
  - create dataset
  - request signed upload URL
  - upload file
  - complete upload
  - start ingest
- Revised Upload API examples to focus on **dataset archive uploads** instead of generic image uploads.
- Clarified that `POST /api/upload/complete` only finalizes the upload session, and that `POST /api/datasets/ingest` must be called afterward to actually begin dataset processing.

### 🎯 Purpose & Impact
- ✅ Makes the dataset import process much easier for developers to understand and integrate.
- 🚀 Reduces confusion around when to use `datasetId`, `sessionId`, and `sourceUrl`, helping avoid API misuse.
- 🛠️ Improves implementation accuracy by showing concrete request/response examples and the correct step-by-step flow.
- 📦 Better supports real-world dataset archive uploads, including remote imports and NDJSON sources.
- 🌍 Helps both new and experienced users work with the Ultralytics Platform API more confidently and with fewer trial-and-error mistakes.