### PR TITLE
Default CoreML ComputeUnit to ALL for RT-DETR correctness

### DIFF
--- a/ultralytics/nn/backends/coreml.py
+++ b/ultralytics/nn/backends/coreml.py
@@ -31,13 +31,15 @@ class CoreMLBackend(BaseBackend):
         import coremltools as ct
 
         LOGGER.info(f"Loading {weight} for CoreML inference...")
-        # Run on the Neural Engine (CPU_AND_NE): ~3x faster than CPU, and the default ComputeUnit.ALL / CPU_AND_GPU
-        # abort the process via an MPSGraph compiler bug on macOS hosts (coremltools 9.x). CPU_AND_NE needs macOS >= 13,
-        # so fall back to CPU_ONLY below that. CoreML inference is macOS-only, so this applies wherever the backend runs.
-        try:
-            self.model = ct.models.MLModel(weight, compute_units=ct.ComputeUnit.CPU_AND_NE)
-        except Exception:
-            self.model = ct.models.MLModel(weight, compute_units=ct.ComputeUnit.CPU_ONLY)
+        # Default ComputeUnit.ALL: tied with CPU_AND_NE on CNNs and the only correct choice on RT-DETR heads
+        # (ANE-only fusion silently corrupts attention outputs). Fall back to CPU_AND_NE if a host hits the
+        # MPSGraph "MLIR pass manager failed" assertion under ALL, then CPU_ONLY on macOS < 13 where ANE is unavailable.
+        for unit in (ct.ComputeUnit.ALL, ct.ComputeUnit.CPU_AND_NE, ct.ComputeUnit.CPU_ONLY):
+            try:
+                self.model = ct.models.MLModel(weight, compute_units=unit)
+                break
+            except Exception:
+                continue
         spec = self.model.get_spec()
         self.input_name = spec.description.input[0].name
         self.dynamic = spec.description.input[0].type.HasField("multiArrayType")


### PR DESCRIPTION
CPU_AND_NE silently corrupts RT-DETR attention outputs on the Apple Neural Engine; ALL restores correctness and is tied speed on CNNs, with CPU_AND_NE and CPU_ONLY kept as load-time fallbacks.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

`CPU_AND_NE` can quietly produce degraded RT-DETR outputs on the Apple Neural Engine. On `rtdetr-l.pt`, coco8 mAP50-95 drops from 0.732 on `CPU_ONLY` to 0.485 on `CPU_AND_NE` without a crash or warning. Switching the default CoreML load path to `ALL` lets CoreML's planner choose a mixed placement, while staying effectively tied with `CPU_AND_NE` on CNN-style YOLO26 models.

The `ALL → CPU_AND_NE → CPU_ONLY` fallback chain keeps the original MPSGraph crash workaround as a load-time fallback.

| Model    | ALL                    | CPU_AND_NE             | CPU_ONLY               |
|----------|------------------------|------------------------|------------------------|
| yolo26n  | 1.72 ms, 0.685 mAP     | 1.75 ms, 0.685 mAP     | 8.11 ms, 0.695 mAP     |
| yolo26l  | 10.51 ms, 0.731 mAP    | 10.41 ms, 0.731 mAP    | 51.25 ms, 0.725 mAP    |
| rtdetr-l | 16.97 ms, 0.714 mAP    | 50.30 ms, 0.485 mAP    | 72.57 ms, 0.732 mAP    |

Latency was measured with 15 warmup iterations and 100 timed raw CoreML `predict()` calls. mAP is coco8 mAP50-95 from Ultralytics validation.

Tested on M5, macOS 26.5.1, coremltools 9.0.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves CoreML model loading by using a safer compute-unit fallback order that preserves correctness on more model types while keeping good performance on macOS 🚀🍎

### 📊 Key Changes
- Updated CoreML backend loading logic in `ultralytics/nn/backends/coreml.py`.
- Changed the preferred CoreML compute unit from `CPU_AND_NE` to `ALL`.
- Added a new fallback sequence when loading CoreML models:
  - `ALL`
  - `CPU_AND_NE`
  - `CPU_ONLY`
- Expanded inline comments to explain why:
  - `ALL` is the most reliable default for both CNNs and RT-DETR-style heads.
  - `CPU_AND_NE` can silently produce incorrect attention outputs on some models.
  - `CPU_ONLY` remains a compatibility fallback for older macOS versions or other load failures.

### 🎯 Purpose & Impact
- Improves inference correctness for CoreML models, especially newer architectures like RT-DETR ✅
- Reduces the risk of silent output corruption when using Apple Neural Engine-focused execution ⚠️
- Maintains strong performance where possible, while still falling back gracefully on problematic systems 🔄
- Makes CoreML inference more robust across different macOS environments and hardware setups 🍏
- Benefits users deploying Ultralytics models on Apple devices by prioritizing reliability first, without removing compatibility 💡