### PR TITLE
Fix Sentry bugs 2026-06-27

### DIFF
--- a/docs/en/reference/models/__init__.md
+++ b/docs/en/reference/models/__init__.md
@@ -1,0 +1,17 @@
+---
+title: models.__init__ API Reference
+description: Reference for `ultralytics.models.__init__` in the Ultralytics package.
+keywords: Ultralytics, ultralytics.models.__init__, API reference, YOLO, Python
+---
+
+# Reference for `ultralytics/models/__init__.py`
+
+!!! success "Improvements"
+
+    This page is sourced from [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/\_\_init\_\_.py](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/__init__.py). Have an improvement or example to add? Open a [Pull Request](https://docs.ultralytics.com/help/contributing) — thank you! 🙏
+
+<br>
+
+## ::: ultralytics.models.__init__.__getattr__
+
+<br><br>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -698,6 +698,7 @@ nav:
           - session: reference/hub/session.md
           - utils: reference/hub/utils.md
       - models:
+          - __init__: reference/models/__init__.md
           - fastsam:
               - model: reference/models/fastsam/model.md
               - predict: reference/models/fastsam/predict.md

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -36,7 +37,7 @@ def test_cli_imports_defer_torchvision() -> None:
         "assert 'torchvision' not in sys.modules; "
         "assert 'ultralytics.models.sam.sam3.geometry_encoders' not in sys.modules"
     )
-    subprocess.run(["python", "-c", code], check=True)
+    subprocess.run([sys.executable, "-c", code], check=True)
 
 
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,18 @@ def test_special_modes() -> None:
     run("yolo cfg")
 
 
+def test_cli_imports_defer_torchvision() -> None:
+    """Verify startup imports do not load torchvision or SAM3 geometry."""
+    code = (
+        "import sys; "
+        "from ultralytics import YOLO; "
+        "from ultralytics.models.sam import Predictor; "
+        "assert 'torchvision' not in sys.modules; "
+        "assert 'ultralytics.models.sam.sam3.geometry_encoders' not in sys.modules"
+    )
+    subprocess.run(["python", "-c", code], check=True)
+
+
 @pytest.mark.parametrize("task,model,data", TASK_MODEL_DATA)
 @pytest.mark.skipif(IS_RASPBERRYPI, reason="Edge devices not intended for training")
 def test_train(task: str, model: str, data: str) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -16,8 +16,8 @@ from ultralytics.engine.exporter import Exporter
 from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models.yolo import classify, detect, obb, pose, segment, semantic
 from ultralytics.nn.distill_model import DistillationModel
-from ultralytics.nn.tasks import load_checkpoint
-from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR
+from ultralytics.nn.tasks import load_checkpoint, torch_safe_load
+from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR, IterableSimpleNamespace
 from ultralytics.utils.torch_utils import unwrap_model
 
 
@@ -217,6 +217,16 @@ def test_load_checkpoint_state_dict_rejected(ckpt, tmp_path):
     torch.save(ckpt, weight)
     with pytest.raises(TypeError, match="supported Ultralytics checkpoint format"):
         load_checkpoint(weight)
+
+
+def test_safe_load_allows_iterable_simple_namespace(tmp_path):
+    """Test restricted checkpoint loading accepts Ultralytics config namespaces saved in checkpoints."""
+    weight = tmp_path / "namespace.pt"
+    torch.save({"train_args": IterableSimpleNamespace(imgsz=640)}, weight)
+
+    ckpt, _ = torch_safe_load(weight, safe_only=True)
+
+    assert ckpt["train_args"].imgsz == 640
 
 
 def test_nan_recovery():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -16,8 +16,8 @@ from ultralytics.engine.exporter import Exporter
 from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models.yolo import classify, detect, obb, pose, segment, semantic
 from ultralytics.nn.distill_model import DistillationModel
-from ultralytics.nn.tasks import load_checkpoint, torch_safe_load
-from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR, IterableSimpleNamespace
+from ultralytics.nn.tasks import load_checkpoint
+from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR
 from ultralytics.utils.torch_utils import unwrap_model
 
 
@@ -217,16 +217,6 @@ def test_load_checkpoint_state_dict_rejected(ckpt, tmp_path):
     torch.save(ckpt, weight)
     with pytest.raises(TypeError, match="supported Ultralytics checkpoint format"):
         load_checkpoint(weight)
-
-
-def test_safe_load_allows_iterable_simple_namespace(tmp_path):
-    """Test restricted checkpoint loading accepts Ultralytics config namespaces saved in checkpoints."""
-    weight = tmp_path / "namespace.pt"
-    torch.save({"train_args": IterableSimpleNamespace(imgsz=640)}, weight)
-
-    ckpt, _ = torch_safe_load(weight, safe_only=True)
-
-    assert ckpt["train_args"].imgsz == 640
 
 
 def test_nan_recovery():

--- a/ultralytics/models/__init__.py
+++ b/ultralytics/models/__init__.py
@@ -3,7 +3,16 @@
 from .fastsam import FastSAM
 from .nas import NAS
 from .rtdetr import RTDETR
-from .sam import SAM
 from .yolo import YOLO, YOLOE, YOLOWorld
 
 __all__ = "NAS", "RTDETR", "SAM", "YOLO", "YOLOE", "FastSAM", "YOLOWorld"  # allow simpler import
+
+
+def __getattr__(name):
+    """Lazy-import SAM so standard YOLO imports don't load optional torchvision internals."""
+    if name == "SAM":
+        # Scoped for import ultralytics speed: SAM pulls optional torchvision-heavy modules.
+        from .sam import SAM
+
+        return SAM
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/ultralytics/models/sam/predict.py
+++ b/ultralytics/models/sam/predict.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import cv2
 import numpy as np
@@ -37,7 +37,9 @@ from .amg import (
     uncrop_boxes_xyxy,
     uncrop_masks,
 )
-from .sam3.geometry_encoders import Prompt
+
+if TYPE_CHECKING:
+    from .sam3.geometry_encoders import Prompt
 
 
 class Predictor(BasePredictor):
@@ -2408,6 +2410,9 @@ class SAM3SemanticPredictor(SAM3Predictor):
 
     def _get_dummy_prompt(self, num_prompts=1):
         """Get a dummy geometric prompt with zero boxes."""
+        # Scoped for import ultralytics speed: SAM3 geometry imports optional torchvision ops.
+        from .sam3.geometry_encoders import Prompt
+
         geometric_prompt = Prompt(
             box_embeddings=torch.zeros(0, num_prompts, 4, device=self.device),
             box_mask=torch.zeros(num_prompts, 0, device=self.device, dtype=torch.bool),

--- a/ultralytics/models/sam/sam3/decoder.py
+++ b/ultralytics/models/sam/sam3/decoder.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import numpy as np
 import torch
 from torch import nn
-from torchvision.ops.roi_align import RoIAlign
 
 from ultralytics.nn.modules.transformer import MLP
 from ultralytics.nn.modules.utils import _get_clones, inverse_sigmoid
@@ -265,11 +264,13 @@ class TransformerDecoder(nn.Module):
             self.compilable_stored_size = None
             self.coord_cache = {}
 
-        self.roi_pooler = (
-            RoIAlign(output_size=7, spatial_scale=1, sampling_ratio=-1, aligned=True)
-            if interaction_layer is not None
-            else None
-        )
+        if interaction_layer is not None:
+            # Scoped for import ultralytics speed: ROI align requires optional torchvision ops.
+            from torchvision.ops.roi_align import RoIAlign
+
+            self.roi_pooler = RoIAlign(output_size=7, spatial_scale=1, sampling_ratio=-1, aligned=True)
+        else:
+            self.roi_pooler = None
         if frozen:
             for p in self.parameters():
                 p.requires_grad_(False)

--- a/ultralytics/models/sam/sam3/geometry_encoders.py
+++ b/ultralytics/models/sam/sam3/geometry_encoders.py
@@ -4,7 +4,6 @@
 
 import torch
 import torch.nn as nn
-import torchvision
 
 from ultralytics.nn.modules.utils import _get_clones
 from ultralytics.utils.ops import xywh2xyxy
@@ -293,7 +292,10 @@ class SequenceGeometryEncoder(nn.Module):
             boxes_xyxy = boxes_xyxy * scale
 
             # RoI align
-            sampled = torchvision.ops.roi_align(img_feats, boxes_xyxy.transpose(0, 1).unbind(0), self.roi_size)
+            # Scoped for import ultralytics speed: ROI align requires optional torchvision ops.
+            from torchvision.ops import roi_align
+
+            sampled = roi_align(img_feats, boxes_xyxy.transpose(0, 1).unbind(0), self.roi_size)
             assert list(sampled.shape) == [
                 bs * n_boxes,
                 self.d_model,

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -74,8 +74,17 @@ from ultralytics.nn.modules import (
     YOLOESegment26,
     v10Detect,
 )
-from ultralytics.utils import DEFAULT_CFG_DICT, LOGGER, SAFE_LOAD, SETTINGS, WINDOWS, YAML, colorstr, emojis
-from ultralytics.utils import IterableSimpleNamespace
+from ultralytics.utils import (
+    DEFAULT_CFG_DICT,
+    LOGGER,
+    SAFE_LOAD,
+    SETTINGS,
+    WINDOWS,
+    YAML,
+    IterableSimpleNamespace,
+    colorstr,
+    emojis,
+)
 from ultralytics.utils.checks import REMOTE_FILE_PREFIXES, check_file, check_requirements, check_suffix, check_yaml
 from ultralytics.utils.loss import (
     E2ELoss,

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -75,6 +75,7 @@ from ultralytics.nn.modules import (
     v10Detect,
 )
 from ultralytics.utils import DEFAULT_CFG_DICT, LOGGER, SAFE_LOAD, SETTINGS, WINDOWS, YAML, colorstr, emojis
+from ultralytics.utils import IterableSimpleNamespace
 from ultralytics.utils.checks import REMOTE_FILE_PREFIXES, check_file, check_requirements, check_suffix, check_yaml
 from ultralytics.utils.loss import (
     E2ELoss,
@@ -1554,7 +1555,10 @@ class _SafeLoad:
         _scan(ul_nn)  # ultralytics block/conv/head/transformer
         _scan(ul_tasks)  # ultralytics task models
 
-        # Non-nn.Module data globals in official checkpoints (classification preprocessing transforms).
+        # Non-nn.Module data globals in official checkpoints.
+        allow.append(IterableSimpleNamespace)
+
+        # Classification preprocessing transforms.
         try:
             import torchvision.transforms.transforms as tvt
             from torchvision.transforms.functional import InterpolationMode


### PR DESCRIPTION
## Summary
Fixes two production issues:

- Sentry `ULTRALYTICS-23C1`: https://ultralytics.sentry.io/issues/7111924189/
- GPU worker/Sentry `ALPHA-1DM`: https://ultralytics.sentry.io/issues/7432157731/

## Fixed Failure Patterns
| Evidence | Root cause | Minimal fix |
| --- | --- | --- |
| `ULTRALYTICS-23C1`: `RuntimeError: operator torchvision::nms does not exist` during CLI/import startup via `ultralytics.models -> SAM -> sam.predict -> sam3.geometry_encoders -> torchvision` | Standard YOLO import paths eagerly imported SAM/SAM3 and therefore optional torchvision internals before they were needed. | Replace the eager `SAM` import with lazy module `__getattr__`, and scope SAM3 `Prompt` / ROI align imports to the methods that need them. Existing runtime torchvision NMS behavior is unchanged. |
| GPU logs and `ALPHA-1DM`: worker training jobs `6a3f0abe7cfae13b647f3c9b`, `6a3fdde54d227c615bd52585`, `6a3fde9952dacc7395c6fdd2` failed loading Platform-hosted `.pt` checkpoints with `Unsupported global: GLOBAL ultralytics.utils.IterableSimpleNamespace` under restricted checkpoint loading. | The restricted checkpoint allowlist included model modules and classification transforms, but missed Ultralytics' own config namespace class saved in valid training checkpoints. | Add `IterableSimpleNamespace` to the existing `_SafeLoad` full allowlist. This keeps restricted loading enabled and does not fall back to unsafe loading. |

## GPU Log Evidence
Saved Docker logs are local only and not committed:

- Export path: `/Users/glennjocher/PycharmProjects/portal/worker-log-export-2026-06-27`
- `ultra1`: `lambda-scalar-workers-gpu-worker-8.log`, container `workers-gpu-worker-8`, worker version `Ultralytics: 8.4.80`
- `ultra5`: `lambda-scalar-workers-gpu-worker-23.log`, container `workers-gpu-worker-23`, worker version `Ultralytics: 8.4.80`
- `ultra5`: `lambda-scalar-Platform-API.log`, `lambda-scalar-Platform-Tunnel.log`; reviewed but no actionable code fix. API traces were signed CDN image 404/download failures returning 400s, and tunnel traces were client disconnect/network churn.

## Change Type
- `ultralytics/models/__init__.py`: replacement/deletion of eager SAM import.
- `ultralytics/models/sam/predict.py`, `sam3/decoder.py`, `sam3/geometry_encoders.py`: replacement of eager optional imports with scoped imports.
- `ultralytics/nn/tasks.py`: one full-allowlist addition for `IterableSimpleNamespace`.
- `tests/test_cli.py`: focused regression coverage that `YOLO` import does not eagerly load torchvision.
- Preserved Ultralytics Actions docs-reference update commit on this PR branch.

## Verification
- `python -m ruff check ultralytics/nn/tasks.py tests/test_engine.py ultralytics/models/__init__.py ultralytics/models/sam/predict.py ultralytics/models/sam/sam3/geometry_encoders.py ultralytics/models/sam/sam3/decoder.py tests/test_cli.py`
- `python -m pytest tests/test_engine.py::test_safe_load_allows_iterable_simple_namespace -q` passed before removing that temporary CI-validation test per maintainer request.
- `python -m pytest tests/test_cli.py::test_cli_imports_defer_torchvision -q`
- `python -m pytest tests/test_cli.py::test_special_modes tests/test_cli.py::test_cli_imports_defer_torchvision -q`
- `python -m pytest tests/test_python.py -q`
- After removing the temporary test before merge: `python -m ruff check tests/test_engine.py ultralytics/nn/tasks.py tests/test_cli.py`
- After removing the temporary test before merge: `python -m pytest tests/test_cli.py::test_cli_imports_defer_torchvision tests/test_engine.py::test_load_checkpoint_state_dict_rejected -q`
- After removing the temporary test before merge: manual `torch_safe_load(..., safe_only=True)` smoke test with `IterableSimpleNamespace` checkpoint payload.
- `PYTHONPATH=$PWD yolo version`
- Import probe confirmed `from ultralytics import YOLO` and `from ultralytics.models.sam import Predictor` do not load `torchvision` or `ultralytics.models.sam.sam3.geometry_encoders`.
- `rg -n "^import torchvision|^from torchvision" ultralytics/models/sam ultralytics/models/__init__.py` shows no eager SAM/SAM3 torchvision imports.

## Sentry
Already marked resolved in next release after earlier dual review:

- `ultralytics` / `ULTRALYTICS-23C1` / https://ultralytics.sentry.io/issues/7111924189/

Pending final green CI before resolve:

- `alpha` / `ALPHA-1DM` / https://ultralytics.sentry.io/issues/7432157731/

## Reviews
Earlier pre-GPU-log review:

- Claude Code reviewer: LGTM.
- Codex CLI reviewer: LGTM.

Fresh GPU-log review covering this PR and the Portal companion PR:

- Claude Code reviewer: runtime changes LGTM; only blocker was removing the temporary safe-load test before merge.
- Codex CLI reviewer: runtime changes LGTM; same temporary-test merge blocker.
- Blocker addressed in `ca646cbe6` by deleting the temporary test before merge.

## Cross-repo
Companion Portal PR: https://github.com/ultralytics/portal/pull/2600

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR improves Ultralytics import startup efficiency by lazily loading SAM and `torchvision`-dependent components, while also adding docs and tests to support the change.

### 📊 Key Changes
- ⚡ **Lazy-loaded `SAM` in `ultralytics.models`**
  - Removed eager import of `SAM` from `ultralytics/models/__init__.py`
  - Added `__getattr__` so `SAM` is only imported when actually needed

- 🧠 **Deferred heavy `torchvision` imports inside SAM modules**
  - Moved `torchvision`-related imports in SAM3 code to function/class scope
  - Delayed loading of:
    - `torchvision.ops.roi_align`
    - SAM3 geometry prompt dependencies
  - Replaced some top-level imports with `TYPE_CHECKING`-only imports where appropriate

- ✅ **Added a CLI/import regression test**
  - New test confirms that importing `YOLO` and SAM `Predictor` does **not** automatically load `torchvision` or SAM3 geometry modules

- 📚 **Added API docs for `ultralytics.models.__init__`**
  - New reference page documents the module and its new `__getattr__` behavior
  - Updated `mkdocs.yml` navigation to include it

- 🛡️ **Expanded checkpoint safe-loading support**
  - Added `IterableSimpleNamespace` to allowed non-`nn.Module` globals during model loading
  - Helps support official checkpoints with extra stored metadata/preprocessing objects

### 🎯 Purpose & Impact
- 🚀 **Faster and lighter imports**
  - Standard YOLO usage can start up with fewer unnecessary dependencies loaded

- 📦 **Better optional dependency handling**
  - Users who are not using SAM or certain `torchvision` ops avoid importing those components unless required

- 🧪 **More reliable behavior**
  - The new test helps prevent future regressions that could slow startup or trigger avoidable import issues

- 👥 **Improved user experience**
  - Especially helpful for CLI users, lightweight environments, and setups where optional `torchvision` features may be unavailable

- 📘 **Clearer developer documentation**
  - The new API reference makes the lazy import behavior easier to discover and understand