### PR TITLE
Remove internal half int8 export state

### DIFF
--- a/docs/en/guides/export-non-yolo-models.md
+++ b/docs/en/guides/export-non-yolo-models.md
@@ -116,7 +116,7 @@ resnet18_openvino_model/
 └── model.bin
 ```
 
-Pass `dynamic=True` for dynamic input shapes, `half=True` for FP16, or `int8=True` for INT8 quantization. INT8 additionally requires a `calibration_dataset` argument.
+Pass `dynamic=True` for dynamic input shapes, `quantize=16` for FP16, or `quantize=8` for INT8 quantization. INT8 additionally requires a `calibration_dataset` argument.
 
 Requires `openvino>=2024.0.0` (or `>=2025.2.0` on macOS 15.4+) and `torch>=2.1`.
 
@@ -215,7 +215,7 @@ torch2onnx(model, im, output_file="resnet18.onnx")
 onnx2mnn("resnet18.onnx", output_file="resnet18.mnn")
 ```
 
-Supports `half=True` for FP16 and `int8=True` for INT8 quantization. Requires `MNN>=2.9.6` and `torch>=1.10`.
+Supports `quantize=16` for FP16 and `quantize=8` for INT8 quantization. Requires `MNN>=2.9.6` and `torch>=1.10`.
 
 ### Export to PaddlePaddle
 
@@ -319,7 +319,7 @@ Yes. torchvision classifiers, detectors, and segmentation models export to `.mlp
 
 ### Can I quantize my exported model to INT8 or FP16?
 
-Yes, for several formats. Pass `half=True` for FP16 or `int8=True` for INT8 when exporting to OpenVINO, CoreML, MNN, or NCNN. INT8 in OpenVINO additionally requires a `calibration_dataset` argument for [post-training quantization](https://www.ultralytics.com/glossary/model-quantization). See each format's integration page for quantization trade-offs.
+Yes, for several formats. Pass `quantize=16` for FP16 or `quantize=8` for INT8 when exporting to OpenVINO, CoreML, MNN, or NCNN. INT8 in OpenVINO additionally requires a `calibration_dataset` argument for [post-training quantization](https://www.ultralytics.com/glossary/model-quantization). See each format's integration page for quantization trade-offs.
 
 ### How do I verify an exported model matches the original?
 

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -48,25 +48,21 @@ def test_amp():
 @pytest.mark.slow
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 @pytest.mark.parametrize(
-    "task, dynamic, int8, half, batch, simplify, nms",
+    "task, dynamic, batch, simplify, nms",
     [  # generate all combinations except for exclusion cases
-        (task, dynamic, int8, half, batch, simplify, nms)
-        for task, dynamic, int8, half, batch, simplify, nms in product(
-            sorted(TASKS), [True, False], [False], [False], [1, 2], [True, False], [True, False]
+        (task, dynamic, batch, simplify, nms)
+        for task, dynamic, batch, simplify, nms in product(
+            sorted(TASKS), [True, False], [1, 2], [True, False], [True, False]
         )
-        if not (
-            (int8 and half) or (task == "classify" and nms) or (task == "obb" and nms and (not TORCH_1_13 or IS_JETSON))
-        )
+        if not ((task == "classify" and nms) or (task == "obb" and nms and (not TORCH_1_13 or IS_JETSON)))
     ],
 )
-def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
+def test_export_onnx_matrix(task, dynamic, batch, simplify, nms):
     """Test YOLO exports to ONNX format with various configurations and parameters."""
     file = YOLO(TASK2MODEL[task]).export(
         format="onnx",
         imgsz=32,
         dynamic=dynamic,
-        int8=int8,
-        half=half,
         batch=batch,
         simplify=simplify,
         nms=nms,
@@ -80,22 +76,21 @@ def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms):
 @pytest.mark.slow
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 @pytest.mark.parametrize(
-    "task, dynamic, int8, half, batch",
-    [  # generate all combinations but exclude those where both int8 and half are True
-        (task, dynamic, int8, half, batch)
+    "task, dynamic, quantize, batch",
+    [
+        (task, dynamic, quantize, batch)
         # Note: tests reduced below pending compute availability expansion as GPU CI runner utilization is high
-        # for task, dynamic, int8, half, batch in product(TASKS, [True, False], [True, False], [True, False], [1, 2])
-        for task, dynamic, int8, half, batch in product(sorted(TASKS), [True], [True], [False], [2])
-        if not (int8 and half)  # exclude cases where both int8 and half are True
+        # for task, dynamic, quantize, batch in product(TASKS, [True, False], [8, 16], [1, 2])
+        for task, dynamic, quantize, batch in product(sorted(TASKS), [True], [8, 16], [2])
     ],
 )
-def test_export_engine_matrix(task, dynamic, int8, half, batch):
+def test_export_engine_matrix(task, dynamic, quantize, batch):
     """Test YOLO model export to TensorRT format for various configurations and run inference."""
     check_tensorrt()
     import tensorrt as trt
 
     is_trt11 = int(trt.__version__.split(".", 1)[0]) >= 11
-    if not is_trt11 and int8 and dynamic:
+    if not is_trt11 and quantize == 8 and dynamic:
         # TensorRT 7-10 calibrator path cannot quantize dynamic-shape models; TensorRT 11 uses ModelOpt explicit Q/DQ
         pytest.skip("INT8 + dynamic export requires explicit quantization, available on TensorRT 11+")
 
@@ -103,8 +98,7 @@ def test_export_engine_matrix(task, dynamic, int8, half, batch):
         format="engine",
         imgsz=32,
         dynamic=dynamic,
-        int8=int8,
-        half=half,
+        quantize=quantize,
         batch=batch,
         data=TASK2DATA[task],
         workspace=1,  # reduce workspace GB for less resource utilization during testing
@@ -113,10 +107,10 @@ def test_export_engine_matrix(task, dynamic, int8, half, batch):
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, device=DEVICES[0])  # exported model inference
     Path(file).unlink()  # cleanup
-    if int8:
+    if quantize == 8:
         Path(file).with_suffix(".cache").unlink(missing_ok=True)  # cleanup TensorRT 7-10 INT8 calibration cache
         Path(file).with_suffix(".int8.onnx").unlink(missing_ok=True)  # cleanup TensorRT 11 ModelOpt INT8 ONNX
-    if half:
+    if quantize == 16:
         Path(file).with_suffix(".fp16.onnx").unlink(missing_ok=True)  # cleanup TensorRT 11 ModelOpt FP16 ONNX
 
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -66,7 +66,7 @@ def test_export_onnx(end2end, isolated_model):
 @pytest.mark.slow
 @pytest.mark.parametrize("precision", [{"int8": True}, {"quantize": 8}])
 def test_export_onnx_int8(isolated_model, precision):
-    """Test INT8 ONNX export via both the legacy int8 flag and the unified quantize arg yield the same artifact."""
+    """Test INT8 ONNX export via both the legacy int8 alias and the unified quantize arg."""
     file = YOLO(isolated_model).export(format="onnx", data="coco8.yaml", fraction=0.25, imgsz=32, **precision)
     assert Path(file).name.endswith("_int8.onnx")
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
@@ -119,7 +119,7 @@ def test_qnn_quantize_requires_w8a16():
 def test_modelopt_quantize_onnx_requires_int8_dataset():
     """Check INT8 ModelOpt quantization fails early without calibration data."""
     with pytest.raises(ValueError, match="requires a calibration dataset"):
-        modelopt_quantize_onnx("model.onnx", int8=True)
+        modelopt_quantize_onnx("model.onnx", quantize=8)
 
 
 def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
@@ -171,25 +171,24 @@ def test_export_openvino(end2end, isolated_model):
 @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_2_1, reason="OpenVINO requires torch>=2.1")
 @pytest.mark.parametrize(
-    "task, dynamic, int8, half, batch, nms, end2end",
+    "task, dynamic, quantize, batch, nms, end2end",
     [  # generate all combinations except for exclusion cases
-        (task, dynamic, int8, half, batch, nms, end2end)
-        for task, dynamic, int8, half, batch, nms, end2end in product(
-            sorted(TASKS), [True, False], [True, False], [True, False], [1, 2], [True, False], [True]
+        (task, dynamic, quantize, batch, nms, end2end)
+        for task, dynamic, quantize, batch, nms, end2end in product(
+            sorted(TASKS), [True, False], [8, 16], [1, 2], [True, False], [True]
         )
-        if not ((int8 and half) or (task == "classify" and nms) or (end2end and nms))
+        if not ((task == "classify" and nms) or (end2end and nms))
     ],
 )
 # disable end2end=False test for now due to github runner OOM during openvino tests
-def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms, end2end):
+def test_export_openvino_matrix(task, dynamic, quantize, batch, nms, end2end):
     """Test YOLO model export to OpenVINO under various configuration matrix conditions."""
     skip_rpi_semantic(task)
     file = YOLO(TASK2MODEL[task]).export(
         format="openvino",
         imgsz=32,
         dynamic=dynamic,
-        int8=int8,
-        half=half,
+        quantize=quantize,
         batch=batch,
         data=TASK2DATA[task],
         nms=nms,
@@ -205,24 +204,22 @@ def test_export_openvino_matrix(task, dynamic, int8, half, batch, nms, end2end):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "task, dynamic, int8, half, batch, simplify, nms, end2end",
+    "task, dynamic, batch, simplify, nms, end2end",
     [  # generate all combinations except for exclusion cases
-        (task, dynamic, int8, half, batch, simplify, nms, end2end)
-        for task, dynamic, int8, half, batch, simplify, nms, end2end in product(
-            sorted(TASKS), [True, False], [False], [False], [1, 2], [True, False], [True, False], [True, False]
+        (task, dynamic, batch, simplify, nms, end2end)
+        for task, dynamic, batch, simplify, nms, end2end in product(
+            sorted(TASKS), [True, False], [1, 2], [True, False], [True, False], [True, False]
         )
-        if not ((int8 and half) or (task == "classify" and nms) or (nms and not TORCH_1_13) or (end2end and nms))
+        if not ((task == "classify" and nms) or (nms and not TORCH_1_13) or (end2end and nms))
     ],
 )
-def test_export_onnx_matrix(task, dynamic, int8, half, batch, simplify, nms, end2end):
+def test_export_onnx_matrix(task, dynamic, batch, simplify, nms, end2end):
     """Test YOLO export to ONNX format with various configurations and parameters."""
     skip_rpi_semantic(task)
     file = YOLO(TASK2MODEL[task]).export(
         format="onnx",
         imgsz=32,
         dynamic=dynamic,
-        int8=int8,
-        half=half,
         batch=batch,
         simplify=simplify,
         nms=nms,
@@ -246,20 +243,20 @@ def test_export_onnx_semantic_dnn():
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "task, dynamic, int8, half, batch, nms, end2end",
+    "task, dynamic, batch, nms, end2end",
     [  # generate all combinations except for exclusion cases
-        (task, dynamic, int8, half, batch, nms, end2end)
-        for task, dynamic, int8, half, batch, nms, end2end in product(
-            sorted(TASKS), [False, True], [False], [False, True], [1, 2], [True, False], [True, False]
+        (task, dynamic, batch, nms, end2end)
+        for task, dynamic, batch, nms, end2end in product(
+            sorted(TASKS), [False, True], [1, 2], [True, False], [True, False]
         )
-        if not ((task == "classify" and nms) or (end2end and nms) or half)
+        if not ((task == "classify" and nms) or (end2end and nms))
     ],
 )
-def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms, end2end, tmp_path):
+def test_export_torchscript_matrix(task, dynamic, batch, nms, end2end, tmp_path):
     """Test YOLO model export to TorchScript format under varied configurations."""
     skip_rpi_semantic(task)
     file = YOLO(isolated_model_path(tmp_path, WEIGHTS_DIR / TASK2MODEL[task])).export(
-        format="torchscript", imgsz=32, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms, end2end=end2end
+        format="torchscript", imgsz=32, dynamic=dynamic, batch=batch, nms=nms, end2end=end2end
     )
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32)  # exported model inference
     Path(file).unlink()  # cleanup
@@ -272,28 +269,26 @@ def test_export_torchscript_matrix(task, dynamic, int8, half, batch, nms, end2en
     MACOS and MACOS_VERSION and MACOS_VERSION >= "15", reason="CoreML YOLO26 matrix test crashes on macOS 15+"
 )
 @pytest.mark.parametrize(
-    "task, dynamic, int8, half, nms, batch, end2end",
+    "task, dynamic, quantize, nms, batch, end2end",
     [  # generate all combinations except for exclusion cases
-        (task, dynamic, int8, half, nms, batch, end2end)
-        for task, dynamic, int8, half, nms, batch, end2end in product(
-            sorted(TASKS), [True, False], [True, False], [True, False], [True, False], [1], [True, False]
+        (task, dynamic, quantize, nms, batch, end2end)
+        for task, dynamic, quantize, nms, batch, end2end in product(
+            sorted(TASKS), [True, False], [8, 16], [True, False], [1], [True, False]
         )
-        if not (int8 and half)
-        and not (task != "detect" and nms)
+        if not (task != "detect" and nms)
         and not (dynamic and nms)
         and not (task == "classify" and dynamic)
         and not (end2end and nms)
     ],
 )
-def test_export_coreml_matrix(task, dynamic, int8, half, nms, batch, end2end):
+def test_export_coreml_matrix(task, dynamic, quantize, nms, batch, end2end):
     """Test YOLO export to CoreML format with various parameter configurations."""
     skip_rpi_semantic(task)
     file = YOLO(TASK2MODEL[task]).export(
         format="coreml",
         imgsz=32,
         dynamic=dynamic,
-        int8=int8,
-        half=half,
+        quantize=quantize,
         batch=batch,
         nms=nms,
         end2end=end2end,
@@ -311,26 +306,25 @@ def test_export_coreml_matrix(task, dynamic, int8, half, nms, batch, end2end):
     reason="Test disabled as TF suffers from install conflicts on Windows, macOS and Raspberry Pi",
 )
 @pytest.mark.parametrize(
-    "task, dynamic, int8, half, batch, nms, end2end",
+    "task, dynamic, quantize, batch, nms, end2end",
     [  # generate all combinations except for exclusion cases
-        (task, dynamic, int8, half, batch, nms, end2end)
-        for task, dynamic, int8, half, batch, nms, end2end in product(
-            sorted(TASKS), [False], [True, False], [True, False], [1], [True, False], [True, False]
+        (task, dynamic, quantize, batch, nms, end2end)
+        for task, dynamic, quantize, batch, nms, end2end in product(
+            sorted(TASKS), [False], [8, 16], [1], [True, False], [True, False]
         )
         if not (
-            (int8 and half)
-            or (task == "classify" and nms)
+            (task == "classify" and nms)
             or (ARM64 and nms)
             or (nms and not TORCH_1_13)
             or (end2end and nms)
         )
     ],
 )
-def test_export_tflite_matrix(task, dynamic, int8, half, batch, nms, end2end):
+def test_export_tflite_matrix(task, dynamic, quantize, batch, nms, end2end):
     """Test YOLO export to TFLite format considering various export configurations."""
     skip_rpi_semantic(task)
     file = YOLO(TASK2MODEL[task]).export(
-        format="tflite", imgsz=32, dynamic=dynamic, int8=int8, half=half, batch=batch, nms=nms, end2end=end2end
+        format="tflite", imgsz=32, dynamic=dynamic, quantize=quantize, batch=batch, nms=nms, end2end=end2end
     )
     r = YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
     if task == "semantic":
@@ -424,19 +418,18 @@ def test_export_mnn(isolated_model):
 @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_1_10, reason="MNN export requires torch>=1.10")
 @pytest.mark.parametrize(
-    "task, int8, half, batch, end2end",
+    "task, quantize, batch, end2end",
     [  # generate all combinations except for exclusion cases
-        (task, int8, half, batch, end2end)
-        for task, int8, half, batch, end2end in product(
-            sorted(TASKS), [True, False], [True, False], [1, 2], [True, False]
-        )
-        if not (int8 and half)
+        (task, quantize, batch, end2end)
+        for task, quantize, batch, end2end in product(sorted(TASKS), [8, 16], [1, 2], [True, False])
     ],
 )
-def test_export_mnn_matrix(task, int8, half, batch, end2end):
+def test_export_mnn_matrix(task, quantize, batch, end2end):
     """Test YOLO export to MNN format considering various export configurations."""
     skip_rpi_semantic(task)
-    file = YOLO(TASK2MODEL[task]).export(format="mnn", imgsz=32, int8=int8, half=half, batch=batch, end2end=end2end)
+    file = YOLO(TASK2MODEL[task]).export(
+        format="mnn", imgsz=32, quantize=quantize, batch=batch, end2end=end2end
+    )
     YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
     Path(file).unlink()  # cleanup
 
@@ -450,11 +443,11 @@ def test_export_ncnn(isolated_model):
 
 @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_2_0, reason="NCNN inference causes segfault on PyTorch<2.0")
-@pytest.mark.parametrize("task, half, batch", list(product(sorted(TASKS), [True, False], [1])))
-def test_export_ncnn_matrix(task, half, batch):
+@pytest.mark.parametrize("task, quantize, batch", list(product(sorted(TASKS), [16], [1])))
+def test_export_ncnn_matrix(task, quantize, batch):
     """Test YOLO export to NCNN format considering various export configurations."""
     skip_rpi_semantic(task)
-    file = YOLO(TASK2MODEL[task]).export(format="ncnn", imgsz=32, half=half, batch=batch)
+    file = YOLO(TASK2MODEL[task]).export(format="ncnn", imgsz=32, quantize=quantize, batch=batch)
     YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
     shutil.rmtree(file, ignore_errors=True)  # retry in case of potential lingering multi-threaded file usage errors
 
@@ -474,10 +467,10 @@ def test_export_imx():
 
 @pytest.mark.slow
 @pytest.mark.skipif(not LINUX or ARM64, reason="RKNN export only supported on non-aarch64 Linux")
-@pytest.mark.parametrize("int8", [True, False])
-def test_export_rknn(isolated_model, int8):
+@pytest.mark.parametrize("quantize", [8, 16])
+def test_export_rknn(isolated_model, quantize):
     """Test YOLO export to RKNN format."""
-    file = YOLO(isolated_model).export(format="rknn", imgsz=32, int8=int8)
+    file = YOLO(isolated_model).export(format="rknn", imgsz=32, quantize=quantize)
     assert next(Path(file).rglob("*.rknn"), None), f"RKNN export failed, no RKNN model found in: {file}"
     shutil.rmtree(file, ignore_errors=True)
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -312,12 +312,7 @@ def test_export_coreml_matrix(task, dynamic, quantize, nms, batch, end2end):
         for task, dynamic, quantize, batch, nms, end2end in product(
             sorted(TASKS), [False], [8, 16], [1], [True, False], [True, False]
         )
-        if not (
-            (task == "classify" and nms)
-            or (ARM64 and nms)
-            or (nms and not TORCH_1_13)
-            or (end2end and nms)
-        )
+        if not ((task == "classify" and nms) or (ARM64 and nms) or (nms and not TORCH_1_13) or (end2end and nms))
     ],
 )
 def test_export_tflite_matrix(task, dynamic, quantize, batch, nms, end2end):
@@ -427,9 +422,7 @@ def test_export_mnn(isolated_model):
 def test_export_mnn_matrix(task, quantize, batch, end2end):
     """Test YOLO export to MNN format considering various export configurations."""
     skip_rpi_semantic(task)
-    file = YOLO(TASK2MODEL[task]).export(
-        format="mnn", imgsz=32, quantize=quantize, batch=batch, end2end=end2end
-    )
+    file = YOLO(TASK2MODEL[task]).export(format="mnn", imgsz=32, quantize=quantize, batch=batch, end2end=end2end)
     YOLO(file)([SOURCE] * batch, imgsz=32)  # exported model inference
     Path(file).unlink()  # cleanup
 

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -546,21 +546,17 @@ class Exporter:
             self.args.device = "0"  # update device to "0"
         self.device = select_device("cpu" if self.args.device is None else self.args.device)
 
-        # Derive the FP16/INT8 booleans the per-format export backends use from the unified `quantize` scheme
-        self.args.half = self.args.quantize == 16
-        self.args.int8 = self.args.quantize in {8, "w8a16"}
-
         # Argument compatibility checks
         fmt_keys = dict(zip(fmts_dict["Argument"], fmts_dict["Arguments"]))[fmt]
         validate_args(fmt, self.args, fmt_keys)
-        if fmt in {"deepx", "axelera", "imx", "edgetpu", "qnn"} and not self.args.int8:
+        if fmt in {"deepx", "axelera", "imx", "edgetpu", "qnn"} and self.args.quantize not in {8, "w8a16"}:
             if self.args.quantize == 32:
                 raise ValueError(
                     f"{fmt} export only supports INT8, but got an explicit quantize=32 (FP32) request. "
                     f"See {QUANTIZE_DOCS_URL}"
                 )
             LOGGER.warning(f"{fmt} export requires INT8 quantization, enabling it.")
-            self.args.int8 = True
+            self.args.quantize = "w8a16" if fmt == "qnn" else 8
         if fmt == "axelera":
             if model.task == "segment" and any(isinstance(m, Segment26) for m in model.modules()):
                 raise ValueError("Axelera export does not currently support YOLO26 segmentation models.")
@@ -596,7 +592,7 @@ class Exporter:
                             "Please upgrade TensorRT to 8.5.0 or later to enable end2end export."
                         )
 
-                    if self.args.int8 and check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
+                    if self.args.quantize == 8 and check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
                         # https://github.com/ultralytics/ultralytics/issues/23841
                         model.end2end = False
                         LOGGER.warning(
@@ -606,7 +602,7 @@ class Exporter:
                         )
                 except ImportError:
                     pass
-        if self.args.half and fmt == "torchscript" and self.device.type == "cpu":
+        if self.args.quantize == 16 and fmt == "torchscript" and self.device.type == "cpu":
             raise ValueError("FP16 TorchScript export is only supported on GPU, i.e. use device=0.")
         self.imgsz = check_imgsz(self.args.imgsz, stride=model.stride, min_dim=2)  # check image size
         if self.args.optimize:
@@ -623,7 +619,7 @@ class Exporter:
             assert self.args.name in RKNN_CHIPS, (
                 f"Invalid processor name '{self.args.name}' for Rockchip RKNN export. Valid names are {RKNN_CHIPS}."
             )
-            if self.args.name in {"rv1103", "rv1106", "rv1103b", "rv1106b"} and not self.args.int8:
+            if self.args.name in {"rv1103", "rv1106", "rv1103b", "rv1106b"} and self.args.quantize != 8:
                 if self.args.quantize not in {None, 8}:
                     raise ValueError(
                         f"Rockchip target '{self.args.name}' only supports INT8, but got quantize={self.args.quantize}. "
@@ -631,11 +627,8 @@ class Exporter:
                     )
                 LOGGER.warning(f"Rockchip target '{self.args.name}' requires INT8 quantization, enabling it.")
                 self.args.quantize = 8
-                self.args.half = False
-                self.args.int8 = True
             elif self.args.quantize is None:
                 self.args.quantize = 16
-                self.args.half = True
         if fmt == "qnn":
             if not self.args.name:
                 LOGGER.warning(
@@ -680,7 +673,7 @@ class Exporter:
                 "See https://docs.ultralytics.com/models/yolo-world for details."
             )
             model.clip_model = None  # openvino int8 export error: https://github.com/ultralytics/ultralytics/pull/18445
-        if self.args.int8 and not self.args.data:
+        if self.args.quantize in {8, "w8a16"} and not self.args.data:
             self.args.data = DEFAULT_CFG.data or TASK2DATA[getattr(model, "task", "detect")]  # assign default data
             LOGGER.warning(
                 f"INT8 export requires a missing 'data' arg for calibration. Using default 'data={self.args.data}'."
@@ -762,7 +755,7 @@ class Exporter:
         y = None
         for _ in range(2):  # dry runs
             y = NMSModel(model, self.args)(im) if self.args.nms and fmt not in {"coreml", "imx"} else model(im)
-        if self.args.half and fmt in {"onnx", "torchscript"} and self.device.type != "cpu":
+        if self.args.quantize == 16 and fmt in {"onnx", "torchscript"} and self.device.type != "cpu":
             im, model = im.half(), model.half()  # to FP16
 
         # Assign
@@ -830,7 +823,7 @@ class Exporter:
                 f"work. Use export 'imgsz={max(self.imgsz)}' if val is required."
             )
             imgsz = self.imgsz[0] if square else str(self.imgsz)[1:-1].replace(" ", "")
-            q = "quantize=16" if self.args.half else ""  # FP16 inference flag for the val/predict hint
+            q = "quantize=16" if self.args.quantize == 16 else ""  # FP16 inference flag for the val/predict hint
             # Export-only formats deploy in-browser and are not loadable by AutoBackend
             predict_validate = (
                 ""
@@ -907,7 +900,7 @@ class Exporter:
     def export_onnx(self, prefix=colorstr("ONNX:")):
         """Export YOLO model to ONNX format."""
         requirements = ["onnx>=1.12.0,<2.0.0"]
-        if self.args.simplify or (self.args.format == "onnx" and self.args.int8):
+        if self.args.simplify or (self.args.format == "onnx" and self.args.quantize == 8):
             # Pass onnxruntime variants as interchangeable candidates so AutoUpdate keeps an installed build
             # (e.g. onnxruntime-qnn for QNN export) instead of reinstalling stable onnxruntime and breaking its ABI.
             ort = "onnxruntime-gpu" if "cuda" in self.device.type else "onnxruntime"
@@ -940,7 +933,7 @@ class Exporter:
             self.args.opset = opset  # for NMSModel
             self.args.simplify = True  # fix OBB runtime error related to topk
 
-        with arange_patch(dynamic=bool(dynamic), half=self.args.half, fmt=self.args.format):
+        with arange_patch(dynamic=bool(dynamic), quantize=self.args.quantize, fmt=self.args.format):
             torch2onnx(
                 NMSModel(self.model, self.args) if self.args.nms else self.model,
                 self.im,
@@ -976,7 +969,7 @@ class Exporter:
             model_onnx.ir_version = 10
 
         # FP16 conversion for CPU export (GPU exports are already FP16 from model.half() during tracing)
-        if self.args.half and self.args.format == "onnx" and self.device.type == "cpu":
+        if self.args.quantize == 16 and self.args.format == "onnx" and self.device.type == "cpu":
             try:
                 from onnxruntime.transformers import float16
 
@@ -986,7 +979,7 @@ class Exporter:
                 LOGGER.warning(f"{prefix} FP16 conversion failure: {e}")
 
         onnx.save(model_onnx, f)
-        if self.args.int8 and self.args.format == "onnx":
+        if self.args.quantize == 8 and self.args.format == "onnx":
             from ultralytics.utils.export.onnx import onnx_int8_quantize
 
             source = Path(f)
@@ -1024,11 +1017,11 @@ class Exporter:
             if self.model.task != "classify":
                 ov_model.set_rt_info("fit_to_window_letterbox", ["model_info", "resize_type"])
 
-            ov.save_model(ov_model, file, compress_to_fp16=self.args.half)
+            ov.save_model(ov_model, file, compress_to_fp16=self.args.quantize == 16)
             YAML.save(Path(file).parent / "metadata.yaml", self.metadata)  # add metadata.yaml
 
         calibration_dataset, ignored_scope = None, None
-        if self.args.int8:
+        if self.args.quantize == 8:
             check_requirements("packaging>=23.2")  # must be installed first to build nncf wheel
             check_requirements("nncf>=2.14.0,<3.0.0" if not TORCH_2_3 else "nncf>=2.14.0")
             import nncf
@@ -1051,14 +1044,13 @@ class Exporter:
             model=NMSModel(self.model, self.args) if self.args.nms else self.model,
             im=self.im,
             dynamic=self.args.dynamic,
-            half=self.args.half,
-            int8=self.args.int8,
+            quantize=self.args.quantize,
             calibration_dataset=calibration_dataset,
             ignored_scope=ignored_scope,
             prefix=prefix,
         )
 
-        suffix = f"_{'int8_' if self.args.int8 else ''}openvino_model{os.sep}"
+        suffix = f"_{'int8_' if self.args.quantize == 8 else ''}openvino_model{os.sep}"
         f = str(self.file).replace(self.file.suffix, suffix)
         f_ov = str(Path(f) / self.file.with_suffix(".xml").name)
 
@@ -1086,8 +1078,7 @@ class Exporter:
         return onnx2mnn(
             onnx_file=self.export_onnx(),
             output_file=self.file.with_suffix(".mnn"),
-            half=self.args.half,
-            int8=self.args.int8,
+            quantize=self.args.quantize,
             metadata=self.metadata,
             prefix=prefix,
         )
@@ -1101,7 +1092,7 @@ class Exporter:
             model=self.model,
             im=self.im,
             output_dir=str(self.file).replace(self.file.suffix, "_ncnn_model/"),
-            half=self.args.half,
+            quantize=self.args.quantize,
             metadata=self.metadata,
             device=self.device,
             prefix=prefix,
@@ -1159,8 +1150,7 @@ class Exporter:
             im=self.im,
             classifier_names=list(self.model.names.values()) if self.model.task == "classify" else None,
             mlmodel=mlmodel,
-            half=self.args.half,
-            int8=self.args.int8,
+            quantize=self.args.quantize,
             metadata=self.metadata,
             prefix=prefix,
         )
@@ -1205,12 +1195,11 @@ class Exporter:
             f_onnx,
             f,
             self.args.workspace,
-            self.args.half,
-            self.args.int8,
+            self.args.quantize,
             self.args.dynamic,
             self.im.shape,
             dla=self.dla,
-            dataset=self.get_int8_calibration_dataloader(prefix) if self.args.int8 else None,
+            dataset=self.get_int8_calibration_dataloader(prefix) if self.args.quantize == 8 else None,
             metadata=self.metadata,
             verbose=self.args.verbose,
             prefix=prefix,
@@ -1233,7 +1222,7 @@ class Exporter:
 
         # Export to TF
         images = None
-        if self.args.int8 and self.args.data:
+        if self.args.quantize == 8 and self.args.data:
             images = [batch["img"] for batch in self.get_int8_calibration_dataloader(prefix)]
             images = (
                 torch.nn.functional.interpolate(torch.cat(images, 0).float(), size=self.imgsz)
@@ -1251,7 +1240,7 @@ class Exporter:
         keras_model = onnx2saved_model(
             f_onnx,
             f,
-            int8=self.args.int8,
+            quantize=self.args.quantize,
             images=images,
             disable_group_convolution=self.args.format in {"tfjs", "edgetpu"},
             prefix=prefix,
@@ -1278,9 +1267,9 @@ class Exporter:
 
         LOGGER.info(f"\n{prefix} starting export with tensorflow {tf.__version__}...")
         saved_model = Path(str(self.file).replace(self.file.suffix, "_saved_model"))
-        if self.args.int8:
+        if self.args.quantize == 8:
             f = saved_model / f"{self.file.stem}_int8.tflite"  # fp32 in/out
-        elif self.args.half:
+        elif self.args.quantize == 16:
             f = saved_model / f"{self.file.stem}_float16.tflite"  # fp32 in/out
         else:
             f = saved_model / f"{self.file.stem}_float32.tflite"
@@ -1342,8 +1331,7 @@ class Exporter:
         output_dir = pb2tfjs(
             pb_file=str(self.file.with_suffix(".pb")),
             output_dir=str(self.file).replace(self.file.suffix, "_web_model/"),
-            half=self.args.half,
-            int8=self.args.int8,
+            quantize=self.args.quantize,
             prefix=prefix,
         )
         YAML.save(Path(output_dir) / "metadata.yaml", self.metadata)
@@ -1358,7 +1346,7 @@ class Exporter:
         f_onnx = self.export_onnx()
         output_dir = Path(str(self.file).replace(self.file.suffix, f"_rknn_model{os.sep}"))
         rknn_dataset = None
-        if self.args.int8:
+        if self.args.quantize == 8:
             dataloader = self.get_int8_calibration_dataloader(prefix)
             image_paths = getattr(dataloader.dataset, "im_files", None)
             if image_paths is None and hasattr(dataloader.dataset, "samples"):
@@ -1372,7 +1360,7 @@ class Exporter:
             onnx_file=f_onnx,
             output_dir=output_dir,
             name=self.args.name,
-            int8=self.args.int8,
+            quantize=self.args.quantize,
             dataset=rknn_dataset,
             metadata=self.metadata,
             prefix=prefix,
@@ -1606,7 +1594,7 @@ class NMSModel(torch.nn.Module):
                     use_triu=not (
                         self.is_tf
                         or (self.args.opset or 14) < 14
-                        or (self.args.format == "openvino" and self.args.int8)  # OpenVINO int8 error with triu
+                        or (self.args.format == "openvino" and self.args.quantize == 8)  # OpenVINO INT8 error with triu
                     ),
                     iou_func=batch_probiou,
                     exit_early=False,

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import torch
 
+from ultralytics.cfg import get_cfg
 from ultralytics.data.build import load_inference_source
 from ultralytics.engine.model import Model
 from ultralytics.models import yolo
@@ -398,6 +399,7 @@ class YOLOE(Model):
                 f"{len(visual_prompts['cls'])} respectively"
             )
             if type(self.predictor) is not predictor:
+                args = get_cfg(overrides={**self.overrides, **kwargs})
                 self.predictor = predictor(
                     overrides={
                         "task": self.model.task,
@@ -405,9 +407,9 @@ class YOLOE(Model):
                         "save": False,
                         "verbose": refer_image is None,
                         "batch": 1,
-                        "device": kwargs.get("device", None),
-                        "quantize": kwargs.get("quantize", 16 if kwargs.get("half") else None),
-                        "imgsz": kwargs.get("imgsz", self.overrides.get("imgsz", 640)),
+                        "device": args.device,
+                        "quantize": args.quantize,
+                        "imgsz": args.imgsz,
                     },
                     _callbacks=self.callbacks,
                 )

--- a/ultralytics/utils/export/coreml.py
+++ b/ultralytics/utils/export/coreml.py
@@ -171,8 +171,7 @@ def torch2coreml(
     classifier_names: list[str] | None,
     output_file: Path | str | None = None,
     mlmodel: bool = False,
-    half: bool = False,
-    int8: bool = False,
+    quantize: int | str | None = None,
     metadata: dict | None = None,
     prefix: str = "",
 ) -> Any:
@@ -185,8 +184,7 @@ def torch2coreml(
         classifier_names (list[str] | None): Class names for classifier config, or None if not a classifier.
         output_file (Path | str | None): Output file path, or None to skip saving.
         mlmodel (bool): Whether to export as ``.mlmodel`` (neural network) instead of ``.mlpackage`` (ML program).
-        half (bool): Whether to quantize to FP16.
-        int8 (bool): Whether to quantize to INT8.
+        quantize (int | str | None): Precision scheme, e.g. 16 for FP16 or 8/``"w8a16"`` for INT8 weights.
         metadata (dict | None): Metadata to embed in the CoreML model.
         prefix (str): Prefix for log messages.
 
@@ -197,6 +195,8 @@ def torch2coreml(
 
     LOGGER.info(f"\n{prefix} starting export with coremltools {ct.__version__}...")
     ts = torch.jit.trace(model.eval(), im, strict=False)  # TorchScript model
+    fp16 = quantize == 16
+    weight_int8 = quantize in {8, "w8a16"}
 
     # Based on apple's documentation it is better to leave out the minimum_deployment target and let that get set
     # Internally based on the model conversion and output type.
@@ -212,7 +212,7 @@ def torch2coreml(
         # ML Program conversion defaults to FP16. Pin FP32 unless FP16/INT8 was requested.
         from ultralytics.nn.modules.head import RTDETRDecoder
 
-        if not (half or int8):
+        if not (fp16 or weight_int8):
             convert_kwargs["compute_precision"] = ct.precision.FLOAT32
         elif any(isinstance(m, RTDETRDecoder) for m in model.modules()):
             # RT-DETR decoder class logits and deformable-sampling indices drift in fp16; pin those op types to fp32.
@@ -221,7 +221,7 @@ def torch2coreml(
                 op_selector=lambda op: op.op_type not in fp32_ops
             )
     ct_model = ct.convert(ts, **convert_kwargs)
-    bits, mode = (8, "kmeans") if int8 else (16, "linear") if half else (32, None)
+    bits, mode = (8, "kmeans") if weight_int8 else (16, "linear") if fp16 else (32, None)
     if bits < 32:
         if "kmeans" in mode:
             check_requirements("scikit-learn")  # scikit-learn package required for k-means quantization

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -92,7 +92,7 @@ def torch2onnx(
 
 def modelopt_quantize_onnx(
     onnx_file: str,
-    int8: bool = False,
+    quantize: int | str | None = None,
     dataset=None,
     shape: tuple[int, int, int, int] = (1, 3, 640, 640),
     dynamic: bool = False,
@@ -106,9 +106,9 @@ def modelopt_quantize_onnx(
 
     Args:
         onnx_file (str): Path to the FP32 ONNX file to convert.
-        int8 (bool): Quantize the ONNX model to INT8 with Q/DQ nodes. If False, outputs an FP16 precision ONNX file.
+        quantize (int | str | None): Precision scheme, 8 for INT8 Q/DQ nodes or 16 for FP16 precision.
         dataset (ultralytics.data.build.InfiniteDataLoader | None): Dataloader providing INT8 calibration images.
-            Required when ``int8=True``.
+            Required when ``quantize=8``.
         shape (tuple[int, int, int, int]): Input shape (batch, channels, height, width) used for dynamic calibration.
         dynamic (bool): Whether the ONNX model uses dynamic input shapes.
         prefix (str): Prefix for log messages.
@@ -116,7 +116,7 @@ def modelopt_quantize_onnx(
     Returns:
         (str): Path to the precision-converted ONNX file.
     """
-    if int8 and dataset is None:
+    if quantize == 8 and dataset is None:
         raise ValueError("INT8 ModelOpt quantization requires a calibration dataset.")
 
     # Require modelopt >= 0.44: older releases import onnx.mapping which was removed in onnx >= 1.18 and crash
@@ -124,8 +124,8 @@ def modelopt_quantize_onnx(
     import onnx
 
     input_name = onnx.load(onnx_file, load_external_data=False).graph.input[0].name
-    if int8:
-        from modelopt.onnx.quantization import quantize
+    if quantize == 8:
+        from modelopt.onnx.quantization import quantize as modelopt_quantize
 
         out_file = str(Path(onnx_file).with_suffix(".int8.onnx"))
         # Collect up to ~500 calibration images (TensorRT recommendation); ModelOpt holds them in memory at once,
@@ -139,7 +139,7 @@ def modelopt_quantize_onnx(
         calib = torch.cat(images).to(torch.float32) / 255.0
         LOGGER.info(f"{prefix} quantizing ONNX to INT8 with ModelOpt using {calib.shape[0]} calibration images...")
         kwargs = {"calibration_shapes": f"{input_name}:{'x'.join(str(d) for d in shape)}"} if dynamic else {}
-        quantize(
+        modelopt_quantize(
             onnx_file,
             quantize_mode="int8",
             calibration_data={input_name: calib.cpu().numpy()},
@@ -173,8 +173,7 @@ def onnx2engine(
     onnx_file: str,
     output_file: Path | str | None = None,
     workspace: int | None = None,
-    half: bool = False,
-    int8: bool = False,
+    quantize: int | str | None = None,
     dynamic: bool = False,
     shape: tuple[int, int, int, int] = (1, 3, 640, 640),
     dla: int | None = None,
@@ -189,8 +188,7 @@ def onnx2engine(
         onnx_file (str): Path to the ONNX file to be converted.
         output_file (Path | str | None): Path to save the generated TensorRT engine file.
         workspace (int | None): Workspace size in GB for TensorRT.
-        half (bool, optional): Enable FP16 precision.
-        int8 (bool, optional): Enable INT8 precision.
+        quantize (int | str | None): Precision scheme, 16 for FP16 or 8 for INT8.
         dynamic (bool, optional): Enable dynamic input shapes.
         shape (tuple[int, int, int, int], optional): Input shape (batch, channels, height, width).
         dla (int | None): DLA core to use (Jetson devices only).
@@ -250,9 +248,9 @@ def onnx2engine(
     flag = 0 if is_trt10 else (1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
     network = builder.create_network(flag)
     # platform_has_fast_fp16/int8 were removed from the Builder in TensorRT 10; default to True when absent
-    half = getattr(builder, "platform_has_fast_fp16", True) and half
-    int8 = getattr(builder, "platform_has_fast_int8", True) and int8
-    if int8 and dataset is None:
+    use_fp16 = getattr(builder, "platform_has_fast_fp16", True) and quantize == 16
+    use_int8 = getattr(builder, "platform_has_fast_int8", True) and quantize == 8
+    if use_int8 and dataset is None:
         raise ValueError("INT8 TensorRT export requires a calibration dataset.")
 
     # Optionally switch to DLA if enabled
@@ -264,9 +262,9 @@ def onnx2engine(
             # https://docs.nvidia.com/deeplearning/tensorrt/latest/api/migration/tensorrt-10x-to-11x-jetson.html
             raise ValueError("DLA is not supported in TensorRT 11.0; export with TensorRT 10.x to use DLA.")
         LOGGER.info(f"{prefix} enabling DLA on core {dla}...")
-        if not half and not int8:
+        if not use_fp16 and not use_int8:
             raise ValueError(
-                "DLA requires either 'half=True' (FP16) or 'int8=True' (INT8) to be enabled. Please enable one of them and try again."
+                "DLA requires either quantize=16 (FP16) or quantize=8 (INT8). Please enable one of them and try again."
             )
         config.default_device_type = trt.DeviceType.DLA
         config.DLA_core = int(dla)
@@ -274,8 +272,8 @@ def onnx2engine(
 
     # TensorRT 11 is strongly-typed and removed the FP16/INT8 builder flags and INT8 calibrator, so reduced
     # precision must be baked into the ONNX graph with NVIDIA ModelOpt before parsing (FP16 AutoCast, INT8 Q/DQ)
-    if is_trt11 and (half or int8):
-        onnx_file = modelopt_quantize_onnx(onnx_file, int8, dataset, shape, dynamic, prefix)
+    if is_trt11 and (use_fp16 or use_int8):
+        onnx_file = modelopt_quantize_onnx(onnx_file, quantize, dataset, shape, dynamic, prefix)
 
     # Read ONNX file
     parser = trt.OnnxParser(network, logger)
@@ -297,11 +295,11 @@ def onnx2engine(
         for inp in inputs:
             profile.set_shape(inp.name, min=min_shape, opt=shape, max=max_shape)
         config.add_optimization_profile(profile)
-        if int8 and not is_trt10:  # deprecated in TensorRT 10, causes internal errors
+        if use_int8 and not is_trt10:  # deprecated in TensorRT 10, causes internal errors
             config.set_calibration_profile(profile)
 
-    LOGGER.info(f"{prefix} building {'INT8' if int8 else 'FP' + ('16' if half else '32')} engine as {output_file}")
-    if int8 and not is_trt11:
+    LOGGER.info(f"{prefix} building {'INT8' if use_int8 else 'FP' + ('16' if use_fp16 else '32')} engine as {output_file}")
+    if use_int8 and not is_trt11:
         config.set_flag(trt.BuilderFlag.INT8)
         config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED
 
@@ -376,7 +374,7 @@ def onnx2engine(
             cache=str(Path(onnx_file).with_suffix(".cache")),
         )
 
-    elif half and not is_trt11:
+    elif use_fp16 and not is_trt11:
         config.set_flag(trt.BuilderFlag.FP16)
 
     # Write file

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -298,7 +298,9 @@ def onnx2engine(
         if use_int8 and not is_trt10:  # deprecated in TensorRT 10, causes internal errors
             config.set_calibration_profile(profile)
 
-    LOGGER.info(f"{prefix} building {'INT8' if use_int8 else 'FP' + ('16' if use_fp16 else '32')} engine as {output_file}")
+    LOGGER.info(
+        f"{prefix} building {'INT8' if use_int8 else 'FP' + ('16' if use_fp16 else '32')} engine as {output_file}"
+    )
     if use_int8 and not is_trt11:
         config.set_flag(trt.BuilderFlag.INT8)
         config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED

--- a/ultralytics/utils/export/mnn.py
+++ b/ultralytics/utils/export/mnn.py
@@ -11,8 +11,7 @@ from ultralytics.utils import LOGGER
 def onnx2mnn(
     onnx_file: str,
     output_file: Path | str,
-    half: bool = False,
-    int8: bool = False,
+    quantize: int | str | None = None,
     metadata: dict | None = None,
     prefix: str = "",
 ) -> str:
@@ -21,8 +20,7 @@ def onnx2mnn(
     Args:
         onnx_file (str): Path to the source ONNX file.
         output_file (Path | str): Path to save the exported MNN model.
-        half (bool): Whether to enable FP16 conversion.
-        int8 (bool): Whether to enable INT8 weight quantization.
+        quantize (int | str | None): Precision scheme, e.g. 16 for FP16 or 8 for INT8 weights.
         metadata (dict | None): Optional metadata embedded via ``--bizCode``.
         prefix (str): Prefix for log messages.
 
@@ -51,9 +49,9 @@ def onnx2mnn(
         "--bizCode",
         json.dumps(metadata or {}),
     ]
-    if int8:
+    if quantize == 8:
         mnn_args.extend(("--weightQuantBits", "8"))
-    if half:
+    if quantize == 16:
         mnn_args.append("--fp16")
     mnnconvert.convert(mnn_args)
     # Remove scratch file created during model convert optimize

--- a/ultralytics/utils/export/ncnn.py
+++ b/ultralytics/utils/export/ncnn.py
@@ -13,7 +13,7 @@ def torch2ncnn(
     model: torch.nn.Module,
     im: torch.Tensor,
     output_dir: Path | str,
-    half: bool = False,
+    quantize: int | str | None = None,
     metadata: dict | None = None,
     device: torch.device | None = None,
     prefix: str = "",
@@ -24,7 +24,7 @@ def torch2ncnn(
         model (torch.nn.Module): The PyTorch model to export.
         im (torch.Tensor): Example input tensor for tracing.
         output_dir (Path | str): Directory to save the exported NCNN model.
-        half (bool): Whether to enable FP16 export.
+        quantize (int | str | None): Precision scheme, e.g. 16 for FP16.
         metadata (dict | None): Optional metadata saved as ``metadata.yaml``.
         device (torch.device | None): Device the model lives on.
         prefix (str): Prefix for log messages.
@@ -57,7 +57,7 @@ def torch2ncnn(
 
     output_dir.mkdir(parents=True, exist_ok=True)  # make ncnn_model directory
     device_type = device.type if device is not None else "cpu"
-    pnnx.export(model, inputs=im, **ncnn_args, **pnnx_args, fp16=half, device=device_type)
+    pnnx.export(model, inputs=im, **ncnn_args, **pnnx_args, fp16=quantize == 16, device=device_type)
 
     for f_debug in ("debug.bin", "debug.param", "debug2.bin", "debug2.param", *pnnx_args.values()):
         Path(f_debug).unlink(missing_ok=True)

--- a/ultralytics/utils/export/openvino.py
+++ b/ultralytics/utils/export/openvino.py
@@ -15,8 +15,7 @@ def torch2openvino(
     im: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
     output_dir: Path | str | None = None,
     dynamic: bool = False,
-    half: bool = False,
-    int8: bool = False,
+    quantize: int | str | None = None,
     calibration_dataset: Any | None = None,
     ignored_scope: dict | None = None,
     prefix: str = "",
@@ -28,9 +27,8 @@ def torch2openvino(
         im (torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...]): Example input tensor(s) for tracing.
         output_dir (Path | str | None): Directory to save the exported OpenVINO model.
         dynamic (bool): Whether to use dynamic input shapes.
-        half (bool): Whether to compress to FP16.
-        int8 (bool): Whether to apply INT8 quantization.
-        calibration_dataset (nncf.Dataset | None): Dataset for INT8 calibration (required when ``int8=True``).
+        quantize (int | str | None): Precision scheme, e.g. 16 for FP16 or 8 for INT8.
+        calibration_dataset (nncf.Dataset | None): Dataset for INT8 calibration (required when ``quantize=8``).
         ignored_scope (dict | None): Kwargs passed to ``nncf.IgnoredScope`` for head patterns.
         prefix (str): Prefix for log messages.
 
@@ -48,7 +46,7 @@ def torch2openvino(
     # the same check on our own trace.
     ts = torch.jit.trace(model, im, strict=False, check_trace=False)
     ov_model = ov.convert_model(ts, input=None if dynamic else input_shape, example_input=im)
-    if int8:
+    if quantize == 8:
         import nncf
 
         ov_model = nncf.quantize(
@@ -62,5 +60,5 @@ def torch2openvino(
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         output_file = output_dir / "model.xml"
-        ov.save_model(ov_model, output_file, compress_to_fp16=half)
+        ov.save_model(ov_model, output_file, compress_to_fp16=quantize == 16)
     return ov_model

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -17,7 +17,7 @@ def onnx2rknn(
     onnx_file: str,
     output_dir: Path | str,
     name: str = "rk3588",
-    int8: bool = False,
+    quantize: int | str | None = None,
     dataset: Path | str | None = None,
     metadata: dict | None = None,
     prefix: str = "",
@@ -28,23 +28,23 @@ def onnx2rknn(
         onnx_file (str): Path to the source ONNX file (already exported, opset <=19).
         output_dir (Path | str): Directory to save the exported RKNN model.
         name (str): Target platform name (e.g. ``"rk3588"``).
-        int8 (bool): Whether to enable INT8 quantization. When False, RKNN Toolkit builds a floating-point model for
-            FP16-capable targets.
+        quantize (int | str | None): Precision scheme, 8 for INT8 or 16/None for floating-point builds.
         dataset (Path | str | None): Path to the generated RKNN Toolkit calibration image-list file, required when
-            ``int8=True``. Users should pass YOLO dataset YAMLs to ``export(data=...)``; ``export_rknn()`` converts them
-            to this internal image-path list.
+            ``quantize=8``. Users should pass YOLO dataset YAMLs to ``export(data=...)``; ``export_rknn()`` converts
+            them to this internal image-path list.
         metadata (dict | None): Metadata saved as ``metadata.yaml``.
         prefix (str): Prefix for log messages.
 
     Returns:
         (str): Path to the exported ``_rknn_model`` directory.
     """
-    if name in {"rv1103", "rv1106", "rv1103b", "rv1106b"} and not int8:
+    use_int8 = quantize == 8
+    if name in {"rv1103", "rv1106", "rv1103b", "rv1106b"} and not use_int8:
         raise ValueError(
-            f"Rockchip target '{name}' requires int8=True. Use a target that supports floating-point builds "
-            f"(e.g. rk2118, rk3562, rk3566, rk3568, rk3576, rk3588, rv1126b) or export with int8=True."
+            f"Rockchip target '{name}' requires quantize=8. Use a target that supports floating-point builds "
+            f"(e.g. rk2118, rk3562, rk3566, rk3568, rk3576, rk3588, rv1126b) or export with quantize=8."
         )
-    if int8:
+    if use_int8:
         if not dataset:
             raise ValueError("RKNN INT8 export requires a generated calibration image-list file.")
         dataset = Path(dataset)
@@ -72,8 +72,8 @@ def onnx2rknn(
     config = {"mean_values": [[0, 0, 0]], "std_values": [[255, 255, 255]], "target_platform": name}
     _check_rknn_return(rknn.config(**config), "config")
     _check_rknn_return(rknn.load_onnx(model=onnx_file), "load_onnx")
-    build_kwargs = {"do_quantization": int8}
-    if int8:
+    build_kwargs = {"do_quantization": use_int8}
+    if use_int8:
         build_kwargs["dataset"] = str(dataset)
     _check_rknn_return(rknn.build(**build_kwargs), "build")
     _check_rknn_return(rknn.export_rknn(str(output_dir / f"{Path(onnx_file).stem}-{name}.rknn")), "export_rknn")

--- a/ultralytics/utils/export/tensorflow.py
+++ b/ultralytics/utils/export/tensorflow.py
@@ -67,7 +67,7 @@ def _tf_kpts_decode(self, kpts: torch.Tensor, is_pose26: bool = False) -> torch.
 def onnx2saved_model(
     onnx_file: str,
     output_dir: Path | str,
-    int8: bool = False,
+    quantize: int | str | None = None,
     images: np.ndarray | None = None,
     disable_group_convolution: bool = False,
     prefix: str = "",
@@ -77,7 +77,7 @@ def onnx2saved_model(
     Args:
         onnx_file (str): ONNX file path.
         output_dir (Path | str): Output directory path for the SavedModel.
-        int8 (bool, optional): Enable INT8 quantization. Defaults to False.
+        quantize (int | str | None): Precision scheme, 8 for INT8.
         images (np.ndarray | None, optional): Calibration images for INT8 quantization in BHWC format.
         disable_group_convolution (bool, optional): Disable group convolution optimization. Defaults to False.
         prefix (str, optional): Logging prefix. Defaults to "".
@@ -127,12 +127,13 @@ def onnx2saved_model(
     )
 
     output_dir = Path(output_dir)
+    use_int8 = quantize == 8
     # Pre-download calibration file to fix https://github.com/PINTO0309/onnx2tf/issues/545
     onnx2tf_file = Path("calibration_image_sample_data_20x128x128x3_float32.npy")
     if not onnx2tf_file.exists():
         attempt_download_asset(f"{onnx2tf_file}.zip", unzip=True, delete=True)
     np_data = None
-    if int8:
+    if use_int8:
         tmp_file = output_dir / "tmp_tflite_int8_calibration_images.npy"  # int8 calibration images file
         if images is not None:
             output_dir.mkdir(parents=True, exist_ok=True)
@@ -179,15 +180,15 @@ def onnx2saved_model(
         output_folder_path=str(output_dir),
         not_use_onnxsim=True,
         verbosity="error",  # note INT8-FP16 activation bug https://github.com/ultralytics/ultralytics/issues/15873
-        output_integer_quantized_tflite=int8,
+        output_integer_quantized_tflite=use_int8,
         custom_input_op_name_np_data_path=np_data,
-        enable_batchmatmul_unfold=not int8,  # fix lower no. of detected objects on GPU delegate
+        enable_batchmatmul_unfold=not use_int8,  # fix lower no. of detected objects on GPU delegate
         output_signaturedefs=True,  # fix error with Attention block group convolution
         disable_group_convolution=disable_group_convolution,  # fix error with group convolution
     )
 
     # Remove/rename TFLite models
-    if int8:
+    if use_int8:
         tmp_file.unlink(missing_ok=True)
         for file in output_dir.rglob("*_dynamic_range_quant.tflite"):
             file.rename(file.with_name(file.stem.replace("_dynamic_range_quant", "_int8") + file.suffix))
@@ -278,14 +279,13 @@ def tflite2edgetpu(tflite_file: str | Path, output_dir: str | Path, prefix: str 
     return str(Path(output_dir) / f"{Path(tflite_file).stem}_edgetpu.tflite")
 
 
-def pb2tfjs(pb_file: str, output_dir: str, half: bool = False, int8: bool = False, prefix: str = "") -> str:
+def pb2tfjs(pb_file: str, output_dir: str, quantize: int | str | None = None, prefix: str = "") -> str:
     """Convert a TensorFlow GraphDef (.pb) model to TensorFlow.js format.
 
     Args:
         pb_file (str): Path to the input TensorFlow GraphDef (.pb) model file.
         output_dir (str): Output directory path for the converted TensorFlow.js model.
-        half (bool, optional): Enable FP16 quantization. Defaults to False.
-        int8 (bool, optional): Enable INT8 quantization. Defaults to False.
+        quantize (int | str | None): Precision scheme, 16 for FP16 or 8 for INT8.
         prefix (str, optional): Logging prefix. Defaults to "".
 
     Returns:
@@ -310,7 +310,7 @@ def pb2tfjs(pb_file: str, output_dir: str, half: bool = False, int8: bool = Fals
     outputs = ",".join(gd_outputs(gd))
     LOGGER.info(f"\n{prefix} output node names: {outputs}")
 
-    quantization = ["--quantize_float16"] if half else ["--quantize_uint8"] if int8 else []
+    quantization = ["--quantize_float16"] if quantize == 16 else ["--quantize_uint8"] if quantize == 8 else []
     with spaces_in_path(pb_file) as fpb_, spaces_in_path(output_dir) as f_:  # exporter cannot handle spaces in paths
         cmd = [
             "tensorflowjs_converter",

--- a/ultralytics/utils/patches.py
+++ b/ultralytics/utils/patches.py
@@ -205,12 +205,12 @@ def torch_save(*args, **kwargs):
 
 
 @contextmanager
-def arange_patch(dynamic: bool = False, half: bool = False, fmt: str = ""):
+def arange_patch(dynamic: bool = False, quantize: int | str | None = None, fmt: str = ""):
     """Workaround for ONNX torch.arange incompatibility with FP16.
 
     https://github.com/pytorch/pytorch/issues/148041.
     """
-    if dynamic and half and fmt == "onnx":
+    if dynamic and quantize == 16 and fmt == "onnx":
         func = torch.arange
 
         def arange(*args, dtype=None, **kwargs):


### PR DESCRIPTION
## Summary
- remove internal exporter args.half/args.int8 state and use args.quantize directly
- replace export helper half/int8 parameters with quantize across CoreML, TensorRT, OpenVINO, MNN, NCNN, RKNN, and TensorFlow helpers
- update export test matrices to pass quantize instead of half/int8 while preserving legacy alias coverage at the config boundary

## Tests
- ruff check ultralytics/engine/exporter.py ultralytics/utils/export/*.py ultralytics/utils/patches.py ultralytics/models/yolo/model.py tests/test_exports.py tests/test_cuda.py
- python -m compileall -q ultralytics/engine/exporter.py ultralytics/utils/export ultralytics/utils/patches.py ultralytics/models/yolo/model.py tests/test_exports.py tests/test_cuda.py
- python -m pytest tests/test_exports.py::test_quantize_deprecation tests/test_exports.py::test_qnn_quantize_requires_w8a16 tests/test_exports.py::test_modelopt_quantize_onnx_requires_int8_dataset tests/test_exports.py::test_torch2onnx_serializes_concurrent_exports -q
- python -m pytest --slow tests/test_exports.py::test_export_onnx_int8 -q

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR simplifies Ultralytics model export by standardizing precision settings around `quantize=8` and `quantize=16`, replacing scattered `int8`/`half` handling across code, tests, and docs 🔧📦

### 📊 Key Changes
- Unified export precision controls across many backends to use `quantize` instead of separate `int8=True` and `half=True` flags.
- Updated exporter logic in `exporter.py` to rely directly on `quantize` for format validation, defaults, warnings, and backend-specific behavior.
- Refactored multiple export utilities to accept `quantize`, including:
  - OpenVINO
  - CoreML
  - TensorRT
  - MNN
  - NCNN
  - RKNN
  - TensorFlow / TFLite / TF.js
- Updated tests to match the new unified API, including export matrix tests for ONNX, OpenVINO, TensorRT, CoreML, TFLite, MNN, NCNN, and RKNN ✅
- Kept backward coverage for legacy behavior in some tests, such as confirming old `int8` alias behavior still works where supported.
- Updated documentation to show the new export syntax:
  - `quantize=16` for FP16
  - `quantize=8` for INT8
- Improved predictor argument handling in `yolo/model.py` by resolving settings through config parsing instead of manually pulling selected kwargs.

### 🎯 Purpose & Impact
- Makes the export API easier to learn and more consistent across formats 🌍
- Reduces confusion from having multiple overlapping precision flags (`half` and `int8`) by replacing them with one clearer setting.
- Lowers maintenance burden for developers by removing duplicated precision-handling logic across exporters.
- Helps prevent invalid export combinations through clearer validation and automatic format-specific adjustments.
- Improves documentation and tests, which should make export behavior more reliable and easier to trust 🧪
- For users, the main visible change is simpler export configuration when targeting optimized deployment formats like TensorRT, OpenVINO, CoreML, and TFLite 🚀