### PR TITLE
Fix `ValueError` in FastSAM `prompt()` with multiple text prompts

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.80"
+__version__ = "8.4.81"
 
 import importlib
 import os

--- a/ultralytics/models/fastsam/predict.py
+++ b/ultralytics/models/fastsam/predict.py
@@ -141,9 +141,9 @@ class FastSAMPredictor(SegmentationPredictor):
                 similarity = self._clip_inference(crop_ims, texts)
                 text_idx = torch.argmax(similarity, dim=-1)  # (M, )
                 if len(filter_idx):
-                    # Remap text_idx to its original index before filter
-                    ori_idxs = [i for i in range(len(result)) if i not in filter_idx]
-                    text_idx = torch.tensor(ori_idxs[int(text_idx)], device=self.device)
+                    # Remap text_idx to its original index before filtering (supports multiple text prompts)
+                    ori_idxs = torch.tensor([i for i in range(len(result)) if i not in filter_idx], device=self.device)
+                    text_idx = ori_idxs[text_idx]
                 idx[text_idx] = True
 
             prompt_results.append(result[idx])


### PR DESCRIPTION
## 🛠️ Summary

`FastSAMPredictor.prompt()` raises a `ValueError` when given **multiple text prompts**.

## 🐞 Problem

With a list of text prompts, `_clip_inference()` returns an `(M, N)` similarity matrix, so `text_idx = torch.argmax(similarity, dim=-1)` is a tensor of shape `(M,)`. When one or more boxes are filtered out (masks with area `<= 100` px), the remap of `text_idx` back to original box indices does:

```python
ori_idxs = [i for i in range(len(result)) if i not in filter_idx]
text_idx = torch.tensor(ori_idxs[int(text_idx)], device=self.device)
```

`int(text_idx)` only works for a single-element tensor. For any `M > 1` it raises:

```
ValueError: only one element tensors can be converted to Python scalars
```

So `texts="a photo of a dog"` works, but `texts=["a photo of a dog", "a photo of a person"]` crashes whenever at least one small box is filtered (a very common case). `texts` is documented as `str | list[str]`, so the list path should work.

## ✅ Fix

Vectorize the remap so it handles any number of text prompts:

```python
ori_idxs = torch.tensor([i for i in range(len(result)) if i not in filter_idx], device=self.device)
text_idx = ori_idxs[text_idx]
```

Single-text behavior is unchanged: indexing `ori_idxs` with a 1-element `text_idx` selects the same original index as before.

## 🧪 Test

Extended `tests/test_cli.py::test_fastsam` with a multi-text prompt call to cover the previously-crashing path:

```python
# Run inference with multiple text prompts to cover the multi-text index remap path
sam_model(source, texts=["a photo of a dog", "a photo of a person"])
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a FastSAM `prompt()` indexing bug when multiple text prompts are provided, and adds a regression test to ensure the multi-text path works correctly. 🛠️

### 📊 Key Changes
- Updates `ultralytics/models/fastsam/predict.py` to correctly remap `text_idx` back to original result indices after filtering when multiple text prompts are used.
- Replaces single-index remapping logic with tensor-based indexing so batched text prompt selections are handled safely.
- Adds a CLI test in `tests/test_cli.py` that runs FastSAM with multiple text prompts to cover the affected code path.

### 🎯 Purpose & Impact
- Prevents a `ValueError` and incorrect index handling in FastSAM `prompt()` for multi-text prompt inputs.
- Improves reliability for users prompting FastSAM with more than one text query in the official Ultralytics Python package.
- Strengthens test coverage and reduces the chance of this regression reappearing. ✅