### PR TITLE
Fix ONNXRuntime C++ model path on Windows

### DIFF
--- a/examples/cpp/ONNXRuntime/inference.cpp
+++ b/examples/cpp/ONNXRuntime/inference.cpp
@@ -3,6 +3,7 @@
 #include "inference.h"
 
 #include <array>
+#include <filesystem>
 #include <iostream>
 #include <regex>
 
@@ -77,7 +78,8 @@ Predictor::Predictor(const Config& config) : config_(config) {
     }
 #endif
 
-    session_ = new Ort::Session(env_, config_.model_path.c_str(), session_options_);
+    const std::filesystem::path model_path = std::filesystem::u8path(config_.model_path);
+    session_ = new Ort::Session(env_, model_path.c_str(), session_options_);
 
     Ort::AllocatorWithDefaultOptions allocator;
     for (size_t i = 0; i < session_->GetInputCount(); ++i) {


### PR DESCRIPTION
## Summary
- use `std::filesystem::u8path()` before creating the ONNX Runtime session so Windows receives the wide path type expected by ONNX Runtime, including UTF-8/non-ASCII paths
- keep Linux/macOS behavior unchanged through the native filesystem path interface
- scanned the remaining C/C++ examples for similar ONNX Runtime session/path loader issues; no other matching platform path mismatch found

Closes #24948

## Tests
- `git diff --check`
- `rg -n "Ort::Session\(|CreateSession\(" examples/cpp examples -g "*.cpp" -g "*.cc" -g "*.cxx" -g "*.h" -g "*.hpp"`
- `rg -n "readNetFromONNX\(|createFromFile\(|read_model\(|torch::jit::load\(" examples/cpp -g "*.cpp" -g "*.cc" -g "*.cxx" -g "*.h" -g "*.hpp"`
- `c++ -std=c++17` filesystem `u8path` compile smoke test

Note: full CMake configure/build was not run because `cmake` is not installed in this environment.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves the C++ ONNX Runtime example by loading model paths through `std::filesystem`, helping model files open more reliably across different path formats and systems.

### 📊 Key Changes
- Added the C++ `<filesystem>` header to the ONNX Runtime inference example.
- Updated model path handling in `examples/cpp/ONNXRuntime/inference.cpp` to convert `config_.model_path` using `std::filesystem::u8path(...)`.
- Changed ONNX session creation to use the filesystem-based path instead of passing the raw string directly.

### 🎯 Purpose & Impact
- 🌍 Improves compatibility with file paths that include non-ASCII or UTF-8 characters.
- 🔒 Makes model loading more robust and portable across operating systems and compiler environments.
- 🧩 Helps developers using the C++ ONNX Runtime example avoid path-related errors when loading exported Ultralytics models.
- 🚀 Small change, but useful for smoother deployment workflows, especially in international or mixed-platform setups.