### PR TITLE
Fix YOLO26 Axelera export output path

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -340,7 +340,7 @@ EXPORT_ENVS = {
         ],
         # Use the Python protobuf runtime for Axelera compiler compatibility.
         "env": {"PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python"},
-        "smoke": ["yolo export format=axelera model=yolo11n.pt imgsz=64 data=coco8.yaml"],
+        "smoke": ["yolo export format=axelera model=yolo26n.pt imgsz=64 data=coco8.yaml"],
     },
     "isolated-deepx": {
         # dx-com 2.3.0 does not provide Python 3.13 wheels.

--- a/ultralytics/utils/export/axelera.py
+++ b/ultralytics/utils/export/axelera.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -54,7 +55,12 @@ def torch2axelera(
     LOGGER.info(f"\n{prefix} starting export with Axelera compiler...")
 
     output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    compile_dir = Path(output_dir.name)
+    if compile_dir.exists():
+        shutil.rmtree(compile_dir)
+    if output_dir != compile_dir and output_dir.exists():
+        shutil.rmtree(output_dir)
+    compile_dir.mkdir(parents=True, exist_ok=True)
 
     axelera_model_metadata = extract_ultralytics_metadata(model)
     config = CompilerConfig(
@@ -71,12 +77,15 @@ def torch2axelera(
         config=config,
         transform_fn=transform_fn,
     )
-    compiler.compile(model=qmodel, config=config, output_dir=output_dir)
+    # Compile locally because the Axelera compiler can emit invalid artifacts for absolute output paths.
+    compiler.compile(model=qmodel, config=config, output_dir=compile_dir)
 
+    output_dir.mkdir(parents=True, exist_ok=True)
     for artifact in [f"{model_name}.axm", "compiler_config_final.toml"]:
-        artifact_path = Path(artifact)
-        if artifact_path.exists():
-            artifact_path.replace(output_dir / artifact_path.name)
+        for artifact_path in [Path(artifact), compile_dir / artifact]:
+            if artifact_path.exists():
+                artifact_path.replace(output_dir / artifact_path.name)
+                break
 
     # Remove intermediate compiler artifacts, keeping only the compiled model and config.
     keep_suffixes = {".axm"}
@@ -87,6 +96,9 @@ def torch2axelera(
 
     if metadata is not None:
         YAML.save(output_dir / "metadata.yaml", metadata)
+
+    if compile_dir != output_dir and compile_dir.exists():
+        shutil.rmtree(compile_dir)
 
     # Restore original PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION value
     if prev_protobuf is None:


### PR DESCRIPTION
## Summary
- switch the Axelera isolated smoke export from yolo11n.pt to yolo26n.pt

## Purpose
- isolate the YOLO26 Axelera export failure behind a single model change

## Tests
- ruff check --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 ultralytics/engine/exporter.py
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves Axelera export reliability by switching its smoke test to YOLO26 and fixing how compiled export files are created, moved, and cleaned up.

### 📊 Key Changes
- 🔄 Updated the Axelera export smoke test from `yolo11n.pt` to `yolo26n.pt`.
- 📁 Changed Axelera compilation to run in a local temporary-style directory instead of compiling directly to the final output path.
- 🧹 Added cleanup logic to remove existing compile/output directories before export, preventing stale files from interfering with new builds.
- 📦 Improved artifact collection so exported files like the `.axm` model and final compiler config are found and moved correctly whether they are emitted in the working directory or compile directory.
- 🗑️ Added final cleanup of intermediate compiler artifacts and temporary compile folders, while preserving the important exported model files and metadata.

### 🎯 Purpose & Impact
- ✅ Makes Axelera exports more dependable by working around a compiler issue that can produce invalid outputs when given absolute paths.
- 🚀 Aligns testing with YOLO26, the latest recommended Ultralytics model, helping ensure current model exports are validated.
- 🧰 Reduces export failures caused by leftover files from earlier runs, which should make repeated exports more predictable.
- 📂 Produces cleaner export folders for users by keeping only the necessary final artifacts.
- 👥 Benefits both developers and end users with a more stable, easier-to-debug Axelera export workflow.