### PR TITLE
Update export smoke models to YOLO26

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -266,7 +266,7 @@ EXPORT_ENVS = {
             ("--extra-index-url", "https://pypi.ngc.nvidia.com"),
         ],
         "env": {},
-        "smoke": ["yolo export format=tflite model=yolo11n.pt imgsz=32"],
+        "smoke": ["yolo export format=tflite model=yolo26n.pt imgsz=32"],
     },
     "coreml": {
         "python": "3.13",
@@ -275,7 +275,7 @@ EXPORT_ENVS = {
         "requirements": [],
         "indexes": [],
         "env": {},
-        "smoke": ["yolo export format=coreml model=yolo11n.pt imgsz=32"],
+        "smoke": ["yolo export format=coreml model=yolo26n.pt imgsz=32"],
     },
     "mnn": {
         "python": "3.13",
@@ -284,7 +284,7 @@ EXPORT_ENVS = {
         "requirements": ["MNN>=2.9.6", "aliyun-log-python-sdk", "protobuf<6.0.0,>=3.20.3"],
         "indexes": [],
         "env": {},
-        "smoke": ["yolo export format=mnn model=yolo11n.pt imgsz=32"],
+        "smoke": ["yolo export format=mnn model=yolo26n.pt imgsz=32"],
     },
     "ncnn": {
         "python": "3.13",
@@ -293,7 +293,7 @@ EXPORT_ENVS = {
         "requirements": ["ncnn", "pnnx"],
         "indexes": [],
         "env": {},
-        "smoke": ["yolo export format=ncnn model=yolo11n.pt imgsz=32"],
+        "smoke": ["yolo export format=ncnn model=yolo26n.pt imgsz=32"],
     },
     "executorch": {
         "python": "3.13",
@@ -302,7 +302,7 @@ EXPORT_ENVS = {
         "requirements": [],
         "indexes": [],
         "env": {},
-        "smoke": ["yolo export format=executorch model=yolo11n.pt imgsz=32"],
+        "smoke": ["yolo export format=executorch model=yolo26n.pt imgsz=32"],
     },
     "isolated-imx": {
         "python": "3.11",
@@ -353,7 +353,7 @@ EXPORT_ENVS = {
         ],
         # DeepX export is only supported on non-aarch64 Linux.
         "env": {},
-        "smoke": ["yolo export format=deepx model=yolo11n.pt imgsz=32 data=coco8.yaml"],
+        "smoke": ["yolo export format=deepx model=yolo26n.pt imgsz=32 data=coco8.yaml"],
     },
 }
 


### PR DESCRIPTION
## Summary
- update isolated smoke exports from yolo11n.pt to yolo26n.pt where the format is not IMX or Axelera
- make `embed` a per-call predict default so users can alternate `model.embed()` and `model.predict()` without manually resetting state
- revert the recent docs note that documented predictor `embed` persistence and replace it with positive embedding usage guidance

Fixes #24903

## Tests
- ruff check --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 ultralytics/engine/exporter.py
- pytest tests/test_python.py::test_model_embeddings -q
- python - <<'PY'
import numpy as np
from ultralytics.trackers.utils.reid import ReID

encoder = ReID("yolo26n-cls.pt", imgsz=32, device="cpu")
img = np.zeros((64, 64, 3), dtype=np.uint8)
dets = np.array([[32, 32, 32, 32]], dtype=np.float32)
feats = encoder(img, dets)
assert len(feats) == 1
assert encoder.model.predictor.args.embed
PY
- git diff --check

## Notes
- IMX remains on yolo11n.pt because IMX only supports YOLO11
- Axelera remains on yolo11n.pt because PR #24956 isolates the YOLO26 Axelera failure
