### PR TITLE
Reduce slow CI Jetson TensorRT coverage

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -79,9 +79,9 @@ def test_export_onnx_matrix(task, dynamic, batch, simplify, nms):
     "task, dynamic, quantize, batch",
     [
         (task, dynamic, quantize, batch)
-        # Note: tests reduced below pending compute availability expansion as GPU CI runner utilization is high
+        # Limit Jetson task coverage for slow CI speed; full task coverage remains on GPU CI.
         # for task, dynamic, quantize, batch in product(TASKS, [True, False], [8, 16], [1, 2])
-        for task, dynamic, quantize, batch in product(sorted(TASKS), [True], [8, 16], [2])
+        for task, dynamic, quantize, batch in product(["detect"] if IS_JETSON else sorted(TASKS), [True], [8, 16], [2])
     ],
 )
 def test_export_engine_matrix(task, dynamic, quantize, batch):

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -254,7 +254,9 @@ class Detect(nn.Module):
         ori_index = scores.max(dim=-1)[0].topk(k)[1].unsqueeze(-1)
         scores = scores.gather(dim=1, index=ori_index.repeat(1, 1, nc))
         scores, index = scores.flatten(1).topk(k)
-        idx = ori_index[torch.arange(batch_size)[..., None], torch.div(index, nc, rounding_mode="trunc")]  # original index
+        idx = ori_index[
+            torch.arange(batch_size)[..., None], torch.div(index, nc, rounding_mode="trunc")
+        ]  # original index
         return scores[..., None], (index % nc)[..., None].float(), idx
 
     def fuse(self) -> None:

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -254,7 +254,7 @@ class Detect(nn.Module):
         ori_index = scores.max(dim=-1)[0].topk(k)[1].unsqueeze(-1)
         scores = scores.gather(dim=1, index=ori_index.repeat(1, 1, nc))
         scores, index = scores.flatten(1).topk(k)
-        idx = ori_index[torch.arange(batch_size)[..., None], index // nc]  # original index
+        idx = ori_index[torch.arange(batch_size)[..., None], torch.div(index, nc, rounding_mode="trunc")]  # original index
         return scores[..., None], (index % nc)[..., None].float(), idx
 
     def fuse(self) -> None:

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -254,9 +254,7 @@ class Detect(nn.Module):
         ori_index = scores.max(dim=-1)[0].topk(k)[1].unsqueeze(-1)
         scores = scores.gather(dim=1, index=ori_index.repeat(1, 1, nc))
         scores, index = scores.flatten(1).topk(k)
-        idx = ori_index[
-            torch.arange(batch_size)[..., None], torch.div(index, nc, rounding_mode="trunc")
-        ]  # original index
+        idx = ori_index[torch.arange(batch_size)[..., None], index // nc]  # original index
         return scores[..., None], (index % nc)[..., None].float(), idx
 
     def fuse(self) -> None:

--- a/ultralytics/utils/export/engine.py
+++ b/ultralytics/utils/export/engine.py
@@ -236,14 +236,14 @@ def onnx2engine(
     config = builder.create_builder_config()
     workspace_bytes = int((workspace or 0) * (1 << 30))
     trt_major = int(trt.__version__.split(".", 1)[0])
-    # TensorRT >= 10 builds via build_serialized_network and uses the tensor (non-binding) API
     is_trt10 = trt_major >= 10
     # TensorRT >= 11 is strongly-typed only: precision builder flags and IInt8Calibrator removed
     is_trt11 = trt_major >= 11
-    if is_trt10 and workspace_bytes > 0:
-        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
-    elif workspace_bytes > 0:  # TensorRT versions 7, 8
-        config.max_workspace_size = workspace_bytes
+    if workspace_bytes > 0:
+        if hasattr(config, "set_memory_pool_limit"):
+            config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+        else:  # TensorRT 7 fallback
+            config.max_workspace_size = workspace_bytes
     # EXPLICIT_BATCH flag is removed in TensorRT 10 (explicit batch is the only/default mode); keep it for TRT 7/8
     flag = 0 if is_trt10 else (1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
     network = builder.create_network(flag)
@@ -380,22 +380,17 @@ def onnx2engine(
         config.set_flag(trt.BuilderFlag.FP16)
 
     # Write file
-    if is_trt10:
-        # TensorRT 10+ returns bytes directly, not a context manager
+    if hasattr(builder, "build_serialized_network"):
         engine = builder.build_serialized_network(network, config)
-        if engine is None:
-            raise RuntimeError("TensorRT engine build failed, check logs for errors")
-        with open(output_file, "wb") as t:
-            if metadata is not None:
-                meta = json.dumps(metadata)
-                t.write(len(meta).to_bytes(4, byteorder="little", signed=True))
-                t.write(meta.encode())
-            t.write(engine)
     else:
-        with builder.build_engine(network, config) as engine, open(output_file, "wb") as t:
-            if metadata is not None:
-                meta = json.dumps(metadata)
-                t.write(len(meta).to_bytes(4, byteorder="little", signed=True))
-                t.write(meta.encode())
-            t.write(engine.serialize())
+        engine = builder.build_engine(network, config)
+        engine = None if engine is None else engine.serialize()
+    if engine is None:
+        raise RuntimeError("TensorRT engine build failed, check logs for errors")
+    with open(output_file, "wb") as t:
+        if metadata is not None:
+            meta = json.dumps(metadata)
+            t.write(len(meta).to_bytes(4, byteorder="little", signed=True))
+            t.write(meta.encode())
+        t.write(engine)
     return str(output_file)


### PR DESCRIPTION
## Summary
- reduce Jetson TensorRT export coverage to one representative detect task while keeping full task coverage on GPU CI
- prefer non-deprecated TensorRT exporter APIs when available, keeping fallbacks for older TensorRT

## Rationale
Run 28304369923 showed JetPack5 spent 46m32s in pytest --slow tests/test_cuda.py; six dynamic FP16 TensorRT task exports accounted for about 38.8 minutes. This PR scopes the Jetson reduction specifically to slow CI speed, while the regular GPU job still keeps the complete TensorRT task matrix.

Warning scans across slow CI and Docker build CI found mostly third-party/export tracing noise. This PR only takes source-level low-risk cleanups and avoids warning filters, TensorRT runtime execution changes, or PyTorch 1.8-sensitive changes.

## Validation
- ruff check tests/test_cuda.py ultralytics/nn/modules/head.py ultralytics/utils/export/engine.py
- python -m compileall -q ultralytics/nn/modules/head.py ultralytics/utils/export/engine.py tests/test_cuda.py
- Jetson matrix import simulation: non-Jetson keeps 12 TensorRT cases, Jetson reduces to 2
- Previous head validated Jetson speed: JetPack5 46m58s -> 16m44s, JetPack6 39m35s -> 13m33s

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR improves TensorRT engine export compatibility across TensorRT versions and streamlines Jetson CI testing to keep slower hardware checks efficient.

### 📊 Key Changes
- Updated TensorRT workspace configuration to use feature detection instead of version-only checks:
  - Uses `set_memory_pool_limit()` when available
  - Falls back to `max_workspace_size` for older TensorRT 7 setups
- Simplified TensorRT engine build logic:
  - Uses `build_serialized_network()` when supported
  - Falls back to `build_engine(...).serialize()` for older versions
  - Consolidates output writing and adds a clear failure check if engine creation returns `None`
- Refined comments around TensorRT version handling for better maintainability 🛠️
- Adjusted Jetson test coverage in `test_export_engine_matrix`:
  - Jetson now runs only the `"detect"` task in this slower CI path
  - Full task coverage is still preserved on regular GPU CI ✅

### 🎯 Purpose & Impact
- Improves export reliability across TensorRT 7, 8, 10, and 11 environments, reducing version-specific breakage 🔧
- Makes the export code more robust by checking for supported APIs directly instead of relying only on version numbers
- Reduces duplicated logic in engine writing, making the code easier to maintain and less error-prone
- Speeds up Jetson CI runs while still keeping important export coverage on embedded hardware ⚡
- Benefits users deploying YOLO models with TensorRT, especially on mixed environments like edge devices and different NVIDIA software stacks 🎯