### PR TITLE
Using self.get_dists in second association of bytetrack

### DIFF
--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -416,9 +416,7 @@ class BYTETracker:
         """Second-stage association between remaining tracked tracks and low-score detections."""
         r_tracked_stracks = [strack_pool[i] for i in u_track if strack_pool[i].state == TrackState.Tracked]
         if r_tracked_stracks and detections_second:
-            dists = matching.iou_distance(r_tracked_stracks, detections_second)
-            if self.args.fuse_score:
-                dists = matching.fuse_score(dists, detections_second)
+            dists = self.get_dists(r_tracked_stracks, detections_second)
             matches, u_track, _ = matching.linear_assignment(dists, thresh=0.5)
             self._apply_matches(matches, r_tracked_stracks, detections_second, activated, refind)
         else:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->
### Summary

Replace the manual distance computation in `BYTETracker._second_association()` with the existing `self.get_dists()` helper.

### Motivation

`self.get_dists()` already encapsulates the distance computation, including optional score fusion based on the tracker configuration (`self.args.fuse_score`). Reusing it avoids duplicating the same logic in `_second_association()` and keeps the distance computation consistent across association stages.

### Changes

Replaced:

```python
dists = matching.iou_distance(r_tracked_stracks, detections_second)
if self.args.fuse_score:
    dists = matching.fuse_score(dists, detections_second)
```

with:

```python
dists = self.get_dists(r_tracked_stracks, detections_second)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates ByteTrack’s second association step to use the tracker’s shared distance computation helper for more consistent matching behavior. 🔄

### 📊 Key Changes
- Replaces direct `matching.iou_distance(...)` usage in `_second_association()` with `self.get_dists(...)`.
- Removes the local conditional score-fusion logic from this block, since `self.get_dists(...)` now centralizes distance handling.
- Keeps the downstream linear assignment and match application flow unchanged.

### 🎯 Purpose & Impact
- Improves consistency between first and second association stages by reusing the same distance calculation pathway. ✅
- Reduces duplicated logic in `byte_tracker.py`, making the code easier to maintain. 🧹
- May fix or prevent mismatches when score fusion or other distance-related behavior is expected to be applied uniformly across association steps. 🎯