### PR TITLE
Bump version to 8.4.81

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.80"
+__version__ = "8.4.81"
 
 import importlib
 import os


### PR DESCRIPTION
Bumps the package version after the Axelera YOLO26 export fix.

Validation:
- python -m compileall -q ultralytics/__init__.py
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR is a small maintenance update that bumps the Ultralytics package version from `8.4.80` to `8.4.81` 🔄

### 📊 Key Changes
- Updated the package version in `ultralytics/__init__.py`
- Changed `__version__` from `8.4.80` to `8.4.81`
- No functional code, model, training, or inference logic changes are included in this diff

### 🎯 Purpose & Impact
- Signals a new release of the `ultralytics` package 📦
- Helps users and tools identify the latest published build correctly
- Likely supports release tracking, packaging, or deployment workflows rather than introducing user-facing features
- For most users, this should have little to no direct impact on behavior, performance, or results ✅