### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,4 +663,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}`  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -299,4 +299,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}`  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,16 +147,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - name: Extract PR Details
+      - name: Get release title
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.check.outputs.current_tag }}
         run: |
-          PR_JSON=$(gh pr list --search "${GITHUB_SHA}" --state merged --json number,title --jq '.[0]')
-          PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
-          PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title' | sed 's/"/\\"/g')
-          echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
-          echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
+          TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
@@ -164,7 +163,7 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.publish.result != 'success'
         uses: slackapi/slack-github-action@v3.0.3
@@ -172,4 +171,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -58,6 +58,9 @@
 13649162+oDestroyeRo@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/13649162?v=4
   username: oDestroyeRo
+145752978+seungcle@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/145752978?v=4
+  username: seungcle
 146309319+leonnil@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/146309319?v=4
   username: leonnil

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,7 +10,9 @@ SOURCE = ASSETS / "bus.jpg"
 SOURCES_LIST = [ASSETS / "bus.jpg", ASSETS, ASSETS / "*", ASSETS / "**/*.jpg"]  # file, dir, and glob patterns
 CUDA_IS_AVAILABLE = checks.cuda_is_available()
 CUDA_DEVICE_COUNT = checks.cuda_device_count()
-TASK_MODEL_DATA = sorted([(task, WEIGHTS_DIR / TASK2MODEL[task], TASK2DATA[task]) for task in TASKS])  # (task, model, data) tuples
+TASK_MODEL_DATA = sorted(
+    [(task, WEIGHTS_DIR / TASK2MODEL[task], TASK2DATA[task]) for task in TASKS]
+)  # (task, model, data) tuples
 MODELS = sorted([*list(TASK2MODEL.values()), "yolo11n-grayscale.pt"])  # task models plus grayscale variant
 SOLUTION_ASSETS = {
     "demo_video": "solutions_ci_demo.mp4",


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- Scopes the broad `<!channel>` ping down to `@yolo-team` to cut company-wide notification noise.
- Publish notifications surface the GitHub release title + *Release* link; the now-dead `Extract PR Details` step is replaced by a lean `gh release view` step.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR streamlines GitHub Actions Slack notifications, improves release-message accuracy, and adds a small docs/testing cleanup.

### 📊 Key Changes
- 🔄 **Simplified Slack alerts in CI and Docker workflows**
  - Replaced long `<!channel>` failure messages with shorter, cleaner alerts.
  - Notifications now ping a specific Slack subgroup instead of the full channel.
  - Added direct links to the failed workflow run for faster access.

- 🚀 **Improved publish workflow release notifications**
  - Removed the old logic that tried to find the merged PR title from the commit SHA.
  - Added a new step to fetch the **GitHub release title** directly from the published tag.
  - Success notifications now include:
    - the workflow name
    - repository name
    - release title or tag
    - direct links to the GitHub release and workflow run
  - Failure notifications were also simplified and standardized.

- 🧑‍💻 **Updated GitHub authors metadata**
  - Added a new contributor entry for `@seungcle` in `docs/mkdocs_github_authors.yaml`.

- 🧹 **Minor test file formatting cleanup**
  - Reformatted `TASK_MODEL_DATA` in `tests/__init__.py` for readability, with no functional change.

### 🎯 Purpose & Impact
- 📣 **More targeted team alerts**
  - Using a Slack subgroup mention helps notify the right people without alerting everyone.

- ⚡ **Faster triage for CI/CD issues**
  - Shorter messages with direct run links make failures easier to spot and investigate.

- 🎯 **More accurate release announcements**
  - Pull request titles can be unreliable for published packages, so using the actual GitHub release title better reflects what was released.

- 🧼 **Cleaner maintenance and documentation**
  - Small metadata and formatting updates improve contributor tracking and code readability with minimal user-facing impact.