### PR TITLE
Use ClassificationDataset for classify INT8 export calibration

### DIFF
--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -83,6 +83,7 @@ class YOLODataset(BaseDataset):
             *args (Any): Additional positional arguments for the parent class.
             **kwargs (Any): Additional keyword arguments for the parent class.
         """
+        self.task = task
         self.use_segments = task == "segment"
         self.use_keypoints = task == "pose"
         self.use_obb = task == "obb"
@@ -202,8 +203,8 @@ class YOLODataset(BaseDataset):
             )
             for lb in labels:
                 lb["segments"] = []
-        if len_cls == 0:
-            LOGGER.warning(f"Labels are missing or empty in {cache_path}, training may not work correctly. {HELP_URL}")
+        if len_cls == 0 and self.task != "classify":
+            raise ValueError(f"All labels empty in {cache_path}, can not start training without labels. {HELP_URL}")
         return labels
 
     def build_transforms(self, hyp: dict | None = None) -> Compose:

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -83,7 +83,6 @@ class YOLODataset(BaseDataset):
             *args (Any): Additional positional arguments for the parent class.
             **kwargs (Any): Additional keyword arguments for the parent class.
         """
-        self.task = task
         self.use_segments = task == "segment"
         self.use_keypoints = task == "pose"
         self.use_obb = task == "obb"
@@ -203,8 +202,8 @@ class YOLODataset(BaseDataset):
             )
             for lb in labels:
                 lb["segments"] = []
-        if len_cls == 0 and self.task != "classify":
-            raise ValueError(f"All labels empty in {cache_path}, can not start training without labels. {HELP_URL}")
+        if len_cls == 0:
+            LOGGER.warning(f"Labels are missing or empty in {cache_path}, training may not work correctly. {HELP_URL}")
         return labels
 
     def build_transforms(self, hyp: dict | None = None) -> Compose:

--- a/ultralytics/data/dataset.py
+++ b/ultralytics/data/dataset.py
@@ -203,7 +203,7 @@ class YOLODataset(BaseDataset):
             for lb in labels:
                 lb["segments"] = []
         if len_cls == 0:
-            raise ValueError(f"All labels empty in {cache_path}, can not start training without labels. {HELP_URL}")
+            LOGGER.warning(f"Labels are missing or empty in {cache_path}, training may not work correctly. {HELP_URL}")
         return labels
 
     def build_transforms(self, hyp: dict | None = None) -> Compose:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -794,23 +794,15 @@ class HUBDatasetStats:
 
     def process_images(self) -> Path:
         """Compress images for Ultralytics HUB."""
-        from ultralytics.data import YOLODataset
+        from ultralytics.data import YOLODataset  # ClassificationDataset
 
         self.im_dir.mkdir(parents=True, exist_ok=True)  # makes dataset-hub/images/
         for split in "train", "val", "test":
-            split_path = self.data.get(split)
-            if split_path is None:
+            if self.data.get(split) is None:
                 continue
-            if self.task == "classify":
-                from torchvision.datasets import ImageFolder  # scope for faster 'import ultralytics'
-
-                dataset = ImageFolder(split_path)
-                im_files = [f for f, _ in dataset.imgs]
-            else:
-                dataset = YOLODataset(img_path=split_path, data=self.data, task=self.task)
-                im_files = dataset.im_files
+            dataset = YOLODataset(img_path=self.data[split], data=self.data)
             with ThreadPool(NUM_THREADS) as pool:
-                for _ in TQDM(pool.imap(self._hub_ops, im_files), total=len(im_files), desc=f"{split} images"):
+                for _ in TQDM(pool.imap(self._hub_ops, dataset.im_files), total=len(dataset), desc=f"{split} images"):
                     pass
         LOGGER.info(f"Done. All images saved to {self.im_dir}")
         return self.im_dir

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -794,15 +794,23 @@ class HUBDatasetStats:
 
     def process_images(self) -> Path:
         """Compress images for Ultralytics HUB."""
-        from ultralytics.data import YOLODataset  # ClassificationDataset
+        from ultralytics.data import YOLODataset
 
         self.im_dir.mkdir(parents=True, exist_ok=True)  # makes dataset-hub/images/
         for split in "train", "val", "test":
-            if self.data.get(split) is None:
+            split_path = self.data.get(split)
+            if split_path is None:
                 continue
-            dataset = YOLODataset(img_path=self.data[split], data=self.data)
+            if self.task == "classify":
+                from torchvision.datasets import ImageFolder  # scope for faster 'import ultralytics'
+
+                dataset = ImageFolder(split_path)
+                im_files = [f for f, _ in dataset.imgs]
+            else:
+                dataset = YOLODataset(img_path=split_path, data=self.data, task=self.task)
+                im_files = dataset.im_files
             with ThreadPool(NUM_THREADS) as pool:
-                for _ in TQDM(pool.imap(self._hub_ops, dataset.im_files), total=len(dataset), desc=f"{split} images"):
+                for _ in TQDM(pool.imap(self._hub_ops, im_files), total=len(im_files), desc=f"{split} images"):
                     pass
         LOGGER.info(f"Done. All images saved to {self.im_dir}")
         return self.im_dir

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -83,7 +83,7 @@ import torch
 from ultralytics import __version__
 from ultralytics.cfg import QUANTIZE_DOCS_URL, TASK2CALIBRATIONDATA, TASK2DATA, get_cfg
 from ultralytics.data import build_dataloader, build_yolo_dataset
-from ultralytics.data.dataset import ClassificationDataset, YOLODataset
+from ultralytics.data.dataset import ClassificationDataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import check_class_names, default_class_names
 from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder, Segment26, SemanticSegment

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -83,7 +83,7 @@ import torch
 from ultralytics import __version__
 from ultralytics.cfg import QUANTIZE_DOCS_URL, TASK2CALIBRATIONDATA, TASK2DATA, get_cfg
 from ultralytics.data import build_dataloader, build_yolo_dataset
-from ultralytics.data.dataset import YOLODataset
+from ultralytics.data.dataset import ClassificationDataset, YOLODataset
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.nn.autobackend import check_class_names, default_class_names
 from ultralytics.nn.modules import C2f, Classify, Detect, RTDETRDecoder, Segment26, SemanticSegment
@@ -850,19 +850,15 @@ class Exporter:
         """Build and return a dataloader for calibration of INT8 models."""
         LOGGER.info(f"{prefix} collecting INT8 calibration images from 'data={self.args.data}'")
         data = (check_cls_dataset if self.model.task == "classify" else check_det_dataset)(self.args.data)
+        cfg = deepcopy(self.args)
+        cfg.imgsz = max(self.imgsz)
         if self.model.task == "classify":
-            dataset = YOLODataset(
-                data[self.args.split or "val"],
-                data=data,
-                fraction=self.args.fraction,
-                task=self.model.task,
-                imgsz=max(self.imgsz),
-                augment=False,
-                batch_size=self.args.batch,
-            )
+            import torchvision.transforms as T  # scope for faster 'import ultralytics'
+
+            dataset = ClassificationDataset(data[self.args.split or "val"], args=cfg, augment=False)
+            # INT8 backends divide images by 255, so emit uint8 [0, 255] center-cropped like classify inference
+            dataset.torch_transforms = T.Compose([T.Resize(cfg.imgsz), T.CenterCrop(cfg.imgsz), T.PILToTensor()])
         else:
-            cfg = deepcopy(self.args)
-            cfg.imgsz = max(self.imgsz)
             dataset = build_yolo_dataset(
                 cfg,
                 data[self.args.split or "val"],
@@ -871,7 +867,7 @@ class Exporter:
                 mode="val",
                 fraction=self.args.fraction,
             )
-        if hasattr(dataset.transforms.transforms[0], "new_shape"):
+        if hasattr(dataset, "transforms") and hasattr(dataset.transforms.transforms[0], "new_shape"):
             dataset.transforms.transforms[0].new_shape = self.imgsz  # LetterBox with non-square imgsz
         n = len(dataset)
         if n < 1:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚙️ This PR makes training and INT8 export more fault-tolerant by softening empty-label errors and improving classification calibration dataset handling.

### 📊 Key Changes
- 🔄 Changed dataset label validation to **warn instead of raising an error** when all labels are empty in `ultralytics/data/dataset.py`.
- 🛠️ Updated INT8 export calibration for **classification models** in `ultralytics/engine/exporter.py` to use `ClassificationDataset` instead of `YOLODataset`.
- 🖼️ Added classification-specific preprocessing for INT8 calibration using `Resize`, `CenterCrop`, and `PILToTensor()` so images are emitted as `uint8` in the expected format.
- 📐 Moved shared image size config setup earlier and added a safer transform check before adjusting `new_shape` for non-square image sizes.
- 🚀 Kept `torchvision` imported only where needed to help maintain faster base `import ultralytics` performance.

### 🎯 Purpose & Impact
- ✅ **Improves robustness during training** by avoiding a hard stop when labels are missing or empty, which can help users debug datasets more easily.
- 🧠 **Fixes classification INT8 calibration behavior** so exported quantized models are calibrated with preprocessing that better matches classification inference.
- 📦 **Reduces risk of export issues** for classification workflows, especially when targeting INT8 backends.
- 🛡️ **Adds safer dataset transform handling** to avoid errors when certain transform attributes are not present.
- 👥 For users, this means a smoother experience when working with imperfect datasets and more reliable export behavior for classification models.