### PR TITLE
Fix macOS ONNX requirement for TFLite export

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -18,6 +18,7 @@ from tests import SOURCE
 from tests.conftest import isolated_model_path
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS, _handle_deprecation, get_cfg
+from ultralytics.engine import exporter as exporter_module
 from ultralytics.engine.exporter import EXPORT_ENVS, export_formats, validate_args
 from ultralytics.utils import (
     ARM64,
@@ -68,6 +69,19 @@ def test_export_onnx_int8(isolated_model, precision):
     assert Path(file).name.endswith("_int8.onnx")
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
     Path(file).unlink()  # cleanup
+
+
+def test_get_onnx_requirement_matches_platform_pins(monkeypatch):
+    """ONNX AutoUpdate requirements should match platform pins used by export extras."""
+    monkeypatch.setattr(exporter_module, "MACOS", False)
+    monkeypatch.setattr(exporter_module, "IS_PYTHON_MINIMUM_3_13", False)
+    assert exporter_module.get_onnx_requirement() == "onnx>=1.12.0,<2.0.0"
+
+    monkeypatch.setattr(exporter_module, "MACOS", True)
+    assert exporter_module.get_onnx_requirement() == "onnx>=1.12.0,<1.18.0"
+
+    monkeypatch.setattr(exporter_module, "IS_PYTHON_MINIMUM_3_13", True)
+    assert exporter_module.get_onnx_requirement() == "onnx>=1.20.0,<2.0.0"
 
 
 def test_quantize_canonicalization():

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -383,6 +383,15 @@ W8A16_FORMATS = frozenset({"coreml", "imx", "qnn"})  # INT8 weights + FP16 activ
 FP32_UNSUPPORTED_FORMATS = frozenset({"edgetpu", "imx", "rknn", "axelera", "deepx", "qnn"})
 
 
+def get_onnx_requirement():
+    """Return the platform-specific ONNX requirement used by export AutoUpdate."""
+    if MACOS:
+        # ONNX>=1.18 can stall the TensorFlow/onnx2tf conversion path on macOS Python<3.13. Python>=3.13
+        # requires newer ONNX wheels, while TensorFlow exports are blocked separately on macOS Python>=3.13.
+        return "onnx>=1.20.0,<2.0.0" if IS_PYTHON_MINIMUM_3_13 else "onnx>=1.12.0,<1.18.0"
+    return "onnx>=1.12.0,<2.0.0"
+
+
 def validate_args(format, passed_args, valid_args):
     """Validate arguments based on the export format.
 
@@ -900,7 +909,7 @@ class Exporter:
     @try_export
     def export_onnx(self, prefix=colorstr("ONNX:")):
         """Export YOLO model to ONNX format."""
-        requirements = ["onnx>=1.12.0,<2.0.0"]
+        requirements = [get_onnx_requirement()]
         if self.args.simplify or (self.args.format == "onnx" and self.args.quantize == 8):
             # Pass onnxruntime variants as interchangeable candidates so AutoUpdate keeps an installed build
             # (e.g. onnxruntime-qnn for QNN export) instead of reinstalling stable onnxruntime and breaking its ABI.


### PR DESCRIPTION
## Summary
- Align runtime ONNX AutoUpdate requirements with the macOS export dependency pins from `pyproject.toml`.
- Use `onnx>=1.12.0,<1.18.0` on macOS Python<3.13 to avoid the TensorFlow/onnx2tf conversion stall reported for TFLite INT8 export.
- Preserve `onnx>=1.12.0,<2.0.0` on non-macOS and `onnx>=1.20.0,<2.0.0` on macOS Python>=3.13.
- Add a focused regression test for the platform-specific ONNX requirement selection.

Fixes #24633

## Tests
- `python -m ruff check ultralytics/engine/exporter.py tests/test_exports.py`
- `python -m ruff format --check ultralytics/engine/exporter.py tests/test_exports.py`
- `python -m py_compile ultralytics/engine/exporter.py tests/test_exports.py`
- Dependency-free AST check of `get_onnx_requirement()` for Linux/default, macOS Python<3.13, and macOS Python>=3.13 cases.

Note: full `pytest tests/test_exports.py::test_get_onnx_requirement_matches_platform_pins` could not be run in this local WSL environment because the project runtime dependencies (`cv2`, `torch`, `numpy`) are not installed there; CI should run this normally.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes macOS-specific ONNX dependency handling for TFLite export by introducing platform-aware ONNX requirement selection and adding tests to keep those pins aligned. 🚀

### 📊 Key Changes
- Added `get_onnx_requirement()` in `ultralytics/engine/exporter.py` to centralize ONNX version selection based on platform and Python version.
- Updated ONNX export AutoUpdate requirements to use the new helper instead of a single global ONNX pin.
- Applied a stricter ONNX upper bound on macOS for Python versions below 3.13 to avoid TensorFlow/`onnx2tf` conversion stalls.
- Preserved newer ONNX requirements for Python 3.13+ where newer wheels are needed.
- Added `test_get_onnx_requirement_matches_platform_pins()` in `tests/test_exports.py` to verify expected ONNX pins across platform and Python-version combinations. 🧪

### 🎯 Purpose & Impact
- Fixes a dependency mismatch affecting macOS export workflows, especially the TFLite conversion path.
- Reduces the risk of AutoUpdate installing incompatible ONNX versions during export.
- Improves reliability and maintainability by centralizing platform-specific dependency logic in one place.
- Adds regression coverage so future dependency changes are less likely to break macOS exports. ✅