### PR TITLE
Fix MultiTrainer memory retention

### DIFF
--- a/docs/en/reference/cfg/__init__.md
+++ b/docs/en/reference/cfg/__init__.md
@@ -28,6 +28,10 @@ keywords: Ultralytics, YOLO, configuration, cfg2dict, get_cfg, check_cfg, save_d
 
 <br><br><hr><br>
 
+## ::: ultralytics.cfg.__init__._get_yolo_cli_command
+
+<br><br><hr><br>
+
 ## ::: ultralytics.cfg.__init__._handle_deprecation
 
 <br><br><hr><br>

--- a/docs/en/reference/cfg/__init__.md
+++ b/docs/en/reference/cfg/__init__.md
@@ -28,10 +28,6 @@ keywords: Ultralytics, YOLO, configuration, cfg2dict, get_cfg, check_cfg, save_d
 
 <br><br><hr><br>
 
-## ::: ultralytics.cfg.__init__._get_yolo_cli_command
-
-<br><br><hr><br>
-
 ## ::: ultralytics.cfg.__init__._handle_deprecation
 
 <br><br><hr><br>

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -325,9 +325,7 @@ def test_train_multi_python_customizations_run_in_process(monkeypatch, tmp_path,
             calls["train"] += 1
             for callback in self.callbacks["on_train_start"]:
                 callback(self)
-            weights_dir = Path(self.overrides["save_dir"]) / "weights"
-            weights_dir.mkdir(parents=True)
-            torch.save({"train_metrics": {"fitness": float(calls["train"])}}, weights_dir / "last.pt")
+            self.validator = SimpleNamespace(metrics=SimpleNamespace(results_dict={"fitness": float(calls["train"])}))
 
     def on_train_start(trainer):
         calls["callback"] += 1
@@ -338,11 +336,39 @@ def test_train_multi_python_customizations_run_in_process(monkeypatch, tmp_path,
         monkeypatch.setattr(model, "_smart_load", lambda key: FakeTrainer)
 
     kwargs = {"trainer": FakeTrainer} if pass_trainer else {}
-    results = model.train(data=["coco8.yaml", "coco8.yaml"], project=tmp_path, epochs=1, imgsz=32, plots=False, **kwargs)
+    results = model.train(
+        data=["coco8.yaml", "coco8.yaml"], project=tmp_path, epochs=1, imgsz=32, plots=False, save=False, **kwargs
+    )
 
     assert model.trainer.use_subprocess is False
     assert calls == {"train": 2, "callback": 2 if add_callback else 0}
     assert isinstance(results, dict) and len(results) == 2
+
+
+def test_train_multi_repeated_dataset_failure_uses_unique_run_name(monkeypatch, tmp_path):
+    """Test repeated multi-dataset failures do not overwrite successful run metrics."""
+    model = YOLO(MODEL)
+    calls = {"train": 0}
+
+    class FakeTrainer:
+        def __init__(self, overrides=None, _callbacks=None):
+            self.overrides = overrides
+
+        def get_model(self, cfg=None, weights=None, verbose=True):
+            return model.model
+
+        def train(self):
+            calls["train"] += 1
+            if calls["train"] == 2:
+                raise RuntimeError("failed repeated dataset")
+            self.validator = SimpleNamespace(metrics=SimpleNamespace(results_dict={"fitness": 1.0}))
+
+    monkeypatch.setattr("ultralytics.engine.model.checks.check_pip_update_available", lambda: None)
+    results = model.train(
+        data=["coco8.yaml", "coco8.yaml"], project=tmp_path, epochs=1, imgsz=32, plots=False, trainer=FakeTrainer
+    )
+
+    assert results == {"coco8": {"fitness": 1.0}, "coco8-2": None}
 
 
 @pytest.mark.parametrize("pretrained,uses_weights", [(True, True), (False, False), (MODEL, True)])

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -307,67 +307,35 @@ def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights)
     assert captured["weights"] is (original_model if uses_weights else None), "Unexpected weights loaded"
 
 
-@pytest.mark.parametrize("pass_trainer,add_callback", [(True, False), (False, True)])
-def test_train_multi_python_customizations_run_in_process(monkeypatch, tmp_path, pass_trainer, add_callback):
-    """Test multi-dataset training preserves Python trainer and callback customizations."""
+def test_train_multi_custom_trainer_metrics_and_failure_keys(monkeypatch, tmp_path):
+    """Test custom multi-dataset runs keep memory metrics and unique failure keys."""
     model = YOLO(MODEL)
-    calls = {"train": 0, "callback": 0}
+    calls = 0
 
     class FakeTrainer:
         def __init__(self, overrides=None, _callbacks=None):
-            self.overrides = overrides
-            self.callbacks = _callbacks
+            pass
 
         def get_model(self, cfg=None, weights=None, verbose=True):
             return model.model
 
         def train(self):
-            calls["train"] += 1
-            for callback in self.callbacks["on_train_start"]:
-                callback(self)
-            self.validator = SimpleNamespace(metrics=SimpleNamespace(results_dict={"fitness": float(calls["train"])}))
-
-    def on_train_start(trainer):
-        calls["callback"] += 1
-
-    monkeypatch.setattr("ultralytics.engine.model.checks.check_pip_update_available", lambda: None)
-    if add_callback:
-        model.add_callback("on_train_start", on_train_start)
-        monkeypatch.setattr(model, "_smart_load", lambda key: FakeTrainer)
-
-    kwargs = {"trainer": FakeTrainer} if pass_trainer else {}
-    results = model.train(
-        data=["coco8.yaml", "coco8.yaml"], project=tmp_path, epochs=1, imgsz=32, plots=False, save=False, **kwargs
-    )
-
-    assert model.trainer.use_subprocess is False
-    assert calls == {"train": 2, "callback": 2 if add_callback else 0}
-    assert isinstance(results, dict) and len(results) == 2
-
-
-def test_train_multi_repeated_dataset_failure_uses_unique_run_name(monkeypatch, tmp_path):
-    """Test repeated multi-dataset failures do not overwrite successful run metrics."""
-    model = YOLO(MODEL)
-    calls = {"train": 0}
-
-    class FakeTrainer:
-        def __init__(self, overrides=None, _callbacks=None):
-            self.overrides = overrides
-
-        def get_model(self, cfg=None, weights=None, verbose=True):
-            return model.model
-
-        def train(self):
-            calls["train"] += 1
-            if calls["train"] == 2:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
                 raise RuntimeError("failed repeated dataset")
             self.validator = SimpleNamespace(metrics=SimpleNamespace(results_dict={"fitness": 1.0}))
 
     monkeypatch.setattr("ultralytics.engine.model.checks.check_pip_update_available", lambda: None)
     results = model.train(
-        data=["coco8.yaml", "coco8.yaml"], project=tmp_path, epochs=1, imgsz=32, plots=False, trainer=FakeTrainer
+        data=["coco8.yaml", "coco8.yaml"],
+        project=tmp_path,
+        plots=False,
+        save=False,
+        trainer=FakeTrainer,
     )
 
+    assert model.trainer.use_subprocess is False
     assert results == {"coco8": {"fitness": 1.0}, "coco8-2": None}
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -307,6 +307,44 @@ def test_train_reuses_loaded_checkpoint_model(monkeypatch, kwargs, uses_weights)
     assert captured["weights"] is (original_model if uses_weights else None), "Unexpected weights loaded"
 
 
+@pytest.mark.parametrize("pass_trainer,add_callback", [(True, False), (False, True)])
+def test_train_multi_python_customizations_run_in_process(monkeypatch, tmp_path, pass_trainer, add_callback):
+    """Test multi-dataset training preserves Python trainer and callback customizations."""
+    model = YOLO(MODEL)
+    calls = {"train": 0, "callback": 0}
+
+    class FakeTrainer:
+        def __init__(self, overrides=None, _callbacks=None):
+            self.overrides = overrides
+            self.callbacks = _callbacks
+
+        def get_model(self, cfg=None, weights=None, verbose=True):
+            return model.model
+
+        def train(self):
+            calls["train"] += 1
+            for callback in self.callbacks["on_train_start"]:
+                callback(self)
+            weights_dir = Path(self.overrides["save_dir"]) / "weights"
+            weights_dir.mkdir(parents=True)
+            torch.save({"train_metrics": {"fitness": float(calls["train"])}}, weights_dir / "last.pt")
+
+    def on_train_start(trainer):
+        calls["callback"] += 1
+
+    monkeypatch.setattr("ultralytics.engine.model.checks.check_pip_update_available", lambda: None)
+    if add_callback:
+        model.add_callback("on_train_start", on_train_start)
+        monkeypatch.setattr(model, "_smart_load", lambda key: FakeTrainer)
+
+    kwargs = {"trainer": FakeTrainer} if pass_trainer else {}
+    results = model.train(data=["coco8.yaml", "coco8.yaml"], project=tmp_path, epochs=1, imgsz=32, plots=False, **kwargs)
+
+    assert model.trainer.use_subprocess is False
+    assert calls == {"train": 2, "callback": 2 if add_callback else 0}
+    assert isinstance(results, dict) and len(results) == 2
+
+
 @pytest.mark.parametrize("pretrained,uses_weights", [(True, True), (False, False), (MODEL, True)])
 def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrained, uses_weights):
     """Test .pt models use checkpoint config while respecting the pretrained argument."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -335,7 +335,7 @@ def test_train_multi_custom_trainer_metrics_and_failure_keys(monkeypatch, tmp_pa
         trainer=FakeTrainer,
     )
 
-    assert model.trainer.use_subprocess is False
+    assert model.trainer.trainer is FakeTrainer
     assert results == {"coco8": {"fitness": 1.0}, "coco8-2": None}
 
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -492,6 +492,11 @@ def get_save_dir(args: SimpleNamespace, name: str | None = None) -> Path:
     return Path(save_dir).resolve()  # resolve to display full path in console
 
 
+def _get_yolo_cli_command(mode: str, args: dict[str, Any]) -> list[str]:
+    """Return a Python module command for launching the Ultralytics CLI."""
+    return [sys.executable, "-m", "ultralytics.cfg.__init__", mode, *(f"{k}={v}" for k, v in args.items())]
+
+
 def _handle_deprecation(custom: dict) -> dict:
     """Handle deprecated configuration keys by mapping them to current equivalents with deprecation warnings.
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -92,6 +92,7 @@ TASK2METRIC = {
 }
 
 ARGV = sys.argv or ["", ""]  # sometimes sys.argv = []
+_YOLO_CLI_COMMAND = [sys.executable, "-m", "ultralytics.cfg.__init__"]
 SOLUTIONS_HELP_MSG = f"""
     Arguments received: {["yolo", *ARGV[1:]]!s}. Ultralytics 'yolo solutions' usage overview:
 
@@ -490,11 +491,6 @@ def get_save_dir(args: SimpleNamespace, name: str | None = None) -> Path:
         save_dir = increment_path(Path(project) / name, exist_ok=args.exist_ok if RANK in {-1, 0} else True)
 
     return Path(save_dir).resolve()  # resolve to display full path in console
-
-
-def _get_yolo_cli_command(mode: str, args: dict[str, Any]) -> list[str]:
-    """Return a Python module command for launching the Ultralytics CLI."""
-    return [sys.executable, "-m", "ultralytics.cfg.__init__", mode, *(f"{k}={v}" for k, v in args.items())]
 
 
 def _handle_deprecation(custom: dict) -> dict:

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -780,8 +780,13 @@ class Model(torch.nn.Module):
         if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
             from ultralytics.engine.trainer import MultiTrainer
 
+            trainer_cls = trainer or self._smart_load("trainer")
             self.trainer = MultiTrainer(
-                trainer or self._smart_load("trainer"), args, self.model, _callbacks=self.callbacks
+                trainer_cls,
+                args,
+                self.model,
+                _callbacks=self.callbacks,
+                use_subprocess=trainer is None and self.callbacks == callbacks.get_default_callbacks(),
             )
             self.metrics = self.trainer.train()
             return self.metrics

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -780,13 +780,12 @@ class Model(torch.nn.Module):
         if isinstance(args.get("data"), (list, tuple)):  # fine-tune a single base model across multiple datasets
             from ultralytics.engine.trainer import MultiTrainer
 
-            trainer_cls = trainer or self._smart_load("trainer")
+            use_python_trainer = trainer is not None or self.callbacks != callbacks.get_default_callbacks()
             self.trainer = MultiTrainer(
-                trainer_cls,
+                (trainer or self._smart_load("trainer")) if use_python_trainer else None,
                 args,
                 self.model,
                 _callbacks=self.callbacks,
-                use_subprocess=trainer is None and self.callbacks == callbacks.get_default_callbacks(),
             )
             self.metrics = self.trainer.train()
             return self.metrics

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -25,7 +25,7 @@ from torch import distributed as dist
 from torch import nn, optim
 
 from ultralytics import __version__
-from ultralytics.cfg import get_cfg, get_save_dir
+from ultralytics.cfg import _get_yolo_cli_command, get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.tasks import load_checkpoint
@@ -1137,7 +1137,7 @@ class MultiTrainer:
         args (dict): Training arguments shared across datasets; its `data` key holds the dataset collection.
         model (torch.nn.Module): Base model whose weights seed each per-dataset fine-tune.
         callbacks (dict | None): Callbacks forwarded to each per-dataset trainer.
-        trainers (list[BaseTrainer]): Completed per-dataset trainers (hold results.csv, save_dir, and metrics).
+        trainers (list[SimpleNamespace]): Completed per-dataset run records.
         metrics (dict): Mapping of each run name (e.g. coco8, coco8-2) to its training-metrics dict from the checkpoint.
         save_dir (Path | None): Sweep directory holding the per-dataset runs and the results JSON/plot.
 
@@ -1149,7 +1149,7 @@ class MultiTrainer:
         >>> results["coco8"]["fitness"]  # final fitness on the coco8 run
     """
 
-    def __init__(self, trainer, args, model, _callbacks: dict | None = None):
+    def __init__(self, trainer, args, model, _callbacks: dict | None = None, use_subprocess: bool = True):
         """Initialize MultiTrainer with a task trainer class, shared training arguments, and the base model.
 
         Args:
@@ -1157,11 +1157,13 @@ class MultiTrainer:
             args (dict): Training arguments; the `data` key holds the list/tuple of datasets to fine-tune on.
             model (torch.nn.Module): Base model whose weights seed each per-dataset fine-tune.
             _callbacks (dict, optional): Callback functions forwarded to each per-dataset trainer.
+            use_subprocess (bool): Whether to isolate per-dataset runs in CLI subprocesses.
         """
         self.trainer = trainer
         self.args = args
         self.model = model
         self.callbacks = _callbacks
+        self.use_subprocess = use_subprocess
         self.trainers = []
         self.metrics = {}
         self.save_dir = None
@@ -1169,6 +1171,8 @@ class MultiTrainer:
     def train(self):
         """Fine-tune the base model on each dataset in series and return a {dataset: metrics} mapping."""
         from types import SimpleNamespace
+
+        from ultralytics.utils.patches import torch_load, torch_save
 
         datasets = self.args["data"]
         # Group every per-dataset run and the summary plot under one sweep directory, e.g. runs/detect/multitrain
@@ -1179,35 +1183,56 @@ class MultiTrainer:
             exist_ok=self.args.get("exist_ok", False),
         )
         self.save_dir = get_save_dir(sweep, name="multitrain")
-        for i, data in enumerate(datasets):
-            LOGGER.info(f"\n{colorstr('blue', 'bold', f'MultiTrainer {i + 1}/{len(datasets)}:')} fine-tuning on {data}")
-            try:
-                overrides = {
-                    **self.args,
-                    "data": data,
-                    "project": str(self.save_dir),  # nest per-dataset runs inside the sweep directory
-                    "name": Path(str(data)).stem,
-                    "resume": False,
-                    "session": None,
-                }
-                trainer = self.trainer(overrides=overrides, _callbacks=self.callbacks)
-                trainer.model = trainer.get_model(weights=self.model, cfg=self.model.yaml)  # seed each run from base
-                trainer.train()
-                self.trainers.append(trainer)
-                # Key by the unique run name (e.g. coco8, coco8-2) so repeated datasets do not collapse. Use the
-                # in-memory metrics; only under DDP (validator ran in a subprocess) reload them from the checkpoint.
-                metrics = getattr(trainer.validator, "metrics", None)
-                if metrics is not None:
-                    metrics = metrics.results_dict
-                else:
-                    from ultralytics.utils.patches import torch_load
-
-                    ckpt = trainer.best if trainer.best.exists() else trainer.last
-                    metrics = torch_load(ckpt)["train_metrics"] if ckpt.exists() else None
-                self.metrics[trainer.save_dir.name] = metrics
-            except Exception as e:  # one bad dataset should not abort the whole sweep
-                LOGGER.error(f"MultiTrainer: fine-tuning on {data} failed, skipping: {e}")
-                self.metrics[Path(str(data)).stem] = None
+        self.save_dir.mkdir(parents=True, exist_ok=True)
+        base_model = self.save_dir / "multitrain_base.pt" if self.use_subprocess else None
+        if base_model:
+            torch_save({"model": deepcopy(self.model).half(), "train_args": getattr(self.model, "args", {})}, base_model)
+        try:
+            for i, data in enumerate(datasets):
+                LOGGER.info(
+                    f"\n{colorstr('blue', 'bold', f'MultiTrainer {i + 1}/{len(datasets)}:')} fine-tuning on {data}"
+                )
+                name = Path(str(data)).stem
+                try:
+                    overrides = {
+                        **self.args,
+                        "data": data,
+                        "project": str(self.save_dir),  # nest per-dataset runs inside the sweep directory
+                        "name": name,
+                        "resume": False,
+                        "session": None,
+                    }
+                    run = SimpleNamespace(
+                        project=overrides["project"],
+                        name=overrides["name"],
+                        task=overrides.get("task"),
+                        mode="train",
+                        exist_ok=overrides.get("exist_ok", False),
+                        save_dir=None,
+                    )
+                    save_dir = get_save_dir(run)
+                    overrides["save_dir"] = str(save_dir)
+                    if self.use_subprocess:
+                        overrides["model"] = str(base_model)
+                        overrides["pretrained"] = True
+                        subprocess.run(
+                            _get_yolo_cli_command("train", {k: v for k, v in overrides.items() if k != "session"}),
+                            check=True,
+                        )
+                    else:
+                        trainer = self.trainer(overrides=overrides, _callbacks=self.callbacks)
+                        trainer.model = trainer.get_model(weights=self.model, cfg=self.model.yaml)
+                        trainer.train()
+                    best, last = save_dir / "weights" / "best.pt", save_dir / "weights" / "last.pt"
+                    ckpt = best if best.exists() else last
+                    self.metrics[save_dir.name] = torch_load(ckpt)["train_metrics"] if ckpt.exists() else None
+                    self.trainers.append(SimpleNamespace(save_dir=save_dir, best=best, last=last))
+                except Exception as e:  # one bad dataset should not abort the whole sweep
+                    LOGGER.error(f"MultiTrainer: fine-tuning on {data} failed, skipping: {e}")
+                    self.metrics[name] = None
+        finally:
+            if base_model:
+                base_model.unlink(missing_ok=True)
         if RANK in {-1, 0} and self.trainers:
             self.save_dir.mkdir(parents=True, exist_ok=True)
             self.save_results()  # JSON of per-dataset + mean metrics for programmatic post-processing

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1186,7 +1186,9 @@ class MultiTrainer:
         self.save_dir.mkdir(parents=True, exist_ok=True)
         base_model = self.save_dir / "multitrain_base.pt" if self.use_subprocess else None
         if base_model:
-            torch_save({"model": deepcopy(self.model).half(), "train_args": getattr(self.model, "args", {})}, base_model)
+            torch_save(
+                {"model": deepcopy(self.model).half(), "train_args": getattr(self.model, "args", {})}, base_model
+            )
         try:
             for i, data in enumerate(datasets):
                 LOGGER.info(
@@ -1219,7 +1221,11 @@ class MultiTrainer:
                         overrides["model"] = str(base_model)
                         overrides["pretrained"] = True
                         subprocess.run(
-                            [*_YOLO_CLI_COMMAND, "train", *(f"{k}={v}" for k, v in overrides.items() if k != "session")],
+                            [
+                                *_YOLO_CLI_COMMAND,
+                                "train",
+                                *(f"{k}={v}" for k, v in overrides.items() if k != "session"),
+                            ],
                             check=True,
                         )
                     else:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -25,7 +25,7 @@ from torch import distributed as dist
 from torch import nn, optim
 
 from ultralytics import __version__
-from ultralytics.cfg import _get_yolo_cli_command, get_cfg, get_save_dir
+from ultralytics.cfg import _YOLO_CLI_COMMAND, get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.tasks import load_checkpoint
@@ -1216,7 +1216,7 @@ class MultiTrainer:
                         overrides["model"] = str(base_model)
                         overrides["pretrained"] = True
                         subprocess.run(
-                            _get_yolo_cli_command("train", {k: v for k, v in overrides.items() if k != "session"}),
+                            [*_YOLO_CLI_COMMAND, "train", *(f"{k}={v}" for k, v in overrides.items() if k != "session")],
                             check=True,
                         )
                     else:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1133,7 +1133,7 @@ class MultiTrainer:
     chart. The base model object is left unchanged; each dataset's fine-tuned weights live in its own run directory.
 
     Attributes:
-        trainer (type[BaseTrainer]): Task trainer class instantiated once per dataset.
+        trainer (type[BaseTrainer] | None): Task trainer class for Python runs, or None for CLI subprocess runs.
         args (dict): Training arguments shared across datasets; its `data` key holds the dataset collection.
         model (torch.nn.Module): Base model whose weights seed each per-dataset fine-tune.
         callbacks (dict | None): Callbacks forwarded to each per-dataset trainer.
@@ -1149,21 +1149,19 @@ class MultiTrainer:
         >>> results["coco8"]["fitness"]  # final fitness on the coco8 run
     """
 
-    def __init__(self, trainer, args, model, _callbacks: dict | None = None, use_subprocess: bool = True):
+    def __init__(self, trainer, args, model, _callbacks: dict | None = None):
         """Initialize MultiTrainer with a task trainer class, shared training arguments, and the base model.
 
         Args:
-            trainer (type[BaseTrainer]): Task trainer class to run once per dataset.
+            trainer (type[BaseTrainer] | None): Task trainer class to run once per dataset. None uses CLI subprocesses.
             args (dict): Training arguments; the `data` key holds the list/tuple of datasets to fine-tune on.
             model (torch.nn.Module): Base model whose weights seed each per-dataset fine-tune.
             _callbacks (dict, optional): Callback functions forwarded to each per-dataset trainer.
-            use_subprocess (bool): Whether to isolate per-dataset runs in CLI subprocesses.
         """
         self.trainer = trainer
         self.args = args
         self.model = model
         self.callbacks = _callbacks
-        self.use_subprocess = use_subprocess
         self.trainers = []
         self.metrics = {}
         self.save_dir = None
@@ -1184,7 +1182,7 @@ class MultiTrainer:
         )
         self.save_dir = get_save_dir(sweep, name="multitrain")
         self.save_dir.mkdir(parents=True, exist_ok=True)
-        base_model = self.save_dir / "multitrain_base.pt" if self.use_subprocess else None
+        base_model = self.save_dir / "multitrain_base.pt" if self.trainer is None else None
         if base_model:
             torch_save(
                 {"model": deepcopy(self.model).half(), "train_args": getattr(self.model, "args", {})}, base_model
@@ -1217,7 +1215,7 @@ class MultiTrainer:
                     save_dir.mkdir(parents=True, exist_ok=True)
                     run_name = save_dir.name
                     overrides["save_dir"] = str(save_dir)
-                    if self.use_subprocess:
+                    if self.trainer is None:
                         overrides["model"] = str(base_model)
                         overrides["pretrained"] = True
                         subprocess.run(
@@ -1235,7 +1233,7 @@ class MultiTrainer:
                     best, last = save_dir / "weights" / "best.pt", save_dir / "weights" / "last.pt"
                     ckpt = best if best.exists() else last
                     metrics = None
-                    if not self.use_subprocess:
+                    if self.trainer is not None:
                         metrics = getattr(getattr(trainer, "validator", None), "metrics", None)
                         if metrics is not None:
                             metrics = metrics.results_dict

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1193,6 +1193,7 @@ class MultiTrainer:
                     f"\n{colorstr('blue', 'bold', f'MultiTrainer {i + 1}/{len(datasets)}:')} fine-tuning on {data}"
                 )
                 name = Path(str(data)).stem
+                run_name = name
                 try:
                     overrides = {
                         **self.args,
@@ -1211,6 +1212,8 @@ class MultiTrainer:
                         save_dir=None,
                     )
                     save_dir = get_save_dir(run)
+                    save_dir.mkdir(parents=True, exist_ok=True)
+                    run_name = save_dir.name
                     overrides["save_dir"] = str(save_dir)
                     if self.use_subprocess:
                         overrides["model"] = str(base_model)
@@ -1225,11 +1228,16 @@ class MultiTrainer:
                         trainer.train()
                     best, last = save_dir / "weights" / "best.pt", save_dir / "weights" / "last.pt"
                     ckpt = best if best.exists() else last
-                    self.metrics[save_dir.name] = torch_load(ckpt)["train_metrics"] if ckpt.exists() else None
+                    metrics = None
+                    if not self.use_subprocess:
+                        metrics = getattr(getattr(trainer, "validator", None), "metrics", None)
+                        if metrics is not None:
+                            metrics = metrics.results_dict
+                    self.metrics[run_name] = metrics or (torch_load(ckpt)["train_metrics"] if ckpt.exists() else None)
                     self.trainers.append(SimpleNamespace(save_dir=save_dir, best=best, last=last))
                 except Exception as e:  # one bad dataset should not abort the whole sweep
                     LOGGER.error(f"MultiTrainer: fine-tuning on {data} failed, skipping: {e}")
-                    self.metrics[name] = None
+                    self.metrics[run_name] = None
         finally:
             if base_model:
                 base_model.unlink(missing_ok=True)

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from ultralytics.cfg import CFG_INT_KEYS, _YOLO_CLI_COMMAND, get_cfg, get_save_dir
+from ultralytics.cfg import _YOLO_CLI_COMMAND, CFG_INT_KEYS, get_cfg, get_save_dir
 from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.patches import torch_load

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from ultralytics.cfg import CFG_INT_KEYS, get_cfg, get_save_dir
+from ultralytics.cfg import CFG_INT_KEYS, _get_yolo_cli_command, get_cfg, get_save_dir
 from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.patches import torch_load
@@ -504,12 +504,7 @@ class Tuner:
                     train_args["data"] = d
                     train_args["save_dir"] = str(save_dir[j])  # pass save_dir to subprocess to ensure same path is used
                     # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
-                    launch = [
-                        __import__("sys").executable,
-                        "-m",
-                        "ultralytics.cfg.__init__",
-                    ]  # workaround yolo not found
-                    cmd = [*launch, "train", *(f"{k}={v}" for k, v in train_args.items())]
+                    cmd = _get_yolo_cli_command("train", train_args)
                     subprocess.run(cmd, check=True)
                     ckpt_file = weights_dir[j] / ("best.pt" if (weights_dir[j] / "best.pt").exists() else "last.pt")
                     metrics_i = torch_load(ckpt_file)["train_metrics"]

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from ultralytics.cfg import CFG_INT_KEYS, _get_yolo_cli_command, get_cfg, get_save_dir
+from ultralytics.cfg import CFG_INT_KEYS, _YOLO_CLI_COMMAND, get_cfg, get_save_dir
 from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.patches import torch_load
@@ -504,7 +504,7 @@ class Tuner:
                     train_args["data"] = d
                     train_args["save_dir"] = str(save_dir[j])  # pass save_dir to subprocess to ensure same path is used
                     # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
-                    cmd = _get_yolo_cli_command("train", train_args)
+                    cmd = [*_YOLO_CLI_COMMAND, "train", *(f"{k}={v}" for k, v in train_args.items())]
                     subprocess.run(cmd, check=True)
                     ckpt_file = weights_dir[j] / ("best.pt" if (weights_dir[j] / "best.pt").exists() else "last.pt")
                     metrics_i = torch_load(ckpt_file)["train_metrics"]


### PR DESCRIPTION
## Summary
- run default MultiTrainer per-dataset training in CLI subprocesses and reload metrics from checkpoints
- stop retaining full trainer/model/dataloader objects in the parent process
- keep custom Python trainers/callbacks on the in-process path to preserve the public API
- reuse the package CLI launch prefix in Tuner without adding a public cfg API
- preserve in-memory metrics for no-checkpoint custom trainer runs and unique keys for repeated-dataset failures

## Tests
- python -m pytest tests/test_python.py::test_train_multi tests/test_engine.py::test_train_multi_custom_trainer_metrics_and_failure_keys -q
- python -m ruff check ultralytics/engine/model.py ultralytics/engine/trainer.py ultralytics/engine/tuner.py ultralytics/cfg/__init__.py tests/test_engine.py
- python smoke: YOLO("yolo26n.pt").train(data=["coco8.yaml", "coco128.yaml"], epochs=1, imgsz=32, batch=8, workers=0, plots=False, device="cpu") returned subprocess_path=True and fitness metrics for both datasets
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR improves multi-dataset training by making `MultiTrainer` more reliable across both Python and CLI workflows, while preserving metrics correctly and avoiding result-name conflicts.

### 📊 Key Changes
- 🧠 Updated multi-dataset training in `model.train()` to better decide when to use an in-process Python trainer versus launching CLI subprocesses.
- 🔁 Expanded `MultiTrainer` to support two execution modes:
  - direct Python trainer classes
  - CLI subprocess training when no custom trainer/callback setup is needed
- 💾 Added temporary base-model checkpoint handling for CLI-based multi-dataset runs so each dataset starts from the same model state.
- 📈 Improved metric collection logic:
  - keeps in-memory validator metrics when available
  - falls back to loading metrics from saved checkpoints if needed
- 🏷️ Fixed repeated-dataset naming so duplicate datasets get unique result keys like `coco8` and `coco8-2` instead of overwriting each other.
- 🛡️ Kept failure isolation in place: if one dataset run fails, the rest of the sweep continues, and the failed run is recorded as `None`.
- 🧪 Added a new test to confirm:
  - memory-resident metrics are preserved
  - duplicate dataset names stay unique
  - failed runs do not break the full multi-dataset training job
- 🧹 Refactored CLI launch command creation into a shared `_YOLO_CLI_COMMAND` constant, which is now reused in both trainer and tuner code.

### 🎯 Purpose & Impact
- ✅ Makes multi-dataset training more robust and predictable, especially when the same dataset appears more than once.
- 📊 Prevents metrics from being lost or overwritten, improving result tracking and comparison across runs.
- 🔄 Enables cleaner support for both advanced Python-based customization and standard CLI-style execution.
- 🚫 Reduces the chance that one failed dataset ruins an entire training sweep.
- 🧰 Simplifies internal command launching and improves maintainability by centralizing the CLI invocation logic.
- 👥 For users, this means more dependable multi-dataset fine-tuning with clearer outputs and better failure handling.