### PR TITLE
Set YOLO-World eval classes on all DDP ranks

### DIFF
--- a/ultralytics/models/yolo/world/train.py
+++ b/ultralytics/models/yolo/world/train.py
@@ -17,10 +17,9 @@ from ultralytics.utils.torch_utils import unwrap_model
 
 def on_pretrain_routine_end(trainer) -> None:
     """Set up model classes and text encoder at the end of the pretrain routine."""
-    if RANK in {-1, 0}:
-        # Set class names for evaluation
-        names = [name.split("/", 1)[0] for name in list(trainer.test_loader.dataset.data["names"].values())]
-        unwrap_model(trainer.ema.ema).set_classes(names, cache_clip_model=False)
+    # Set on all ranks: validation runs on every rank, but txt_feats/nc are not DDP buffers so they don't sync
+    names = [name.split("/", 1)[0] for name in list(trainer.test_loader.dataset.data["names"].values())]
+    unwrap_model(trainer.ema.ema).set_classes(names, cache_clip_model=False)
 
 
 class WorldTrainer(DetectionTrainer):


### PR DESCRIPTION
Closes #24887

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR fixes YOLO-World training in distributed setups by ensuring class names are initialized on every rank, not just the main process 🛠️

### 📊 Key Changes
- Updated `on_pretrain_routine_end()` in `ultralytics/models/yolo/world/train.py`.
- Removed the `RANK in {-1, 0}` check so `set_classes()` now runs on **all ranks** during distributed training.
- Kept the class-name extraction logic the same, using validation dataset names and stripping any suffix after `/`.
- Added a clarifying comment explaining why this is needed: validation runs on every rank, but `txt_feats` and `nc` are **not synchronized** as DDP buffers.

### 🎯 Purpose & Impact
- Prevents mismatches across GPUs during YOLO-World training and validation ⚙️
- Ensures each distributed worker has the correct class setup, improving consistency and stability.
- Fixes a subtle multi-GPU/DDP issue that could lead to incorrect validation behavior or rank-specific errors.
- Has little to no impact on single-GPU training, but makes distributed training more reliable and predictable 🚀