### PR TITLE
Add C++ inference guidance to export docs

### DIFF
--- a/docs/en/modes/export.md
+++ b/docs/en/modes/export.md
@@ -237,6 +237,19 @@ For **pose models** (e.g., `yolo26n-pose.pt`), the output tensor is typically sh
 
 The examples in the [ONNX inference examples](https://github.com/ultralytics/ultralytics/tree/main/examples) demonstrate how to process these outputs for each model type.
 
+### Is there an official Ultralytics C++ inference API?
+
+Ultralytics does not currently provide a dedicated C++ inference API for YOLO models. For C++ deployments, export the
+model to a runtime format such as [ONNX](../integrations/onnx.md), [TensorRT](../integrations/tensorrt.md),
+[TorchScript](../integrations/torchscript.md), or [MNN](../integrations/mnn.md), then load the exported artifact with
+that runtime's native C++ API.
+
+For example, export a detection model with `yolo export model=yolo26n.pt format=onnx` and run the `.onnx` file with
+ONNX Runtime C++, or export with `format=engine` and run the TensorRT engine from a TensorRT C++ application. When you
+use custom C++ post-processing, match the output tensor layout for your task and export settings; YOLO26 end-to-end
+detection exports usually return `(batch, max_det, 6)`, while non-end-to-end exports return raw prediction tensors that
+require external post-processing.
+
 ### Why is `output0` FP32 when exporting quantized models with `end2end=True`?
 
 When exporting with `quantize=16` (FP16) or `quantize=8` (INT8), most tensors are converted to lower precision to reduce model size and improve performance. However, when `end2end=True` is enabled, post-processing (including class indices) is embedded directly in the exported graph.


### PR DESCRIPTION
## Summary
- Add an export FAQ entry clarifying that Ultralytics does not currently provide a dedicated C++ inference API.
- Point C++ deployments to exported runtime formats such as ONNX, TensorRT, TorchScript, and MNN.
- Remind users to match custom C++ post-processing to the exported tensor layout, especially YOLO26 end-to-end vs non-end-to-end outputs.

Related to #22789

## Tests
- `git diff --check`
- Docs sanity check confirming the new FAQ heading and linked integration pages are present.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds documentation guidance for C++ inference workflows in the export docs, clarifying that Ultralytics does not currently provide an official dedicated C++ inference API for YOLO models. 🚀

### 📊 Key Changes
- Adds a new FAQ-style section to `docs/en/modes/export.md` about official Ultralytics C++ inference support.
- Explains that C++ deployments should use exported runtime formats such as ONNX, TensorRT, TorchScript, or MNN with each runtime's native C++ API.
- Includes practical export examples for YOLO26 detection models using ONNX and TensorRT workflows.
- Clarifies output handling expectations for custom C++ post-processing, including the difference between end-to-end and non-end-to-end detection exports.

### 🎯 Purpose & Impact
- Improves export documentation for developers deploying YOLO26 models in C++ environments. 📘
- Reduces confusion around whether an official Ultralytics C++ inference API exists.
- Helps users choose the correct deployment path and better understand exported output tensor layouts.
- Likely lowers support friction for export and inference questions related to ONNX Runtime and TensorRT in C++ setups. 🎯