### PR TITLE
Add tracker state guidance to tracking docs

### DIFF
--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -673,7 +673,7 @@ Multi-object tracking in video analytics involves both identifying objects and m
 
 ### Can I store the tracker inside a YOLO model file?
 
-No. Standard Ultralytics `.pt` and `.pth` files store the YOLO model weights, while the tracker is created at inference time by [`model.track()`](../reference/engine/model.md#ultralytics.engine.model.Model.track). Track IDs depend on tracker state across consecutive frames, so a single standalone image can return detections such as boxes, classes, and confidences, but it cannot produce meaningful persistent tracking IDs by itself.
+No. Standard Ultralytics `.pt` files store the YOLO model weights, while the tracker is created at inference time by [`model.track()`](../reference/engine/model.md#ultralytics.engine.model.Model.track). Track IDs depend on tracker state across consecutive frames, so a single standalone image can return detections such as boxes, classes, and confidences, but it cannot produce meaningful persistent tracking IDs by itself.
 
 For deployment, package the detector and tracker together in your application and call `model.track()` frame by frame with `persist=True` when frames come from the same video stream. Use separate model or tracker instances for unrelated streams so state does not carry over between videos.
 

--- a/docs/en/modes/track.md
+++ b/docs/en/modes/track.md
@@ -671,6 +671,12 @@ Together, let's enhance the tracking capabilities of the Ultralytics YOLO ecosys
 
 Multi-object tracking in video analytics involves both identifying objects and maintaining a unique ID for each detected object across video frames. Ultralytics YOLO supports this by providing real-time tracking along with object IDs, facilitating tasks such as security surveillance and sports analytics. The system uses trackers such as [BoT-SORT](https://github.com/NirAharon/BoT-SORT), [ByteTrack](https://github.com/FoundationVision/ByteTrack), OC-SORT, Deep OC-SORT, FastTracker, and TrackTrack, which can be configured via YAML files.
 
+### Can I store the tracker inside a YOLO model file?
+
+No. Standard Ultralytics `.pt` and `.pth` files store the YOLO model weights, while the tracker is created at inference time by [`model.track()`](../reference/engine/model.md#ultralytics.engine.model.Model.track). Track IDs depend on tracker state across consecutive frames, so a single standalone image can return detections such as boxes, classes, and confidences, but it cannot produce meaningful persistent tracking IDs by itself.
+
+For deployment, package the detector and tracker together in your application and call `model.track()` frame by frame with `persist=True` when frames come from the same video stream. Use separate model or tracker instances for unrelated streams so state does not carry over between videos.
+
 ### How do I configure a custom tracker for Ultralytics YOLO?
 
 You can configure a custom tracker by copying an existing tracker configuration file (e.g., `custom_tracker.yaml`) from the [Ultralytics tracker configuration directory](https://github.com/ultralytics/ultralytics/tree/main/ultralytics/cfg/trackers) and modifying parameters as needed, except for the `tracker_type`. Use this file in your tracking model like so:


### PR DESCRIPTION
## Summary
- Add a tracking FAQ clarifying that YOLO `.pt`/`.pth` files store model weights, not tracker state or tracker configuration as a self-contained output pipeline.
- Explain that persistent tracking IDs depend on state across consecutive frames created by `model.track()`.
- Recommend packaging detector and tracker together in the deployment application and using `persist=True` only for frames from the same stream.

Related to #24846

## Tests
- `git diff --check`
- Docs sanity check confirming the new FAQ heading, `model.track()`, and `persist=True` guidance are present.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 Adds tracker state guidance to the tracking documentation, clarifying that trackers are created at inference time and are not stored inside YOLO model weight files.

### 📊 Key Changes
- Added a new FAQ section: **"Can I store the tracker inside a YOLO model file?"**
- Clarified that standard Ultralytics `.pt` and `.pth` files contain model weights only, not tracker state.
- Explained that persistent track IDs require tracker state across consecutive frames and cannot be meaningfully produced from a single standalone image.
- Added deployment guidance recommending packaging the detector and tracker together in the application.
- Documented best practice to call `model.track()` frame by frame with `persist=True` for the same video stream.
- Advised using separate model or tracker instances for unrelated streams to avoid state leakage between videos.

### 🎯 Purpose & Impact
- Reduces user confusion around what is and is not saved in YOLO model files.
- Helps users deploy tracking correctly by distinguishing detector weights from runtime tracker state.
- Improves documentation for multi-stream and video tracking workflows, lowering the risk of incorrect ID behavior.
- Provides practical usage guidance that should reduce repeat questions and support overhead.