### PR TITLE
Fix sticky-NaN EMA checkpoint loss and legacy safe-load rejection

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -264,7 +264,8 @@ def test_checkpoint_nonfinite_ema_resync():
     """Test a non-finite EMA on a finite model is resynced (not skipped) so the run still produces a checkpoint."""
 
     def poison_ema(trainer):
-        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
+        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run).
+        """
         if trainer.ema is not None:
             next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -264,8 +264,7 @@ def test_checkpoint_nonfinite_ema_resync():
     """Test a non-finite EMA on a finite model is resynced (not skipped) so the run still produces a checkpoint."""
 
     def poison_ema(trainer):
-        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run).
-        """
+        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
         if trainer.ema is not None:
             next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -260,6 +260,25 @@ def test_checkpoint_fp16_overflow():
     )
 
 
+def test_checkpoint_nonfinite_ema_resync():
+    """Test a non-finite EMA on a finite model is resynced (not skipped) so the run still produces a checkpoint."""
+
+    def poison_ema(trainer):
+        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
+        if trainer.ema is not None:
+            next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
+
+    overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 2}
+    trainer = detect.DetectionTrainer(overrides=overrides)
+    trainer.add_callback("on_train_epoch_end", poison_ema)
+    trainer.train()
+    assert trainer.last.exists(), "no checkpoint saved when the EMA went non-finite on a finite model"
+    model, _ = load_checkpoint(trainer.last)
+    assert all(torch.isfinite(v).all() for v in model.state_dict().values() if isinstance(v, torch.Tensor)), (
+        "saved checkpoint contains NaN/Inf"
+    )
+
+
 @pytest.mark.parametrize(
     "kwargs,uses_weights",
     [({}, True), ({"pretrained": True}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)],

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -662,22 +662,19 @@ class BaseTrainer:
         """Save model training checkpoints with additional metadata."""
         import io
 
-        # The EMA running average is sticky: one transient non-finite weight permanently poisons it
-        # (ema = decay*ema + (1-decay)*model), and _handle_nan_recovery only fires on a non-finite loss/fitness, so a
-        # finite-loss run with a poisoned EMA would otherwise skip every save and finish with no checkpoint at all.
-        # Resync just the poisoned tensors from the live model (in-place, also un-poisoning later epochs) so a valid
-        # checkpoint is still produced; only skip when the model itself is also non-finite. fp16 overflow on the saved
-        # copy is handled below.
+        # A transient NaN/Inf permanently poisons the EMA running average (ema = decay*ema + (1-decay)*model), so
+        # save_model would otherwise skip every epoch and the run would finish with no checkpoint. Resync each
+        # poisoned EMA tensor from the live model (keys are a subset of the model's); skip only if the model tensor
+        # is also non-finite. fp16 overflow on the saved copy is handled below.
         ema = unwrap_model(self.ema.ema)
         if not all(torch.isfinite(v).all() for v in ema.state_dict().values() if isinstance(v, torch.Tensor)):
-            model_sd = unwrap_model(self.model).state_dict()  # EMA keys are a subset (teacher stripped under distill)
-            if not all(torch.isfinite(v).all() for v in model_sd.values() if isinstance(v, torch.Tensor)):
-                LOGGER.warning(f"Skipping checkpoint save at epoch {self.epoch}: EMA and model contain NaN/Inf")
-                return False
+            model_sd = unwrap_model(self.model).state_dict()
             for k, v in ema.state_dict().items():
                 if isinstance(v, torch.Tensor) and not torch.isfinite(v).all():
+                    if not torch.isfinite(model_sd[k]).all():
+                        LOGGER.warning(f"Skipping checkpoint save at epoch {self.epoch}: EMA and model contain NaN/Inf")
+                        return False
                     v.copy_(model_sd[k])
-            LOGGER.warning(f"Resynced non-finite EMA tensors from model at epoch {self.epoch} to preserve checkpoint")
         ema = deepcopy(ema).half()
         # Clamp fp16 serialization overflow without mutating the live EMA.
         for v in ema.state_dict().values():

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -662,11 +662,22 @@ class BaseTrainer:
         """Save model training checkpoints with additional metadata."""
         import io
 
-        # Skip only genuinely non-finite fp32 EMA weights; fp16 overflow is handled on the saved copy below.
+        # The EMA running average is sticky: one transient non-finite weight permanently poisons it
+        # (ema = decay*ema + (1-decay)*model), and _handle_nan_recovery only fires on a non-finite loss/fitness, so a
+        # finite-loss run with a poisoned EMA would otherwise skip every save and finish with no checkpoint at all.
+        # Resync just the poisoned tensors from the live model (in-place, also un-poisoning later epochs) so a valid
+        # checkpoint is still produced; only skip when the model itself is also non-finite. fp16 overflow on the saved
+        # copy is handled below.
         ema = unwrap_model(self.ema.ema)
         if not all(torch.isfinite(v).all() for v in ema.state_dict().values() if isinstance(v, torch.Tensor)):
-            LOGGER.warning(f"Skipping checkpoint save at epoch {self.epoch}: EMA contains NaN/Inf")
-            return False
+            model_sd = unwrap_model(self.model).state_dict()  # EMA keys are a subset (teacher stripped under distill)
+            if not all(torch.isfinite(v).all() for v in model_sd.values() if isinstance(v, torch.Tensor)):
+                LOGGER.warning(f"Skipping checkpoint save at epoch {self.epoch}: EMA and model contain NaN/Inf")
+                return False
+            for k, v in ema.state_dict().items():
+                if isinstance(v, torch.Tensor) and not torch.isfinite(v).all():
+                    v.copy_(model_sd[k])
+            LOGGER.warning(f"Resynced non-finite EMA tensors from model at epoch {self.epoch} to preserve checkpoint")
         ema = deepcopy(ema).half()
         # Clamp fp16 serialization overflow without mutating the live EMA.
         for v in ema.state_dict().values():

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1564,8 +1564,9 @@ class _SafeLoad:
         _scan(ul_nn)  # ultralytics block/conv/head/transformer
         _scan(ul_tasks)  # ultralytics task models
 
-        # Non-nn.Module data globals in official checkpoints.
+        # Non-nn.Module data globals in official checkpoints, incl. the pre-8.0.44 `ultralytics.yolo.utils` path.
         allow.append(IterableSimpleNamespace)
+        allow.append((IterableSimpleNamespace, "ultralytics.yolo.utils.IterableSimpleNamespace"))
 
         # Classification preprocessing transforms.
         try:


### PR DESCRIPTION
## Summary

Two fixes for failures observed on the Ultralytics Platform GPU training workers (Docker logs from hosts `ultra1`/`ultra5`, container `ultralytics-worker-gpu`, ultralytics `8.4.80`). Both land at the source in the package.

### 1. Sticky-NaN EMA no longer throws away an entire training run — `engine/trainer.py`
**What was broken:** a full training run on a *valid* config finished with **no `best.pt`/`last.pt`** and a hard `FileNotFoundError: Training completed but no checkpoint was saved` (worker job `6a4119fbfc...`, `yolov8n, batch=-1, imgsz=640, lr0=0.001`; child stderr showed repeated `Skipping checkpoint save at epoch N: EMA contains NaN/Inf`). This is the historical #1 train-failure class.

**Root cause:** the EMA is a running average (`ema = decay*ema + (1-decay)*model`), so a single transient non-finite weight permanently poisons it. `save_model()` then returns `False` on **every** epoch (its `isfinite` scan fails), and the loop's `_handle_nan_recovery` only fires on a non-finite **loss/fitness** — which never happens when the loss stays finite. Result: no checkpoint is ever written.

**Fix (Replace):** in the existing non-finite-EMA branch, if the live model is finite, copy **only the poisoned EMA tensors** from the model in-place (which also un-poisons subsequent epochs) and still write the checkpoint; skip **only** when the model itself is also non-finite (preserving the #24731 guarantee never to persist garbage). The in-place copy is safe under distillation because `ModelEMA` strips the teacher, so EMA keys are a strict subset of the model's keys.

### 2. Legacy first-party checkpoints load under restricted loading — `nn/tasks.py`
**What was broken:** users fine-tuning from their own platform-trained `.pt` hit `TypeError: ... references types outside the supported Ultralytics checkpoint format` under `ULTRALYTICS_SAFE_LOAD=true`. The rejected global (from the worker logs' `WeightsUnpickler error`) is the **first-party** `ultralytics.yolo.utils.IterableSimpleNamespace` — the pre-8.0.44 pickle path of the class that holds `model.args`.

**Root cause:** the `_SafeLoad` allow-list registers `IterableSimpleNamespace` only under its current module path (added in #24949); the legacy `ultralytics.yolo.utils.*` path is not allow-listed, so torch's `weights_only` unpickler rejects it by literal name.

**Fix (Add, 1 line):** allow-list the legacy path via the existing `(class, "module.Name")` alias pattern (same mechanism already used for `Silence`/`YOLOv10DetectionModel`). This maps exactly one trusted first-party data class under its legacy name — it does **not** widen the allow-list to any arbitrary/third-party module, so the RCE-prevention purpose of `ULTRALYTICS_SAFE_LOAD` is unchanged.

## Action types
- `engine/trainer.py` — **Replace** (a pure delete of the skip would re-introduce the #24731 garbage-persist bug)
- `nn/tasks.py` — **Add** (1 line; no Delete/Replace lever for a literal pickle global name)
- `tests/test_engine.py` — **Add** test

## Verification
- `pytest tests/test_engine.py -k "nonfinite_ema_resync or fp16_overflow or nan_recovery"` → **3 passed** (new `test_checkpoint_nonfinite_ema_resync` trains coco8, poisons the live EMA with `Inf`, asserts a finite checkpoint is produced; adjacent EMA tests unregressed).
- Empirical safe-load test against this branch: a checkpoint pickling `IterableSimpleNamespace` under the legacy module path is **REJECTED before / LOADS OK after**; the modern path is unaffected.
- `ruff check` clean on all changed files.

## Dual review
Independently reviewed by two reviewers, both **LGTM** on the final diff: Codex CLI (re-ran the focused test; accepted the single-GPU / rank-0-artifact analysis for the EMA change) and a Claude Opus 4.8 reviewer (verified the distillation key-subset invariant, the `#24731` guarantee, and the one-class security scope).

## Notes
- The EMA fix surfaced only in the GPU worker **Docker logs** (the package `before_send` drops `FileNotFoundError`, and the worker re-raises a generic `RuntimeError`), so it has no distinct Sentry issue.
- Companion portal PR (predict-service OOM): ultralytics/portal#2630

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes checkpoint saving more robust by automatically repairing a corrupted EMA state, adds a regression test for that case, and improves compatibility with older Ultralytics checkpoint metadata.

### 📊 Key Changes
- 🔄 Updated `save_model()` in `ultralytics/engine/trainer.py` to **resync non-finite EMA weights from the live model** instead of immediately skipping checkpoint saving.
- ⚠️ Checkpoint saving is now skipped **only when both the EMA and the live model contain NaN/Inf**, which indicates a real model failure.
- 💾 Preserved the existing fp16 overflow handling for saved checkpoints without changing the live EMA in memory.
- 🧪 Added a new test in `tests/test_engine.py` to simulate a **poisoned EMA with a still-finite model**, verifying that training still produces a valid checkpoint.
- 🧩 Expanded safe checkpoint loading in `ultralytics/nn/tasks.py` to allow an older `IterableSimpleNamespace` import path used in pre-8.0.44 checkpoints.

### 🎯 Purpose & Impact
- ✅ Prevents training runs from ending with **no checkpoint saved** just because the EMA was temporarily corrupted.
- 🔒 Improves reliability for long or edge-case training jobs where a one-time NaN/Inf in EMA could previously block all later saves.
- 📦 Ensures saved checkpoints remain **finite and usable**, reducing recovery and debugging headaches.
- ♻️ Improves backward compatibility when loading older official checkpoints that used legacy module paths.
- 👥 Benefits both researchers and production users by making YOLO training more fault-tolerant and checkpoint loading more seamless.