### PR TITLE
Shut down stale DataLoader workers on reset

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -264,7 +264,8 @@ def test_checkpoint_nonfinite_ema_resync():
     """Test a non-finite EMA on a finite model is resynced (not skipped) so the run still produces a checkpoint."""
 
     def poison_ema(trainer):
-        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
+        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run).
+        """
         if trainer.ema is not None:
             next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -264,8 +264,7 @@ def test_checkpoint_nonfinite_ema_resync():
     """Test a non-finite EMA on a finite model is resynced (not skipped) so the run still produces a checkpoint."""
 
     def poison_ema(trainer):
-        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run).
-        """
+        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
         if trainer.ema is not None:
             next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -95,6 +95,8 @@ class InfiniteDataLoader(dataloader.DataLoader):
 
     def reset(self):
         """Reset the iterator to allow modifications to the dataset during training."""
+        if hasattr(self.iterator, "_workers"):
+            self.iterator._shutdown_workers()  # free old worker pipes before creating new iterator
         self.iterator = self._get_iterator()
 
 


### PR DESCRIPTION
`InfiniteDataLoader.reset()` (close-mosaic epoch) reassigns `self.iterator` without shutting down the previous multiprocessing iterator, leaking its worker pipes. Across a long `MultiTrainer` sweep over many datasets the open-fd count climbs past the default 1024 limit and crashes with `OSError: [Errno 24] Too many open files`, first showing up as bogus `corrupt image/label` spam. Independent of #24977 (thanks @glenn-jocher), which fixed trainer retention rather than this loader-level leak.

```python
# before
def reset(self):
    self.iterator = self._get_iterator()

# after
def reset(self):
    if hasattr(self.iterator, "_workers"):
        self.iterator._shutdown_workers()  # free old worker pipes before creating new iterator
    self.iterator = self._get_iterator()
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves dataloader reset behavior by properly shutting down old worker processes before creating a new iterator, helping prevent resource leaks during training 🔧

### 📊 Key Changes
- Updated `reset()` in `ultralytics/data/build.py`
- Added a check for existing dataloader workers with `hasattr(self.iterator, "_workers")`
- Explicitly calls `self.iterator._shutdown_workers()` before creating a new iterator
- Keeps the existing behavior of rebuilding the iterator after reset

### 🎯 Purpose & Impact
- Prevents old worker pipes and processes from lingering after a dataloader reset 🧹
- Makes dataset modifications during training safer and cleaner
- Reduces the risk of resource leaks, stuck workers, or instability in long-running training jobs
- Improves reliability for users who reset or rebuild dataloaders dynamically during training 🚀