### PR TITLE
Guard fuse_deconv_and_bn against non-BatchNorm bn

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -264,7 +264,8 @@ def test_checkpoint_nonfinite_ema_resync():
     """Test a non-finite EMA on a finite model is resynced (not skipped) so the run still produces a checkpoint."""
 
     def poison_ema(trainer):
-        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
+        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run).
+        """
         if trainer.ema is not None:
             next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -264,8 +264,7 @@ def test_checkpoint_nonfinite_ema_resync():
     """Test a non-finite EMA on a finite model is resynced (not skipped) so the run still produces a checkpoint."""
 
     def poison_ema(trainer):
-        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run).
-        """
+        """Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."""
         if trainer.ema is not None:
             next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -318,6 +318,8 @@ def fuse_deconv_and_bn(deconv, bn):
         >>> bn = nn.BatchNorm2d(3)
         >>> fused_deconv = fuse_deconv_and_bn(deconv, bn)
     """
+    if not isinstance(bn, nn.BatchNorm2d):  # ConvTranspose(bn=False) leaves bn as nn.Identity, nothing to fuse
+        return deconv.requires_grad_(False)
     # Compute fused weights
     w_deconv = deconv.weight.view(deconv.out_channels, -1)
     w_bn = torch.diag(bn.weight.div(torch.sqrt(bn.eps + bn.running_var)))

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -318,9 +318,7 @@ def fuse_deconv_and_bn(deconv, bn):
         >>> bn = nn.BatchNorm2d(3)
         >>> fused_deconv = fuse_deconv_and_bn(deconv, bn)
     """
-    if not isinstance(
-        bn, nn.modules.batchnorm._BatchNorm
-    ):  # ConvTranspose(bn=False) leaves bn as nn.Identity, nothing to fuse
+    if isinstance(bn, nn.Identity):  # ConvTranspose(bn=False) leaves bn as nn.Identity, nothing to fuse
         return deconv.requires_grad_(False)
     # Compute fused weights
     w_deconv = deconv.weight.view(deconv.out_channels, -1)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -318,7 +318,9 @@ def fuse_deconv_and_bn(deconv, bn):
         >>> bn = nn.BatchNorm2d(3)
         >>> fused_deconv = fuse_deconv_and_bn(deconv, bn)
     """
-    if not isinstance(bn, nn.modules.batchnorm._BatchNorm):  # ConvTranspose(bn=False) leaves bn as nn.Identity, nothing to fuse
+    if not isinstance(
+        bn, nn.modules.batchnorm._BatchNorm
+    ):  # ConvTranspose(bn=False) leaves bn as nn.Identity, nothing to fuse
         return deconv.requires_grad_(False)
     # Compute fused weights
     w_deconv = deconv.weight.view(deconv.out_channels, -1)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -318,7 +318,7 @@ def fuse_deconv_and_bn(deconv, bn):
         >>> bn = nn.BatchNorm2d(3)
         >>> fused_deconv = fuse_deconv_and_bn(deconv, bn)
     """
-    if not isinstance(bn, nn.BatchNorm2d):  # ConvTranspose(bn=False) leaves bn as nn.Identity, nothing to fuse
+    if not isinstance(bn, nn.modules.batchnorm._BatchNorm):  # ConvTranspose(bn=False) leaves bn as nn.Identity, nothing to fuse
         return deconv.requires_grad_(False)
     # Compute fused weights
     w_deconv = deconv.weight.view(deconv.out_channels, -1)


### PR DESCRIPTION
`fuse_deconv_and_bn` dereferences `bn.weight`, so a `ConvTranspose` built with `bn=False` (where `bn` is `nn.Identity`) crashes `model.fuse()` with `AttributeError: 'Identity' object has no attribute 'weight'`. No shipped config uses the `ConvTranspose` wrapper, so this only bites custom deconv heads with batch norm disabled. The guard skips only the `nn.Identity` no-op, so real norms (BatchNorm, SyncBatchNorm) still fuse and any unsupported module still fails loudly rather than being silently dropped (`fuse()` deletes `m.bn` afterward).

```python
if isinstance(bn, nn.Identity):  # ConvTranspose(bn=False) leaves bn as nn.Identity, nothing to fuse
    return deconv.requires_grad_(False)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes deconvolution–BatchNorm fusion safer by correctly skipping fusion when the BatchNorm layer is just an `nn.Identity`.

### 📊 Key Changes
- Added a guard in `fuse_deconv_and_bn()` in `ultralytics/utils/torch_utils.py`.
- The function now checks whether `bn` is `nn.Identity` before trying to fuse it.
- If `bn` is `nn.Identity`, the function simply returns the original deconvolution layer with gradients disabled, instead of running fusion logic.
- This specifically handles cases like `ConvTranspose(bn=False)`, where no real BatchNorm layer exists.

### 🎯 Purpose & Impact
- ✅ Prevents errors when model optimization code encounters deconvolution layers without BatchNorm.
- ⚡ Makes layer fusion more robust during inference/export preparation.
- 🔒 Improves compatibility with configurations that disable BatchNorm on transpose convolution layers.
- 👨‍💻 Reduces edge-case failures for developers and users working with custom model architectures in Ultralytics.