### PR TITLE
fix: RTDETR benchmark mAP=0 in benchmark

### DIFF
--- a/docs/en/integrations/axelera.md
+++ b/docs/en/integrations/axelera.md
@@ -146,7 +146,8 @@ For detailed instructions, see our [Ultralytics Installation guide](../quickstar
     ```bash
     sudo apt update
     sudo apt install -y metis-dkms=1.5.5
-    sudo rmmod metis; sudo modprobe metis
+    sudo rmmod metis
+    sudo modprobe metis
     ```
 
     Then re-run `axdevice` to confirm the device is detected.

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -328,6 +328,9 @@ mykola@ultralytics.com:
 not.committed.yet:
   avatar: https://avatars.githubusercontent.com/u/135830346?v=4
   username: UltralyticsAssistant
+oaslananka@gmail.com:
+  avatar: null
+  username: null
 olivier@mg-crea.com:
   avatar: https://avatars.githubusercontent.com/u/108273?v=4
   username: mgcrea

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -373,6 +373,9 @@ sometimesocrazy@gmail.com:
 stormsson@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/1133032?v=4
   username: stormsson
+tatsuya.toyoda@axelera.ai:
+  avatar: https://avatars.githubusercontent.com/u/270336679?v=4
+  username: tatsuya-toyoda
 thunderbirdtr@gmail.com:
   avatar: https://avatars.githubusercontent.com/u/1688848?v=4
   username: onuralpszr

--- a/ultralytics/utils/benchmarks.py
+++ b/ultralytics/utils/benchmarks.py
@@ -39,7 +39,7 @@ from pathlib import Path
 import numpy as np
 import torch.cuda
 
-from ultralytics import YOLO, YOLOWorld
+from ultralytics import RTDETR, YOLO, YOLOWorld
 from ultralytics.cfg import TASK2DATA, TASK2METRIC
 from ultralytics.engine.exporter import export_formats
 from ultralytics.nn.modules import Segment26
@@ -206,7 +206,7 @@ def benchmark(
                     verbose=False,
                     **kwargs,
                 )
-                exported_model = YOLO(filename, task=model.task)
+                exported_model = RTDETR(filename) if isinstance(model, RTDETR) else YOLO(filename, task=model.task)
                 assert suffix in str(filename), "export failed"
             emoji = "❎"  # indicates export succeeded
 


### PR DESCRIPTION
Exported RTDETR was reloaded as YOLO, using DetectionValidator instead of RTDETRValidator and breaking postprocess.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

Reloading exported RTDETR as `YOLO` ran `DetectionValidator` instead of `RTDETRValidator`, which have different postprocess and produced mAP=0. The benchmark now reloads with the `RTDETR` wrapper so the correct validator runs.

```bash
yolo benchmark model=rtdetr-l.pt format=onnx imgsz=640 data=coco8.yaml
# mAP50-95 on coco8: 0.0 (before) → 0.7311 (after)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR improves benchmark compatibility for RT-DETR models and makes small documentation/author metadata updates, mainly to support smoother exports and cleaner docs.

### 📊 Key Changes
- Added `RTDETR` import in `ultralytics/utils/benchmarks.py` 🤖
- Updated benchmark export loading logic so exported RT-DETR models are reopened with `RTDETR(...)` instead of `YOLO(...)` ✅
- Kept existing `YOLO(...)` loading behavior for non-RT-DETR models unchanged 🔁
- Improved the Axelera integration docs by splitting `rmmod` and `modprobe` into separate commands for clarity 🛠️
- Added/updated GitHub author metadata entries in `docs/mkdocs_github_authors.yaml` 👤

### 🎯 Purpose & Impact
- Enables benchmarking to work more reliably with RT-DETR exports, reducing the chance of incorrect model loading during tests or comparisons 🚀
- Preserves existing behavior for YOLO models, so current benchmark workflows should remain stable and familiar 👍
- Makes Axelera setup instructions easier to follow, which can help users avoid command-line confusion during device setup 📘
- Improves documentation attribution metadata, helping keep contributor info organized behind the scenes 🧹