### PR TITLE
Bump MkDocs plugin requirement

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -329,8 +329,8 @@ not.committed.yet:
   avatar: https://avatars.githubusercontent.com/u/135830346?v=4
   username: UltralyticsAssistant
 oaslananka@gmail.com:
-  avatar: null
-  username: null
+  avatar: https://avatars.githubusercontent.com/u/285490571?v=4
+  username: oaslananka
 olivier@mg-crea.com:
   avatar: https://avatars.githubusercontent.com/u/108273?v=4
   username: mgcrea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dev = [
     "pytest-xdist>=3.0.0",
     "coverage[toml]",
     "zensical>=0.0.15; python_version >= '3.10'",
-    "mkdocs-ultralytics-plugin>=0.2.4", # for meta descriptions and images, dates and authors
+    "mkdocs-ultralytics-plugin>=0.2.5", # for meta descriptions and images, dates and authors
     "minijinja>=2.0.0", # render docs macros without mkdocs-macros-plugin
 ]
 export-base = [


### PR DESCRIPTION
## Summary
- Require `mkdocs-ultralytics-plugin>=0.2.5` for docs builds.

## Tests
- `git diff --check -- pyproject.toml`
- Parsed `pyproject.toml` and verified the dev dependency is `mkdocs-ultralytics-plugin>=0.2.5`
- `python -m pip index versions mkdocs-ultralytics-plugin`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR makes a small documentation-related maintenance update by adding missing GitHub author info and upgrading the MkDocs Ultralytics plugin version ✨

### 📊 Key Changes
- Updated `docs/mkdocs_github_authors.yaml` to add the GitHub avatar and username for `oaslananka@gmail.com` 👤
- Upgraded the docs dependency in `pyproject.toml` from `mkdocs-ultralytics-plugin>=0.2.4` to `>=0.2.5` 📚
- Kept the change limited to documentation metadata and tooling, with no model, training, or inference code changes 🔧

### 🎯 Purpose & Impact
- Improves documentation attribution by correctly linking contributions to the right GitHub profile 🙌
- Ensures the docs build uses a newer version of the Ultralytics MkDocs plugin, which may include fixes or improvements for author info, metadata, images, or page rendering 🚀
- Low risk for users, since this does not affect YOLO training, validation, prediction, or deployment behavior ✅
- Helps maintain cleaner, more accurate project documentation and contributor records over time 🧹