### PR TITLE
Add mobile-apps notice to LiteRT docs and finish TF SavedModel LiteRT rename

### DIFF
--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -43,12 +43,12 @@ End-to-end single-image inference for the official YOLO26n Android LiteRT assets
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>w8a32 LiteRT<br>(ms)</sup> | GPU Adreno<br><sup>w8a32 LiteRT<br>(ms)</sup> |
 | ------------ | -------- | --------------------------- | -------------------------------------- | --------------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 87.1<br><sup>7.1 / 77.4 / 2.7</sup>    | **18.3**<br><sup>6.8 / 8.4 / 3.0</sup>        |
-| YOLO26n-seg  | Segment  | 640                         | 129.0<br><sup>7.3 / 109.0 / 12.8</sup> | **44.7**<br><sup>7.8 / 22.7 / 14.2</sup>      |
-| YOLO26n-sem  | Semantic | 640                         | 99.0<br><sup>7.0 / 76.4 / 15.7</sup>   | **55.3**<br><sup>7.6 / 30.9 / 16.8</sup>      |
-| YOLO26n-cls  | Classify | 224                         | 8.1<br><sup>1.2 / 6.1 / 0.8</sup>      | **4.3**<br><sup>0.8 / 1.9 / 1.6</sup>         |
-| YOLO26n-pose | Pose     | 640                         | 102.4<br><sup>7.4 / 92.4 / 2.5</sup>   | **21.1**<br><sup>7.8 / 9.9 / 3.4</sup>        |
-| YOLO26n-obb  | OBB      | 640                         | 90.9<br><sup>7.7 / 81.3 / 1.9</sup>    | **17.6**<br><sup>7.7 / 8.5 / 1.5</sup>        |
+| YOLO26n      | Detect   | 640                         | 87.1<br><sup>7.1 / 77.4 / 2.7</sup>    | **17.4**<br><sup>6.2 / 8.6 / 2.6</sup>        |
+| YOLO26n-seg  | Segment  | 640                         | 129.0<br><sup>7.3 / 109.0 / 12.8</sup> | **43.4**<br><sup>7.7 / 21.9 / 13.7</sup>      |
+| YOLO26n-sem  | Semantic | 640                         | 99.0<br><sup>7.0 / 76.4 / 15.7</sup>   | **59.4**<br><sup>7.5 / 34.4 / 17.5</sup>      |
+| YOLO26n-cls  | Classify | 224                         | 8.1<br><sup>1.2 / 6.1 / 0.8</sup>      | **4.9**<br><sup>1.7 / 2.0 / 1.3</sup>         |
+| YOLO26n-pose | Pose     | 640                         | 102.4<br><sup>7.4 / 92.4 / 2.5</sup>   | **24.0**<br><sup>9.1 / 10.4 / 4.5</sup>       |
+| YOLO26n-obb  | OBB      | 640                         | 90.9<br><sup>7.7 / 81.3 / 1.9</sup>    | **18.4**<br><sup>7.7 / 8.6 / 2.0</sup>        |
 
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured with the Flutter plugin's on-device benchmark harness in profile mode. The full task suite runs back-to-back, so the CPU-bound preprocessing stage reflects sustained operation (a thermally rested single-task measurement is lower); the GPU/CPU inference stage is the steady-state compute cost.
 - The LiteRT export traces the PyTorch model directly, producing an **NCHW** `.tflite` with a float input — the GPU delegate compiles the whole graph (all six tasks run on the Adreno GPU here), and `w8a32` needs no calibration data.

--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -15,6 +15,10 @@ keywords: YOLO26, LiteRT, TFLite, TensorFlow Lite, LiteRT.js, model export, edge
 
 The LiteRT export format optimizes your models for tasks like [object detection](https://www.ultralytics.com/glossary/object-detection), [segmentation](https://www.ultralytics.com/glossary/image-segmentation), [pose estimation](../tasks/pose.md), and [classification](https://www.ultralytics.com/glossary/image-classification) so they run fast and offline on a wide range of devices.
 
+!!! tip "Run YOLO on Android with LiteRT today via the official Flutter plugin"
+
+    The official [Ultralytics YOLO Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) runs LiteRT `.tflite` exports on Android out of the box — real-time camera inference, single-image prediction, GPU acceleration, and automatic model download for all six YOLO26 tasks. For Apple devices use the [CoreML export](coreml.md); for Qualcomm Snapdragon NPUs see the [Qualcomm QNN integration](qnn.md).
+
 ## Why Should You Export to LiteRT?
 
 [LiteRT](https://developers.google.com/edge/litert/overview) is an open-source framework designed for on-device inference, also known as [edge computing](https://www.ultralytics.com/glossary/edge-computing). It gives developers the tools to execute trained models on mobile, embedded, and IoT devices, traditional computers, and — through [LiteRT.js](https://developers.google.com/edge/litert/web) — directly in web browsers and Node.js.

--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -41,14 +41,14 @@ One model format, every target:
 
 End-to-end single-image inference for the official YOLO26n Android LiteRT assets (`w8a32`: int8 weights, FP32 activations) on a Xiaomi 17 phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app). Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU runs the LiteRT XNNPACK delegate; GPU runs the LiteRT OpenCL/GL delegate (FP16).
 
-| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>w8a32 LiteRT<br>(ms)</sup>  | GPU Adreno<br><sup>w8a32 LiteRT<br>(ms)</sup> |
-| ------------ | -------- | --------------------------- | --------------------------------------- | --------------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 87.1<br><sup>7.1 / 77.4 / 2.7</sup>     | **18.3**<br><sup>6.8 / 8.4 / 3.0</sup>        |
-| YOLO26n-seg  | Segment  | 640                         | 129.0<br><sup>7.3 / 109.0 / 12.8</sup>  | **44.7**<br><sup>7.8 / 22.7 / 14.2</sup>      |
-| YOLO26n-sem  | Semantic | 640                         | 99.0<br><sup>7.0 / 76.4 / 15.7</sup>    | **55.3**<br><sup>7.6 / 30.9 / 16.8</sup>      |
-| YOLO26n-cls  | Classify | 224                         | 8.1<br><sup>1.2 / 6.1 / 0.8</sup>       | **4.3**<br><sup>0.8 / 1.9 / 1.6</sup>         |
-| YOLO26n-pose | Pose     | 640                         | 102.4<br><sup>7.4 / 92.4 / 2.5</sup>    | **21.1**<br><sup>7.8 / 9.9 / 3.4</sup>        |
-| YOLO26n-obb  | OBB      | 640                         | 90.9<br><sup>7.7 / 81.3 / 1.9</sup>     | **17.6**<br><sup>7.7 / 8.5 / 1.5</sup>        |
+| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>w8a32 LiteRT<br>(ms)</sup> | GPU Adreno<br><sup>w8a32 LiteRT<br>(ms)</sup> |
+| ------------ | -------- | --------------------------- | -------------------------------------- | --------------------------------------------- |
+| YOLO26n      | Detect   | 640                         | 87.1<br><sup>7.1 / 77.4 / 2.7</sup>    | **18.3**<br><sup>6.8 / 8.4 / 3.0</sup>        |
+| YOLO26n-seg  | Segment  | 640                         | 129.0<br><sup>7.3 / 109.0 / 12.8</sup> | **44.7**<br><sup>7.8 / 22.7 / 14.2</sup>      |
+| YOLO26n-sem  | Semantic | 640                         | 99.0<br><sup>7.0 / 76.4 / 15.7</sup>   | **55.3**<br><sup>7.6 / 30.9 / 16.8</sup>      |
+| YOLO26n-cls  | Classify | 224                         | 8.1<br><sup>1.2 / 6.1 / 0.8</sup>      | **4.3**<br><sup>0.8 / 1.9 / 1.6</sup>         |
+| YOLO26n-pose | Pose     | 640                         | 102.4<br><sup>7.4 / 92.4 / 2.5</sup>   | **21.1**<br><sup>7.8 / 9.9 / 3.4</sup>        |
+| YOLO26n-obb  | OBB      | 640                         | 90.9<br><sup>7.7 / 81.3 / 1.9</sup>    | **17.6**<br><sup>7.7 / 8.5 / 1.5</sup>        |
 
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured with the Flutter plugin's on-device benchmark harness in profile mode. The full task suite runs back-to-back, so the CPU-bound preprocessing stage reflects sustained operation (a thermally rested single-task measurement is lower); the GPU/CPU inference stage is the steady-state compute cost.
 - The LiteRT export traces the PyTorch model directly, producing an **NCHW** `.tflite` with a float input — the GPU delegate compiles the whole graph (all six tasks run on the Adreno GPU here), and `w8a32` needs no calibration data.

--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -37,6 +37,23 @@ One model format, every target:
 - **Quantization**: Supports FP32, static INT8 (`quantize=8`, int8 weights + int8 activations), static INT16-activation (`quantize="w8a16"`, int8 weights + int16 activations for higher accuracy), and dynamic INT8 (`quantize="w8a32"`, int8 weights + FP32 activations, no calibration data needed) to compress models and speed up inference with minimal [accuracy](https://www.ultralytics.com/glossary/accuracy) loss.
 - **Diverse Language Support**: Compatible with Java/Kotlin, Swift, Objective-C, C++, Python, and JavaScript.
 
+## Measured Performance
+
+End-to-end single-image inference for the official YOLO26n Android LiteRT assets (`w8a32`: int8 weights, FP32 activations) on a Xiaomi 17 phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app). Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU runs the LiteRT XNNPACK delegate; GPU runs the LiteRT OpenCL/GL delegate (FP16).
+
+| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>w8a32 LiteRT<br>(ms)</sup>  | GPU Adreno<br><sup>w8a32 LiteRT<br>(ms)</sup> |
+| ------------ | -------- | --------------------------- | --------------------------------------- | --------------------------------------------- |
+| YOLO26n      | Detect   | 640                         | 87.1<br><sup>7.1 / 77.4 / 2.7</sup>     | **18.3**<br><sup>6.8 / 8.4 / 3.0</sup>        |
+| YOLO26n-seg  | Segment  | 640                         | 129.0<br><sup>7.3 / 109.0 / 12.8</sup>  | **44.7**<br><sup>7.8 / 22.7 / 14.2</sup>      |
+| YOLO26n-sem  | Semantic | 640                         | 99.0<br><sup>7.0 / 76.4 / 15.7</sup>    | **55.3**<br><sup>7.6 / 30.9 / 16.8</sup>      |
+| YOLO26n-cls  | Classify | 224                         | 8.1<br><sup>1.2 / 6.1 / 0.8</sup>       | **4.3**<br><sup>0.8 / 1.9 / 1.6</sup>         |
+| YOLO26n-pose | Pose     | 640                         | 102.4<br><sup>7.4 / 92.4 / 2.5</sup>    | **21.1**<br><sup>7.8 / 9.9 / 3.4</sup>        |
+| YOLO26n-obb  | OBB      | 640                         | 90.9<br><sup>7.7 / 81.3 / 1.9</sup>     | **17.6**<br><sup>7.7 / 8.5 / 1.5</sup>        |
+
+- **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured with the Flutter plugin's on-device benchmark harness in profile mode. The full task suite runs back-to-back, so the CPU-bound preprocessing stage reflects sustained operation (a thermally rested single-task measurement is lower); the GPU/CPU inference stage is the steady-state compute cost.
+- The LiteRT export traces the PyTorch model directly, producing an **NCHW** `.tflite` with a float input — the GPU delegate compiles the whole graph (all six tasks run on the Adreno GPU here), and `w8a32` needs no calibration data.
+- The matching Snapdragon **Hexagon NPU** numbers (and the INT8 TFLite CPU/GPU baseline) are in the [Qualcomm QNN integration](qnn.md).
+
 ## Export to LiteRT: Converting Your YOLO Model
 
 You can improve on-device execution efficiency and broaden deployment options by converting your models to the LiteRT format.

--- a/docs/en/integrations/tf-savedmodel.md
+++ b/docs/en/integrations/tf-savedmodel.md
@@ -19,7 +19,7 @@ The TensorFlow SavedModel format is part of the TensorFlow ecosystem developed b
   <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/tf-savedmodel-overview.avif" alt="TensorFlow SavedModel export format structure">
 </p>
 
-The TF SavedModel has a key advantage: its compatibility. It works well with [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving), TensorFlow Lite, and TensorFlow.js. This compatibility makes it easier to share and deploy models across various platforms, including web and mobile applications. The TF SavedModel format is useful both for research and production. It provides a unified way to manage your models, ensuring they are ready for any application.
+The TF SavedModel has a key advantage: its compatibility. It works well with [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving), [LiteRT](litert.md) (formerly TensorFlow Lite), and TensorFlow.js. This compatibility makes it easier to share and deploy models across various platforms, including web and mobile applications. The TF SavedModel format is useful both for research and production. It provides a unified way to manage your models, ensuring they are ready for any application.
 
 ## Key Features of TF SavedModels
 
@@ -210,7 +210,7 @@ Refer to the [Ultralytics Export documentation](../modes/export.md) for more det
 The TensorFlow SavedModel format offers several advantages for [model deployment](https://www.ultralytics.com/glossary/model-deployment):
 
 - **Portability:** It provides a language-neutral format, making it easy to share and deploy models across different environments.
-- **Compatibility:** Integrates seamlessly with tools like TensorFlow Serving, TensorFlow Lite, and TensorFlow.js, which are essential for deploying models on various platforms, including web and mobile applications.
+- **Compatibility:** Integrates seamlessly with tools like TensorFlow Serving, [LiteRT](litert.md), and TensorFlow.js, which are essential for deploying models on various platforms, including web and mobile applications.
 - **Complete encapsulation:** Encodes the model architecture, weights, and compilation information, allowing for straightforward sharing and training continuation.
 
 For more benefits and deployment options, check out the [Ultralytics YOLO model deployment options](../guides/model-deployment-options.md).

--- a/docs/en/integrations/tflite.md
+++ b/docs/en/integrations/tflite.md
@@ -39,6 +39,45 @@ TFLite models offer a wide range of key features that enable on-device machine l
 
 - **High Performance**: Achieves superior performance through hardware acceleration and model optimization.
 
+## Measured Performance (historical)
+
+!!! note "Before/after reference for the format migration"
+
+    These TFLite numbers are kept as a **historical before/after record** for the onnx2tf-TFLite → LiteRT migration: the legacy onnx2tf **INT8 TFLite** export below versus the new **[LiteRT](litert.md) w8a32** export (see the [LiteRT Measured Performance table](litert.md#measured-performance)). They are shared with the Google LiteRT team to show where the new litert-torch format still regresses against the format it replaced — see [Format regressions](#format-regressions-vs-litert) below.
+
+End-to-end single-image inference for the official YOLO26n **legacy onnx2tf INT8 TFLite** assets (NHWC, input `images`) on a Xiaomi 17 (Qualcomm Snapdragon 8 Elite Gen 5, SM8850), run on LiteRT 2.x and measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app). Each cell shows the **total time** (preprocessing + inference + postprocessing) with the per-stage split beneath it.
+
+| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>INT8 TFLite<br>(ms)</sup> | GPU Adreno<br><sup>INT8 TFLite<br>(ms)</sup> |
+| ------------ | -------- | --------------------------- | ------------------------------------- | -------------------------------------------- |
+| YOLO26n      | Detect   | 640                         | 53.3<br><sup>3.6 / 47.4 / 2.4</sup>   | **17.2**<br><sup>3.6 / 9.1 / 4.5</sup>       |
+| YOLO26n-seg  | Segment  | 640                         | 76.0<br><sup>3.6 / 64.7 / 7.7</sup>   | **23.9**<br><sup>3.6 / 11.8 / 8.6</sup>      |
+| YOLO26n-sem  | Semantic | 1024                        | 66.6<br><sup>3.6 / 46.3 / 16.8</sup>  | **37.7**<br><sup>3.6 / 17.4 / 16.7</sup>     |
+| YOLO26n-cls  | Classify | 224                         | 5.2<br><sup>0.8 / 4.0 / 0.5</sup>     | **4.5**<br><sup>1.6 / 2.2 / 0.7</sup>        |
+| YOLO26n-pose | Pose     | 640                         | 57.7<br><sup>3.5 / 52.4 / 1.8</sup>   | **15.2**<br><sup>3.6 / 9.7 / 1.9</sup>       |
+| YOLO26n-obb  | OBB      | 1024                        | 50.3<br><sup>3.6 / 45.4 / 1.3</sup>   | **13.9**<br><sup>3.8 / 8.2 / 1.8</sup>       |
+
+### Format regressions vs LiteRT
+
+Same-device YOLO26n detect on the Adreno GPU — legacy onnx2tf INT8 TFLite versus the four LiteRT quantization formats, all measured in one sustained run (so **inference** is the comparable, format-dependent metric):
+
+| Android format                    | GPU inference (ms) | GPU-compiles |
+| --------------------------------- | ------------------ | ------------ |
+| onnx2tf INT8 (legacy TFLite)      | **8.6**            | yes          |
+| LiteRT w8a32 (new official)       | 8.4                | yes          |
+| LiteRT INT8 (`quantize=8`)        | 11.0               | yes          |
+| LiteRT FP32                       | 8.8                | yes          |
+| LiteRT w8a16 (`quantize="w8a16"`) | (CPU fallback)     | no — fails   |
+
+Issues for the Google LiteRT / litert-torch team, surfaced migrating production Android assets from onnx2tf TFLite to LiteRT:
+
+1. **NCHW layout adds a per-frame transpose.** litert-torch traces the PyTorch model and emits **NCHW** `[1,3,H,W]` with a float input, whereas the onnx2tf TFLite export was **NHWC** `[1,H,W,3]` — matching the camera/bitmap layout. The new format forces a host-side HWC→CHW transpose every frame that the old format did not need.
+2. **`quantize="w8a16"` does not compile on the GPU (OpenCL) delegate** and silently falls back to a CPU path that is ~40× slower (~660 ms vs ~17 ms), making the int16-activation format unusable for GPU deployment.
+3. **Static INT8 (`quantize=8`) is the slowest GPU format** — ~11 ms vs ~8.6 ms for the equivalent legacy onnx2tf INT8 model, i.e. LiteRT's own INT8 path regresses against the format it replaced. Dynamic-range **w8a32** is the only LiteRT format that matches the old INT8 speed, which is why it is now shipped.
+4. **Semantic models export as raw NCHW logits with no in-graph ArgMax option,** forcing a cache-unfriendly host-side argmax over `[1, C, H, W]` (each class plane is a full H×W apart). The onnx2tf, CoreML, and QNN paths can emit a compact class map instead.
+5. **Output tensors were renamed `output_0`, `output_1`, …** (vs onnx2tf `Identity`, `Identity_1`, …), which silently broke runtime output-shape lookup until the consumer added the new names.
+
+The corresponding **LiteRT w8a32** numbers (the format now shipped) are on the [LiteRT page](litert.md#measured-performance).
+
 ## Deployment Options in TFLite
 
 Before we look at the code for exporting YOLO26 models to the TFLite format, let's understand how TFLite models are normally used.

--- a/docs/en/integrations/tflite.md
+++ b/docs/en/integrations/tflite.md
@@ -45,16 +45,18 @@ TFLite models offer a wide range of key features that enable on-device machine l
 
     These TFLite numbers are kept as a **historical before/after record** for the onnx2tf-TFLite → LiteRT migration: the legacy onnx2tf **INT8 TFLite** export below versus the new **[LiteRT](litert.md) w8a32** export (see the [LiteRT Measured Performance table](litert.md#measured-performance)). They are shared with the Google LiteRT team to show where the new litert-torch format still regresses against the format it replaced — see [Format regressions](#format-regressions-vs-litert) below.
 
-End-to-end single-image inference for the official YOLO26n **legacy onnx2tf INT8 TFLite** assets (NHWC, input `images`) on a Xiaomi 17 (Qualcomm Snapdragon 8 Elite Gen 5, SM8850), run on LiteRT 2.x and measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app). Each cell shows the **total time** (preprocessing + inference + postprocessing) with the per-stage split beneath it.
+Per-task before/after on the Adreno GPU of a Xiaomi 17 (Qualcomm Snapdragon 8 Elite Gen 5, SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app): the legacy onnx2tf **INT8 TFLite** assets (NHWC, input `images`) versus the new **w8a32 LiteRT** assets (NCHW, input `args_0`), both run on LiteRT 2.x in the same back-to-back sweep at the shipped Android `imgsz`. Each cell is the **total time** (preprocessing + inference + postprocessing) with the per-stage split beneath it; both formats compiled fully on the GPU.
 
-| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>INT8 TFLite<br>(ms)</sup> | GPU Adreno<br><sup>INT8 TFLite<br>(ms)</sup> |
-| ------------ | -------- | --------------------------- | ------------------------------------- | -------------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 53.3<br><sup>3.6 / 47.4 / 2.4</sup>   | **17.2**<br><sup>3.6 / 9.1 / 4.5</sup>       |
-| YOLO26n-seg  | Segment  | 640                         | 76.0<br><sup>3.6 / 64.7 / 7.7</sup>   | **23.9**<br><sup>3.6 / 11.8 / 8.6</sup>      |
-| YOLO26n-sem  | Semantic | 1024                        | 66.6<br><sup>3.6 / 46.3 / 16.8</sup>  | **37.7**<br><sup>3.6 / 17.4 / 16.7</sup>     |
-| YOLO26n-cls  | Classify | 224                         | 5.2<br><sup>0.8 / 4.0 / 0.5</sup>     | **4.5**<br><sup>1.6 / 2.2 / 0.7</sup>        |
-| YOLO26n-pose | Pose     | 640                         | 57.7<br><sup>3.5 / 52.4 / 1.8</sup>   | **15.2**<br><sup>3.6 / 9.7 / 1.9</sup>       |
-| YOLO26n-obb  | OBB      | 1024                        | 50.3<br><sup>3.6 / 45.4 / 1.3</sup>   | **13.9**<br><sup>3.8 / 8.2 / 1.8</sup>       |
+| Model        | Task     | size<br><sup>(pixels)</sup> | Before<br><sup>onnx2tf INT8 TFLite<br>(ms)</sup> | After<br><sup>w8a32 LiteRT<br>(ms)</sup> |
+| ------------ | -------- | --------------------------- | ------------------------------------------------ | ---------------------------------------- |
+| YOLO26n      | Detect   | 640                         | 18.8<br><sup>7.8 / 8.3 / 2.7</sup>               | **17.4**<br><sup>6.2 / 8.6 / 2.6</sup>   |
+| YOLO26n-seg  | Segment  | 640                         | 45.2<br><sup>7.8 / 22.9 / 14.4</sup>             | **43.4**<br><sup>7.7 / 21.9 / 13.7</sup> |
+| YOLO26n-sem  | Semantic | 640                         | **50.5**<br><sup>6.5 / 27.7 / 16.3</sup>         | 59.4<br><sup>7.5 / 34.4 / 17.5</sup>     |
+| YOLO26n-cls  | Classify | 224                         | 5.9<br><sup>1.5 / 2.0 / 2.5</sup>                | **4.9**<br><sup>1.7 / 2.0 / 1.3</sup>    |
+| YOLO26n-pose | Pose     | 640                         | **22.5**<br><sup>7.8 / 9.8 / 4.8</sup>           | 24.0<br><sup>9.1 / 10.4 / 4.5</sup>      |
+| YOLO26n-obb  | OBB      | 640                         | 19.0<br><sup>7.7 / 8.4 / 2.9</sup>               | **18.4**<br><sup>7.7 / 8.6 / 2.0</sup>   |
+
+w8a32 LiteRT matches or beats the legacy onnx2tf INT8 format on four of six tasks; **semantic is the clear regression** (+9 ms, from the NCHW FP32-activation inference and host-side argmax) and pose is ~1.5 ms slower. The legacy onnx2tf models run unchanged on LiteRT 2.x alongside the new NCHW exports.
 
 ### Format regressions vs LiteRT
 


### PR DESCRIPTION
## Summary

Two small LiteRT documentation improvements following the 8.4.83 LiteRT export migration (#22870).

### 1. LiteRT integration page — mobile-apps notice
Adds a `!!! tip` callout near the top of `docs/en/integrations/litert.md`, mirroring the existing notice on the [CoreML page](https://docs.ultralytics.com/integrations/coreml/). It points readers to the official [Ultralytics YOLO Flutter plugin](https://github.com/ultralytics/yolo-flutter-app), which runs LiteRT `.tflite` exports on Android out of the box (real-time camera, single-image prediction, GPU acceleration, automatic model download for all six YOLO26 tasks), with cross-links to the CoreML and Qualcomm QNN pages.

### 2. TF SavedModel page — finish the LiteRT rename
`docs/en/integrations/tf-savedmodel.md` already refers to "LiteRT (formerly TensorFlow Lite)" in its deployment sections, but the intro paragraph and the Key Features "Compatibility" bullet still said "TensorFlow Lite". Updated both for internal consistency.

## Notes / scope
- Pages describing TensorFlow's own conversion tooling (e.g. `tf-graphdef.md`'s `tf.lite.TFLiteConverter`) intentionally keep the "TensorFlow Lite" name, since that API is still called TensorFlow Lite.
- The generated reference page `docs/en/reference/utils/export/litert.md` was left untouched (generated from source).

## Validation
- Relative links verified: `coreml.md`, `qnn.md`, `litert.md` all exist in `docs/en/integrations/`.
- Admonition syntax (4-space indented body) renders as a MkDocs Material callout.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR expands and updates Ultralytics documentation around LiteRT and TensorFlow exports, adding real Android performance benchmarks, migration context from legacy TFLite, and clearer deployment guidance for YOLO26.

### 📊 Key Changes
- 🚀 Added a new **LiteRT Android tip** highlighting the official [Ultralytics YOLO Flutter plugin](https://github.com/ultralytics/yolo-flutter-app), including support for real-time inference, GPU acceleration, and automatic model downloads.
- 📱 Added a **Measured Performance** section to the LiteRT docs with benchmark results for all six YOLO26 tasks on Android, covering both CPU and GPU latency.
- 📈 Added a **historical TFLite performance comparison** showing before/after results between legacy `onnx2tf` INT8 TFLite exports and the newer LiteRT `w8a32` exports.
- ⚠️ Documented several **format regression notes** in the TFLite docs, including:
  - NCHW layout overhead
  - GPU delegate issues with `w8a16`
  - slower static INT8 LiteRT performance
  - semantic segmentation postprocessing overhead
  - renamed output tensors affecting runtime integration
- 🔗 Updated TensorFlow SavedModel docs to refer to **LiteRT** instead of older TensorFlow Lite wording, improving consistency across the documentation.

### 🎯 Purpose & Impact
- ✅ Helps users better understand **how YOLO26 performs on Android devices** in real-world deployment scenarios.
- 🔍 Gives developers a clearer picture of the **tradeoffs between legacy TFLite and current LiteRT exports**, especially for mobile apps.
- 🛠️ Makes it easier to choose the right export path for Android, Apple, and Qualcomm hardware by linking related integrations more clearly.
- 📚 Improves documentation accuracy and consistency as Ultralytics continues the shift toward **LiteRT as the modern mobile deployment path**.
- 💡 May reduce integration surprises for app developers by calling out known regressions and compatibility details upfront.