### PR TITLE
Fix EMA-NaN no-checkpoint loss and unhelpful imgsz error

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -279,6 +279,26 @@ def test_checkpoint_nonfinite_ema_resync():
     )
 
 
+def test_checkpoint_nonfinite_ema_and_model_sanitized():
+    """Test a tensor non-finite in both EMA and model is sanitized (not skipped) so the run still produces a checkpoint."""
+
+    def poison_ema_and_model(trainer):
+        """Force the first parameter non-finite in both the live EMA and the model (finite-loss sticky-NaN)."""
+        if trainer.ema is not None:
+            next(iter(trainer.ema.ema.parameters())).data.flatten()[0] = float("inf")
+            next(iter(unwrap_model(trainer.model).parameters())).data.flatten()[0] = float("nan")
+
+    overrides = {"data": "coco8.yaml", "model": "yolo26n.yaml", "imgsz": 32, "epochs": 1}
+    trainer = detect.DetectionTrainer(overrides=overrides)
+    trainer.add_callback("on_train_epoch_end", poison_ema_and_model)
+    trainer.train()
+    assert trainer.last.exists(), "no checkpoint saved when a tensor went non-finite in both EMA and model"
+    model, _ = load_checkpoint(trainer.last)
+    assert all(torch.isfinite(v).all() for v in model.state_dict().values() if isinstance(v, torch.Tensor)), (
+        "saved checkpoint contains NaN/Inf"
+    )
+
+
 @pytest.mark.parametrize(
     "kwargs,uses_weights",
     [({}, True), ({"pretrained": True}, True), ({"pretrained": False}, False), ({"pretrained": MODEL}, True)],

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -596,6 +596,8 @@ def test_utils_checks():
     checks.check_yolov5u_filename("yolov5n.pt")
     checks.check_requirements("numpy")  # check requirements.txt
     checks.check_imgsz([600, 600], max_dim=1)
+    with pytest.raises(ValueError):
+        checks.check_imgsz("640x480")  # malformed imgsz string raises a helpful ValueError, not a raw SyntaxError
     checks.check_imshow(warn=True)
     checks.check_version("ultralytics", "8.0.0")
     # parse_version must pad to a 3-tuple so shorter version strings compare correctly

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.83"
+__version__ = "8.4.84"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -663,17 +663,14 @@ class BaseTrainer:
         import io
 
         # A transient NaN/Inf permanently poisons the EMA running average (ema = decay*ema + (1-decay)*model), so
-        # save_model would otherwise skip every epoch and the run would finish with no checkpoint. Resync each
-        # poisoned EMA tensor from the live model (keys are a subset of the model's); skip only if the model tensor
-        # is also non-finite. fp16 overflow on the saved copy is handled below.
+        # save_model would otherwise skip every epoch and the run would finish with no checkpoint on valid input.
+        # Resync each poisoned EMA tensor from the live model where finite; any tensor that is non-finite in both is
+        # left for the nan_to_num_ pass below, so a usable checkpoint is always written.
         ema = unwrap_model(self.ema.ema)
         if not all(torch.isfinite(v).all() for v in ema.state_dict().values() if isinstance(v, torch.Tensor)):
             model_sd = unwrap_model(self.model).state_dict()
             for k, v in ema.state_dict().items():
-                if isinstance(v, torch.Tensor) and not torch.isfinite(v).all():
-                    if not torch.isfinite(model_sd[k]).all():
-                        LOGGER.warning(f"Skipping checkpoint save at epoch {self.epoch}: EMA and model contain NaN/Inf")
-                        return False
+                if isinstance(v, torch.Tensor) and not torch.isfinite(v).all() and torch.isfinite(model_sd[k]).all():
                     v.copy_(model_sd[k])
         ema = deepcopy(ema).half()
         # Clamp fp16 serialization overflow without mutating the live EMA.

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -164,7 +164,13 @@ def check_imgsz(imgsz, stride=32, min_dim=1, max_dim=2, floor=0):
     elif isinstance(imgsz, (list, tuple)):
         imgsz = list(imgsz)
     elif isinstance(imgsz, str):  # i.e. '640' or '[640,640]'
-        imgsz = [int(imgsz)] if imgsz.isnumeric() else ast.literal_eval(imgsz)
+        try:
+            imgsz = [int(imgsz)] if imgsz.isnumeric() else ast.literal_eval(imgsz)
+        except (ValueError, SyntaxError):
+            raise ValueError(
+                f"'imgsz={imgsz}' is not a valid image size. "
+                f"Valid imgsz values are int i.e. 'imgsz=640' or list i.e. 'imgsz=[640,640]'"
+            ) from None
     else:
         raise TypeError(
             f"'imgsz={imgsz}' is of invalid type {type(imgsz).__name__}. "


### PR DESCRIPTION
## Summary

Fixes two production failures surfaced by the Ultralytics Platform GPU worker logs and the `ultralytics` Sentry project.

### 1. Training runs finish with **no checkpoint saved** (the persistent one) — `engine/trainer.py`

**Evidence:** GPU worker logs (ultra5 `workers-gpu-worker-24`, `ultralytics 8.4.83`) show 4 jobs (`furwa-asim/oman-biowatch-1` `t3-2/t3-3/t3-4/t3-5-2`) that trained fine (final `mAP50` up to 0.947) but died with:

```
WARNING ⚠️ Skipping checkpoint save at epoch N: EMA and model contain NaN/Inf
...
FileNotFoundError: Training completed but no checkpoint was saved. Expected .../weights/best.pt or .../weights/last.pt
```

Also the top `alpha` worker‑gpu Sentry cluster (`ALPHA-1DM`, "Training failed (exit 1)").

**Root cause:** a transient NaN/Inf permanently poisons the EMA running average (`ema = decay*ema + (1-decay)*model`). `save_model()` skipped the save whenever a tensor was non‑finite. #24977 skipped on *any* non‑finite EMA tensor; #24986 narrowed it to resync poisoned EMA tensors from the live model but **kept a `return False`** when a tensor was non‑finite in *both* EMA and model. Production logs show that residual branch still fires ("EMA **and** model contain NaN/Inf") and still throws away an otherwise‑good run.

**The recurring mistake in prior fixes was retaining a "give up and save nothing" branch.** This removes it:

- Resync each poisoned EMA tensor from the live model **where the model tensor is finite** (preserves trained weights).
- Where a tensor is non‑finite in **both**, leave it for the pre‑existing `torch.nan_to_num_` pass (already applied to the deepcopied `.half()` serialization copy for fp16 overflow) — so the saved EMA weights are always finite and a usable checkpoint is **always** written.

Genuine divergence is still caught loudly by `_handle_nan_recovery` (loss‑NaN → recover from `last.pt` → raise after 3 attempts), so this only rescues runs that validated well but had an isolated poisoned tensor.

Net **−3 lines** (removes the skip branch). Adds `tests/test_engine.py::test_checkpoint_nonfinite_ema_and_model_sanitized`, which **fails without the fix and passes with it** (verified by reverting the fix); the existing `test_checkpoint_nonfinite_ema_resync` still passes (zero regression).

### 2. Malformed `imgsz` leaks a raw `SyntaxError` — `utils/checks.py`

**Evidence:** Sentry `ULTRALYTICS-1WZ5` — `SyntaxError: invalid decimal literal (<unknown>, line 1)` (325 events / 96 users). A user‑supplied `imgsz` like `640x480` reaches `ast.literal_eval()` and raises a raw parser error with no hint that `imgsz` is the culprit.

**Fix:** wrap the parse and raise a helpful `ValueError` consistent with the `TypeError`/`ValueError` already raised in the same function. Adds an assertion to `tests/test_python.py::test_utils_checks`.

## Verification
- `pytest tests/test_engine.py::test_checkpoint_nonfinite_ema_and_model_sanitized tests/test_engine.py::test_checkpoint_nonfinite_ema_resync tests/test_engine.py::test_nan_recovery tests/test_engine.py::test_checkpoint_fp16_overflow tests/test_python.py::test_utils_checks` → all pass
- `ruff check` + `ruff format --check` on changed files → clean
- Reverting the trainer fix makes the new test fail (proves it exercises the bug)

## Change type
Fix 1 = **deletion** (removes the skip branch). Fix 2 = **replacement** (helpful error). Only additions are the two tests.

Cross-referenced with **ultralytics/portal#2639** (NDJSON ingest guard) from the same log/Sentry sweep.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves training checkpoint reliability and input validation, while bumping Ultralytics to version `8.4.84` 🚀

### 📊 Key Changes
- Added stronger checkpoint sanitization when both EMA and model weights contain `NaN` or `Inf` values 🧹
- Updated trainer checkpoint logic to avoid skipping saves when non-finite values appear during training 💾
- Added a test to confirm checkpoints are still created and saved without `NaN`/`Inf` tensors ✅
- Improved `check_imgsz()` error handling for malformed image size strings like `"640x480"` 🖼️
- Added a test to ensure invalid `imgsz` strings raise a helpful `ValueError` instead of a raw parsing error 🧪
- Bumped package version from `8.4.83` to `8.4.84` 📦

### 🎯 Purpose & Impact
- Makes training more robust by ensuring runs can still produce usable checkpoints even after non-finite tensor issues ⚡
- Reduces the risk of losing training progress due to poisoned EMA/model weights 🛡️
- Provides clearer feedback for users who enter invalid image size arguments, making configuration errors easier to fix 🙌
- Improves overall reliability for YOLO26 and other Ultralytics model training workflows, especially in edge cases involving numerical instability 🔧