### PR TITLE
Simplify `RTDETR` dataset transforms and remove stretch argument from `v8_transforms`

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1689,10 +1689,11 @@ class LetterBox(BaseTransform):
         if image is not None:
             labels["img"] = image
         params = self.get_params(labels)
-        labels = self.apply_image(labels, params)
-        if not return_image_only:
-            labels = self.apply_instances(labels, params)
-        labels = self.apply_semantic(labels, params)
+        if params["orig_shape"] != params["new_shape"]:
+            labels = self.apply_image(labels, params)
+            if not return_image_only:
+                labels = self.apply_instances(labels, params)
+            labels = self.apply_semantic(labels, params)
         if return_image_only:
             return labels["img"]
         return labels

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1689,11 +1689,10 @@ class LetterBox(BaseTransform):
         if image is not None:
             labels["img"] = image
         params = self.get_params(labels)
-        if params["orig_shape"] != params["new_shape"]:
-            labels = self.apply_image(labels, params)
-            if not return_image_only:
-                labels = self.apply_instances(labels, params)
-            labels = self.apply_semantic(labels, params)
+        labels = self.apply_image(labels, params)
+        if not return_image_only:
+            labels = self.apply_instances(labels, params)
+        labels = self.apply_semantic(labels, params)
         if return_image_only:
             return labels["img"]
         return labels

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2692,7 +2692,7 @@ class RandomLoadText(BaseTransform):
         return labels
 
 
-def v8_transforms(dataset, imgsz: int, hyp: IterableSimpleNamespace, stretch: bool = False):
+def v8_transforms(dataset, imgsz: int, hyp: IterableSimpleNamespace):
     """Apply a series of image transformations for training.
 
     This function creates a composition of image augmentation techniques to prepare images for YOLO training. It
@@ -2703,7 +2703,6 @@ def v8_transforms(dataset, imgsz: int, hyp: IterableSimpleNamespace, stretch: bo
         imgsz (int): The target image size for resizing.
         hyp (IterableSimpleNamespace): A namespace of hyperparameters controlling various aspects of the
             transformations.
-        stretch (bool): If True, applies stretching to the image. If False, uses LetterBox resizing.
 
     Returns:
         (Compose): A composition of image transformations to be applied to the dataset.
@@ -2739,7 +2738,7 @@ def v8_transforms(dataset, imgsz: int, hyp: IterableSimpleNamespace, stretch: bo
         scale=hyp.scale,
         shear=hyp.shear,
         perspective=hyp.perspective,
-        size=(imgsz, imgsz) if not stretch else None,
+        size=(imgsz, imgsz),
     )
 
     pre_transform = Compose([mosaic, affine])

--- a/ultralytics/models/rtdetr/val.py
+++ b/ultralytics/models/rtdetr/val.py
@@ -8,7 +8,6 @@ from typing import Any
 import torch
 
 from ultralytics.data import YOLODataset
-from ultralytics.data.augment import Compose, Format, v8_transforms
 from ultralytics.models.yolo.detect import DetectionValidator
 from ultralytics.utils import colorstr, ops
 
@@ -69,36 +68,6 @@ class RTDETRDataset(YOLODataset):
             >>> image, hw0, hw = dataset.load_image(0)
         """
         return super().load_image(i=i, rect_mode=rect_mode)
-
-    def build_transforms(self, hyp=None):
-        """Build transformation pipeline for the dataset.
-
-        Args:
-            hyp (dict, optional): Hyperparameters for transformations.
-
-        Returns:
-            (Compose): Composition of transformation functions.
-        """
-        if self.augment:
-            hyp.mosaic = hyp.mosaic if self.augment and not self.rect else 0.0
-            hyp.mixup = hyp.mixup if self.augment and not self.rect else 0.0
-            hyp.cutmix = hyp.cutmix if self.augment and not self.rect else 0.0
-            transforms = v8_transforms(self, self.imgsz, hyp, stretch=True)
-        else:
-            # transforms = Compose([LetterBox(new_shape=(self.imgsz, self.imgsz), auto=False, scale_fill=True)])
-            transforms = Compose([])
-        transforms.append(
-            Format(
-                bbox_format="xywh",
-                normalize=True,
-                return_mask=self.use_segments,
-                return_keypoint=self.use_keypoints,
-                batch_idx=True,
-                mask_ratio=hyp.mask_ratio,
-                mask_overlap=hyp.overlap_mask,
-            )
-        )
-        return transforms
 
 
 class RTDETRValidator(DetectionValidator):


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Streamlines RT-DETR validation transforms by removing the custom stretch-based augmentation path, aligning preprocessing more closely with standard YOLO behavior 🚀

### 📊 Key Changes
- Removed the unused `stretch` argument from `v8_transforms()` in `ultralytics/data/augment.py`.
- `v8_transforms()` now always uses fixed square sizing with `size=(imgsz, imgsz)`.
- Deleted the custom `build_transforms()` method from the RT-DETR dataset class in `ultralytics/models/rtdetr/val.py`.
- Removed related imports for `Compose`, `Format`, and `v8_transforms` from RT-DETR validation code.

### 🎯 Purpose & Impact
- Simplifies the augmentation pipeline by eliminating a special-case stretch mode 🧹
- Reduces duplicated or model-specific transform logic for RT-DETR validation.
- Improves maintainability and consistency across Ultralytics validation workflows.
- May affect RT-DETR preprocessing behavior where stretch-style resizing was previously used, but should make transforms more predictable and aligned with the shared dataset pipeline.