### PR TITLE
Update LiteRT and TFLite benchmark docs

### DIFF
--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -39,19 +39,19 @@ One model format, every target:
 
 ## Measured Performance
 
-End-to-end single-image inference for the official YOLO26n Android LiteRT assets (`w8a32`: int8 weights, FP32 activations) on a Xiaomi 17 phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app). Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU runs the LiteRT XNNPACK delegate; GPU runs the LiteRT OpenCL/GL delegate (FP16).
+End-to-end single-image inference for the official YOLO26n Android LiteRT assets (`w8a32`: int8 weights, FP32 activations) on a [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) `0.6.8`. Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU runs the LiteRT XNNPACK delegate; GPU runs the LiteRT OpenCL/GL delegate (FP16).
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>w8a32 LiteRT<br>(ms)</sup> | GPU Adreno<br><sup>w8a32 LiteRT<br>(ms)</sup> |
 | ------------ | -------- | --------------------------- | -------------------------------------- | --------------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 87.1<br><sup>7.1 / 77.4 / 2.7</sup>    | **17.4**<br><sup>6.2 / 8.6 / 2.6</sup>        |
-| YOLO26n-seg  | Segment  | 640                         | 129.0<br><sup>7.3 / 109.0 / 12.8</sup> | **43.4**<br><sup>7.7 / 21.9 / 13.7</sup>      |
-| YOLO26n-sem  | Semantic | 640                         | 99.0<br><sup>7.0 / 76.4 / 15.7</sup>   | **59.4**<br><sup>7.5 / 34.4 / 17.5</sup>      |
-| YOLO26n-cls  | Classify | 224                         | 8.1<br><sup>1.2 / 6.1 / 0.8</sup>      | **4.9**<br><sup>1.7 / 2.0 / 1.3</sup>         |
-| YOLO26n-pose | Pose     | 640                         | 102.4<br><sup>7.4 / 92.4 / 2.5</sup>   | **24.0**<br><sup>9.1 / 10.4 / 4.5</sup>       |
-| YOLO26n-obb  | OBB      | 640                         | 90.9<br><sup>7.7 / 81.3 / 1.9</sup>    | **18.4**<br><sup>7.7 / 8.6 / 2.0</sup>        |
+| YOLO26n      | Detect   | 640                         | 52.4<br><sup>1.8 / 48.2 / 2.4</sup>   | **13.5**<br><sup>1.9 / 8.1 / 3.5</sup>        |
+| YOLO26n-seg  | Segment  | 640                         | 72.8<br><sup>1.8 / 65.3 / 5.7</sup>   | **28.6**<br><sup>1.8 / 20.1 / 6.7</sup>       |
+| YOLO26n-sem  | Semantic | 640                         | 60.3<br><sup>1.8 / 50.4 / 8.1</sup>   | **32.9**<br><sup>1.8 / 23.0 / 8.2</sup>       |
+| YOLO26n-cls  | Classify | 224                         | 10.5<br><sup>0.9 / 9.6 / 0.1</sup>    | **3.2**<br><sup>1.0 / 2.2 / 0.1</sup>         |
+| YOLO26n-pose | Pose     | 640                         | 56.9<br><sup>1.8 / 53.9 / 1.2</sup>   | **14.0**<br><sup>1.9 / 9.3 / 2.8</sup>        |
+| YOLO26n-obb  | OBB      | 640                         | 50.5<br><sup>1.8 / 47.3 / 1.4</sup>   | **13.0**<br><sup>2.9 / 7.9 / 2.3</sup>        |
 
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured with the Flutter plugin's on-device benchmark harness in profile mode. The full task suite runs back-to-back, so the CPU-bound preprocessing stage reflects sustained operation (a thermally rested single-task measurement is lower); the GPU/CPU inference stage is the steady-state compute cost.
-- The LiteRT export traces the PyTorch model directly, producing an **NCHW** `.tflite` with a float input — the GPU delegate compiles the whole graph (all six tasks run on the Adreno GPU here), and `w8a32` needs no calibration data.
+- The LiteRT export traces the PyTorch model directly, producing an **NCHW** `.tflite` with a float input — the GPU delegate compiles the whole graph (all six tasks run on the Adreno GPU here), and `w8a32` needs no calibration data. The official Android assets are hosted on the [yolo-flutter-app `v0.6.6` release](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.6.6), with the detailed benchmark record in [the Flutter performance doc](https://github.com/ultralytics/yolo-flutter-app/blob/main/doc/performance.md).
 - The matching Snapdragon **Hexagon NPU** numbers (and the INT8 TFLite CPU/GPU baseline) are in the [Qualcomm QNN integration](qnn.md).
 
 ## Export to LiteRT: Converting Your YOLO Model

--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -52,7 +52,7 @@ The exported `*_qnn.onnx` file is self-contained: it embeds the QNN context bina
 
 ### Android Phone
 
-End-to-end single-image inference for the official YOLO26n models on a Xiaomi 17 phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850) — Qualcomm Oryon CPU, Adreno GPU, and Hexagon NPU (HTP v81). Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU and GPU run INT8 TFLite via LiteRT; the NPU runs QNN context binaries (INT8 weights, 16-bit activations).
+End-to-end single-image inference for the official YOLO26n models on a [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850) — Qualcomm Oryon CPU, Adreno GPU, and Hexagon NPU (HTP v81). Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU and GPU run INT8 TFLite via LiteRT; the NPU runs QNN context binaries (INT8 weights, 16-bit activations).
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>INT8 TFLite<br>(ms)</sup> | GPU Adreno<br><sup>INT8 TFLite<br>(ms)</sup> | NPU Hexagon<br><sup>QNN W8A16<br>(ms)</sup>      |
 | ------------ | -------- | --------------------------- | ------------------------------------- | -------------------------------------------- | ------------------------------------------------ |
@@ -64,6 +64,7 @@ End-to-end single-image inference for the official YOLO26n models on a Xiaomi 17
 | YOLO26n-obb  | OBB      | 1024                        | 50.3<br><sup>3.6 / 45.4 / 1.3</sup>   | **13.9**<br><sup>3.8 / 8.2 / 1.8</sup>       | 21.0<br><sup>8.8 / 10.9 / 1.3</sup>              |
 
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured with the [Flutter plugin's](https://github.com/ultralytics/yolo-flutter-app) on-device benchmark harness on a thermally rested device. Sustained real-time camera frame times run higher (per-frame capture letterboxing plus thermal settling); use the app's on-screen pre/inference/post breakdown for steady-state numbers on your device.
+- This table is kept as the QNN comparison snapshot. Current Android LiteRT CPU/GPU numbers measured with `ultralytics_yolo` `0.6.8` are in the [LiteRT integration](litert.md#measured-performance), and the detailed benchmark record is in the [Flutter performance doc](https://github.com/ultralytics/yolo-flutter-app/blob/main/doc/performance.md).
 - <sup>1</sup> Semantic QNN uses the in-graph ArgMax class-map output from this release, which replaced erratic 123-1065 ms logits decoding with a stable ~49 ms; the GPU remains slightly faster for semantic at 1024px.
 
 ### Windows on Snapdragon Laptop

--- a/docs/en/integrations/tflite.md
+++ b/docs/en/integrations/tflite.md
@@ -45,22 +45,22 @@ TFLite models offer a wide range of key features that enable on-device machine l
 
     These TFLite numbers are kept as a **historical before/after record** for the onnx2tf-TFLite → LiteRT migration: the legacy onnx2tf **INT8 TFLite** export below versus the new **[LiteRT](litert.md) w8a32** export (see the [LiteRT Measured Performance table](litert.md#measured-performance)). They are shared with the Google LiteRT team to show where the new litert-torch format still regresses against the format it replaced — see [Format regressions](#format-regressions-vs-litert) below.
 
-Per-task before/after on the Adreno GPU of a Xiaomi 17 (Qualcomm Snapdragon 8 Elite Gen 5, SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app): the legacy onnx2tf **INT8 TFLite** assets (NHWC, input `images`) versus the new **w8a32 LiteRT** assets (NCHW, input `args_0`), both run on LiteRT 2.x in the same back-to-back sweep at the shipped Android `imgsz`. Each cell is the **total time** (preprocessing + inference + postprocessing) with the per-stage split beneath it; both formats compiled fully on the GPU.
+Per-task before/after on the Adreno GPU of a [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) (Qualcomm Snapdragon 8 Elite Gen 5, SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) `0.6.8`: the legacy onnx2tf **INT8 TFLite** assets (NHWC, input `images`) versus the new **w8a32 LiteRT** assets (NCHW, input `args_0`), both run on LiteRT 2.x in the same back-to-back sweep at the shipped Android `imgsz`. Each cell is the **total time** (preprocessing + inference + postprocessing) with the per-stage split beneath it; both formats compiled fully on the GPU.
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | Before<br><sup>onnx2tf INT8 TFLite<br>(ms)</sup> | After<br><sup>w8a32 LiteRT<br>(ms)</sup> |
 | ------------ | -------- | --------------------------- | ------------------------------------------------ | ---------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 18.8<br><sup>7.8 / 8.3 / 2.7</sup>               | **17.4**<br><sup>6.2 / 8.6 / 2.6</sup>   |
-| YOLO26n-seg  | Segment  | 640                         | 45.2<br><sup>7.8 / 22.9 / 14.4</sup>             | **43.4**<br><sup>7.7 / 21.9 / 13.7</sup> |
-| YOLO26n-sem  | Semantic | 640                         | **50.5**<br><sup>6.5 / 27.7 / 16.3</sup>         | 59.4<br><sup>7.5 / 34.4 / 17.5</sup>     |
-| YOLO26n-cls  | Classify | 224                         | 5.9<br><sup>1.5 / 2.0 / 2.5</sup>                | **4.9**<br><sup>1.7 / 2.0 / 1.3</sup>    |
-| YOLO26n-pose | Pose     | 640                         | **22.5**<br><sup>7.8 / 9.8 / 4.8</sup>           | 24.0<br><sup>9.1 / 10.4 / 4.5</sup>      |
-| YOLO26n-obb  | OBB      | 640                         | 19.0<br><sup>7.7 / 8.4 / 2.9</sup>               | **18.4**<br><sup>7.7 / 8.6 / 2.0</sup>   |
+| YOLO26n      | Detect   | 640                         | 14.0<br><sup>1.8 / 8.1 / 4.2</sup>               | **13.5**<br><sup>1.9 / 8.1 / 3.5</sup>   |
+| YOLO26n-seg  | Segment  | 640                         | 30.1<br><sup>1.9 / 20.3 / 8.0</sup>              | **28.6**<br><sup>1.8 / 20.1 / 6.7</sup>  |
+| YOLO26n-sem  | Semantic | 640                         | **26.4**<br><sup>1.9 / 16.4 / 8.1</sup>          | 32.9<br><sup>1.8 / 23.0 / 8.2</sup>      |
+| YOLO26n-cls  | Classify | 224                         | 3.5<br><sup>0.9 / 2.2 / 0.4</sup>                | **3.2**<br><sup>1.0 / 2.2 / 0.1</sup>    |
+| YOLO26n-pose | Pose     | 640                         | 17.4<br><sup>2.4 / 9.9 / 5.1</sup>               | **14.0**<br><sup>1.9 / 9.3 / 2.8</sup>   |
+| YOLO26n-obb  | OBB      | 640                         | 13.9<br><sup>3.0 / 8.3 / 2.7</sup>               | **13.0**<br><sup>2.9 / 7.9 / 2.3</sup>   |
 
-w8a32 LiteRT matches or beats the legacy onnx2tf INT8 format on four of six tasks; **semantic is the clear regression** (+9 ms, from the NCHW FP32-activation inference and host-side argmax) and pose is ~1.5 ms slower. The legacy onnx2tf models run unchanged on LiteRT 2.x alongside the new NCHW exports.
+w8a32 LiteRT matches or beats the legacy onnx2tf INT8 format on five of six tasks in total latency. **Semantic remains the format regression** because the w8a32 NCHW logits cost more inference time than the legacy NHWC logits, even after preprocessing cleanup. The legacy onnx2tf models run unchanged on LiteRT 2.x alongside the new NCHW exports. The official Android LiteRT assets are hosted on the [yolo-flutter-app `v0.6.6` release](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.6.6), with the detailed benchmark record in [the Flutter performance doc](https://github.com/ultralytics/yolo-flutter-app/blob/main/doc/performance.md).
 
 ### Format regressions vs LiteRT
 
-Same-device YOLO26n detect on the Adreno GPU — legacy onnx2tf INT8 TFLite versus the four LiteRT quantization formats, all measured in one sustained run (so **inference** is the comparable, format-dependent metric):
+Same-device YOLO26n detect on the Adreno GPU of a [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) — legacy onnx2tf INT8 TFLite versus the four LiteRT quantization formats, all measured in one sustained run (so **inference** is the comparable, format-dependent metric):
 
 | Android format                    | GPU inference (ms) | GPU-compiles |
 | --------------------------------- | ------------------ | ------------ |
@@ -72,7 +72,7 @@ Same-device YOLO26n detect on the Adreno GPU — legacy onnx2tf INT8 TFLite vers
 
 Issues for the Google LiteRT / litert-torch team, surfaced migrating production Android assets from onnx2tf TFLite to LiteRT:
 
-1. **NCHW layout adds a per-frame transpose.** litert-torch traces the PyTorch model and emits **NCHW** `[1,3,H,W]` with a float input, whereas the onnx2tf TFLite export was **NHWC** `[1,H,W,3]` — matching the camera/bitmap layout. The new format forces a host-side HWC→CHW transpose every frame that the old format did not need.
+1. **NCHW layout makes consumers layout-aware.** litert-torch traces the PyTorch model and emits **NCHW** `[1,3,H,W]` with a float input, whereas the onnx2tf TFLite export was **NHWC** `[1,H,W,3]` — matching the camera/bitmap layout. The current Flutter plugin writes planar CHW directly during RGB packing, avoiding a separate HWC→CHW transpose, but simpler consumers still need either direct planar packing or an extra transpose.
 2. **`quantize="w8a16"` does not compile on the GPU (OpenCL) delegate** and silently falls back to a CPU path that is ~40× slower (~660 ms vs ~17 ms), making the int16-activation format unusable for GPU deployment.
 3. **Static INT8 (`quantize=8`) is the slowest GPU format** — ~11 ms vs ~8.6 ms for the equivalent legacy onnx2tf INT8 model, i.e. LiteRT's own INT8 path regresses against the format it replaced. Dynamic-range **w8a32** is the only LiteRT format that matches the old INT8 speed, which is why it is now shipped.
 4. **Semantic models export as raw NCHW logits with no in-graph ArgMax option,** forcing a cache-unfriendly host-side argmax over `[1, C, H, W]` (each class plane is a full H×W apart). The onnx2tf, CoreML, and QNN paths can emit a compact class map instead.

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -229,7 +229,7 @@ def test_track_second_association_indices():
     """Low-confidence detections matched in second association keep full detection-set indices."""
     from ultralytics.engine.results import Boxes
     from ultralytics.trackers.byte_tracker import BYTETracker
-    from ultralytics.utils import ROOT, IterableSimpleNamespace, YAML
+    from ultralytics.utils import ROOT, YAML, IterableSimpleNamespace
 
     args = IterableSimpleNamespace(**{**YAML.load(ROOT / "cfg/trackers/bytetrack.yaml"), "fuse_score": False})
     tracker = BYTETracker(args)


### PR DESCRIPTION
## Summary
- refresh LiteRT CPU/GPU benchmark rows with the current Xiaomi 17 measurements
- refresh the TFLite before/after migration table and format notes
- add Flutter plugin 0.6.8 benchmark source notes, Xiaomi links, and Flutter performance doc backlinks
- clarify that the QNN page keeps its mixed-backend comparison snapshot while current LiteRT CPU/GPU rows live on the LiteRT page

## Validation
- git diff --check -- docs/en/integrations/litert.md docs/en/integrations/tflite.md docs/en/integrations/qnn.md

## Related
- ultralytics/yolo-flutter-app#553

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates Android LiteRT/TFLite/QNN performance documentation with refreshed YOLO26n benchmarks, clearer references, and improved context for deployment comparisons 📱⚡

### 📊 Key Changes
- Refreshed LiteRT measured performance tables with new CPU/GPU latency numbers from the Ultralytics Flutter plugin `0.6.8` 🚀
- Updated TFLite before/after comparison data between legacy onnx2tf INT8 TFLite and new w8a32 LiteRT exports 📊
- Clarified that w8a32 LiteRT now matches or beats legacy TFLite on 5 of 6 tasks, with semantic segmentation still noted as the main regression ⚠️
- Added links to the Xiaomi 17 device page, official Android LiteRT assets, and the detailed Flutter performance benchmark documentation 🔗
- Added a note in the QNN docs pointing users to the latest LiteRT CPU/GPU results for current Android comparisons 📌
- Refined explanation of NCHW layout impact, noting the Flutter plugin now avoids a separate transpose by writing planar CHW directly 🛠️
- Minor test import ordering cleanup in `tests/test_python.py` 🧹

### 🎯 Purpose & Impact
- Gives users more accurate and up-to-date mobile performance expectations for YOLO26n on modern Android hardware 📱
- Helps developers compare LiteRT, TFLite, and QNN deployment paths more clearly when choosing an inference backend ⚙️
- Improves transparency around LiteRT migration tradeoffs, especially semantic segmentation performance and tensor layout considerations 🔍
- Makes benchmark results easier to reproduce by documenting plugin version, device details, official assets, and detailed performance records ✅
- Strengthens documentation quality without changing model behavior or runtime code for users 📚