### PR TITLE
Fix TAL OOM recovery, AutoBatch loss estimation, LiteRT INT8 calibration, and nc validation

### DIFF
--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -43,12 +43,12 @@ End-to-end single-image inference for the official YOLO26n Android LiteRT assets
 
 | Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>w8a32 LiteRT<br>(ms)</sup> | GPU Adreno<br><sup>w8a32 LiteRT<br>(ms)</sup> |
 | ------------ | -------- | --------------------------- | -------------------------------------- | --------------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 52.4<br><sup>1.8 / 48.2 / 2.4</sup>   | **13.5**<br><sup>1.9 / 8.1 / 3.5</sup>        |
-| YOLO26n-seg  | Segment  | 640                         | 72.8<br><sup>1.8 / 65.3 / 5.7</sup>   | **28.6**<br><sup>1.8 / 20.1 / 6.7</sup>       |
-| YOLO26n-sem  | Semantic | 640                         | 60.3<br><sup>1.8 / 50.4 / 8.1</sup>   | **32.9**<br><sup>1.8 / 23.0 / 8.2</sup>       |
-| YOLO26n-cls  | Classify | 224                         | 10.5<br><sup>0.9 / 9.6 / 0.1</sup>    | **3.2**<br><sup>1.0 / 2.2 / 0.1</sup>         |
-| YOLO26n-pose | Pose     | 640                         | 56.9<br><sup>1.8 / 53.9 / 1.2</sup>   | **14.0**<br><sup>1.9 / 9.3 / 2.8</sup>        |
-| YOLO26n-obb  | OBB      | 640                         | 50.5<br><sup>1.8 / 47.3 / 1.4</sup>   | **13.0**<br><sup>2.9 / 7.9 / 2.3</sup>        |
+| YOLO26n      | Detect   | 640                         | 52.4<br><sup>1.8 / 48.2 / 2.4</sup>    | **13.5**<br><sup>1.9 / 8.1 / 3.5</sup>        |
+| YOLO26n-seg  | Segment  | 640                         | 72.8<br><sup>1.8 / 65.3 / 5.7</sup>    | **28.6**<br><sup>1.8 / 20.1 / 6.7</sup>       |
+| YOLO26n-sem  | Semantic | 640                         | 60.3<br><sup>1.8 / 50.4 / 8.1</sup>    | **32.9**<br><sup>1.8 / 23.0 / 8.2</sup>       |
+| YOLO26n-cls  | Classify | 224                         | 10.5<br><sup>0.9 / 9.6 / 0.1</sup>     | **3.2**<br><sup>1.0 / 2.2 / 0.1</sup>         |
+| YOLO26n-pose | Pose     | 640                         | 56.9<br><sup>1.8 / 53.9 / 1.2</sup>    | **14.0**<br><sup>1.9 / 9.3 / 2.8</sup>        |
+| YOLO26n-obb  | OBB      | 640                         | 50.5<br><sup>1.8 / 47.3 / 1.4</sup>    | **13.0**<br><sup>2.9 / 7.9 / 2.3</sup>        |
 
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured with the Flutter plugin's on-device benchmark harness in profile mode. The full task suite runs back-to-back, so the CPU-bound preprocessing stage reflects sustained operation (a thermally rested single-task measurement is lower); the GPU/CPU inference stage is the steady-state compute cost.
 - The LiteRT export traces the PyTorch model directly, producing an **NCHW** `.tflite` with a float input — the GPU delegate compiles the whole graph (all six tasks run on the Adreno GPU here), and `w8a32` needs no calibration data. The official Android assets are hosted on the [yolo-flutter-app `v0.6.6` release](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.6.6), with the detailed benchmark record in [the Flutter performance doc](https://github.com/ultralytics/yolo-flutter-app/blob/main/doc/performance.md).

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -49,7 +49,7 @@ def skip_rpi_semantic():
 
 
 def test_select_device_initialized_cuda(monkeypatch):
-    """select_device must return the requested index once CUDA is initialized, as remapping no longer applies."""
+    """Select_device must return the requested index once CUDA is initialized, as remapping no longer applies."""
     from ultralytics.utils import torch_utils
 
     monkeypatch.setattr(torch_utils.torch.cuda, "is_available", lambda: True)

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.84"
+__version__ = "8.4.85"
 
 import importlib
 import os

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -493,6 +493,11 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> dict[str, Any]
             data["val"] = data.pop("validation")  # replace 'validation' key with 'val' key
     if "names" not in data and "nc" not in data:
         raise SyntaxError(emojis(f"{dataset} key missing ❌.\n either 'names' or 'nc' are required in all data YAMLs."))
+    if "nc" in data and not isinstance(data["nc"], int):
+        try:
+            data["nc"] = int(data["nc"])
+        except (TypeError, ValueError):
+            raise SyntaxError(emojis(f"{dataset} 'nc: {data['nc']}' must be an integer ❌."))
     if "names" in data and "nc" in data and len(data["names"]) != data["nc"]:
         raise SyntaxError(emojis(f"{dataset} 'names' length {len(data['names'])} and 'nc: {data['nc']}' must match."))
     if "names" not in data:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -495,8 +495,11 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> dict[str, Any]
         raise SyntaxError(emojis(f"{dataset} key missing ❌.\n either 'names' or 'nc' are required in all data YAMLs."))
     if "nc" in data and not isinstance(data["nc"], int):
         try:
-            data["nc"] = int(str(data["nc"]))  # coerce integer-like strings only, e.g. '10' but not 1.9
-        except ValueError:
+            nc = float(data["nc"])  # accept integer-like values, e.g. '10' or 10.0, but not 1.9 or placeholders
+            if nc != int(nc):
+                raise ValueError
+            data["nc"] = int(nc)
+        except (TypeError, ValueError):
             raise SyntaxError(emojis(f"{dataset} 'nc: {data['nc']}' must be an integer ❌."))
     if "names" in data and "nc" in data and len(data["names"]) != data["nc"]:
         raise SyntaxError(emojis(f"{dataset} 'names' length {len(data['names'])} and 'nc: {data['nc']}' must match."))

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -495,8 +495,8 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> dict[str, Any]
         raise SyntaxError(emojis(f"{dataset} key missing ❌.\n either 'names' or 'nc' are required in all data YAMLs."))
     if "nc" in data and not isinstance(data["nc"], int):
         try:
-            data["nc"] = int(data["nc"])
-        except (TypeError, ValueError):
+            data["nc"] = int(str(data["nc"]))  # coerce integer-like strings only, e.g. '10' but not 1.9
+        except ValueError:
             raise SyntaxError(emojis(f"{dataset} 'nc: {data['nc']}' must be an integer ❌."))
     if "names" in data and "nc" in data and len(data["names"]) != data["nc"]:
         raise SyntaxError(emojis(f"{dataset} 'names' length {len(data['names'])} and 'nc: {data['nc']}' must match."))

--- a/ultralytics/utils/export/litert.py
+++ b/ultralytics/utils/export/litert.py
@@ -126,10 +126,6 @@ def torch2litert(
                 if imgs.shape[0] < im.shape[0]:
                     imgs = imgs.repeat(-(-im.shape[0] // imgs.shape[0]), 1, 1, 1)[: im.shape[0]]
                 calib_samples.append({"args_0": imgs.numpy()})
-            assert calib_samples, (
-                f"No calibration batches of size {im.shape[0]} were collected; the calibration dataset needs at least "
-                f"'batch={im.shape[0]}' images for static LiteRT quantization (reduce 'batch' or add more 'data')."
-            )
             qt.load_quantization_recipe(recipe.static_wi8_ai8() if static_int8 else recipe.static_wi8_ai16())
             # Keep FP32 graph input/output (weights/activations stay int8/int16 internally): matches the historical
             # onnx2tf "fp32 in/out" contract that downstream consumers (LiteRT GPU delegate, on-device runtimes) expect,

--- a/ultralytics/utils/export/litert.py
+++ b/ultralytics/utils/export/litert.py
@@ -121,9 +121,11 @@ def torch2litert(
             calib_samples = []
             for batch in calibration_dataset:
                 imgs = batch["img"].cpu().float() / 255.0
-                # litert-torch traces a fixed batch; feed whole batches matching im's batch dim (skip a partial tail).
-                if imgs.shape[0] == im.shape[0]:
-                    calib_samples.append({"args_0": imgs.numpy()})
+                # litert-torch traces a fixed batch; tile under-sized batches up to im's batch dim (repeats are
+                # statistics-identical for calibration)
+                if imgs.shape[0] < im.shape[0]:
+                    imgs = imgs.repeat(-(-im.shape[0] // imgs.shape[0]), 1, 1, 1)[: im.shape[0]]
+                calib_samples.append({"args_0": imgs.numpy()})
             assert calib_samples, (
                 f"No calibration batches of size {im.shape[0]} were collected; the calibration dataset needs at least "
                 f"'batch={im.shape[0]}' images for static LiteRT quantization (reduce 'batch' or add more 'data')."

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -97,13 +97,13 @@ class TaskAlignedAssigner(nn.Module):
         try:
             return self._forward(pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt)
         except RuntimeError as e:
-            if "out of memory" in str(e).lower():
-                # Move tensors to CPU, compute, then move back to original device
-                LOGGER.warning("CUDA OutOfMemoryError in TaskAlignedAssigner, using CPU")
-                cpu_tensors = [t.cpu() for t in (pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt)]
-                result = self._forward(*cpu_tensors)
-                return tuple(t.to(device) for t in result)
-            raise
+            if "out of memory" not in str(e).lower():
+                raise
+        # Recover outside the except block: exiting it drops e.__traceback__, releasing the failed attempt's GPU
+        # intermediates back to the allocator so the copy-back below can succeed
+        LOGGER.warning("CUDA OutOfMemoryError in TaskAlignedAssigner, using CPU")
+        result = self._forward(*(t.cpu() for t in (pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt)))
+        return tuple(t.to(device) for t in result)
 
     def _forward(self, pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt):
         """Compute the task-aligned assignment.

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -894,9 +894,14 @@ def profile_ops(input, ops, n=10, device=None, max_num_obj=0):
                     if max_num_obj:  # simulate training with predictions per image grid (for AutoBatch)
                         with cuda_memory_usage(device) as cuda_info:
                             anchors = int(sum((x.shape[-1] / s) * (x.shape[-2] / s) for s in m.stride.tolist()))
-                            sim = (  # box-loss (bs, max_num_obj, anchors) + cls-loss (bs, anchors, nc) terms
-                                torch.randn(x.shape[0], max_num_obj, anchors, device=device, dtype=torch.float32),
-                                torch.randn(x.shape[0], anchors, len(m.names), device=device, dtype=torch.float32),
+                            # Envelope of the detect-loss memory peaks: TaskAlignedAssigner.get_box_metrics holds ~6
+                            # simultaneous (bs, max_num_obj, anchors) fp32 buffers (mask_in_gts, overlaps, bbox_scores,
+                            # gathered pd_scores, pow temps + align_metric); the cls path holds ~6 (bs, anchors, nc)
+                            # fp32-equivalents (int64 target_scores + torch.where output, fg_scores_mask, then
+                            # pred/target/unreduced-BCE in v8DetectionLoss)
+                            sim = (
+                                torch.randn(x.shape[0], 6 * max_num_obj, anchors, device=device, dtype=torch.float32),
+                                torch.randn(x.shape[0], anchors, 6 * len(m.names), device=device, dtype=torch.float32),
                             )
                         del sim
                         mem += cuda_info["memory"] / 1e9  # (GB)

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -893,13 +893,12 @@ def profile_ops(input, ops, n=10, device=None, max_num_obj=0):
                     tb += (t[2] - t[1]) * 1000 / n  # ms per op backward
                     if max_num_obj:  # simulate training with predictions per image grid (for AutoBatch)
                         with cuda_memory_usage(device) as cuda_info:
-                            torch.randn(
-                                x.shape[0],
-                                max_num_obj,
-                                int(sum((x.shape[-1] / s) * (x.shape[-2] / s) for s in m.stride.tolist())),
-                                device=device,
-                                dtype=torch.float32,
+                            anchors = int(sum((x.shape[-1] / s) * (x.shape[-2] / s) for s in m.stride.tolist()))
+                            sim = (  # box-loss (bs, max_num_obj, anchors) + cls-loss (bs, anchors, nc) terms
+                                torch.randn(x.shape[0], max_num_obj, anchors, device=device, dtype=torch.float32),
+                                torch.randn(x.shape[0], anchors, len(m.names), device=device, dtype=torch.float32),
                             )
+                        del sim
                         mem += cuda_info["memory"] / 1e9  # (GB)
                 s_in, s_out = (tuple(x.shape) if isinstance(x, torch.Tensor) else "list" for x in (x, y))  # shapes
                 p = sum(x.numel() for x in m.parameters()) if isinstance(m, nn.Module) else 0  # parameters


### PR DESCRIPTION
## Fix training OOM recovery, AutoBatch loss estimation, LiteRT INT8 calibration, and `nc` validation

Root-cause fixes for four failure classes surfaced by a combined Sentry sweep (both `alpha` and `ultralytics` projects, 24h window) and a 96h GPU training fleet log sweep on 2026-07-02. All failures reproduce on `8.4.84` (current `main`).

### Fixes

| Failure | Root cause | Fix | Type |
|---|---|---|---|
| Fatal `torch.OutOfMemoryError` inside the TaskAlignedAssigner CPU fallback (`tal.py:105` copy-back) — 17/17 failed fleet training jobs in the sweep window; Sentry ALPHA-1DM (343 events) | The CPU recompute and `.to(device)` copy-back ran **inside** the `except RuntimeError as e:` block, so `e.__traceback__` kept the failed `_forward` attempt's ~6 simultaneous `(bs, n_max_boxes, anchors)` fp32 GPU tensors alive during recovery — the copy-back then re-OOM'd allocating 14–34 GiB. The fallback never worked for exactly the workloads it exists for | Move recovery out of the `except` block; exiting it drops the traceback and returns the failed attempt's memory to the allocator before the CPU recompute and copy-back. Non-OOM `RuntimeError`s still re-raise | Replace |
| Residual OOM flavor: `batch=-1` picks batches the BCE classification loss can't afford (`loss.py:436`, 23.79 GiB alloc) on instance-dense / high-`nc` datasets | `profile_ops`' AutoBatch simulation allocated a single `(bs, max_num_obj, anchors)` tensor — the real detect loss holds ~6 simultaneous box-path buffers (TAL `get_box_metrics`) plus ~6 `(bs, anchors, nc)` cls-path fp32-equivalents | Simulate both peak envelopes (6× box + 6× cls) inside the same `cuda_memory_usage` block so the linear fit sees the true per-batch loss memory; errs toward smaller batches within the 0.6 fraction | Replace |
| Static-INT8 LiteRT export fails 100% deterministically with `No calibration batches of size N were collected` whenever the calibration dataset has fewer images than `args.batch` | `get_int8_calibration_dataloader` reduces the dataloader batch to `min(args.batch, n)` with `drop_last=True`, but the model was traced at `args.batch` — the size-match skip in `torch2litert` then collected zero samples | Tile under-sized batches up to the traced batch dim (repeats are statistics-identical for calibration). The assert became unreachable dead code and was deleted | Replace + Delete |
| `check_det_dataset` rejects valid YAML with the self-contradictory message `'names' length 10 and 'nc: 10' must match` (7% of ULTRALYTICS-2151 samples); names-absent quoted `nc` crashes at `range(str)` | `len(data["names"]) != data["nc"]` does no type coercion, so a YAML-quoted `nc: "10"` (str) never equals int 10 | Coerce `nc` to int once before the guard, accepting integer-like values (`10`, `"10"`, `10.0`) and rejecting non-integral/placeholder values (`1.9`, `number_of_classes`) with a clear `'nc: ...' must be an integer` error | Add (5 lines) |

Also bumps `__version__` to **8.4.85** for release.

### Verification

- `tests/test_python.py -k profile` + a direct `profile_ops(max_num_obj=50)` smoke run exercising the new simulation branch
- Live `check_det_dataset` probes: accepts `10` / `"10"` / `10.0`, rejects `1.9` / `10.0`-vs-9-names mismatch / `number_of_classes` / non-numeric; targeted pytest (7 passed)
- `ruff check` + `ruff format` clean on all changed files

### Review

Independent dual review, both LGTM: Claude Code reviewer (4 rounds, adversarial) and Codex CLI (`gpt-5.5`, high reasoning, 3 rounds — earlier rounds drove the 6× envelope scaling and the integral-float `nc` semantics). Sole remaining note (`nc: .inf` → `OverflowError`) judged non-blocking pathological-input polish by both reviewers.

Cross-reference: companion platform-side PR (worker harness fixes from the same sweep): https://github.com/ultralytics/portal/pull/2656

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR bumps Ultralytics to `8.4.85` and improves dataset validation, LiteRT export calibration, CUDA OOM recovery, and AutoBatch memory profiling.

### 📊 Key Changes
- 📦 Updated package version from `8.4.84` to `8.4.85`.
- ✅ Strengthened dataset YAML validation by ensuring `nc` is an integer, while still accepting integer-like values such as `"10"` or `10.0`.
- 📱 Improved LiteRT quantization calibration by repeating smaller calibration batches instead of failing when the final batch is undersized.
- 🧠 Refined CUDA out-of-memory fallback in `TaskAlignedAssigner` to release failed GPU traceback memory before retrying on CPU.
- 📊 Enhanced AutoBatch profiling memory simulation to better reflect detection-loss memory peaks during training.
- 📝 Minor documentation and test docstring formatting updates for LiteRT benchmarks and CUDA device selection.

### 🎯 Purpose & Impact
- 🛡️ Helps users catch invalid dataset configs earlier with clearer errors, reducing confusing training failures.
- 📲 Makes LiteRT export more robust, especially for small datasets or partial calibration batches.
- 💪 Improves training stability when GPU memory is tight by making CPU fallback more reliable after CUDA OOM errors.
- ⚖️ Provides more realistic memory estimates for AutoBatch, helping users choose safer batch sizes.
- ✨ Includes small polish updates to docs and tests for consistency and readability.