### PR TITLE
Fix re-entrant `select_device` crash after `CUDA_VISIBLE_DEVICES` remap

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -49,27 +49,37 @@ def skip_rpi_semantic():
 
 
 def test_select_device_initialized_cuda(monkeypatch):
-    """Select_device must return the requested index once CUDA is initialized, as remapping no longer applies."""
+    """Select_device must honor requested indices across cold-remap, warm-physical, and re-request regimes."""
     from ultralytics.utils import torch_utils
 
     monkeypatch.setattr(torch_utils.torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
     monkeypatch.setattr(torch_utils, "get_gpu_info", lambda i: f"Mock GPU {i}, 1MiB")
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")  # auto-restored after test
+    monkeypatch.setattr(torch_utils, "_CVD_REMAP", None)  # auto-restored after test
+    monkeypatch.setattr(torch_utils, "_CVD_AT_IMPORT", None)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    # Warm process (CUDA initialized by external code): requested index is physical
     monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: True)
     assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"
+    # Repeated warm calls stay physical; the inert env write from the first call must not read as a remap
+    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"
+    # Stale env from a rejected warm call must not authorize a false remap on retry
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+    for _ in range(2):
+        with pytest.raises(ValueError):
+            torch_utils.select_device("2,3", verbose=False)
+    # Cold process: remap via CUDA_VISIBLE_DEVICES
     monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: False)
-    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:0"  # remapped via CUDA_VISIBLE_DEVICES
-    # Re-entrant call after this process already remapped, e.g. trainer then final_eval validator with device=3
+    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:0"  # remapped, GPU 1 is cuda:0
+    # Re-request after our own pre-init remap (trainer then final_eval validator): one visible device
     monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: True)
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 1)
+    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:0"
+    # CUDA_VISIBLE_DEVICES inherited at process start counts as an applied remap
+    monkeypatch.setattr(torch_utils, "_CVD_REMAP", None)
+    monkeypatch.setattr(torch_utils, "_CVD_AT_IMPORT", "3")
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
-    assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"  # index 3 is visible device 0
-    # Post-init env write is a no-op for torch: repeated initialized calls must not misread it as a remap
-    monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
-    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"  # writes CUDA_VISIBLE_DEVICES="1"
-    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"  # still physical index, not a remap
+    assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"
 
 
 def test_model_forward():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -60,6 +60,11 @@ def test_select_device_initialized_cuda(monkeypatch):
     assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"
     monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: False)
     assert str(torch_utils.select_device("1", verbose=False)) == "cuda:0"  # remapped via CUDA_VISIBLE_DEVICES
+    # Re-entrant call after this process already remapped, e.g. trainer then final_eval validator with device=3
+    monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
+    assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"  # index 3 is visible device 0
 
 
 def test_model_forward():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -65,6 +65,11 @@ def test_select_device_initialized_cuda(monkeypatch):
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 1)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
     assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"  # index 3 is visible device 0
+    # Post-init env write is a no-op for torch: repeated initialized calls must not misread it as a remap
+    monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"  # writes CUDA_VISIBLE_DEVICES="1"
+    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"  # still physical index, not a remap
 
 
 def test_model_forward():

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.87"
+__version__ = "8.4.86"
 
 import importlib
 import os

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -220,7 +220,8 @@ def select_device(device="", newline=False, verbose=True):
         if "," in device:
             device = ",".join([x for x in device.split(",") if x])  # remove sequential commas, i.e. "0,,1" -> "0,1"
         visible = os.environ.get("CUDA_VISIBLE_DEVICES", None)
-        remap |= visible == device  # requested devices already remapped by an earlier call in this process
+        # Treat as remapped if an earlier pre-init call already set CUDA_VISIBLE_DEVICES to these exact devices
+        remap |= visible == device and torch.cuda.device_count() == len(device.split(","))
         os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
         valid = (
             torch.cuda.device_count() >= len(device.split(","))

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -220,6 +220,7 @@ def select_device(device="", newline=False, verbose=True):
         if "," in device:
             device = ",".join([x for x in device.split(",") if x])  # remove sequential commas, i.e. "0,,1" -> "0,1"
         visible = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+        remap |= visible == device  # requested devices already remapped by an earlier call in this process
         os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
         valid = (
             torch.cuda.device_count() >= len(device.split(","))

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -134,6 +134,10 @@ def get_gpu_info(index):
     return f"{properties.name}, {properties.total_memory / (1 << 20):.0f}MiB"
 
 
+_CVD_AT_IMPORT = os.environ.get("CUDA_VISIBLE_DEVICES")  # value applied at CUDA init if set before process start
+_CVD_REMAP = None  # device string this process wrote to CUDA_VISIBLE_DEVICES before CUDA init
+
+
 def select_device(device="", newline=False, verbose=True):
     """Select the appropriate PyTorch device based on the provided arguments.
 
@@ -161,6 +165,7 @@ def select_device(device="", newline=False, verbose=True):
     Notes:
         Sets the 'CUDA_VISIBLE_DEVICES' environment variable for specifying which GPUs to use.
     """
+    global _CVD_REMAP
     if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
         return device
 
@@ -220,8 +225,8 @@ def select_device(device="", newline=False, verbose=True):
         if "," in device:
             device = ",".join([x for x in device.split(",") if x])  # remove sequential commas, i.e. "0,,1" -> "0,1"
         visible = os.environ.get("CUDA_VISIBLE_DEVICES", None)
-        # Treat as remapped if an earlier pre-init call already set CUDA_VISIBLE_DEVICES to these exact devices
-        remap |= visible == device and torch.cuda.device_count() == len(device.split(","))
+        # A remap is known applied if this process wrote it pre-init or it was inherited at process start
+        remap = remap or device == _CVD_REMAP or visible == device == _CVD_AT_IMPORT
         os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
         valid = (
             torch.cuda.device_count() >= len(device.split(","))
@@ -245,6 +250,8 @@ def select_device(device="", newline=False, verbose=True):
                 f"\nos.environ['CUDA_VISIBLE_DEVICES']: {visible}\n"
                 f"{install}"
             )
+        if not torch.cuda.is_initialized():
+            _CVD_REMAP = device  # validated pre-init write, takes effect at CUDA init
 
     if not cpu and not mps and torch.cuda.is_available():  # prefer GPU if available
         devices = device.split(",") if device else "0"  # i.e. "0,1" -> ["0", "1"]


### PR DESCRIPTION
## Problem

#24987 broke every training run that selects a nonzero GPU index on a multi-GPU host (e.g. `device=3`). Training completes all epochs, then crashes in `final_eval`:

```
ValueError: Invalid CUDA 'device=3' requested. Use 'device=cpu' or pass valid CUDA device(s) if available...
torch.cuda.is_available(): True
torch.cuda.device_count(): 1
```

This is currently failing production Ultralytics Platform training jobs (100 epochs of work lost at the final-validation step).

## Root cause

`select_device` is called twice per training run with the same original device string:

1. `Trainer.__init__` calls `select_device("3")` before CUDA init → `remap=True` → sets `CUDA_VISIBLE_DEVICES=3` → torch now sees 1 device, physical GPU 3 is `cuda:0`. Training runs fine.
2. `final_eval` → `BaseValidator.__call__` re-calls `select_device(self.args.device)` with the **original** string `"3"`. CUDA is now initialized, so #24987's new non-remap path validates `int("3") < torch.cuda.device_count()` — but `device_count()` is 1 because of the remap in step 1 → hard crash.

The non-remap path added in #24987 assumes the requested index is a physical index, but after this process has already remapped via `CUDA_VISIBLE_DEVICES`, the same string refers to pre-remap numbering.

## Fix

One line: if `CUDA_VISIBLE_DEVICES` already equals the requested device string, this process performed the remap itself — treat the call as remapped (`cuda:0`-relative), exactly like before #24987.

The externally-initialized-CUDA case that #24987 fixed is preserved (its test still passes unchanged); the new test line reproduces the production crash and fails without this fix.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves GPU device selection reliability by tracking valid `CUDA_VISIBLE_DEVICES` remaps across cold and warm CUDA states 🔧

### 📊 Key Changes
- Added internal tracking for `CUDA_VISIBLE_DEVICES` values present at import time and values set by `select_device()` before CUDA initialization.
- Updated `select_device()` logic to only treat GPU indices as remapped when the remap is known to be valid and applied.
- Prevents stale or rejected `CUDA_VISIBLE_DEVICES` values from incorrectly authorizing future GPU remaps.
- Expanded tests to cover:
  - Warm CUDA processes where indices should remain physical.
  - Cold CUDA processes where remapping should apply.
  - Repeated device selection calls.
  - Inherited `CUDA_VISIBLE_DEVICES` values from process startup.
  - Invalid or stale GPU selections raising errors correctly.

### 🎯 Purpose & Impact
- Improves consistency when selecting GPUs in complex workflows like training followed by validation or final evaluation 🚀
- Reduces risk of silently using the wrong GPU due to stale environment variables.
- Makes CUDA behavior safer and more predictable for users running multi-GPU training or long-lived Python processes.
- Helps developers and advanced users avoid confusing device remapping bugs in custom pipelines and CI tests ✅