### PR TITLE
Fix select_device re-request after CUDA_VISIBLE_DEVICES remap applied

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -60,6 +60,11 @@ def test_select_device_initialized_cuda(monkeypatch):
     assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"
     monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: False)
     assert str(torch_utils.select_device("1", verbose=False)) == "cuda:0"  # remapped via CUDA_VISIBLE_DEVICES
+    # Re-request after remap was applied (trainer final_eval): CVD="3" set pre-init, so GPU 3 is cuda:0 of 1 visible
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
+    monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: True)
+    assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"
 
 
 def test_model_forward():

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.85"
+__version__ = "8.4.86"
 
 import importlib
 import os

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -220,6 +220,7 @@ def select_device(device="", newline=False, verbose=True):
         if "," in device:
             device = ",".join([x for x in device.split(",") if x])  # remove sequential commas, i.e. "0,,1" -> "0,1"
         visible = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+        remap = remap or visible == device  # CVD applied at CUDA init (e.g. earlier call) -> indices already remapped
         os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
         valid = (
             torch.cuda.device_count() >= len(device.split(","))


### PR DESCRIPTION
Fixes a production regression from #24987: training with `device=N` sets `CUDA_VISIBLE_DEVICES=N` before CUDA init, remapping GPU N to `cuda:0` with `device_count()=1`. When the validator re-requests the same device after CUDA init (`trainer.final_eval()`), the new physical-index validation rejected it:

```
ValueError: Invalid CUDA 'device=3' requested. ...
torch.cuda.is_available(): True
torch.cuda.device_count(): 1
```

**Fix (1 line):** when `CUDA_VISIBLE_DEVICES` already equals the requested device string, the remap was applied at CUDA init, so indices are validated and returned in the remapped namespace — restoring pre-#24987 behavior for this path while keeping the #24987 fix for genuinely-inert-remap cases.

**Why CI missed it:** GPU runners expose a single GPU at index 0, so `device=0` passes both the remapped and physical validation; the failure requires training on a nonzero GPU index (e.g. `device=3`) and re-calling `select_device` after init. The regression test now covers exactly this scenario (verified failing on main, passing here).

Also bumps version to 8.4.86 for immediate release.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes GPU device selection when `CUDA_VISIBLE_DEVICES` was already applied, improving reliability for CUDA training/evaluation workflows 🚀

### 📊 Key Changes
- Updated `select_device()` logic to detect when the requested CUDA device matches the existing `CUDA_VISIBLE_DEVICES` value 🧠
- Ensures already-remapped CUDA indices are handled correctly after CUDA has been initialized, such as during trainer `final_eval` ✅
- Added a regression test covering re-requesting GPU `"3"` when `CUDA_VISIBLE_DEVICES="3"` is already active and only one GPU is visible 🧪
- Bumped package version from `8.4.85` to `8.4.86` 📦

### 🎯 Purpose & Impact
- Prevents incorrect GPU indexing when CUDA visibility has already been configured ⚙️
- Improves stability for users training or evaluating on specific GPUs in multi-GPU environments 🖥️
- Reduces risk of device selection errors in repeated or downstream calls to `select_device()` 🔁
- Helps ensure smoother Ultralytics YOLO workflows on CUDA systems ✨