### PR TITLE
Add cold-process nonzero-device GPU train test

### DIFF
--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -129,6 +129,21 @@ def test_train():
     assert results is not None
 
 
+@pytest.mark.skipif(not DEVICES or max(DEVICES) == 0, reason="requires an idle CUDA device with nonzero index")
+@pytest.mark.skipif(IS_JETSON, reason="Edge devices not intended for training")
+def test_train_cold_process_nonzero_device():
+    """Train on a nonzero GPU index in a fresh process, where cold CUDA state remaps then re-validates at final_eval.
+
+    A warm pytest process has CUDA initialized with all GPUs visible, so select_device never takes the
+    CUDA_VISIBLE_DEVICES remap path; only a subprocess reproduces real CLI usage (e.g. Platform pods).
+    """
+    import subprocess
+
+    env = {k: v for k, v in os.environ.items() if k != "CUDA_VISIBLE_DEVICES"}
+    cmd = ["yolo", "train", f"model={MODEL}", "data=coco8.yaml", "imgsz=32", "epochs=1", f"device={max(DEVICES)}"]
+    subprocess.run(cmd, check=True, env=env)
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 def test_predict_multiple_devices():


### PR DESCRIPTION
Closes the CI gap that let the #24987 regression (fixed in #25018) reach production.

**Why the GPU job missed it:** `test_train` already trains on a nonzero device index, but by then earlier GPU tests have initialized CUDA with all GPUs visible, so `select_device` consistently takes the post-init physical-index path — the log shows `AutoBatch: Using batch-size 4 for CUDA:2` (not `CUDA:0`). The bug required a **cold process**: first `select_device` call remaps via `CUDA_VISIBLE_DEVICES` (GPU N → `cuda:0`, count=1), then `final_eval` re-validates post-init and rejects index N. Real CLI runs (Platform pods) always start cold; a warm pytest process structurally cannot hit this.

**Fix:** run `yolo train device=<max idle index>` in a subprocess with `CUDA_VISIBLE_DEVICES` unset — exact production profile. Verified logic: this test fails on pre-#25018 main and passes on current main. Skipped automatically on single-GPU/Jetson runners.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a CUDA regression test to ensure YOLO training works correctly on nonzero GPU indices in fresh CLI processes 🚀

### 📊 Key Changes
- Added a new CUDA test: `test_train_cold_process_nonzero_device`.
- Runs `yolo train` in a fresh subprocess using a nonzero GPU device index.
- Clears `CUDA_VISIBLE_DEVICES` from the subprocess environment to better simulate real CLI usage.
- Skips the test when:
  - No suitable nonzero CUDA device is available.
  - Running on Jetson/edge devices, which are not intended for this training scenario.

### 🎯 Purpose & Impact
- Improves test coverage for multi-GPU systems, especially when training starts from a cold CUDA state 🧪
- Helps catch device-selection issues where CUDA device remapping may behave differently in subprocess or CLI workflows.
- Better reflects real-world usage in environments like Ultralytics Platform pods and other containerized training setups ☁️
- Increases confidence that training works reliably when users select GPUs such as `device=1`, `device=2`, etc. 💪