### PR TITLE
Clean-sheet device selection: stop mutating `CUDA_VISIBLE_DEVICES`

### DIFF
--- a/docs/en/reference/utils/torch_utils.md
+++ b/docs/en/reference/utils/torch_utils.md
@@ -40,6 +40,10 @@ keywords: Ultralytics, torch utils, model optimization, device selection, infere
 
 <br><br><hr><br>
 
+## ::: ultralytics.utils.torch_utils.parse_device
+
+<br><br><hr><br>
+
 ## ::: ultralytics.utils.torch_utils.select_device
 
 <br><br><hr><br>

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -119,12 +119,14 @@ def test_export_engine_matrix(task, dynamic, quantize, batch):
 def test_train():
     """Test model training on a minimal dataset using available CUDA devices."""
     device = tuple(DEVICES) if len(DEVICES) > 1 else DEVICES[0]
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
     results = YOLO(MODEL).train(data="coco8-grayscale.yaml", imgsz=64, epochs=1, device=DEVICES[0], batch=-1)
-    results = YOLO(MODEL).train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, compile=True)
+    model = YOLO(MODEL)
+    results = model.train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, compile=True)
+    assert model.trainer.args.device == ",".join(str(d) for d in DEVICES), "trained on wrong GPUs"
+    assert model.trainer.device.index == DEVICES[0], "trained on wrong GPU"
+    assert os.environ.get("CUDA_VISIBLE_DEVICES") == visible, "CUDA_VISIBLE_DEVICES must never be mutated"
     results = YOLO(MODEL).train(data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
-    visible = tuple(int(x) for x in os.environ["CUDA_VISIBLE_DEVICES"].split(","))
-    visible = visible[0] if len(visible) == 1 else visible
-    assert visible == device, f"Passed GPUs '{device}', but used GPUs '{visible}'"
     # Both single-GPU and DDP return metrics (recovered from the saved checkpoint under DDP)
     assert results is not None
 
@@ -132,10 +134,10 @@ def test_train():
 @pytest.mark.skipif(not DEVICES or max(DEVICES) == 0, reason="requires an idle CUDA device with nonzero index")
 @pytest.mark.skipif(IS_JETSON, reason="Edge devices not intended for training")
 def test_train_cold_process_nonzero_device():
-    """Train on a nonzero GPU index in a fresh process, where cold CUDA state remaps then re-validates at final_eval.
+    """Train on a nonzero GPU index in a fresh process with cold CUDA state, reproducing real CLI usage.
 
-    A warm pytest process has CUDA initialized with all GPUs visible, so select_device never takes the
-    CUDA_VISIBLE_DEVICES remap path; only a subprocess reproduces real CLI usage (e.g. Platform pods).
+    A warm pytest process has CUDA initialized, so a subprocess without CUDA_VISIBLE_DEVICES is the only way to
+    reproduce cold-start device selection as on production pods (e.g. Ultralytics Platform).
     """
     import subprocess
 

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -13,7 +13,7 @@ from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS
 from ultralytics.utils import ASSETS, IS_JETSON, WEIGHTS_DIR
 from ultralytics.utils.autodevice import GPUInfo
 from ultralytics.utils.checks import check_amp, check_tensorrt
-from ultralytics.utils.torch_utils import TORCH_1_13
+from ultralytics.utils.torch_utils import TORCH_1_13, parse_device
 
 # Try to find idle devices if CUDA is available
 DEVICES = []
@@ -119,12 +119,13 @@ def test_export_engine_matrix(task, dynamic, quantize, batch):
 def test_train():
     """Test model training on a minimal dataset using available CUDA devices."""
     device = tuple(DEVICES) if len(DEVICES) > 1 else DEVICES[0]
+    expected = parse_device(device)  # canonical torch indices, e.g. physical ids translate under external CVD
     visible = os.environ.get("CUDA_VISIBLE_DEVICES")
     results = YOLO(MODEL).train(data="coco8-grayscale.yaml", imgsz=64, epochs=1, device=DEVICES[0], batch=-1)
     model = YOLO(MODEL)
     results = model.train(data="coco8.yaml", imgsz=64, epochs=1, device=device, batch=15, compile=True)
-    assert model.trainer.args.device == ",".join(str(d) for d in DEVICES), "trained on wrong GPUs"
-    assert model.trainer.device.index == DEVICES[0], "trained on wrong GPU"
+    assert model.trainer.args.device == expected, "trained on wrong GPUs"
+    assert model.trainer.device.index == int(expected.split(",")[0]), "trained on wrong GPU"
     assert os.environ.get("CUDA_VISIBLE_DEVICES") == visible, "CUDA_VISIBLE_DEVICES must never be mutated"
     results = YOLO(MODEL).train(data="coco128.yaml", imgsz=64, epochs=1, device=device, batch=15, val=False)
     # Both single-GPU and DDP return metrics (recovered from the saved checkpoint under DDP)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -75,6 +75,9 @@ def test_select_device(monkeypatch):
     assert str(torch_utils.select_device(torch.device("cuda", 1), verbose=False)) == "cuda:1"
     with pytest.raises(ValueError):  # torch.device inputs are validated like strings, no raw CUDA errors
         torch_utils.select_device(torch.device("cuda", 3), verbose=False)
+    set_calls.clear()
+    assert str(torch_utils.select_device(torch.device("cuda"), verbose=False)) == "cuda:1"
+    assert not set_calls  # indexless torch.device('cuda') means the current device and never moves it
     assert torch_utils.parse_device([0, 1]) == "0,1"
     assert torch_utils.parse_device("00,01") == "0,1"  # leading zeros stripped for valid torch device strings
     # Physical GPU ids under an external CUDA_VISIBLE_DEVICES restriction translate to torch indices

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -89,13 +89,16 @@ def test_select_device(monkeypatch):
 
     monkeypatch.setattr(autodevice.GPUInfo, "__init__", lambda self: None)
     monkeypatch.setattr(
-        autodevice.GPUInfo, "select_idle_gpu", lambda self, indices=None, **kw: [i for i in (0, 3) if i in indices]
+        autodevice.GPUInfo,
+        "select_idle_gpu",
+        lambda self, count=1, indices=None, **kw: [i for i in (0, 1, 3) if i in indices][:count],
     )
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
-    assert torch_utils.parse_device("-1") == "1"  # physical GPU 3 is torch index 1 under CVD='1,3'; hidden 0 excluded
-    assert torch_utils.parse_device("1") == "0"  # ids matching visible physical GPUs resolve as physical GPU ids
-    assert torch_utils.parse_device("-1,1") == "1,0"  # mixed auto + explicit physical ids translate together
+    assert torch_utils.parse_device("-1") == "0"  # idle physical GPU 1 is torch index 0 under CVD='1,3'; 0 is hidden
+    assert torch_utils.parse_device("1") == "1"  # in-range ids are torch indices, so repeated parses are stable
+    assert torch_utils.parse_device("-1,3") == "0,1"  # mixed: idle physical GPU 1 + physical GPU 3 as torch indices
+    assert torch_utils.parse_device("0,1") == "0,1"  # already-translated outputs re-parse unchanged (idempotent)
 
 
 def test_model_forward():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -48,23 +48,29 @@ def skip_rpi_semantic():
         pytest.skip("Semantic segmentation tests are skipped on Raspberry Pi due to memory constraints.")
 
 
-def test_select_device_initialized_cuda(monkeypatch):
-    """Select_device must return the requested index once CUDA is initialized, as remapping no longer applies."""
+def test_select_device(monkeypatch):
+    """The same device string must resolve to the same GPU on every call, and the environment is never mutated."""
+    import os
+
     from ultralytics.utils import torch_utils
 
     monkeypatch.setattr(torch_utils.torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(torch_utils.torch.cuda, "set_device", lambda i: None)
     monkeypatch.setattr(torch_utils, "get_gpu_info", lambda i: f"Mock GPU {i}, 1MiB")
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")  # auto-restored after test
-    monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: True)
-    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"
-    monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: False)
-    assert str(torch_utils.select_device("1", verbose=False)) == "cuda:0"  # remapped via CUDA_VISIBLE_DEVICES
-    # Re-request after remap was applied (trainer final_eval): CVD="3" set pre-init, so GPU 3 is cuda:0 of 1 visible
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    for _ in range(2):  # repeated calls are idempotent, e.g. Trainer.__init__ then final_eval, or predict() twice
+        assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"
+        with pytest.raises(ValueError):
+            torch_utils.select_device("3", verbose=False)
+        assert os.environ.get("CUDA_VISIBLE_DEVICES") is None  # CUDA_VISIBLE_DEVICES never written
+    assert torch_utils.parse_device([0, 1]) == "0,1"
+    # Physical GPU ids hidden by an external CUDA_VISIBLE_DEVICES restriction translate to torch indices
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+    assert str(torch_utils.select_device("3", verbose=False)) == "cuda:1"
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 1)
-    monkeypatch.setattr(torch_utils.torch.cuda, "is_initialized", lambda: True)
-    assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"
+    assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"  # e.g. pods launched with CVD preset
 
 
 def test_model_forward():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -87,7 +87,7 @@ def test_select_device(monkeypatch):
     # '-1' idle-GPU auto-selection searches only externally visible GPUs and translates physical ids to torch indices
     from ultralytics.utils import autodevice
 
-    monkeypatch.setattr(autodevice.GPUInfo, "__init__", lambda self: None)
+    monkeypatch.setattr(autodevice.GPUInfo, "__init__", lambda self: self.__dict__.update(nvml_available=False))
     monkeypatch.setattr(
         autodevice.GPUInfo,
         "select_idle_gpu",

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -80,6 +80,7 @@ def test_select_device(monkeypatch):
     assert not set_calls  # indexless torch.device('cuda') means the current device and never moves it
     assert torch_utils.parse_device([0, 1]) == "0,1"
     assert torch_utils.parse_device("00,01") == "0,1"  # leading zeros stripped for valid torch device strings
+    assert torch_utils.parse_device(torch.device("cuda")) == ""  # indexless 'cuda' stays the '' default request
     # Physical GPU ids under an external CUDA_VISIBLE_DEVICES restriction translate to torch indices
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
     assert str(torch_utils.select_device("3", verbose=False)) == "cuda:1"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -65,6 +65,7 @@ def test_select_device(monkeypatch):
             torch_utils.select_device("3", verbose=False)
         assert os.environ.get("CUDA_VISIBLE_DEVICES") is None  # CUDA_VISIBLE_DEVICES never written
     assert torch_utils.parse_device([0, 1]) == "0,1"
+    assert torch_utils.parse_device("00,01") == "0,1"  # leading zeros stripped for valid torch device strings
     # Physical GPU ids hidden by an external CUDA_VISIBLE_DEVICES restriction translate to torch indices
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
     assert str(torch_utils.select_device("3", verbose=False)) == "cuda:1"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -72,6 +72,14 @@ def test_select_device(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 1)
     assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"  # e.g. pods launched with CVD preset
+    # '-1' idle-GPU auto-selection returns physical ids, which also translate under an external restriction
+    from ultralytics.utils import autodevice
+
+    monkeypatch.setattr(autodevice.GPUInfo, "__init__", lambda self: None)
+    monkeypatch.setattr(autodevice.GPUInfo, "select_idle_gpu", lambda self, **kwargs: [3])
+    monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
+    assert torch_utils.parse_device("-1") == "1"  # physical GPU 3 is torch index 1 under CVD='1,3'
 
 
 def test_model_forward():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -54,16 +54,20 @@ def test_select_device(monkeypatch):
 
     from ultralytics.utils import torch_utils
 
+    set_calls = []
     monkeypatch.setattr(torch_utils.torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
-    monkeypatch.setattr(torch_utils.torch.cuda, "set_device", lambda i: None)
+    monkeypatch.setattr(torch_utils.torch.cuda, "set_device", set_calls.append)
     monkeypatch.setattr(torch_utils, "get_gpu_info", lambda i: f"Mock GPU {i}, 1MiB")
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    assert str(torch_utils.select_device("", verbose=False)) == "cuda:0"
+    assert not set_calls  # default '' request must never move the current device, e.g. diagnostics like check_yolo()
     for _ in range(2):  # repeated calls are idempotent, e.g. Trainer.__init__ then final_eval, or predict() twice
         assert str(torch_utils.select_device("1", verbose=False)) == "cuda:1"
         with pytest.raises(ValueError):
             torch_utils.select_device("3", verbose=False)
         assert os.environ.get("CUDA_VISIBLE_DEVICES") is None  # CUDA_VISIBLE_DEVICES never written
+    assert set_calls == [1, 1]  # explicit requests set the default device for indexless 'cuda' operations
     assert torch_utils.parse_device([0, 1]) == "0,1"
     assert torch_utils.parse_device("00,01") == "0,1"  # leading zeros stripped for valid torch device strings
     # Physical GPU ids hidden by an external CUDA_VISIBLE_DEVICES restriction translate to torch indices
@@ -72,14 +76,16 @@ def test_select_device(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 1)
     assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"  # e.g. pods launched with CVD preset
-    # '-1' idle-GPU auto-selection returns physical ids, which also translate under an external restriction
+    # '-1' idle-GPU auto-selection searches only externally visible GPUs and translates physical ids to torch indices
     from ultralytics.utils import autodevice
 
     monkeypatch.setattr(autodevice.GPUInfo, "__init__", lambda self: None)
-    monkeypatch.setattr(autodevice.GPUInfo, "select_idle_gpu", lambda self, **kwargs: [3])
+    monkeypatch.setattr(
+        autodevice.GPUInfo, "select_idle_gpu", lambda self, indices=None, **kw: [i for i in (0, 3) if i in indices]
+    )
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
-    assert torch_utils.parse_device("-1") == "1"  # physical GPU 3 is torch index 1 under CVD='1,3'
+    assert torch_utils.parse_device("-1") == "1"  # physical GPU 3 is torch index 1 under CVD='1,3'; hidden 0 excluded
 
 
 def test_model_forward():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import csv
+import os
 import shutil
 import tarfile
 import urllib
@@ -50,13 +51,12 @@ def skip_rpi_semantic():
 
 def test_select_device(monkeypatch):
     """The same device string must resolve to the same GPU on every call, and the environment is never mutated."""
-    import os
-
     from ultralytics.utils import torch_utils
 
     set_calls = []
     monkeypatch.setattr(torch_utils.torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(torch_utils.torch.cuda, "current_device", lambda: 0)
     monkeypatch.setattr(torch_utils.torch.cuda, "set_device", set_calls.append)
     monkeypatch.setattr(torch_utils, "get_gpu_info", lambda i: f"Mock GPU {i}, 1MiB")
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
@@ -67,15 +67,23 @@ def test_select_device(monkeypatch):
         with pytest.raises(ValueError):
             torch_utils.select_device("3", verbose=False)
         assert os.environ.get("CUDA_VISIBLE_DEVICES") is None  # CUDA_VISIBLE_DEVICES never written
-    assert set_calls == [1, 1]  # explicit requests set the default device for indexless 'cuda' operations
+    assert set_calls == [1, 1]  # explicit single-GPU requests set the default device for indexless 'cuda' operations
+    assert str(torch_utils.select_device("0,1", verbose=False)) == "cuda:0"
+    assert set_calls == [1, 1]  # multi-GPU requests never move the current device; DDP ranks pin theirs in _setup_ddp
+    monkeypatch.setattr(torch_utils.torch.cuda, "current_device", lambda: 1)
+    assert str(torch_utils.select_device("", verbose=False)) == "cuda:1"  # default '' resolves to the current device
+    assert str(torch_utils.select_device(torch.device("cuda", 1), verbose=False)) == "cuda:1"
+    with pytest.raises(ValueError):  # torch.device inputs are validated like strings, no raw CUDA errors
+        torch_utils.select_device(torch.device("cuda", 3), verbose=False)
     assert torch_utils.parse_device([0, 1]) == "0,1"
     assert torch_utils.parse_device("00,01") == "0,1"  # leading zeros stripped for valid torch device strings
-    # Physical GPU ids hidden by an external CUDA_VISIBLE_DEVICES restriction translate to torch indices
+    # Physical GPU ids under an external CUDA_VISIBLE_DEVICES restriction translate to torch indices
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
     assert str(torch_utils.select_device("3", verbose=False)) == "cuda:1"
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 1)
     assert str(torch_utils.select_device("3", verbose=False)) == "cuda:0"  # e.g. pods launched with CVD preset
+    assert torch_utils.parse_device(torch_utils.parse_device("3")) == "0"  # idempotent: trainer + select_device parse
     # '-1' idle-GPU auto-selection searches only externally visible GPUs and translates physical ids to torch indices
     from ultralytics.utils import autodevice
 
@@ -86,6 +94,8 @@ def test_select_device(monkeypatch):
     monkeypatch.setattr(torch_utils.torch.cuda, "device_count", lambda: 2)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
     assert torch_utils.parse_device("-1") == "1"  # physical GPU 3 is torch index 1 under CVD='1,3'; hidden 0 excluded
+    assert torch_utils.parse_device("1") == "0"  # ids matching visible physical GPUs resolve as physical GPU ids
+    assert torch_utils.parse_device("-1,1") == "1,0"  # mixed auto + explicit physical ids translate together
 
 
 def test_model_forward():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -99,6 +99,9 @@ def test_select_device(monkeypatch):
     assert torch_utils.parse_device("1") == "1"  # in-range ids are torch indices, so repeated parses are stable
     assert torch_utils.parse_device("-1,3") == "0,1"  # mixed: idle physical GPU 1 + physical GPU 3 as torch indices
     assert torch_utils.parse_device("0,1") == "0,1"  # already-translated outputs re-parse unchanged (idempotent)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,2,9,1")  # malformed: CUDA stops at the invalid id 9, 2 usable GPUs
+    assert torch_utils.parse_device("9") == "9"  # unusable id is not translated, so select_device rejects it
+    assert torch_utils.parse_device("2") == "1"  # physical GPU 2 is torch index 1 of the usable prefix
 
 
 def test_model_forward():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -102,6 +102,9 @@ def test_select_device(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,2,9,1")  # malformed: CUDA stops at the invalid id 9, 2 usable GPUs
     assert torch_utils.parse_device("9") == "9"  # unusable id is not translated, so select_device rejects it
     assert torch_utils.parse_device("2") == "1"  # physical GPU 2 is torch index 1 of the usable prefix
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "01,03")  # leading zeros are valid for CUDA's atoi-style parsing
+    assert torch_utils.parse_device("3") == "1"  # visible ids normalize like requested ids
+    assert torch_utils.parse_device("-1") == "0"  # idle physical GPU 1 found via normalized visible ids
 
 
 def test_model_forward():

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.86"
+__version__ = "8.4.87"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1253,6 +1253,7 @@ class Exporter:
             quantize=self.args.quantize,
             images=images,
             disable_group_convolution=self.args.format == "edgetpu",
+            cuda=self.device.type == "cuda",
             prefix=prefix,
         )
         YAML.save(f / "metadata.yaml", self.metadata)  # add metadata.yaml

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -57,6 +57,7 @@ from ultralytics.utils.torch_utils import (
     convert_optimizer_state_dict_to_fp16,
     init_seeds,
     one_cycle,
+    parse_device,
     select_device,
     strip_optimizer,
     torch_distributed_zero_first,
@@ -126,9 +127,8 @@ class BaseTrainer:
         self.hub_session = overrides.pop("session", None)  # HUB
         self.args = get_cfg(cfg, overrides)
         self.check_resume(overrides)
+        self.args.device = parse_device(self.args.device)  # canonical string, resolves '-1' auto-selection once
         self.device = select_device(self.args.device)
-        # Update "-1" devices so post-training val does not repeat search
-        self.args.device = os.getenv("CUDA_VISIBLE_DEVICES") if "cuda" in str(self.device) else str(self.device)
         self.validator = None
         self.metrics = None
         self.plots = {}
@@ -163,16 +163,10 @@ class BaseTrainer:
         # Callbacks - initialize early so on_pretrain_routine_start can capture original args.data
         self.callbacks = _callbacks or callbacks.get_default_callbacks()
 
-        if isinstance(self.args.device, str) and len(self.args.device):  # i.e. device='0' or device='0,1,2,3'
-            world_size = len(self.args.device.split(","))
-        elif isinstance(self.args.device, (tuple, list)):  # i.e. device=[0, 1, 2, 3] (multi-GPU from CLI is list)
-            world_size = len(self.args.device)
-        elif self.args.device in {"cpu", "mps"}:  # i.e. device='cpu' or 'mps'
+        if self.device.type in {"cpu", "mps"}:
             world_size = 0
-        elif torch.cuda.is_available():  # i.e. device=None or device='' or device=number
-            world_size = 1  # default to device 0
-        else:  # i.e. device=None or device=''
-            world_size = 0
+        else:  # i.e. device='0', '0,1,2,3', 'npu:0', or '' auto-selecting a single GPU
+            world_size = len(self.args.device.split(",")) if self.args.device else 1
 
         self.ddp = world_size > 1 and "LOCAL_RANK" not in os.environ
         self.world_size = world_size
@@ -256,8 +250,9 @@ class BaseTrainer:
 
     def _setup_ddp(self):
         """Initialize and set the DistributedDataParallel parameters for training."""
-        torch.cuda.set_device(RANK)
-        self.device = torch.device("cuda", RANK)
+        index = int(self.args.device.split(",")[LOCAL_RANK]) if self.args.device else LOCAL_RANK
+        torch.cuda.set_device(index)
+        self.device = torch.device("cuda", index)
         os.environ["TORCH_NCCL_BLOCKING_WAIT"] = "1"  # set to enforce timeout
         dist.init_process_group(
             backend="nccl" if dist.is_nccl_available() else "gloo",
@@ -361,7 +356,7 @@ class BaseTrainer:
             # o2m+o2o pose loss branches) under torch.compile.
             self.model = nn.parallel.DistributedDataParallel(
                 self.model,
-                device_ids=[RANK],
+                device_ids=[self.device.index],
                 static_graph=bool(self.args.compile),
                 find_unused_parameters=not bool(self.args.compile),
             )

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -250,7 +250,7 @@ class BaseTrainer:
 
     def _setup_ddp(self):
         """Initialize and set the DistributedDataParallel parameters for training."""
-        index = int(self.args.device.split(",")[LOCAL_RANK]) if self.args.device else LOCAL_RANK
+        index = int(self.args.device.split(",")[LOCAL_RANK])  # world_size > 1 guarantees a multi-device string
         torch.cuda.set_device(index)
         self.device = torch.device("cuda", index)
         os.environ["TORCH_NCCL_BLOCKING_WAIT"] = "1"  # set to enforce timeout

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -178,7 +178,10 @@ class BaseValidator:
                 self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
             model = AutoBackend(
                 model=model or self.args.model,
-                device=select_device(self.args.device, verbose=RANK == -1),
+                # DDP ranks reuse the device assigned in trainer._setup_ddp() via torch.cuda.set_device()
+                device=select_device(self.args.device)
+                if RANK == -1
+                else torch.device("cuda", torch.cuda.current_device()),
                 dnn=self.args.dnn,
                 data=self.args.data,
                 fp16=self.args.quantize == 16,

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -178,7 +178,7 @@ class BaseValidator:
                 self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
             model = AutoBackend(
                 model=model or self.args.model,
-                device=select_device(self.args.device) if RANK == -1 else torch.device("cuda", RANK),
+                device=select_device(self.args.device, verbose=RANK == -1),
                 dnn=self.args.dnn,
                 data=self.args.data,
                 fp16=self.args.quantize == 16,

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -170,7 +170,7 @@ class BOTSORT(BYTETracker):
         # ReID module
         self.proximity_thresh = args.proximity_thresh
         self.appearance_thresh = args.appearance_thresh
-        self.encoder = build_encoder(args.with_reid, args.model)
+        self.encoder = build_encoder(args.with_reid, args.model, getattr(args, "device", None))
 
     def get_kalmanfilter(self) -> KalmanFilterXYWH:
         """Return an instance of KalmanFilterXYWH for predicting and updating object states in the tracking process."""

--- a/ultralytics/trackers/deep_oc_sort.py
+++ b/ultralytics/trackers/deep_oc_sort.py
@@ -180,7 +180,9 @@ class DeepOCSORT(OCSORT):
         self.appearance_thresh = getattr(args, "appearance_thresh", 0.75)
         self.alpha_fixed_emb = getattr(args, "alpha_fixed_emb", 0.95)
 
-        self.encoder = build_encoder(getattr(args, "with_reid", False), getattr(args, "model", "auto"))
+        self.encoder = build_encoder(
+            getattr(args, "with_reid", False), getattr(args, "model", "auto"), getattr(args, "device", None)
+        )
 
     def init_track(self, results, img: np.ndarray | None = None) -> list[DeepOCSortTrack]:
         """Build `DeepOCSortTrack` instances, attaching ReID features when enabled.

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -46,6 +46,7 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
 
     tracker = check_yaml(predictor.args.tracker)
     cfg = IterableSimpleNamespace(**YAML.load(tracker))
+    cfg.device = predictor.device  # run any ReID encoder on the predictor's device
 
     if cfg.tracker_type not in TRACKER_MAP:
         raise AssertionError(f"Only {sorted(TRACKER_MAP)} are supported for now, but got '{cfg.tracker_type}'")

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -388,7 +388,9 @@ class TRACKTRACK:
 
         from .utils.reid import build_encoder
 
-        self.encoder = build_encoder(getattr(args, "with_reid", False), getattr(args, "model", "auto"))
+        self.encoder = build_encoder(
+            getattr(args, "with_reid", False), getattr(args, "model", "auto"), getattr(args, "device", None)
+        )
 
     @classmethod
     def setup_predictor(cls, predictor):

--- a/ultralytics/trackers/utils/reid.py
+++ b/ultralytics/trackers/utils/reid.py
@@ -46,7 +46,7 @@ class ReID:
 
             self.model = YOLO(model)
             # Initialize predictor with embed=[idx] so subsequent calls return embeddings.
-            self.model(embed=[len(self.model.model.model) - 2], verbose=False, save=False)
+            self.model(embed=[len(self.model.model.model) - 2], device=self.device, verbose=False, save=False)
             self.fp16 = False
         else:
             from pathlib import Path
@@ -116,13 +116,14 @@ class ReID:
         return [f.cpu().numpy() for f in feats]
 
 
-def build_encoder(with_reid: bool, model: str | None):
+def build_encoder(with_reid: bool, model: str | None, device: str | torch.device | None = None):
     """Return a ReID encoder, the native-features pass-through, or None.
 
     Args:
         with_reid (bool): Whether ReID is enabled at all.
         model (str | None): `"auto"` returns a callable that converts pre-extracted backbone features to numpy arrays;
             any other value loads a `ReID` model from that path. Ignored when `with_reid` is False.
+        device (str | torch.device | None): Inference device for the ReID model; defaults to CUDA if available.
 
     Returns:
         (Callable | None): A `(img, dets) -> list[np.ndarray]` encoder, or None when ReID is disabled.
@@ -137,7 +138,7 @@ def build_encoder(with_reid: bool, model: str | None):
             return [f.cpu().numpy() for f in feats]
 
         return _auto_encoder
-    return ReID(model)
+    return ReID(model, device=device)
 
 
 def smooth_feature(

--- a/ultralytics/utils/autobatch.py
+++ b/ultralytics/utils/autobatch.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from copy import deepcopy
 
 import numpy as np
@@ -82,7 +81,7 @@ def autobatch(
 
     # Inspect CUDA memory
     gb = 1 << 30  # bytes to GiB (1024 ** 3)
-    d = f"CUDA:{os.getenv('CUDA_VISIBLE_DEVICES', '0').strip()[0]}"  # 'CUDA:0'
+    d = f"CUDA:{device.index}"  # 'CUDA:0'
     properties = torch.cuda.get_device_properties(device)  # device properties
     t = properties.total_memory / gb  # GiB total
     r = torch.cuda.memory_reserved(device) / gb  # GiB reserved

--- a/ultralytics/utils/autodevice.py
+++ b/ultralytics/utils/autodevice.py
@@ -134,7 +134,11 @@ class GPUInfo:
         LOGGER.info(f"{'-' * len(hdr)}\n")
 
     def select_idle_gpu(
-        self, count: int = 1, min_memory_fraction: float = 0, min_util_fraction: float = 0
+        self,
+        count: int = 1,
+        min_memory_fraction: float = 0,
+        min_util_fraction: float = 0,
+        indices: list[int] | None = None,
     ) -> list[int]:
         """Select the most idle GPUs based on utilization and free memory.
 
@@ -142,6 +146,8 @@ class GPUInfo:
             count (int): The number of idle GPUs to select.
             min_memory_fraction (float): Minimum free memory required as a fraction of total memory.
             min_util_fraction (float): Minimum free utilization rate required from 0.0 - 1.0.
+            indices (list[int] | None): Restrict selection to these GPU indices, e.g. the GPUs visible under an
+                external CUDA_VISIBLE_DEVICES restriction. None searches all GPUs.
 
         Returns:
             (list[int]): Indices of the selected GPUs, sorted by idleness (lowest utilization first).
@@ -169,7 +175,8 @@ class GPUInfo:
         eligible_gpus = [
             gpu
             for gpu in self.gpu_stats
-            if gpu.get("memory_free", 0) / gpu.get("memory_total", 1) >= min_memory_fraction
+            if (indices is None or gpu["index"] in indices)
+            and gpu.get("memory_free", 0) / gpu.get("memory_total", 1) >= min_memory_fraction
             and (100 - gpu.get("utilization", 100)) >= min_util_fraction * 100
         ]
         # Random tiebreaker prevents race conditions when multiple processes start simultaneously

--- a/ultralytics/utils/autodevice.py
+++ b/ultralytics/utils/autodevice.py
@@ -146,8 +146,8 @@ class GPUInfo:
             count (int): The number of idle GPUs to select.
             min_memory_fraction (float): Minimum free memory required as a fraction of total memory.
             min_util_fraction (float): Minimum free utilization rate required from 0.0 - 1.0.
-            indices (list[int] | None): Restrict selection to these GPU indices, e.g. the GPUs visible under an
-                external CUDA_VISIBLE_DEVICES restriction. None searches all GPUs.
+            indices (list[int] | None): Restrict selection to these GPU indices, e.g. the GPUs visible under an external
+                CUDA_VISIBLE_DEVICES restriction. None searches all GPUs.
 
         Returns:
             (list[int]): Indices of the selected GPUs, sorted by idleness (lowest utilization first).

--- a/ultralytics/utils/export/paddle.py
+++ b/ultralytics/utils/export/paddle.py
@@ -33,11 +33,16 @@ def torch2paddle(
 
     check_requirements(
         (
-            "paddlepaddle-gpu>=3.0.0,<3.3.0"  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
-            if im.device.type == "cuda"
-            else "paddlepaddle==3.0.0"  # pin 3.0.0 for ARM64
-            if ARM64
-            else "paddlepaddle>=3.0.0,<3.3.0",  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
+            # Interchangeable candidates so an installed variant is never dual-installed over (both ship 'paddle')
+            (
+                "paddlepaddle-gpu>=3.0.0,<3.3.0"  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
+                if im.device.type == "cuda"
+                else "paddlepaddle==3.0.0"  # pin 3.0.0 for ARM64
+                if ARM64
+                else "paddlepaddle>=3.0.0,<3.3.0",  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
+                "paddlepaddle>=3.0.0,<3.3.0",
+                "paddlepaddle-gpu>=3.0.0,<3.3.0",
+            ),
             "x2paddle",
         )
     )

--- a/ultralytics/utils/export/paddle.py
+++ b/ultralytics/utils/export/paddle.py
@@ -34,7 +34,7 @@ def torch2paddle(
     check_requirements(
         (
             "paddlepaddle-gpu>=3.0.0,<3.3.0"  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
-            if torch.cuda.is_available()
+            if im.device.type == "cuda"
             else "paddlepaddle==3.0.0"  # pin 3.0.0 for ARM64
             if ARM64
             else "paddlepaddle>=3.0.0,<3.3.0",  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340

--- a/ultralytics/utils/export/paddle.py
+++ b/ultralytics/utils/export/paddle.py
@@ -40,7 +40,7 @@ def torch2paddle(
                 else "paddlepaddle==3.0.0"  # pin 3.0.0 for ARM64
                 if ARM64
                 else "paddlepaddle>=3.0.0,<3.3.0",  # pin <3.3.0 https://github.com/PaddlePaddle/Paddle/issues/77340
-                "paddlepaddle>=3.0.0,<3.3.0",
+                "paddlepaddle==3.0.0" if ARM64 else "paddlepaddle>=3.0.0,<3.3.0",
                 "paddlepaddle-gpu>=3.0.0,<3.3.0",
             ),
             "x2paddle",

--- a/ultralytics/utils/export/tensorflow.py
+++ b/ultralytics/utils/export/tensorflow.py
@@ -69,6 +69,7 @@ def onnx2saved_model(
     quantize: int | str | None = None,
     images: np.ndarray | None = None,
     disable_group_convolution: bool = False,
+    cuda: bool = False,
     prefix: str = "",
 ):
     """Convert an ONNX model to TensorFlow SavedModel format using onnx2tf.
@@ -79,6 +80,7 @@ def onnx2saved_model(
         quantize (int | str | None): Precision scheme, 8 for INT8.
         images (np.ndarray | None, optional): Calibration images for INT8 quantization in BHWC format.
         disable_group_convolution (bool, optional): Disable group convolution optimization. Defaults to False.
+        cuda (bool, optional): True if exporting on a CUDA device, selects GPU onnxruntime. Defaults to False.
         prefix (str, optional): Logging prefix. Defaults to "".
 
     Returns:
@@ -89,7 +91,6 @@ def onnx2saved_model(
         - Downloads calibration data if INT8 quantization is enabled.
         - Removes temporary files and renames quantized models after conversion.
     """
-    cuda = torch.cuda.is_available()
     try:
         import tensorflow as tf
     except ImportError:

--- a/ultralytics/utils/export/tensorflow.py
+++ b/ultralytics/utils/export/tensorflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from functools import partial
 from pathlib import Path
 
@@ -80,7 +81,8 @@ def onnx2saved_model(
         quantize (int | str | None): Precision scheme, 8 for INT8.
         images (np.ndarray | None, optional): Calibration images for INT8 quantization in BHWC format.
         disable_group_convolution (bool, optional): Disable group convolution optimization. Defaults to False.
-        cuda (bool, optional): True if exporting on a CUDA device, selects GPU onnxruntime. Defaults to False.
+        cuda (bool, optional): True if exporting on a CUDA device; selects GPU onnxruntime and keeps GPUs visible to
+            TensorFlow, which are otherwise hidden so CPU exports never touch GPU memory. Defaults to False.
         prefix (str, optional): Logging prefix. Defaults to "".
 
     Returns:
@@ -96,6 +98,9 @@ def onnx2saved_model(
     except ImportError:
         check_requirements("tensorflow>2.19.0" if IS_PYTHON_MINIMUM_3_13 else "tensorflow>=2.0.0,<=2.19.0")
         import tensorflow as tf
+    if not cuda:
+        with contextlib.suppress(Exception):  # fails only if TF GPUs are already initialized by earlier user code
+            tf.config.set_visible_devices([], "GPU")  # hide GPUs so non-CUDA exports never allocate GPU memory
     check_requirements(
         f"onnx2tf{'>=2.3.0,<2.3.16' if IS_PYTHON_MINIMUM_3_13 else '>=1.26.3,<1.29.0'}",  # pin to avoid h5py build issues on aarch64
         cmds="--no-deps",
@@ -109,7 +114,8 @@ def onnx2saved_model(
             "onnx>=1.12.0,<2.0.0",
             f"onnx2tf{'>=2.3.0,<2.3.16' if IS_PYTHON_MINIMUM_3_13 else '>=1.26.3,<1.29.0'}",
             "onnxslim>=0.1.82",
-            "onnxruntime-gpu" if cuda else "onnxruntime",
+            # Interchangeable candidates so an installed variant (e.g. onnxruntime-gpu) is never dual-installed over
+            ("onnxruntime-gpu" if cuda else "onnxruntime", "onnxruntime", "onnxruntime-gpu", "onnxruntime-qnn"),
             "protobuf>=6.31.1,<7.0.0"
             if IS_PYTHON_MINIMUM_3_13
             else "protobuf>=5",  # TF>2.19 (Python 3.13) needs protobuf>=6.31.1; cap <7 to match TF gencode and avoid PaddlePaddle segfault

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -161,25 +161,22 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
         device = device.replace(remove, "")  # to string, 'cuda:0' -> '0' and '(0, 1)' -> '0,1'
     if device == "cuda":
         device = "0"
-    if "," in device:
-        device = ",".join(x for x in device.split(",") if x)  # remove sequential commas, i.e. "0,,1" -> "0,1"
-    device = ",".join(str(int(x)) if x.isdigit() else x for x in device.split(","))  # strip leading zeros, "00" -> "0"
+    device = ",".join(str(int(x)) if x.isdigit() else x for x in device.split(",") if x)  # "0,,01" -> "0,1"
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "").split(",")
     if "-1" in device:
         from ultralytics.utils.autodevice import GPUInfo
 
         # Replace each -1 with a selected idle GPU or remove it; GPUInfo returns physical NVML ids
         parts = device.split(",")
         selected = GPUInfo().select_idle_gpu(count=parts.count("-1"), min_memory_fraction=0.2)
-        if visible := os.environ.get("CUDA_VISIBLE_DEVICES"):  # translate physical ids to torch indices
-            vis = visible.replace(" ", "").split(",")
-            selected = [vis.index(str(x)) for x in selected if str(x) in vis]
+        if visible != [""]:  # external CUDA_VISIBLE_DEVICES set -> translate physical ids to torch indices
+            selected = [visible.index(str(x)) for x in selected if str(x) in visible]
         for i in range(len(parts)):
             if parts[i] == "-1":
                 parts[i] = str(selected.pop(0)) if selected else ""
         device = ",".join(p for p in parts if p)
     indices = device.split(",")
     if device and all(x.isdigit() for x in indices) and any(int(x) >= torch.cuda.device_count() for x in indices):
-        visible = os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "").split(",")
         if all(x in visible for x in indices):  # physical GPU ids under an external CUDA_VISIBLE_DEVICES restriction
             device = ",".join(str(visible.index(x)) for x in indices)  # translate to torch indices
     return device

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -152,11 +152,12 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
         '0,1'
 
     Notes:
-        Each '-1' is replaced with an idle GPU index. When an external CUDA_VISIBLE_DEVICES restriction is active and
-        every requested id matches a visible physical GPU id, ids resolve as physical GPU ids and are translated to
-        the corresponding torch indices, e.g. '3' -> '0' when CUDA_VISIBLE_DEVICES='3'; all other requests are torch
-        indices. Returned indices are relative to the active restriction, so strings persisted under one environment
-        (e.g. resumed checkpoint args) address the same physical GPUs only in that environment.
+        Each '-1' is replaced with an idle GPU index. Requested ids exceeding the torch device count that match
+        physical GPU ids visible under an external CUDA_VISIBLE_DEVICES restriction are translated to the
+        corresponding torch indices, e.g. '3' -> '0' when CUDA_VISIBLE_DEVICES='3'; in-range ids are always torch
+        indices, keeping parsing idempotent. Returned indices are relative to the active restriction, so strings
+        persisted under one environment (e.g. resumed checkpoint args) address the same physical GPUs only in that
+        environment.
     """
     device = str(device).lower()
     for remove in "cuda:", "none", "(", ")", "[", "]", "'", " ":
@@ -165,21 +166,24 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
         device = "0"
     device = ",".join(str(int(x)) if x.isdigit() else x for x in device.split(",") if x)  # "0,,01" -> "0,1"
     visible = [x for x in os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "").split(",") if x]
+    indices = [x for x in device.split(",") if x.isdigit()]  # requested ids, excluding '-1' and non-numeric tokens
+    if indices and all(x in visible for x in indices) and any(int(x) >= torch.cuda.device_count() for x in indices):
+        # Ids exceeding the torch device count can only be physical GPU ids under an external CUDA_VISIBLE_DEVICES
+        # restriction -> translate to torch indices; in-range ids are torch indices, keeping repeated parses stable
+        device = ",".join(str(visible.index(x)) if x.isdigit() else x for x in device.split(","))
     if "-1" in device:
         from ultralytics.utils.autodevice import GPUInfo
 
-        # Replace each -1 with an idle GPU (physical NVML id) or remove it, searching only externally visible GPUs
+        # Replace each -1 with an idle GPU or remove it; GPUInfo searches physical NVML ids among externally visible
+        # GPUs only, translated back to torch indices under a CUDA_VISIBLE_DEVICES restriction
         parts = device.split(",")
         candidates = [int(x) for x in visible if x.isdigit()] if visible else None
         selected = GPUInfo().select_idle_gpu(count=parts.count("-1"), min_memory_fraction=0.2, indices=candidates)
+        selected = [visible.index(str(x)) for x in selected] if visible else selected
         for i in range(len(parts)):
             if parts[i] == "-1":
                 parts[i] = str(selected.pop(0)) if selected else ""
         device = ",".join(p for p in parts if p)
-    indices = device.split(",")
-    if device and all(x.isdigit() for x in indices) and all(x in visible for x in indices):
-        # All requested ids match externally visible physical GPU ids -> translate to torch indices, e.g. '3' -> '0'
-        device = ",".join(str(visible.index(x)) for x in indices)
     return device
 
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -67,10 +67,10 @@ def torch_distributed_zero_first(local_rank: int):
     use_ids = initialized and dist.get_backend() == "nccl"
 
     if initialized and local_rank not in {-1, 0}:
-        dist.barrier(device_ids=[local_rank]) if use_ids else dist.barrier()
+        dist.barrier(device_ids=[torch.cuda.current_device()]) if use_ids else dist.barrier()
     yield
     if initialized and local_rank == 0:
-        dist.barrier(device_ids=[local_rank]) if use_ids else dist.barrier()
+        dist.barrier(device_ids=[torch.cuda.current_device()]) if use_ids else dist.barrier()
 
 
 def smart_inference_mode():
@@ -134,6 +134,53 @@ def get_gpu_info(index):
     return f"{properties.name}, {properties.total_memory / (1 << 20):.0f}MiB"
 
 
+def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
+    """Parse a device request of any form into a canonical device string.
+
+    Args:
+        device (str | int | list | tuple | torch.device, optional): Device request, e.g. 'cuda:0', '0,1', [0, 1],
+            'cpu', 'mps', or '-1' to auto-select an idle GPU ('-1,-1' for two).
+
+    Returns:
+        (str): Canonical device string, e.g. '', 'cpu', 'mps', '0', or '0,1'.
+
+    Notes:
+        Each '-1' is replaced with an idle GPU index. Requests matching physical GPU ids hidden by an external
+        CUDA_VISIBLE_DEVICES restriction are translated to the corresponding torch indices, e.g. '3' -> '0' when
+        CUDA_VISIBLE_DEVICES='3'.
+
+    Examples:
+        >>> parse_device("cuda:0")
+        '0'
+
+        >>> parse_device([0, 1])
+        '0,1'
+    """
+    device = str(device).lower()
+    for remove in "cuda:", "none", "(", ")", "[", "]", "'", " ":
+        device = device.replace(remove, "")  # to string, 'cuda:0' -> '0' and '(0, 1)' -> '0,1'
+    if device == "cuda":
+        device = "0"
+    if "," in device:
+        device = ",".join(x for x in device.split(",") if x)  # remove sequential commas, i.e. "0,,1" -> "0,1"
+    if "-1" in device:
+        from ultralytics.utils.autodevice import GPUInfo
+
+        # Replace each -1 with a selected idle GPU or remove it
+        parts = device.split(",")
+        selected = GPUInfo().select_idle_gpu(count=parts.count("-1"), min_memory_fraction=0.2)
+        for i in range(len(parts)):
+            if parts[i] == "-1":
+                parts[i] = str(selected.pop(0)) if selected else ""
+        device = ",".join(p for p in parts if p)
+    indices = device.split(",")
+    if device and all(x.isdigit() for x in indices) and any(int(x) >= torch.cuda.device_count() for x in indices):
+        visible = os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "").split(",")
+        if all(x in visible for x in indices):  # physical GPU ids under an external CUDA_VISIBLE_DEVICES restriction
+            device = ",".join(str(visible.index(x)) for x in indices)  # translate to torch indices
+    return device
+
+
 def select_device(device="", newline=False, verbose=True):
     """Select the appropriate PyTorch device based on the provided arguments.
 
@@ -159,15 +206,15 @@ def select_device(device="", newline=False, verbose=True):
         device(type='cpu')
 
     Notes:
-        Sets the 'CUDA_VISIBLE_DEVICES' environment variable for specifying which GPUs to use.
+        CUDA indices are torch device indices, which reflect any externally set CUDA_VISIBLE_DEVICES. This function
+        never modifies CUDA_VISIBLE_DEVICES; the selected device is made the default CUDA device with
+        torch.cuda.set_device() so that indexless 'cuda' operations land on it.
     """
     if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
         return device
 
     s = f"Ultralytics {__version__} 🚀 Python-{PYTHON_VERSION} torch-{TORCH_VERSION} "
-    device = str(device).lower()
-    for remove in "cuda:", "none", "(", ")", "[", "]", "'", " ":
-        device = device.replace(remove, "")  # to string, 'cuda:0' -> '0' and '(0, 1)' -> '0,1'
+    device = parse_device(device)
 
     # Huawei Ascend NPU
     if device.startswith("npu"):
@@ -197,36 +244,10 @@ def select_device(device="", newline=False, verbose=True):
             LOGGER.info(f"{s}NPU:{idx} ({torch.npu.get_device_name(idx)})\n")
         return torch.device(f"npu:{idx}")
 
-    # Auto-select GPUs
-    if "-1" in device:
-        from ultralytics.utils.autodevice import GPUInfo
-
-        # Replace each -1 with a selected GPU or remove it
-        parts = device.split(",")
-        selected = GPUInfo().select_idle_gpu(count=parts.count("-1"), min_memory_fraction=0.2)
-        for i in range(len(parts)):
-            if parts[i] == "-1":
-                parts[i] = str(selected.pop(0)) if selected else ""
-        device = ",".join(p for p in parts if p)
-
     cpu = device == "cpu"
     mps = device in {"mps", "mps:0"}  # Apple Metal Performance Shaders (MPS)
-    remap = not torch.cuda.is_initialized()  # CUDA_VISIBLE_DEVICES remapping only applies before CUDA init
-    if cpu or mps:
-        os.environ["CUDA_VISIBLE_DEVICES"] = ""  # force torch.cuda.is_available() = False
-    elif device:  # non-cpu device requested
-        if device == "cuda":
-            device = "0"
-        if "," in device:
-            device = ",".join([x for x in device.split(",") if x])  # remove sequential commas, i.e. "0,,1" -> "0,1"
-        visible = os.environ.get("CUDA_VISIBLE_DEVICES", None)
-        remap = remap or visible == device  # CVD applied at CUDA init (e.g. earlier call) -> indices already remapped
-        os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
-        valid = (
-            torch.cuda.device_count() >= len(device.split(","))
-            if remap
-            else all(x.isdigit() and int(x) < torch.cuda.device_count() for x in device.split(","))
-        )
+    if not cpu and not mps and device:  # non-cpu device requested
+        valid = all(x.isdigit() and int(x) < torch.cuda.device_count() for x in device.split(","))
         if not (torch.cuda.is_available() and valid):
             LOGGER.info(s)
             install = (
@@ -241,16 +262,17 @@ def select_device(device="", newline=False, verbose=True):
                 f" i.e. 'device=0' or 'device=0,1,2,3' for Multi-GPU.\n"
                 f"\ntorch.cuda.is_available(): {torch.cuda.is_available()}"
                 f"\ntorch.cuda.device_count(): {torch.cuda.device_count()}"
-                f"\nos.environ['CUDA_VISIBLE_DEVICES']: {visible}\n"
+                f"\nos.environ['CUDA_VISIBLE_DEVICES']: {os.environ.get('CUDA_VISIBLE_DEVICES')}\n"
                 f"{install}"
             )
 
     if not cpu and not mps and torch.cuda.is_available():  # prefer GPU if available
-        devices = device.split(",") if device else "0"  # i.e. "0,1" -> ["0", "1"]
+        devices = device.split(",") if device else ["0"]  # i.e. "0,1" -> ["0", "1"]
         space = " " * len(s)
         for i, d in enumerate(devices):
-            s += f"{'' if i == 0 else space}CUDA:{d} ({get_gpu_info(i if remap else int(d))})\n"  # bytes to MB
-        arg = "cuda:0" if remap else f"cuda:{devices[0]}"
+            s += f"{'' if i == 0 else space}CUDA:{d} ({get_gpu_info(int(d))})\n"
+        arg = f"cuda:{devices[0]}"
+        torch.cuda.set_device(int(devices[0]))  # default device for indexless 'cuda' operations
     elif mps and TORCH_2_0 and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f"MPS ({get_cpu_info()})\n"

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -165,7 +165,9 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
     if device == "cuda":
         device = "0"
     device = ",".join(str(int(x)) if x.isdigit() else x for x in device.split(",") if x)  # "0,,01" -> "0,1"
+    # Visible physical ids truncated to the torch device count, mirroring CUDA's stop at the first invalid CVD entry
     visible = [x for x in os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "").split(",") if x]
+    visible = visible[: torch.cuda.device_count()]
     indices = [x for x in device.split(",") if x.isdigit()]  # requested ids, excluding '-1' and non-numeric tokens
     if indices and all(x in visible for x in indices) and any(int(x) >= torch.cuda.device_count() for x in indices):
         # Ids exceeding the torch device count can only be physical GPU ids under an external CUDA_VISIBLE_DEVICES

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -167,9 +167,12 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
     if "-1" in device:
         from ultralytics.utils.autodevice import GPUInfo
 
-        # Replace each -1 with a selected idle GPU or remove it
+        # Replace each -1 with a selected idle GPU or remove it; GPUInfo returns physical NVML ids
         parts = device.split(",")
         selected = GPUInfo().select_idle_gpu(count=parts.count("-1"), min_memory_fraction=0.2)
+        if visible := os.environ.get("CUDA_VISIBLE_DEVICES"):  # translate physical ids to torch indices
+            vis = visible.replace(" ", "").split(",")
+            selected = [vis.index(str(x)) for x in selected if str(x) in vis]
         for i in range(len(parts)):
             if parts[i] == "-1":
                 parts[i] = str(selected.pop(0)) if selected else ""
@@ -212,6 +215,8 @@ def select_device(device="", newline=False, verbose=True):
         torch.cuda.set_device() so that indexless 'cuda' operations land on it.
     """
     if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
+        if isinstance(device, torch.device) and device.type == "cuda" and device.index is not None:
+            torch.cuda.set_device(device)  # default device for indexless 'cuda' operations
         return device
 
     s = f"Ultralytics {__version__} 🚀 Python-{PYTHON_VERSION} torch-{TORCH_VERSION} "

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -163,6 +163,7 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
         device = "0"
     if "," in device:
         device = ",".join(x for x in device.split(",") if x)  # remove sequential commas, i.e. "0,,1" -> "0,1"
+    device = ",".join(str(int(x)) if x.isdigit() else x for x in device.split(","))  # strip leading zeros, "00" -> "0"
     if "-1" in device:
         from ultralytics.utils.autodevice import GPUInfo
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -165,9 +165,10 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
     if device == "cuda":
         device = "0"
     device = ",".join(str(int(x)) if x.isdigit() else x for x in device.split(",") if x)  # "0,,01" -> "0,1"
-    # Visible physical ids truncated to the torch device count, mirroring CUDA's stop at the first invalid CVD entry
-    visible = [x for x in os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "").split(",") if x]
-    visible = visible[: torch.cuda.device_count()]
+    # Visible physical ids normalized like requested ids and truncated to the torch device count, mirroring CUDA's
+    # atoi-style parsing and its stop at the first invalid CVD entry
+    cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "")
+    visible = [str(int(x)) if x.isdigit() else x for x in cvd.split(",") if x][: torch.cuda.device_count()]
     indices = [x for x in device.split(",") if x.isdigit()]  # requested ids, excluding '-1' and non-numeric tokens
     if indices and all(x in visible for x in indices) and any(int(x) >= torch.cuda.device_count() for x in indices):
         # Ids exceeding the torch device count can only be physical GPU ids under an external CUDA_VISIBLE_DEVICES

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -154,7 +154,8 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
     Notes:
         Each '-1' is replaced with an idle GPU index. Requests matching physical GPU ids hidden by an external
         CUDA_VISIBLE_DEVICES restriction are translated to the corresponding torch indices, e.g. '3' -> '0' when
-        CUDA_VISIBLE_DEVICES='3'.
+        CUDA_VISIBLE_DEVICES='3'. Returned indices are relative to the active restriction, so strings persisted
+        under one environment (e.g. resumed checkpoint args) address the same physical GPUs only in that environment.
     """
     device = str(device).lower()
     for remove in "cuda:", "none", "(", ")", "[", "]", "'", " ":
@@ -166,11 +167,13 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
     if "-1" in device:
         from ultralytics.utils.autodevice import GPUInfo
 
-        # Replace each -1 with a selected idle GPU or remove it; GPUInfo returns physical NVML ids
+        # Replace each -1 with a selected idle GPU or remove it; GPUInfo searches physical NVML ids, restricted to
+        # externally visible GPUs so a hidden idle GPU is never selected
         parts = device.split(",")
-        selected = GPUInfo().select_idle_gpu(count=parts.count("-1"), min_memory_fraction=0.2)
+        candidates = [int(x) for x in visible if x.isdigit()] if visible != [""] else None
+        selected = GPUInfo().select_idle_gpu(count=parts.count("-1"), min_memory_fraction=0.2, indices=candidates)
         if visible != [""]:  # external CUDA_VISIBLE_DEVICES set -> translate physical ids to torch indices
-            selected = [visible.index(str(x)) for x in selected if str(x) in visible]
+            selected = [visible.index(str(x)) for x in selected]
         for i in range(len(parts)):
             if parts[i] == "-1":
                 parts[i] = str(selected.pop(0)) if selected else ""
@@ -208,8 +211,9 @@ def select_device(device="", newline=False, verbose=True):
 
     Notes:
         CUDA indices are torch device indices, which reflect any externally set CUDA_VISIBLE_DEVICES. This function
-        never modifies CUDA_VISIBLE_DEVICES; the selected device is made the default CUDA device with
-        torch.cuda.set_device() so that indexless 'cuda' operations land on it.
+        never modifies CUDA_VISIBLE_DEVICES; an explicitly requested device is made the default CUDA device with
+        torch.cuda.set_device() so that indexless 'cuda' operations land on it, while the default '' request leaves
+        the current device untouched.
     """
     if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
         if isinstance(device, torch.device) and device.type == "cuda" and device.index is not None:
@@ -275,7 +279,8 @@ def select_device(device="", newline=False, verbose=True):
         for i, d in enumerate(devices):
             s += f"{'' if i == 0 else space}CUDA:{d} ({get_gpu_info(int(d))})\n"
         arg = f"cuda:{devices[0]}"
-        torch.cuda.set_device(int(devices[0]))  # default device for indexless 'cuda' operations
+        if device:  # explicit request only, so incidental select_device('') calls never move the current device
+            torch.cuda.set_device(int(devices[0]))  # default device for indexless 'cuda' operations
     elif mps and TORCH_2_0 and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f"MPS ({get_cpu_info()})\n"

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -159,6 +159,8 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
         persisted under one environment (e.g. resumed checkpoint args) address the same physical GPUs only in that
         environment.
     """
+    if isinstance(device, torch.device) and device.type == "cuda" and device.index is None:
+        return ""  # indexless torch.device('cuda') means the current CUDA device, i.e. the '' default request
     device = str(device).lower()
     for remove in "cuda:", "none", "(", ")", "[", "]", "'", " ":
         device = device.replace(remove, "")  # to string, 'cuda:0' -> '0' and '(0, 1)' -> '0,1'
@@ -221,11 +223,10 @@ def select_device(device="", newline=False, verbose=True):
         to the current device) and multi-GPU requests (DDP ranks pin their own device in trainer._setup_ddp()) leave
         the current device untouched.
     """
-    if isinstance(device, torch.device) and device.type == "cuda":
-        # 'cuda:N' is validated and set as the default device below like any string request, while an indexless
-        # torch.device('cuda') keeps its PyTorch meaning: the current device, via the '' default request
-        device = "" if device.index is None else str(device.index)
-    elif isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
+    if isinstance(device, torch.device):
+        if device.type != "cuda":
+            return device  # non-CUDA torch.device inputs pass through; cuda ones canonicalize via parse_device below
+    elif str(device).startswith(("tpu", "intel", "vulkan")):
         return device
 
     s = f"Ultralytics {__version__} 🚀 Python-{PYTHON_VERSION} torch-{TORCH_VERSION} "

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -222,7 +222,9 @@ def select_device(device="", newline=False, verbose=True):
         the current device untouched.
     """
     if isinstance(device, torch.device) and device.type == "cuda":
-        device = str(device)  # 'cuda:N' is validated and set as the default device below like any string request
+        # 'cuda:N' is validated and set as the default device below like any string request, while an indexless
+        # torch.device('cuda') keeps its PyTorch meaning: the current device, via the '' default request
+        device = "" if device.index is None else str(device.index)
     elif isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
         return device
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -152,10 +152,11 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
         '0,1'
 
     Notes:
-        Each '-1' is replaced with an idle GPU index. Requests matching physical GPU ids hidden by an external
-        CUDA_VISIBLE_DEVICES restriction are translated to the corresponding torch indices, e.g. '3' -> '0' when
-        CUDA_VISIBLE_DEVICES='3'. Returned indices are relative to the active restriction, so strings persisted
-        under one environment (e.g. resumed checkpoint args) address the same physical GPUs only in that environment.
+        Each '-1' is replaced with an idle GPU index. When an external CUDA_VISIBLE_DEVICES restriction is active and
+        every requested id matches a visible physical GPU id, ids resolve as physical GPU ids and are translated to
+        the corresponding torch indices, e.g. '3' -> '0' when CUDA_VISIBLE_DEVICES='3'; all other requests are torch
+        indices. Returned indices are relative to the active restriction, so strings persisted under one environment
+        (e.g. resumed checkpoint args) address the same physical GPUs only in that environment.
     """
     device = str(device).lower()
     for remove in "cuda:", "none", "(", ")", "[", "]", "'", " ":
@@ -163,25 +164,22 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
     if device == "cuda":
         device = "0"
     device = ",".join(str(int(x)) if x.isdigit() else x for x in device.split(",") if x)  # "0,,01" -> "0,1"
-    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "").split(",")
+    visible = [x for x in os.environ.get("CUDA_VISIBLE_DEVICES", "").replace(" ", "").split(",") if x]
     if "-1" in device:
         from ultralytics.utils.autodevice import GPUInfo
 
-        # Replace each -1 with a selected idle GPU or remove it; GPUInfo searches physical NVML ids, restricted to
-        # externally visible GPUs so a hidden idle GPU is never selected
+        # Replace each -1 with an idle GPU (physical NVML id) or remove it, searching only externally visible GPUs
         parts = device.split(",")
-        candidates = [int(x) for x in visible if x.isdigit()] if visible != [""] else None
+        candidates = [int(x) for x in visible if x.isdigit()] if visible else None
         selected = GPUInfo().select_idle_gpu(count=parts.count("-1"), min_memory_fraction=0.2, indices=candidates)
-        if visible != [""]:  # external CUDA_VISIBLE_DEVICES set -> translate physical ids to torch indices
-            selected = [visible.index(str(x)) for x in selected]
         for i in range(len(parts)):
             if parts[i] == "-1":
                 parts[i] = str(selected.pop(0)) if selected else ""
         device = ",".join(p for p in parts if p)
     indices = device.split(",")
-    if device and all(x.isdigit() for x in indices) and any(int(x) >= torch.cuda.device_count() for x in indices):
-        if all(x in visible for x in indices):  # physical GPU ids under an external CUDA_VISIBLE_DEVICES restriction
-            device = ",".join(str(visible.index(x)) for x in indices)  # translate to torch indices
+    if device and all(x.isdigit() for x in indices) and all(x in visible for x in indices):
+        # All requested ids match externally visible physical GPU ids -> translate to torch indices, e.g. '3' -> '0'
+        device = ",".join(str(visible.index(x)) for x in indices)
     return device
 
 
@@ -211,13 +209,14 @@ def select_device(device="", newline=False, verbose=True):
 
     Notes:
         CUDA indices are torch device indices, which reflect any externally set CUDA_VISIBLE_DEVICES. This function
-        never modifies CUDA_VISIBLE_DEVICES; an explicitly requested device is made the default CUDA device with
-        torch.cuda.set_device() so that indexless 'cuda' operations land on it, while the default '' request leaves
+        never modifies CUDA_VISIBLE_DEVICES; an explicit single-GPU request is made the default CUDA device with
+        torch.cuda.set_device() so that indexless 'cuda' operations land on it, while default '' requests (resolved
+        to the current device) and multi-GPU requests (DDP ranks pin their own device in trainer._setup_ddp()) leave
         the current device untouched.
     """
-    if isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
-        if isinstance(device, torch.device) and device.type == "cuda" and device.index is not None:
-            torch.cuda.set_device(device)  # default device for indexless 'cuda' operations
+    if isinstance(device, torch.device) and device.type == "cuda":
+        device = str(device)  # 'cuda:N' is validated and set as the default device below like any string request
+    elif isinstance(device, torch.device) or str(device).startswith(("tpu", "intel", "vulkan")):
         return device
 
     s = f"Ultralytics {__version__} 🚀 Python-{PYTHON_VERSION} torch-{TORCH_VERSION} "
@@ -274,13 +273,13 @@ def select_device(device="", newline=False, verbose=True):
             )
 
     if not cpu and not mps and torch.cuda.is_available():  # prefer GPU if available
-        devices = device.split(",") if device else ["0"]  # i.e. "0,1" -> ["0", "1"]
+        devices = device.split(",") if device else [str(torch.cuda.current_device())]  # '' -> current default device
         space = " " * len(s)
         for i, d in enumerate(devices):
             s += f"{'' if i == 0 else space}CUDA:{d} ({get_gpu_info(int(d))})\n"
         arg = f"cuda:{devices[0]}"
-        if device:  # explicit request only, so incidental select_device('') calls never move the current device
-            torch.cuda.set_device(int(devices[0]))  # default device for indexless 'cuda' operations
+        if device and len(devices) == 1:  # explicit single-GPU request only: '' never moves the current device, and
+            torch.cuda.set_device(int(devices[0]))  # multi-GPU DDP ranks each pin their own device in _setup_ddp()
     elif mps and TORCH_2_0 and torch.backends.mps.is_available():
         # Prefer MPS if available
         s += f"MPS ({get_cpu_info()})\n"

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -138,16 +138,11 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
     """Parse a device request of any form into a canonical device string.
 
     Args:
-        device (str | int | list | tuple | torch.device, optional): Device request, e.g. 'cuda:0', '0,1', [0, 1],
-            'cpu', 'mps', or '-1' to auto-select an idle GPU ('-1,-1' for two).
+        device (str | int | list | tuple | torch.device, optional): Device request, e.g. 'cuda:0', '0,1', [0, 1], 'cpu',
+            'mps', or '-1' to auto-select an idle GPU ('-1,-1' for two).
 
     Returns:
         (str): Canonical device string, e.g. '', 'cpu', 'mps', '0', or '0,1'.
-
-    Notes:
-        Each '-1' is replaced with an idle GPU index. Requests matching physical GPU ids hidden by an external
-        CUDA_VISIBLE_DEVICES restriction are translated to the corresponding torch indices, e.g. '3' -> '0' when
-        CUDA_VISIBLE_DEVICES='3'.
 
     Examples:
         >>> parse_device("cuda:0")
@@ -155,6 +150,11 @@ def parse_device(device: str | int | list | tuple | torch.device = "") -> str:
 
         >>> parse_device([0, 1])
         '0,1'
+
+    Notes:
+        Each '-1' is replaced with an idle GPU index. Requests matching physical GPU ids hidden by an external
+        CUDA_VISIBLE_DEVICES restriction are translated to the corresponding torch indices, e.g. '3' -> '0' when
+        CUDA_VISIBLE_DEVICES='3'.
     """
     device = str(device).lower()
     for remove in "cuda:", "none", "(", ")", "[", "]", "'", " ":


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves CUDA device handling, multi-GPU training reliability, ReID tracker device placement, and export dependency behavior 🚀

### 📊 Key Changes
- Added a new `parse_device()` utility to normalize device inputs like `cuda:0`, `[0, 1]`, `-1`, `cpu`, and `mps` into consistent device strings 🧭
- Updated `select_device()` so it no longer mutates `CUDA_VISIBLE_DEVICES`, making device selection safer and more predictable ⚙️
- Improved support for externally restricted GPU environments, such as containers or Ultralytics Platform pods using preset `CUDA_VISIBLE_DEVICES` 🐳
- Fixed multi-GPU/DDP training device assignment to use the correct CUDA indices per rank 🔥
- Added stronger tests for CUDA device parsing, idle GPU selection, training device correctness, and environment stability ✅
- Ensured ReID encoders in trackers run on the same device as the predictor for better consistency and performance 🎯
- Improved TensorFlow and Paddle export behavior by selecting GPU/CPU dependencies more carefully and avoiding unnecessary GPU memory allocation during CPU exports 📦
- Updated autobatch GPU reporting to use the actual selected CUDA device index 📊
- Added documentation reference for the new `parse_device()` utility 📚
- Bumped Ultralytics version from `8.4.86` to `8.4.87` 🔖

### 🎯 Purpose & Impact
- Makes GPU selection more reliable across CLI, Python, DDP, containers, and production environments 🛡️
- Prevents unexpected changes to `CUDA_VISIBLE_DEVICES`, reducing hard-to-debug training and validation issues 🔍
- Improves correctness when training on nonzero GPUs or using externally mapped GPU IDs 🧠
- Reduces risk of DDP jobs training or validating on the wrong GPU 🚦
- Helps tracking workflows with ReID use the intended accelerator automatically ⚡
- Makes export workflows cleaner by avoiding duplicate dependency installs and unnecessary GPU usage 💾
- Overall, users should see more predictable CUDA behavior, fewer device-related failures, and smoother training/export experiences 😊