### PR TITLE
Preload torchvision during warmup for non-end2end NMS path

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -305,7 +305,7 @@ class AutoBackend(nn.Module):
         from ultralytics.utils.nms import non_max_suppression
 
         if not self.end2end:
-            import torchvision  # noqa: F401
+            import torchvision  # noqa (import here triggers torchvision NMS use in nms.py)
         if self.format in {"pt", "torchscript", "onnx", "engine", "saved_model", "pb", "triton"} and (
             self.device.type != "cpu" or self.format == "triton"
         ):

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -304,6 +304,8 @@ class AutoBackend(nn.Module):
         """
         from ultralytics.utils.nms import non_max_suppression
 
+        if not self.end2end:
+            import torchvision  # noqa: F401
         if self.format in {"pt", "torchscript", "onnx", "engine", "saved_model", "pb", "triton"} and (
             self.device.type != "cpu" or self.format == "triton"
         ):

--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -147,7 +147,7 @@ def non_max_suppression(
             i = TorchNMS.fast_nms(boxes, scores, iou_thres, iou_func=batch_probiou)
         else:
             boxes = x[:, :4] + c  # boxes (offset by class)
-            # Speed strategy: torchvision for val or already loaded (faster), TorchNMS for predict (lower latency)
+            # Speed strategy: torchvision if already imported (preloaded by warmup/val/streams), else TorchNMS (no slow import)
             if "torchvision" in sys.modules:
                 import torchvision  # scope as slow import
 


### PR DESCRIPTION
Fixes #25022 

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves inference warmup behavior by preloading `torchvision` for standard NMS paths, helping speed up later non-max suppression calls 🚀

### 📊 Key Changes
- Added a conditional `torchvision` import during `AutoBackend.warmup()` when the model is **not end-to-end**.
- Updated NMS comments to clarify the strategy:
  - Use `torchvision` NMS when it has already been imported.
  - Fall back to `TorchNMS` when `torchvision` is not loaded to avoid slow import overhead.
- Keeps end-to-end models unaffected, since they do not rely on the same post-processing NMS path.

### 🎯 Purpose & Impact
- Reduces first-inference latency after warmup by ensuring `torchvision` NMS is available when needed ⚡
- Preserves low-latency prediction behavior by avoiding unnecessary `torchvision` imports outside warmup.
- Improves consistency across validation, streaming, and warmed-up inference workflows.
- Provides a small but useful performance optimization with no expected user-facing API changes ✅