### PR TITLE
Fix leaked dataloader workers at end of training (atexit `killed by signal: Terminated` crash)

### DIFF
--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -85,32 +85,21 @@ class InfiniteDataLoader(dataloader.DataLoader):
     def __del__(self):
         """Ensure that workers are properly terminated when the DataLoader is deleted."""
         try:
-            if not hasattr(self.iterator, "_workers"):
-                return
-            for w in self.iterator._workers:  # force terminate
+            for w in getattr(self.iterator, "_workers", ()):  # force terminate
                 if w.is_alive():
                     w.terminate()
-            self.iterator._shutdown_workers()  # cleanup
+            self.close()
         except Exception:
             pass
 
     def close(self):
-        """Gracefully shut down persistent workers, unregistering them from torch's SIGCHLD worker watchdog.
-
-        Without this, workers stay alive (and watchdog-registered) until interpreter exit, where a SIGTERM reaching
-        them from outside the parent process races multiprocessing's atexit join and raises
-        'DataLoader worker (pid N) is killed by signal' from torch's SIGCHLD handler.
-        """
-        try:
-            if hasattr(self.iterator, "_workers"):
-                self.iterator._shutdown_workers()  # joins workers and calls torch._C._remove_worker_pids
-        except Exception:
-            pass
+        """Shut down persistent workers, unregistering them from torch's SIGCHLD watchdog before interpreter exit."""
+        if hasattr(self.iterator, "_workers"):
+            self.iterator._shutdown_workers()  # joins workers and calls torch._C._remove_worker_pids
 
     def reset(self):
         """Reset the iterator to allow modifications to the dataset during training."""
-        if hasattr(self.iterator, "_workers"):
-            self.iterator._shutdown_workers()  # free old worker pipes before creating new iterator
+        self.close()  # free old worker pipes before creating new iterator
         self.iterator = self._get_iterator()
 
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -54,6 +54,7 @@ class InfiniteDataLoader(dataloader.DataLoader):
         __len__: Return the length of the batch sampler's sampler.
         __iter__: Yield batches from the underlying iterator.
         __del__: Ensure workers are properly terminated.
+        close: Gracefully shut down persistent workers when the DataLoader is no longer needed.
         reset: Reset the iterator, useful when modifying dataset settings during training.
 
     Examples:
@@ -90,6 +91,19 @@ class InfiniteDataLoader(dataloader.DataLoader):
                 if w.is_alive():
                     w.terminate()
             self.iterator._shutdown_workers()  # cleanup
+        except Exception:
+            pass
+
+    def close(self):
+        """Gracefully shut down persistent workers, unregistering them from torch's SIGCHLD worker watchdog.
+
+        Without this, workers stay alive (and watchdog-registered) until interpreter exit, where a SIGTERM reaching
+        them from outside the parent process races multiprocessing's atexit join and raises
+        'DataLoader worker (pid N) is killed by signal' from torch's SIGCHLD handler.
+        """
+        try:
+            if hasattr(self.iterator, "_workers"):
+                self.iterator._shutdown_workers()  # joins workers and calls torch._C._remove_worker_pids
         except Exception:
             pass
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -599,6 +599,9 @@ class BaseTrainer:
                 self.plot_metrics()
             self.run_callbacks("on_train_end")
         self._clear_memory()
+        for loader in (self.train_loader, self.test_loader):
+            if hasattr(loader, "close"):
+                loader.close()  # shut down persistent dataloader workers so none survive to interpreter exit
         unset_deterministic()
         self.run_callbacks("teardown")
 


### PR DESCRIPTION
## Bug

At the end of `yolo train` (all results already saved), `InfiniteDataLoader` keeps its persistent iterator alive, so its daemon worker processes are still running **and still registered with torch's SIGCHLD watchdog** when the interpreter exits. With `workers=8` that is 24 leaked daemon processes (8 train + 16 val, since val uses `workers*2`). `InfiniteDataLoader.__del__` would clean them up, but the loader is never garbage-collected before exit.

At interpreter exit, multiprocessing's atexit `_exit_function` SIGTERMs every live daemon child and `join()`s it. If a leaked worker dies "by signal" while torch's watchdog is armed, the run ends with:

```
Exception ignored in atexit callback: <function _exit_function at 0x...>
Traceback (most recent call last):
  File ".../multiprocessing/util.py", line 360, in _exit_function
    p.join()
  ...
  File ".../torch/utils/data/_utils/signal_handling.py", line 73, in handler
    _error_if_any_worker_fails()
RuntimeError: DataLoader worker (pid N) is killed by signal: Terminated.
```

**Why it is session-dependent:** torch's worker-side SIGTERM handler (`torch/csrc/DataLoader.cpp`) special-cases the parent — when `si_pid == getppid()` the worker does `_exit(EXIT_SUCCESS)`. So the parent's own atexit SIGTERM exits cleanly; the visible crash needs a SIGTERM reaching a leaked worker from a *different* process (e.g. a terminal/session manager signalling the process group on teardown). That's why the traceback reproduces consistently in some interactive sessions and never in others. The leak itself is deterministic on every run.

## Fix

- Add `InfiniteDataLoader.close()`: gracefully shuts down the persistent iterator's workers (`_shutdown_workers()` joins them and calls `torch._C._remove_worker_pids`, unregistering them from the watchdog).
- Call it for `self.train_loader` and `self.test_loader` at the end of `BaseTrainer._do_train()`, so no dataloader workers survive to interpreter exit.

## Reproduction

Deterministic repro script (verified on main @ 2c073adc0, torch 2.8.0, py3.12, RTX 5090):

<details>
<summary>repro_dataloader_teardown.py</summary>

```python
"""Deterministic reproduction: ultralytics leaks live dataloader workers after train().

THE BUG
-------
At the end of `yolo train` (all results already saved), ultralytics' InfiniteDataLoader
(ultralytics/data/build.py) still holds a persistent iterator whose daemon worker
processes are:
  (a) still alive, and
  (b) still registered with torch's SIGCHLD watchdog (_error_if_any_worker_fails).

Nothing shuts them down before interpreter exit; InfiniteDataLoader.__del__ would, but
it is only invoked if the loader gets garbage-collected, which normally never happens
before exit. At exit, multiprocessing's atexit hook (_exit_function) SIGTERMs every
live daemon child and join()s it. If any worker dies "by signal" while torch's
watchdog is armed, Python prints:

    Exception ignored in atexit callback: <function _exit_function at 0x...>
    ...
    RuntimeError: DataLoader worker (pid N) is killed by signal: Terminated.

WHY IT IS FLAKY IN THE WILD (and deterministic here)
----------------------------------------------------
torch's worker-side SIGTERM handler (torch/csrc/DataLoader.cpp) special-cases the
parent: if si_pid == getppid() the worker does _exit(EXIT_SUCCESS). So the parent's
own atexit SIGTERM produces a clean exit and no watchdog error. The visible crash
needs a SIGTERM from a *different* process -- e.g. a terminal/session manager
signalling the whole process group on teardown -- hence "reproduces in some
interactive sessions, never in others". This script emulates that external signal
with a plain `kill` subprocess, making the crash reproduce every time.

WHAT YOU WILL SEE (on buggy versions, e.g. main @ 2c073adc0 / 8.4.86)
---------------------------------------------------------------------
  PART 1: 24 leaked live daemon workers (8 train + 16 val) and watchdog armed.
          On a fixed version this prints 0 and the script exits cleanly.
  PART 2: an uncaught
          RuntimeError: DataLoader worker (pid N) is killed by signal: Terminated.
          raised in the *main* process long after training finished.

USAGE
-----
  pip install ultralytics    # or PYTHONPATH to a checkout of upstream main
  python repro_dataloader_teardown.py     # coco8 + yolo11n.pt auto-download (~7 MB)
"""

import multiprocessing
import subprocess
import time

from ultralytics import YOLO

YOLO("yolo11n.pt").train(
    data="coco8.yaml", epochs=1, imgsz=320, batch=8, workers=8, plots=False
)

# ---- PART 1: training is over, all results saved. Nothing should be running. ----
import torch.utils.data._utils.signal_handling as sh

kids = multiprocessing.active_children()
print()
print("=" * 72)
print(f"PART 1: live daemon dataloader workers after train(): {len(kids)}  (expected: 0)")
print(f"        torch SIGCHLD watchdog still armed:           {sh._SIGCHLD_handler_set}")
print("=" * 72)

if not kids:
    print("No leaked workers -- this ultralytics version is fixed.")
    raise SystemExit(0)

# ---- PART 2: trigger the crash deterministically. --------------------------------
# Emulate the session-teardown SIGTERM that hits the leaked worker from a process
# other than its parent (parent-sent SIGTERM is special-cased to a clean exit by
# torch's worker signal handler, which is exactly why the bug is timing/session
# dependent in the wild).
victim = kids[0]
print(f"\nPART 2: external SIGTERM to leaked worker pid={victim.pid} ...")
print("        torch's still-armed watchdog now raises in the main process:\n")
subprocess.run(["kill", "-TERM", str(victim.pid)], check=True)
time.sleep(5)  # SIGCHLD lands here -> uncaught RuntimeError (this is the bug firing)

print("UNEXPECTED: no RuntimeError -- watchdog did not fire (bug not reproduced).")
```

</details>

**Before (main @ 2c073adc0):**

```
PART 1: live daemon dataloader workers after train(): 24  (expected: 0)
        torch SIGCHLD watchdog still armed:           True
...
RuntimeError: DataLoader worker (pid 7749) is killed by signal: Terminated.
```

**After (this PR):**

```
PART 1: live daemon dataloader workers after train(): 0  (expected: 0)
No leaked workers -- this ultralytics version is fixed.
(exit code 0)
```

Also verified after the fix: `yolo detect train model=yolo11n.pt data=coco8.yaml epochs=2 imgsz=320 batch=8 workers=8 plots=False` completes rc=0 with a clean exit, and two back-to-back `YOLO(...).train(...)` calls in one process still work (loaders are rebuilt per `train()` call, so closing them at teardown is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves DataLoader cleanup to prevent persistent worker processes from lingering after training ends 🧹

### 📊 Key Changes
- Added a new `close()` method to `InfiniteDataLoader` for graceful worker shutdown.
- Updated `__del__()` to use safer worker access and call `close()` for cleanup.
- Updated `reset()` to reuse `close()` before recreating the iterator.
- Trainer now explicitly closes both training and validation/test loaders after training completes.

### 🎯 Purpose & Impact
- Reduces the risk of leftover DataLoader worker processes after training exits 🚀
- Improves shutdown reliability, especially when using persistent workers.
- Helps avoid interpreter-exit warnings or cleanup issues related to PyTorch worker processes.
- Makes training teardown cleaner and more robust for users running repeated or automated training jobs.