### PR TITLE
Fix inverted read-speed condition in dataset file speed check

### DIFF
--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -130,7 +130,7 @@ def check_file_speeds(
         avg_speed = float("inf")
         speed_msg = ""
 
-    if avg_ping < threshold_ms or avg_speed < threshold_mb:
+    if avg_ping < threshold_ms and avg_speed > threshold_mb:
         LOGGER.info(f"{prefix}Fast image access ✅ ({ping_msg}{speed_msg}{size_msg})")
     else:
         LOGGER.warning(


### PR DESCRIPTION
## Description

`check_file_speeds()` in `ultralytics/data/utils.py` logs **"Fast image access ✅"** when the measured read speed is *below* `threshold_mb`:

```python
if avg_ping < threshold_ms or avg_speed < threshold_mb:
    LOGGER.info(f"{prefix}Fast image access ✅ ...")
```

The read-speed comparison is inverted, and combined with `or` it means a slow disk can never trigger the slow-access warning — e.g. a network mount with 2 ms ping but 5 MB/s reads is reported as fast, and even a 100 ms ping + 5 MB/s combination still prints "Fast image access ✅" because `5 < 50` satisfies the condition. The warning branch (with the link to the model-training-tips guide) is effectively unreachable for slow storage, which is exactly the case it was added for.

This PR changes the condition so "fast" requires low ping **and** high throughput:

```python
if avg_ping < threshold_ms and avg_speed > threshold_mb:
```

The `avg_speed = float("inf")` fallback (when no read speeds were collected) keeps working: the result then depends on ping alone, as before.

Verified locally:
- fast local file, default thresholds → "Fast image access ✅"
- read speed below `threshold_mb` → "Slow image access detected" warning (previously logged "Fast")
- ping above `threshold_ms` → "Slow image access detected" warning

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes the dataset file speed check so “Fast image access” is reported only when both latency and read speed meet the configured thresholds. ⚡

### 📊 Key Changes
- Corrects the condition in `check_file_speeds()` from an `or` check to an `and` check.
- Requires average ping to be below the latency threshold and average read speed to be above the throughput threshold before logging fast access.
- Prevents slow reads from being incorrectly classified as fast when ping alone is acceptable.

### 🎯 Purpose & Impact
- Improves accuracy of dataset storage performance warnings. ✅
- Helps users identify slow dataset locations more reliably during training or validation setup.
- Reduces misleading logs that could hide I/O bottlenecks affecting Ultralytics workflows.