### PR TITLE
Add cover image for `knowledge-distillation.md`

### DIFF
--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -31,6 +31,8 @@ Train a smaller student model with guidance from a larger teacher model by addin
 
 [Knowledge distillation](https://www.ultralytics.com/glossary/knowledge-distillation) transfers knowledge from a large, accurate **teacher model** to a smaller **student model**. The student learns to mimic the teacher's internal feature representations, often achieving better accuracy than training from scratch.
 
+![Knowledge distillation workflow image](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/knowledge-distillation.avif‎)
+
 **Use distillation when:**
 
 - You need a smaller, faster model for deployment

--- a/docs/en/guides/knowledge-distillation.md
+++ b/docs/en/guides/knowledge-distillation.md
@@ -31,7 +31,7 @@ Train a smaller student model with guidance from a larger teacher model by addin
 
 [Knowledge distillation](https://www.ultralytics.com/glossary/knowledge-distillation) transfers knowledge from a large, accurate **teacher model** to a smaller **student model**. The student learns to mimic the teacher's internal feature representations, often achieving better accuracy than training from scratch.
 
-![Knowledge distillation workflow image](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/knowledge-distillation.avif‎)
+![Knowledge distillation workflow image](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/knowledge-distillation.avif)
 
 **Use distillation when:**
 


### PR DESCRIPTION
CC: @glenn-jocher

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a knowledge distillation workflow cover image to the documentation guide 🖼️

### 📊 Key Changes
- Inserts an AVIF image into `docs/en/guides/knowledge-distillation.md` near the guide introduction.
- Uses descriptive alt text: “Knowledge distillation workflow image”.
- References the image from the Ultralytics assets CDN.

### 🎯 Purpose & Impact
- Improves the visual clarity and presentation of the knowledge distillation guide.
- Helps readers quickly understand the teacher-student workflow concept.
- Enhances documentation quality with a minimal, focused change.