### PR TITLE
Harden publish workflow recovery, notifications, and dispatch guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/ultralytics' && github.actor == 'glenn-jocher'
+    if: github.repository == 'ultralytics/ultralytics' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -36,6 +36,7 @@ jobs:
           import os
           from actions.utils import check_pypi_version
           local_version, online_version, publish = check_pypi_version()
+          publish = publish or os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch"  # manual recovery re-run
           os.system(f'echo "increment={publish}" >> $GITHUB_OUTPUT')
           os.system(f'echo "current_tag=v{local_version}" >> $GITHUB_OUTPUT')
           os.system(f'echo "previous_tag=v{online_version}" >> $GITHUB_OUTPUT')
@@ -49,11 +50,15 @@ jobs:
           PREVIOUS_TAG: ${{ steps.check_pypi.outputs.previous_tag }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          git config --global user.name "UltralyticsAssistant"
-          git config --global user.email "web@ultralytics.com"
-          git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
-          git push origin "$CURRENT_TAG"
-          ultralytics-actions-summarize-release
+          if [ -z "$(git ls-remote --tags origin "refs/tags/$CURRENT_TAG")" ]; then
+            git config --global user.name "UltralyticsAssistant"
+            git config --global user.email "web@ultralytics.com"
+            git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
+            git push origin "$CURRENT_TAG"
+          fi
+          if ! gh release view "$CURRENT_TAG" >/dev/null 2>&1; then
+            ultralytics-actions-summarize-release
+          fi
           uv cache prune --ci
 
   build:
@@ -113,6 +118,8 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true # tolerate recovery re-runs after partial failures
 
   sbom:
     needs: [check, build, publish]
@@ -136,12 +143,12 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           path: sbom-env
-      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json
+      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
-    needs: [check, publish]
+    needs: [check, publish, sbom]
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
     permissions:
@@ -158,7 +165,7 @@ jobs:
           TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
-        if: needs.publish.result == 'success' && github.event_name == 'push'
+        if: needs.publish.result == 'success' && needs.sbom.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
@@ -166,7 +173,7 @@ jobs:
           payload: |
             text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
-        if: needs.publish.result != 'success'
+        if: needs.publish.result != 'success' || needs.sbom.result != 'success'
         uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,8 @@ jobs:
           publish = publish or os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch"  # manual recovery re-run
           os.system(f'echo "increment={publish}" >> $GITHUB_OUTPUT')
           os.system(f'echo "current_tag=v{local_version}" >> $GITHUB_OUTPUT')
-          os.system(f'echo "previous_tag=v{online_version}" >> $GITHUB_OUTPUT')
+          if online_version != local_version:  # empty on recovery re-runs so summarize falls back to the true previous tag
+              os.system(f'echo "previous_tag=v{online_version}" >> $GITHUB_OUTPUT')
           if publish:
               print('Ready to publish new version to PyPI ✅.')
       - name: Tag and Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,11 +32,13 @@ jobs:
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
+        env:
+          PYPI_DISPATCH: ${{ github.event.inputs.pypi }}
         run: |
           import os
           from actions.utils import check_pypi_version
           local_version, online_version, publish = check_pypi_version()
-          publish = publish or os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch"  # manual recovery re-run
+          publish = publish or os.environ.get("PYPI_DISPATCH") == "true"  # manual recovery re-run
           os.system(f'echo "increment={publish}" >> $GITHUB_OUTPUT')
           os.system(f'echo "current_tag=v{local_version}" >> $GITHUB_OUTPUT')
           if online_version != local_version:  # empty on recovery re-runs so summarize falls back to the true previous tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ jobs:
             git push origin "$CURRENT_TAG"
           fi
           if ! gh release view "$CURRENT_TAG" >/dev/null 2>&1; then
+            [ -n "$PREVIOUS_TAG" ] || git fetch --unshallow --tags # summarize resolves the previous tag from git history
             ultralytics-actions-summarize-release
           fi
           uv cache prune --ci


### PR DESCRIPTION
## 🛠️ Summary

Ports three robustness fixes to `publish.yml` that came out of adversarial review rounds on [ultralytics/template#91](https://github.com/ultralytics/template/pull/91). The release pipeline previously had no recovery path after a partial failure, and Slack could report success before the pipeline actually finished.

### 1. Failed releases can now be recovered via `workflow_dispatch`
Previously, once the tag was pushed, any downstream failure (build, PyPI upload, SBOM) left the release unrecoverable: a re-run hit `git tag -a` on the existing tag and the `check` job died. Now:
- `workflow_dispatch` always sets `increment=True` (manual recovery re-run)
- Tagging is skipped when the tag already exists on origin (`git ls-remote`)
- Release summarization is gated independently on release existence (`gh release view`), healing the tag-pushed-but-no-release state
- PyPI upload uses `skip-existing: true` so re-runs tolerate already-uploaded dists (including the `ultralytics-opencv-headless` variant when only one of the two uploads succeeded)
- SBOM upload uses `--clobber` so re-runs can overwrite

A partially failed release can be re-run from any point and completes only what's missing.

### 2. Slack success can no longer fire prematurely
`notify` now includes `sbom` in `needs` and in the success/failure conditions, so the ✅ message reflects the entire pipeline rather than racing the SBOM job.

### 3. `workflow_dispatch` can no longer release a non-main commit
The `check` job now requires `github.ref == 'refs/heads/main'`; previously a dispatch from a feature branch could tag and release a commit that never landed on main.

## 🧪 Testing

- YAML validated
- Same logic reviewed through four adversarial Codex review rounds (until LGTM) on ultralytics/template#91; no-failure path is behavior-identical to the current workflow

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the Ultralytics release workflow to be safer, recoverable, and more reliable for PyPI publishing, GitHub releases, SBOM uploads, and Slack notifications 🚀

### 📊 Key Changes
- Restricts automated publishing to pushes on the `main` branch by @glenn-jocher 🔒
- Adds manual PyPI dispatch recovery support, allowing failed or partial releases to be re-run safely 🛠️
- Prevents duplicate Git tags and GitHub releases by checking whether they already exist before creating them ✅
- Enables PyPI `skip-existing` to tolerate re-runs after partial publish failures 📦
- Uploads SBOM files with `--clobber`, allowing existing release assets to be replaced during recovery ♻️
- Makes Slack success notifications depend on both publish and SBOM jobs completing successfully 🔔
- Updates failure notifications to trigger if either publishing or SBOM generation fails ⚠️

### 🎯 Purpose & Impact
- Reduces risk of accidental releases from non-`main` branches 🌿
- Makes release recovery smoother when workflows fail midway, avoiding manual cleanup 🧰
- Improves release pipeline reliability by handling already-created tags, releases, PyPI packages, and SBOM assets gracefully 🧱
- Provides more accurate Slack notifications so the team gets clearer release status updates 📣
- Helps ensure users receive complete, properly published Ultralytics releases with supporting metadata like SBOMs 🧾