### PR TITLE
Pin PNNX for NCNN export stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
               uv_system_args=(--system)
             fi
             uv pip install "${uv_system_args[@]}" -e ".[export,export-executorch]" \
-              ncnn pnnx "coverage[toml]" \
+              ncnn pnnx==20260526 "coverage[toml]" \
               --torch-backend cpu
       - name: Check environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
             if [[ "${{ matrix.os }}" != "cpu-latest" ]]; then
               uv_system_args=(--system)
             fi
+            # Pin PNNX until 20260704 NCNN inference segfault is fixed: https://github.com/pnnx/pnnx/issues/293
             uv pip install "${uv_system_args[@]}" -e ".[export,export-executorch]" \
               ncnn pnnx==20260526 "coverage[toml]" \
               --torch-backend cpu

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -266,7 +266,7 @@ EXPORT_ENVS = {
         "python": "3.13",
         "extras": ["export-base"],
         "torch": None,
-        "requirements": ["ncnn", "pnnx"],
+        "requirements": ["ncnn", "pnnx==20260526"],
         "indexes": [],
         "env": {},
         "smoke": ["yolo export format=ncnn model=yolo26n.pt imgsz=32"],

--- a/ultralytics/utils/export/ncnn.py
+++ b/ultralytics/utils/export/ncnn.py
@@ -35,6 +35,7 @@ def torch2ncnn(
     from ultralytics.utils.checks import check_requirements
 
     check_requirements("ncnn", cmds="--no-deps")  # no deps to avoid installing opencv-python
+    # Pin until PNNX 20260704 NCNN inference segfault is fixed: https://github.com/pnnx/pnnx/issues/293
     check_requirements("pnnx==20260526")
     import ncnn
     import pnnx

--- a/ultralytics/utils/export/ncnn.py
+++ b/ultralytics/utils/export/ncnn.py
@@ -35,7 +35,7 @@ def torch2ncnn(
     from ultralytics.utils.checks import check_requirements
 
     check_requirements("ncnn", cmds="--no-deps")  # no deps to avoid installing opencv-python
-    check_requirements("pnnx")
+    check_requirements("pnnx==20260526")
     import ncnn
     import pnnx
 


### PR DESCRIPTION
## Summary
- pin PNNX to 20260526 for NCNN export checks and benchmark CI installs
- keep NCNN paired with the latest available ncnn wheel, 1.0.20260526
- avoid the same-day pnnx 20260704 regression that segfaults during NCNN inference

## Validation
- PyPI metadata: pnnx 20260704 first uploaded 2026-07-04T13:44:03Z; ncnn latest is 1.0.20260526
- python -m compileall ultralytics/engine/exporter.py ultralytics/utils/export/ncnn.py
- ruff check ultralytics/engine/exporter.py ultralytics/utils/export/ncnn.py
- ruff format --check ultralytics/engine/exporter.py ultralytics/utils/export/ncnn.py
- disposable Python 3.13 venv: YOLO_AUTOINSTALL=false python -m ultralytics.cfg.__init__ benchmark model=yolo26n.pt imgsz=160 format=ncnn verbose=0.216

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Pins PNNX to a stable version to prevent NCNN export/inference crashes and improve reliability 🛠️

### 📊 Key Changes
- Pinned `pnnx` to version `20260526` across CI, export requirements, and NCNN export checks 📌
- Added comments explaining the pin is temporary due to a known PNNX `20260704` NCNN inference segfault issue 🐛
- Updated NCNN export validation so users install the known-good PNNX version automatically ✅

### 🎯 Purpose & Impact
- Improves stability for users exporting Ultralytics models, including YOLO26, to NCNN 🚀
- Prevents CI failures and user-facing crashes caused by the newer affected PNNX release 🔒
- Keeps NCNN export workflows reliable while the upstream PNNX issue is being resolved ⏳