### PR TITLE
Cap dataloader workers for tiny datasets

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -18,7 +18,7 @@ from PIL import Image
 
 from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
 from ultralytics import RTDETR, YOLO
-from ultralytics.data.build import load_inference_source
+from ultralytics.data.build import build_dataloader, load_inference_source
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.utils import (
     ARM64,
@@ -41,6 +41,31 @@ from ultralytics.utils import (
 )
 from ultralytics.utils.downloads import download, safe_download
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
+
+
+class TinyDataset(torch.utils.data.Dataset):
+    """Minimal dataset for dataloader worker-count tests."""
+
+    def __init__(self, size: int):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, index):
+        return torch.tensor(index)
+
+
+def test_dataloader_caps_workers_to_batches():
+    """Test tiny datasets do not spawn persistent workers beyond useful batch count."""
+    single_batch = build_dataloader(TinyDataset(4), batch=4, workers=8)
+    two_batches = build_dataloader(TinyDataset(8), batch=4, workers=8)
+    try:
+        assert single_batch.num_workers == 0
+        assert two_batches.num_workers <= 2
+    finally:
+        single_batch.close()
+        two_batches.close()
 
 
 def skip_rpi_semantic():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -16,8 +16,8 @@ import pytest
 import torch
 from PIL import Image
 
-from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
 import ultralytics.data.build as data_build
+from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
 from ultralytics import RTDETR, YOLO
 from ultralytics.data.build import build_dataloader, load_inference_source
 from ultralytics.data.utils import check_det_dataset

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -17,6 +17,7 @@ import torch
 from PIL import Image
 
 from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
+import ultralytics.data.build as data_build
 from ultralytics import RTDETR, YOLO
 from ultralytics.data.build import build_dataloader, load_inference_source
 from ultralytics.data.utils import check_det_dataset
@@ -56,6 +57,22 @@ def test_dataloader_caps_workers_to_batches():
         single_batch.close()
         drop_last_single_batch.close()
         two_batches.close()
+
+
+def test_dataloader_cap_preserves_distributed_drop_last(monkeypatch):
+    """Test worker cap follows distributed sampler size without changing global drop_last behavior."""
+    sampler_cls = data_build.distributed.DistributedSampler
+
+    def distributed_sampler(dataset, shuffle):
+        return sampler_cls(dataset, num_replicas=3, rank=0, shuffle=shuffle)
+
+    monkeypatch.setattr(data_build.distributed, "DistributedSampler", distributed_sampler)
+    loader = build_dataloader(range(8), batch=4, workers=8, rank=0, drop_last=True)
+    try:
+        assert len(loader) == 1
+        assert loader.num_workers == 0
+    finally:
+        loader.close()
 
 
 def skip_rpi_semantic():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -75,6 +75,12 @@ def test_dataloader_cap_preserves_distributed_drop_last(monkeypatch):
         loader.close()
 
 
+def test_dataloader_empty_dataset_uses_dataloader_validation():
+    """Test empty datasets fail through DataLoader validation instead of worker-cap math."""
+    with pytest.raises(ValueError, match="positive integer"):
+        build_dataloader([], batch=4, workers=2)
+
+
 def skip_rpi_semantic():
     """Skip semantic segmentation tests on Raspberry Pi due to memory constraints."""
     if IS_RASPBERRYPI:

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -43,28 +43,18 @@ from ultralytics.utils.downloads import download, safe_download
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
 
 
-class TinyDataset(torch.utils.data.Dataset):
-    """Minimal dataset for dataloader worker-count tests."""
-
-    def __init__(self, size: int):
-        self.size = size
-
-    def __len__(self):
-        return self.size
-
-    def __getitem__(self, index):
-        return torch.tensor(index)
-
-
 def test_dataloader_caps_workers_to_batches():
     """Test tiny datasets do not spawn persistent workers beyond useful batch count."""
-    single_batch = build_dataloader(TinyDataset(4), batch=4, workers=8)
-    two_batches = build_dataloader(TinyDataset(8), batch=4, workers=8)
+    single_batch = build_dataloader(range(4), batch=4, workers=8)
+    drop_last_single_batch = build_dataloader(range(5), batch=4, workers=8, drop_last=True)
+    two_batches = build_dataloader(range(8), batch=4, workers=8)
     try:
         assert single_batch.num_workers == 0
+        assert drop_last_single_batch.num_workers == 0
         assert two_batches.num_workers <= 2
     finally:
         single_batch.close()
+        drop_last_single_batch.close()
         two_batches.close()
 
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.87"
+__version__ = "8.4.88"
 
 import importlib
 import os

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -347,8 +347,8 @@ def build_dataloader(
         if shuffle
         else ContiguousDistributedSampler(dataset)
     )
-    samples = len(sampler) if sampler else len(dataset)
-    drop_last = drop_last and samples % batch != 0
+    samples = len(sampler) if sampler is not None else len(dataset)
+    drop_last = drop_last and len(dataset) % batch != 0
     batches = samples // batch if drop_last else math.ceil(samples / batch)
     nd = torch.cuda.device_count()  # number of CUDA devices
     # Do not create more worker processes than final loader batches. Single-batch loaders run in-process to avoid

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -340,11 +340,6 @@ def build_dataloader(
         >>> dataloader = build_dataloader(dataset, batch=16, workers=4, shuffle=True)
     """
     batch = min(batch, len(dataset))
-    batches = math.ceil(len(dataset) / max(batch, 1))
-    nd = torch.cuda.device_count()  # number of CUDA devices
-    # Do not create more worker processes than batches. Single-batch loaders run in-process to avoid persistent
-    # DataLoader worker pools that add overhead and can stall tiny datasets while holding CUDA context.
-    nw = min(os.cpu_count() // max(nd, 1), workers, 0 if batches <= 1 else batches)  # number of workers
     sampler = (
         None
         if rank == -1
@@ -352,6 +347,13 @@ def build_dataloader(
         if shuffle
         else ContiguousDistributedSampler(dataset)
     )
+    samples = len(sampler) if sampler else len(dataset)
+    drop_last = drop_last and samples % batch != 0
+    batches = samples // batch if drop_last else math.ceil(samples / batch)
+    nd = torch.cuda.device_count()  # number of CUDA devices
+    # Do not create more worker processes than final loader batches. Single-batch loaders run in-process to avoid
+    # persistent DataLoader worker pools that add overhead and can stall tiny datasets while holding CUDA context.
+    nw = min(os.cpu_count() // max(nd, 1), workers, 0 if batches <= 1 else batches)  # number of workers
     generator = torch.Generator()
     generator.manual_seed(6148914691236517205 + RANK)
     return InfiniteDataLoader(
@@ -365,7 +367,7 @@ def build_dataloader(
         collate_fn=getattr(dataset, "collate_fn", None),
         worker_init_fn=seed_worker,
         generator=generator,
-        drop_last=drop_last and len(dataset) % batch != 0,
+        drop_last=drop_last,
     )
 
 

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -340,8 +340,11 @@ def build_dataloader(
         >>> dataloader = build_dataloader(dataset, batch=16, workers=4, shuffle=True)
     """
     batch = min(batch, len(dataset))
+    batches = math.ceil(len(dataset) / max(batch, 1))
     nd = torch.cuda.device_count()  # number of CUDA devices
-    nw = min(os.cpu_count() // max(nd, 1), workers)  # number of workers
+    # Do not create more worker processes than batches. Single-batch loaders run in-process to avoid persistent
+    # DataLoader worker pools that add overhead and can stall tiny datasets while holding CUDA context.
+    nw = min(os.cpu_count() // max(nd, 1), workers, 0 if batches <= 1 else batches)  # number of workers
     sampler = (
         None
         if rank == -1

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -339,7 +339,8 @@ def build_dataloader(
         >>> dataset = YOLODataset(...)
         >>> dataloader = build_dataloader(dataset, batch=16, workers=4, shuffle=True)
     """
-    batch = min(batch, len(dataset))
+    dataset_len = len(dataset)
+    batch = min(batch, dataset_len)
     sampler = (
         None
         if rank == -1
@@ -347,9 +348,9 @@ def build_dataloader(
         if shuffle
         else ContiguousDistributedSampler(dataset)
     )
-    samples = len(sampler) if sampler is not None else len(dataset)
-    drop_last = drop_last and len(dataset) % batch != 0
-    batches = samples // batch if drop_last else math.ceil(samples / batch)
+    samples = len(sampler) if sampler is not None else dataset_len
+    drop_last = drop_last and bool(batch) and dataset_len % batch != 0
+    batches = (samples // batch if drop_last else math.ceil(samples / batch)) if batch else 0
     nd = torch.cuda.device_count()  # number of CUDA devices
     # Do not create more worker processes than final loader batches. Single-batch loaders run in-process to avoid
     # persistent DataLoader worker pools that add overhead and can stall tiny datasets while holding CUDA context.


### PR DESCRIPTION
## Summary
- Cap dataloader workers from the final loader batch count after sampler construction, while preserving existing global `drop_last` semantics.
- Run single-batch loaders in-process so tiny training jobs do not spawn persistent worker pools that can outlive a wedged trainer and keep CUDA contexts busy.
- Preserve PyTorch DataLoader validation for empty datasets instead of introducing a worker-cap `ZeroDivisionError`.
- Add regression coverage for single-process tiny loaders, distributed sampler/drop-last behavior, and empty-dataset validation.
- Bump package version to `8.4.88` for Portal adoption.

Deleted: excess dataloader worker processes for single-batch loaders; custom test dataset scaffolding in favor of built-in `range` datasets.

Rule 2 justification: net-positive because the bugfix needs regression coverage for single-process, distributed sampler, and empty-dataset semantics; there was no existing focused test for this worker-count path.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves dataloader worker handling for small datasets, reducing unnecessary multiprocessing overhead and potential stalls 🚀

### 📊 Key Changes
- Added logic in `build_dataloader()` to cap worker processes based on the actual number of batches created.
- Single-batch dataloaders now run in-process with `num_workers=0` to avoid unnecessary persistent worker pools.
- Worker calculation now accounts for distributed sampling, ensuring correct behavior in multi-GPU or distributed training setups.
- Preserves `drop_last` behavior while avoiding edge-case issues with tiny or empty datasets.
- Added new tests covering:
  - Tiny datasets with one or two batches ✅
  - Distributed sampling with `drop_last=True` 🌐
  - Empty dataset validation behavior 🧪
- Bumped package version from `8.4.87` to `8.4.88`.

### 🎯 Purpose & Impact
- Reduces overhead for small datasets by avoiding extra worker processes that provide no benefit ⚡
- Helps prevent stalls or resource contention caused by persistent DataLoader workers holding CUDA context.
- Improves reliability for training and validation on tiny datasets, quick tests, and edge-case workflows.
- Maintains correct behavior for distributed training users, minimizing risk of regressions.
- Users should see smoother, more efficient dataloader behavior without needing to change their code 🎉