### PR TITLE
Fix ByteTrack second association ignoring low-confidence detections with `fuse_score=True`

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -337,6 +337,26 @@ def test_track_second_association_indices():
     assert len(low) == 1 and int(low[0, -1]) == 2, f"second-association idx not preserved:\n{tracks}"
 
 
+def test_track_second_association_low_conf_keeps_id():
+    """Low-confidence detection is recovered by the second association under the default fuse_score=True."""
+    from ultralytics.engine.results import Boxes
+    from ultralytics.trackers.byte_tracker import BYTETracker
+    from ultralytics.utils import ROOT, YAML, IterableSimpleNamespace
+
+    args = IterableSimpleNamespace(**YAML.load(ROOT / "cfg/trackers/bytetrack.yaml"))  # default fuse_score=True
+    assert args.fuse_score is True
+    tracker = BYTETracker(args)
+    box = [100, 100, 200, 200]  # same box on both frames, so IoU is 1.0
+    # frame 1: high score starts the track; frame 2: score drops into the low band (track_low_thresh < 0.15 < track_high_thresh)
+    frame1 = tracker.update(Boxes(torch.tensor([[*box, 0.9, 0]], dtype=torch.float32), (640, 640)))
+    frame2 = tracker.update(Boxes(torch.tensor([[*box, 0.15, 0]], dtype=torch.float32), (640, 640)))
+    assert len(frame1) == 1, f"expected one track on frame 1:\n{frame1}"
+    tid = int(frame1[0, 4])
+    # the low-score box must be kept and mapped to the same id via the second association
+    assert len(frame2) == 1, f"low-confidence detection lost by second association:\n{frame2}"
+    assert int(frame2[0, 4]) == tid, f"id switched on low-confidence frame: {tid} -> {int(frame2[0, 4])}\n{frame2}"
+
+
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.parametrize("model", MODELS)
 def test_track_stream(model, tmp_path):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -337,15 +337,15 @@ def test_track_second_association_indices():
     assert len(low) == 1 and int(low[0, -1]) == 2, f"second-association idx not preserved:\n{tracks}"
 
 
-def test_track_second_association_low_conf_keeps_id():
+@pytest.mark.parametrize("tracker_type", ["bytetrack", "fasttrack"])
+def test_track_second_association_low_conf_keeps_id(tracker_type):
     """Low-confidence detection is recovered by the second association under the default fuse_score=True."""
     from ultralytics.engine.results import Boxes
-    from ultralytics.trackers.byte_tracker import BYTETracker
+    from ultralytics.trackers.track import TRACKER_MAP
     from ultralytics.utils import ROOT, YAML, IterableSimpleNamespace
 
-    args = IterableSimpleNamespace(**YAML.load(ROOT / "cfg/trackers/bytetrack.yaml"))  # default fuse_score=True
-    assert args.fuse_score is True
-    tracker = BYTETracker(args)
+    args = IterableSimpleNamespace(**YAML.load(ROOT / f"cfg/trackers/{tracker_type}.yaml"))  # default fuse_score=True
+    tracker = TRACKER_MAP[tracker_type](args)
     box = [100, 100, 200, 200]  # same box on both frames, so IoU is 1.0
     # frame 1: high score starts the track; frame 2: score drops into the low band (track_low_thresh < 0.15 < track_high_thresh)
     frame1 = tracker.update(Boxes(torch.tensor([[*box, 0.9, 0]], dtype=torch.float32), (640, 640)))

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -419,9 +419,7 @@ class BYTETracker:
         """Second-stage association between remaining tracked tracks and low-score detections."""
         r_tracked_stracks = [strack_pool[i] for i in u_track if strack_pool[i].state == TrackState.Tracked]
         if r_tracked_stracks and detections_second:
-            # Second stage uses IoU alone by design (ByteTrack paper arXiv:2110.06864, sec. 3.2).
-            # Fusing the low detection score here pushes the cost above the 0.5 threshold for any IoU,
-            # which turns this recovery step into a no-op under the default fuse_score=True.
+            # IoU-only by design (ByteTrack paper sec. 3.2): fusing low scores pushes costs above the 0.5 threshold
             dists = matching.iou_distance(r_tracked_stracks, detections_second)
             matches, u_track, _ = matching.linear_assignment(dists, thresh=0.5)
             self._apply_matches(matches, r_tracked_stracks, detections_second, activated, refind)

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -419,9 +419,10 @@ class BYTETracker:
         """Second-stage association between remaining tracked tracks and low-score detections."""
         r_tracked_stracks = [strack_pool[i] for i in u_track if strack_pool[i].state == TrackState.Tracked]
         if r_tracked_stracks and detections_second:
+            # Second stage uses IoU alone by design (ByteTrack paper arXiv:2110.06864, sec. 3.2).
+            # Fusing the low detection score here pushes the cost above the 0.5 threshold for any IoU,
+            # which turns this recovery step into a no-op under the default fuse_score=True.
             dists = matching.iou_distance(r_tracked_stracks, detections_second)
-            if self.args.fuse_score:
-                dists = matching.fuse_score(dists, detections_second)
             matches, u_track, _ = matching.linear_assignment(dists, thresh=0.5)
             self._apply_matches(matches, r_tracked_stracks, detections_second, activated, refind)
         else:

--- a/ultralytics/trackers/fast_tracker.py
+++ b/ultralytics/trackers/fast_tracker.py
@@ -212,8 +212,6 @@ class FASTTracker(BYTETracker):
         r_tracked_stracks = [strack_pool[i] for i in u_track if strack_pool[i].state == TrackState.Tracked]
         if r_tracked_stracks and detections_second:
             dists = matching.iou_distance(r_tracked_stracks, detections_second)
-            if self.args.fuse_score:
-                dists = matching.fuse_score(dists, detections_second)
             matches, u_track, _ = matching.linear_assignment(dists, thresh=0.5)
             self._apply_matches(matches, r_tracked_stracks, detections_second, activated, refind)
         else:


### PR DESCRIPTION
The second association in `BYTETracker` (the step that is supposed to recover a track from low-score detections) is a no-op under the default config. With `fuse_score=True` it can never produce a match, so every low-confidence detection in the second band gets dropped.

**What happens**

`_second_association` builds an IoU cost, fuses it with the detection score when `fuse_score` is on, and then runs the assignment:

```python
dists = matching.iou_distance(r_tracked_stracks, detections_second)
if self.args.fuse_score:
    dists = matching.fuse_score(dists, detections_second)
matches, u_track, _ = matching.linear_assignment(dists, thresh=0.5)
```

The detections that reach this stage are the ones with score between `track_low_thresh` and `track_high_thresh` (0.1–0.25 by default), so their score is low by definition, and fusing it here works against the matching instead of helping it. `fuse_score` returns `1 - IoU * score`, so for any second-band detection:

```
fused_cost = 1 - IoU * score  >  1 - 1 * 0.25  =  0.75
```

That holds for any IoU, even a perfect one. The threshold in this stage is `0.5`, hardcoded, not `match_thresh` — so the fused cost sits above 0.75, always above 0.5, and `linear_assignment` returns no match. In order to recover a track here you'd need a score close to 1, but a detection with score close to 1 wouldn't even be in the low band .. so the step is dead code whenever `fuse_score=True`.

This is a regression from #23771 (merged 2026-03-02). Before that PR the second stage used IoU alone, which was correct in 8.3.x. The PR note says "Behaviour is unchanged when `fuse_score=False` (default)", but the default is not `False`: `cfg/trackers/bytetrack.yaml` and `cfg/trackers/botsort.yaml` both ship `fuse_score: True`. So the change is active by default, and it silently disables the step it was meant to improve. The ByteTrack paper (arXiv:2110.06864, sec. 3.2) uses IoU alone in the second association on purpose, because low-score boxes are unreliable and their score shouldn't weigh the cost — ifzhang/ByteTrack, roboflow/supervision and mikel-brostrom/boxmot all keep it IoU-only. ultralytics after #23771 is the only one fusing the score there.

**Impact**

I want to be honest about the scope, it has a limit. The deterministic effect is that low-score detections during a confidence dip are always lost, the box gets dropped for those frames, for any object. On top of that there is an id-switch risk, but only when the object moves during the dip: with the detections dropped, the Kalman filter coasts on the old velocity and drifts off, so when the confidence returns the first-stage re-association no longer overlaps and the object starts over with a new id. A still object is fine, the prediction doesn't move, so it recovers the same id through the first stage once the score is back within `track_buffer`. So this is not "the tracker is broken", it is a recovery step that quietly does nothing under the default.

**Fix**

Remove the score fusion inside `_second_association` and keep IoU alone. This restores the paper behaviour and the 8.3.x behaviour. The first association (`get_dists`) still fuses the score, that part is unchanged.

**Validation**

I added a regression test (`test_track_second_association_low_conf_keeps_id`) that calls `BYTETracker.update()` with the default config (`fuse_score=True`): a high-score box followed by the same box at score 0.15 (inside the low band, IoU = 1) must keep the same id. It fails on `main` — the second frame returns an empty output — and passes with the fix. The existing `test_track_second_association_indices` still passes. I also checked it end-to-end with two small scripts, one for a still object and one for a moving one: the still case loses the box during the dip and recovers the same id with the fix, and the moving case loses the box and gets an ID switch (1 → 2) on `main`, staying id=1 with the fix.

`pytest tests/test_python.py -k second_association` is green. Hope this helps!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a ByteTrack regression where low-confidence detections could be dropped during second association when `fuse_score=True` is enabled by default. 🛠️

### 📊 Key Changes
- Updates `BYTETracker._second_association()` to use IoU-only matching for low-score detections, aligning the second association stage with ByteTrack behavior.
- Removes score fusion from the second association path to prevent low-confidence detections from being incorrectly rejected.
- Adds a regression test confirming a low-confidence detection keeps the same track ID across frames under default `fuse_score=True` settings.

### 🎯 Purpose & Impact
- Improves tracking consistency by preserving IDs when detections temporarily drop into the low-confidence band. 🎯
- Restores intended ByteTrack recovery behavior for low-score detections.
- Reduces ID switches and missed tracks for users relying on default Ultralytics tracking settings.