### PR TITLE
fix(ci): pin NumPy <2 for torch 2.3.0 / torchvision 0.18.0 SlowTests shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
             python: "3.12"
             torch: "2.3.0"
             torchvision: "0.18.0"
-            numpy_extra: export-legacy-torch
+            numpy_extra: export-legacy-torch # torchvision 0.18.0 adjust_hue casts negative hue via np.uint8(), rejected by NumPy 2 (fixed in torchvision 0.19.0)
           - os: ubuntu-latest
             python: "3.12"
             torch: "2.4.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
             python: "3.12"
             torch: "2.3.0"
             torchvision: "0.18.0"
-            numpy_extra: export-legacy-torch # torchvision 0.18.0 adjust_hue casts negative hue via np.uint8(), rejected by NumPy 2 (fixed in torchvision 0.19.0)
+            numpy_extra: export-legacy-torch
           - os: ubuntu-latest
             python: "3.12"
             torch: "2.4.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
             python: "3.12"
             torch: "2.3.0"
             torchvision: "0.18.0"
+            numpy_extra: export-legacy-torch # torchvision 0.18.0 adjust_hue casts negative hue via np.uint8(), rejected by NumPy 2 (fixed in torchvision 0.19.0)
           - os: ubuntu-latest
             python: "3.12"
             torch: "2.4.0"


### PR DESCRIPTION
## Summary

The `SlowTests (ubuntu-latest, 3.12, torch 2.3.0, torchvision 0.18.0)` shard fails with:

```
tests/test_python.py::test_classify_transforms_train[None-0.0-False]
OverflowError: Python integer -3 out of bounds for uint8
  at torchvision/transforms/_functional_pil.py (adjust_hue)
```

### Root cause

torchvision 0.18.0 `adjust_hue()` runs `np_h += np.uint8(hue_factor * 255)`. `ColorJitter(hue=0.015)` in `classify_augmentations` samples the hue factor in `[-0.015, 0.015]`, and for the negative half `np.uint8(negative)` raises `OverflowError` under NumPy 2 (NumPy 2 removed the silent out-of-range scalar wrapping that NumPy 1.x did). torchvision 0.19.0 fixed this to `np.int32(hue_factor * 255).astype(np.uint8)`, so torchvision >= 0.19 on NumPy 2 is fine (the 2.4.0 / 0.19.0 shard passes).

### Fix

Every legacy SlowTests shard with torchvision <= 0.17.0 already sets `numpy_extra: export-legacy-torch` (which pulls `numpy<2`). The torch 2.3.0 / torchvision 0.18.0 shard was the only build with the broken `adjust_hue` that was missing it. This adds `numpy_extra: export-legacy-torch` to that shard so it resolves `numpy<2`, matching the matrix intent stated in the comment above it: "keep NumPy <2 only where the older torch builds actually need it".

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a CI safeguard for legacy Torch/Torchvision compatibility with NumPy 2 🛠️

### 📊 Key Changes
- Adds `numpy_extra: export-legacy-torch` to the CI matrix entry using Python 3.12, Torch 2.3.0, and Torchvision 0.18.0.
- Documents the reason directly in the workflow: Torchvision 0.18.0 has a NumPy 2 incompatibility in `adjust_hue()` due to deprecated `np.uint8()` behavior.
- Keeps the affected test environment running while applying the appropriate legacy export handling.

### 🎯 Purpose & Impact
- Improves CI reliability by preventing known failures from older Torchvision versions with NumPy 2 ✅
- Maintains test coverage for legacy Torch/Torchvision combinations without blocking development.
- Helps developers quickly understand why this compatibility flag exists, reducing future confusion during CI maintenance.