### PR TITLE
Use text fence for hailortcli device output in Hailo docs

### DIFF
--- a/docs/en/integrations/hailo.md
+++ b/docs/en/integrations/hailo.md
@@ -380,7 +380,7 @@ hailortcli fw-control identify
 
 You should see the device type, firmware version, and serial number printed.
 
-```bash
+```text
 Executing on device: 0001:01:00.0
 Identifying board
 Control Protocol Version: 2


### PR DESCRIPTION
The `hailortcli fw-control identify` sample output block was fenced as `bash`, but it is device output, not shell source. This made shell formatters (prettier-plugin-sh in ultralytics/actions) attempt to parse it and fail on `Firmware Version: 4.23.0 (release,app,extended context switch buffer)`, which broke CI formatting on #25039.

The formatter is being fixed centrally in ultralytics/actions#796 to skip unparseable shell fences; this change is defense-in-depth and also renders more accurately (no shell syntax highlighting on output text). All other `bash` fences on the page are real commands and are left unchanged. The page already uses a `text` fence elsewhere.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Hailo integration documentation by correcting the formatting language for sample command output. 📝

### 📊 Key Changes
- Changed a code block in `docs/en/integrations/hailo.md` from `bash` to `text`.
- The updated block shows example output from `hailortcli fw-control identify`, not a command to run.

### 🎯 Purpose & Impact
- Improves documentation accuracy and readability for users following Hailo setup steps. ✅
- Prevents misleading syntax highlighting for command output.
- Helps make the integration guide clearer and more polished for both new and experienced users. 🚀