### PR TITLE
Fix `track()` device mismatch with exported models under the default `tracktrack` tracker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,7 +433,7 @@ jobs:
       - name: Install requirements
         run: |
           # Install TensorRT into the job venv so uv can reuse the runner image cache.
-          uv pip install -e ".[export-base]" pytest-cov onnxruntime-gpu "torch<2.11" "tensorrt-cu12>=7.0.0,!=10.2.0" "nvidia-modelopt[onnx]>=0.44"  # TODO: remove torch pin after GPU runner driver update to CUDA 13.0
+          uv pip install -e ".[export-base]" pytest-cov onnxruntime-gpu "torch<2.11" "tensorrt-cu12>=7.0.0,!=10.2.0" "nvidia-modelopt[onnx]>=0.44" lap  # TODO: remove torch pin after GPU runner driver update to CUDA 13.0
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Check environment

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -180,6 +180,15 @@ def test_predict_multiple_devices():
 
 
 @pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
+def test_track_exported_model():
+    """Track with an exported model on GPU; exported backends return raw preds as a single Tensor."""
+    file = YOLO(MODEL).export(format="torchscript", imgsz=160, device=DEVICES[0])
+    results = YOLO(file).track(SOURCE, imgsz=160, device=DEVICES[0])
+    assert len(results[0].boxes)
+    Path(file).unlink()  # cleanup
+
+
+@pytest.mark.skipif(not DEVICES, reason="No CUDA devices available")
 def test_autobatch():
     """Check optimal batch size for YOLO model training using autobatch utility."""
     from ultralytics.utils.autobatch import check_train_batch_size

--- a/ultralytics/trackers/track_tracker.py
+++ b/ultralytics/trackers/track_tracker.py
@@ -137,8 +137,8 @@ def attach_raw_preds_hook(predictor) -> None:
 
     @wraps(orig)
     def _wrapped(preds, img, orig_imgs, *args, **kwargs):
-        # copy=True so the in-place NMS xywh->xyxy conversion can't mutate this captured tensor (CPU aliasing)
-        predictor._raw_preds = preds.detach().to("cpu", copy=True) if isinstance(preds, torch.Tensor) else preds
+        # clone() so the in-place NMS xywh->xyxy conversion can't mutate this capture; keep source device for box_iou
+        predictor._raw_preds = preds.detach().clone() if isinstance(preds, torch.Tensor) else preds
         predictor._postprocess_im = img
         predictor._postprocess_im0s = orig_imgs
         return orig(preds, img, orig_imgs, *args, **kwargs)


### PR DESCRIPTION
Tracking on GPU with any exported model crashes with the default tracker (`tracktrack.yaml`, default since #24897):

```python
from ultralytics import YOLO

f = YOLO("yolo11n.pt").export(format="onnx", device=0)
YOLO(f, task="detect").track("https://ultralytics.com/images/bus.jpg", device=0)
```

```
  File "ultralytics/trackers/track.py", line 107, in on_predict_postprocess_end
    tracker_cls.compute_frame_extras(predictor) if hasattr(tracker_cls, "compute_frame_extras") else None
  File "ultralytics/trackers/track_tracker.py", line 170, in compute_dets_del
    max_iou = box_iou(loose_boxes.xyxy, tight_boxes.xyxy).max(dim=1).values
  File "ultralytics/utils/metrics.py", line 99, in box_iou
    inter = (torch.min(a2, b2) - torch.max(a1, b1)).clamp_(0).prod(2)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Same crash with torchscript and with end2end models (yolo26n.onnx), on detect and obb, through the Python API and the CLI. The controls all work: same command on CPU, same command with `tracker="bytetrack.yaml"`, and the `.pt` weights directly.

**Root cause**

`attach_raw_preds_hook` (`track_tracker.py:141`) stores the raw preds with `preds.detach().to("cpu", copy=True)`, but only when `preds` is a single `torch.Tensor`. The `.pt` backend returns a tuple, so it is stored as-is and never crashes — every exported backend returns a Tensor on the inference device, and that one gets moved to CPU. Then `compute_dets_del` re-runs `_orig_postprocess` on the CPU preds, so `box_iou` at line 170 receives `loose_boxes` on CPU against `predictor.results` on `cuda:0`. It came in with #24371, and none of the later changes to the file (#24768, #24927, #24930, #25021) touch this path.

**Fix**

One line: `preds.detach().to("cpu", copy=True)` -> `preds.detach().clone()`, keeping the capture on its source device. The original inline comment explains why the copy exists: "copy=True so the in-place NMS xywh->xyxy conversion can't mutate this captured tensor (CPU aliasing)". `clone()` gives exactly the same guarantee, it always allocates new storage (I checked `data_ptr()` differs on both CPU and GPU), so the anti-aliasing intent is kept — the `"cpu"` destination was incidental to it. Nothing downstream assumes CPU: `compute_dets_del` already normalises with `.cpu()` before going to numpy (line 176), and the tuple branch for `.pt` is untouched.

On memory: the clone holds ~2.8 MB extra on the GPU (1x84x8400 fp32) and it is released within the same frame (`compute_dets_del` sets `_raw_preds = None`). In order to check there is no accumulation I ran a 200-frame stream: `memory_allocated` stays flat at 7.7 MB on frames 20/100/200, and the tracktrack peak stayed below the bytetrack peak in the same session. As a side note, this also removes one forced GPU->CPU sync per frame.

The diff adds more lines than it removes because the logic change is a 1-line replacement — the added lines are the GPU regression test that was missing (`tests/test_cuda.py` had no track test).

**Validation**

RTX 4060, torch 2.12.1+cu130, main @ 45728ce:

| Model | Task | Device | main | with fix |
|---|---|---|---|---|
| yolo11n.onnx (fp32) | detect | cuda:0 | crash | 4 boxes, ids assigned |
| yolo11n.torchscript | detect | cuda:0 | crash | 4 boxes, ids assigned |
| yolo26n.onnx (end2end) | detect | cuda:0 | crash | 4 boxes, ids assigned |
| yolo11n-obb.onnx | obb | cuda:0 | crash | 83 boxes, ids assigned |
| yolo11n.onnx | detect | cpu | OK | OK, unchanged |
| yolo11n.pt | detect | cuda:0 | OK | OK, tuple branch unchanged |

New test `test_track_exported_model` in `tests/test_cuda.py`: exports a torchscript on GPU and tracks with it. Without the fix it fails with the exact `RuntimeError` above; with the fix it passes in ~2 s. I also re-checked fp16 (`half=True` onnx export, and `.pt` with `half=True`), both fine — dtype is preserved the same way the old code preserved it.

Not touched on purpose: `setup_predictor` only attaches the hook for detect/obb (segment/pose are out by design, the docstring covers it), and no other tracker goes through `attach_raw_preds_hook`, `TRACKTRACK` is the only one defining `setup_predictor`/`compute_frame_extras`. I hit this while testing exported models after the tracker work in #25034 .. let me know if you prefer aligning devices at the `box_iou` call site instead, but keeping the capture on its source device seemed the smaller change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a GPU device mismatch in `track()` when using exported TorchScript models with the default tracker. 🛠️

### 📊 Key Changes
- Updates raw prediction capture in `ultralytics/trackers/track_tracker.py` to keep tensors on their source device instead of moving them to CPU.
- Uses `detach().clone()` to protect captured predictions from in-place postprocessing mutation while preserving device placement.
- Adds a CUDA regression test that exports a model to TorchScript and verifies `YOLO(file).track(..., device=...)` succeeds on GPU.

### 🎯 Purpose & Impact
- Prevents device mismatch errors during tracking with exported models on CUDA. 🚀
- Improves reliability of tracking workflows that use exported backends.
- Adds test coverage to reduce the chance of future regressions in exported-model tracking.