### PR TITLE
Fix `classes` filter applied after `max_det` truncation in end-to-end NMS

### DIFF
--- a/docs/en/guides/end2end-detection.md
+++ b/docs/en/guides/end2end-detection.md
@@ -187,10 +187,10 @@ However, `end2end=False` combined with `nms=True` is a valid configuration — i
 
 ### What does the max_det parameter control in end-to-end models?
 
-The [`max_det`](../modes/predict.md#inference-arguments) parameter (default: 300) sets the maximum number of detections the one-to-one head can output per image. You can adjust it at inference or export time:
+The [`max_det`](../modes/predict.md#inference-arguments) parameter (default: 300) sets the maximum number of detections returned per image. You can adjust it at inference or export time:
 
 ```python
-model.predict("image.jpg", max_det=100)  # fewer detections, slightly faster
+model.predict("image.jpg", max_det=100)  # fewer detections
 model.export(format="onnx", max_det=500)  # more detections for dense scenes
 ```
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -242,6 +242,16 @@ def test_predict_img(model_name):
     assert len(model(batch, imgsz=32, classes=0)) == len(batch)  # multiple sources in a batch
 
 
+@pytest.mark.parametrize("model_name", ["yolo26n.pt", "yolo11n.pt"])  # end2end and NMS-based models
+def test_predict_classes_with_max_det(model_name):
+    """Test that the classes filter applies before max_det truncation in both end2end and NMS-based models."""
+    boxes = YOLO(WEIGHTS_DIR / model_name)(SOURCE, classes=[0], max_det=300, verbose=False)[0].boxes
+    assert len(boxes) > 1  # bus.jpg contains multiple persons
+    top1 = YOLO(WEIGHTS_DIR / model_name)(SOURCE, classes=[0], max_det=1, verbose=False)[0].boxes  # fresh model
+    assert len(top1) == 1 and int(top1.cls) == 0
+    assert float(top1.conf) == pytest.approx(float(boxes.conf.max()))  # best person kept, not an arbitrary one
+
+
 @pytest.mark.parametrize("model", MODELS)
 def test_predict_visualize(model):
     """Test model prediction methods with 'visualize=True' to generate prediction visualizations."""
@@ -806,6 +816,25 @@ def test_utils_ops():
 
     # segment2box must not drop a polygon lying on the left image edge (all x == 0) to a zero box
     assert segment2box(np.array([[0, 100], [0, 150], [0, 200]]), 640, 640).tolist() == [0, 100, 0, 200]
+
+
+def test_nms_end2end_classes_before_max_det():
+    """The end-to-end NMS branch must filter classes before truncating to max_det, like the NMS-based branch."""
+    from ultralytics.utils.nms import non_max_suppression
+
+    # (2, 4, 6) end2end predictions sorted by descending confidence: [x1, y1, x2, y2, conf, cls]
+    pred = torch.tensor(
+        [
+            [[0, 0, 9, 9, 0.9, 5], [1, 1, 9, 9, 0.8, 0], [2, 2, 9, 9, 0.7, 0], [3, 3, 9, 9, 0.6, 0]],
+            [[0, 0, 9, 9, 0.9, 0], [1, 1, 9, 9, 0.8, 5], [2, 2, 9, 9, 0.7, 5], [3, 3, 9, 9, 0.6, 0]],
+        ],
+        dtype=torch.float32,
+    )
+    for out, confs in zip(non_max_suppression(pred, conf_thres=0.25, classes=[0], max_det=2), ([0.8, 0.7], [0.9, 0.6])):
+        assert out.shape[0] == 2 and (out[:, 5] == 0).all()  # top-2 class-0 boxes kept, not truncated away
+        assert torch.allclose(out[:, 4], torch.tensor(confs))
+    out = non_max_suppression(pred, conf_thres=0.25, max_det=2)[0]  # without classes, top-2 overall unchanged
+    assert torch.allclose(out[:, 4], torch.tensor([0.9, 0.8]))
 
 
 def test_process_mask_empty():

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -399,8 +399,7 @@ class BasePredictor:
             if self.args.end2end is not None:
                 model.end2end = self.args.end2end
             if model.end2end:
-                # Keep head top-k >= 300 (Detect.max_det default in nn/modules/head.py) so `classes` filtering
-                # in NMS sees all candidates; final max_det truncation happens in non_max_suppression
+                # Keep head top-k >= 300 so `classes` filtering in NMS sees all candidates before `max_det` truncation
                 model.set_head_attr(max_det=max(self.args.max_det, 300), agnostic_nms=self.args.agnostic_nms)
         self.model = AutoBackend(
             model=model or self.args.model,

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -399,7 +399,9 @@ class BasePredictor:
             if self.args.end2end is not None:
                 model.end2end = self.args.end2end
             if model.end2end:
-                model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
+                # Keep head top-k >= 300 (Detect.max_det default in nn/modules/head.py) so `classes` filtering
+                # in NMS sees all candidates; final max_det truncation happens in non_max_suppression
+                model.set_head_attr(max_det=max(self.args.max_det, 300), agnostic_nms=self.args.agnostic_nms)
         self.model = AutoBackend(
             model=model or self.args.model,
             device=select_device(self.args.device, verbose=verbose),

--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -67,7 +67,7 @@ def non_max_suppression(
         output = [pred[pred[:, 4] > conf_thres] for pred in prediction]
         if classes is not None:
             output = [pred[(pred[:, 5:6] == classes).any(1)] for pred in output]
-        return [pred[:max_det] for pred in output]  # filter by class before limiting detections
+        return [pred[:max_det] for pred in output]  # apply max_det after classes filter
 
     bs = prediction.shape[0]  # batch size (BCN, i.e. 1,84,6300)
     nc = nc or (prediction.shape[1] - 4)  # number of classes

--- a/ultralytics/utils/nms.py
+++ b/ultralytics/utils/nms.py
@@ -64,10 +64,10 @@ def non_max_suppression(
         classes = torch.tensor(classes, device=prediction.device)
 
     if prediction.shape[-1] == 6 or end2end:  # end-to-end model (BNC, i.e. 1,300,6)
-        output = [pred[pred[:, 4] > conf_thres][:max_det] for pred in prediction]
+        output = [pred[pred[:, 4] > conf_thres] for pred in prediction]
         if classes is not None:
             output = [pred[(pred[:, 5:6] == classes).any(1)] for pred in output]
-        return output
+        return [pred[:max_det] for pred in output]  # filter by class before limiting detections
 
     bs = prediction.shape[0]  # batch size (BCN, i.e. 1,84,6300)
     nc = nc or (prediction.shape[1] - 4)  # number of classes


### PR DESCRIPTION
Predicting with `classes` + `max_det` on any end-to-end model returns fewer detections than the model actually found, down to zero. The same arguments on a NMS-based model work as expected:

```python
from ultralytics import YOLO

img = "https://ultralytics.com/images/bus.jpg"
for k in (300, 4, 1):
    print(k, len(YOLO("yolo26n.pt")(img, classes=[0], max_det=k, verbose=False)[0].boxes))
```

| Call (bus.jpg) | Boxes returned |
|---|---|
| yolo26n.pt `classes=[0], max_det=300` | 4 persons (0.913 / 0.905 / 0.870 / 0.556) |
| yolo26n.pt `classes=[0], max_det=4` | 3 persons |
| yolo26n.pt `classes=[0], max_det=1` | **0 boxes** |
| yolo26n.pt no `classes`, `max_det=1` | 1 (bus, 0.924) |
| yolo11n.pt `classes=[0], max_det=1` | 1 person (0.888) |

So with `max_det=1` the user asks for the best person, there are four persons above 0.55 conf in the image, and gets nothing back, with no warning. The same happens on YOLOv10 and on every model exported with embedded NMS (`nms=True`) or native end2end, through Python and the CLI, and it makes YOLO11 -> YOLO26 migrations return different results with identical arguments.

Resolves #25044

**Root cause**

The truncation happens before the `classes` filter, in two stages:

1. The end-to-end branch of `non_max_suppression` (`ultralytics/utils/nms.py:67`) slices `[:max_det]` on the conf-filtered preds and only then applies `classes`. With `max_det=1` the slice keeps only the bus, and the classes filter deletes it.
2. For torch end2end models there is a second stage upstream: `setup_model` lowers the head top-k to `args.max_det` (`ultralytics/engine/predictor.py:402`, since #23396), so with `max_det=1` the head itself returns a single candidate and nothing downstream can recover the persons.

The NMS-based branch of the same function does it in the correct order: `classes` filter at `nms.py:126-131`, `max_det` truncation at the end (`nms.py:157`). `RTDETRPredictor.postprocess` also filters classes before `[: self.args.max_det]` (`models/rtdetr/predict.py:62-64`). So the end-to-end branch is the only one with the inverted order, and that is why YOLO11 and YOLO26 diverge.

On the history: #13971 (v8.2.43) added the `classes` filter to this branch with no truncation at all; the `[:max_det]` slice came later with #15917 (v8.2.85) and landed between the conf filter and the classes filter.

**Fix**

Both stages need a change, I verified each one alone is not enough:

- `ultralytics/utils/nms.py`: reorder to conf filter -> classes filter -> `[:max_det]`, matching the NMS-based branch and RT-DETR. This alone fully fixes exported models (the graph carries its own baked top-k and the `max_det` slice runs at inference time), but not torch end2end models, where the head already truncated.
- `ultralytics/engine/predictor.py`: keep the head top-k at `max(args.max_det, 300)` (300 is the `Detect.max_det` default in `nn/modules/head.py`) so the classes filter sees all candidates; the final `max_det` truncation now happens in `non_max_suppression`. This is unconditional in order to keep the head state independent from `classes` (`setup_model` runs once per predictor), it does not touch the export path of the head, and `max_det > 300` still raises the top-k as #23396 intended.
- `docs/en/guides/end2end-detection.md`: two-line change in the `max_det` FAQ — it said `max_det` sets what the head outputs and that a lower value is "slightly faster" at predict time, which stops being accurate with this change (the head keeps its 300 top-k in predict; export is unchanged). Reworded to "maximum number of detections returned per image" so the docs stay correct for both paths.

Results without `classes` are bit-identical: the head top-k is sorted by descending conf, so `topk(300)` plus a later `[:max_det]` slice selects exactly the same boxes as `topk(max_det)`. I checked with a 48-case matrix (yolo26n/yolo11n x classes None/[0]/[5]/[0,5]/all-80/absent-class x max_det 1/4/300/3000), comparing full output tensors at 6 decimals against main: everything identical except the two buggy cases, which now return the missing persons. The cost is the head gathering 300 rows instead of `max_det`: predict on yolo26n with `max_det=1` went from ~6.43 to ~6.51 ms/img on a RTX 4060 (~1%, only torch end2end with `max_det < 300`); the nms branch itself shows identical times within noise.

**Validation**

RTX 4060, torch 2.12.1+cu130, main @ e821386:

- yolo26n.pt `classes=[0], max_det=1`: 0 boxes -> 1 person (0.913). Without `classes`: bus 0.924, unchanged.
- yolo11n.onnx exported with `nms=True` and yolo26n.onnx (native end2end): 0 -> 1 person (0.902 / 0.915), identical outputs without `classes`.
- yolo11n.pt (NMS-based branch): identical in all 24 matrix cases, that branch was never broken.
- Edge cases: empty preds, all below conf, batch of 3 (main also drops a class-0 box from one batch item, the fix keeps it), classes as int/tuple/list, CUDA, absent class.
- seg/pose/obb end2end share the same branch with cls at index 5, all covered; `val()` is not affected (`classes` is not applied to predictions there) and nothing changes for train or the regular NMS path.

Two new tests, both failing on main and passing with the fix: `test_predict_classes_with_max_det` (end-to-end, covers both stages — it keeps failing if either partial fix is applied alone) and a synthetic unit test on `non_max_suppression` for the branch order, including batch. Regression sweep `test_predict_img` on yolo26n/-seg/-pose/-obb plus model forward/methods/ops: 14 passed. The diff adds more lines than it removes because the logic change is 4 lines — the rest is the regression coverage that was missing.

One honest limit: the 300 ceiling (or the baked top-k of an exported graph) is structural. If the requested classes fall outside the global top-300 candidates they are still lost — e.g. an ONNX exported with `max_det=2` returns 1 person with `classes=[0], max_det=2`, not 2. That is pre-existing (before this fix it returned 0) and the mitigation is a larger `max_det` at export time. I realise the end-to-end FAQ documents the head truncation, but returning 0 results with valid detections present and no warning, while YOLO11 returns them with the same arguments, looks like the same class of divergence that #13907 treated as a bug .. let me know if you prefer a different mechanism for the head top-k part.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes end-to-end detection behavior so `classes` filtering is applied before `max_det` truncation, preserving the best detections for requested classes. 🛠️

### 📊 Key Changes
- Updates end-to-end NMS logic in `ultralytics/utils/nms.py` to filter by confidence, then class, then apply final `max_det` limiting.
- Adjusts predictor setup so end-to-end model heads keep enough candidates available for downstream class filtering.
- Adds regression tests covering YOLO26 and YOLO11 prediction paths, plus direct end-to-end NMS behavior.
- Clarifies `max_det` wording in the end-to-end detection guide documentation. 📚

### 🎯 Purpose & Impact
- Ensures `classes` filtering works correctly when `max_det` is small, avoiding cases where valid target-class detections are truncated away too early.
- Aligns end-to-end NMS behavior more closely with standard NMS-based model behavior.
- Improves reliability for users filtering predictions by class in object detection workflows. ✅
