### PR TITLE
Fix `classify_transforms` ignoring `interpolation` for non-square sizes

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2814,14 +2814,14 @@ def classify_transforms(
             "'crop_fraction' arg of classify_transforms is deprecated, will be removed in a future version."
         )
 
-    # Aspect ratio is preserved, crops center within image, no borders are added, image is lost
-    if scale_size[0] == scale_size[1]:
-        # Simple case, use torchvision built-in Resize with the shortest edge mode (scalar size arg)
-        tfl = [T.Resize(scale_size[0], interpolation=getattr(T.InterpolationMode, interpolation))]
-    else:
-        # Resize the shortest edge to matching target dim for non-square target
-        tfl = [T.Resize(scale_size, interpolation=getattr(T.InterpolationMode, interpolation))]
-    tfl += [T.CenterCrop(size), T.ToTensor(), T.Normalize(mean=torch.tensor(mean), std=torch.tensor(std))]
+    # Square target uses the scalar shortest-edge mode (preserves aspect); non-square resizes to the exact (h, w).
+    resize = scale_size[0] if scale_size[0] == scale_size[1] else scale_size
+    tfl = [
+        T.Resize(resize, interpolation=getattr(T.InterpolationMode, interpolation)),
+        T.CenterCrop(size),
+        T.ToTensor(),
+        T.Normalize(mean=torch.tensor(mean), std=torch.tensor(std)),
+    ]
     return T.Compose(tfl)
 
 

--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -2820,7 +2820,7 @@ def classify_transforms(
         tfl = [T.Resize(scale_size[0], interpolation=getattr(T.InterpolationMode, interpolation))]
     else:
         # Resize the shortest edge to matching target dim for non-square target
-        tfl = [T.Resize(scale_size)]
+        tfl = [T.Resize(scale_size, interpolation=getattr(T.InterpolationMode, interpolation))]
     tfl += [T.CenterCrop(size), T.ToTensor(), T.Normalize(mean=torch.tensor(mean), std=torch.tensor(std))]
     return T.Compose(tfl)
 


### PR DESCRIPTION
## Description

`classify_transforms()` in `ultralytics/data/augment.py` accepts an `interpolation` argument, but only the square-size branch passes it to `T.Resize`. The non-square branch drops it:

```python
if scale_size[0] == scale_size[1]:
    tfl = [T.Resize(scale_size[0], interpolation=getattr(T.InterpolationMode, interpolation))]
else:
    tfl = [T.Resize(scale_size)]  # interpolation silently ignored
```

So `classify_transforms(size=(224, 320), interpolation="BICUBIC")` silently resizes with torchvision's default `BILINEAR` instead of the requested mode. This PR passes `interpolation` in the non-square branch the same way the square branch does.

Default behavior is unchanged: the default `interpolation="BILINEAR"` matches `T.Resize`'s own default, so existing pipelines produce bit-identical results — only explicit non-default `interpolation` with a non-square `size` is affected.

Verified locally:
- `classify_transforms(size=(224, 320), interpolation="BICUBIC")` → first transform now reports `InterpolationMode.BICUBIC` (previously `BILINEAR`)
- default non-square call still uses `BILINEAR`; square path unchanged
- end-to-end transform of a PIL image returns the expected `(3, 224, 320)` tensor

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `classify_transforms` so custom interpolation is respected when resizing non-square classification inputs. 🛠️

### 📊 Key Changes
- Updates `ultralytics/data/augment.py` to pass the requested `interpolation` mode into `T.Resize()` for non-square target sizes.
- Aligns non-square resize behavior with the existing square-size resize path.
- Ensures interpolation settings are consistently applied before center crop, tensor conversion, and normalization.

### 🎯 Purpose & Impact
- Improves correctness for image classification preprocessing when users specify a non-default interpolation mode.
- Helps produce more predictable augmentation and validation pipelines for non-square classification image sizes.
- Low-risk bug fix with localized impact to classification transforms. ✅