### PR TITLE
Add https://youtu.be/_fvGA9LPXzs to docs

### DIFF
--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -15,13 +15,13 @@ The output of an instance segmentation model is a set of masks or contours that 
 
 <p align="center">
   <br>
-  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/_fvGA9LPXzs"
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/o4Zd-IeMlSY?si=37nusCzDTd74Obsp"
     title="YouTube video player" frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> Semantic Segmentation with Ultralytics YOLO26 | Quickstart Tutorial
+  <strong>Watch:</strong> Run Segmentation with Pretrained Ultralytics YOLO Model in Python.
 </p>
 
 !!! tip

--- a/docs/en/tasks/segment.md
+++ b/docs/en/tasks/segment.md
@@ -15,13 +15,13 @@ The output of an instance segmentation model is a set of masks or contours that 
 
 <p align="center">
   <br>
-  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/o4Zd-IeMlSY?si=37nusCzDTd74Obsp"
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/_fvGA9LPXzs"
     title="YouTube video player" frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> Run Segmentation with Pretrained Ultralytics YOLO Model in Python.
+  <strong>Watch:</strong> Semantic Segmentation with Ultralytics YOLO26 | Quickstart Tutorial
 </p>
 
 !!! tip

--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -13,13 +13,13 @@ model_name: yolo26n-sem
 
 <p align="center">
   <br>
-  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/zF2T17ppKIE"
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/_fvGA9LPXzs"
     title="YouTube video player" frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> How to Train Ultralytics YOLO26 Semantic Segmentation Model on Custom Dataset | Ultralytics Platform
+  <strong>Watch:</strong> Semantic Segmentation with Ultralytics YOLO26 | Quickstart Tutorial
 </p>
 
 The output of a semantic segmentation model is a single height-by-width class map where each pixel value corresponds to a predicted class ID. This makes semantic segmentation ideal for scene parsing tasks such as autonomous driving, medical imaging, and land-cover mapping.


### PR DESCRIPTION
Updates the video embed in `docs/en/tasks/semantic.md`: replaces the previous video (https://youtu.be/zF2T17ppKIE) with the new official quickstart "Semantic Segmentation with Ultralytics YOLO26 | Quickstart Tutorial" (https://youtu.be/_fvGA9LPXzs) and updates the **Watch:** caption to match the video title.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the YOLO26 semantic segmentation documentation with a new tutorial video and clearer video title 🎥

### 📊 Key Changes
- Replaced the embedded YouTube video in `docs/en/tasks/semantic.md` with a new quickstart tutorial link.
- Updated the video caption from a custom dataset training focus to **“Semantic Segmentation with Ultralytics YOLO26 | Quickstart Tutorial”**.
- Kept the surrounding semantic segmentation documentation unchanged.

### 🎯 Purpose & Impact
- Improves the learning experience for users exploring YOLO26 semantic segmentation 🚀
- Provides a more general quickstart resource suitable for beginners and broad audiences.
- Helps users more easily understand how to get started with semantic segmentation using Ultralytics YOLO26.