### PR TITLE
Fix crashes on invalid copy_paste_mode and optimizer values

### DIFF
--- a/ultralytics/data/augment.py
+++ b/ultralytics/data/augment.py
@@ -1880,7 +1880,7 @@ class CopyPaste(BaseMixTransform):
     def __init__(self, dataset=None, pre_transform=None, p: float = 0.5, mode: str = "flip") -> None:
         """Initialize CopyPaste object with dataset, pre_transform, and probability of applying CopyPaste."""
         super().__init__(dataset=dataset, pre_transform=pre_transform, p=p)
-        assert mode in {"flip", "mixup"}, f"Expected `mode` to be `flip` or `mixup`, but got {mode}."
+        assert mode in ("flip", "mixup"), f"Expected `mode` to be `flip` or `mixup`, but got {mode}."
         self.mode = mode
 
     def __call__(self, labels: dict[str, Any]) -> dict[str, Any]:

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1084,7 +1084,7 @@ class BaseTrainer:
             g = [x.values() for x in g[:3]]  # convert to list of params
 
         optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "SGD", "MuSGD", "auto"}
-        name = {x.lower(): x for x in optimizers}.get(str(name).lower(), name)
+        name = {x.lower(): x for x in optimizers}.get(str(name).lower(), str(name))
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optim_args = dict(lr=lr, betas=(momentum, 0.999), weight_decay=0.0)
         elif name == "RMSProp":

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1084,7 +1084,7 @@ class BaseTrainer:
             g = [x.values() for x in g[:3]]  # convert to list of params
 
         optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "SGD", "MuSGD", "auto"}
-        name = {x.lower(): x for x in optimizers}.get(name.lower())
+        name = {x.lower(): x for x in optimizers}.get(str(name).lower(), name)
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optim_args = dict(lr=lr, betas=(momentum, 0.999), weight_decay=0.0)
         elif name == "RMSProp":


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves optimizer name handling during training and makes a small CopyPaste augmentation cleanup for better robustness and consistency 🛠️

### 📊 Key Changes
- Updated optimizer selection to safely handle non-string optimizer names by converting inputs with `str(name)` before lowercase matching ⚙️
- Preserves the original optimizer value as a fallback when it does not match known optimizers, improving error handling and flexibility ✅
- Replaced a set literal with a tuple in the CopyPaste augmentation mode assertion for a minor style/consistency cleanup 🎨

### 🎯 Purpose & Impact
- Reduces the chance of training crashes caused by unexpected optimizer name input types 🚀
- Makes optimizer configuration more robust for users passing values from configs, scripts, or external tools 🧩
- No expected behavior change for standard training workflows; existing optimizer names like `SGD`, `AdamW`, and `auto` continue to work as before 🔄