### PR TITLE
Fix `save_txt` keypoint scaling in `PoseValidator`

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -454,6 +454,29 @@ def test_val(task: str, weight: str, data: str) -> None:
         metrics.confusion_matrix.to_json()
 
 
+def test_val_save_txt_pose(tmp_path):
+    """Test that pose keypoints saved by val(save_txt=True) are normalized to the original image space."""
+    model = YOLO(WEIGHTS_DIR / "yolo26n-pose.pt")
+    # imgsz=640 (not the imgsz=32 used elsewhere): coco8-pose images are non-square, so the letterbox offset is only
+    # large enough to push mis-scaled keypoints outside [0, 1] at full resolution; at small imgsz they would stay in
+    # range and hide the regression.
+    metrics = model.val(data="coco8-pose.yaml", imgsz=640, conf=0.25, save_txt=True, project=tmp_path, name="val")
+    txt_files = list((Path(metrics.save_dir) / "labels").glob("*.txt"))
+    assert txt_files, "val(save_txt=True) saved no label files"
+    for txt_file in txt_files:
+        for line in txt_file.read_text().splitlines():
+            values = [float(v) for v in line.split()]
+            x, y, w, h = values[1:5]  # normalized xywh box
+            kpts = torch.tensor(values[5:]).view(-1, 3)  # (17, 3) of normalized (x, y, conf) keypoints
+            assert ((kpts[:, :2] >= 0) & (kpts[:, :2] <= 1)).all(), f"keypoints not in [0, 1] in {txt_file.name}"
+            # Keypoints scaled into the wrong (letterbox) space also land off the person, so check that visible
+            # keypoints cluster on the box; the 0.05 margin allows joints (wrists, ankles) just outside a tight box.
+            visible = kpts[kpts[:, 2] > 0.5, :2]
+            if len(visible):
+                cx, cy = visible.mean(0)
+                assert abs(cx - x) < w / 2 + 0.05 and abs(cy - y) < h / 2 + 0.05, "keypoints misaligned with box"
+
+
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
 def test_train_multi():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -455,14 +455,17 @@ def test_val(task: str, weight: str, data: str) -> None:
 
 
 def test_val_save_txt_pose(tmp_path):
-    """Test that pose keypoints saved by val(save_txt=True) are normalized to the original image space."""
+    """Test that pose keypoints saved by val(save_txt=True) and val(save_json=True) are in the original image space."""
     model = YOLO(WEIGHTS_DIR / "yolo26n-pose.pt")
     # imgsz=640 (not the imgsz=32 used elsewhere): coco8-pose images are non-square, so the letterbox offset is only
     # large enough to push mis-scaled keypoints outside [0, 1] at full resolution; at small imgsz they would stay in
-    # range and hide the regression.
-    metrics = model.val(data="coco8-pose.yaml", imgsz=640, conf=0.25, save_txt=True, project=tmp_path, name="val")
+    # range and hide the regression. save_json=True also exercises pred_to_json, the other consumer of the scaled key.
+    metrics = model.val(
+        data="coco8-pose.yaml", imgsz=640, conf=0.25, save_txt=True, save_json=True, project=tmp_path, name="val"
+    )
     txt_files = list((Path(metrics.save_dir) / "labels").glob("*.txt"))
     assert txt_files, "val(save_txt=True) saved no label files"
+    assert (Path(metrics.save_dir) / "predictions.json").exists(), "val(save_json=True) saved no predictions.json"
     for txt_file in txt_files:
         for line in txt_file.read_text().splitlines():
             values = [float(v) for v in line.split()]

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -219,7 +219,7 @@ class PoseValidator(DetectionValidator):
         format, and appends the results with keypoints to the internal JSON dictionary (self.jdict).
 
         Args:
-            predn (dict[str, torch.Tensor]): Prediction dictionary containing 'bboxes', 'conf', 'cls', and 'kpts'
+            predn (dict[str, torch.Tensor]): Prediction dictionary containing 'bboxes', 'conf', 'cls', and 'keypoints'
                 tensors.
             pbatch (dict[str, Any]): Batch dictionary containing 'imgsz', 'ori_shape', 'ratio_pad', and 'im_file'.
 
@@ -229,7 +229,7 @@ class PoseValidator(DetectionValidator):
             before saving to the JSON dictionary.
         """
         super().pred_to_json(predn, pbatch)
-        kpts = predn["kpts"]
+        kpts = predn["keypoints"]
         for i, k in enumerate(kpts.flatten(1, 2).tolist()):
             self.jdict[-len(kpts) + i]["keypoints"] = k  # keypoints
 
@@ -237,7 +237,7 @@ class PoseValidator(DetectionValidator):
         """Scales predictions to the original image size."""
         return {
             **super().scale_preds(predn, pbatch),
-            "kpts": ops.scale_coords(
+            "keypoints": ops.scale_coords(
                 pbatch["imgsz"],
                 predn["keypoints"].clone(),
                 pbatch["ori_shape"],


### PR DESCRIPTION
`val(save_txt=True)` on pose models writes the keypoints in letterbox space instead of the original image space, so after normalisation they end up outside [0, 1] and far from the person:

```python
from ultralytics import YOLO

YOLO("yolo11n-pose.pt").val(data="coco8-pose.yaml", imgsz=640, save_txt=True)
```

Checking the saved `labels/*.txt` on main @ fcb350d (RTX 4060, torch 2.12.1+cu130): keypoint coordinates go from 0.0111 up to **1.5304**, with 732 of 6664 values outside [0, 1], in 4 of 4 files. The boxes in the same files are correct (0.0–0.9767), so each line mixes a good box with keypoints scaled to a different space.

**Root cause**

#21719 fixed the `save_txt` box scaling by moving the scaling into the new `scale_preds` method. For keypoints it stored the scaled tensor under a new `"kpts"` key and migrated `pred_to_json` to read it, but `save_one_txt` kept reading `predn["keypoints"]`, which after that refactor stays in letterbox space (~imgsz pixels). `Results.save_txt` then normalises those values by `ori_shape`, and that is where the out-of-range coordinates come from. So the same `predn` dict produces a correct json and a broken txt.

**Fix**

`scale_preds` now overwrites the canonical `"keypoints"` key instead of adding `"kpts"`, and `pred_to_json` reads `"keypoints"` again. This is how the sibling validators already work: Detect overwrites `"bboxes"`, Segment overwrites `"masks"`, OBB overwrites `"bboxes"` — Pose was the only one writing the scaled result to a different key than the one `save_one_txt` reads. With the key unified, `save_one_txt` receives the scaled tensor without touching it, and the stale letterbox copy no longer exists in the dict. I grepped for other consumers of the `"kpts"` key and there are none (the `kpts` hits in `nn/modules/head.py` and `utils/loss.py` belong to the model head output, a different dict).

The minimal alternative was a one-liner — point `save_one_txt` at `predn["kpts"]` — but that keeps two keys for the same tensor and the unscaled `"keypoints"` stays in the dict, so in order to keep Pose consistent with the other three validators I preferred the unified key. I'm happy to switch to the one-liner if you prefer the smaller diff.

**Scope**: this affects `val()` only. `predict(save_txt=True)` was already correct, `PosePredictor.construct_result` scales the keypoints itself with `ops.scale_coords` before `Results.update` and never goes through `scale_preds`.

**Validation**

RTX 4060, main @ fcb350d, yolo11n-pose.pt on coco8-pose at imgsz=640:

| Check | main | with fix |
|---|---|---|
| keypoints in `labels/*.txt` | 732/6664 outside [0, 1], max 1.5304 | 0/6664 outside, max 1.0 |
| boxes in `labels/*.txt` | OK (0.0–0.9767) | OK, unchanged |
| `predictions.json` (save_json) | baseline | byte-identical, max abs diff 0.0 over 196 keypoint entries |
| pose / box mAP50-95 | 0.3488 / 0.7172 | identical |

New test `test_val_save_txt_pose` in `tests/test_python.py`: without the fix it fails with `keypoints not in [0, 1] in 000000000110.txt`, with the fix it passes in ~3 s. It also checks that the visible keypoints cluster on their box, so a wrong "fix" that only clipped the values into range would still fail. It runs at imgsz=640 on purpose — at the small imgsz used elsewhere the letterbox offset is not large enough to push the bad values outside [0, 1], and the regression stays hidden. The existing `test_val[pose]` passes unchanged, and `ruff format --check` / `ruff check` are clean.

This completes the keypoints case that was left out of #21719 .. let me know what you think.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes pose validation text export so saved keypoints are correctly normalized to the original image space. 🧍‍♂️✅

### 📊 Key Changes
- Updates `PoseValidator` prediction scaling to consistently use the `keypoints` field instead of `kpts`.
- Adjusts pose JSON export documentation and access to match the corrected prediction key.
- Adds a regression test for `val(save_txt=True)` on `coco8-pose.yaml` using `yolo26n-pose.pt` to verify saved keypoints remain normalized and aligned with detected boxes.

### 🎯 Purpose & Impact
- Prevents pose keypoints saved with `save_txt=True` from being incorrectly scaled in letterboxed image space.
- Improves reliability of exported pose labels for downstream workflows, evaluation, and dataset inspection.
- Adds test coverage to catch future regressions in pose keypoint scaling behavior.


### Core Principles

Deleted: the duplicate scaled `kpts` prediction key; replaced it with the canonical `keypoints` key already consumed by text and JSON export.

Net-positive justification: the added regression test is required because the prior small-img validation path kept the bad normalized keypoints inside range and missed the failure.
