### PR TITLE
Fix `Heatmap`, `ObjectBlurrer` and other solutions crash with OBB models

### DIFF
--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import cv2
 import numpy as np
 import pytest
+import torch
 
 from tests import MODEL
 from ultralytics import solutions
@@ -70,7 +71,7 @@ def process_video(solution, video_path: str, needs_frame_count: bool = False):
             "ObjectCounterwithOBB",
             solutions.ObjectCounter,
             False,
-            "demo_video",
+            "parking_video",  # yolo26n-obb.pt yields no tracks on demo_video, so it would not exercise the OBB path
             {"region": REGION, "model": "yolo26n-obb.pt", "show": SHOW},
         ),
         (
@@ -210,6 +211,45 @@ def test_left_click_selection():
     dc.boxes, dc.track_ids = [[10, 10, 50, 50]], [1]
     dc.mouse_event_for_distance(cv2.EVENT_LBUTTONDOWN, 30, 30, None, None)
     assert 1 in dc.selected_boxes, f"Expected track_id 1 in selected_boxes, got {dc.selected_boxes}"
+
+
+def test_left_click_selection_obb():
+    """Test distance calculation left click selection with (4, 2) OBB corner boxes."""
+    dc = solutions.DistanceCalculation()
+    dc.boxes = [torch.tensor([[30.0, 10.0], [50.0, 30.0], [30.0, 50.0], [10.0, 30.0]])]  # rotated box corners
+    dc.track_ids = [1]
+    dc.mouse_event_for_distance(cv2.EVENT_LBUTTONDOWN, 30, 30, None, None)
+    assert 1 in dc.selected_boxes, f"Expected track_id 1 in selected_boxes, got {dc.selected_boxes}"
+
+
+@pytest.mark.skipif(IS_RASPBERRYPI, reason="Disabled for testing due to --slow test errors after YOLOE PR.")
+@pytest.mark.parametrize(
+    "solution_class, extra_kwargs",
+    [
+        (solutions.Heatmap, {"colormap": cv2.COLORMAP_PARULA, "region": None}),
+        (solutions.ObjectBlurrer, {"blur_ratio": 0.02}),
+        (solutions.VisionEye, {}),
+        (solutions.RegionCounter, {"region": REGION}),
+        (solutions.ParkingManagement, {"json_file": "parking_areas"}),
+    ],
+    ids=["Heatmap", "ObjectBlurrer", "VisionEye", "RegionCounter", "ParkingManagement"],
+)
+def test_solution_obb_boxes(solution_class, extra_kwargs, solution_assets):
+    """Regression: solutions consuming self.boxes must handle (4, 2) OBB corner boxes without crashing.
+
+    OBB models fill self.boxes with (4, 2) corner points instead of xyxy scalars, and get_enclosing_box normalizes
+    them. A single parking_video frame already yields OBB tracks, so one frame exercises each crash site without
+    processing the whole video. Reuses the parking_video and yolo26n-obb.pt assets already in the test matrix.
+    """
+    kwargs = {"model": "yolo26n-obb.pt", "show": SHOW, "imgsz": 320, **extra_kwargs}
+    if kwargs.get("json_file") == "parking_areas":
+        kwargs["json_file"] = str(solution_assets("parking_areas"))
+    cap = cv2.VideoCapture(str(solution_assets("parking_video")))
+    success, im0 = cap.read()
+    cap.release()
+    assert success, "Failed to read first frame of parking_video"
+    results = solution_class(**kwargs)(im0)
+    assert results.plot_im is not None, f"{solution_class.__name__} returned no plot_im on OBB input"
 
 
 def test_right_click_reset():

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -252,6 +252,18 @@ def test_solution_obb_boxes(solution_class, extra_kwargs, solution_assets):
     assert results.plot_im is not None, f"{solution_class.__name__} returned no plot_im on OBB input"
 
 
+def test_object_blurrer_obb_outside_frame():
+    """An OBB box that clips fully outside the frame produces an empty ROI and must be skipped before cv2.blur."""
+    blurrer = solutions.ObjectBlurrer()
+    frame = np.zeros((480, 640, 3), dtype=np.uint8)
+    inside = torch.tensor([[100.0, 100], [200, 100], [200, 200], [100, 200]])  # (4, 2) OBB, in frame
+    outside = torch.tensor([[700.0, 100], [760, 100], [760, 200], [700, 200]])  # (4, 2) OBB, fully off the right edge
+    blurrer.boxes, blurrer.clss, blurrer.confs, blurrer.track_ids = [inside, outside], [0, 0], [0.9, 0.9], [1, 2]
+    with patch.object(blurrer, "extract_tracks"), patch.object(blurrer, "display_output"):
+        results = blurrer.process(frame)
+    assert results.plot_im is not None
+
+
 def test_right_click_reset():
     """Test distance calculation right click reset functionality."""
     dc = solutions.DistanceCalculation()

--- a/ultralytics/solutions/distance_calculation.py
+++ b/ultralytics/solutions/distance_calculation.py
@@ -59,7 +59,8 @@ class DistanceCalculation(BaseSolution):
             self.left_mouse_count += 1
             if self.left_mouse_count <= 2:
                 for box, track_id in zip(self.boxes, self.track_ids):
-                    if box[0] < x < box[2] and box[1] < y < box[3] and track_id not in self.selected_boxes:
+                    x0, y0, x1, y1 = self.get_enclosing_box(box)
+                    if x0 < x < x1 and y0 < y < y1 and track_id not in self.selected_boxes:
                         self.selected_boxes[track_id] = box
 
         elif event == cv2.EVENT_RBUTTONDOWN:
@@ -105,7 +106,10 @@ class DistanceCalculation(BaseSolution):
         if len(self.selected_boxes) == 2:
             # Calculate centroids of selected boxes
             self.centroids.extend(
-                [[int((box[0] + box[2]) // 2), int((box[1] + box[3]) // 2)] for box in self.selected_boxes.values()]
+                [
+                    [int((box[0] + box[2]) // 2), int((box[1] + box[3]) // 2)]
+                    for box in map(self.get_enclosing_box, self.selected_boxes.values())
+                ]
             )
             # Calculate Euclidean distance between centroids
             pixels_distance = math.sqrt(

--- a/ultralytics/solutions/heatmap.py
+++ b/ultralytics/solutions/heatmap.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import cv2
 import numpy as np
+import torch
 
 from ultralytics.solutions.object_counter import ObjectCounter
 from ultralytics.solutions.solutions import SolutionAnnotator, SolutionResults
@@ -50,13 +51,15 @@ class Heatmap(ObjectCounter):
         self.colormap = self.CFG["colormap"]
         self.heatmap = None
 
-    def heatmap_effect(self, box: list[float]) -> None:
+    def heatmap_effect(self, box: torch.Tensor) -> None:
         """Efficiently calculate heatmap area and effect location for applying colormap.
 
         Args:
-            box (list[float]): Bounding box coordinates [x0, y0, x1, y1].
+            box (torch.Tensor): Bounding box coordinates [x0, y0, x1, y1] or (4, 2) OBB corner points.
         """
-        x0, y0, x1, y1 = map(int, box)
+        x0, y0, x1, y1 = map(int, self.get_enclosing_box(box))
+        h, w = self.heatmap.shape[:2]
+        x0, y0, x1, y1 = max(x0, 0), max(y0, 0), min(x1, w), min(y1, h)  # clip OBB corners to image bounds
         radius_squared = (min(x1 - x0, y1 - y0) // 2) ** 2
 
         # Create a meshgrid with region of interest (ROI) for vectorized distance calculations

--- a/ultralytics/solutions/object_blurrer.py
+++ b/ultralytics/solutions/object_blurrer.py
@@ -74,6 +74,8 @@ class ObjectBlurrer(BaseSolution):
         for box, cls, conf in zip(self.boxes, self.clss, self.confs):
             x0, y0, x1, y1 = map(int, self.get_enclosing_box(box))
             x0, y0, x1, y1 = max(x0, 0), max(y0, 0), min(x1, w), min(y1, h)  # clip OBB corners to image bounds
+            if x0 >= x1 or y0 >= y1:  # box fully outside the frame clips to an empty ROI, cv2.blur would assert
+                continue
             # Crop and blur the detected object
             blur_obj = cv2.blur(im0[y0:y1, x0:x1], (self.blur_ratio, self.blur_ratio))
             # Update the blurred area in the original image

--- a/ultralytics/solutions/object_blurrer.py
+++ b/ultralytics/solutions/object_blurrer.py
@@ -70,14 +70,14 @@ class ObjectBlurrer(BaseSolution):
         annotator = SolutionAnnotator(im0, self.line_width)
 
         # Iterate over bounding boxes and classes
+        h, w = im0.shape[:2]
         for box, cls, conf in zip(self.boxes, self.clss, self.confs):
+            x0, y0, x1, y1 = map(int, self.get_enclosing_box(box))
+            x0, y0, x1, y1 = max(x0, 0), max(y0, 0), min(x1, w), min(y1, h)  # clip OBB corners to image bounds
             # Crop and blur the detected object
-            blur_obj = cv2.blur(
-                im0[int(box[1]) : int(box[3]), int(box[0]) : int(box[2])],
-                (self.blur_ratio, self.blur_ratio),
-            )
+            blur_obj = cv2.blur(im0[y0:y1, x0:x1], (self.blur_ratio, self.blur_ratio))
             # Update the blurred area in the original image
-            im0[int(box[1]) : int(box[3]), int(box[0]) : int(box[2])] = blur_obj
+            im0[y0:y1, x0:x1] = blur_obj
             annotator.box_label(
                 box, label=self.adjust_box_label(cls, conf), color=colors(cls, True)
             )  # Annotate bounding box

--- a/ultralytics/solutions/parking_management.py
+++ b/ultralytics/solutions/parking_management.py
@@ -247,7 +247,8 @@ class ParkingManagement(BaseSolution):
             region_polygon = np.array(region["points"], dtype=np.int32).reshape((-1, 1, 2))
             region_occupied = False
             for box, cls in zip(self.boxes, self.clss):
-                xc, yc = int((box[0] + box[2]) / 2), int((box[1] + box[3]) / 2)
+                x0, y0, x1, y1 = self.get_enclosing_box(box)
+                xc, yc = int((x0 + x1) / 2), int((y0 + y1) / 2)
                 inside_distance = cv2.pointPolygonTest(region_polygon, (xc, yc), False)
                 if inside_distance >= 0:
                     # cv2.circle(im0, (xc, yc), radius=self.line_width * 4, color=self.dc, thickness=-1)

--- a/ultralytics/solutions/region_counter.py
+++ b/ultralytics/solutions/region_counter.py
@@ -114,7 +114,8 @@ class RegionCounter(BaseSolution):
 
         for box, cls, track_id, conf in zip(self.boxes, self.clss, self.track_ids, self.confs):
             annotator.box_label(box, label=self.adjust_box_label(cls, conf, track_id), color=colors(track_id, True))
-            center = self.Point(((box[0] + box[2]) / 2, (box[1] + box[3]) / 2))
+            x0, y0, x1, y1 = self.get_enclosing_box(box)
+            center = self.Point(((x0 + x1) / 2, (y0 + y1) / 2))
             for region in self.counting_regions:
                 if region["prepared_polygon"].contains(center):
                     region["counts"] += 1

--- a/ultralytics/solutions/solutions.py
+++ b/ultralytics/solutions/solutions.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import cv2
 import numpy as np
+import torch
 
 from ultralytics import YOLO
 from ultralytics.solutions.config import SolutionConfig
@@ -199,6 +200,27 @@ class BaseSolution:
         self.track_line.append(tuple(box.mean(dim=0)) if box.numel() > 4 else (box[:4:2].mean(), box[1:4:2].mean()))
         if len(self.track_line) > 30:
             self.track_line.pop(0)
+
+    @staticmethod
+    def get_enclosing_box(box: torch.Tensor | list[float]) -> torch.Tensor | list[float]:
+        """Return the axis-aligned box [x1, y1, x2, y2] enclosing a box extracted by `extract_tracks`.
+
+        Boxes from OBB models are (4, 2) xyxyxyxy corner points, while boxes from detection models are already
+        axis-aligned [x1, y1, x2, y2]. This method normalizes both formats to [x1, y1, x2, y2] for solutions that
+        require axis-aligned coordinates, e.g. for image slicing or box centers.
+
+        Args:
+            box (torch.Tensor | list[float]): Bounding box in [x1, y1, x2, y2] format or (4, 2) OBB corner points.
+
+        Returns:
+            (torch.Tensor | list[float]): Axis-aligned bounding box in [x1, y1, x2, y2] format.
+
+        Examples:
+            >>> import torch
+            >>> BaseSolution.get_enclosing_box(torch.tensor([[2.0, 1.0], [4.0, 3.0], [2.0, 5.0], [0.0, 3.0]]))
+            tensor([0., 1., 4., 5.])
+        """
+        return torch.cat([box.amin(0), box.amax(0)]) if isinstance(box, torch.Tensor) and box.numel() > 4 else box
 
     def initialize_region(self) -> None:
         """Initialize the counting region and line segment based on configuration settings."""

--- a/ultralytics/solutions/vision_eye.py
+++ b/ultralytics/solutions/vision_eye.py
@@ -58,7 +58,7 @@ class VisionEye(BaseSolution):
         for cls, t_id, box, conf in zip(self.clss, self.track_ids, self.boxes, self.confs):
             # Annotate the image with bounding boxes, labels, and vision mapping
             annotator.box_label(box, label=self.adjust_box_label(cls, conf, t_id), color=colors(int(t_id), True))
-            annotator.visioneye(box, self.vision_point)
+            annotator.visioneye(self.get_enclosing_box(box), self.vision_point)
 
         plot_im = annotator.result()
         self.display_output(plot_im)  # Display the annotated output using the base class function


### PR DESCRIPTION
Running `Heatmap` or `ObjectBlurrer` with an OBB model crashes on the first frame that has tracks:

```python
import cv2
from ultralytics import solutions

im0 = cv2.imread("boats.jpg")  # https://ultralytics.com/images/boats.jpg
solutions.Heatmap(model="yolo11n-obb.pt", show=False)(im0)
```

```
File "ultralytics/solutions/heatmap.py", line 59, in heatmap_effect
    x0, y0, x1, y1 = map(int, box)
ValueError: only one element tensors can be converted to Python scalars
```

`ObjectBlurrer` fails the same way at `object_blurrer.py:76` (`int(box[1])`). The same code with a detection model works fine, and the object counting guide shows OBB models for solutions (`model="yolo26n-obb.pt"`), so a user following the docs hits this directly.

Resolves #25057

**Root cause**

`BaseSolution.extract_tracks` (`solutions.py:175`) supports OBB explicitly: for OBB models it fills `self.boxes` with `xyxyxyxy`, a (4, 2) tensor of corner points per box, instead of the 4-scalar `xyxy` of detection models. `BaseSolution` already handles both shapes in two places — `store_tracking_history` (`solutions.py:199`) computes the centre with `box.mean(dim=0) if box.numel() > 4 else ...`, and `box_label` draws the rotated polygon for (4, 2) input. That is why `ObjectCounter` works with OBB models. But several solutions consume `self.boxes` assuming 4 scalars (`map(int, box)`, `int(box[1])`, `(box[0] + box[2]) / 2`), and calling `int()` on a 2-element row tensor raises the error above.

Following the "scan for other occurrences" pattern from #21816, I checked every solution that consumes `self.boxes` and ran each one with an OBB model in order to confirm which ones break. Six are affected — five crash on the first frame with tracks, one is latent:

| Solution | Crash site | Error on main |
|---|---|---|
| `Heatmap` | `heatmap.py:59` | `ValueError: only one element tensors can be converted to Python scalars` |
| `ObjectBlurrer` | `object_blurrer.py:76` | same `ValueError` |
| `RegionCounter` | `region_counter.py:117` | `ValueError: Point() takes only scalar or 1-size vector arguments` |
| `VisionEye` | `solutions.py:712` (`visioneye`) | same `ValueError` as Heatmap |
| `ParkingManagement` | `parking_management.py:250` | same `ValueError` as Heatmap |
| `DistanceCalculation` | `distance_calculation.py:62,108` | latent (mouse callback): `RuntimeError: Boolean value of Tensor ... is ambiguous` |

Not affected (verified with the same OBB model): `ObjectCounter`, `TrackZone`, `QueueManager`, `SpeedEstimator`, `SecurityAlarm`, `Analytics`. They only touch the boxes through `box_label` and `store_tracking_history`, which already handle the (4, 2) shape. `ObjectCropper` also fails with OBB models, but for a different reason — it runs its own `predict` and reads `results.boxes`, which is `None` for OBB. That is a separate bug with a separate cause, so I kept it out of this PR.

**Fix**

A small static helper in `BaseSolution`, `get_enclosing_box`, that returns the axis-aligned enclosing box `[x1, y1, x2, y2]` (min/max of the 4 corners) when the input is a (4, 2) OBB box, and returns the input untouched otherwise — same `numel() > 4` gate that `store_tracking_history` already uses. Each affected consumer derives a local xyxy from it and keeps passing the original box to `box_label`, so the rotated OBB polygon is still drawn.

Why this approach and not the alternatives:

- Converting inside `extract_tracks` would break the paths that need the (4, 2): `store_tracking_history` needs the corners for the centre and `box_label` needs them for the polygon.
- Repeating the min/max guard in six places would work, but the helper keeps a single source of truth, and `BaseSolution` already owns the OBB normalisation (`extract_tracks`, `store_tracking_history`).
- The centre of the enclosing box is exactly `box.mean(dim=0)` (verified on real boxes, max diff 0.0), so the centre-based consumers (`RegionCounter`, `ParkingManagement`, `VisionEye`, `DistanceCalculation`) stay consistent with the centre `ObjectCounter` already computes for OBB.

There is one behaviour change to mention: in `Heatmap` and `ObjectBlurrer` the enclosing box is also clipped to image bounds. This is needed for OBB and a no-op for detection. Detection `xyxy` is already clipped to the frame in post-processing (`ops.scale_boxes` → `clip_boxes`), so `max(x, 0)`/`min(x, w)` never changes it. OBB `xyxyxyxy` corners are not clipped, and tracked corners can end up outside the frame (on boats.jpg they reach x=2007.7 on a 1920-wide frame, and y spans -94.2 to 1151 on 1080; 18 of 169 enclosing boxes are out of bounds). Without the clip `Heatmap` raises `IndexError` on the heatmap array (boolean-mask/slice shape mismatch) and `ObjectBlurrer` hits a `cv2` `!_src.empty()` assertion on the empty crop — both reproduced on boats.jpg. So the clip only changes the OBB path, which is the path this PR fixes.

**Tests**

The reason CI never caught this is simple: `tests/test_solutions.py` exercises these solutions only with a detection model. The single OBB case, `ObjectCounterwithOBB`, covers exactly one of the OBB-safe classes — and on `demo_video` the tracker returns zero OBB tracks, so even that one was not exercising the OBB path. Changes:

- A focused regression test `test_solution_obb_boxes`, parametrized over the five affected solutions that consume `self.boxes` (`Heatmap`, `ObjectBlurrer`, `VisionEye`, `RegionCounter`, `ParkingManagement`). Each processes a **single** `parking_video` frame with `yolo26n-obb.pt` and asserts a `plot_im` is returned. The first frame already yields OBB tracks (37 boxes), so one frame is enough to hit each crash site, there is no need to run the whole 82-frame clip. It reuses `parking_video`, `parking_areas` and the `yolo26n-obb.pt` already in the matrix, so no new CI assets.
- `test_left_click_selection_obb` for the latent `DistanceCalculation` path — the mouse callback is hard to drive end-to-end, so it exercises the selection with a (4, 2) box directly.
- `ObjectCounterwithOBB` moved from `demo_video` to `parking_video` so it actually gets OBB tracks (inline comment included) — it stays as the control showing `ObjectCounter` already handles the shape.

**Validation**

RTX 4060, main @ fcb350d (8.4.90):

- On clean main the six solutions fail with the exact errors in the table above (re-verified with a stash/restore cycle); with the fix all of them run clean on OBB input, and 4 detection-model controls give the same output as before.
- OBB test subset (`-k "OBB or obb"`): 7 passed — five single-frame `test_solution_obb_boxes` regressions (~0.08s each), the `DistanceCalculation` unit test, and the moved `ObjectCounterwithOBB` control.
- Full `tests/test_solutions.py`: 40 passed, 1 skipped. `ObjectCounter` with OBB unchanged, and for detection boxes the helper is a passthrough that returns the same object, no copy.
- `ruff format --check` and `ruff check`: clean.

I realise the diff touches 8 files for what started as a Heatmap report, but the six failures share the same root cause, and fixing only two of them would leave the same crash waiting in the other four ..

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes crashes in multiple Ultralytics Solutions when using YOLO26 OBB models by normalizing oriented boxes to enclosing axis-aligned boxes. 🧰

### 📊 Key Changes
- Adds a shared `get_enclosing_box()` helper to handle both standard `[x1, y1, x2, y2]` boxes and OBB corner-point boxes.
- Updates `DistanceCalculation`, `Heatmap`, `ObjectBlurrer`, `ParkingManagement`, `RegionCounter`, and `VisionEye` to safely consume OBB outputs.
- Clips heatmap and blur regions to image bounds to avoid slicing/indexing issues with rotated boxes.
- Adds regression tests for OBB left-click selection and OBB compatibility across affected Solutions using `yolo26n-obb.pt`.

### 🎯 Purpose & Impact
- Prevents crashes when users run Solutions with OBB models, improving reliability for rotated-object workflows. ✅
- Expands test coverage to ensure OBB paths are exercised and future regressions are caught early.
- Improves consistency across Solutions by centralizing OBB-to-axis-aligned box handling.


### Core Principles

Deleted: repeated direct `self.boxes` scalar assumptions in affected solution consumers; replaced with one `BaseSolution.get_enclosing_box()` normalization point.

Net-positive justification: `extract_tracks` must preserve OBB corners for drawing/history, while these consumers need axis-aligned coordinates for centers and image slicing, so the shared helper plus targeted regressions prevent six duplicated fixes.
