### PR TITLE
Refactor OBB dataset documentation

### DIFF
--- a/docs/en/datasets/obb/dota-v2.md
+++ b/docs/en/datasets/obb/dota-v2.md
@@ -1,4 +1,5 @@
 ---
+title: DOTA OBB Dataset
 comments: true
 description: Explore the DOTA dataset for object detection in aerial images, featuring 1.7M Oriented Bounding Boxes across 18 categories. Ideal for aerial image analysis.
 keywords: DOTA dataset, object detection, aerial images, oriented bounding boxes, OBB, DOTA v1.0, DOTA v1.5, DOTA v2.0, multiscale detection, Ultralytics
@@ -6,7 +7,7 @@ keywords: DOTA dataset, object detection, aerial images, oriented bounding boxes
 
 # DOTA Dataset with OBB
 
-[DOTA](https://captain-whu.github.io/DOTA/index.html) stands as a specialized dataset, emphasizing [object detection](https://www.ultralytics.com/glossary/object-detection) in aerial images. Originating from the DOTA series of datasets, it offers annotated images capturing a diverse array of aerial scenes with [Oriented Bounding Boxes (OBB)](index.md).
+The [DOTA](https://captain-whu.github.io/DOTA/index.html) dataset is a large-scale benchmark for [object detection](https://www.ultralytics.com/glossary/object-detection) in aerial images, released in three versions (v1.0, v1.5, v2.0) with up to 1.7M [Oriented Bounding Box (OBB)](index.md) annotations across 18 categories, captured from diverse aerial sensors and platforms.
 
 ![DOTA dataset object classes for aerial detection](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/dota-classes-visual.avif)
 
@@ -20,7 +21,7 @@ keywords: DOTA dataset, object detection, aerial images, oriented bounding boxes
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> How to Train Ultralytics YOLO26 on the DOTA Dataset for Oriented Bounding Boxes in Google Colab
+  <strong>Watch:</strong> How to Train Ultralytics YOLO on the DOTA Dataset for Oriented Bounding Boxes in Google Colab
 </p>
 
 - Collection from various sensors and platforms, with image sizes ranging from 800 × 800 to 20,000 × 20,000 pixels.
@@ -34,7 +35,7 @@ keywords: DOTA dataset, object detection, aerial images, oriented bounding boxes
 
 - Contains 15 common categories.
 - Comprises 2,806 images with 188,282 instances.
-- Split ratios: 1/2 for training, 1/6 for validation, and 1/3 for testing.
+- Split ratios: 1/2 for training (1,411 images), 1/6 for validation (458 images), and 1/3 for testing (937 images).
 
 ### DOTA-v1.5
 
@@ -74,7 +75,7 @@ A dataset YAML (Yet Another Markup Language) file specifies image/label roots, c
 - [`DOTAv1.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/DOTAv1.yaml)
 - [`DOTAv1.5.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/DOTAv1.5.yaml)
 
-Use the YAML that matches the release you downloaded, or author a custom YAML if you are working with DOTA-v2 or another derivative.
+Use the YAML that matches the release you downloaded, or author a custom YAML if you are working with DOTA-v2 or another derivative. Both releases download automatically (2 GB) from Ultralytics GitHub assets the first time you train.
 
 !!! example "DOTAv1.yaml"
 
@@ -115,7 +116,7 @@ The raw imagery routinely exceeds 10,000 pixels on a side, so tiling is required
 
 ## Usage
 
-To train a model on the DOTA v1 dataset, you can utilize the following code snippets. Always refer to your model's documentation for a thorough list of available arguments. For those looking to experiment with a smaller subset first, consider using the [DOTA8 dataset](dota8.md), which contains just 8 images for quick testing.
+To train a model on the DOTA v1 dataset, you can utilize the following code snippets. Always refer to your model's documentation for a thorough list of available arguments. For those looking to experiment with a smaller subset first, consider using the [DOTA8 dataset](dota8.md), which contains just 8 images for quick testing and is browsable on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/dota8).
 
 !!! warning
 
@@ -165,10 +166,10 @@ If you use DOTA in your work, please cite the relevant research papers:
           author={Ding, Jian and Xue, Nan and Xia, Gui-Song and Bai, Xiang and Yang, Wen and Yang, Michael and Belongie, Serge and Luo, Jiebo and Datcu, Mihai and Pelillo, Marcello and Zhang, Liangpei},
           journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
           title={Object Detection in Aerial Images: A Large-Scale Benchmark and Challenges},
-          year={2021},
-          volume={},
-          number={},
-          pages={1-1},
+          year={2022},
+          volume={44},
+          number={11},
+          pages={7778-7796},
           doi={10.1109/TPAMI.2021.3117983}
         }
         ```

--- a/docs/en/datasets/obb/dota128.md
+++ b/docs/en/datasets/obb/dota128.md
@@ -16,6 +16,7 @@ keywords: DOTA128 dataset, Ultralytics, YOLO26, object detection, debugging, tra
 - **Images**: 128 aerial tiles (all in train folder, used for both train and val) sourced from DOTAv1.
 - **Classes**: Inherits the 15 DOTAv1 categories such as plane, ship, and large vehicle.
 - **Labels**: YOLO-format oriented bounding boxes saved as `.txt` files beside each image.
+- **Download**: 34 MB, fetched automatically from Ultralytics GitHub assets the first time you train.
 
 This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
 
@@ -77,10 +78,10 @@ If you use the DOTA dataset in your research or development work, please cite th
           author={Ding, Jian and Xue, Nan and Xia, Gui-Song and Bai, Xiang and Yang, Wen and Yang, Michael and Belongie, Serge and Luo, Jiebo and Datcu, Mihai and Pelillo, Marcello and Zhang, Liangpei},
           journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
           title={Object Detection in Aerial Images: A Large-Scale Benchmark and Challenges},
-          year={2021},
-          volume={},
-          number={},
-          pages={1-1},
+          year={2022},
+          volume={44},
+          number={11},
+          pages={7778-7796},
           doi={10.1109/TPAMI.2021.3117983}
         }
         ```

--- a/docs/en/datasets/obb/dota8.md
+++ b/docs/en/datasets/obb/dota8.md
@@ -28,7 +28,7 @@ keywords: DOTA8 dataset, Ultralytics, YOLO26, object detection, debugging, train
         └── val/
     ```
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+Explore [DOTA8 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/dota8) to browse the aerial tiles with their oriented-box overlays, view the class distribution and annotation heatmaps in the **Charts** tab, and clone it to train your own model in the cloud.
 
 ## Dataset YAML
 

--- a/docs/en/datasets/obb/dota8.md
+++ b/docs/en/datasets/obb/dota8.md
@@ -16,6 +16,7 @@ keywords: DOTA8 dataset, Ultralytics, YOLO26, object detection, debugging, train
 - **Images**: 8 aerial tiles (4 train, 4 val) sourced from DOTAv1.
 - **Classes**: Inherits the 15 DOTAv1 categories such as plane, ship, and large vehicle.
 - **Labels**: YOLO-format oriented bounding boxes saved as `.txt` files beside each image.
+- **Download**: 1 MB, fetched automatically from Ultralytics GitHub assets the first time you train.
 - **Recommended layout**:
 
     ```
@@ -88,10 +89,10 @@ If you use the DOTA dataset in your research or development work, please cite th
           author={Ding, Jian and Xue, Nan and Xia, Gui-Song and Bai, Xiang and Yang, Wen and Yang, Michael and Belongie, Serge and Luo, Jiebo and Datcu, Mihai and Pelillo, Marcello and Zhang, Liangpei},
           journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
           title={Object Detection in Aerial Images: A Large-Scale Benchmark and Challenges},
-          year={2021},
-          volume={},
-          number={},
-          pages={1-1},
+          year={2022},
+          volume={44},
+          number={11},
+          pages={7778-7796},
           doi={10.1109/TPAMI.2021.3117983}
         }
         ```


### PR DESCRIPTION
## Summary

Refactor of the oriented bounding box (OBB) dataset pages under `docs/en/datasets/obb/`, done one page per commit. Numbers are verified against each dataset YAML; `dota8` is additionally confirmed with a real download-and-count and a 1-epoch training run. The DOTA benchmark paper's BibTeX entry (shared across all three dataset pages) is updated from its IEEE early-access placeholder to the final published record. `dota-v2` also gets a `title` field, exact split counts alongside its existing ratios, and a corrected video caption after the referenced video's title didn't match.

### Pages

- [x] dota8
- [x] dota128
- [x] dota-v2
- [x] index (audited, no changes needed — already conforms to the shared list-page template used by sibling task index pages)


### Core Principles

Deleted: outdated DOTA early-access citation placeholders and the generic DOTA8 Platform sentence; replaced with final citation metadata and verified dataset details.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves DOTA OBB dataset documentation with clearer dataset details, download guidance, Ultralytics Platform links, and corrected citations 📚✨

### 📊 Key Changes
- Added a page title and refined the DOTA dataset overview to better explain versions, scale, categories, and OBB annotations 🛰️
- Clarified DOTAv1 split counts for train, validation, and test images 📊
- Added automatic download size notes for DOTA, DOTA128, and DOTA8 datasets 💾
- Updated DOTA8 docs with a direct link to browse the dataset on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/dota8) 🌐
- Adjusted video wording from “YOLO26” to the more general “Ultralytics YOLO” 🎥
- Corrected DOTA citation metadata, including year, volume, issue, and page numbers 📝

### 🎯 Purpose & Impact
- Makes DOTA OBB documentation more accurate, complete, and beginner-friendly ✅
- Helps users better understand dataset size, structure, splits, and setup expectations before training 🚀
- Improves discoverability of DOTA8 on Ultralytics Platform for quick inspection, experimentation, and cloud training 🔍
- Ensures researchers cite the DOTA benchmark correctly in academic and development work 🎓