### PR TITLE
Refactor pose dataset docs

### DIFF
--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -20,7 +20,7 @@ The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset adapts COCO (Co
 - COCO-Pose builds upon the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge, which labels 1,710,498 individual keypoints across 156,165 annotated people.
 - Each person is annotated with 17 keypoints — nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles — stored as `(x, y, visibility)` triplets.
 - Like COCO, it provides standardized evaluation metrics, including Object Keypoint Similarity (OKS) for pose estimation tasks, making it suitable for comparing model performance.
-- **Download size**: ~27 GB on first use — the download script fetches `train2017.zip`, `val2017.zip`, and `test2017.zip` together, even though the test archive is only needed for the optional test-dev2017 submission split.
+- **Download size**: ~27 GB on first use. The `coco-pose.yaml` header lists 20.1 GB (`train2017.zip` + `val2017.zip` only), but the download script also fetches the 7 GB `test2017.zip` unconditionally, even though that archive is needed only for the optional test-dev2017 submission split.
 
 ## Dataset Structure
 

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -24,7 +24,7 @@ The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset adapts COCO (Co
 
 ## Dataset Structure
 
-COCO-Pose covers the COCO 2017 images that contain keypoint-annotated people, so its splits are smaller than full COCO's. It is divided into three subsets:
+For training and validation, COCO-Pose includes only COCO 2017 images with keypoint-annotated people, so its labeled splits are smaller than full COCO's. Its YAML defines three subsets:
 
 1. **Train2017**: This subset contains 56,599 images from the COCO dataset, annotated for training pose estimation models.
 2. **Val2017**: This subset has 2,346 images used for validation purposes during model training.

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -1,13 +1,13 @@
 ---
 title: COCO-Pose Estimation Dataset
 comments: true
-description: Explore the Ultralytics COCO-Pose dataset: 58,945 images with 156K+ annotated people and 17 keypoints each, for training YOLO26 pose estimation models.
+description: "Explore the Ultralytics COCO-Pose dataset: 58,945 images with 156K+ annotated people and a 17-keypoint schema, for training YOLO26 pose estimation models."
 keywords: COCO-Pose, pose estimation, dataset, keypoints, COCO Keypoints 2017, YOLO, deep learning, computer vision
 ---
 
 # COCO-Pose Dataset
 
-The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset adapts COCO (Common Objects in Context) for [pose estimation](../../tasks/pose.md): 58,945 images from COCO Keypoints 2017, annotated with 156,165 people at 17 keypoints each. It is the standard set for training and benchmarking keypoint models such as [Ultralytics YOLO26](../../models/yolo26.md), and the 8-image [COCO8-Pose](coco8-pose.md) subset mirrors its format for quick sanity checks.
+The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset adapts COCO (Common Objects in Context) for [pose estimation](../../tasks/pose.md): 58,945 images from COCO Keypoints 2017, annotated with 156,165 people using a 17-keypoint schema. It is the standard set for training and benchmarking keypoint models such as [Ultralytics YOLO26](../../models/yolo26.md), and the 8-image [COCO8-Pose](coco8-pose.md) subset mirrors its format for quick sanity checks.
 
 ![COCO pose estimation with human keypoints](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/pose-sample-image.avif)
 
@@ -18,7 +18,7 @@ The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset adapts COCO (Co
 ## Key Features
 
 - COCO-Pose builds upon the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge, which labels 1,710,498 individual keypoints across 156,165 annotated people.
-- Each person is annotated with 17 keypoints — nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles — stored as `(x, y, visibility)` triplets.
+- Each person annotation uses 17 keypoint types — nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles — stored as `(x, y, visibility)` triplets.
 - Like COCO, it provides standardized evaluation metrics, including Object Keypoint Similarity (OKS) for pose estimation tasks, making it suitable for comparing model performance.
 - **Download size**: ~27 GB on first use. The `coco-pose.yaml` header lists 20.1 GB (`train2017.zip` + `val2017.zip` only), but the download script also fetches the 7 GB `test2017.zip` unconditionally, even though that archive is needed only for the optional test-dev2017 submission split.
 
@@ -106,7 +106,7 @@ We would like to acknowledge the COCO Consortium for creating and maintaining th
 
 ### What is the COCO-Pose dataset and how is it used with Ultralytics YOLO for pose estimation?
 
-COCO-Pose supplies the COCO Keypoints 2017 images and annotations converted to YOLO keypoint format, with 17 keypoints per person across 58,945 images. Point any Ultralytics YOLO pose model at it with `data=coco-pose.yaml`, and the [Training](../../modes/train.md) page documents every argument you can tune from there.
+COCO-Pose supplies the COCO Keypoints 2017 images and annotations converted to YOLO keypoint format, using a 17-keypoint schema across 58,945 images. Point any Ultralytics YOLO pose model at it with `data=coco-pose.yaml`, and the [Training](../../modes/train.md) page documents every argument you can tune from there.
 
 ### How can I train a YOLO26 model on the COCO-Pose dataset?
 
@@ -122,6 +122,6 @@ COCO-Pose ships two labeled splits: 56,599 train2017 images and 2,346 val2017 im
 
 ### What are the key features and applications of the COCO-Pose dataset?
 
-COCO-Pose annotates 17 human keypoints per person and inherits COCO's standardized metrics, including Object Keypoint Similarity (OKS), for comparing models. That combination suits human pose applications such as sports analytics, healthcare, and human-computer interaction. Pretrained YOLO26-pose weights are listed under [COCO-Pose Pretrained Models](#coco-pose-pretrained-models).
+COCO-Pose uses 17 human keypoint types and inherits COCO's standardized metrics, including Object Keypoint Similarity (OKS), for comparing models. That combination suits human pose applications such as sports analytics, healthcare, and human-computer interaction. Pretrained YOLO26-pose weights are listed under [COCO-Pose Pretrained Models](#coco-pose-pretrained-models).
 
 For more on keypoint models, see the [Pose Estimation](../../tasks/pose.md) task docs.

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -28,7 +28,7 @@ COCO-Pose covers the COCO 2017 images that contain keypoint-annotated people, so
 
 1. **Train2017**: This subset contains 56,599 images from the COCO dataset, annotated for training pose estimation models.
 2. **Val2017**: This subset has 2,346 images used for validation purposes during model training.
-3. **Test2017**: This subset consists of images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for performance evaluation.
+3. **Test-dev2017**: A 20,288-image subset of the full 40,670-image test2017 set. Ground truth annotations are withheld, and results are submitted to the [COCO keypoints evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7403) for scoring.
 
 Training at this scale is where [Ultralytics Platform](https://platform.ultralytics.com/) helps most — it manages the compute so you can launch and monitor runs without provisioning your own GPUs.
 
@@ -118,7 +118,7 @@ The COCO-Pose dataset provides several standardized evaluation metrics for pose 
 
 ### How is the dataset structured and split for the COCO-Pose dataset?
 
-COCO-Pose ships two labeled splits: 56,599 train2017 images and 2,346 val2017 images. A third split, test2017, keeps its ground truth private, so submissions are scored by the [COCO evaluation server](https://cocodataset.org/#upload). See the [Dataset Structure](#dataset-structure) section, or the `coco-pose.yaml` file on [GitHub](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco-pose.yaml) for the exact split paths.
+COCO-Pose ships two labeled splits: 56,599 train2017 images and 2,346 val2017 images. A third split, test-dev2017 (20,288 of the full 40,670 test2017 images), keeps its ground truth private, so submissions are scored via the [COCO keypoints evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7403). See the [Dataset Structure](#dataset-structure) section, or the `coco-pose.yaml` file on [GitHub](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco-pose.yaml) for the exact split paths.
 
 ### What are the key features and applications of the COCO-Pose dataset?
 

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -1,6 +1,7 @@
 ---
+title: COCO-Pose Estimation Dataset
 comments: true
-description: Explore the COCO-Pose dataset for advanced pose estimation. Learn about datasets, pretrained models, metrics, and applications for training with YOLO.
+description: Explore the COCO-Pose dataset: 58,945 images with 156K+ annotated people and 17 keypoints each, for training pose estimation models with YOLO26.
 keywords: COCO-Pose, pose estimation, dataset, keypoints, COCO Keypoints 2017, YOLO, deep learning, computer vision
 ---
 
@@ -16,9 +17,10 @@ The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset is a specialize
 
 ## Key Features
 
-- COCO-Pose builds upon the COCO Keypoints 2017 dataset which contains 200K images labeled with keypoints for pose estimation tasks.
+- COCO-Pose builds upon the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge: 58,945 images annotated with 156,165 people and 1,710,498 individual keypoints for pose estimation tasks.
 - The dataset supports 17 keypoints for human figures, facilitating detailed pose estimation.
 - Like COCO, it provides standardized evaluation metrics, including Object Keypoint Similarity (OKS) for pose estimation tasks, making it suitable for comparing model performance.
+- **Download size**: ~20.1 GB.
 
 ## Dataset Structure
 
@@ -27,6 +29,8 @@ The COCO-Pose dataset is split into three subsets:
 1. **Train2017**: This subset contains 56599 images from the COCO dataset, annotated for training pose estimation models.
 2. **Val2017**: This subset has 2346 images used for validation purposes during model training.
 3. **Test2017**: This subset consists of images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for performance evaluation.
+
+This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
 
 ## Applications
 
@@ -106,30 +110,7 @@ The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset is a specialize
 
 ### How can I train a YOLO26 model on the COCO-Pose dataset?
 
-Training a YOLO26 model on the COCO-Pose dataset can be accomplished using either Python or CLI commands. For example, to train a YOLO26n-pose model for 100 epochs with an image size of 640, you can follow the steps below:
-
-!!! example "Train Example"
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        # Load a model
-        model = YOLO("yolo26n-pose.pt")  # load a pretrained model (recommended for training)
-
-        # Train the model
-        results = model.train(data="coco-pose.yaml", epochs=100, imgsz=640)
-        ```
-
-    === "CLI"
-
-        ```bash
-        # Start training from a pretrained *.pt model
-        yolo pose train data=coco-pose.yaml model=yolo26n-pose.pt epochs=100 imgsz=640
-        ```
-
-For more details on the training process and available arguments, check the [training page](../../modes/train.md).
+Load `yolo26n-pose.pt` and call `model.train(data="coco-pose.yaml", epochs=100, imgsz=640)` — see the [Train Example](#usage) above for the full Python and CLI snippets, and the [training page](../../modes/train.md) for a comprehensive list of arguments.
 
 ### What are the different metrics provided by the COCO-Pose dataset for evaluating model performance?
 

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -28,7 +28,7 @@ COCO-Pose covers the COCO 2017 images that contain keypoint-annotated people, so
 
 1. **Train2017**: This subset contains 56,599 images from the COCO dataset, annotated for training pose estimation models.
 2. **Val2017**: This subset has 2,346 images used for validation purposes during model training.
-3. **Test-dev2017**: A 20,288-image subset of the full 40,670-image test2017 set. Ground truth annotations are withheld, and results are submitted to the [COCO keypoints evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7403) for scoring.
+3. **Test-dev2017**: A 20,288-image subset of the full 40,670-image test2017 set with withheld ground truth. The dataset YAML links this split to the [COCO test-dev keypoints evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7403).
 
 Training at this scale is where [Ultralytics Platform](https://platform.ultralytics.com/) helps most — it manages the compute so you can launch and monitor runs without provisioning your own GPUs.
 
@@ -118,7 +118,7 @@ The COCO-Pose dataset provides several standardized evaluation metrics for pose 
 
 ### How is the dataset structured and split for the COCO-Pose dataset?
 
-COCO-Pose ships two labeled splits: 56,599 train2017 images and 2,346 val2017 images. A third split, test-dev2017 (20,288 of the full 40,670 test2017 images), keeps its ground truth private, so submissions are scored via the [COCO keypoints evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7403). See the [Dataset Structure](#dataset-structure) section, or the `coco-pose.yaml` file on [GitHub](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco-pose.yaml) for the exact split paths.
+COCO-Pose ships two labeled splits: 56,599 train2017 images and 2,346 val2017 images. A third split, test-dev2017 (20,288 of the full 40,670 test2017 images), keeps its ground truth private; the dataset YAML links it to the [COCO test-dev keypoints evaluation server](https://codalab.lisn.upsaclay.fr/competitions/7403). See the [Dataset Structure](#dataset-structure) section, or the `coco-pose.yaml` file on [GitHub](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco-pose.yaml) for the exact split paths.
 
 ### What are the key features and applications of the COCO-Pose dataset?
 

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -30,7 +30,7 @@ The COCO-Pose dataset is split into three subsets:
 2. **Val2017**: This subset has 2346 images used for validation purposes during model training.
 3. **Test2017**: This subset consists of images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for performance evaluation.
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+Training at this scale is where [Ultralytics Platform](https://platform.ultralytics.com/) helps most — it manages the compute so you can launch and monitor runs without provisioning your own GPUs.
 
 ## Applications
 

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -20,7 +20,7 @@ The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset adapts COCO (Co
 - COCO-Pose builds upon the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge, which labels 1,710,498 individual keypoints across 156,165 annotated people.
 - Each person is annotated with 17 keypoints — nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles — stored as `(x, y, visibility)` triplets.
 - Like COCO, it provides standardized evaluation metrics, including Object Keypoint Similarity (OKS) for pose estimation tasks, making it suitable for comparing model performance.
-- **Download size**: ~20.1 GB.
+- **Download size**: ~27 GB on first use — the download script fetches `train2017.zip`, `val2017.zip`, and `test2017.zip` together, even though the test archive is only needed for the optional test-dev2017 submission split.
 
 ## Dataset Structure
 

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -1,13 +1,13 @@
 ---
 title: COCO-Pose Estimation Dataset
 comments: true
-description: Explore the COCO-Pose dataset: 58,945 images with 156K+ annotated people and 17 keypoints each, for training pose estimation models with YOLO26.
+description: Explore the Ultralytics COCO-Pose dataset: 58,945 images with 156K+ annotated people and 17 keypoints each, for training YOLO26 pose estimation models.
 keywords: COCO-Pose, pose estimation, dataset, keypoints, COCO Keypoints 2017, YOLO, deep learning, computer vision
 ---
 
 # COCO-Pose Dataset
 
-The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset is a specialized version of the COCO (Common Objects in Context) dataset, designed for pose estimation tasks. It leverages the COCO Keypoints 2017 images and labels to enable the training of models like YOLO for pose estimation tasks.
+The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset adapts COCO (Common Objects in Context) for [pose estimation](../../tasks/pose.md): 58,945 images from COCO Keypoints 2017, annotated with 156,165 people at 17 keypoints each. It is the standard set for training and benchmarking keypoint models such as [Ultralytics YOLO26](../../models/yolo26.md), and the 8-image [COCO8-Pose](coco8-pose.md) subset mirrors its format for quick sanity checks.
 
 ![COCO pose estimation with human keypoints](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/pose-sample-image.avif)
 
@@ -17,24 +17,24 @@ The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset is a specialize
 
 ## Key Features
 
-- COCO-Pose builds upon the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge: 58,945 images annotated with 156,165 people and 1,710,498 individual keypoints for pose estimation tasks.
-- The dataset supports 17 keypoints for human figures, facilitating detailed pose estimation.
+- COCO-Pose builds upon the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge, which labels 1,710,498 individual keypoints across 156,165 annotated people.
+- Each person is annotated with 17 keypoints — nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles — stored as `(x, y, visibility)` triplets.
 - Like COCO, it provides standardized evaluation metrics, including Object Keypoint Similarity (OKS) for pose estimation tasks, making it suitable for comparing model performance.
 - **Download size**: ~20.1 GB.
 
 ## Dataset Structure
 
-The COCO-Pose dataset is split into three subsets:
+COCO-Pose covers the COCO 2017 images that contain keypoint-annotated people, so its splits are smaller than full COCO's. It is divided into three subsets:
 
-1. **Train2017**: This subset contains 56599 images from the COCO dataset, annotated for training pose estimation models.
-2. **Val2017**: This subset has 2346 images used for validation purposes during model training.
+1. **Train2017**: This subset contains 56,599 images from the COCO dataset, annotated for training pose estimation models.
+2. **Val2017**: This subset has 2,346 images used for validation purposes during model training.
 3. **Test2017**: This subset consists of images used for testing and benchmarking the trained models. Ground truth annotations for this subset are not publicly available, and the results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for performance evaluation.
 
 Training at this scale is where [Ultralytics Platform](https://platform.ultralytics.com/) helps most — it manages the compute so you can launch and monitor runs without provisioning your own GPUs.
 
 ## Applications
 
-The COCO-Pose dataset is specifically used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in keypoint detection and pose estimation tasks, such as OpenPose. The dataset's large number of annotated images and standardized evaluation metrics make it an essential resource for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) researchers and practitioners focused on pose estimation.
+The COCO-Pose dataset is specifically used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models on keypoint detection and [pose estimation](../../tasks/pose.md). The dataset's large number of annotated images and standardized evaluation metrics make it an essential resource for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) researchers and practitioners working on human pose.
 
 ## Dataset YAML
 
@@ -106,7 +106,7 @@ We would like to acknowledge the COCO Consortium for creating and maintaining th
 
 ### What is the COCO-Pose dataset and how is it used with Ultralytics YOLO for pose estimation?
 
-The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset is a specialized version of the COCO (Common Objects in Context) dataset designed for pose estimation tasks. It builds upon the COCO Keypoints 2017 images and annotations, allowing for the training of models like Ultralytics YOLO for detailed pose estimation. For instance, you can use the COCO-Pose dataset to train a YOLO26n-pose model by loading a pretrained model and training it with a YAML configuration. For training examples, refer to the [Training](../../modes/train.md) documentation.
+COCO-Pose supplies the COCO Keypoints 2017 images and annotations converted to YOLO keypoint format, with 17 keypoints per person across 58,945 images. Point any Ultralytics YOLO pose model at it with `data=coco-pose.yaml`, and the [Training](../../modes/train.md) page documents every argument you can tune from there.
 
 ### How can I train a YOLO26 model on the COCO-Pose dataset?
 
@@ -118,16 +118,10 @@ The COCO-Pose dataset provides several standardized evaluation metrics for pose 
 
 ### How is the dataset structured and split for the COCO-Pose dataset?
 
-The COCO-Pose dataset is split into three subsets:
-
-1. **Train2017**: Contains 56599 COCO images, annotated for training pose estimation models.
-2. **Val2017**: 2346 images for validation purposes during model training.
-3. **Test2017**: Images used for testing and benchmarking trained models. Ground truth annotations for this subset are not publicly available; results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for performance evaluation.
-
-These subsets help organize the training, validation, and testing phases effectively. For configuration details, explore the `coco-pose.yaml` file available on [GitHub](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco-pose.yaml).
+COCO-Pose ships two labeled splits: 56,599 train2017 images and 2,346 val2017 images. A third split, test2017, keeps its ground truth private, so submissions are scored by the [COCO evaluation server](https://cocodataset.org/#upload). See the [Dataset Structure](#dataset-structure) section, or the `coco-pose.yaml` file on [GitHub](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco-pose.yaml) for the exact split paths.
 
 ### What are the key features and applications of the COCO-Pose dataset?
 
-The COCO-Pose dataset extends the COCO Keypoints 2017 annotations to include 17 keypoints for human figures, enabling detailed pose estimation. Standardized evaluation metrics (e.g., OKS) facilitate comparisons across different models. Applications of the COCO-Pose dataset span various domains, such as sports analytics, healthcare, and human-computer interaction, wherever detailed pose estimation of human figures is required. For practical use, leveraging pretrained models like those provided in the documentation (e.g., YOLO26n-pose) can significantly streamline the process ([Key Features](#key-features)).
+COCO-Pose annotates 17 human keypoints per person and inherits COCO's standardized metrics, including Object Keypoint Similarity (OKS), for comparing models. That combination suits human pose applications such as sports analytics, healthcare, and human-computer interaction. Pretrained YOLO26-pose weights are listed under [COCO-Pose Pretrained Models](#coco-pose-pretrained-models).
 
-If you use the COCO-Pose dataset in your research or development work, please cite the paper with the following [BibTeX entry](#citations-and-acknowledgments).
+For more on keypoint models, see the [Pose Estimation](../../tasks/pose.md) task docs.

--- a/docs/en/datasets/pose/coco8-pose.md
+++ b/docs/en/datasets/pose/coco8-pose.md
@@ -16,7 +16,7 @@ keywords: COCO8-Pose, Ultralytics, pose detection dataset, object detection, YOL
 - **Classes**: 1 (person) with 17 keypoints per annotation.
 - **Recommended directory layout**: `datasets/coco8-pose/images/{train,val}` and `datasets/coco8-pose/labels/{train,val}` with YOLO-format keypoints stored as `.txt` files.
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+Explore [COCO8-Pose on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco8-pose) to browse every image with its keypoint skeletons, view the keypoint and class distributions in the **Charts** tab, and clone it to train your own model in the cloud.
 
 ## Dataset YAML
 

--- a/docs/en/datasets/pose/coco8-pose.md
+++ b/docs/en/datasets/pose/coco8-pose.md
@@ -1,7 +1,7 @@
 ---
 title: COCO8-Pose Estimation Dataset
 comments: true
-description: Explore the Ultralytics COCO8-Pose dataset: 8 images (4 train / 4 val) with 17 keypoints per person, for pose estimation sanity checks with YOLO26.
+description: "Explore the Ultralytics COCO8-Pose dataset: 8 images (4 train / 4 val) using a 17-keypoint schema, for pose estimation sanity checks with YOLO26."
 keywords: COCO8-Pose, Ultralytics, pose estimation dataset, keypoint detection, YOLO26, machine learning, computer vision, training data
 ---
 
@@ -9,12 +9,12 @@ keywords: COCO8-Pose, Ultralytics, pose estimation dataset, keypoint detection, 
 
 ## Introduction
 
-[Ultralytics](https://www.ultralytics.com/) COCO8-Pose is a small but versatile pose estimation dataset composed of the first 8 images of the COCO train 2017 set (4 for training, 4 for validation), annotated with 17 keypoints for the single "person" class. This dataset is ideal for testing and debugging [pose estimation](../../tasks/pose.md) models, or for experimenting with new keypoint-detection approaches. With 8 images, it is small enough to be easily manageable, yet diverse enough to test training pipelines for errors and act as a sanity check before training on the full [COCO-Pose](coco.md) dataset.
+[Ultralytics](https://www.ultralytics.com/) COCO8-Pose is a small but versatile pose estimation dataset composed of the first 8 images of the COCO train 2017 set (4 for training, 4 for validation), using a 17-keypoint schema for the single "person" class. This dataset is ideal for testing and debugging [pose estimation](../../tasks/pose.md) models, or for experimenting with new keypoint-detection approaches. With 8 images, it is small enough to be easily manageable, yet diverse enough to test training pipelines for errors and act as a sanity check before training on the full [COCO-Pose](coco.md) dataset.
 
 ## Dataset Structure
 
 - **Total images**: 8 (4 train / 4 val).
-- **Classes**: 1 (person) with 17 keypoints per annotation.
+- **Classes**: 1 (person) with 17 keypoint types per annotation.
 - **Download size**: ~1 MB.
 - **Recommended directory layout**: `datasets/coco8-pose/images/{train,val}` and `datasets/coco8-pose/labels/{train,val}` with YOLO-format keypoints stored as `.txt` files.
 
@@ -96,7 +96,7 @@ Load `yolo26n-pose.pt` and call `model.train(data="coco8-pose.yaml", epochs=100,
 
 ### What are the benefits of using the COCO8-Pose dataset?
 
-With 8 total images (4 train / 4 val), 1 class, 17 keypoints per instance, and a ~1 MB download, COCO8-Pose is small enough to manage in seconds yet diverse enough to sanity-check a pose training pipeline for errors before scaling up to the full [COCO-Pose](coco.md) dataset. For more about its features and usage, see the [Dataset Introduction](#introduction) section.
+With 8 total images (4 train / 4 val), 1 class, a 17-keypoint schema, and a ~1 MB download, COCO8-Pose is small enough to manage in seconds yet diverse enough to sanity-check a pose training pipeline for errors before scaling up to the full [COCO-Pose](coco.md) dataset. For more about its features and usage, see the [Dataset Introduction](#introduction) section.
 
 ### How does mosaicing benefit the YOLO26 training process using the COCO8-Pose dataset?
 

--- a/docs/en/datasets/pose/coco8-pose.md
+++ b/docs/en/datasets/pose/coco8-pose.md
@@ -1,7 +1,7 @@
 ---
 title: COCO8-Pose Estimation Dataset
 comments: true
-description: Explore the compact, versatile COCO8-Pose dataset for testing and debugging pose estimation models. Ideal for quick experiments with YOLO26.
+description: Explore the Ultralytics COCO8-Pose dataset: 8 images (4 train / 4 val) with 17 keypoints per person, for pose estimation sanity checks with YOLO26.
 keywords: COCO8-Pose, Ultralytics, pose estimation dataset, keypoint detection, YOLO26, machine learning, computer vision, training data
 ---
 

--- a/docs/en/datasets/pose/coco8-pose.md
+++ b/docs/en/datasets/pose/coco8-pose.md
@@ -1,19 +1,21 @@
 ---
+title: COCO8-Pose Estimation Dataset
 comments: true
-description: Explore the compact, versatile COCO8-Pose dataset for testing and debugging object detection models. Ideal for quick experiments with YOLO26.
-keywords: COCO8-Pose, Ultralytics, pose detection dataset, object detection, YOLO26, machine learning, computer vision, training data
+description: Explore the compact, versatile COCO8-Pose dataset for testing and debugging pose estimation models. Ideal for quick experiments with YOLO26.
+keywords: COCO8-Pose, Ultralytics, pose estimation dataset, keypoint detection, YOLO26, machine learning, computer vision, training data
 ---
 
 # COCO8-Pose Dataset
 
 ## Introduction
 
-[Ultralytics](https://www.ultralytics.com/) COCO8-Pose is a small but versatile pose detection dataset composed of the first 8 images of the COCO train 2017 set, 4 for training and 4 for validation. This dataset is ideal for testing and debugging [object detection](https://www.ultralytics.com/glossary/object-detection) models, or for experimenting with new detection approaches. With 8 images, it is small enough to be easily manageable, yet diverse enough to test training pipelines for errors and act as a sanity check before training larger datasets.
+[Ultralytics](https://www.ultralytics.com/) COCO8-Pose is a small but versatile pose estimation dataset composed of the first 8 images of the COCO train 2017 set (4 for training, 4 for validation), annotated with 17 keypoints for the single "person" class. This dataset is ideal for testing and debugging [pose estimation](../../tasks/pose.md) models, or for experimenting with new keypoint-detection approaches. With 8 images, it is small enough to be easily manageable, yet diverse enough to test training pipelines for errors and act as a sanity check before training on the full [COCO-Pose](coco.md) dataset.
 
 ## Dataset Structure
 
 - **Total images**: 8 (4 train / 4 val).
 - **Classes**: 1 (person) with 17 keypoints per annotation.
+- **Download size**: ~1 MB.
 - **Recommended directory layout**: `datasets/coco8-pose/images/{train,val}` and `datasets/coco8-pose/labels/{train,val}` with YOLO-format keypoints stored as `.txt` files.
 
 Explore [COCO8-Pose on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco8-pose) to browse every image with its keypoint skeletons, view the keypoint and class distributions in the **Charts** tab, and clone it to train your own model in the cloud.
@@ -61,8 +63,6 @@ Here are some examples of images from the COCO8-Pose dataset, along with their c
 
 - **Mosaiced Image**: This image demonstrates a training batch composed of mosaiced dataset images. Mosaicing is a technique used during training that combines multiple images into a single image to increase the variety of objects and scenes within each training batch. This helps improve the model's ability to generalize to different object sizes, aspect ratios, and contexts.
 
-The example showcases the variety and complexity of the images in the COCO8-Pose dataset and the benefits of using mosaicing during the training process.
-
 ## Citations and Acknowledgments
 
 If you use the COCO dataset in your research or development work, please cite the following paper:
@@ -88,50 +88,22 @@ We would like to acknowledge the COCO Consortium for creating and maintaining th
 
 ### What is the COCO8-Pose dataset, and how is it used with Ultralytics YOLO26?
 
-The COCO8-Pose dataset is a small, versatile pose detection dataset that includes the first 8 images from the COCO train 2017 set, with 4 images for training and 4 for validation. It's designed for testing and debugging object detection models and experimenting with new detection approaches. This dataset is ideal for quick experiments with [Ultralytics YOLO26](../../models/yolo26.md). For more details on dataset configuration, check out the [dataset YAML file](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco8-pose.yaml).
+The COCO8-Pose dataset is a small, versatile pose estimation dataset that includes the first 8 images from the COCO train 2017 set, with 4 images for training and 4 for validation. It's designed for testing and debugging pose estimation models and experimenting with new keypoint-detection approaches. This dataset is ideal for quick experiments with [Ultralytics YOLO26](../../models/yolo26.md). For more details on dataset configuration, check out the [dataset YAML file](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco8-pose.yaml).
 
 ### How do I train a YOLO26 model using the COCO8-Pose dataset in Ultralytics?
 
-To train a YOLO26n-pose model on the COCO8-Pose dataset for 100 epochs with an image size of 640, follow these examples:
-
-!!! example "Train Example"
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        # Load a model
-        model = YOLO("yolo26n-pose.pt")
-
-        # Train the model
-        results = model.train(data="coco8-pose.yaml", epochs=100, imgsz=640)
-        ```
-
-    === "CLI"
-
-        ```bash
-        yolo pose train data=coco8-pose.yaml model=yolo26n-pose.pt epochs=100 imgsz=640
-        ```
-
-For a comprehensive list of training arguments, refer to the model [Training](../../modes/train.md) page.
+Load `yolo26n-pose.pt` and call `model.train(data="coco8-pose.yaml", epochs=100, imgsz=640)` — see the [Train Example](#usage) above for the full Python and CLI snippets, and the model [Training](../../modes/train.md) page for a comprehensive list of arguments.
 
 ### What are the benefits of using the COCO8-Pose dataset?
 
-The COCO8-Pose dataset offers several benefits:
-
-- **Compact Size**: With only 8 images, it is easy to manage and perfect for quick experiments.
-- **Diverse Data**: Despite its small size, it includes a variety of scenes, useful for thorough pipeline testing.
-- **Error Debugging**: Ideal for identifying training errors and performing sanity checks before scaling up to larger datasets.
-
-For more about its features and usage, see the [Dataset Introduction](#introduction) section.
+With 8 total images (4 train / 4 val), 1 class, 17 keypoints per instance, and a ~1 MB download, COCO8-Pose is small enough to manage in seconds yet diverse enough to sanity-check a pose training pipeline for errors before scaling up to the full [COCO-Pose](coco.md) dataset. For more about its features and usage, see the [Dataset Introduction](#introduction) section.
 
 ### How does mosaicing benefit the YOLO26 training process using the COCO8-Pose dataset?
 
-Mosaicing, demonstrated in the sample images of the COCO8-Pose dataset, combines multiple images into one, increasing the variety of objects and scenes within each training batch. This technique helps improve the model's ability to generalize across various object sizes, aspect ratios, and contexts, ultimately enhancing model performance. See the [Sample Images and Annotations](#sample-images-and-annotations) section for example images.
+Mosaicing combines multiple images into one, increasing the variety of objects and scenes within each training batch, which helps the model generalize across object sizes, aspect ratios, and contexts. See the [Sample Images and Annotations](#sample-images-and-annotations) section for an example.
 
 ### Where can I find the COCO8-Pose dataset YAML file and how do I use it?
 
 The COCO8-Pose dataset YAML file can be found at <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco8-pose.yaml>. This file defines the dataset configuration, including paths, classes, and other relevant information. Use this file with the YOLO26 training scripts as mentioned in the [Train Example](#how-do-i-train-a-yolo26-model-using-the-coco8-pose-dataset-in-ultralytics) section.
 
-For more FAQs and detailed documentation, visit the [Ultralytics Documentation](../../index.md).
+For more on keypoint models, see the [Pose Estimation](../../tasks/pose.md) task docs.

--- a/docs/en/datasets/pose/dog-pose.md
+++ b/docs/en/datasets/pose/dog-pose.md
@@ -1,14 +1,15 @@
 ---
+title: Dog-Pose Estimation Dataset
 comments: true
-description: Discover the Dog-Pose dataset for pose detection. Featuring 6,773 training and 1,703 test images, it is a robust dataset for training YOLO26 models.
-keywords: Dog-Pose, Ultralytics, pose detection dataset, YOLO26, machine learning, computer vision, training data
+description: Discover the Dog-Pose dataset for canine keypoint estimation: 6,773 training and 1,703 validation images with 24 keypoints per dog, for YOLO26.
+keywords: Dog-Pose, Ultralytics, pose estimation dataset, YOLO26, machine learning, computer vision, training data
 ---
 
 # Dog-Pose Dataset
 
 ## Introduction
 
-The [Ultralytics](https://www.ultralytics.com/) Dog-Pose dataset is a high-quality and extensive dataset specifically curated for dog keypoint estimation. With 6,773 training images and 1,703 test images, this dataset provides a solid foundation for training robust pose estimation models.
+The [Ultralytics](https://www.ultralytics.com/) Dog-Pose dataset is a high-quality and extensive dataset specifically curated for dog keypoint estimation. With 6,773 training images and 1,703 validation images, this dataset provides a solid foundation for training robust pose estimation models.
 
 <p align="center">
   <br>
@@ -18,7 +19,7 @@ The [Ultralytics](https://www.ultralytics.com/) Dog-Pose dataset is a high-quali
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> How to Train Ultralytics YOLO26 on the Stanford Dog Pose Estimation Dataset | Step-by-Step Tutorial
+  <strong>Watch:</strong> How to Train an Ultralytics YOLO Model on the Stanford Dog Pose Estimation Dataset | Step-by-Step Tutorial
 </p>
 
 Each annotated image includes 24 keypoints with 3 dimensions per keypoint (x, y, visibility), making it a valuable resource for advanced research and development in computer vision.
@@ -31,6 +32,7 @@ This dataset is intended for use with [Ultralytics Platform](https://platform.ul
 
 - **Split**: 6,773 train / 1,703 val images with matching YOLO-format label files.
 - **Keypoints**: 24 per dog with `(x, y, visibility)` triplets.
+- **Download size**: ~337 MB.
 - **Layout**:
 
     ```
@@ -113,41 +115,19 @@ We would like to acknowledge the Stanford team for creating and maintaining this
 
 ### What is the Dog-pose dataset, and how is it used with Ultralytics YOLO26?
 
-The Dog-Pose dataset features 6,773 training and 1,703 test images annotated with 24 keypoints for dog pose estimation. It's designed for training and validating models with [Ultralytics YOLO26](../../models/yolo26.md), supporting applications like animal behavior analysis, pet monitoring, and veterinary studies. The dataset's comprehensive annotations make it ideal for developing accurate pose estimation models for canines.
+The Dog-Pose dataset features 6,773 training and 1,703 validation images annotated with 24 keypoints for dog pose estimation. It's designed for training and validating models with [Ultralytics YOLO26](../../models/yolo26.md), supporting applications like animal behavior analysis, pet monitoring, and veterinary studies. The dataset's comprehensive annotations make it ideal for developing accurate pose estimation models for canines.
 
 ### How do I train a YOLO26 model using the Dog-pose dataset in Ultralytics?
 
-To train a YOLO26n-pose model on the Dog-pose dataset for 100 epochs with an image size of 640, follow these examples:
-
-!!! example "Train Example"
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        # Load a model
-        model = YOLO("yolo26n-pose.pt")
-
-        # Train the model
-        results = model.train(data="dog-pose.yaml", epochs=100, imgsz=640)
-        ```
-
-    === "CLI"
-
-        ```bash
-        yolo pose train data=dog-pose.yaml model=yolo26n-pose.pt epochs=100 imgsz=640
-        ```
-
-For a comprehensive list of training arguments, refer to the model [Training](../../modes/train.md) page.
+Load `yolo26n-pose.pt` and call `model.train(data="dog-pose.yaml", epochs=100, imgsz=640)` — see the [Train Example](#usage) above for the full Python and CLI snippets, and the model [Training](../../modes/train.md) page for a comprehensive list of arguments.
 
 ### What are the benefits of using the Dog-pose dataset?
 
 The Dog-pose dataset offers several benefits:
 
-**Large and Diverse Dataset**: With over 8,400 images, it provides substantial data covering a wide range of dog poses, breeds, and contexts, enabling robust model training and evaluation.
+**Large and Diverse Dataset**: With 8,476 total images (6,773 train / 1,703 val), it provides substantial data covering a wide range of dog poses, breeds, and contexts, enabling robust model training and evaluation.
 
-**Detailed Keypoint Annotations**: Each image includes 24 keypoints with 3 dimensions per keypoint (x, y, visibility), offering precise annotations for training accurate pose detection models.
+**Detailed Keypoint Annotations**: Each image includes 24 keypoints with 3 dimensions per keypoint (x, y, visibility), offering precise annotations for training accurate pose estimation models.
 
 **Real-World Scenarios**: Includes images from varied environments, enhancing the model's ability to generalize to real-world applications like [pet monitoring](https://www.ultralytics.com/blog/custom-training-ultralytics-yolo11-for-dog-pose-estimation) and behavior analysis.
 
@@ -172,4 +152,4 @@ The Dog-pose dataset YAML file can be found at <https://github.com/ultralytics/u
 
 To use this file with YOLO26 training scripts, simply reference it in your training command as shown in the [Usage](#usage) section. The dataset will be automatically downloaded when first used, making setup straightforward.
 
-For more FAQs and detailed documentation, visit the [Ultralytics Documentation](../../index.md).
+For more on keypoint models, see the [Pose Estimation](../../tasks/pose.md) task docs.

--- a/docs/en/datasets/pose/dog-pose.md
+++ b/docs/en/datasets/pose/dog-pose.md
@@ -1,7 +1,7 @@
 ---
 title: Dog-Pose Estimation Dataset
 comments: true
-description: Discover the Dog-Pose dataset for canine keypoint estimation: 6,773 training and 1,703 validation images with 24 keypoints per dog, for YOLO26.
+description: Explore the Ultralytics Dog-Pose dataset: 6,773 training and 1,703 validation images with 24 keypoints per dog, for canine pose estimation with YOLO26.
 keywords: Dog-Pose, Ultralytics, pose estimation dataset, YOLO26, machine learning, computer vision, training data
 ---
 
@@ -9,7 +9,7 @@ keywords: Dog-Pose, Ultralytics, pose estimation dataset, YOLO26, machine learni
 
 ## Introduction
 
-The [Ultralytics](https://www.ultralytics.com/) Dog-Pose dataset is a high-quality and extensive dataset specifically curated for dog keypoint estimation. With 6,773 training images and 1,703 validation images, this dataset provides a solid foundation for training robust pose estimation models.
+The [Ultralytics](https://www.ultralytics.com/) Dog-Pose dataset is a high-quality and extensive dataset specifically curated for dog keypoint estimation, providing 6,773 training and 1,703 validation images.
 
 <p align="center">
   <br>
@@ -24,13 +24,13 @@ The [Ultralytics](https://www.ultralytics.com/) Dog-Pose dataset is a high-quali
 
 Each annotated image includes 24 keypoints with 3 dimensions per keypoint (x, y, visibility), making it a valuable resource for advanced research and development in computer vision.
 
-<img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-dogs.avif" alt="Ultralytics Dog-pose display image" width="800">
+<img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-dogs.avif" alt="Ultralytics Dog-Pose display image" width="800">
 
 For a specific breed or a different animal altogether, [Ultralytics Platform](https://platform.ultralytics.com/) handles uploading, labeling, and training a custom keypoint model on your own data without managing infrastructure.
 
 ## Dataset Structure
 
-- **Split**: 6,773 train / 1,703 val images with matching YOLO-format label files.
+- **Total images**: 8,476 (6,773 train / 1,703 val) with matching YOLO-format label files.
 - **Keypoints**: 24 per dog with `(x, y, visibility)` triplets.
 - **Download size**: ~337 MB.
 - **Layout**:
@@ -43,7 +43,7 @@ For a specific breed or a different animal altogether, [Ultralytics Platform](ht
 
 ## Dataset YAML
 
-A YAML (Yet Another Markup Language) file is used to define the dataset configuration. It includes paths, keypoint details, and other relevant information. In the case of the Dog-pose dataset, The `dog-pose.yaml` is available at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/dog-pose.yaml](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/dog-pose.yaml).
+A YAML (Yet Another Markup Language) file is used to define the dataset configuration. It includes paths, keypoint details, and other relevant information. In the case of the Dog-Pose dataset, the `dog-pose.yaml` file is available at <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/dog-pose.yaml>.
 
 !!! example "ultralytics/cfg/datasets/dog-pose.yaml"
 
@@ -53,7 +53,7 @@ A YAML (Yet Another Markup Language) file is used to define the dataset configur
 
 ## Usage
 
-To train a YOLO26n-pose model on the Dog-pose dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page.
+To train a YOLO26n-pose model on the Dog-Pose dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page.
 
 !!! example "Train Example"
 
@@ -78,17 +78,17 @@ To train a YOLO26n-pose model on the Dog-pose dataset for 100 [epochs](https://w
 
 ## Sample Images and Annotations
 
-Here are some examples of images from the Dog-pose dataset, along with their corresponding annotations:
+Here are some examples of images from the Dog-Pose dataset, along with their corresponding annotations:
 
 <img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/mosaiced-training-batch-2-dog-pose.avif" alt="Dog pose estimation dataset mosaic training batch" width="800">
 
 - **Mosaiced Image**: This image demonstrates a training batch composed of mosaiced dataset images. Mosaicing is a technique used during training that combines multiple images into a single image to increase the variety of objects and scenes within each training batch. This helps improve the model's ability to generalize to different object sizes, aspect ratios, and contexts.
 
-The example showcases the variety and complexity of the images in the Dog-pose dataset and the benefits of using mosaicing during the training process.
+The example showcases the variety and complexity of the images in the Dog-Pose dataset and the benefits of using mosaicing during the training process.
 
 ## Citations and Acknowledgments
 
-If you use the Dog-pose dataset in your research or development work, please cite the following paper:
+If you use the Dog-Pose dataset in your research or development work, please cite the following paper:
 
 !!! quote ""
 
@@ -109,46 +109,29 @@ If you use the Dog-pose dataset in your research or development work, please cit
         }
         ```
 
-We would like to acknowledge the Stanford team for creating and maintaining this valuable resource for the [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) community. For more information about the Dog-pose dataset and its creators, visit the [Stanford Dogs Dataset website](http://vision.stanford.edu/aditya86/ImageNetDogs/).
+We would like to acknowledge the Stanford team for creating and maintaining this valuable resource for the [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) community. For more information about the Dog-Pose dataset and its creators, visit the [Stanford Dogs Dataset website](http://vision.stanford.edu/aditya86/ImageNetDogs/).
 
 ## FAQ
 
-### What is the Dog-pose dataset, and how is it used with Ultralytics YOLO26?
+### What is the Dog-Pose dataset, and how is it used with Ultralytics YOLO26?
 
 The Dog-Pose dataset features 6,773 training and 1,703 validation images annotated with 24 keypoints for dog pose estimation. It's designed for training and validating models with [Ultralytics YOLO26](../../models/yolo26.md), supporting applications like animal behavior analysis, pet monitoring, and veterinary studies. The dataset's comprehensive annotations make it ideal for developing accurate pose estimation models for canines.
 
-### How do I train a YOLO26 model using the Dog-pose dataset in Ultralytics?
+### How do I train a YOLO26 model using the Dog-Pose dataset in Ultralytics?
 
 Load `yolo26n-pose.pt` and call `model.train(data="dog-pose.yaml", epochs=100, imgsz=640)` — see the [Train Example](#usage) above for the full Python and CLI snippets, and the model [Training](../../modes/train.md) page for a comprehensive list of arguments.
 
-### What are the benefits of using the Dog-pose dataset?
+### What are the benefits of using the Dog-Pose dataset?
 
-The Dog-pose dataset offers several benefits:
+With 8,476 total images (6,773 train / 1,703 val) covering a wide range of dog breeds and poses, and 24 keypoints in 3 dimensions (x, y, visibility) per annotation, the Dog-Pose dataset gives models the real-world scenario coverage needed for applications like [pet monitoring](https://www.ultralytics.com/blog/custom-training-ultralytics-yolo11-for-dog-pose-estimation) and behavior analysis. For more about its features and usage, see the [Dataset Introduction](#introduction) section.
 
-**Large and Diverse Dataset**: With 8,476 total images (6,773 train / 1,703 val), it provides substantial data covering a wide range of dog poses, breeds, and contexts, enabling robust model training and evaluation.
+### How does mosaicing benefit the YOLO26 training process using the Dog-Pose dataset?
 
-**Detailed Keypoint Annotations**: Each image includes 24 keypoints with 3 dimensions per keypoint (x, y, visibility), offering precise annotations for training accurate pose estimation models.
+Mosaicing combines multiple Dog-Pose images into a single training batch, increasing the variety of dog poses, sizes, and backgrounds the model sees per step, which improves generalization to new contexts and scales while reducing overfitting. For example images, refer to the [Sample Images and Annotations](#sample-images-and-annotations) section.
 
-**Real-World Scenarios**: Includes images from varied environments, enhancing the model's ability to generalize to real-world applications like [pet monitoring](https://www.ultralytics.com/blog/custom-training-ultralytics-yolo11-for-dog-pose-estimation) and behavior analysis.
+### Where can I find the Dog-Pose dataset YAML file and how do I use it?
 
-**Transfer Learning Advantage**: The dataset works well with [transfer learning](https://www.ultralytics.com/blog/understanding-few-shot-zero-shot-and-transfer-learning) techniques, allowing models pretrained on human pose datasets to adapt to dog-specific features.
-
-For more about its features and usage, see the [Dataset Introduction](#introduction) section.
-
-### How does mosaicing benefit the YOLO26 training process using the Dog-pose dataset?
-
-Mosaicing, as illustrated in the sample images from the Dog-pose dataset, merges multiple images into a single composite, enriching the diversity of objects and scenes in each training batch. This technique offers several benefits:
-
-- Increases the variety of dog poses, sizes, and backgrounds in each batch
-- Improves the model's ability to detect dogs in different contexts and scales
-- Enhances generalization by exposing the model to more diverse visual patterns
-- Reduces overfitting by creating novel combinations of training examples
-
-This approach leads to more robust models that perform better in real-world scenarios. For example images, refer to the [Sample Images and Annotations](#sample-images-and-annotations) section.
-
-### Where can I find the Dog-pose dataset YAML file and how do I use it?
-
-The Dog-pose dataset YAML file can be found at <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/dog-pose.yaml>. This file defines the dataset configuration, including paths, classes, keypoint details, and other relevant information. The YAML specifies 24 keypoints with 3 dimensions per keypoint, making it suitable for detailed pose estimation tasks.
+The Dog-Pose dataset YAML file can be found at <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/dog-pose.yaml>. This file defines the dataset configuration, including paths, classes, keypoint details, and other relevant information. The YAML specifies 24 keypoints with 3 dimensions per keypoint, making it suitable for detailed pose estimation tasks.
 
 To use this file with YOLO26 training scripts, simply reference it in your training command as shown in the [Usage](#usage) section. The dataset will be automatically downloaded when first used, making setup straightforward.
 

--- a/docs/en/datasets/pose/dog-pose.md
+++ b/docs/en/datasets/pose/dog-pose.md
@@ -127,7 +127,7 @@ With 8,476 total images (6,773 train / 1,703 val) covering a wide range of dog b
 
 ### How does mosaicing benefit the YOLO26 training process using the Dog-Pose dataset?
 
-Mosaicing combines multiple Dog-Pose images into a single training batch, increasing the variety of dog poses, sizes, and backgrounds the model sees per step, which improves generalization to new contexts and scales while reducing overfitting. For example images, refer to the [Sample Images and Annotations](#sample-images-and-annotations) section.
+Mosaicing combines multiple Dog-Pose images into a single training image, increasing the variety of dog poses, sizes, and backgrounds the model sees per step, which improves generalization to new contexts and scales while reducing overfitting. For example images, refer to the [Sample Images and Annotations](#sample-images-and-annotations) section.
 
 ### Where can I find the Dog-Pose dataset YAML file and how do I use it?
 

--- a/docs/en/datasets/pose/dog-pose.md
+++ b/docs/en/datasets/pose/dog-pose.md
@@ -26,7 +26,7 @@ Each annotated image includes 24 keypoints with 3 dimensions per keypoint (x, y,
 
 <img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/ultralytics-dogs.avif" alt="Ultralytics Dog-pose display image" width="800">
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+For a specific breed or a different animal altogether, [Ultralytics Platform](https://platform.ultralytics.com/) handles uploading, labeling, and training a custom keypoint model on your own data without managing infrastructure.
 
 ## Dataset Structure
 

--- a/docs/en/datasets/pose/dog-pose.md
+++ b/docs/en/datasets/pose/dog-pose.md
@@ -1,7 +1,7 @@
 ---
 title: Dog-Pose Estimation Dataset
 comments: true
-description: Explore the Ultralytics Dog-Pose dataset: 6,773 training and 1,703 validation images with 24 keypoints per dog, for canine pose estimation with YOLO26.
+description: "Explore the Ultralytics Dog-Pose dataset: 6,773 training and 1,703 validation images with 24 keypoints per dog, for canine pose estimation with YOLO26."
 keywords: Dog-Pose, Ultralytics, pose estimation dataset, YOLO26, machine learning, computer vision, training data
 ---
 

--- a/docs/en/datasets/pose/hand-keypoints.md
+++ b/docs/en/datasets/pose/hand-keypoints.md
@@ -9,7 +9,7 @@ keywords: Hand KeyPoints, pose estimation, dataset, keypoints, MediaPipe, YOLO, 
 
 ## Introduction
 
-The hand-keypoints dataset contains 26,768 images of hands annotated with keypoints, making it suitable for training models like Ultralytics YOLO for pose estimation tasks. The annotations were generated using the Google MediaPipe library, ensuring high [accuracy](https://www.ultralytics.com/glossary/accuracy) and consistency, and the dataset is compatible with [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics) formats.
+The [Ultralytics](https://www.ultralytics.com/) Hand Keypoints dataset contains 26,768 images of hands annotated with 21 keypoints each, generated using the [Google MediaPipe](https://developers.google.com/mediapipe/solutions/vision/hand_landmarker) library for high [accuracy](https://www.ultralytics.com/glossary/accuracy) and consistency. It's compatible with [Ultralytics YOLO26](../../models/yolo26.md) formats for training pose estimation models.
 
 <p align="center">
   <br>
@@ -22,13 +22,11 @@ The hand-keypoints dataset contains 26,768 images of hands annotated with keypoi
   <strong>Watch:</strong> Hand Keypoints Estimation with Ultralytics YOLO | Human Hand Pose Estimation Tutorial
 </p>
 
-## Hand Landmarks
+## Keypoints
 
 ![Hand keypoints landmark diagram with 21 points](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/hand_landmarks.jpg)
 
-## Keypoints
-
-The dataset includes keypoints for hand detection. The keypoints are annotated as follows:
+Each hand is annotated with 21 keypoints as follows:
 
 1. Wrist
 2. Thumb (4 points)
@@ -37,28 +35,25 @@ The dataset includes keypoints for hand detection. The keypoints are annotated a
 5. Ring finger (4 points)
 6. Little finger (4 points)
 
-Each hand has a total of 21 keypoints.
-
-## Key Features
-
-- **Large Dataset**: 26,768 images with hand keypoint annotations.
-- **YOLO26 Compatibility**: Labels ship in YOLO keypoint format and are ready for use with YOLO26 models.
-- **21 Keypoints**: Detailed hand pose representation spanning the wrist and four points per finger.
-
 ## Dataset Structure
 
-The hand keypoint dataset is split into two subsets:
-
-1. **Train**: This subset contains 18,776 images from the hand keypoints dataset, annotated for training pose estimation models.
-2. **Val**: This subset contains 7,992 images that can be used for validation purposes during model training.
-
+- **Total images**: 26,768 (18,776 train / 7,992 val).
+- **Classes**: 1 (hand).
+- **Keypoints**: 21 per hand with `(x, y, visibility)` triplets.
 - **Download size**: ~369 MB.
 
 For a custom gesture vocabulary beyond generic hand landmarks, [Ultralytics Platform](https://platform.ultralytics.com/) handles labeling and training your own dataset from the browser.
 
 ## Applications
 
-Hand keypoints can be used for [gesture recognition](https://www.ultralytics.com/blog/enhancing-hand-keypoints-estimation-with-ultralytics-yolo11), [AR/VR controls](../../tasks/pose.md), robotic manipulation, and hand movement analysis in healthcare. They can also be applied in animation for motion capture and biometric authentication systems for security. The detailed tracking of finger positions enables precise interaction with virtual objects and touchless control interfaces.
+Hand keypoints support several real-world applications:
+
+- **[Gesture recognition](https://www.ultralytics.com/blog/enhancing-hand-keypoints-estimation-with-ultralytics-yolo11)**: human-computer interaction and touchless control interfaces.
+- **[AR/VR controls](../../tasks/pose.md)**: precise interaction with virtual objects.
+- **Robotic manipulation**: fine-grained control of robotic hands.
+- **Healthcare**: hand movement analysis for medical diagnostics.
+- **Animation**: motion capture for realistic hand movement.
+- **Biometric authentication**: security systems based on hand geometry.
 
 ## Dataset YAML
 
@@ -97,7 +92,7 @@ To train a YOLO26n-pose model on the Hand Keypoints dataset for 100 [epochs](htt
 
 ## Sample Images and Annotations
 
-The Hand keypoints dataset contains a diverse set of images with human hands annotated with keypoints. Here are some examples of images from the dataset, along with their corresponding annotations:
+The Hand Keypoints dataset contains a diverse set of images with human hands annotated with keypoints. Here are some examples of images from the dataset, along with their corresponding annotations:
 
 ![Hand keypoints pose estimation dataset sample](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/human-hand-pose.avif)
 
@@ -107,7 +102,7 @@ The example showcases the variety and complexity of the images in the Hand Keypo
 
 ## Citations and Acknowledgments
 
-If you use the hand-keypoints dataset in your research or development work, please acknowledge the following sources:
+If you use the Hand Keypoints dataset in your research or development work, please acknowledge the following sources:
 
 !!! quote ""
 
@@ -129,28 +124,13 @@ We would also like to acknowledge the creator of this dataset, [Rion Dsilva](htt
 
 Load `yolo26n-pose.pt` and call `model.train(data="hand-keypoints.yaml", epochs=100, imgsz=640)` — see the [Train Example](#usage) above for the full Python and CLI snippets, and the model [Training](../../modes/train.md) page for a comprehensive list of arguments.
 
-### What are the key features of the Hand Keypoints dataset?
+### What are the benefits of using the Hand Keypoints dataset?
 
-The Hand Keypoints dataset is designed for advanced [pose estimation](index.md) tasks and includes several key features:
-
-- **Large Dataset**: Contains 26,768 images with hand keypoint annotations.
-- **YOLO26 Compatibility**: Ready for use with YOLO26 models.
-- **21 Keypoints**: Detailed hand pose representation, including wrist and finger joints.
-
-For more details, you can explore the [Hand Keypoints Dataset](#introduction) section.
+With 26,768 annotated images and 21 keypoints per hand generated via Google MediaPipe, the Hand Keypoints dataset gives pose estimation models the scale and annotation accuracy needed for [advanced pose estimation](../../tasks/pose.md) tasks. See the [Keypoints](#keypoints) section for the full landmark breakdown.
 
 ### What applications can benefit from using the Hand Keypoints dataset?
 
-The Hand Keypoints dataset can be applied in various fields, including:
-
-- **Gesture Recognition**: Enhancing human-computer interaction.
-- **AR/VR Controls**: Improving user experience in augmented and virtual reality.
-- **Robotic Manipulation**: Enabling precise control of robotic hands.
-- **Healthcare**: Analyzing hand movements for medical diagnostics.
-- **Animation**: Capturing motion for realistic animations.
-- **Biometric Authentication**: Enhancing security systems.
-
-For more information, refer to the [Applications](#applications) section.
+Hand Keypoints supports gesture recognition, AR/VR controls, robotic manipulation, healthcare movement analysis, animation, and biometric authentication — see the [Applications](#applications) section for details on each.
 
 ### How is the Hand Keypoints dataset structured?
 

--- a/docs/en/datasets/pose/hand-keypoints.md
+++ b/docs/en/datasets/pose/hand-keypoints.md
@@ -1,7 +1,7 @@
 ---
 title: Hand Keypoints Pose Estimation Dataset
 comments: true
-description: Explore the Ultralytics Hand Keypoints dataset: 26,768 hand images with 21 keypoints each, for gesture recognition and pose estimation with YOLO26.
+description: "Explore the Ultralytics Hand Keypoints dataset: 26,768 hand images with 21 keypoints each, for gesture recognition and pose estimation with YOLO26."
 keywords: Hand KeyPoints, pose estimation, dataset, keypoints, MediaPipe, YOLO, deep learning, computer vision
 ---
 

--- a/docs/en/datasets/pose/hand-keypoints.md
+++ b/docs/en/datasets/pose/hand-keypoints.md
@@ -1,6 +1,7 @@
 ---
+title: Hand Keypoints Pose Estimation Dataset
 comments: true
-description: Explore the hand keypoints estimation dataset for advanced pose estimation. Learn about datasets, pretrained models, metrics, and applications for training with YOLO.
+description: Explore the Ultralytics Hand Keypoints dataset: 26,768 hand images with 21 keypoints each, for gesture recognition and pose estimation with YOLO26.
 keywords: Hand KeyPoints, pose estimation, dataset, keypoints, MediaPipe, YOLO, deep learning, computer vision
 ---
 
@@ -18,7 +19,7 @@ The hand-keypoints dataset contains 26,768 images of hands annotated with keypoi
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> Hand Keypoints Estimation with Ultralytics YOLO26 | Human Hand Pose Estimation Tutorial
+  <strong>Watch:</strong> Hand Keypoints Estimation with Ultralytics YOLO | Human Hand Pose Estimation Tutorial
 </p>
 
 ## Hand Landmarks
@@ -50,6 +51,10 @@ The hand keypoint dataset is split into two subsets:
 
 1. **Train**: This subset contains 18,776 images from the hand keypoints dataset, annotated for training pose estimation models.
 2. **Val**: This subset contains 7,992 images that can be used for validation purposes during model training.
+
+- **Download size**: ~369 MB.
+
+This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
 
 ## Applications
 
@@ -122,30 +127,7 @@ We would also like to acknowledge the creator of this dataset, [Rion Dsilva](htt
 
 ### How do I train a YOLO26 model on the Hand Keypoints dataset?
 
-To train a YOLO26 model on the Hand Keypoints dataset, you can use either Python or the command line interface (CLI). Here's an example for training a YOLO26n-pose model for 100 epochs with an image size of 640:
-
-!!! example
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        # Load a model
-        model = YOLO("yolo26n-pose.pt")  # load a pretrained model (recommended for training)
-
-        # Train the model
-        results = model.train(data="hand-keypoints.yaml", epochs=100, imgsz=640)
-        ```
-
-    === "CLI"
-
-        ```bash
-        # Start training from a pretrained *.pt model
-        yolo pose train data=hand-keypoints.yaml model=yolo26n-pose.pt epochs=100 imgsz=640
-        ```
-
-For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page.
+Load `yolo26n-pose.pt` and call `model.train(data="hand-keypoints.yaml", epochs=100, imgsz=640)` — see the [Train Example](#usage) above for the full Python and CLI snippets, and the model [Training](../../modes/train.md) page for a comprehensive list of arguments.
 
 ### What are the key features of the Hand Keypoints dataset?
 

--- a/docs/en/datasets/pose/hand-keypoints.md
+++ b/docs/en/datasets/pose/hand-keypoints.md
@@ -54,7 +54,7 @@ The hand keypoint dataset is split into two subsets:
 
 - **Download size**: ~369 MB.
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+For a custom gesture vocabulary beyond generic hand landmarks, [Ultralytics Platform](https://platform.ultralytics.com/) handles labeling and training your own dataset from the browser.
 
 ## Applications
 

--- a/docs/en/datasets/pose/index.md
+++ b/docs/en/datasets/pose/index.md
@@ -1,7 +1,7 @@
 ---
 comments: true
-description: Learn about Ultralytics YOLO format for pose estimation datasets, supported formats, COCO-Pose, COCO8-Pose, Tiger-Pose, and how to add your own dataset.
-keywords: pose estimation, Ultralytics, YOLO format, COCO-Pose, COCO8-Pose, Tiger-Pose, dataset conversion, keypoints
+description: Learn the Ultralytics YOLO format for pose estimation datasets — COCO-Pose, COCO8-Pose, Dog-Pose, Hand Keypoints, Tiger-Pose — and how to add your own.
+keywords: pose estimation, Ultralytics, YOLO format, COCO-Pose, COCO8-Pose, Dog-Pose, Hand Keypoints, Tiger-Pose, dataset conversion, keypoints
 title: Pose Estimation Datasets
 ---
 
@@ -82,27 +82,27 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 
 ### COCO-Pose
 
-- **Description**: COCO-Pose is a large-scale [object detection](https://www.ultralytics.com/glossary/object-detection), segmentation, and pose estimation dataset. It is a subset of the popular COCO dataset and focuses on human pose estimation. COCO-Pose includes multiple keypoints for each human instance.
+- **Description**: COCO-Pose is a large-scale pose estimation dataset. It is a subset of the popular COCO dataset and focuses on human pose estimation. COCO-Pose includes multiple keypoints for each human instance.
 - **Label Format**: Same as Ultralytics YOLO format as described above, with keypoints for human poses.
 - **Number of Classes**: 1 (Human).
 - **Keypoints**: 17 keypoints including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles.
 - **Usage**: Suitable for training human pose estimation models.
-- **Additional Notes**: The dataset is rich and diverse, containing over 200k labeled images.
+- **Additional Notes**: The dataset builds on the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge: 58,945 images annotated with 156,165 people.
 - [Read more about COCO-Pose](coco.md)
 
 ### COCO8-Pose
 
-- **Description**: [Ultralytics](https://www.ultralytics.com/) COCO8-Pose is a small, but versatile pose detection dataset composed of the first 8 images of the COCO train 2017 set, 4 for training and 4 for validation.
+- **Description**: [Ultralytics](https://www.ultralytics.com/) COCO8-Pose is a small, but versatile pose estimation dataset composed of the first 8 images of the COCO train 2017 set, 4 for training and 4 for validation.
 - **Label Format**: Same as Ultralytics YOLO format as described above, with keypoints for human poses.
 - **Number of Classes**: 1 (Human).
 - **Keypoints**: 17 keypoints including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles.
-- **Usage**: Suitable for testing and debugging object detection models, or for experimenting with new detection approaches.
+- **Usage**: Suitable for testing and debugging pose estimation models, or for experimenting with new keypoint-detection approaches.
 - **Additional Notes**: COCO8-Pose is ideal for sanity checks and [CI checks](../../help/CI.md).
 - [Read more about COCO8-Pose](coco8-pose.md)
 
 ### Dog-Pose
 
-- **Description**: The Dog Pose dataset contains 6,773 training and 1,703 test images, providing a diverse and extensive resource for canine keypoint estimation.
+- **Description**: The Dog Pose dataset contains 6,773 training and 1,703 validation images, providing a diverse and extensive resource for canine keypoint estimation.
 - **Label Format**: Follows the Ultralytics YOLO format, with annotations for multiple keypoints specific to dog anatomy.
 - **Number of Classes**: 1 (Dog).
 - **Keypoints**: Includes 24 keypoints tailored to dog poses, such as limbs, joints, and head positions.

--- a/docs/en/datasets/pose/index.md
+++ b/docs/en/datasets/pose/index.md
@@ -51,7 +51,7 @@ The `train` and `val` fields specify the paths to the directories containing the
 
 `names` is a dictionary of class names. The order of the names should match the order of the object class indices in the YOLO dataset files.
 
-(Optional) if the points are symmetric then need flip_idx, like left-right side of human or face. For example if we assume five keypoints of facial landmark: [left eye, right eye, nose, left mouth, right mouth], and the original index is [0, 1, 2, 3, 4], then flip_idx is [1, 0, 2, 4, 3] (just exchange the left-right index, i.e. 0-1 and 3-4, and do not modify others like nose in this example).
+(Optional) `flip_idx` maps each keypoint to its mirror image, so horizontal-flip augmentation keeps left and right consistent on symmetric skeletons such as a human body or face. For five facial landmarks indexed as [left eye, right eye, nose, left mouth, right mouth] = [0, 1, 2, 3, 4], `flip_idx` is [1, 0, 2, 4, 3]: the left-right pairs 0-1 and 3-4 swap, and the nose keeps its own index.
 
 ## Usage
 
@@ -82,10 +82,10 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 
 ### COCO-Pose
 
-- **Description**: COCO-Pose is a large-scale pose estimation dataset. It is a subset of the popular COCO dataset and focuses on human pose estimation. COCO-Pose includes multiple keypoints for each human instance.
+- **Description**: COCO-Pose is a large-scale human pose estimation dataset covering the COCO 2017 images that contain keypoint-annotated people.
 - **Label Format**: Same as Ultralytics YOLO format as described above, with keypoints for human poses.
-- **Number of Classes**: 1 (Human).
-- **Keypoints**: 17 keypoints including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles.
+- **Number of Classes**: 1 (person).
+- **Keypoints**: 17 keypoints including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles, each with a visibility dimension.
 - **Usage**: Suitable for training human pose estimation models.
 - **Additional Notes**: The dataset builds on the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge: 58,945 images annotated with 156,165 people.
 - [Read more about COCO-Pose](coco.md)
@@ -94,35 +94,35 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 
 - **Description**: [Ultralytics](https://www.ultralytics.com/) COCO8-Pose is a small, but versatile pose estimation dataset composed of the first 8 images of the COCO train 2017 set, 4 for training and 4 for validation.
 - **Label Format**: Same as Ultralytics YOLO format as described above, with keypoints for human poses.
-- **Number of Classes**: 1 (Human).
-- **Keypoints**: 17 keypoints including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles.
+- **Number of Classes**: 1 (person).
+- **Keypoints**: 17 keypoints including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles, each with a visibility dimension.
 - **Usage**: Suitable for testing and debugging pose estimation models, or for experimenting with new keypoint-detection approaches.
 - **Additional Notes**: COCO8-Pose is ideal for sanity checks and [CI checks](../../help/CI.md).
 - [Read more about COCO8-Pose](coco8-pose.md)
 
 ### Dog-Pose
 
-- **Description**: The Dog Pose dataset contains 6,773 training and 1,703 validation images, providing a diverse and extensive resource for canine keypoint estimation.
+- **Description**: The [Ultralytics](https://www.ultralytics.com/) Dog-Pose dataset contains 6,773 training and 1,703 validation images for canine keypoint estimation.
 - **Label Format**: Follows the Ultralytics YOLO format, with annotations for multiple keypoints specific to dog anatomy.
-- **Number of Classes**: 1 (Dog).
-- **Keypoints**: Includes 24 keypoints tailored to dog poses, such as limbs, joints, and head positions.
+- **Number of Classes**: 1 (dog).
+- **Keypoints**: 24 keypoints, each with a visibility dimension, tailored to dog poses such as limbs, joints, and head positions.
 - **Usage**: Ideal for training models to estimate dog poses in various scenarios, from research to [real-world applications](https://www.ultralytics.com/blog/custom-training-ultralytics-yolo11-for-dog-pose-estimation).
 - [Read more about Dog-Pose](dog-pose.md)
 
 ### Hand Keypoints
 
-- **Description**: The hand keypoints pose dataset comprises nearly 26K images, with 18,776 images allocated for training and 7,992 for validation.
+- **Description**: The [Ultralytics](https://www.ultralytics.com/) Hand Keypoints dataset comprises 26,768 images, with 18,776 allocated for training and 7,992 for validation.
 - **Label Format**: Same as the Ultralytics YOLO format described above, but with 21 keypoints for a human hand and a visibility dimension.
-- **Number of Classes**: 1 (Hand).
+- **Number of Classes**: 1 (hand).
 - **Keypoints**: 21 keypoints.
 - **Usage**: Great for human hand pose estimation and [gesture recognition](https://www.ultralytics.com/blog/enhancing-hand-keypoints-estimation-with-ultralytics-yolo11).
 - [Read more about Hand Keypoints](hand-keypoints.md)
 
 ### Tiger-Pose
 
-- **Description**: The [Ultralytics](https://www.ultralytics.com/) Tiger Pose dataset comprises 263 images sourced from a [YouTube video](https://www.youtube.com/watch?v=MIBAT6BGE6U), with 210 images allocated for training and 53 for validation.
-- **Label Format**: Same as Ultralytics YOLO format as described above, with 12 keypoints for animal pose and no visible dimension.
-- **Number of Classes**: 1 (Tiger).
+- **Description**: The [Ultralytics](https://www.ultralytics.com/) Tiger-Pose dataset comprises 263 images sourced from a [YouTube video](https://www.youtube.com/watch?v=MIBAT6BGE6U), with 210 images allocated for training and 53 for validation.
+- **Label Format**: Same as Ultralytics YOLO format as described above, with 12 keypoints for animal pose and no visibility dimension.
+- **Number of Classes**: 1 (tiger).
 - **Keypoints**: 12 keypoints.
 - **Usage**: Great for animal pose or any other pose that is not human-based.
 - [Read more about Tiger-Pose](tiger-pose.md)
@@ -130,6 +130,8 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 ### Adding your own dataset
 
 If you have your own dataset and would like to use it for training pose estimation models with Ultralytics YOLO format, ensure that it follows the format specified above under "Ultralytics YOLO format". Convert your annotations to the required format and specify the paths, number of classes, and class names in the YAML configuration file.
+
+To skip the conversion step entirely, [Ultralytics Platform](https://platform.ultralytics.com/) lets you upload raw images, annotate keypoints in the browser, and train on the resulting dataset directly.
 
 ### Conversion Tool
 
@@ -162,20 +164,16 @@ For 2D poses, keypoints include normalized x and y coordinates. With a visibilit
 
 ### How do I use the COCO-Pose dataset with Ultralytics YOLO?
 
-To use the [COCO-Pose dataset](coco.md) with Ultralytics YOLO:
+`coco-pose.yaml` ships with the package and downloads the images and labels on first use, so no manual preparation is needed:
 
-1. Download the dataset and prepare your label files in the YOLO format.
-2. Create a YAML configuration file specifying paths to training and validation images, keypoint shape, and class names.
-3. Use the configuration file for training:
+```python
+from ultralytics import YOLO
 
-    ```python
-    from ultralytics import YOLO
+model = YOLO("yolo26n-pose.pt")  # load pretrained model
+results = model.train(data="coco-pose.yaml", epochs=100, imgsz=640)
+```
 
-    model = YOLO("yolo26n-pose.pt")  # load pretrained model
-    results = model.train(data="coco-pose.yaml", epochs=100, imgsz=640)
-    ```
-
-    For more information, visit [COCO-Pose](coco.md) and [train](../../modes/train.md) sections.
+For the dataset details see [COCO-Pose](coco.md), and the [Train](../../modes/train.md) page for the full argument list.
 
 ### How can I add my own dataset for pose estimation in Ultralytics YOLO?
 

--- a/docs/en/datasets/pose/index.md
+++ b/docs/en/datasets/pose/index.md
@@ -85,7 +85,7 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 - **Description**: COCO-Pose is a large-scale human pose estimation dataset covering the COCO 2017 images that contain keypoint-annotated people.
 - **Label Format**: Same as Ultralytics YOLO format as described above, with keypoints for human poses.
 - **Number of Classes**: 1 (person).
-- **Keypoints**: 17 keypoints including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles, each with a visibility dimension.
+- **Keypoints**: 17 keypoint types including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles, each with a visibility dimension.
 - **Usage**: Suitable for training human pose estimation models.
 - **Additional Notes**: The dataset builds on the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge: 58,945 images annotated with 156,165 people.
 - [Read more about COCO-Pose](coco.md)
@@ -95,7 +95,7 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 - **Description**: [Ultralytics](https://www.ultralytics.com/) COCO8-Pose is a small, but versatile pose estimation dataset composed of the first 8 images of the COCO train 2017 set, 4 for training and 4 for validation.
 - **Label Format**: Same as Ultralytics YOLO format as described above, with keypoints for human poses.
 - **Number of Classes**: 1 (person).
-- **Keypoints**: 17 keypoints including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles, each with a visibility dimension.
+- **Keypoints**: 17 keypoint types including nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles, each with a visibility dimension.
 - **Usage**: Suitable for testing and debugging pose estimation models, or for experimenting with new keypoint-detection approaches.
 - **Additional Notes**: COCO8-Pose is ideal for sanity checks and [CI checks](../../help/CI.md).
 - [Read more about COCO8-Pose](coco8-pose.md)

--- a/docs/en/datasets/pose/tiger-pose.md
+++ b/docs/en/datasets/pose/tiger-pose.md
@@ -1,6 +1,7 @@
 ---
+title: Tiger-Pose Estimation Dataset
 comments: true
-description: Explore Ultralytics Tiger-Pose dataset with 263 diverse images. Ideal for testing, training, and refining pose estimation algorithms.
+description: Explore the Ultralytics Tiger-Pose dataset: 263 images (210 train / 53 val) with 12 keypoints per tiger, ideal for testing pose estimation pipelines.
 keywords: Ultralytics, Tiger-Pose, dataset, pose estimation, YOLO26, training data, machine learning, neural networks
 ---
 
@@ -18,6 +19,7 @@ This dataset is intended for use with [Ultralytics Platform](https://platform.ul
 
 - **Total images**: 263 (210 train / 53 val).
 - **Keypoints**: 12 per tiger (no visibility flag).
+- **Download size**: ~49.8 MB.
 - **Directory layout**: YOLO-format keypoints stored under `labels/{train,val}` alongside `images/{train,val}` directories.
 
 <p align="center">
@@ -28,7 +30,7 @@ This dataset is intended for use with [Ultralytics Platform](https://platform.ul
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> Train YOLO26 Pose Model on Tiger-Pose Dataset Using Ultralytics Platform
+  <strong>Watch:</strong> Train an Ultralytics YOLO Pose Model on the Tiger-Pose Dataset
 </p>
 
 ## Dataset YAML
@@ -111,29 +113,7 @@ The Ultralytics Tiger-Pose dataset is designed for pose estimation tasks, consis
 
 ### How do I train a YOLO26 model on the Tiger-Pose dataset?
 
-To train a YOLO26n-pose model on the Tiger-Pose dataset for 100 epochs with an image size of 640, use the following code snippets. For more details, visit the [Training](../../modes/train.md) page:
-
-!!! example "Train Example"
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        # Load a model
-        model = YOLO("yolo26n-pose.pt")  # load a pretrained model (recommended for training)
-
-        # Train the model
-        results = model.train(data="tiger-pose.yaml", epochs=100, imgsz=640)
-        ```
-
-
-    === "CLI"
-
-        ```bash
-        # Start training from a pretrained *.pt model
-        yolo pose train data=tiger-pose.yaml model=yolo26n-pose.pt epochs=100 imgsz=640
-        ```
+Load `yolo26n-pose.pt` and call `model.train(data="tiger-pose.yaml", epochs=100, imgsz=640)` — see the [Train Example](#usage) above for the full Python and CLI snippets, and the [Training](../../modes/train.md) page for a comprehensive list of arguments.
 
 ### What configurations does the `tiger-pose.yaml` file include?
 
@@ -141,30 +121,8 @@ The `tiger-pose.yaml` file is used to specify the configuration details of the T
 
 ### How can I run inference using a YOLO26 model trained on the Tiger-Pose dataset?
 
-To perform inference using a YOLO26 model trained on the Tiger-Pose dataset, you can use the following code snippets. For a detailed guide, visit the [Prediction](../../modes/predict.md) page:
-
-!!! example "Inference Example"
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        # Load a model
-        model = YOLO("path/to/best.pt")  # load a tiger-pose trained model
-
-        # Run inference
-        results = model.predict(source="https://youtu.be/MIBAT6BGE6U", show=True)
-        ```
-
-
-    === "CLI"
-
-        ```bash
-        # Run inference using a tiger-pose trained model
-        yolo pose predict source="https://youtu.be/MIBAT6BGE6U" show=True model="path/to/best.pt"
-        ```
+Load your trained checkpoint (e.g., `path/to/best.pt`) and call `model.predict(source=..., show=True)` — see the [Inference Example](#inference-example) above for the full Python and CLI snippets, and the [Prediction](../../modes/predict.md) page for a comprehensive list of arguments.
 
 ### What are the benefits of using the Tiger-Pose dataset for pose estimation?
 
-The Tiger-Pose dataset, despite its manageable size of 210 images for training, provides a diverse collection of images that are ideal for testing pose estimation pipelines. The dataset helps identify potential errors and acts as a preliminary step before working with larger datasets. Additionally, the dataset supports the training and refinement of pose estimation algorithms using advanced tools like [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics), enhancing model performance and [accuracy](https://www.ultralytics.com/glossary/accuracy).
+With 263 total images (210 train / 53 val), 1 class, 12 keypoints per instance, and a ~49.8 MB download, Tiger-Pose is small enough to manage quickly yet diverse enough to sanity-check a pose training pipeline and identify errors before working with larger datasets, using tools like [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).

--- a/docs/en/datasets/pose/tiger-pose.md
+++ b/docs/en/datasets/pose/tiger-pose.md
@@ -80,6 +80,8 @@ The example showcases the variety and complexity of the images in the Tiger-Pose
 
 ## Inference Example
 
+After training, load your best checkpoint and run inference on new images or video — see the [Prediction](../../modes/predict.md) page for the full list of arguments.
+
 !!! example "Inference Example"
 
     === "Python"
@@ -109,7 +111,7 @@ The dataset has been released under the [AGPL-3.0 License](https://github.com/ul
 
 ### What is the Ultralytics Tiger-Pose dataset used for?
 
-The Ultralytics Tiger-Pose dataset is designed for pose estimation tasks, consisting of 263 images sourced from a [YouTube video](https://www.youtube.com/watch?v=MIBAT6BGE6U). The dataset is divided into 210 training images and 53 validation images. It is particularly useful for testing, training, and refining pose estimation algorithms using [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+The Ultralytics Tiger-Pose dataset is designed for pose estimation tasks, consisting of 263 images sourced from a [YouTube video](https://www.youtube.com/watch?v=MIBAT6BGE6U). The dataset is divided into 210 training images and 53 validation images, making it well-suited for testing, training, and refining pose estimation algorithms.
 
 ### How do I train a YOLO26 model on the Tiger-Pose dataset?
 
@@ -117,7 +119,7 @@ Load `yolo26n-pose.pt` and call `model.train(data="tiger-pose.yaml", epochs=100,
 
 ### What configurations does the `tiger-pose.yaml` file include?
 
-The `tiger-pose.yaml` file is used to specify the configuration details of the Tiger-Pose dataset. It includes crucial data such as file paths and class definitions. To see the exact configuration, you can check out the [Ultralytics Tiger-Pose Dataset Configuration File](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/tiger-pose.yaml).
+The `tiger-pose.yaml` file defines the dataset path, train/val image directories, a single class (`tiger`), and `kpt_shape: [12, 2]` — 12 keypoints per instance with no visibility flag. See the [Ultralytics Tiger-Pose Dataset Configuration File](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/tiger-pose.yaml) for the exact configuration.
 
 ### How can I run inference using a YOLO26 model trained on the Tiger-Pose dataset?
 
@@ -125,4 +127,4 @@ Load your trained checkpoint (e.g., `path/to/best.pt`) and call `model.predict(s
 
 ### What are the benefits of using the Tiger-Pose dataset for pose estimation?
 
-With 263 total images (210 train / 53 val), 1 class, 12 keypoints per instance, and a ~49.8 MB download, Tiger-Pose is small enough to manage quickly yet diverse enough to sanity-check a pose training pipeline and identify errors before working with larger datasets, using tools like [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+With 263 total images (210 train / 53 val), 1 class, 12 keypoints per instance, and a ~49.8 MB download, Tiger-Pose is small enough to manage quickly yet diverse enough to sanity-check a pose training pipeline and identify errors before working with larger datasets.

--- a/docs/en/datasets/pose/tiger-pose.md
+++ b/docs/en/datasets/pose/tiger-pose.md
@@ -13,7 +13,7 @@ keywords: Ultralytics, Tiger-Pose, dataset, pose estimation, YOLO26, training da
 
 Despite its manageable training split of 210 images, the Tiger-Pose dataset offers diversity, making it suitable for assessing training pipelines, identifying potential errors, and serving as a valuable preliminary step before working with larger datasets for [pose estimation](../../tasks/pose.md).
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+Once your pipeline trains clean on this small set, swap in your own animal or object keypoints and scale up training on [Ultralytics Platform](https://platform.ultralytics.com/) without leaving the browser.
 
 ## Dataset Structure
 

--- a/docs/en/datasets/pose/tiger-pose.md
+++ b/docs/en/datasets/pose/tiger-pose.md
@@ -1,7 +1,7 @@
 ---
 title: Tiger-Pose Estimation Dataset
 comments: true
-description: Explore the Ultralytics Tiger-Pose dataset: 263 images (210 train / 53 val) with 12 keypoints per tiger, ideal for testing pose estimation pipelines.
+description: "Explore the Ultralytics Tiger-Pose dataset: 263 images (210 train / 53 val) with 12 keypoints per tiger, ideal for testing pose estimation pipelines."
 keywords: Ultralytics, Tiger-Pose, dataset, pose estimation, YOLO26, training data, machine learning, neural networks
 ---
 


### PR DESCRIPTION
## Summary

Refactors the pose estimation dataset pages under `docs/en/datasets/pose/`. Dataset counts, splits, class names, keypoint schemas, and archive sizes are checked against their YAML files; COCO-Pose statistics are checked against the official COCO 2017 Keypoints Challenge data. COCO-Pose now documents the ~27 GB first-use download, including the test archive fetched unconditionally by the YAML script. COCO8-Pose was additionally verified with a real download/count and a 1-epoch training run.

Corrects the stale COCO-Pose "200K images" claim to 58,945 images / 156,165 annotated people, the Dog-Pose 1,703-image split from test to validation, and generation-specific captions on older videos.

### Pages

- [x] coco8-pose
- [x] tiger-pose
- [x] dog-pose
- [x] hand-keypoints
- [x] coco (COCO-Pose)
- [x] index

Deleted: duplicated training and inference examples, repeated FAQ content, stale split/count claims, and repeated wording that implied every COCO person has all 17 keypoints annotated.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Refreshes Ultralytics pose dataset documentation with accurate dataset statistics, clearer YOLO26 workflows, improved metadata, and stronger guidance for training and validation.

### 📊 Key Changes

- Updated COCO-Pose details with corrected image, annotation, split, keypoint, and download-size information, including the `test-dev2017` evaluation split.
- Expanded dataset documentation for COCO8-Pose, Dog-Pose, Hand Keypoints, and Tiger-Pose with:
  - Accurate train/validation counts and download sizes.
  - Clear class and keypoint definitions.
  - Consistent pose-estimation terminology.
  - Improved descriptions, titles, keywords, and metadata.
- Clarified YOLO keypoint formats, including visibility values and `flip_idx` behavior for horizontally flipped keypoints.
- Simplified repeated training and inference examples by linking to shared usage, training, and prediction sections.
- Improved FAQ content and removed redundant explanations across pose dataset pages.
- Added more practical guidance for using [Ultralytics Platform](https://platform.ultralytics.com/) to annotate, train, and manage custom keypoint datasets.
- Updated dataset index navigation and descriptions to consistently cover COCO-Pose, COCO8-Pose, Dog-Pose, Hand Keypoints, and Tiger-Pose.
- Added clearer references to [YOLO26 pose models](../../models/yolo26.md), pose estimation tasks, COCO evaluation, and dataset YAML files.

### 🎯 Purpose & Impact

- ✅ Makes pose dataset documentation more accurate, consistent, and easier for both new and experienced users to understand.
- 🚀 Helps users select the right dataset and quickly start training YOLO26 pose models using built-in YAML configurations.
- 🧪 Highlights small datasets such as COCO8-Pose and Tiger-Pose as practical sanity checks before larger training runs.
- 📏 Provides transparent dataset sizes and split details, helping users estimate download and compute requirements.
- 🖐️ Clarifies supported human, hand, dog, and tiger keypoint schemas for custom pose-estimation workflows.
- ☁️ Encourages simpler dataset annotation and cloud training through [Ultralytics Platform](https://platform.ultralytics.com/).