### PR TITLE
Refactor segmentation dataset documentation

### DIFF
--- a/docs/en/datasets/segment/carparts-seg.md
+++ b/docs/en/datasets/segment/carparts-seg.md
@@ -29,7 +29,7 @@ The Carparts Segmentation Dataset splits its 3,833 images as follows:
 - **Training set**: 3,156 images used for [training](https://www.ultralytics.com/glossary/training-data) the [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) [model](https://www.ultralytics.com/glossary/foundation-model).
 - **Validation set**: 401 images used during training to tune [hyperparameters](../../guides/hyperparameter-tuning.md) and prevent [overfitting](https://www.ultralytics.com/glossary/overfitting) on [validation data](https://www.ultralytics.com/glossary/validation-data).
 - **Testing set**: 276 images used to evaluate the model on held-out [test data](https://www.ultralytics.com/glossary/test-data) after training.
-- **Classes**: 23 car-part categories — bumpers, doors, lights, glass, mirrors, hood, tailgate, trunk, and wheel — plus a catch-all `object` class for parts outside those categories.
+- **Classes**: 23 in total — 22 named car-part categories (bumpers, doors, lights, glass, mirrors, hood, tailgate, trunk, and wheels) plus a catch-all `object` class for parts outside those categories.
 - **Download size**: ~133 MB.
 
 ## Applications
@@ -133,7 +133,7 @@ The **Carparts Segmentation Dataset** is a curated collection of 3,833 annotated
 
 ### How many images and classes does the Carparts Segmentation Dataset contain?
 
-The dataset totals 3,833 images — 3,156 for training, 401 for validation, and 276 for testing — across 23 car-part classes, plus a catch-all `object` class for parts outside the named categories. The full archive downloads automatically as a ~133 MB `.zip` on first use.
+The dataset totals 3,833 images — 3,156 for training, 401 for validation, and 276 for testing — across 23 classes: 22 named car-part categories plus a catch-all `object` class for parts outside them. The full archive downloads automatically as a ~133 MB `.zip` on first use.
 
 ### How can I train an Ultralytics YOLO26 model on the Carparts Segmentation Dataset?
 

--- a/docs/en/datasets/segment/carparts-seg.md
+++ b/docs/en/datasets/segment/carparts-seg.md
@@ -1,6 +1,7 @@
 ---
+title: Carparts-Seg Dataset
 comments: true
-description: Explore the Carparts Segmentation Dataset for automotive AI applications. Enhance your segmentation models with rich, annotated data using Ultralytics YOLO.
+description: Train Ultralytics YOLO segmentation models on Carparts-Seg — 3,833 annotated images across 23 car-part classes for automotive AI applications.
 keywords: Carparts Segmentation Dataset, computer vision, automotive AI, vehicle maintenance, Ultralytics, YOLO, segmentation models, deep learning, object segmentation
 ---
 
@@ -8,9 +9,7 @@ keywords: Carparts Segmentation Dataset, computer vision, automotive AI, vehicle
 
 <a href="https://colab.research.google.com/github/ultralytics/notebooks/blob/main/notebooks/how-to-train-ultralytics-yolo-on-carparts-segmentation-dataset.ipynb" target="_blank"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open Carparts Segmentation Dataset In Colab"></a>
 
-The Carparts Segmentation Dataset is a curated collection of images and videos designed for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) applications, specifically focusing on [segmentation tasks](../../tasks/segment.md). This dataset provides a diverse set of visuals captured from multiple perspectives, offering valuable [annotated](https://www.ultralytics.com/glossary/data-labeling) examples for training and testing segmentation models.
-
-Whether you're working on [automotive research](https://www.ultralytics.com/solutions/computer-vision-in-automotive), developing AI solutions for vehicle maintenance, or exploring computer vision applications, the Carparts Segmentation Dataset serves as a valuable resource for enhancing the [accuracy](https://www.ultralytics.com/glossary/accuracy) and efficiency of your projects using models like [Ultralytics YOLO](../../models/yolo26.md).
+The [Ultralytics](https://www.ultralytics.com/) Carparts Segmentation Dataset provides 3,833 annotated images across 23 car-part classes — including bumpers, doors, lights, mirrors, hood, and trunk — for training [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) models on automotive [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) tasks. Captured from multiple perspectives and [annotated](https://www.ultralytics.com/glossary/data-labeling) with pixel-level masks, it pairs directly with [Ultralytics YOLO](../../models/yolo26.md) for use cases ranging from automotive quality control and auto repair to insurance-claim damage assessment and autonomous-vehicle perception.
 
 <p align="center">
   <br>
@@ -25,11 +24,13 @@ Whether you're working on [automotive research](https://www.ultralytics.com/solu
 
 ## Dataset Structure
 
-The data distribution within the Carparts Segmentation Dataset is organized as follows:
+The Carparts Segmentation Dataset splits its 3,833 images as follows:
 
-- **Training set**: Includes 3516 images, each accompanied by its corresponding annotations. This set is used for [training](https://www.ultralytics.com/glossary/training-data) the [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) [model](https://www.ultralytics.com/glossary/foundation-model).
-- **Testing set**: Comprises 401 images, with each one paired with its respective annotations. This set is used to evaluate the model's performance after training using [test data](https://www.ultralytics.com/glossary/test-data).
-- **Validation set**: Consists of 276 images, each having corresponding annotations. This set is used during training to tune [hyperparameters](../../guides/hyperparameter-tuning.md) and prevent [overfitting](https://www.ultralytics.com/glossary/overfitting) using [validation data](https://www.ultralytics.com/glossary/validation-data).
+- **Training set**: 3,156 images used for [training](https://www.ultralytics.com/glossary/training-data) the [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) [model](https://www.ultralytics.com/glossary/foundation-model).
+- **Validation set**: 401 images used during training to tune [hyperparameters](../../guides/hyperparameter-tuning.md) and prevent [overfitting](https://www.ultralytics.com/glossary/overfitting) on [validation data](https://www.ultralytics.com/glossary/validation-data).
+- **Testing set**: 276 images used to evaluate the model on held-out [test data](https://www.ultralytics.com/glossary/test-data) after training.
+- **Classes**: 23 car-part categories — bumpers, doors, lights, glass, mirrors, hood, tailgate, trunk, and wheel — plus a catch-all `object` class for parts outside those categories.
+- **Download size**: ~133 MB.
 
 ## Applications
 
@@ -44,7 +45,7 @@ Carparts Segmentation finds applications in various domains including:
 - **Recycling**: Sorting vehicle components for efficient recycling processes.
 - **Smart City Initiatives**: Contributing data for urban planning and traffic management systems within [Smart Cities](https://en.wikipedia.org/wiki/Smart_city).
 
-By accurately identifying and categorizing different vehicle components, carparts segmentation streamlines processes and contributes to increased efficiency and automation across these industries.
+The complete Carparts Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com/).
 
 ## Dataset YAML
 
@@ -96,13 +97,11 @@ To train an [Ultralytics YOLO26](../../models/yolo26.md) model on the Carparts S
 
 ## Sample Data and Annotations
 
-The Carparts Segmentation dataset includes a diverse array of images and videos captured from various perspectives. Below are examples showcasing the data and its corresponding annotations:
+Below is an example image from the Carparts Segmentation Dataset with its [object segmentation](../../tasks/segment.md) masks overlaid, showing how individual car parts are outlined and labeled:
 
 ![Car parts segmentation dataset sample image](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/carparts-seg-sample.avif)
 
-- The image demonstrates [object segmentation](../../tasks/segment.md) within a car image sample. Annotated [bounding boxes](https://www.ultralytics.com/glossary/bounding-box) with masks highlight the identified car parts (e.g., headlights, grille).
-- The dataset features a variety of images captured under different conditions (locations, lighting, object densities), providing a comprehensive resource for training robust car part segmentation models.
-- This example underscores the dataset's complexity and the importance of [high-quality data](https://www.ultralytics.com/blog/the-importance-of-high-quality-computer-vision-datasets) for computer vision tasks, especially in specialized domains like automotive component analysis. Techniques like [data augmentation](https://www.ultralytics.com/glossary/data-augmentation) can further enhance model generalization.
+The dataset spans varied locations, lighting conditions, and object densities, giving models trained on it exposure to the range of real-world scenes they'll need to generalize across.
 
 ## Citations and Acknowledgments
 
@@ -113,59 +112,36 @@ If you utilize the Carparts Segmentation dataset in your research or development
     === "BibTeX"
 
         ```bibtex
-           @misc{ car-seg-un1pm_dataset,
-                title = { car-seg Dataset },
-                type = { Open Source Dataset },
-                author = { Gianmarco Russo },
-                url = { https://universe.roboflow.com/gianmarco-russo-vt9xr/car-seg-un1pm },
-                year = { 2023 },
-                month = { nov },
-                note = { visited on 2024-01-24 },
-            }
+        @misc{car-seg-un1pm_dataset,
+              title = { car-seg Dataset },
+              type = { Open Source Dataset },
+              author = { Gianmarco Russo },
+              url = { https://universe.roboflow.com/gianmarco-russo-vt9xr/car-seg-un1pm },
+              year = { 2023 },
+              month = { nov },
+              note = { visited on 2024-01-24 },
+        }
         ```
 
 We acknowledge the contribution of Gianmarco Russo and the Roboflow team in creating and maintaining this valuable dataset for the computer vision community. For more datasets, visit the [Ultralytics Datasets collection](../index.md).
 
 ## FAQ
 
-### What is the Carparts Segmentation Dataset?
+### What is the Carparts Segmentation Dataset, and how is it used in Ultralytics YOLO26?
 
-The Carparts Segmentation Dataset is a specialized collection of images and videos for training computer vision models to perform [segmentation](../../tasks/segment.md) on car parts. It includes diverse visuals with detailed annotations, suitable for automotive AI applications.
+The **Carparts Segmentation Dataset** is a curated collection of 3,833 annotated images spanning 23 car-part classes — bumpers, doors, lights, mirrors, hood, trunk, and more — for training and evaluating [instance segmentation](../../tasks/segment.md) models. It's built for automotive computer vision applications like quality control, auto repair, and damage assessment, and is used directly with Ultralytics [YOLO26](../../models/yolo26.md) via the `carparts-seg.yaml` configuration file.
 
-### How can I use the Carparts Segmentation Dataset with Ultralytics YOLO26?
+### How many images and classes does the Carparts Segmentation Dataset contain?
 
-You can train an [Ultralytics YOLO26](../../models/yolo26.md) segmentation model using this dataset. Load a pretrained model (e.g., `yolo26n-seg.pt`) and initiate training using the provided Python or CLI examples, referencing the `carparts-seg.yaml` configuration file. Check the [Training Guide](../../modes/train.md) for detailed instructions.
+The dataset totals 3,833 images — 3,156 for training, 401 for validation, and 276 for testing — across 23 car-part classes, plus a catch-all `object` class for parts outside the named categories. The full archive downloads automatically as a ~133 MB `.zip` on first use.
 
-!!! example "Train Example Snippet"
+### How can I train an Ultralytics YOLO26 model on the Carparts Segmentation Dataset?
 
-    === "Python"
+Load a pretrained segmentation model (e.g., `yolo26n-seg.pt`) and train it with the `carparts-seg.yaml` configuration using the Python or CLI snippets in the [Usage](#usage) section above. See the [Training guide](../../modes/train.md) for the full list of available arguments.
 
-        ```python
-        from ultralytics import YOLO
+### What are some applications of the Carparts Segmentation Dataset?
 
-        # Load a model
-        model = YOLO("yolo26n-seg.pt")  # load a pretrained model (recommended for training)
-
-        # Train the model
-        results = model.train(data="carparts-seg.yaml", epochs=100, imgsz=640)
-        ```
-
-    === "CLI"
-
-        ```bash
-        yolo segment train data=carparts-seg.yaml model=yolo26n-seg.pt epochs=100 imgsz=640
-        ```
-
-### What are some applications of Carparts Segmentation?
-
-Carparts Segmentation is useful in:
-
-- **Automotive Quality Control**: Ensuring parts meet standards ([AI in Manufacturing](https://www.ultralytics.com/solutions/computer-vision-in-manufacturing)).
-- **Auto Repair**: Identifying parts needing service.
-- **E-commerce**: Cataloging parts online.
-- **Autonomous Vehicles**: Improving vehicle perception ([AI in Automotive](https://www.ultralytics.com/solutions/computer-vision-in-automotive)).
-- **Insurance**: Assessing vehicle damage automatically.
-- **Recycling**: Sorting parts efficiently.
+Carparts segmentation supports automotive quality control, auto repair, e-commerce cataloging, traffic monitoring, autonomous-vehicle perception, insurance damage assessment, recycling, and smart-city initiatives — see the [Applications](#applications) section above for details on each use case.
 
 ### Where can I find the dataset configuration file for Carparts Segmentation?
 

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -7,7 +7,7 @@ keywords: COCO-Seg, dataset, YOLO models, instance segmentation, object detectio
 
 # COCO-Seg Dataset
 
-The [COCO-Seg](https://cocodataset.org/#home) dataset provides [COCO](https://cocodataset.org/#home) (Common Objects in Context) instance segmentation masks — 118,287 training and 5,000 validation images with pixel-accurate masks across 80 object categories — in the [Ultralytics YOLO](../../models/index.md) label format. It uses COCO's original images and native segmentation annotations, converted for YOLO training, making it a crucial resource for researchers and developers working on [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) tasks.
+The [COCO-Seg](https://cocodataset.org/#home) dataset provides [COCO](https://cocodataset.org/#home) (Common Objects in Context) instance segmentation masks — 118,287 training and 5,000 validation images with polygon masks across 80 object categories — in the [Ultralytics YOLO](../../models/index.md) label format. It uses COCO's original images and native segmentation annotations, converted for YOLO training, making it a crucial resource for researchers and developers working on [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) tasks.
 
 ## COCO-Seg Pretrained Models
 
@@ -17,7 +17,7 @@ The [COCO-Seg](https://cocodataset.org/#home) dataset provides [COCO](https://co
 
 - COCO-Seg provides instance segmentation masks for 123,287 labeled COCO train2017/val2017 images (118,287 train + 5,000 val), out of COCO's broader ~330K-image release.
 - The dataset consists of the same 80 object categories found in the original COCO dataset.
-- Annotations provide pixel-accurate instance segmentation masks in the YOLO polygon label format.
+- Annotations provide instance segmentation masks in the YOLO polygon label format.
 - COCO-Seg provides standardized mAP and mAR metrics for evaluating instance segmentation performance, enabling effective comparison of model performance.
 - **Download size**: ~27 GB on first use. The `coco.yaml` header lists 20.1 GB (`train2017.zip` + `val2017.zip` only), but the download script also fetches the 7 GB `test2017.zip` unconditionally, even though that archive is needed only for the optional test-dev2017 submission split.
 
@@ -136,7 +136,7 @@ The COCO-Seg dataset includes several key features:
 
 - Provides instance segmentation masks for 123,287 labeled COCO train2017/val2017 images (118,287 train + 5,000 val).
 - Annotates the same 80 object categories found in the original COCO.
-- Provides pixel-accurate instance segmentation masks in the YOLO polygon label format.
+- Provides instance segmentation masks in the YOLO polygon label format.
 - Uses standardized evaluation metrics such as mean Average [Precision](https://www.ultralytics.com/glossary/precision) (mAP) and mean Average Recall (mAR) for [instance segmentation](../../tasks/segment.md) tasks.
 
 ### What pretrained models are available for COCO-Seg, and what are their performance metrics?

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -1,12 +1,13 @@
 ---
+title: COCO Segmentation Dataset
 comments: true
-description: Explore the COCO-Seg dataset, an extension of COCO, with detailed segmentation annotations. Learn how to train YOLO models with COCO-Seg.
+description: Explore the COCO-Seg dataset, an extension of COCO with 123,287 segmentation-labeled images across 80 classes. Learn how to train YOLO models with COCO-Seg.
 keywords: COCO-Seg, dataset, YOLO models, instance segmentation, object detection, COCO dataset, YOLO26, computer vision, Ultralytics, machine learning
 ---
 
 # COCO-Seg Dataset
 
-The [COCO-Seg](https://cocodataset.org/#home) dataset, an extension of the COCO (Common Objects in Context) dataset, is specially designed to aid research in object [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation). It uses the same images as COCO but introduces more detailed segmentation annotations. This dataset is a crucial resource for researchers and developers working on instance segmentation tasks, especially for training [Ultralytics YOLO](../../models/index.md) models.
+The [COCO-Seg](https://cocodataset.org/#home) dataset extends [COCO](https://cocodataset.org/#home) (Common Objects in Context) with 118,287 training and 5,000 validation images carrying pixel-accurate instance segmentation masks across 80 object categories. It uses the same images as COCO but introduces more detailed segmentation annotations, making it a crucial resource for researchers and developers training [Ultralytics YOLO](../../models/index.md) models on [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) tasks.
 
 ## COCO-Seg Pretrained Models
 
@@ -14,22 +15,25 @@ The [COCO-Seg](https://cocodataset.org/#home) dataset, an extension of the COCO 
 
 ## Key Features
 
-- COCO-Seg retains the original 330K images from COCO.
+- COCO-Seg provides instance segmentation masks for 123,287 labeled COCO train2017/val2017 images (118,287 train + 5,000 val), out of COCO's broader ~330K-image release.
 - The dataset consists of the same 80 object categories found in the original COCO dataset.
 - Annotations now include more detailed instance segmentation masks for each object in the images.
-- COCO-Seg provides standardized evaluation metrics like [mean Average Precision](https://www.ultralytics.com/glossary/mean-average-precision-map) (mAP) for object detection, and mean Average [Recall](https://www.ultralytics.com/glossary/recall) (mAR) for instance segmentation tasks, enabling effective comparison of model performance.
+- COCO-Seg provides standardized mAP and mAR metrics for evaluating instance segmentation performance, enabling effective comparison of model performance.
+- **Download size**: ~27 GB on first use. The `coco.yaml` header lists 20.1 GB (`train2017.zip` + `val2017.zip` only), but the download script also fetches the 7 GB `test2017.zip` unconditionally, even though that archive is needed only for the optional test-dev2017 submission split.
 
 ## Dataset Structure
 
 The COCO-Seg dataset is partitioned into three subsets:
 
-1. **Train2017**: 118K images for training instance segmentation models.
-2. **Val2017**: 5K images used for validation during model development.
-3. **Test2017**: 20K images used for benchmarking. Ground-truth annotations for this subset are not publicly available, so predictions must be submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for scoring.
+1. **Train2017**: 118,287 images for training instance segmentation models.
+2. **Val2017**: 5,000 images used for validation during model development.
+3. **Test2017**: 20,288 of 40,670 images used for benchmarking. Ground-truth annotations for this subset are not publicly available, so predictions must be submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for scoring.
+
+For smaller experimentation needs, see the [COCO128-Seg](coco128-seg.md) (128 images) and [COCO8-Seg](coco8-seg.md) (8 images) subsets.
 
 ## Applications
 
-COCO-Seg is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in instance segmentation, such as the YOLO models. The large number of annotated images, the diversity of object categories, and the standardized evaluation metrics make it an indispensable resource for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) researchers and practitioners.
+COCO-Seg is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models on [instance segmentation](../../tasks/segment.md), such as the YOLO models. The large number of annotated images, the diversity of object categories, and the standardized evaluation metrics make it an indispensable resource for [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) researchers and practitioners. Full COCO-Seg annotations can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com/).
 
 ## Dataset YAML
 
@@ -74,8 +78,6 @@ COCO-Seg, like its predecessor COCO, contains a diverse set of images with vario
 
 - **Mosaiced Image**: This image demonstrates a training batch composed of mosaiced dataset images. [Mosaicing](../../guides/hyperparameter-tuning.md) is a technique used during training that combines multiple images into a single image to increase the variety of objects and scenes within each training batch. This aids the model's ability to generalize to different object sizes, aspect ratios, and contexts.
 
-The example showcases the variety and complexity of the images in the COCO-Seg dataset and the benefits of using mosaicing during the training process.
-
 ## Citations and Acknowledgments
 
 If you use the COCO-Seg dataset in your research or development work, please cite the original COCO paper and acknowledge the extension to COCO-Seg:
@@ -101,11 +103,11 @@ We extend our thanks to the COCO Consortium for creating and maintaining this in
 
 ### What is the COCO-Seg dataset and how does it differ from the original COCO dataset?
 
-The [COCO-Seg](https://cocodataset.org/#home) dataset is an extension of the original COCO (Common Objects in Context) dataset, specifically designed for instance segmentation tasks. While it uses the same images as the COCO dataset, COCO-Seg includes more detailed segmentation annotations, making it a powerful resource for researchers and developers focusing on [object instance segmentation](../../tasks/segment.md).
+[COCO-Seg](https://cocodataset.org/#home) adds pixel-accurate instance segmentation masks to the same 118,287 train2017 and 5,000 val2017 images used by the original COCO (Common Objects in Context) dataset, instead of only bounding boxes. This makes it a powerful resource for researchers and developers focusing on [object instance segmentation](../../tasks/segment.md).
 
 ### How can I train a YOLO26 model using the COCO-Seg dataset?
 
-To train a YOLO26n-seg model on the COCO-Seg dataset for 100 epochs with an image size of 640, you can use the following code snippets. For a detailed list of available arguments, refer to the model [Training](../../modes/train.md) page.
+To train a YOLO26n-seg model on the COCO-Seg dataset for 100 epochs with an image size of 640, you can use the following code snippets. For a detailed list of available training arguments, refer to the model [Training](../../modes/train.md) page.
 
 !!! example "Train Example"
 
@@ -132,10 +134,10 @@ To train a YOLO26n-seg model on the COCO-Seg dataset for 100 epochs with an imag
 
 The COCO-Seg dataset includes several key features:
 
-- Retains the original 330K images from the COCO dataset.
+- Provides instance segmentation masks for 123,287 labeled COCO train2017/val2017 images (118,287 train + 5,000 val).
 - Annotates the same 80 object categories found in the original COCO.
 - Provides more detailed instance segmentation masks for each object.
-- Uses standardized evaluation metrics such as mean Average [Precision](https://www.ultralytics.com/glossary/precision) (mAP) for [object detection](https://www.ultralytics.com/glossary/object-detection) and mean Average Recall (mAR) for instance segmentation tasks.
+- Uses standardized evaluation metrics such as mean Average [Precision](https://www.ultralytics.com/glossary/precision) (mAP) and mean Average Recall (mAR) for [instance segmentation](../../tasks/segment.md) tasks.
 
 ### What pretrained models are available for COCO-Seg, and what are their performance metrics?
 
@@ -149,8 +151,8 @@ These models range from the lightweight YOLO26n-seg to the more powerful YOLO26x
 
 The COCO-Seg dataset is partitioned into three subsets for specific training and evaluation needs:
 
-1. **Train2017**: Contains 118K images used primarily for training instance segmentation models.
-2. **Val2017**: Comprises 5K images utilized for validation during the training process.
-3. **Test2017**: Encompasses 20K images reserved for testing and benchmarking trained models. Note that ground truth annotations for this subset are not publicly available, and performance results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for assessment.
+1. **Train2017**: Contains 118,287 images used primarily for training instance segmentation models.
+2. **Val2017**: Comprises 5,000 images utilized for validation during the training process.
+3. **Test2017**: Encompasses 20,288 of 40,670 images reserved for testing and benchmarking trained models. Note that ground truth annotations for this subset are not publicly available, and performance results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for assessment.
 
-For smaller experimentation needs, you might also consider using the [COCO8-seg dataset](coco8-seg.md), which is a compact version containing just 8 images from the COCO train 2017 set.
+For smaller experimentation needs, you might also consider the [COCO128-Seg dataset](coco128-seg.md) (128 images) or the [COCO8-Seg dataset](coco8-seg.md), a compact version containing just 8 images from the COCO train 2017 set.

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -7,7 +7,7 @@ keywords: COCO-Seg, dataset, YOLO models, instance segmentation, object detectio
 
 # COCO-Seg Dataset
 
-The [COCO-Seg](https://cocodataset.org/#home) dataset extends [COCO](https://cocodataset.org/#home) (Common Objects in Context) with 118,287 training and 5,000 validation images carrying pixel-accurate instance segmentation masks across 80 object categories. It uses the same images as COCO but introduces more detailed segmentation annotations, making it a crucial resource for researchers and developers training [Ultralytics YOLO](../../models/index.md) models on [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) tasks.
+The [COCO-Seg](https://cocodataset.org/#home) dataset provides [COCO](https://cocodataset.org/#home) (Common Objects in Context) instance segmentation masks — 118,287 training and 5,000 validation images with pixel-accurate masks across 80 object categories — in the [Ultralytics YOLO](../../models/index.md) label format. It uses COCO's original images and native segmentation annotations, converted for YOLO training, making it a crucial resource for researchers and developers working on [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) tasks.
 
 ## COCO-Seg Pretrained Models
 
@@ -17,7 +17,7 @@ The [COCO-Seg](https://cocodataset.org/#home) dataset extends [COCO](https://coc
 
 - COCO-Seg provides instance segmentation masks for 123,287 labeled COCO train2017/val2017 images (118,287 train + 5,000 val), out of COCO's broader ~330K-image release.
 - The dataset consists of the same 80 object categories found in the original COCO dataset.
-- Annotations now include more detailed instance segmentation masks for each object in the images.
+- Annotations provide a pixel-accurate instance segmentation mask for each object, converted to the YOLO polygon label format.
 - COCO-Seg provides standardized mAP and mAR metrics for evaluating instance segmentation performance, enabling effective comparison of model performance.
 - **Download size**: ~27 GB on first use. The `coco.yaml` header lists 20.1 GB (`train2017.zip` + `val2017.zip` only), but the download script also fetches the 7 GB `test2017.zip` unconditionally, even though that archive is needed only for the optional test-dev2017 submission split.
 
@@ -72,7 +72,7 @@ To train a YOLO26n-seg model on the COCO-Seg dataset for 100 [epochs](https://ww
 
 ## Sample Images and Annotations
 
-COCO-Seg, like its predecessor COCO, contains a diverse set of images with various object categories and complex scenes. However, COCO-Seg introduces more detailed instance segmentation masks for each object in the images. Here are some examples of images from the dataset, along with their corresponding instance segmentation masks:
+COCO-Seg contains the same diverse images, object categories, and complex scenes as COCO, with each object's instance segmentation mask provided in the YOLO label format. Here are some examples of images from the dataset, along with their corresponding instance segmentation masks:
 
 ![COCO segmentation dataset mosaic training batch](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/mosaiced-training-batch-3.avif)
 
@@ -103,7 +103,7 @@ We extend our thanks to the COCO Consortium for creating and maintaining this in
 
 ### What is the COCO-Seg dataset and how does it differ from the original COCO dataset?
 
-[COCO-Seg](https://cocodataset.org/#home) adds pixel-accurate instance segmentation masks to the same 118,287 train2017 and 5,000 val2017 images used by the original COCO (Common Objects in Context) dataset, instead of only bounding boxes. This makes it a powerful resource for researchers and developers focusing on [object instance segmentation](../../tasks/segment.md).
+[COCO-Seg](https://cocodataset.org/#home) is the [Ultralytics YOLO](../../models/index.md)-format packaging of COCO's (Common Objects in Context) native instance segmentation masks for the same 118,287 train2017 and 5,000 val2017 images. The original COCO annotations already include these polygon masks for all 80 object categories; COCO-Seg converts them to the YOLO label format used for [object instance segmentation](../../tasks/segment.md) training.
 
 ### How can I train a YOLO26 model using the COCO-Seg dataset?
 
@@ -136,7 +136,7 @@ The COCO-Seg dataset includes several key features:
 
 - Provides instance segmentation masks for 123,287 labeled COCO train2017/val2017 images (118,287 train + 5,000 val).
 - Annotates the same 80 object categories found in the original COCO.
-- Provides more detailed instance segmentation masks for each object.
+- Provides a pixel-accurate instance segmentation mask for each object in the YOLO label format.
 - Uses standardized evaluation metrics such as mean Average [Precision](https://www.ultralytics.com/glossary/precision) (mAP) and mean Average Recall (mAR) for [instance segmentation](../../tasks/segment.md) tasks.
 
 ### What pretrained models are available for COCO-Seg, and what are their performance metrics?

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -27,7 +27,7 @@ The COCO-Seg dataset is partitioned into three subsets:
 
 1. **Train2017**: 118,287 images for training instance segmentation models.
 2. **Val2017**: 5,000 images used for validation during model development.
-3. **Test2017**: 20,288 of 40,670 images used for benchmarking. Ground-truth annotations for this subset are not publicly available, so predictions must be submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for scoring.
+3. **Test-dev2017**: 20,288 of the 40,670 test2017 images, used for benchmarking. Ground-truth annotations for this subset are not publicly available, so predictions must be submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for scoring.
 
 For smaller experimentation needs, see the [COCO128-Seg](coco128-seg.md) (128 images) and [COCO8-Seg](coco8-seg.md) (8 images) subsets.
 
@@ -153,6 +153,6 @@ The COCO-Seg dataset is partitioned into three subsets for specific training and
 
 1. **Train2017**: Contains 118,287 images used primarily for training instance segmentation models.
 2. **Val2017**: Comprises 5,000 images utilized for validation during the training process.
-3. **Test2017**: Encompasses 20,288 of 40,670 images reserved for testing and benchmarking trained models. Note that ground truth annotations for this subset are not publicly available, and performance results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for assessment.
+3. **Test-dev2017**: Encompasses 20,288 of the 40,670 test2017 images reserved for testing and benchmarking trained models. Note that ground truth annotations for this subset are not publicly available, and performance results are submitted to the [COCO evaluation server](https://cocodataset.org/#upload) for assessment.
 
 For smaller experimentation needs, you might also consider the [COCO128-Seg dataset](coco128-seg.md) (128 images) or the [COCO8-Seg dataset](coco8-seg.md), a compact version containing just 8 images from the COCO train 2017 set.

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -17,7 +17,7 @@ The [COCO-Seg](https://cocodataset.org/#home) dataset provides [COCO](https://co
 
 - COCO-Seg provides instance segmentation masks for 123,287 labeled COCO train2017/val2017 images (118,287 train + 5,000 val), out of COCO's broader ~330K-image release.
 - The dataset consists of the same 80 object categories found in the original COCO dataset.
-- Annotations provide a pixel-accurate instance segmentation mask for each object, converted to the YOLO polygon label format.
+- Annotations provide pixel-accurate instance segmentation masks in the YOLO polygon label format.
 - COCO-Seg provides standardized mAP and mAR metrics for evaluating instance segmentation performance, enabling effective comparison of model performance.
 - **Download size**: ~27 GB on first use. The `coco.yaml` header lists 20.1 GB (`train2017.zip` + `val2017.zip` only), but the download script also fetches the 7 GB `test2017.zip` unconditionally, even though that archive is needed only for the optional test-dev2017 submission split.
 
@@ -72,7 +72,7 @@ To train a YOLO26n-seg model on the COCO-Seg dataset for 100 [epochs](https://ww
 
 ## Sample Images and Annotations
 
-COCO-Seg contains the same diverse images, object categories, and complex scenes as COCO, with each object's instance segmentation mask provided in the YOLO label format. Here are some examples of images from the dataset, along with their corresponding instance segmentation masks:
+COCO-Seg contains the same diverse images, object categories, and complex scenes as COCO, with instance segmentation masks provided in the YOLO label format. Here are some examples of images from the dataset, along with their corresponding instance segmentation masks:
 
 ![COCO segmentation dataset mosaic training batch](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/mosaiced-training-batch-3.avif)
 
@@ -136,7 +136,7 @@ The COCO-Seg dataset includes several key features:
 
 - Provides instance segmentation masks for 123,287 labeled COCO train2017/val2017 images (118,287 train + 5,000 val).
 - Annotates the same 80 object categories found in the original COCO.
-- Provides a pixel-accurate instance segmentation mask for each object in the YOLO label format.
+- Provides pixel-accurate instance segmentation masks in the YOLO polygon label format.
 - Uses standardized evaluation metrics such as mean Average [Precision](https://www.ultralytics.com/glossary/precision) (mAP) and mean Average Recall (mAR) for [instance segmentation](../../tasks/segment.md) tasks.
 
 ### What pretrained models are available for COCO-Seg, and what are their performance metrics?

--- a/docs/en/datasets/segment/coco128-seg.md
+++ b/docs/en/datasets/segment/coco128-seg.md
@@ -15,7 +15,7 @@ keywords: COCO128-Seg, Ultralytics, segmentation dataset, YOLO26, COCO 2017, mod
 
 - **Images**: 128 total, with train and val split identically (see note below).
 - **Classes**: Same 80 object categories as COCO.
-- **Labels**: YOLO-format polygons saved beside each image inside `labels/{train,val}`.
+- **Labels**: YOLO-format polygons stored in `labels/train2017` for the shared train and val image directory.
 - **Download size**: ~7 MB.
 
 !!! note
@@ -123,7 +123,7 @@ For a thorough explanation of available arguments and configuration options, you
 
 ### Why is the COCO128-Seg dataset important for model development and debugging?
 
-Because the ~7 MB download and 128-image train/val loop complete in minutes, COCO128-Seg lets you run a full 1-epoch sanity check on a new pipeline — verifying the model trains, validates, and saves checkpoints correctly — before committing hours to the full COCO-Seg dataset. Learn more about supported dataset formats in the [Ultralytics segmentation dataset guide](index.md).
+Because the download and train/val loop are much smaller than full COCO, COCO128-Seg lets you run a 1-epoch sanity check on a new pipeline — verifying the model trains, validates, and saves checkpoints correctly — before scaling to the full COCO-Seg dataset. Learn more about supported dataset formats in the [Ultralytics segmentation dataset guide](index.md).
 
 ### Where can I find the YAML configuration file for the COCO128-Seg dataset?
 

--- a/docs/en/datasets/segment/coco128-seg.md
+++ b/docs/en/datasets/segment/coco128-seg.md
@@ -1,6 +1,7 @@
 ---
+title: COCO128 Segmentation Dataset
 comments: true
-description: Discover the COCO128-Seg dataset by Ultralytics, a compact yet diverse segmentation dataset ideal for testing and training YOLO26 models.
+description: Discover the COCO128-Seg dataset by Ultralytics, a 128-image, ~7 MB instance segmentation dataset ideal for testing and training YOLO26 models.
 keywords: COCO128-Seg, Ultralytics, segmentation dataset, YOLO26, COCO 2017, model training, computer vision, dataset configuration
 ---
 
@@ -12,9 +13,14 @@ keywords: COCO128-Seg, Ultralytics, segmentation dataset, YOLO26, COCO 2017, mod
 
 ## Dataset Structure
 
-- **Images**: 128 total. The default YAML reuses the same directory for train and val so you can quickly iterate, but you can duplicate or customize the split if desired.
+- **Images**: 128 total, with train and val split identically (see note below).
 - **Classes**: Same 80 object categories as COCO.
 - **Labels**: YOLO-format polygons saved beside each image inside `labels/{train,val}`.
+- **Download size**: ~7 MB.
+
+!!! note
+
+    The default YAML points train and val at the same 128 images, so validation metrics measure fit on the training set rather than generalization on held-out data. Duplicate or customize the split if you need a true held-out set.
 
 This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
 
@@ -60,8 +66,6 @@ Here are some examples of images from the COCO128-Seg dataset, along with their 
 <img src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/mosaiced-training-batch-2.avif" alt="COCO128-seg instance segmentation dataset mosaic" width="800">
 
 - **Mosaiced Image**: This image demonstrates a training batch composed of mosaiced dataset images. Mosaicing is a technique used during training that combines multiple images into a single image to increase the variety of objects and scenes within each training batch. This helps improve the model's ability to generalize to different object sizes, aspect ratios, and contexts.
-
-The example showcases the variety and complexity of the images in the COCO128-Seg dataset and the benefits of using mosaicing during the training process.
 
 ## Citations and Acknowledgments
 
@@ -119,12 +123,18 @@ For a thorough explanation of available arguments and configuration options, you
 
 ### Why is the COCO128-Seg dataset important for model development and debugging?
 
-The **COCO128-Seg dataset** offers a balanced combination of manageability and diversity with 128 images, making it perfect for quickly testing and debugging segmentation models or experimenting with new detection techniques. Its moderate size allows for fast training iterations while providing enough diversity to validate training pipelines before scaling to larger datasets. Learn more about supported dataset formats in the [Ultralytics segmentation dataset guide](index.md).
+Because the ~7 MB download and 128-image train/val loop complete in minutes, COCO128-Seg lets you run a full 1-epoch sanity check on a new pipeline — verifying the model trains, validates, and saves checkpoints correctly — before committing hours to the full COCO-Seg dataset. Learn more about supported dataset formats in the [Ultralytics segmentation dataset guide](index.md).
 
 ### Where can I find the YAML configuration file for the COCO128-Seg dataset?
 
 The YAML configuration file for the **COCO128-Seg dataset** is available in the Ultralytics repository. You can access the file directly at <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco128-seg.yaml>. The YAML file includes essential information about dataset paths, classes, and configuration settings required for model training and validation.
 
-### What are some benefits of using mosaicing during training with the COCO128-Seg dataset?
+### How does COCO128-Seg compare to COCO8-Seg and the full COCO-Seg dataset?
 
-Using **mosaicing** during training helps increase the diversity and variety of objects and scenes in each training batch. This technique combines multiple images into a single composite image, enhancing the model's ability to generalize to different object sizes, aspect ratios, and contexts within the scene. Mosaicing is beneficial for improving a model's robustness and [accuracy](https://www.ultralytics.com/glossary/accuracy), especially when working with moderately-sized datasets like COCO128-Seg. For an example of mosaiced images, see the [Sample Images and Annotations](#sample-images-and-annotations) section.
+COCO128-Seg (128 images) sits between [COCO8-Seg](coco8-seg.md) (8 images) and the full [COCO-Seg](coco.md) dataset (118,287 training images) in terms of size:
+
+- **COCO8-Seg**: 8 images (4 train, 4 val) — ideal for quick sanity checks and debugging.
+- **COCO128-Seg**: 128 images — balanced between size and diversity, with train and val sharing the same directory.
+- **Full COCO-Seg**: 118,287 training images — comprehensive but resource-intensive, requiring ~27 GB on first download.
+
+COCO128-Seg offers more diversity than COCO8-Seg while remaining far more manageable than the full COCO-Seg dataset for experimentation and initial model development.

--- a/docs/en/datasets/segment/coco8-seg.md
+++ b/docs/en/datasets/segment/coco8-seg.md
@@ -119,7 +119,7 @@ For a thorough explanation of available arguments and configuration options, you
 
 ### Why is the COCO8-Seg dataset important for model development and debugging?
 
-Because the ~1 MB download and 8-image train/val loop complete in seconds, COCO8-Seg lets you run a full training-and-validation pass to catch pipeline errors — a broken data loader, a misconfigured loss, a bad augmentation — before committing to a multi-hour run on a larger dataset. Learn more about supported dataset formats in the [Ultralytics segmentation dataset guide](index.md).
+Because the download and train/val loop are much smaller than full COCO, COCO8-Seg lets you run a training-and-validation pass to catch pipeline errors — a broken data loader, a misconfigured loss, or a bad augmentation — before committing to a larger dataset. Learn more about supported dataset formats in the [Ultralytics segmentation dataset guide](index.md).
 
 ### Where can I find the YAML configuration file for the COCO8-Seg dataset?
 

--- a/docs/en/datasets/segment/coco8-seg.md
+++ b/docs/en/datasets/segment/coco8-seg.md
@@ -1,6 +1,7 @@
 ---
+title: COCO8 Segmentation Dataset
 comments: true
-description: Discover the versatile and manageable COCO8-Seg dataset by Ultralytics, ideal for testing and debugging segmentation models or new detection approaches.
+description: Discover the versatile and manageable COCO8-Seg dataset by Ultralytics, an 8-image, ~1 MB segmentation set ideal for testing and debugging models.
 keywords: COCO8-Seg, Ultralytics, segmentation dataset, YOLO26, COCO 2017, model training, computer vision, dataset configuration
 ---
 
@@ -15,6 +16,7 @@ keywords: COCO8-Seg, Ultralytics, segmentation dataset, YOLO26, COCO 2017, model
 - **Images**: 8 total (4 train / 4 val).
 - **Classes**: 80 COCO categories.
 - **Labels**: YOLO-format polygons stored under `labels/{train,val}` matching each image file.
+- **Download size**: ~1 MB.
 
 Explore [COCO8-Seg on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco8-seg) to browse every image with its polygon masks, view the class distribution and annotation heatmaps in the **Charts** tab, and clone it to train your own model in the cloud.
 
@@ -61,8 +63,6 @@ Here are some examples of images from the COCO8-Seg dataset, along with their co
 
 - **Mosaiced Image**: This image demonstrates a training batch composed of mosaiced dataset images. Mosaicing is a technique used during training that combines multiple images into a single image to increase the variety of objects and scenes within each training batch. This helps improve the model's ability to generalize to different object sizes, aspect ratios, and contexts.
 
-The example showcases the variety and complexity of the images in the COCO8-Seg dataset and the benefits of using mosaicing during the training process.
-
 ## Citations and Acknowledgments
 
 If you use the COCO dataset in your research or development work, please cite the following paper:
@@ -88,7 +88,7 @@ We would like to acknowledge the COCO Consortium for creating and maintaining th
 
 ### What is the COCO8-Seg dataset, and how is it used in Ultralytics YOLO26?
 
-The **COCO8-Seg dataset** is a compact instance segmentation dataset by Ultralytics, consisting of the first 8 images from the COCO train 2017 set—4 images for training and 4 for validation. This dataset is tailored for testing and debugging segmentation models or experimenting with new detection methods. It is particularly useful with Ultralytics [YOLO26](https://github.com/ultralytics/ultralytics) for rapid iteration and pipeline error-checking before scaling to larger datasets. For detailed usage, refer to the model [Training](../../modes/train.md) page.
+The **COCO8-Seg dataset** is a compact instance segmentation dataset by Ultralytics, consisting of the first 8 images from the COCO train 2017 set (4 for training, 4 for validation). This dataset is tailored for testing and debugging segmentation models or experimenting with new detection methods. It is particularly useful with Ultralytics [YOLO26](https://github.com/ultralytics/ultralytics) for rapid iteration and pipeline error-checking before scaling to larger datasets. For detailed usage, refer to the model [Training](../../modes/train.md) page.
 
 ### How can I train a YOLO26n-seg model using the COCO8-Seg dataset?
 
@@ -119,12 +119,18 @@ For a thorough explanation of available arguments and configuration options, you
 
 ### Why is the COCO8-Seg dataset important for model development and debugging?
 
-The **COCO8-Seg dataset** offers a compact yet diverse set of 8 images, making it perfect for quickly testing and debugging segmentation models or experimenting with new detection techniques. Its small size allows for fast sanity checks and early pipeline validation, helping identify issues before scaling to larger datasets. Learn more about supported dataset formats in the [Ultralytics segmentation dataset guide](index.md).
+Because the ~1 MB download and 8-image train/val loop complete in seconds, COCO8-Seg lets you run a full training-and-validation pass to catch pipeline errors — a broken data loader, a misconfigured loss, a bad augmentation — before committing to a multi-hour run on a larger dataset. Learn more about supported dataset formats in the [Ultralytics segmentation dataset guide](index.md).
 
 ### Where can I find the YAML configuration file for the COCO8-Seg dataset?
 
 The YAML configuration file for the **COCO8-Seg dataset** is available in the Ultralytics repository. You can access the file directly at <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco8-seg.yaml>. The YAML file includes essential information about dataset paths, classes, and configuration settings required for model training and validation.
 
-### What are some benefits of using mosaicing during training with the COCO8-Seg dataset?
+### How does COCO8-Seg compare to COCO128-Seg and the full COCO-Seg dataset?
 
-Using **mosaicing** during training helps increase the diversity and variety of objects and scenes in each training batch. This technique combines multiple images into a single composite image, enhancing the model's ability to generalize to different object sizes, aspect ratios, and contexts within the scene. Mosaicing is beneficial for improving a model's robustness and [accuracy](https://www.ultralytics.com/glossary/accuracy), especially when working with small datasets like COCO8-Seg. For an example of mosaiced images, see the [Sample Images and Annotations](#sample-images-and-annotations) section.
+COCO8-Seg (8 images) sits below [COCO128-Seg](coco128-seg.md) (128 images) and the full [COCO-Seg](coco.md) dataset (118,287 training images) in terms of size:
+
+- **COCO8-Seg**: 8 images (4 train, 4 val) — the fastest sanity check, ideal for CI and quick debugging.
+- **COCO128-Seg**: 128 images — balanced between size and diversity, with train and val sharing the same directory.
+- **Full COCO-Seg**: 118,287 training images — comprehensive but resource-intensive, requiring ~27 GB on first download.
+
+Use COCO8-Seg for the fastest possible pipeline check, then scale to COCO128-Seg or the full COCO-Seg dataset as confidence grows.

--- a/docs/en/datasets/segment/coco8-seg.md
+++ b/docs/en/datasets/segment/coco8-seg.md
@@ -16,7 +16,7 @@ keywords: COCO8-Seg, Ultralytics, segmentation dataset, YOLO26, COCO 2017, model
 - **Classes**: 80 COCO categories.
 - **Labels**: YOLO-format polygons stored under `labels/{train,val}` matching each image file.
 
-This dataset is intended for use with [Ultralytics Platform](https://platform.ultralytics.com/) and [YOLO26](https://github.com/ultralytics/ultralytics).
+Explore [COCO8-Seg on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/coco8-seg) to browse every image with its polygon masks, view the class distribution and annotation heatmaps in the **Charts** tab, and clone it to train your own model in the cloud.
 
 ## Dataset YAML
 
@@ -88,7 +88,7 @@ We would like to acknowledge the COCO Consortium for creating and maintaining th
 
 ### What is the COCO8-Seg dataset, and how is it used in Ultralytics YOLO26?
 
-The **COCO8-Seg dataset** is a compact instance segmentation dataset by Ultralytics, consisting of the first 8 images from the COCO train 2017 set—4 images for training and 4 for validation. This dataset is tailored for testing and debugging segmentation models or experimenting with new detection methods. It is particularly useful with Ultralytics [YOLO26](https://github.com/ultralytics/ultralytics) and [Platform](https://platform.ultralytics.com/) for rapid iteration and pipeline error-checking before scaling to larger datasets. For detailed usage, refer to the model [Training](../../modes/train.md) page.
+The **COCO8-Seg dataset** is a compact instance segmentation dataset by Ultralytics, consisting of the first 8 images from the COCO train 2017 set—4 images for training and 4 for validation. This dataset is tailored for testing and debugging segmentation models or experimenting with new detection methods. It is particularly useful with Ultralytics [YOLO26](https://github.com/ultralytics/ultralytics) for rapid iteration and pipeline error-checking before scaling to larger datasets. For detailed usage, refer to the model [Training](../../modes/train.md) page.
 
 ### How can I train a YOLO26n-seg model using the COCO8-Seg dataset?
 

--- a/docs/en/datasets/segment/crack-seg.md
+++ b/docs/en/datasets/segment/crack-seg.md
@@ -1,6 +1,7 @@
 ---
+title: Crack-Seg Dataset
 comments: true
-description: Explore the extensive Crack Segmentation Dataset, ideal for transportation safety, infrastructure maintenance, and self-driving car model development using Ultralytics YOLO.
+description: Train Ultralytics YOLO segmentation models on the Crack Segmentation Dataset — 4,029 annotated road and wall images for a single crack class.
 keywords: Crack Segmentation Dataset, Ultralytics, transportation safety, public safety, self-driving cars, computer vision, road safety, infrastructure maintenance, dataset, YOLO, segmentation, deep learning
 ---
 
@@ -8,7 +9,7 @@ keywords: Crack Segmentation Dataset, Ultralytics, transportation safety, public
 
 <a href="https://colab.research.google.com/github/ultralytics/notebooks/blob/main/notebooks/how-to-train-ultralytics-yolo-on-crack-segmentation-dataset.ipynb" target="_blank"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open Crack Segmentation Dataset In Colab"></a>
 
-The Crack Segmentation Dataset is an extensive resource designed for individuals involved in transportation and public safety studies. It is also beneficial for developing [self-driving car](https://www.ultralytics.com/blog/ai-in-self-driving-cars) models or exploring various [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) applications. This dataset is part of the broader collection available on the Ultralytics [Datasets Hub](../../datasets/index.md).
+The [Ultralytics](https://www.ultralytics.com/) Crack Segmentation Dataset provides 4,029 annotated images of cracks on roads and walls for training [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) models on a single `crack` class. Captured across diverse pavement and structural scenarios, it pairs directly with [Ultralytics YOLO](../../models/yolo26.md) for use cases ranging from transportation safety and [self-driving car](https://www.ultralytics.com/blog/ai-in-self-driving-cars) perception to [infrastructure maintenance](https://www.ultralytics.com/blog/using-ai-for-crack-detection-and-segmentation) and structural [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) inspection.
 
 <p align="center">
   <br>
@@ -21,21 +22,23 @@ The Crack Segmentation Dataset is an extensive resource designed for individuals
   <strong>Watch:</strong> How to Train a Crack Segmentation Model using Ultralytics YOLO26 | AI in Construction 🎉
 </p>
 
-Comprising 4029 static images captured from diverse road and wall scenarios, this dataset is a valuable asset for crack segmentation tasks. Whether you are researching transportation infrastructure or aiming to enhance the [accuracy](https://www.ultralytics.com/glossary/accuracy) of autonomous driving systems, this dataset provides a rich collection of images for training [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models.
-
 ## Dataset Structure
 
-The Crack Segmentation Dataset is organized into three subsets:
+The Crack Segmentation Dataset splits its 4,029 images as follows:
 
-- **Training set**: 3717 images with corresponding annotations.
-- **Testing set**: 200 images with corresponding annotations.
-- **Validation set**: 112 images with corresponding annotations.
+- **Training set**: 3,717 images used for [training](https://www.ultralytics.com/glossary/training-data) the [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) model.
+- **Validation set**: 200 images used during training to tune [hyperparameters](../../guides/hyperparameter-tuning.md) and prevent [overfitting](https://www.ultralytics.com/glossary/overfitting).
+- **Testing set**: 112 images held out to evaluate the model after training.
+- **Classes**: a single `crack` class covering every annotated crack on roads and walls.
+- **Download size**: ~91.6 MB.
 
 ## Applications
 
-Crack segmentation finds practical applications in [infrastructure maintenance](https://www.ultralytics.com/blog/using-ai-for-crack-detection-and-segmentation), aiding in the identification and assessment of structural damage in buildings, bridges, and roads. It also plays a crucial role in enhancing [road safety](https://www.who.int/news-room/fact-sheets/detail/road-traffic-injuries) by enabling automated systems to detect pavement cracks for timely repairs.
+Crack segmentation supports [infrastructure maintenance](https://www.ultralytics.com/blog/using-ai-for-crack-detection-and-segmentation) by identifying and assessing structural damage in buildings, bridges, and roads. It also enhances [road safety](https://www.who.int/news-room/fact-sheets/detail/road-traffic-injuries) by letting automated systems detect pavement cracks for timely repairs.
 
-In industrial settings, crack detection using deep learning models like [Ultralytics YOLO26](../../models/yolo26.md) helps ensure building integrity in construction, prevents costly downtimes in [manufacturing](https://www.ultralytics.com/solutions/computer-vision-in-manufacturing), and makes road inspections safer and more effective. Automatically identifying and classifying cracks allows maintenance teams to prioritize repairs efficiently, contributing to better [model evaluation insights](../../guides/model-evaluation-insights.md).
+In industrial settings, crack detection with models like [Ultralytics YOLO26](../../models/yolo26.md) helps verify building integrity in construction, prevents costly downtime in [manufacturing](https://www.ultralytics.com/solutions/computer-vision-in-manufacturing), and makes road inspections safer. Automatically classifying cracks lets maintenance teams prioritize the most urgent repairs.
+
+The complete Crack Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com/).
 
 ## Dataset YAML
 
@@ -80,13 +83,11 @@ To train the Ultralytics YOLO26n-seg model on the Crack Segmentation dataset for
 
 ## Sample Data and Annotations
 
-The Crack Segmentation dataset contains a diverse collection of images captured from various perspectives, showcasing different types of cracks on roads and walls. Here are some examples:
+Below is an example from the Crack Segmentation Dataset with its [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) masks overlaid, outlining identified cracks on road and wall surfaces:
 
 ![Crack segmentation dataset sample for infrastructure inspection](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/crack-segmentation-sample.avif)
 
-- This image demonstrates [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation), featuring annotated [bounding boxes](https://www.ultralytics.com/glossary/bounding-box) with masks outlining identified cracks. The dataset includes images from different locations and environments, making it a comprehensive resource for developing robust models for this task. Techniques like [data augmentation](https://www.ultralytics.com/glossary/data-augmentation) can further enhance dataset diversity. Learn more about instance segmentation and tracking in our [guide](../../guides/instance-segmentation-and-tracking.md).
-
-- The example highlights the diversity within the Crack Segmentation dataset, emphasizing the importance of high-quality data for training effective computer vision models.
+The dataset spans varied locations, surfaces, and lighting conditions, so models trained on it see the range of real-world scenes they need to generalize across. [Data augmentation](https://www.ultralytics.com/glossary/data-augmentation) can broaden that variety further — see our [instance segmentation and tracking guide](../../guides/instance-segmentation-and-tracking.md) for related workflows.
 
 ## Citations and Acknowledgments
 
@@ -108,47 +109,26 @@ If you use the Crack Segmentation dataset in your research or development work, 
         }
         ```
 
-We acknowledge the team at Roboflow for making the Crack Segmentation dataset available, providing a valuable resource for the computer vision community, particularly for projects related to road safety and infrastructure assessment.
+We acknowledge the team at Roboflow for making the Crack Segmentation dataset available, providing a valuable resource for the computer vision community, particularly for projects related to road safety and infrastructure assessment. For more datasets, visit the [Ultralytics Datasets collection](../index.md).
 
 ## FAQ
 
-### What is the Crack Segmentation Dataset?
+### What is the Crack Segmentation Dataset, and how is it used in Ultralytics YOLO26?
 
-The Crack Segmentation Dataset is a collection of 4029 static images designed for transportation and public safety studies. It's suitable for tasks like [self-driving car](https://www.ultralytics.com/blog/ai-in-self-driving-cars) model development and [infrastructure maintenance](https://www.ultralytics.com/blog/using-ai-for-crack-detection-and-segmentation). It includes training, testing, and validation sets for crack detection and [segmentation](../../tasks/segment.md) tasks.
+The **Crack Segmentation Dataset** is a collection of 4,029 annotated images of cracks on roads and walls for training and evaluating [instance segmentation](../../tasks/segment.md) models on a single `crack` class. It's built for transportation-safety and infrastructure applications like structural inspection and pavement assessment, and is used directly with Ultralytics [YOLO26](../../models/yolo26.md) via the `crack-seg.yaml` configuration file.
 
-### How do I train a model using the Crack Segmentation Dataset with Ultralytics YOLO26?
+### How many images and classes does the Crack Segmentation Dataset contain?
 
-To train an [Ultralytics YOLO26](../../models/yolo26.md) model on this dataset, use the provided Python or CLI examples. Detailed instructions and parameters are available on the model [Training](../../modes/train.md) page. You can manage your training process using tools like [Ultralytics Platform](https://platform.ultralytics.com).
+The dataset totals 4,029 images — 3,717 for training, 200 for validation, and 112 for testing — all annotated for a single `crack` class. The full archive downloads automatically as a ~91.6 MB `.zip` on first use.
 
-!!! example "Train Example"
+### How do I train an Ultralytics YOLO26 model on the Crack Segmentation Dataset?
 
-    === "Python"
+Load a pretrained segmentation model (e.g., `yolo26n-seg.pt`) and train it with the `crack-seg.yaml` configuration using the Python or CLI snippets in the [Usage](#usage) section above. See the [Training guide](../../modes/train.md) for the full list of available arguments.
 
-        ```python
-        from ultralytics import YOLO
+### Why use the Crack Segmentation Dataset for self-driving car and infrastructure projects?
 
-        # Load a pretrained model (recommended)
-        model = YOLO("yolo26n-seg.pt")
+Its diverse images of cracks across roads and walls cover many real-world scenarios, improving the robustness of models trained for crack detection. Accurate segmentation supports [road safety](https://www.ultralytics.com/blog/ai-in-self-driving-cars) and infrastructure-assessment systems that must identify potential hazards reliably — see the [Applications](#applications) section above and our [model training tips](../../guides/model-training-tips.md) for best practices.
 
-        # Train the model
-        results = model.train(data="crack-seg.yaml", epochs=100, imgsz=640)
-        ```
+### Where can I find the dataset configuration file for Crack Segmentation?
 
-    === "CLI"
-
-        ```bash
-        # Start training from a pretrained model via CLI
-        yolo segment train data=crack-seg.yaml model=yolo26n-seg.pt epochs=100 imgsz=640
-        ```
-
-### Why use the Crack Segmentation Dataset for self-driving car projects?
-
-This dataset is valuable for self-driving car projects due to its diverse images of roads and walls, covering various real-world scenarios. This diversity improves the robustness of models trained for crack detection, which is crucial for road safety and infrastructure assessment. The detailed annotations aid in [developing models](../../guides/model-training-tips.md) that can accurately identify potential road hazards.
-
-### What features does Ultralytics YOLO offer for crack segmentation?
-
-Ultralytics YOLO provides real-time [object detection](https://www.ultralytics.com/glossary/object-detection), segmentation, and classification capabilities, making it highly suitable for crack segmentation tasks. It efficiently handles large datasets and complex scenarios. The framework includes comprehensive modes for [Training](../../modes/train.md), [Prediction](../../modes/predict.md), and [Exporting](../../modes/export.md) models. YOLO's [anchor-free detection](https://www.ultralytics.com/blog/benefits-ultralytics-yolo11-being-anchor-free-detector) approach can improve performance on irregular shapes like cracks, and performance can be measured using standard [metrics](../../guides/yolo-performance-metrics.md).
-
-### How do I cite the Crack Segmentation Dataset?
-
-If using this dataset in your work, please cite it using the provided BibTeX entry above to give appropriate credit to the creators.
+The `crack-seg.yaml` file, which defines the dataset paths and the single `crack` class, is located in the Ultralytics GitHub repository: [crack-seg.yaml](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/crack-seg.yaml).

--- a/docs/en/datasets/segment/package-seg.md
+++ b/docs/en/datasets/segment/package-seg.md
@@ -1,14 +1,15 @@
 ---
+title: Package-Seg Dataset
 comments: true
-description: Explore the Package Segmentation Dataset. Optimize logistics and enhance vision models with curated images for package identification and sorting.
-keywords: Package Segmentation Dataset, computer vision, package identification, logistics, warehouse automation, segmentation models, training data, Ultralytics YOLO
+description: Train Ultralytics YOLO segmentation models on the Package Segmentation Dataset — 2,197 annotated images across a single package class for logistics AI.
+keywords: Package Segmentation Dataset, Ultralytics, computer vision, package identification, logistics, warehouse automation, segmentation models, YOLO, deep learning
 ---
 
 # Package Segmentation Dataset
 
 <a href="https://colab.research.google.com/github/ultralytics/notebooks/blob/main/notebooks/how-to-train-ultralytics-yolo-on-package-segmentation-dataset.ipynb" target="_blank"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open Package Segmentation Dataset In Colab"></a>
 
-The Package Segmentation Dataset is a curated collection of images specifically tailored for tasks related to package segmentation within the field of [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv). This dataset is designed to assist researchers, developers, and enthusiasts working on projects involving package identification, sorting, and handling, primarily focusing on [image segmentation](https://www.ultralytics.com/glossary/image-segmentation) tasks.
+The [Ultralytics](https://www.ultralytics.com/) Package Segmentation Dataset is a curated collection of 2,197 annotated images of packages for training [instance segmentation](https://www.ultralytics.com/glossary/instance-segmentation) models on a single `package` class. Built for logistics and warehouse-automation use cases like package identification, sorting, and handling, it pairs directly with [Ultralytics YOLO](../../models/yolo26.md) for real-time package analysis in [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) pipelines. Explore more segmentation datasets on our [datasets overview page](index.md).
 
 <p align="center">
   <br>
@@ -18,22 +19,22 @@ The Package Segmentation Dataset is a curated collection of images specifically 
     allowfullscreen>
   </iframe>
   <br>
-  <strong>Watch:</strong> Train Package Segmentation Model using Ultralytics YOLO26 | Industrial Packages 🎉
+  <strong>Watch:</strong> Train a Package Segmentation Model using Ultralytics YOLO | Industrial Packages 🎉
 </p>
-
-Containing a diverse set of images showcasing various packages in different contexts and environments, the dataset serves as a valuable resource for training and evaluating segmentation models. Whether you are engaged in logistics, warehouse automation, or any application requiring precise package analysis, the Package Segmentation Dataset provides a targeted and comprehensive set of images to enhance the performance of your computer vision algorithms. Explore more datasets for segmentation tasks on our [datasets overview page](index.md).
 
 ## Dataset Structure
 
-The distribution of data in the Package Segmentation Dataset is structured as follows:
+The Package Segmentation Dataset splits its 2,197 images as follows:
 
-- **Training set**: Encompasses 1920 images accompanied by their corresponding annotations.
-- **Testing set**: Consists of 188 images, each paired with its respective annotations.
-- **Validation set**: Comprises 89 images, each with corresponding annotations.
+- **Training set**: 1,920 images used for [training](https://www.ultralytics.com/glossary/training-data) the [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) model.
+- **Validation set**: 188 images used during training to tune [hyperparameters](../../guides/hyperparameter-tuning.md) and prevent [overfitting](https://www.ultralytics.com/glossary/overfitting).
+- **Testing set**: 89 images held out to evaluate the model after training.
+- **Classes**: a single `package` class covering every annotated package.
+- **Download size**: ~103 MB.
 
 ## Applications
 
-Package segmentation, facilitated by the Package Segmentation Dataset, is crucial for optimizing logistics, enhancing last-mile delivery, improving manufacturing quality control, and contributing to smart city solutions. From e-commerce to security applications, this dataset is a key resource, fostering innovation in computer vision for diverse and efficient package analysis applications.
+Package segmentation optimizes logistics, last-mile delivery, manufacturing quality control, and smart-city systems, with applications spanning e-commerce fulfillment and security screening. Precise package masks let automated systems locate, count, and inspect parcels in real time.
 
 ### Smart Warehouses and Logistics
 
@@ -41,11 +42,13 @@ In modern warehouses, [vision AI solutions](https://www.ultralytics.com/solution
 
 ### Quality Control and Damage Detection
 
-Package segmentation models can be used to identify damaged packages by analyzing their shape and appearance. By detecting irregularities or deformations in package outlines, these models help ensure that only intact packages proceed through the supply chain, reducing customer complaints and return rates. This is a key aspect of [quality control in manufacturing](https://www.ultralytics.com/blog/improving-manufacturing-with-computer-vision) and is vital for maintaining product integrity.
+Package segmentation models can identify damaged packages by analyzing their shape and appearance. By detecting irregularities or deformations in package outlines, these models help ensure that only intact packages proceed through the supply chain, reducing customer complaints and return rates. This is a key aspect of [quality control in manufacturing](https://www.ultralytics.com/blog/improving-manufacturing-with-computer-vision) and is vital for maintaining product integrity.
+
+The complete Package Segmentation Dataset can also be browsed and managed on [Ultralytics Platform](https://platform.ultralytics.com/).
 
 ## Dataset YAML
 
-A YAML (Yet Another Markup Language) file defines the dataset configuration, including paths, classes, and other essential details. For the Package Segmentation dataset, the `package-seg.yaml` file is maintained at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/package-seg.yaml](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/package-seg.yaml).
+A [YAML](https://www.ultralytics.com/glossary/yaml) (Yet Another Markup Language) file defines the dataset configuration, including paths, classes, and other essential details. For the Package Segmentation dataset, the `package-seg.yaml` file is maintained at [https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/package-seg.yaml](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/package-seg.yaml).
 
 !!! example "ultralytics/cfg/datasets/package-seg.yaml"
 
@@ -55,7 +58,7 @@ A YAML (Yet Another Markup Language) file defines the dataset configuration, inc
 
 ## Usage
 
-To train an [Ultralytics YOLO26n](../../models/yolo26.md) model on the Package Segmentation dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training page](../../modes/train.md).
+To train an [Ultralytics YOLO26n](../../models/yolo26.md) model on the Package Segmentation dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, use the following code snippets. The dataset (~103 MB) downloads automatically on first use. For a comprehensive list of available arguments, refer to the model [Training page](../../modes/train.md).
 
 !!! example "Train Example"
 
@@ -95,24 +98,11 @@ To train an [Ultralytics YOLO26n](../../models/yolo26.md) model on the Package S
 
 ## Sample Data and Annotations
 
-The Package Segmentation dataset comprises a varied collection of images captured from multiple perspectives. Below are instances of data from the dataset, accompanied by their respective segmentation masks:
+Below is an example from the Package Segmentation Dataset with its segmentation masks overlaid, outlining detected packages:
 
 ![Package segmentation dataset sample for logistics](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/package-seg-sample.avif)
 
-- This image displays an instance of package segmentation, featuring annotated masks outlining recognized package objects. The dataset incorporates a diverse collection of images taken in different locations, environments, and densities. It serves as a comprehensive resource for developing models specific to this [segmentation task](../../tasks/segment.md).
-- The example emphasizes the diversity and complexity present in the dataset, underscoring the significance of high-quality data for computer vision tasks involving package segmentation.
-
-## Benefits of Using YOLO26 for Package Segmentation
-
-[Ultralytics YOLO26](../../models/yolo26.md) offers several advantages for package segmentation tasks:
-
-1.  **Speed and Accuracy Balance**: YOLO26 achieves high precision and efficiency, making it ideal for [real-time inference](https://www.ultralytics.com/glossary/real-time-inference) in fast-paced logistics environments. It provides a strong balance compared to models like [YOLOv8](../../models/yolov8.md).
-
-2.  **Adaptability**: Models trained with YOLO26 can adapt to various warehouse conditions, from dim lighting to cluttered spaces, ensuring robust performance.
-
-3.  **Scalability**: During peak periods like holiday seasons, YOLO26 models can efficiently scale to handle increased package volumes without compromising performance or [accuracy](https://www.ultralytics.com/glossary/accuracy).
-
-4.  **Integration Capabilities**: YOLO26 can be easily integrated with existing warehouse management systems and deployed across various platforms using formats like [ONNX](../../integrations/onnx.md) or [TensorRT](../../integrations/tensorrt.md), facilitating end-to-end automated solutions.
+The dataset spans varied locations, environments, and package densities, so models trained on it see the range of real-world logistics scenes they need to generalize across. See the [segmentation task](../../tasks/segment.md) page for related workflows.
 
 ## Citations and Acknowledgments
 
@@ -134,30 +124,26 @@ If you integrate the Package Segmentation dataset into your research or developm
         }
         ```
 
-We express our gratitude to the creators of the Package Segmentation dataset for their contribution to the computer vision community. For further exploration of datasets and model training, consider visiting our [Ultralytics Datasets](../index.md) page and our guide on [model training tips](../../guides/model-training-tips.md).
+We express our gratitude to the creators of the Package Segmentation dataset for their contribution to the computer vision community. For more datasets, visit the [Ultralytics Datasets collection](../index.md) and our guide on [model training tips](../../guides/model-training-tips.md).
 
 ## FAQ
 
-### What is the Package Segmentation Dataset and how can it help in computer vision projects?
+### What is the Package Segmentation Dataset, and how is it used in Ultralytics YOLO26?
 
-- The Package Segmentation Dataset is a curated collection of images tailored for tasks involving package [image segmentation](https://www.ultralytics.com/glossary/image-segmentation). It includes diverse images of packages in various contexts, making it invaluable for training and evaluating segmentation models. This dataset is particularly useful for applications in logistics, warehouse automation, and any project requiring precise package analysis.
+The Package Segmentation Dataset is a collection of 2,197 annotated images of packages for training and evaluating [instance segmentation](../../tasks/segment.md) models on a single `package` class. It targets logistics and warehouse-automation applications like package identification, sorting, and quality control, and is used directly with Ultralytics [YOLO26](../../models/yolo26.md) via the `package-seg.yaml` configuration file.
+
+### How many images and classes does the Package Segmentation Dataset contain?
+
+The dataset totals 2,197 images — 1,920 for training, 188 for validation, and 89 for testing — all annotated for a single `package` class. The full archive downloads automatically as a ~103 MB `.zip` on first use.
 
 ### How do I train an Ultralytics YOLO26 model on the Package Segmentation Dataset?
 
-- You can train an [Ultralytics YOLO26](../../models/yolo26.md) model using both Python and CLI methods. Use the code snippets provided in the [Usage](#usage) section. Refer to the model [Training page](../../modes/train.md) for more details on arguments and configurations.
+Load a pretrained segmentation model (e.g., `yolo26n-seg.pt`) and train it with the `package-seg.yaml` configuration using the Python or CLI snippets in the [Usage](#usage) section above. See the [Training guide](../../modes/train.md) for the full list of available arguments.
 
-### What are the components of the Package Segmentation Dataset, and how is it structured?
+### Why use Ultralytics YOLO26 for package segmentation in logistics?
 
-- The dataset is structured into three main components:
-    - **Training set**: Contains 1920 images with annotations.
-    - **Testing set**: Comprises 188 images with corresponding annotations.
-    - **Validation set**: Includes 89 images with annotations.
-- This structure ensures a balanced dataset for thorough model training, validation, and testing, following best practices outlined in [model evaluation guides](../../guides/model-evaluation-insights.md).
+YOLO26 provides state-of-the-art [accuracy](https://www.ultralytics.com/glossary/accuracy) and real-time speed for [instance segmentation](../../tasks/segment.md), letting automated systems detect and sort packages reliably even in dim or cluttered warehouses — see the [Applications](#applications) section above. Trained models export to formats like [ONNX](../../integrations/onnx.md) and [TensorRT](../../integrations/tensorrt.md) for deployment across warehouse hardware.
 
-### Why should I use Ultralytics YOLO26 with the Package Segmentation Dataset?
+### Where can I find the dataset configuration file for Package Segmentation?
 
-- Ultralytics YOLO26 provides state-of-the-art [accuracy](https://www.ultralytics.com/glossary/accuracy) and speed for real-time [object detection](https://www.ultralytics.com/glossary/object-detection) and segmentation tasks. Using it with the Package Segmentation Dataset allows you to leverage YOLO26's capabilities for precise package segmentation, which is especially beneficial for industries like [logistics](https://www.ultralytics.com/blog/ultralytics-yolo11-the-key-to-computer-vision-in-logistics) and warehouse automation.
-
-### How can I access and use the package-seg.yaml file for the Package Segmentation Dataset?
-
-- The `package-seg.yaml` file is hosted on Ultralytics' GitHub repository and contains essential information about the dataset's paths, classes, and configuration. You can view or download it at <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/package-seg.yaml>. This file is crucial for configuring your models to utilize the dataset efficiently. For more insights and practical examples, explore our [Python Usage](../../usage/python.md) section.
+The `package-seg.yaml` file, which defines the dataset paths and the single `package` class, is located in the Ultralytics GitHub repository: [package-seg.yaml](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/package-seg.yaml).

--- a/ultralytics/cfg/datasets/carparts-seg.yaml
+++ b/ultralytics/cfg/datasets/carparts-seg.yaml
@@ -10,9 +10,9 @@
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: carparts-seg # dataset root dir
-train: images/train # train images (relative to 'path') 3516 images
-val: images/val # val images (relative to 'path') 276 images
-test: images/test # test images (relative to 'path') 401 images
+train: images/train # train images (relative to 'path') 3156 images
+val: images/val # val images (relative to 'path') 401 images
+test: images/test # test images (relative to 'path') 276 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/crack-seg.yaml
+++ b/ultralytics/cfg/datasets/crack-seg.yaml
@@ -11,8 +11,8 @@
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: crack-seg # dataset root dir
 train: images/train # train images (relative to 'path') 3717 images
-val: images/val # val images (relative to 'path') 112 images
-test: images/test # test images (relative to 'path') 200 images
+val: images/val # val images (relative to 'path') 200 images
+test: images/test # test images (relative to 'path') 112 images
 
 # Classes
 names:

--- a/ultralytics/cfg/datasets/package-seg.yaml
+++ b/ultralytics/cfg/datasets/package-seg.yaml
@@ -11,8 +11,8 @@
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: package-seg # dataset root dir
 train: images/train # train images (relative to 'path') 1920 images
-val: images/val # val images (relative to 'path') 89 images
-test: images/test # test images (relative to 'path') 188 images
+val: images/val # val images (relative to 'path') 188 images
+test: images/test # test images (relative to 'path') 89 images
 
 # Classes
 names:


### PR DESCRIPTION
## Summary

Refactors `docs/en/datasets/segment/` page by page. For each page, split counts, class counts, and download sizes are verified against the dataset's YAML (or a real download for small datasets), missing `title` frontmatter and download-size facts are added, and cross-links and FAQ content are improved.

Where a real download-and-count showed the YAML split-count comments no longer matched the archive, the comments are corrected in the same commit so the rendered `--8<--` YAML block agrees with the page prose (`crack-seg.yaml` val/test, `carparts-seg.yaml` train/val/test, `package-seg.yaml` val/test).

### Pages

- [x] coco128-seg.md
- [x] coco.md
- [x] coco8-seg.md
- [x] carparts-seg.md
- [x] crack-seg.md
- [x] package-seg.md


Deleted: stale split counts, duplicated FAQ/example content, and unsupported dataset claims.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Updated segmentation dataset documentation and configurations with corrected dataset splits, clearer metadata, download sizes, and improved YOLO26 and Ultralytics Platform guidance.

### 📊 Key Changes

- Added page titles and refreshed descriptions for Carparts-Seg, Crack-Seg, Package-Seg, COCO-Seg, COCO128-Seg, and COCO8-Seg.
- Corrected validation and test split assignments in:
  - Carparts-Seg: 3,156 train, 401 validation, 276 test.
  - Crack-Seg: 3,717 train, 200 validation, 112 test.
  - Package-Seg: 1,920 train, 188 validation, 89 test.
- Added dataset details such as class counts, image totals, label formats, and approximate download sizes.
- Clarified COCO-Seg coverage:
  - 118,287 training images and 5,000 validation images.
  - 80 classes with YOLO-format polygon masks.
  - Approximately 27 GB required for the full download.
  - Documented the Test-dev2017 subset and smaller COCO128-Seg and COCO8-Seg alternatives.
- Added an important warning that COCO128-Seg uses the same images for training and validation by default, so its validation metrics do not measure generalization.
- Improved COCO8-Seg and COCO128-Seg guidance for pipeline checks, debugging, and scaling experiments.
- Added links to browse and manage supported datasets on [Ultralytics Platform](https://platform.ultralytics.com/).
- Streamlined sample-data descriptions, FAQs, citations, and training guidance around Ultralytics [YOLO26](../../models/yolo26.md).

### 🎯 Purpose & Impact

- ✅ Prevents incorrect evaluation caused by outdated or reversed validation and test split documentation.
- 📈 Gives users more reliable information when selecting datasets, estimating storage needs, and planning training workflows.
- 🧪 Makes COCO8-Seg and COCO128-Seg more useful for fast sanity checks before committing to larger training runs.
- 🚗📦🏗️ Provides clearer context for automotive, logistics, infrastructure, and general-purpose segmentation applications.
- ☁️ Improves dataset discoverability and management through [Ultralytics Platform](https://platform.ultralytics.com/).
- 🔧 Aligns dataset documentation and YAML configurations so users can train and evaluate models with fewer setup errors.