### PR TITLE
Fix `DistillationModel` warmup for single-channel datasets

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -203,6 +203,25 @@ def test_distill_resume(tmp_path: Path):
     assert trainer.start_epoch == trainer.epoch == 1, "resume test failed"
 
 
+def test_distill_grayscale(tmp_path: Path):
+    """Test knowledge distillation on a single-channel dataset (https://github.com/ultralytics/ultralytics/issues/25066)."""
+    train_args = {
+        "data": "coco8-grayscale.yaml",
+        "imgsz": 32,
+        "epochs": 1,
+        "plots": False,
+        "val": False,
+        "workers": 0,
+        "project": tmp_path,
+        "exist_ok": True,
+    }
+    teacher = YOLO("yolo26n.yaml")
+    teacher.train(name="teacher", **train_args)
+    student = YOLO("yolo26n.yaml")
+    student.train(distill_model=teacher.trainer.last, name="student", **train_args)
+    assert isinstance(unwrap_model(student.trainer.model), DistillationModel)
+
+
 @pytest.mark.parametrize(
     "ckpt",
     [

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -16,7 +16,7 @@ from ultralytics.engine.exporter import Exporter
 from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models.yolo import classify, detect, obb, pose, segment, semantic
 from ultralytics.nn.distill_model import DistillationModel
-from ultralytics.nn.tasks import load_checkpoint
+from ultralytics.nn.tasks import DetectionModel, load_checkpoint
 from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR
 from ultralytics.utils.torch_utils import unwrap_model
 
@@ -203,23 +203,12 @@ def test_distill_resume(tmp_path: Path):
     assert trainer.start_epoch == trainer.epoch == 1, "resume test failed"
 
 
-def test_distill_grayscale(tmp_path: Path):
+def test_distill_grayscale():
     """Test knowledge distillation on a single-channel dataset (https://github.com/ultralytics/ultralytics/issues/25066)."""
-    train_args = {
-        "data": "coco8-grayscale.yaml",
-        "imgsz": 32,
-        "epochs": 1,
-        "plots": False,
-        "val": False,
-        "workers": 0,
-        "project": tmp_path,
-        "exist_ok": True,
-    }
-    teacher = YOLO("yolo26n.yaml")
-    teacher.train(name="teacher", **train_args)
-    student = YOLO("yolo26n.yaml")
-    student.train(distill_model=teacher.trainer.last, name="student", **train_args)
-    assert isinstance(unwrap_model(student.trainer.model), DistillationModel)
+    teacher = DetectionModel("yolo26n.yaml", ch=1, nc=80, verbose=False)
+    student = DetectionModel("yolo26n.yaml", ch=1, nc=80, verbose=False)
+    student.args = SimpleNamespace(imgsz=32, dis=1.0)
+    assert isinstance(DistillationModel(teacher_model=teacher, student_model=student), DistillationModel)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -203,12 +203,16 @@ def test_distill_resume(tmp_path: Path):
     assert trainer.start_epoch == trainer.epoch == 1, "resume test failed"
 
 
-def test_distill_grayscale():
+def test_distill_grayscale(tmp_path: Path):
     """Test knowledge distillation on a single-channel dataset (https://github.com/ultralytics/ultralytics/issues/25066)."""
-    teacher = DetectionModel("yolo26n.yaml", ch=1, nc=80, verbose=False)
+    teacher = DetectionModel("yolo26n.yaml", ch=3, nc=80, verbose=False)
+    teacher_path = tmp_path / "teacher.pt"
+    torch.save({"model": teacher}, teacher_path)
     student = DetectionModel("yolo26n.yaml", ch=1, nc=80, verbose=False)
     student.args = SimpleNamespace(imgsz=32, dis=1.0)
-    assert isinstance(DistillationModel(teacher_model=teacher, student_model=student), DistillationModel)
+    model = DistillationModel(teacher_model=teacher_path, student_model=student)
+    assert isinstance(model, DistillationModel)
+    assert model.teacher_model.yaml["channels"] == 1
 
 
 @pytest.mark.parametrize(

--- a/ultralytics/nn/distill_model.py
+++ b/ultralytics/nn/distill_model.py
@@ -84,10 +84,11 @@ class DistillationModel(nn.Module):
 
         # Get feature dimensions via dummy forward pass (hooks capture outputs)
         imgsz = student_model.args.imgsz
+        ch = student_model.yaml.get("channels", 3)
         student_model.eval()
         with torch.no_grad():
-            teacher_model(torch.zeros(2, 3, imgsz, imgsz).to(device))
-            student_model(torch.zeros(2, 3, imgsz, imgsz).to(device))
+            teacher_model(torch.zeros(2, ch, imgsz, imgsz).to(device))
+            student_model(torch.zeros(2, ch, imgsz, imgsz).to(device))
         student_model.train()
         teacher_output = [self._teacher_feats[idx] for idx in self.feats_idx]
         student_output = [self._student_feats[idx] for idx in self.feats_idx]

--- a/ultralytics/nn/distill_model.py
+++ b/ultralytics/nn/distill_model.py
@@ -67,8 +67,13 @@ class DistillationModel(nn.Module):
             student_model (nn.Module): Student model module to be trained.
         """
         super().__init__()
+        ch = student_model.yaml.get("channels", 3)
         if isinstance(teacher_model, (str, Path)):
             teacher_model = load_checkpoint(teacher_model)[0]
+            if teacher_model.yaml.get("channels", 3) != ch:
+                weights = teacher_model
+                teacher_model = type(weights)(weights.yaml.copy(), ch=ch, nc=weights.yaml["nc"], verbose=False)
+                teacher_model.load(weights)
         device = next(student_model.parameters()).device
         self.teacher_model = teacher_model.to(device)
         self._freeze_teacher()
@@ -84,11 +89,11 @@ class DistillationModel(nn.Module):
 
         # Get feature dimensions via dummy forward pass (hooks capture outputs)
         imgsz = student_model.args.imgsz
-        ch = student_model.yaml.get("channels", 3)
         student_model.eval()
         with torch.no_grad():
-            teacher_model(torch.zeros(2, ch, imgsz, imgsz).to(device))
-            student_model(torch.zeros(2, ch, imgsz, imgsz).to(device))
+            im = torch.zeros(2, ch, imgsz, imgsz, device=device)
+            teacher_model(im)
+            student_model(im)
         student_model.train()
         teacher_output = [self._teacher_feats[idx] for idx in self.feats_idx]
         student_output = [self._student_feats[idx] for idx in self.feats_idx]


### PR DESCRIPTION
The knowledge distillation warmup in `DistillationModel.__init__` hardcoded a 3-channel dummy input, so training with `distill_model` crashed on datasets with `channels: 1` or other non-RGB channel counts:

```text
RuntimeError: Given groups=1, weight of size [16, 1, 3, 3], expected input[2, 3, 64, 64] to have 1 channels, but got 3 channels instead
```

The fix reuses the student model's configured channel count, `student_model.yaml.get("channels", 3)`, which is already owned by dataset-driven model construction. Path-loaded teacher checkpoints with a different channel count are rebuilt for the student channel count and loaded through the existing model weight-transfer path, so RGB teacher checkpoints can distill grayscale students without a new `input_shape` argument or guard.

Fixes https://github.com/ultralytics/ultralytics/issues/25066

Added `test_distill_grayscale`, a direct regression that saves an RGB teacher checkpoint, wraps a single-channel student, and exercises the exact path-loaded teacher warmup path.

Deleted: the hardcoded 3-channel distillation warmup tensors and the training-based grayscale regression setup.
