### PR TITLE
Raise Edge TPU compiler failures instead of returning corrupt stub

### DIFF
--- a/ultralytics/utils/export/tensorflow.py
+++ b/ultralytics/utils/export/tensorflow.py
@@ -281,7 +281,7 @@ def tflite2edgetpu(tflite_file: str | Path, output_dir: str | Path, prefix: str 
         str(tflite_file),
     ]  # argv list avoids shell metacharacter issues in output_dir/tflite_file paths
     LOGGER.info(f"{prefix} running '{shlex.join(cmd)}'")
-    subprocess.run(cmd)
+    subprocess.run(cmd, check=True)
     return str(Path(output_dir) / f"{Path(tflite_file).stem}_edgetpu.tflite")
 
 


### PR DESCRIPTION
## Raise Edge TPU compiler failures instead of returning a corrupt stub

Found in a Sentry sweep of the Ultralytics Platform workers.

### Issues fixed

| Sentry issue | Project | Error | Link |
|---|---|---|---|
| ALPHA-D1 | alpha (`worker-cpu`) | `AssertionError: 0.001 MB output model too small (likely corrupt or unsupported ops)` | https://ultralytics.sentry.io/issues/7222365471/ |
| ALPHA-1PF | alpha (`worker-cpu`) | logger-level duplicate of the same failure (`Edge TPU: export failure 362.5s: ...`) | https://ultralytics.sentry.io/issues/7592196008/ |

### Root cause

`tflite2edgetpu()` ran `edgetpu_compiler` via `subprocess.run(cmd)` **without** `check=True` and unconditionally returned the expected `*_edgetpu.tflite` path. When the compiler fails (e.g. yolo26x-seg INT8 — 812 MB SavedModel fed to the EOL Coral compiler, 362 s of `--search_delegate` retries), its non-zero exit code and diagnostics were silently discarded, a ~1 KB stub file was returned, and the failure only surfaced via `try_export`'s downstream file-size assert with a misleading "corrupt or unsupported ops" message.

### Fix (replacement, net zero lines)

`subprocess.run(cmd)` → `subprocess.run(cmd, check=True)` — the lone unchecked subprocess call in the function; every other call already uses `check=True`. Compiler failures now raise `CalledProcessError` at the source (compiler output already streams to the log), which `try_export` catches and reports with the real diagnostic. Models that genuinely exceed Edge TPU capability still fail — correctly, with the compiler's actual error instead of a false "corrupt" guess.

### Verification

- `python3 -m py_compile` + `ruff check` + `ruff format --check`: clean
- Edge TPU export tests need Linux + the Coral compiler and were not runnable on this macOS host; the change matches the file's existing `check=True` pattern and only converts a silently-swallowed non-zero exit into a raised error

### Reviews

- Codex CLI adversarial review: **LGTM** (confirmed a usable compiled model implies exit 0, so `check=True` cannot reject good exports)

### Cross-references

Same sweep fixed portal (SAM WebSocket send-after-close: ALPHA-1PP/1PM) and hub-sdk (heartbeat thread death: ULTRALYTICS-1XXH/1XXG). PRs: ultralytics/portal#2719, ultralytics/hub-sdk#318. ALPHA-D1/ALPHA-1PF report to the `alpha` Sentry project via the Platform worker's logging integration but the owning code is this package — fixed once here.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Edge TPU export reliability by ensuring compiler failures are detected and reported properly 🚀

### 📊 Key Changes
- Updated the TensorFlow Lite to Edge TPU conversion step to run `subprocess.run(cmd, check=True)`.
- Ensures the Edge TPU compiler process raises an error if it exits unsuccessfully.
- Keeps the existing safer command handling that avoids shell-related path issues.

### 🎯 Purpose & Impact
- Helps users quickly identify failed Edge TPU exports instead of continuing silently ⚠️
- Improves debugging by surfacing compiler errors directly during export.
- Reduces risk of producing or referencing missing/invalid Edge TPU `.tflite` files.
- Makes export behavior more reliable for deploying Ultralytics models to Coral Edge TPU devices ✅