### PR TITLE
Fix ExecuTorch ARM torch compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ export-coreml = [
 ]
 export-executorch = [
     "executorch",
+    "torch>=2.12.0,<2.13.0; platform_system == 'Linux' and platform_machine == 'aarch64'",
     "numpy<=2.3.5",
 ]
 export-deepx = [

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -545,7 +545,9 @@ def check_executorch_requirements():
     if LINUX and ARM64 and IS_DOCKER:
         check_requirements("packaging>=22.0")
 
-    check_requirements("executorch", cmds=f"torch=={TORCH_VERSION.split('+')[0]}")
+    torch_requirement = ">=2.12.0,<2.13.0" if LINUX and ARM64 else f"=={TORCH_VERSION.split('+')[0]}"
+    check_requirements("executorch", cmds=f"torch{torch_requirement}")
+    check_version(TORCH_VERSION, torch_requirement, name="torch", hard=True)
 
 
 def check_tensorrt(min_version: str = "7.0.0"):

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -545,9 +545,7 @@ def check_executorch_requirements():
     if LINUX and ARM64 and IS_DOCKER:
         check_requirements("packaging>=22.0")
 
-    torch_requirement = ">=2.12.0,<2.13.0" if LINUX and ARM64 else f"=={TORCH_VERSION.split('+')[0]}"
-    check_requirements("executorch", cmds=f"torch{torch_requirement}")
-    check_version(TORCH_VERSION, torch_requirement, name="torch", hard=True)
+    check_requirements("executorch", cmds=f"torch=={TORCH_VERSION.split('+')[0]}")
 
 
 def check_tensorrt(min_version: str = "7.0.0"):


### PR DESCRIPTION
## Summary
- constrain the ExecuTorch optional extra to torch >=2.12,<2.13 on Linux ARM64

## Root cause
- The last green ARM benchmark run (28930061007, 2026-07-08 08:51 UTC) installed executorch==1.3.1 with torch==2.12.1+cpu and ExecuTorch inference passed.
- torch 2.13.0 and torchvision 0.28.0 CPython 3.13 Linux ARM64 wheels were published later today (2026-07-08 16:03-16:07 UTC).
- The failing ARM benchmark then resolved executorch==1.3.1 with torch==2.13.0+cpu and failed importing executorch.runtime with an undefined PyTorch C++ ABI symbol.
- ExecuTorch 1.3.1 metadata currently allows torch>=2.12.0a0, so Ultralytics must declare the narrower Linux ARM64 compatibility boundary for the ExecuTorch extra.

## Delete > Replace > Add
- Delete: removed the extra runtime-check changes from the first PR version; the effective diff is one dependency line.
- Replace: replace the previously unbounded Linux ARM64 torch resolution with the last known working ExecuTorch-compatible torch range.
- Add: one platform-specific dependency constraint in pyproject.toml.

This bugfix is net-positive by one line because the broken behavior is caused by missing dependency metadata, not removable local code.

## Tests
- uv pip compile pyproject.toml --extra export-executorch --torch-backend cpu --python-version 3.13 --python-platform aarch64-manylinux_2_28 --no-header --no-annotate
  - resolves torch==2.12.1+cpu / torchvision==0.27.1+cpu
- uv pip compile pyproject.toml --extra export-executorch --torch-backend cpu --python-version 3.13 --python-platform x86_64-manylinux_2_28 --no-header --no-annotate
  - resolves torch==2.13.0+cpu / torchvision==0.28.0+cpu
- Prior head 2f76b43cb5 passed Benchmarks (ubuntu-24.04-arm, 3.13, yolo26n); current head keeps the same pyproject resolver fix and removes only the extra runtime-check changes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a Linux ARM64-specific PyTorch dependency for ExecuTorch exports to improve compatibility on aarch64 systems 🚀

### 📊 Key Changes
- Added `torch>=2.12.0,<2.13.0` to the `export-executorch` optional dependency group ⚙️
- Scoped the new PyTorch requirement to `Linux` on `aarch64` only, avoiding changes for other platforms 🧩
- Kept existing ExecuTorch export dependencies, including `executorch` and `numpy<=2.3.5` ✅

### 🎯 Purpose & Impact
- Improves out-of-the-box setup for users exporting YOLO models to ExecuTorch on ARM64 Linux devices 💻
- Reduces dependency conflicts by applying the PyTorch version constraint only where needed 🎯
- Helps ensure a more reliable export workflow for edge and embedded deployment scenarios using Ultralytics models 📦