### PR TITLE
Reject None for typed CLI defaults

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -19,6 +19,7 @@ from PIL import Image
 import ultralytics.data.build as data_build
 from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
 from ultralytics import RTDETR, YOLO
+from ultralytics.cfg import get_cfg
 from ultralytics.data.build import build_dataloader, load_inference_source
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.utils import (
@@ -79,6 +80,107 @@ def test_dataloader_empty_dataset_uses_dataloader_validation():
     """Test empty datasets fail through DataLoader validation instead of worker-cap math."""
     with pytest.raises(ValueError, match="positive integer"):
         build_dataloader([], batch=4, workers=2)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"box": None},
+        {"close_mosaic": None},
+        {"cls_pw": None},
+        {"copy_paste_mode": None},
+        {"degrees": None},
+        {"fraction": None},
+        {"hsv_s": None},
+        {"iou": None},
+        {"lrf": None},
+        {"max_det": None},
+        {"mixup": None},
+        {"mosaic": None},
+        {"multi_scale": None},
+        {"nbs": None},
+        {"optimizer": None},
+        {"save_json": None},
+        {"save_period": None},
+        {"seed": None},
+        {"split": None},
+    ],
+)
+def test_cfg_rejects_required_none(overrides):
+    """Required config values should fail before None reaches runtime code."""
+    with pytest.raises(TypeError, match=next(iter(overrides))):
+        get_cfg(overrides=overrides)
+
+
+@pytest.mark.parametrize(
+    "key", ["auto_augment", "compile", "conf", "end2end", "line_width", "quantize", "time", "workspace"]
+)
+def test_cfg_accepts_optional_none(key):
+    """Optional config values keep accepting None."""
+    assert getattr(get_cfg(overrides={key: None}), key) is None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"auto_augment": "invalid"},
+        {"cache": "gpu"},
+        {"cache": 1.5},
+        {"compile": {}},
+        {"compile": "max-autotune"},
+        {"copy_paste_mode": {}},
+        {"optimizer": [1, 2]},
+        {"split": {}},
+        {"split": 0.5},
+        {"split": "trainval"},
+    ],
+)
+def test_cfg_rejects_invalid_option_values(overrides):
+    """String-like config options should validate at the cfg layer."""
+    with pytest.raises((TypeError, ValueError), match=next(iter(overrides))):
+        get_cfg(overrides=overrides)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"cls_pw": -5},
+        {"cls_pw": 10},
+        {"dis": -5},
+        {"dis": float("inf")},
+        {"mask_ratio": 0},
+        {"max_det": -1},
+        {"max_det": 0},
+        {"nbs": 0},
+        {"seed": -1},
+        {"shear": -5},
+        {"vid_stride": -1},
+    ],
+)
+def test_cfg_rejects_invalid_numeric_ranges(overrides):
+    """Numerically bounded config values should fail before runtime use."""
+    with pytest.raises(ValueError, match=next(iter(overrides))):
+        get_cfg(overrides=overrides)
+
+
+def test_cfg_accepts_valid_option_values():
+    """Valid option values should continue passing through config validation."""
+    args = get_cfg(
+        overrides={
+            "auto_augment": "augmix",
+            "cache": "ram",
+            "compile": "reduce-overhead",
+            "copy_paste_mode": "mixup",
+            "optimizer": "SGD",
+            "split": "test",
+        }
+    )
+    assert args.auto_augment == "augmix"
+    assert args.cache == "ram"
+    assert args.compile == "reduce-overhead"
+    assert args.copy_paste_mode == "mixup"
+    assert args.optimizer == "SGD"
+    assert args.split == "test"
 
 
 def skip_rpi_semantic():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -82,105 +82,12 @@ def test_dataloader_empty_dataset_uses_dataloader_validation():
         build_dataloader([], batch=4, workers=2)
 
 
-@pytest.mark.parametrize(
-    "overrides",
-    [
-        {"box": None},
-        {"close_mosaic": None},
-        {"cls_pw": None},
-        {"copy_paste_mode": None},
-        {"degrees": None},
-        {"fraction": None},
-        {"hsv_s": None},
-        {"iou": None},
-        {"lrf": None},
-        {"max_det": None},
-        {"mixup": None},
-        {"mosaic": None},
-        {"multi_scale": None},
-        {"nbs": None},
-        {"optimizer": None},
-        {"save_json": None},
-        {"save_period": None},
-        {"seed": None},
-        {"split": None},
-    ],
-)
-def test_cfg_rejects_required_none(overrides):
-    """Required config values should fail before None reaches runtime code."""
-    with pytest.raises(TypeError, match=next(iter(overrides))):
-        get_cfg(overrides=overrides)
-
-
-@pytest.mark.parametrize(
-    "key", ["auto_augment", "compile", "conf", "end2end", "line_width", "quantize", "time", "workspace"]
-)
-def test_cfg_accepts_optional_none(key):
-    """Optional config values keep accepting None."""
-    assert getattr(get_cfg(overrides={key: None}), key) is None
-
-
-@pytest.mark.parametrize(
-    "overrides",
-    [
-        {"auto_augment": "invalid"},
-        {"cache": "gpu"},
-        {"cache": 1.5},
-        {"compile": {}},
-        {"compile": "max-autotune"},
-        {"copy_paste_mode": {}},
-        {"optimizer": [1, 2]},
-        {"split": {}},
-        {"split": 0.5},
-        {"split": "trainval"},
-    ],
-)
-def test_cfg_rejects_invalid_option_values(overrides):
-    """String-like config options should validate at the cfg layer."""
-    with pytest.raises((TypeError, ValueError), match=next(iter(overrides))):
-        get_cfg(overrides=overrides)
-
-
-@pytest.mark.parametrize(
-    "overrides",
-    [
-        {"cls_pw": -5},
-        {"cls_pw": 10},
-        {"dis": -5},
-        {"dis": float("inf")},
-        {"mask_ratio": 0},
-        {"max_det": -1},
-        {"max_det": 0},
-        {"nbs": 0},
-        {"seed": -1},
-        {"shear": -5},
-        {"vid_stride": -1},
-    ],
-)
-def test_cfg_rejects_invalid_numeric_ranges(overrides):
-    """Numerically bounded config values should fail before runtime use."""
-    with pytest.raises(ValueError, match=next(iter(overrides))):
-        get_cfg(overrides=overrides)
-
-
-def test_cfg_accepts_valid_option_values():
-    """Valid option values should continue passing through config validation."""
-    args = get_cfg(
-        overrides={
-            "auto_augment": "augmix",
-            "cache": "ram",
-            "compile": "reduce-overhead",
-            "copy_paste_mode": "mixup",
-            "optimizer": "SGD",
-            "split": "test",
-        }
-    )
-    assert args.auto_augment == "augmix"
-    assert args.cache == "ram"
-    assert args.compile == "reduce-overhead"
-    assert args.copy_paste_mode == "mixup"
-    assert args.optimizer == "SGD"
-    assert args.split == "test"
+def test_cfg_rejects_fuzzed_scalars():
+    """Test invalid scalar overrides fail in config validation."""
+    with pytest.raises(TypeError, match="degrees"):
+        get_cfg(overrides={"degrees": None})
+    with pytest.raises(ValueError, match="cls_pw"):
+        get_cfg(overrides={"cls_pw": 10})
 
 
 def skip_rpi_semantic():

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import math
 import os
 import shutil
 import subprocess
@@ -198,7 +199,6 @@ CFG_FLOAT_KEYS = frozenset(
         "warmup_epochs",
         "box",
         "cls",
-        "cls_pw",
         "dfl",
         "dis",
         "degrees",
@@ -213,6 +213,7 @@ CFG_FRACTION_KEYS = frozenset(
         "dropout",
         "lr0",
         "lrf",
+        "cls_pw",
         "momentum",
         "weight_decay",
         "warmup_momentum",
@@ -285,6 +286,23 @@ CFG_BOOL_KEYS = frozenset(
         "end2end",
         "cls_remap",
     }
+)
+CFG_OPTION_KEYS = {
+    "auto_augment": {"randaugment", "autoaugment", "augmix"},
+    "copy_paste_mode": {"flip", "mixup"},
+    "optimizer": {"SGD", "MuSGD", "Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "auto"},
+    "split": {"train", "val", "test"},
+}
+CFG_CACHE_VALUES = {"ram", "disk"}
+CFG_COMPILE_VALUES = {"default", "reduce-overhead", "max-autotune-no-cudagraphs"}
+CFG_NON_NEGATIVE_KEYS = frozenset({"degrees", "dis", "seed", "shear"})
+CFG_POSITIVE_KEYS = frozenset({"mask_ratio", "max_det", "nbs", "vid_stride"})
+CFG_TYPED_KEYS = CFG_FLOAT_KEYS | CFG_FRACTION_KEYS | CFG_INT_KEYS | CFG_BOOL_KEYS | {"scale"}
+CFG_OPTIONAL_KEYS = frozenset({"auto_augment"})
+CFG_REQUIRED_KEYS = frozenset(
+    k
+    for k in CFG_TYPED_KEYS | CFG_OPTION_KEYS.keys()
+    if k not in CFG_OPTIONAL_KEYS and DEFAULT_CFG_DICT.get(k) is not None
 )
 
 
@@ -393,70 +411,93 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
 
     Notes:
         - The function modifies the input dictionary in-place.
-        - None values are ignored as they may be from optional arguments.
+        - None values are accepted only for optional arguments.
         - Fraction keys are checked to be within the range [0.0, 1.0].
     """
     for k, v in cfg.items():
-        if v is not None:  # None values may be from optional args
-            if k in CFG_FLOAT_KEYS and not isinstance(v, FLOAT_OR_INT):
+        if v is None:
+            if k in CFG_REQUIRED_KEYS and hard:
+                raise TypeError(f"'{k}=None' is invalid. '{k}' must not be None.")
+            continue
+        if k in CFG_FLOAT_KEYS:
+            if not isinstance(v, FLOAT_OR_INT):
                 if hard:
                     raise TypeError(
                         f"'{k}={v}' is of invalid type {type(v).__name__}. "
                         f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
                     )
                 cfg[k] = float(v)
-            elif k == "scale":
-                if isinstance(v, (list, tuple)):
-                    if len(v) != 2 or not all(isinstance(x, (int, float)) for x in v):
-                        if hard:
-                            raise TypeError(
-                                f"'{k}={v}' is of invalid type {type(v).__name__}. "
-                                f"Valid '{k}' types are int, float, or a tuple/list of two floats (i.e. '{k}=(0.5, 2.0)')"
-                            )
-                        continue
+            if not math.isfinite(float(cfg[k])):
+                raise ValueError(f"'{k}={cfg[k]}' is invalid. '{k}' must be a finite number.")
+        elif k == "scale":
+            if isinstance(v, (list, tuple)):
+                if len(v) != 2 or not all(isinstance(x, (int, float)) for x in v):
+                    if hard:
+                        raise TypeError(
+                            f"'{k}={v}' is of invalid type {type(v).__name__}. "
+                            f"Valid '{k}' types are int, float, or a tuple/list of two floats (i.e. '{k}=(0.5, 2.0)')"
+                        )
                     continue
-                elif not isinstance(v, FLOAT_OR_INT):
-                    if hard:
-                        raise TypeError(
-                            f"'{k}={v}' is of invalid type {type(v).__name__}. "
-                            f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
-                        )
-                    cfg[k] = v = float(v)
-                if not (0.0 <= v <= 1.0):
-                    raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
-            elif k in CFG_FRACTION_KEYS:
-                if not isinstance(v, FLOAT_OR_INT):
-                    if hard:
-                        raise TypeError(
-                            f"'{k}={v}' is of invalid type {type(v).__name__}. "
-                            f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
-                        )
-                    cfg[k] = v = float(v)
-                if not (0.0 <= v <= 1.0):
-                    raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
-            elif k in CFG_INT_KEYS and not isinstance(v, int):
-                if hard:
-                    raise TypeError(
-                        f"'{k}={v}' is of invalid type {type(v).__name__}. '{k}' must be an int (i.e. '{k}=8')"
-                    )
-                cfg[k] = int(v)
-            elif k in CFG_BOOL_KEYS and not isinstance(v, bool):
+                if not all(math.isfinite(float(x)) for x in v):
+                    raise ValueError(f"'{k}={v}' is invalid. '{k}' values must be finite numbers.")
+                continue
+            elif not isinstance(v, FLOAT_OR_INT):
                 if hard:
                     raise TypeError(
                         f"'{k}={v}' is of invalid type {type(v).__name__}. "
-                        f"'{k}' must be a bool (i.e. '{k}=True' or '{k}=False')"
+                        f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
                     )
-                cfg[k] = bool(v)
-            elif k == "quantize":  # canonicalize 8/16/32 or w-notation to a scheme (unset stays None for FP32)
-                scheme = QUANTIZE_ALIASES.get(str(v).lower())
-                if scheme is None:
-                    if hard:
-                        raise ValueError(
-                            f"'{k}={v}' is invalid. Valid '{k}' values are {QUANTIZE_VALID_VALUES}. "
-                            f"See {QUANTIZE_DOCS_URL}"
-                        )
-                else:
-                    cfg[k] = scheme
+                cfg[k] = v = float(v)
+            if not math.isfinite(float(v)):
+                raise ValueError(f"'{k}={v}' is invalid. '{k}' must be a finite number.")
+            if not (0.0 <= v <= 1.0):
+                raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
+        elif k in CFG_FRACTION_KEYS:
+            if not isinstance(v, FLOAT_OR_INT):
+                if hard:
+                    raise TypeError(
+                        f"'{k}={v}' is of invalid type {type(v).__name__}. "
+                        f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
+                    )
+                cfg[k] = v = float(v)
+            if not (0.0 <= v <= 1.0):
+                raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
+        elif k in CFG_INT_KEYS and not isinstance(v, int):
+            if hard:
+                raise TypeError(f"'{k}={v}' is of invalid type {type(v).__name__}. '{k}' must be an int (i.e. '{k}=8')")
+            cfg[k] = int(v)
+        elif k in CFG_BOOL_KEYS and not isinstance(v, bool):
+            if hard:
+                raise TypeError(
+                    f"'{k}={v}' is of invalid type {type(v).__name__}. "
+                    f"'{k}' must be a bool (i.e. '{k}=True' or '{k}=False')"
+                )
+            cfg[k] = bool(v)
+        elif k == "quantize":  # canonicalize 8/16/32 or w-notation to a scheme (unset stays None for FP32)
+            scheme = QUANTIZE_ALIASES.get(str(v).lower())
+            if scheme is None:
+                if hard:
+                    raise ValueError(
+                        f"'{k}={v}' is invalid. Valid '{k}' values are {QUANTIZE_VALID_VALUES}. See {QUANTIZE_DOCS_URL}"
+                    )
+            else:
+                cfg[k] = scheme
+        elif k == "cache":
+            if not isinstance(v, bool) and (not isinstance(v, str) or v.lower() not in CFG_CACHE_VALUES):
+                raise TypeError(f"'{k}={v}' is invalid. '{k}' must be a bool or one of {sorted(CFG_CACHE_VALUES)}.")
+        elif k == "compile":
+            if not isinstance(v, bool) and (not isinstance(v, str) or v not in CFG_COMPILE_VALUES):
+                raise TypeError(f"'{k}={v}' is invalid. '{k}' must be a bool or one of {sorted(CFG_COMPILE_VALUES)}.")
+        elif k in CFG_OPTION_KEYS:
+            options = CFG_OPTION_KEYS[k]
+            value = v if k != "optimizer" or not isinstance(v, str) else v.lower()
+            valid = {x.lower() for x in options} if k == "optimizer" else options
+            if not isinstance(v, str) or value not in valid:
+                raise ValueError(f"'{k}={v}' is invalid. Valid '{k}' values are {sorted(options)}.")
+        if k in CFG_NON_NEGATIVE_KEYS and cfg[k] < 0:
+            raise ValueError(f"'{k}={cfg[k]}' is invalid. '{k}' must be greater than or equal to 0.")
+        if k in CFG_POSITIVE_KEYS and cfg[k] <= 0:
+            raise ValueError(f"'{k}={cfg[k]}' is invalid. '{k}' must be greater than 0.")
 
 
 def get_save_dir(args: SimpleNamespace, name: str | None = None) -> Path:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import ast
-import math
 import os
 import shutil
 import subprocess
@@ -287,23 +286,6 @@ CFG_BOOL_KEYS = frozenset(
         "cls_remap",
     }
 )
-CFG_OPTION_KEYS = {
-    "auto_augment": {"randaugment", "autoaugment", "augmix"},
-    "copy_paste_mode": {"flip", "mixup"},
-    "optimizer": {"SGD", "MuSGD", "Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "auto"},
-    "split": {"train", "val", "test"},
-}
-CFG_CACHE_VALUES = {"ram", "disk"}
-CFG_COMPILE_VALUES = {"default", "reduce-overhead", "max-autotune-no-cudagraphs"}
-CFG_NON_NEGATIVE_KEYS = frozenset({"degrees", "dis", "seed", "shear"})
-CFG_POSITIVE_KEYS = frozenset({"mask_ratio", "max_det", "nbs", "vid_stride"})
-CFG_TYPED_KEYS = CFG_FLOAT_KEYS | CFG_FRACTION_KEYS | CFG_INT_KEYS | CFG_BOOL_KEYS | {"scale"}
-CFG_OPTIONAL_KEYS = frozenset({"auto_augment"})
-CFG_REQUIRED_KEYS = frozenset(
-    k
-    for k in CFG_TYPED_KEYS | CFG_OPTION_KEYS.keys()
-    if k not in CFG_OPTIONAL_KEYS and DEFAULT_CFG_DICT.get(k) is not None
-)
 
 
 def cfg2dict(cfg: str | Path | dict | SimpleNamespace) -> dict:
@@ -411,93 +393,73 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
 
     Notes:
         - The function modifies the input dictionary in-place.
-        - None values are accepted only for optional arguments.
+        - None values are ignored as they may be from optional arguments.
         - Fraction keys are checked to be within the range [0.0, 1.0].
     """
+    typed_keys = CFG_FLOAT_KEYS | CFG_FRACTION_KEYS | CFG_INT_KEYS | CFG_BOOL_KEYS | {"scale"}
     for k, v in cfg.items():
-        if v is None:
-            if k in CFG_REQUIRED_KEYS and hard:
-                raise TypeError(f"'{k}=None' is invalid. '{k}' must not be None.")
-            continue
-        if k in CFG_FLOAT_KEYS:
-            if not isinstance(v, FLOAT_OR_INT):
+        if v is None and DEFAULT_CFG_DICT.get(k) is not None and k in typed_keys:
+            raise TypeError(f"'{k}=None' is invalid. '{k}' must not be None.")
+        if v is not None:  # None values may be from optional args
+            if k in CFG_FLOAT_KEYS and not isinstance(v, FLOAT_OR_INT):
                 if hard:
                     raise TypeError(
                         f"'{k}={v}' is of invalid type {type(v).__name__}. "
                         f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
                     )
                 cfg[k] = float(v)
-            if not math.isfinite(float(cfg[k])):
-                raise ValueError(f"'{k}={cfg[k]}' is invalid. '{k}' must be a finite number.")
-        elif k == "scale":
-            if isinstance(v, (list, tuple)):
-                if len(v) != 2 or not all(isinstance(x, (int, float)) for x in v):
+            elif k == "scale":
+                if isinstance(v, (list, tuple)):
+                    if len(v) != 2 or not all(isinstance(x, (int, float)) for x in v):
+                        if hard:
+                            raise TypeError(
+                                f"'{k}={v}' is of invalid type {type(v).__name__}. "
+                                f"Valid '{k}' types are int, float, or a tuple/list of two floats (i.e. '{k}=(0.5, 2.0)')"
+                            )
+                        continue
+                    continue
+                elif not isinstance(v, FLOAT_OR_INT):
                     if hard:
                         raise TypeError(
                             f"'{k}={v}' is of invalid type {type(v).__name__}. "
-                            f"Valid '{k}' types are int, float, or a tuple/list of two floats (i.e. '{k}=(0.5, 2.0)')"
+                            f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
                         )
-                    continue
-                if not all(math.isfinite(float(x)) for x in v):
-                    raise ValueError(f"'{k}={v}' is invalid. '{k}' values must be finite numbers.")
-                continue
-            elif not isinstance(v, FLOAT_OR_INT):
+                    cfg[k] = v = float(v)
+                if not (0.0 <= v <= 1.0):
+                    raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
+            elif k in CFG_FRACTION_KEYS:
+                if not isinstance(v, FLOAT_OR_INT):
+                    if hard:
+                        raise TypeError(
+                            f"'{k}={v}' is of invalid type {type(v).__name__}. "
+                            f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
+                        )
+                    cfg[k] = v = float(v)
+                if not (0.0 <= v <= 1.0):
+                    raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
+            elif k in CFG_INT_KEYS and not isinstance(v, int):
+                if hard:
+                    raise TypeError(
+                        f"'{k}={v}' is of invalid type {type(v).__name__}. '{k}' must be an int (i.e. '{k}=8')"
+                    )
+                cfg[k] = int(v)
+            elif k in CFG_BOOL_KEYS and not isinstance(v, bool):
                 if hard:
                     raise TypeError(
                         f"'{k}={v}' is of invalid type {type(v).__name__}. "
-                        f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
+                        f"'{k}' must be a bool (i.e. '{k}=True' or '{k}=False')"
                     )
-                cfg[k] = v = float(v)
-            if not math.isfinite(float(v)):
-                raise ValueError(f"'{k}={v}' is invalid. '{k}' must be a finite number.")
-            if not (0.0 <= v <= 1.0):
-                raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
-        elif k in CFG_FRACTION_KEYS:
-            if not isinstance(v, FLOAT_OR_INT):
-                if hard:
-                    raise TypeError(
-                        f"'{k}={v}' is of invalid type {type(v).__name__}. "
-                        f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
-                    )
-                cfg[k] = v = float(v)
-            if not (0.0 <= v <= 1.0):
-                raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
-        elif k in CFG_INT_KEYS and not isinstance(v, int):
-            if hard:
-                raise TypeError(f"'{k}={v}' is of invalid type {type(v).__name__}. '{k}' must be an int (i.e. '{k}=8')")
-            cfg[k] = int(v)
-        elif k in CFG_BOOL_KEYS and not isinstance(v, bool):
-            if hard:
-                raise TypeError(
-                    f"'{k}={v}' is of invalid type {type(v).__name__}. "
-                    f"'{k}' must be a bool (i.e. '{k}=True' or '{k}=False')"
-                )
-            cfg[k] = bool(v)
-        elif k == "quantize":  # canonicalize 8/16/32 or w-notation to a scheme (unset stays None for FP32)
-            scheme = QUANTIZE_ALIASES.get(str(v).lower())
-            if scheme is None:
-                if hard:
-                    raise ValueError(
-                        f"'{k}={v}' is invalid. Valid '{k}' values are {QUANTIZE_VALID_VALUES}. See {QUANTIZE_DOCS_URL}"
-                    )
-            else:
-                cfg[k] = scheme
-        elif k == "cache":
-            if not isinstance(v, bool) and (not isinstance(v, str) or v.lower() not in CFG_CACHE_VALUES):
-                raise TypeError(f"'{k}={v}' is invalid. '{k}' must be a bool or one of {sorted(CFG_CACHE_VALUES)}.")
-        elif k == "compile":
-            if not isinstance(v, bool) and (not isinstance(v, str) or v not in CFG_COMPILE_VALUES):
-                raise TypeError(f"'{k}={v}' is invalid. '{k}' must be a bool or one of {sorted(CFG_COMPILE_VALUES)}.")
-        elif k in CFG_OPTION_KEYS:
-            options = CFG_OPTION_KEYS[k]
-            value = v if k != "optimizer" or not isinstance(v, str) else v.lower()
-            valid = {x.lower() for x in options} if k == "optimizer" else options
-            if not isinstance(v, str) or value not in valid:
-                raise ValueError(f"'{k}={v}' is invalid. Valid '{k}' values are {sorted(options)}.")
-        if k in CFG_NON_NEGATIVE_KEYS and cfg[k] < 0:
-            raise ValueError(f"'{k}={cfg[k]}' is invalid. '{k}' must be greater than or equal to 0.")
-        if k in CFG_POSITIVE_KEYS and cfg[k] <= 0:
-            raise ValueError(f"'{k}={cfg[k]}' is invalid. '{k}' must be greater than 0.")
+                cfg[k] = bool(v)
+            elif k == "quantize":  # canonicalize 8/16/32 or w-notation to a scheme (unset stays None for FP32)
+                scheme = QUANTIZE_ALIASES.get(str(v).lower())
+                if scheme is None:
+                    if hard:
+                        raise ValueError(
+                            f"'{k}={v}' is invalid. Valid '{k}' values are {QUANTIZE_VALID_VALUES}. "
+                            f"See {QUANTIZE_DOCS_URL}"
+                        )
+                else:
+                    cfg[k] = scheme
 
 
 def get_save_dir(args: SimpleNamespace, name: str | None = None) -> Path:


### PR DESCRIPTION
## Summary
- reject `None` when it overwrites a typed non-optional default in `check_cfg()`
- move `cls_pw` into the existing fraction-key validation bucket
- add one focused regression test for the fuzzed scalar path

Deleted: `cls_pw` from the unbounded `CFG_FLOAT_KEYS` bucket.

Justification: the net-new line count is the minimum central cfg ownership check needed to stop CLI `arg=none` from replacing typed defaults before runtime code sees them.

## Tests
- `ruff format ultralytics/cfg/__init__.py tests/test_python.py && ruff check ultralytics/cfg/__init__.py tests/test_python.py && pytest tests/test_python.py::test_cfg_rejects_fuzzed_scalars -q`

Refs #25056

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves configuration validation to reject invalid scalar overrides more safely, with new tests to prevent regressions. ✅

### 📊 Key Changes
- Added stricter validation in `check_cfg()` to reject `None` values for typed config keys when a default value exists.
- Introduced a `typed_keys` group covering float, fraction, integer, boolean, and `scale` config fields.
- Ensured invalid overrides like `degrees=None` now raise a clear `TypeError`.
- Updated config key grouping so `cls_pw` is validated as a fraction-type value.
- Added tests in `tests/test_python.py` to verify fuzzed/invalid scalar values are correctly rejected.

### 🎯 Purpose & Impact
- Prevents silent acceptance of invalid configuration values that could cause confusing behavior later in training or inference. 🛡️
- Provides clearer error messages when users pass unsupported config overrides.
- Improves robustness against malformed inputs, including fuzzed or accidental bad values.
- Helps maintain reliable YOLO training behavior by validating important hyperparameters earlier. 🚀