### PR TITLE
Skip OpenVINO inference on Windows CI

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -196,17 +196,17 @@ def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
 
 
 @pytest.mark.skipif(not TORCH_2_1, reason="OpenVINO requires torch>=2.1")
-@pytest.mark.skipif(WINDOWS, reason="OpenVINO inference intermittently crashes GitHub Windows runners")
 @pytest.mark.parametrize("end2end", [False, True])
 def test_export_openvino(end2end, isolated_model):
     """Test YOLO export to OpenVINO format for model inference compatibility."""
     file = YOLO(isolated_model).export(format="openvino", imgsz=32, end2end=end2end)
+    if WINDOWS:
+        pytest.skip("OpenVINO inference intermittently crashes GitHub Windows runners")
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_2_1, reason="OpenVINO requires torch>=2.1")
-@pytest.mark.skipif(WINDOWS, reason="OpenVINO inference intermittently crashes GitHub Windows runners")
 @pytest.mark.parametrize(
     "task, dynamic, quantize, batch, nms, end2end",
     [  # generate all combinations except for exclusion cases
@@ -231,6 +231,8 @@ def test_export_openvino_matrix(task, dynamic, quantize, batch, nms, end2end):
         nms=nms,
         end2end=end2end,
     )
+    if WINDOWS:
+        pytest.skip("OpenVINO inference intermittently crashes GitHub Windows runners")
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch)  # exported model inference
     shutil.rmtree(file, ignore_errors=True)  # retry in case of potential lingering multi-threaded file usage errors
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -5,7 +5,6 @@ import shutil
 import sys
 import threading
 import time
-import uuid
 from contextlib import redirect_stderr, redirect_stdout
 from itertools import product
 from pathlib import Path
@@ -197,19 +196,17 @@ def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
 
 
 @pytest.mark.skipif(not TORCH_2_1, reason="OpenVINO requires torch>=2.1")
+@pytest.mark.skipif(WINDOWS, reason="OpenVINO inference intermittently crashes GitHub Windows runners")
 @pytest.mark.parametrize("end2end", [False, True])
 def test_export_openvino(end2end, isolated_model):
     """Test YOLO export to OpenVINO format for model inference compatibility."""
     file = YOLO(isolated_model).export(format="openvino", imgsz=32, end2end=end2end)
-    if WINDOWS:
-        # Ensure a unique export path per test to prevent OpenVINO file writes
-        file = Path(file)
-        file = file.rename(file.with_stem(f"{file.stem}-{uuid.uuid4()}"))
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not TORCH_2_1, reason="OpenVINO requires torch>=2.1")
+@pytest.mark.skipif(WINDOWS, reason="OpenVINO inference intermittently crashes GitHub Windows runners")
 @pytest.mark.parametrize(
     "task, dynamic, quantize, batch, nms, end2end",
     [  # generate all combinations except for exclusion cases
@@ -234,10 +231,6 @@ def test_export_openvino_matrix(task, dynamic, quantize, batch, nms, end2end):
         nms=nms,
         end2end=end2end,
     )
-    if WINDOWS:
-        # Use unique filenames due to Windows file permissions bug possibly due to latent threaded use
-        file = Path(file)
-        file = file.rename(file.with_stem(f"{file.stem}-{uuid.uuid4()}"))
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch)  # exported model inference
     shutil.rmtree(file, ignore_errors=True)  # retry in case of potential lingering multi-threaded file usage errors
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -232,6 +232,7 @@ def test_export_openvino_matrix(task, dynamic, quantize, batch, nms, end2end):
         end2end=end2end,
     )
     if WINDOWS:
+        shutil.rmtree(file, ignore_errors=True)
         pytest.skip("OpenVINO inference intermittently crashes GitHub Windows runners")
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch)  # exported model inference
     shutil.rmtree(file, ignore_errors=True)  # retry in case of potential lingering multi-threaded file usage errors


### PR DESCRIPTION
## Summary
- keep Windows OpenVINO export coverage but skip the native OpenVINO inference call after export succeeds on Windows runners
- avoid the hosted Windows `openvino._ov_api` `0xc000001d` crash that can kill xdist workers and time out the job
- keep OpenVINO export/inference coverage on Linux and macOS, where adjacent CI runs pass with `openvino==2026.2.1`

Deleted: Windows-specific OpenVINO export directory rename workaround and unused `uuid` import.

## Tests
- `ruff format tests/test_exports.py && ruff check tests/test_exports.py`
- `pytest --collect-only -q tests/test_exports.py --export-env base`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR disables OpenVINO inference tests on Windows CI to avoid intermittent crashes on GitHub runners 🪟⚠️

### 📊 Key Changes
- Removed the `uuid` import and the previous workaround that renamed OpenVINO export folders with unique names.
- Updated `test_export_openvino` to skip OpenVINO inference on Windows instead of attempting to run it.
- Updated `test_export_openvino_matrix` to clean up exported files with `shutil.rmtree()` before skipping on Windows.
- Added clear skip messages explaining that OpenVINO inference intermittently crashes GitHub Windows runners.

### 🎯 Purpose & Impact
- Improves CI reliability by avoiding known unstable OpenVINO inference runs on Windows ✅
- Reduces flaky test failures that are unrelated to Ultralytics code quality or model export functionality.
- Keeps OpenVINO export testing active on other platforms while isolating the Windows-specific instability.
- Simplifies the test logic by removing the filename-renaming workaround that did not fully resolve the issue.