### PR TITLE
Keep Windows OpenVINO inference tests

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,6 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import io
+import os
 import shutil
 import sys
 import threading
@@ -9,6 +10,9 @@ from contextlib import redirect_stderr, redirect_stdout
 from itertools import product
 from pathlib import Path
 from types import SimpleNamespace
+
+if sys.platform == "win32":
+    os.environ.setdefault("ONEDNN_MAX_CPU_ISA", "AVX2")
 
 import pytest
 import torch
@@ -200,8 +204,6 @@ def test_torch2onnx_serializes_concurrent_exports(monkeypatch, tmp_path):
 def test_export_openvino(end2end, isolated_model):
     """Test YOLO export to OpenVINO format for model inference compatibility."""
     file = YOLO(isolated_model).export(format="openvino", imgsz=32, end2end=end2end)
-    if WINDOWS:
-        pytest.skip("OpenVINO inference intermittently crashes GitHub Windows runners")
     YOLO(file)(SOURCE, imgsz=32)  # exported model inference
 
 
@@ -231,9 +233,6 @@ def test_export_openvino_matrix(task, dynamic, quantize, batch, nms, end2end):
         nms=nms,
         end2end=end2end,
     )
-    if WINDOWS:
-        shutil.rmtree(file, ignore_errors=True)
-        pytest.skip("OpenVINO inference intermittently crashes GitHub Windows runners")
     YOLO(file)([SOURCE] * batch, imgsz=64 if dynamic else 32, batch=batch)  # exported model inference
     shutil.rmtree(file, ignore_errors=True)  # retry in case of potential lingering multi-threaded file usage errors
 


### PR DESCRIPTION
## Summary
- set the Windows OpenVINO export tests to cap oneDNN CPU dispatch at AVX2 before OpenVINO can load
- restore Windows OpenVINO inference coverage instead of skipping after export

Deleted: Windows-only OpenVINO inference skip branches in `tests/test_exports.py`.

## Tests
- `ruff format tests/test_exports.py --check`
- `ruff check tests/test_exports.py`
- `pytest --collect-only -q tests/test_exports.py --export-env base`
- `pytest -q tests/test_exports.py::test_export_openvino --export-env base`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves OpenVINO export testing on Windows by enabling safer CPU instruction handling instead of skipping inference tests 🧪

### 📊 Key Changes
- Added a Windows-specific environment setting: `ONEDNN_MAX_CPU_ISA=AVX2` ⚙️
- Re-enabled OpenVINO exported model inference tests on Windows GitHub runners ✅
- Removed previous Windows-only `pytest.skip()` calls for OpenVINO inference tests 🪟
- Kept cleanup logic for exported OpenVINO files after matrix tests 🧹

### 🎯 Purpose & Impact
- Reduces intermittent OpenVINO crashes on Windows CI by limiting oneDNN CPU instruction usage 🛡️
- Expands test coverage by validating OpenVINO export and inference on Windows again 📈
- Helps improve reliability and confidence in YOLO model deployment to OpenVINO across platforms 🚀
- Benefits developers and users by catching Windows-specific export or inference issues earlier 🔍