### PR TITLE
Make Codecov uploads best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,11 @@ jobs:
           coverage xml -o coverage-benchmarks.xml
       - name: Upload Coverage Reports to CodeCov
         if: github.repository == 'ultralytics/ultralytics'
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           flags: Benchmarks
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           use_oidc: true
       - name: Prune uv Cache
         run: uv cache prune --ci
@@ -198,10 +199,11 @@ jobs:
           YOLO_AUTOINSTALL: "false"
       - name: Upload Coverage Reports to CodeCov
         if: github.repository == 'ultralytics/ultralytics' # && matrix.os == 'ubuntu-latest' && matrix.python == '3.13'
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           flags: Tests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           use_oidc: true
       - name: Prune uv Cache
         run: uv cache prune --ci
@@ -450,10 +452,11 @@ jobs:
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Upload Coverage Reports to CodeCov
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           flags: GPU
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           use_oidc: true
 
   # Raspberry Pi stays separate because it is a long-tail self-hosted runner with its own setup and cleanup flow.


### PR DESCRIPTION
## Summary
- Make Benchmarks, Tests, and GPU Codecov upload steps non-blocking with `continue-on-error: true`.
- Set `fail_ci_if_error: false` so Codecov uploader/service failures do not fail passing CI jobs.

Deleted: Codecov upload hard-fail behavior from Benchmarks, Tests, and GPU CI jobs.

## Rationale
Codecov is reporting infrastructure, not the test itself. A transient Codecov CLI download/signature/upload failure should not turn a completed passing test job red.

## Tests
- `git diff --check`
- `actionlint .github/workflows/ci.yml` (reports existing custom runner label and shellcheck warnings elsewhere in the workflow; no new Codecov-step syntax issue)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Makes Codecov coverage uploads non-blocking so CI is more resilient to external service issues 🚦

### 📊 Key Changes
- Added `continue-on-error: true` to Codecov upload steps across benchmark, test, and GPU CI jobs ✅
- Changed Codecov `fail_ci_if_error` from `true` to `false` for these workflows 🛠️
- Keeps coverage reporting enabled while preventing upload failures from failing the entire CI run 📈

### 🎯 Purpose & Impact
- Reduces false CI failures caused by temporary Codecov outages, network problems, or upload issues 🌐
- Helps developers focus on real test and benchmark failures instead of external reporting interruptions 🔍
- Improves reliability of the `ultralytics/ultralytics` development workflow without affecting test execution or coverage generation 🚀