### PR TITLE
Add Ambarella export guide

### DIFF
--- a/docs/en/guides/model-deployment-options.md
+++ b/docs/en/guides/model-deployment-options.md
@@ -56,7 +56,7 @@ Here is a short description of each format and when to reach for it. For the ful
 - **[DEEPX](../integrations/deepx.md)** (`deepx`): Targets DEEPX NPU hardware with INT8 quantization for embedded edge inference.
 - **[Qualcomm QNN](../integrations/qnn.md)** (`qnn`): On-device inference on Snapdragon Hexagon NPU, Adreno GPU, and CPU through the Qualcomm AI stack.
 
-For an additional edge target, the [Hailo integration](../integrations/hailo.md) compiles YOLO detection models to Hailo HEF. It is not a direct `model.export()` target: detection models are exported to ONNX first, then compiled to HEF with the external Hailo Dataflow Compiler for Hailo-8, Hailo-8L, and Hailo-15 accelerators.
+Additional edge targets follow an ONNX-first workflow rather than a direct `model.export()` format. The [Hailo integration](../integrations/hailo.md) compiles YOLO detection models to Hailo HEF with the external Hailo Dataflow Compiler for Hailo-8, Hailo-8L, and Hailo-15 accelerators. The [Ambarella integration](../integrations/ambarella.md) compiles ONNX exports to the AmbaPB format with Ambarella's CVFlow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
 
 ## Deployment Options Compared
 

--- a/docs/en/guides/model-deployment-options.md
+++ b/docs/en/guides/model-deployment-options.md
@@ -56,7 +56,7 @@ Here is a short description of each format and when to reach for it. For the ful
 - **[DEEPX](../integrations/deepx.md)** (`deepx`): Targets DEEPX NPU hardware with INT8 quantization for embedded edge inference.
 - **[Qualcomm QNN](../integrations/qnn.md)** (`qnn`): On-device inference on Snapdragon Hexagon NPU, Adreno GPU, and CPU through the Qualcomm AI stack.
 
-Additional edge targets follow an ONNX-first workflow rather than a direct `model.export()` format. The [Hailo integration](../integrations/hailo.md) compiles YOLO detection models to Hailo HEF with the external Hailo Dataflow Compiler for Hailo-8, Hailo-8L, and Hailo-15 accelerators. The [Ambarella integration](../integrations/ambarella.md) compiles ONNX exports to the AmbaPB format with Ambarella's CVFlow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
+Additional edge targets follow an ONNX-first workflow rather than a direct `model.export()` format. The [Hailo integration](../integrations/hailo.md) compiles YOLO detection models to Hailo HEF with the external Hailo Dataflow Compiler for Hailo-8, Hailo-8L, and Hailo-15 accelerators. The [Ambarella integration](../integrations/ambarella.md) compiles ONNX exports to the AmbaPB format with Ambarella's CVflow toolchain for CVflow® SoCs such as the CV72, optionally using SpongeTorch compression-aware training.
 
 ## Deployment Options Compared
 

--- a/docs/en/integrations/ambarella.md
+++ b/docs/en/integrations/ambarella.md
@@ -6,11 +6,11 @@ keywords: Ambarella, Ambarella YOLO, deploy YOLO on Ambarella, Ambarella object 
 
 # Ambarella CVflow Export for Ultralytics YOLO Models
 
-!!! warning "Not a direct Ultralytics export format"
+!!! warning "Preview guide — not yet vendor verified"
 
-    There is no `format="ambarella"` export target. The workflow uses the standard ONNX export (`format="onnx"`) combined with the `amba_config`/`amba_chipset` arguments, and the resulting ONNX model is then compiled into the deployable AmbaPB format offline with Ambarella's CVflow toolchain.
+    This guide is an early preview and is not yet complete or verified by Ambarella. Commands, compatibility details, and workflow steps may change as vendor feedback becomes available. There is currently no `format="ambarella"` export target; the workflow uses the standard ONNX export (`format="onnx"`) combined with the `amba_config`/`amba_chipset` arguments, then compiles the resulting ONNX model into the deployable AmbaPB format offline with Ambarella's CVflow toolchain.
 
-Deploying [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) models on [Ambarella](https://www.ambarella.com/) SoCs requires a model format optimized for the CVflow® AI engine. [This fork of Ultralytics](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46) integrates Ambarella's **SpongeTorch** compression toolkit directly into the train, validate, and export pipeline, so you can produce pruned and quantization-optimized models that run efficiently on Ambarella hardware. This guide demonstrates the complete [object detection](https://www.ultralytics.com/glossary/object-detection) workflow: compression-aware training, ONNX export, compilation with the CVflow toolchain, and inference with the compiled AmbaPB model.
+Deploying [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) models on [Ambarella](https://www.ambarella.com/) SoCs requires a model format optimized for the CVflow® AI engine. [This fork of Ultralytics](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46) integrates Ambarella's **SpongeTorch** compression toolkit directly into the train, validate, and export pipeline, so you can produce pruned and quantization-optimized models that run efficiently on Ambarella hardware. This guide outlines the current [object detection](https://www.ultralytics.com/glossary/object-detection) workflow: compression-aware training, ONNX export, compilation with the CVflow toolchain, and inference with the compiled AmbaPB model.
 
 !!! note
 
@@ -256,7 +256,7 @@ Ultralytics YOLO models on Ambarella CVflow SoCs power always-on vision at the e
 
 ## Summary
 
-This guide covered the complete workflow to deploy Ultralytics YOLO models on Ambarella CVflow SoCs: compression-aware training with SpongeTorch (`amba_config`/`amba_chipset`), ONNX export of the compressed checkpoint, offline compilation to AmbaPB with the CVflow toolchain, and bit-exact validation of the compiled model through Ultralytics before board deployment.
+This preview guide outlined the current workflow to deploy Ultralytics YOLO models on Ambarella CVflow SoCs: compression-aware training with SpongeTorch (`amba_config`/`amba_chipset`), ONNX export of the compressed checkpoint, offline compilation to AmbaPB with the CVflow toolchain, and bit-exact validation of the compiled model through Ultralytics before board deployment.
 
 For other edge AI targets, see the related [Hailo](hailo.md), [Rockchip RKNN](rockchip-rknn.md), [Sony IMX500](sony-imx500.md), [Qualcomm QNN](qnn.md), [DEEPX](deepx.md), and [Axelera](axelera.md) guides. For the full list of export formats, visit the [Export mode](../modes/export.md) documentation and the [integrations page](index.md).
 

--- a/docs/en/integrations/ambarella.md
+++ b/docs/en/integrations/ambarella.md
@@ -1,32 +1,48 @@
 ---
 comments: true
-description: Learn how to train, compress, and export Ultralytics YOLO models for Ambarella CVflow SoCs using SpongeTorch compression-aware training and the CVFlow toolchain.
-keywords: YOLO26, Ambarella, CVflow, SpongeTorch, SpongeKit, AmbaPB, model export, model compression, pruning, quantization, Ultralytics, edge AI, NPU, CV72, embedded devices
+description: Deploy Ultralytics YOLO models on Ambarella CVflow SoCs like the CV72 with SpongeTorch compression-aware training, ONNX export, and CVflow toolchain compilation.
+keywords: Ambarella, Ambarella YOLO, deploy YOLO on Ambarella, Ambarella object detection, CVflow, Ambarella CVflow, CV72, CV72S, CV75, CV5, CV3-AD, N1, SpongeTorch, SpongeKit, AmbaPB, CVflow toolchain, Cooper Developer Platform, model compression, pruning, quantization, edge AI, NPU, AI camera, security camera, smart camera, Ultralytics, YOLO26, YOLO11, ONNX export, embedded AI, edge deployment
 ---
 
-# Ambarella Export for Ultralytics YOLO Models
+# Ambarella CVflow Export for Ultralytics YOLO Models
 
 !!! warning "Not a direct Ultralytics export format"
 
-    There is no format="ambarella" export target. The workflow uses the standard ONNX export (format="onnx") combined with the amba_config/amba_chipset arguments, and the resulting ONNX model is then compiled into the deployable AmbaPB format offline with Ambarella's CVFlow toolchain.
+    There is no `format="ambarella"` export target. The workflow uses the standard ONNX export (`format="onnx"`) combined with the `amba_config`/`amba_chipset` arguments, and the resulting ONNX model is then compiled into the deployable AmbaPB format offline with Ambarella's CVflow toolchain.
 
-Deploying [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) models on Ambarella SoCs requires a model format optimized for the CVflow® neural processing engine. [This fork of Ultralytics](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46) integrates Ambarella's **SpongeTorch** compression toolkit directly into the train, validate, and export pipeline, so you can produce pruned and quantization-optimized models that run efficiently on Ambarella hardware. This guide walks through the complete workflow: compression-aware training, ONNX export, compilation with the CVFlow toolchain, and inference with the compiled AmbaPB model.
+Deploying [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) models on [Ambarella](https://www.ambarella.com/) SoCs requires a model format optimized for the CVflow® AI engine. [This fork of Ultralytics](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46) integrates Ambarella's **SpongeTorch** compression toolkit directly into the train, validate, and export pipeline, so you can produce pruned and quantization-optimized models that run efficiently on Ambarella hardware. This guide walks through the complete workflow for [object detection](https://www.ultralytics.com/glossary/object-detection) and other YOLO tasks: compression-aware training, ONNX export, compilation with the CVflow toolchain, and inference with the compiled AmbaPB model.
 
 !!! note
 
-    This workflow requires proprietary Ambarella toolchain components (`spongetorch`, the CVFlow compiler, and `cvflowbackend`) that are not available on PyPI. Register on the Ambarella Developer Platform to obtain SDK access.
+    This workflow requires proprietary Ambarella toolchain components (`spongetorch`, the CVflow compiler, and `cvflowbackend`) that are not available on PyPI. Register on the [Ambarella Developer Zone](https://www.ambarella.com/developer/) to obtain SDK access through the Cooper™ Developer Platform.
 
 ## What is Ambarella CVflow?
 
-Ambarella designs low-power AI vision SoCs built around the CVflow architecture, a dedicated neural vector processing engine that delivers high inference throughput at very low power. CVflow SoCs such as the CV72 power intelligent cameras, robotics, automotive, and industrial edge AI applications. Models trained in standard frameworks like [PyTorch](https://www.ultralytics.com/glossary/pytorch) are compiled to CVflow's native format with Ambarella's offline toolchain before deployment.
+[Ambarella](https://www.ambarella.com/) is a Santa Clara-based semiconductor company known for its low-power AI vision SoCs, widely used in IP security cameras, dash cameras, drones, robotics, and automotive systems. Its chips are built around **CVflow®**, a dedicated neural vector processing architecture (the on-chip AI accelerator, or NPU) that delivers high inference throughput at very low power — the CV72S runs 4K security-camera AI workloads under 3 W. Models trained in standard frameworks like [PyTorch](https://www.ultralytics.com/glossary/pytorch) are compiled to CVflow's native format with Ambarella's offline toolchain before deployment.
+
+Current CVflow SoC families and their typical applications:
+
+| SoC family  | Typical applications                                                 |
+| ----------- | -------------------------------------------------------------------- |
+| CV72 / CV75 | 4K AI security cameras, smart cameras, industrial vision             |
+| CV5 / CV52  | Drones, action cameras, robotics, multi-camera systems               |
+| CV3-AD      | Automotive ADAS and autonomous driving domain controllers            |
+| N1          | On-premise generative AI and multi-stream video analytics appliances |
+
+## Why Deploy YOLO on Ambarella?
+
+- **Performance per watt**: CVflow SoCs are designed for always-on edge AI, running real-time [object detection](https://www.ultralytics.com/glossary/object-detection) within camera-grade power budgets.
+- **Compression-aware training**: SpongeTorch applies [pruning](https://www.ultralytics.com/glossary/pruning) and [quantization](https://www.ultralytics.com/glossary/model-quantization)-aware optimization during training, so the model learns to stay accurate while becoming NPU-friendly.
+- **Bit-exact host validation**: the compiled AmbaPB model runs through Ultralytics `predict`/`val` on your workstation exactly as it will execute on the chip, so you can measure quantized [mAP](https://www.ultralytics.com/glossary/mean-average-precision-map) before touching hardware.
+- **Integrated camera pipeline**: Ambarella SoCs combine the AI engine with an ISP and video encoders, making them a single-chip solution for AI cameras.
 
 ## Workflow Overview
 
 The pipeline has four stages:
 
-1. **Compression-aware training** - train with a SpongeKit config (`amba_config`) so SpongeTorch applies pruning/quantization progressively during training.
+1. **Compression-aware training** — train with a SpongeKit config (`amba_config`) so SpongeTorch applies pruning/quantization progressively during training.
 2. **ONNX export** — export the compressed checkpoint with the same `amba_config`, preserving the compression structure in the ONNX graph.
-3. **CVFlow compilation** — compile the ONNX model to an AmbaPB artifact with the CVFlow toolchain.
+3. **CVflow compilation** — compile the ONNX model to an AmbaPB artifact with the CVflow toolchain.
 4. **Inference and validation** — run the compiled `*.ambapb.ckpt.onnx` model through Ultralytics `predict`/`val` via the AmbaPB backend, then deploy on the board.
 
 Stages 1–2 can also be skipped in favor of a plain ONNX export if you do not need SpongeTorch's training-time optimizations (see [Exporting Without SpongeTorch](#exporting-without-spongetorch)).
@@ -53,6 +69,8 @@ Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tre
         pip install /path/to/cvflowbackend-*.whl
         ```
 
+The AmbaPB inference backend locates `cvflowbackend` through the CVflow toolchain's `tv2` command (`tv2 -libpath cvflowbackend`), so the toolchain must be installed and on your `PATH` before running inference or validation with compiled models.
+
 ### SpongeKit Configuration File
 
 SpongeTorch is driven by a SpongeKit configuration file (protobuf-text format, `.prototxt`) that defines the compression passes to apply: pruning sparsity targets, quantization settings, and the compression schedule. Example configurations and the config schema documentation ship with the SpongeTorch distribution in the SDK. The same config file must be used for training, validation, and export.
@@ -66,7 +84,7 @@ Two arguments control the SpongeTorch integration across `train`, `val`, and `ex
 | `amba_config`  | `str` | `None`  | Path to the SpongeKit config passed to `spongetorch.prepare()`. Enables compression-aware training and SpongeTorch-aware export. |
 | `amba_chipset` | `str` | `None`  | Target chipset name passed to `spongetorch.set_target_chipset()`, e.g. `CV72`.                                                   |
 
-An additional export-only argument is available:
+The fork also adds a general export argument:
 
 | Argument      | Type  | Default | Description                                                                 |
 | ------------- | ----- | ------- | --------------------------------------------------------------------------- |
@@ -103,7 +121,7 @@ When `amba_config` is set, the trainer wraps the model and optimizer with `spong
 
 !!! note "Checkpoint gating"
 
-    `best.pt` and `last.pt` are intentionally not saved until the SpongeTorch compression schedule crosses its `end_step` - a half-compressed checkpoint would not be usable. Ensure `epochs` is long enough for the schedule in your config to complete; the log reports when checkpoint saving begins.
+    `best.pt` and `last.pt` are intentionally not saved until the SpongeTorch compression schedule crosses its `end_step` — a half-compressed checkpoint would not be usable. Ensure `epochs` is long enough for the schedule in your config to complete; the log reports when checkpoint saving begins. If training ends before the schedule completes, the final epoch is saved anyway with a warning, but such a checkpoint should not be deployed.
 
 !!! tip "Fine-tune instead of training from scratch"
 
@@ -122,7 +140,7 @@ Validate accuracy before compiling, using the same config:
           amba_config=config.prototxt amba_chipset=CV72
         ```
 
-The validator re-applies `spongetorch.prepare()` when required and disables Conv+BN fusion so the compression structure is preserved. Compare mAP against your uncompressed baseline; if the accuracy drop is too large, adjust the SpongeKit config and retrain.
+The validator re-applies `spongetorch.prepare()` when required and disables Conv+BN fusion so the compression structure is preserved. Compare mAP against your uncompressed baseline; if the [accuracy](https://www.ultralytics.com/glossary/accuracy) drop is too large, adjust the SpongeKit config and retrain.
 
 ## Export to ONNX
 
@@ -150,16 +168,16 @@ Export the compressed checkpoint with the **same** `amba_config` used in trainin
           amba_config=config.prototxt amba_chipset=CV72
         ```
 
-The exporter rebuilds the model, re-applies `spongetorch.prepare()` with your config, reloads the sparse checkpoint weights into the prepared structure, and traces to ONNX with Conv+BN fusion disabled - producing a graph in the exact form the CVFlow compiler expects.
+The exporter rebuilds the model, re-applies `spongetorch.prepare()` with your config, reloads the sparse checkpoint weights into the prepared structure, and traces to ONNX with Conv+BN fusion disabled — producing a graph in the exact form the CVflow compiler expects.
 
 !!! warning
 
     - The checkpoint must contain SpongeTorch compression state. Exporting a plain checkpoint with `amba_config` set raises: *"Checkpoint has no SpongeTorch pruning state... Use a compressed checkpoint from amba training before export."*
     - The config must match the one used during training, or the weight reload fails.
 
-## Compile with the CVFlow Toolchain
+## Compile with the CVflow Toolchain
 
-Compile the exported ONNX model for your target chipset using the CVFlow compiler from the SDK, following the SDK's compilation guide. The compiler maps the graph onto the CVflow NPU (quantization, scheduling, memory planning) and produces the deployable AmbaPB artifact.
+Compile the exported ONNX model for your target chipset using the CVflow compiler from the SDK, following the SDK's compilation guide. The compiler maps the graph onto the CVflow AI engine (quantization, scheduling, memory planning) and produces the deployable AmbaPB artifact.
 
 !!! note
 
@@ -167,7 +185,7 @@ Compile the exported ONNX model for your target chipset using the CVFlow compile
 
 ## Run Inference with the Compiled Model
 
-The compiled AmbaPB model loads directly through the Ultralytics API - [AutoBackend](../reference/nn/autobackend.md) detects the `.ambapb` suffix and routes inference through `cvflowbackend`, executing the model bit-exactly as it will run on the NPU:
+The compiled AmbaPB model loads directly through the Ultralytics API — [AutoBackend](../reference/nn/autobackend.md) detects the `.ambapb` suffix and routes inference through `cvflowbackend`, executing the model bit-exactly as it will run on the AI engine:
 
 !!! example "Usage"
 
@@ -192,15 +210,15 @@ The compiled AmbaPB model loads directly through the Ultralytics API - [AutoBack
         yolo val model=model.ambapb.ckpt.onnx data=coco8.yaml
         ```
 
-This is the final accuracy check before hardware deployment, including all compiler quantization effects. The backend uses CVFlow inference mode `acinf` by default; set the environment variable `ULTRALYTICS_AMBAPB_DEBUG=1` to log input/output details for debugging.
+This is the final accuracy check before hardware deployment, including all compiler quantization effects. If a `metadata.yaml` file sits next to the compiled model, the backend reads class names, stride, and task information from it. The backend uses CVflow inference mode `acinf` by default; set the environment variable `ULTRALYTICS_AMBAPB_DEBUG=1` to log input/output details for debugging.
 
 ## Deploy on the Board
 
-Load the compiled model on your Ambarella device using the Ambarella SDK runtime. Preprocessing and postprocessing must match Ultralytics conventions: letterboxed RGB input normalized to `0–1`, and standard YOLO detection decoding on the outputs. Refer to the SDK deployment documentation for runtime APIs.
+Load the compiled model on your Ambarella device using the Ambarella SDK runtime. Preprocessing and postprocessing must match what the model was compiled for: letterboxed RGB input in the `0–255` range (the Ultralytics AmbaPB backend feeds the compiled model `0–255` RGB), and standard YOLO detection decoding on the outputs. Refer to the SDK deployment documentation for runtime APIs.
 
 ## Exporting Without SpongeTorch
 
-If you do not need SpongeTorch's training-time pruning and quantization-aware optimizations, the standard Ultralytics pipeline also produces a CVFlow-compilable model:
+If you do not need SpongeTorch's training-time pruning and quantization-aware optimizations, the standard Ultralytics pipeline also produces a CVflow-compilable model:
 
 !!! example "Usage"
 
@@ -210,4 +228,41 @@ If you do not need SpongeTorch's training-time pruning and quantization-aware op
         yolo export model=yolo26n.pt format=onnx
         ```
 
-Compile the resulting ONNX with the CVFlow toolchain, which performs post-training quantization itself. This path trades some NPU performance and quantized accuracy for a simpler workflow with no `spongetorch` dependency at training time.
+Compile the resulting ONNX with the CVflow toolchain, which performs post-training quantization itself. This path trades some NPU performance and quantized accuracy for a simpler workflow with no `spongetorch` dependency at training time.
+
+## Real-World Applications
+
+Ultralytics YOLO models on Ambarella CVflow SoCs power always-on vision at the edge:
+
+- **AI security cameras**: real-time person and vehicle detection on 4K IP cameras within a sub-3 W power budget.
+- **Drones and robotics**: onboard object detection and tracking for navigation, inspection, and delivery on CV5-class chips.
+- **Automotive**: ADAS perception workloads such as pedestrian and vehicle detection on CV3-AD domain controllers.
+- **Industrial and retail analytics**: multi-stream people counting, PPE detection, and shelf monitoring on edge appliances.
+
+## Summary
+
+This guide covered the complete workflow to deploy Ultralytics YOLO models on Ambarella CVflow SoCs: compression-aware training with SpongeTorch (`amba_config`/`amba_chipset`), ONNX export of the compressed checkpoint, offline compilation to AmbaPB with the CVflow toolchain, and bit-exact validation of the compiled model through Ultralytics before board deployment.
+
+For other edge AI targets, see the related [Hailo](hailo.md), [Rockchip RKNN](rockchip-rknn.md), [Sony IMX500](sony-imx500.md), [Qualcomm QNN](qnn.md), [DEEPX](deepx.md), and [Axelera](axelera.md) guides. For the full list of export formats, visit the [Export mode](../modes/export.md) documentation and the [integrations page](index.md).
+
+## FAQ
+
+### Can I export a YOLO model directly to Ambarella format with `model.export()`?
+
+No. There is no `format="ambarella"` target. Export to ONNX (optionally with SpongeTorch compression via `amba_config`), then compile the ONNX model to AmbaPB offline with Ambarella's CVflow toolchain from the SDK.
+
+### Which Ambarella chips can run Ultralytics YOLO models?
+
+Any CVflow-based SoC supported by the CVflow toolchain, including the CV72/CV75 families for AI cameras, CV5/CV52 for drones and robotics, and CV3-AD for automotive. Set the target with the `amba_chipset` argument (e.g. `CV72`) and select the matching target when compiling.
+
+### What is SpongeTorch and do I need it?
+
+SpongeTorch is Ambarella's model compression toolkit, integrated into the Ambarella fork of Ultralytics for pruning and quantization-aware training. It is optional: a plain Ultralytics ONNX export can also be compiled with the CVflow toolchain using post-training quantization, at some cost in NPU performance and quantized accuracy.
+
+### Where do I get the Ambarella SDK, SpongeTorch, and the CVflow toolchain?
+
+They are proprietary and not on PyPI. Register on the [Ambarella Developer Zone](https://www.ambarella.com/developer/) to request SDK access; the `spongetorch` and `cvflowbackend` wheels and the CVflow compiler ship with the SDK distribution.
+
+### How do I check the accuracy of the compiled model before deploying?
+
+Run `yolo val model=model.ambapb.ckpt.onnx data=your_data.yaml` with the Ambarella fork installed. The AmbaPB backend executes the compiled model bit-exactly as it runs on the CVflow AI engine, so the reported mAP includes all compiler quantization effects.

--- a/docs/en/integrations/ambarella.md
+++ b/docs/en/integrations/ambarella.md
@@ -33,7 +33,7 @@ Current CVflow SoC families and their typical applications:
 
 - **Performance per watt**: CVflow SoCs are designed for always-on edge AI, running real-time [object detection](https://www.ultralytics.com/glossary/object-detection) within camera-grade power budgets.
 - **Compression-aware training**: SpongeTorch applies [pruning](https://www.ultralytics.com/glossary/pruning) and [quantization](https://www.ultralytics.com/glossary/model-quantization)-aware optimization during training, so the model learns to stay accurate while becoming NPU-friendly.
-- **Compiled-model host validation**: the compiled AmbaPB model runs through Ultralytics `predict`/`val` on your workstation, so you can measure quantized [mAP](https://www.ultralytics.com/glossary/mean-average-precision-map) before touching hardware.
+- **Bit-exact host validation**: the compiled AmbaPB model runs through Ultralytics `predict`/`val` on your workstation exactly as it will execute on the chip, so you can measure quantized [mAP](https://www.ultralytics.com/glossary/mean-average-precision-map) before touching hardware.
 - **Integrated camera pipeline**: Ambarella SoCs combine the AI engine with an ISP and video encoders, making them a single-chip solution for AI cameras.
 
 ## Workflow Overview
@@ -51,7 +51,7 @@ SpongeTorch training and SpongeTorch-aware export can be replaced by a plain ONN
 
 ### Installation
 
-Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46), then follow the installation instructions for your Ambarella SDK release:
+Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46), then install the Ambarella toolchain wheels from the SDK distribution:
 
 !!! Tip "Installation"
 
@@ -63,9 +63,11 @@ Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tre
         cd ultralytics
         git checkout amba_v8.4.46
         pip install -e .
-        ```
 
-Ambarella toolchain package names and installation methods depend on the SDK release. Follow its documentation to install SpongeTorch, `cvflowbackend`, and the CVflow compiler.
+        # Install Ambarella toolchain wheels from the SDK
+        pip install /path/to/spongetorch-*.whl
+        pip install /path/to/cvflowbackend-*.whl
+        ```
 
 The AmbaPB inference backend locates `cvflowbackend` through the CVflow toolchain's `tv2` command (`tv2 -libpath cvflowbackend`), so the toolchain must be installed and on your `PATH` before running inference or validation with compiled models.
 
@@ -198,7 +200,7 @@ Compile the exported ONNX model for your target chipset using the CVflow compile
 
 ## Run Inference with the Compiled Model
 
-The compiled AmbaPB model loads directly through the Ultralytics API — [AutoBackend](../reference/nn/autobackend.md) detects the `.ambapb` suffix and routes host inference through `cvflowbackend`:
+The compiled AmbaPB model loads directly through the Ultralytics API — [AutoBackend](../reference/nn/autobackend.md) detects the `.ambapb` suffix and routes inference through `cvflowbackend`, executing the model bit-exactly as it will run on the AI engine:
 
 !!! example "Usage"
 
@@ -223,11 +225,11 @@ The compiled AmbaPB model loads directly through the Ultralytics API — [AutoBa
         yolo val model=model.ambapb.ckpt.onnx data=coco8.yaml
         ```
 
-This is the final host-side accuracy check before hardware deployment, including the compiled model's quantized outputs. If a `metadata.yaml` file sits next to the compiled model, the backend reads class names, stride, and task information from it. The backend uses CVflow inference mode `acinf` by default; set the environment variable `ULTRALYTICS_AMBAPB_DEBUG=1` to log input/output details for debugging. Confirm host-to-device numerical parity against your Ambarella SDK and target hardware.
+This is the final accuracy check before hardware deployment, including all compiler quantization effects. If a `metadata.yaml` file sits next to the compiled model, the backend reads class names, stride, and task information from it. The backend uses CVflow inference mode `acinf` by default; set the environment variable `ULTRALYTICS_AMBAPB_DEBUG=1` to log input/output details for debugging.
 
 ## Deploy on the Board
 
-Load the compiled model on your Ambarella device using the Ambarella SDK runtime. Preprocessing and postprocessing must match what the detection model was compiled for: letterboxed RGB input in the `0–255` range (the Ultralytics AmbaPB backend feeds the compiled model `0–255` RGB), and standard YOLO detection decoding on the outputs. Refer to the SDK deployment documentation for runtime APIs and verify host-to-device parity on your target.
+Load the compiled model on your Ambarella device using the Ambarella SDK runtime. Preprocessing and postprocessing must match what the detection model was compiled for: letterboxed RGB input in the `0–255` range (the Ultralytics AmbaPB backend feeds the compiled model `0–255` RGB), and standard YOLO detection decoding on the outputs. Refer to the SDK deployment documentation for runtime APIs.
 
 ## Exporting Without SpongeTorch
 
@@ -241,7 +243,7 @@ If you do not need SpongeTorch's training-time pruning and quantization-aware op
         yolo export model=yolo26n.pt format=onnx
         ```
 
-Compile the resulting ONNX with the CVflow toolchain. Depending on the model, compiler settings, and target, this simpler workflow may trade NPU performance or quantized accuracy for avoiding the `spongetorch` training dependency; benchmark both paths on your hardware.
+Compile the resulting ONNX with the CVflow toolchain, which performs post-training quantization itself. This path trades some NPU performance and quantized accuracy for a simpler workflow with no `spongetorch` dependency at training time.
 
 ## Real-World Applications
 
@@ -254,7 +256,7 @@ Ultralytics YOLO models on Ambarella CVflow SoCs power always-on vision at the e
 
 ## Summary
 
-This guide covered the complete workflow to deploy Ultralytics YOLO models on Ambarella CVflow SoCs: compression-aware training with SpongeTorch (`amba_config`/`amba_chipset`), ONNX export of the compressed checkpoint, offline compilation to AmbaPB with the CVflow toolchain, and host-side validation of the compiled model through Ultralytics before board deployment.
+This guide covered the complete workflow to deploy Ultralytics YOLO models on Ambarella CVflow SoCs: compression-aware training with SpongeTorch (`amba_config`/`amba_chipset`), ONNX export of the compressed checkpoint, offline compilation to AmbaPB with the CVflow toolchain, and bit-exact validation of the compiled model through Ultralytics before board deployment.
 
 For other edge AI targets, see the related [Hailo](hailo.md), [Rockchip RKNN](rockchip-rknn.md), [Sony IMX500](sony-imx500.md), [Qualcomm QNN](qnn.md), [DEEPX](deepx.md), and [Axelera](axelera.md) guides. For the full list of export formats, visit the [Export mode](../modes/export.md) documentation and the [integrations page](index.md).
 
@@ -270,12 +272,12 @@ Any CVflow-based SoC supported by your CVflow toolchain may be targeted, includi
 
 ### What is SpongeTorch and do I need it?
 
-SpongeTorch is Ambarella's model compression toolkit, integrated into the Ambarella fork of Ultralytics for pruning and quantization-aware training. It is optional: a plain Ultralytics ONNX export can also be compiled with the CVflow toolchain, with performance and accuracy depending on the model, compiler settings, and target.
+SpongeTorch is Ambarella's model compression toolkit, integrated into the Ambarella fork of Ultralytics for pruning and quantization-aware training. It is optional: a plain Ultralytics ONNX export can also be compiled with the CVflow toolchain using post-training quantization, at some cost in NPU performance and quantized accuracy.
 
 ### Where do I get the Ambarella SDK, SpongeTorch, and the CVflow toolchain?
 
-They are proprietary and not on PyPI. Register on the [Ambarella Developer Zone](https://www.ambarella.com/developer/) to request access, then follow the installation documentation for your SDK release.
+They are proprietary and not on PyPI. Register on the [Ambarella Developer Zone](https://www.ambarella.com/developer/) to request SDK access; the `spongetorch` and `cvflowbackend` wheels and the CVflow compiler ship with the SDK distribution.
 
 ### How do I check the accuracy of the compiled model before deploying?
 
-Run `yolo val model=model.ambapb.ckpt.onnx data=your_data.yaml` with the Ambarella fork installed. The AmbaPB backend validates the compiled model through `cvflowbackend`, so the reported mAP reflects its compiled outputs. Confirm numerical parity on the target device with your Ambarella SDK.
+Run `yolo val model=model.ambapb.ckpt.onnx data=your_data.yaml` with the Ambarella fork installed. The AmbaPB backend executes the compiled model bit-exactly as it runs on the CVflow AI engine, so the reported mAP includes all compiler quantization effects.

--- a/docs/en/integrations/ambarella.md
+++ b/docs/en/integrations/ambarella.md
@@ -51,7 +51,7 @@ SpongeTorch training and SpongeTorch-aware export can be replaced by a plain ONN
 
 ### Installation
 
-Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46), then install the Ambarella toolchain wheels from the SDK distribution:
+Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46), then follow the installation instructions for your Ambarella SDK release:
 
 !!! Tip "Installation"
 
@@ -64,10 +64,9 @@ Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tre
         git checkout amba_v8.4.46
         pip install -e .
 
-        # Install Ambarella toolchain wheels from the SDK
-        pip install /path/to/spongetorch-*.whl
-        pip install /path/to/cvflowbackend-*.whl
         ```
+
+Ambarella toolchain package names and installation methods depend on the SDK release. Follow its documentation to install SpongeTorch, `cvflowbackend`, and the CVflow compiler.
 
 The AmbaPB inference backend locates `cvflowbackend` through the CVflow toolchain's `tv2` command (`tv2 -libpath cvflowbackend`), so the toolchain must be installed and on your `PATH` before running inference or validation with compiled models.
 
@@ -276,7 +275,7 @@ SpongeTorch is Ambarella's model compression toolkit, integrated into the Ambare
 
 ### Where do I get the Ambarella SDK, SpongeTorch, and the CVflow toolchain?
 
-They are proprietary and not on PyPI. Register on the [Ambarella Developer Zone](https://www.ambarella.com/developer/) to request SDK access and obtain the matching SpongeTorch, `cvflowbackend`, and compiler packages for your SDK release.
+They are proprietary and not on PyPI. Register on the [Ambarella Developer Zone](https://www.ambarella.com/developer/) to request access, then follow the installation documentation for your SDK release.
 
 ### How do I check the accuracy of the compiled model before deploying?
 

--- a/docs/en/integrations/ambarella.md
+++ b/docs/en/integrations/ambarella.md
@@ -63,7 +63,6 @@ Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tre
         cd ultralytics
         git checkout amba_v8.4.46
         pip install -e .
-
         ```
 
 Ambarella toolchain package names and installation methods depend on the SDK release. Follow its documentation to install SpongeTorch, `cvflowbackend`, and the CVflow compiler.

--- a/docs/en/integrations/ambarella.md
+++ b/docs/en/integrations/ambarella.md
@@ -61,15 +61,15 @@ SpongeTorch is driven by a SpongeKit configuration file (protobuf-text format, `
 
 Two arguments control the SpongeTorch integration across `train`, `val`, and `export` modes:
 
-| Argument       | Type  | Default | Description                                                                                                                       |
-| -------------- | ----- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `amba_config`  | `str` | `None`  | Path to the SpongeKit config passed to `spongetorch.prepare()`. Enables compression-aware training and SpongeTorch-aware export.  |
-| `amba_chipset` | `str` | `None`  | Target chipset name passed to `spongetorch.set_target_chipset()`, e.g. `CV72`.  |
+| Argument       | Type  | Default | Description                                                                                                                      |
+| -------------- | ----- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `amba_config`  | `str` | `None`  | Path to the SpongeKit config passed to `spongetorch.prepare()`. Enables compression-aware training and SpongeTorch-aware export. |
+| `amba_chipset` | `str` | `None`  | Target chipset name passed to `spongetorch.set_target_chipset()`, e.g. `CV72`.                                                   |
 
 An additional export-only argument is available:
 
-| Argument      | Type  | Default | Description                                                              |
-| ------------- | ----- | ------- | ------------------------------------------------------------------------ |
+| Argument      | Type  | Default | Description                                                                 |
+| ------------- | ----- | ------- | --------------------------------------------------------------------------- |
 | `export_file` | `str` | `None`  | Custom export output path/name, e.g. `'/tmp/model.onnx'` or `'model.onnx'`. |
 
 ## Compression-Aware Training
@@ -96,7 +96,7 @@ Train (or fine-tune) your model with SpongeTorch compression enabled:
 
         ```bash
         yolo train model=yolo26n.pt data=coco8.yaml epochs=100 \
-            amba_config=config.prototxt amba_chipset=CV72
+          amba_config=config.prototxt amba_chipset=CV72
         ```
 
 When `amba_config` is set, the trainer wraps the model and optimizer with `spongetorch.prepare()` at setup. Compression is applied progressively on a step schedule, so the network learns to stay accurate while becoming sparse and quantization-friendly. The trained checkpoint stores SpongeTorch's sparse state (`_orig`/`_mask` tensors), which the export step later requires. The config file is copied into the run directory as `amba_config.prototxt` for reproducibility.
@@ -119,7 +119,7 @@ Validate accuracy before compiling, using the same config:
 
         ```bash
         yolo val model=runs/detect/train/weights/best.pt data=coco8.yaml \
-            amba_config=config.prototxt amba_chipset=CV72
+          amba_config=config.prototxt amba_chipset=CV72
         ```
 
 The validator re-applies `spongetorch.prepare()` when required and disables Conv+BN fusion so the compression structure is preserved. Compare mAP against your uncompressed baseline; if the accuracy drop is too large, adjust the SpongeKit config and retrain.
@@ -147,7 +147,7 @@ Export the compressed checkpoint with the **same** `amba_config` used in trainin
 
         ```bash
         yolo export model=runs/detect/train/weights/best.pt format=onnx \
-            amba_config=config.prototxt amba_chipset=CV72
+          amba_config=config.prototxt amba_chipset=CV72
         ```
 
 The exporter rebuilds the model, re-applies `spongetorch.prepare()` with your config, reloads the sparse checkpoint weights into the prepared structure, and traces to ONNX with Conv+BN fusion disabled - producing a graph in the exact form the CVFlow compiler expects.

--- a/docs/en/integrations/ambarella.md
+++ b/docs/en/integrations/ambarella.md
@@ -1,0 +1,213 @@
+---
+comments: true
+description: Learn how to train, compress, and export Ultralytics YOLO models for Ambarella CVflow SoCs using SpongeTorch compression-aware training and the CVFlow toolchain.
+keywords: YOLO26, Ambarella, CVflow, SpongeTorch, SpongeKit, AmbaPB, model export, model compression, pruning, quantization, Ultralytics, edge AI, NPU, CV72, embedded devices
+---
+
+# Ambarella Export for Ultralytics YOLO Models
+
+!!! warning "Not a direct Ultralytics export format"
+
+    There is no format="ambarella" export target. The workflow uses the standard ONNX export (format="onnx") combined with the amba_config/amba_chipset arguments, and the resulting ONNX model is then compiled into the deployable AmbaPB format offline with Ambarella's CVFlow toolchain.
+
+Deploying [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) models on Ambarella SoCs requires a model format optimized for the CVflow® neural processing engine. [This fork of Ultralytics](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46) integrates Ambarella's **SpongeTorch** compression toolkit directly into the train, validate, and export pipeline, so you can produce pruned and quantization-optimized models that run efficiently on Ambarella hardware. This guide walks through the complete workflow: compression-aware training, ONNX export, compilation with the CVFlow toolchain, and inference with the compiled AmbaPB model.
+
+!!! note
+
+    This workflow requires proprietary Ambarella toolchain components (`spongetorch`, the CVFlow compiler, and `cvflowbackend`) that are not available on PyPI. Register on the Ambarella Developer Platform to obtain SDK access.
+
+## What is Ambarella CVflow?
+
+Ambarella designs low-power AI vision SoCs built around the CVflow architecture, a dedicated neural vector processing engine that delivers high inference throughput at very low power. CVflow SoCs such as the CV72 power intelligent cameras, robotics, automotive, and industrial edge AI applications. Models trained in standard frameworks like [PyTorch](https://www.ultralytics.com/glossary/pytorch) are compiled to CVflow's native format with Ambarella's offline toolchain before deployment.
+
+## Workflow Overview
+
+The pipeline has four stages:
+
+1. **Compression-aware training** - train with a SpongeKit config (`amba_config`) so SpongeTorch applies pruning/quantization progressively during training.
+2. **ONNX export** — export the compressed checkpoint with the same `amba_config`, preserving the compression structure in the ONNX graph.
+3. **CVFlow compilation** — compile the ONNX model to an AmbaPB artifact with the CVFlow toolchain.
+4. **Inference and validation** — run the compiled `*.ambapb.ckpt.onnx` model through Ultralytics `predict`/`val` via the AmbaPB backend, then deploy on the board.
+
+Stages 1–2 can also be skipped in favor of a plain ONNX export if you do not need SpongeTorch's training-time optimizations (see [Exporting Without SpongeTorch](#exporting-without-spongetorch)).
+
+## Prerequisites
+
+### Installation
+
+Install [this Ultralytics fork](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46), then install the Ambarella toolchain wheels from the SDK distribution:
+
+!!! Tip "Installation"
+
+    === "CLI"
+
+        ```bash
+        # Install this Ultralytics fork from source
+        git clone https://github.com/Ambarella-Inc/ultralytics
+        cd ultralytics
+        git checkout amba_v8.4.46
+        pip install -e .
+
+        # Install Ambarella toolchain wheels from the SDK
+        pip install /path/to/spongetorch-*.whl
+        pip install /path/to/cvflowbackend-*.whl
+        ```
+
+### SpongeKit Configuration File
+
+SpongeTorch is driven by a SpongeKit configuration file (protobuf-text format, `.prototxt`) that defines the compression passes to apply: pruning sparsity targets, quantization settings, and the compression schedule. Example configurations and the config schema documentation ship with the SpongeTorch distribution in the SDK. The same config file must be used for training, validation, and export.
+
+## Amba Arguments
+
+Two arguments control the SpongeTorch integration across `train`, `val`, and `export` modes:
+
+| Argument       | Type  | Default | Description                                                                                                                       |
+| -------------- | ----- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `amba_config`  | `str` | `None`  | Path to the SpongeKit config passed to `spongetorch.prepare()`. Enables compression-aware training and SpongeTorch-aware export.  |
+| `amba_chipset` | `str` | `None`  | Target chipset name passed to `spongetorch.set_target_chipset()`, e.g. `CV72`.  |
+
+An additional export-only argument is available:
+
+| Argument      | Type  | Default | Description                                                              |
+| ------------- | ----- | ------- | ------------------------------------------------------------------------ |
+| `export_file` | `str` | `None`  | Custom export output path/name, e.g. `'/tmp/model.onnx'` or `'model.onnx'`. |
+
+## Compression-Aware Training
+
+Train (or fine-tune) your model with SpongeTorch compression enabled:
+
+!!! example "Usage"
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        model = YOLO("yolo26n.pt")
+        model.train(
+            data="coco8.yaml",
+            epochs=100,
+            amba_config="config.prototxt",
+            amba_chipset="CV72",
+        )
+        ```
+
+    === "CLI"
+
+        ```bash
+        yolo train model=yolo26n.pt data=coco8.yaml epochs=100 \
+            amba_config=config.prototxt amba_chipset=CV72
+        ```
+
+When `amba_config` is set, the trainer wraps the model and optimizer with `spongetorch.prepare()` at setup. Compression is applied progressively on a step schedule, so the network learns to stay accurate while becoming sparse and quantization-friendly. The trained checkpoint stores SpongeTorch's sparse state (`_orig`/`_mask` tensors), which the export step later requires. The config file is copied into the run directory as `amba_config.prototxt` for reproducibility.
+
+!!! note "Checkpoint gating"
+
+    `best.pt` and `last.pt` are intentionally not saved until the SpongeTorch compression schedule crosses its `end_step` - a half-compressed checkpoint would not be usable. Ensure `epochs` is long enough for the schedule in your config to complete; the log reports when checkpoint saving begins.
+
+!!! tip "Fine-tune instead of training from scratch"
+
+    For best accuracy, first train your model normally (or start from a pretrained checkpoint), then run a shorter compression fine-tune with `amba_config` on the trained weights.
+
+### Validating the Compressed Checkpoint
+
+Validate accuracy before compiling, using the same config:
+
+!!! example "Usage"
+
+    === "CLI"
+
+        ```bash
+        yolo val model=runs/detect/train/weights/best.pt data=coco8.yaml \
+            amba_config=config.prototxt amba_chipset=CV72
+        ```
+
+The validator re-applies `spongetorch.prepare()` when required and disables Conv+BN fusion so the compression structure is preserved. Compare mAP against your uncompressed baseline; if the accuracy drop is too large, adjust the SpongeKit config and retrain.
+
+## Export to ONNX
+
+Export the compressed checkpoint with the **same** `amba_config` used in training:
+
+!!! example "Usage"
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        model = YOLO("runs/detect/train/weights/best.pt")
+        model.export(
+            format="onnx",
+            amba_config="config.prototxt",
+            amba_chipset="CV72",
+        )
+        ```
+
+    === "CLI"
+
+        ```bash
+        yolo export model=runs/detect/train/weights/best.pt format=onnx \
+            amba_config=config.prototxt amba_chipset=CV72
+        ```
+
+The exporter rebuilds the model, re-applies `spongetorch.prepare()` with your config, reloads the sparse checkpoint weights into the prepared structure, and traces to ONNX with Conv+BN fusion disabled - producing a graph in the exact form the CVFlow compiler expects.
+
+!!! warning
+
+    - The checkpoint must contain SpongeTorch compression state. Exporting a plain checkpoint with `amba_config` set raises: *"Checkpoint has no SpongeTorch pruning state... Use a compressed checkpoint from amba training before export."*
+    - The config must match the one used during training, or the weight reload fails.
+
+## Compile with the CVFlow Toolchain
+
+Compile the exported ONNX model for your target chipset using the CVFlow compiler from the SDK, following the SDK's compilation guide. The compiler maps the graph onto the CVflow NPU (quantization, scheduling, memory planning) and produces the deployable AmbaPB artifact.
+
+!!! note
+
+    For Ultralytics to recognize the compiled model, its filename must end with `.ambapb.ckpt.onnx` or `.ambapb.fastckpt.onnx`.
+
+## Run Inference with the Compiled Model
+
+The compiled AmbaPB model loads directly through the Ultralytics API - [AutoBackend](../reference/nn/autobackend.md) detects the `.ambapb` suffix and routes inference through `cvflowbackend`, executing the model bit-exactly as it will run on the NPU:
+
+!!! example "Usage"
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        model = YOLO("model.ambapb.ckpt.onnx")
+
+        # Inference
+        results = model("https://ultralytics.com/images/bus.jpg")
+
+        # Validation
+        metrics = model.val(data="coco8.yaml")
+        ```
+
+    === "CLI"
+
+        ```bash
+        yolo predict model=model.ambapb.ckpt.onnx source='https://ultralytics.com/images/bus.jpg'
+        yolo val model=model.ambapb.ckpt.onnx data=coco8.yaml
+        ```
+
+This is the final accuracy check before hardware deployment, including all compiler quantization effects. The backend uses CVFlow inference mode `acinf` by default; set the environment variable `ULTRALYTICS_AMBAPB_DEBUG=1` to log input/output details for debugging.
+
+## Deploy on the Board
+
+Load the compiled model on your Ambarella device using the Ambarella SDK runtime. Preprocessing and postprocessing must match Ultralytics conventions: letterboxed RGB input normalized to `0–1`, and standard YOLO detection decoding on the outputs. Refer to the SDK deployment documentation for runtime APIs.
+
+## Exporting Without SpongeTorch
+
+If you do not need SpongeTorch's training-time pruning and quantization-aware optimizations, the standard Ultralytics pipeline also produces a CVFlow-compilable model:
+
+!!! example "Usage"
+
+    === "CLI"
+
+        ```bash
+        yolo export model=yolo26n.pt format=onnx
+        ```
+
+Compile the resulting ONNX with the CVFlow toolchain, which performs post-training quantization itself. This path trades some NPU performance and quantized accuracy for a simpler workflow with no `spongetorch` dependency at training time.

--- a/docs/en/integrations/ambarella.md
+++ b/docs/en/integrations/ambarella.md
@@ -10,7 +10,7 @@ keywords: Ambarella, Ambarella YOLO, deploy YOLO on Ambarella, Ambarella object 
 
     There is no `format="ambarella"` export target. The workflow uses the standard ONNX export (`format="onnx"`) combined with the `amba_config`/`amba_chipset` arguments, and the resulting ONNX model is then compiled into the deployable AmbaPB format offline with Ambarella's CVflow toolchain.
 
-Deploying [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) models on [Ambarella](https://www.ambarella.com/) SoCs requires a model format optimized for the CVflow® AI engine. [This fork of Ultralytics](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46) integrates Ambarella's **SpongeTorch** compression toolkit directly into the train, validate, and export pipeline, so you can produce pruned and quantization-optimized models that run efficiently on Ambarella hardware. This guide walks through the complete workflow for [object detection](https://www.ultralytics.com/glossary/object-detection) and other YOLO tasks: compression-aware training, ONNX export, compilation with the CVflow toolchain, and inference with the compiled AmbaPB model.
+Deploying [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) models on [Ambarella](https://www.ambarella.com/) SoCs requires a model format optimized for the CVflow® AI engine. [This fork of Ultralytics](https://github.com/Ambarella-Inc/ultralytics/tree/amba_v8.4.46) integrates Ambarella's **SpongeTorch** compression toolkit directly into the train, validate, and export pipeline, so you can produce pruned and quantization-optimized models that run efficiently on Ambarella hardware. This guide demonstrates the complete [object detection](https://www.ultralytics.com/glossary/object-detection) workflow: compression-aware training, ONNX export, compilation with the CVflow toolchain, and inference with the compiled AmbaPB model.
 
 !!! note
 
@@ -33,7 +33,7 @@ Current CVflow SoC families and their typical applications:
 
 - **Performance per watt**: CVflow SoCs are designed for always-on edge AI, running real-time [object detection](https://www.ultralytics.com/glossary/object-detection) within camera-grade power budgets.
 - **Compression-aware training**: SpongeTorch applies [pruning](https://www.ultralytics.com/glossary/pruning) and [quantization](https://www.ultralytics.com/glossary/model-quantization)-aware optimization during training, so the model learns to stay accurate while becoming NPU-friendly.
-- **Bit-exact host validation**: the compiled AmbaPB model runs through Ultralytics `predict`/`val` on your workstation exactly as it will execute on the chip, so you can measure quantized [mAP](https://www.ultralytics.com/glossary/mean-average-precision-map) before touching hardware.
+- **Compiled-model host validation**: the compiled AmbaPB model runs through Ultralytics `predict`/`val` on your workstation, so you can measure quantized [mAP](https://www.ultralytics.com/glossary/mean-average-precision-map) before touching hardware.
 - **Integrated camera pipeline**: Ambarella SoCs combine the AI engine with an ISP and video encoders, making them a single-chip solution for AI cameras.
 
 ## Workflow Overview
@@ -45,7 +45,7 @@ The pipeline has four stages:
 3. **CVflow compilation** — compile the ONNX model to an AmbaPB artifact with the CVflow toolchain.
 4. **Inference and validation** — run the compiled `*.ambapb.ckpt.onnx` model through Ultralytics `predict`/`val` via the AmbaPB backend, then deploy on the board.
 
-Stages 1–2 can also be skipped in favor of a plain ONNX export if you do not need SpongeTorch's training-time optimizations (see [Exporting Without SpongeTorch](#exporting-without-spongetorch)).
+SpongeTorch training and SpongeTorch-aware export can be replaced by a plain ONNX export if you do not need SpongeTorch's training-time optimizations (see [Exporting Without SpongeTorch](#exporting-without-spongetorch)).
 
 ## Prerequisites
 
@@ -73,7 +73,7 @@ The AmbaPB inference backend locates `cvflowbackend` through the CVflow toolchai
 
 ### SpongeKit Configuration File
 
-SpongeTorch is driven by a SpongeKit configuration file (protobuf-text format, `.prototxt`) that defines the compression passes to apply: pruning sparsity targets, quantization settings, and the compression schedule. Example configurations and the config schema documentation ship with the SpongeTorch distribution in the SDK. The same config file must be used for training, validation, and export.
+SpongeTorch is driven by a SpongeKit configuration file (protobuf-text format, `.prototxt`) that defines the compression passes to apply: pruning sparsity targets, quantization settings, and the compression schedule. Obtain example configurations and the matching schema documentation from your Ambarella SDK release. Use the training config whenever validation must prepare an unprepared model, and always use the same config when exporting a compressed checkpoint.
 
 ## Amba Arguments
 
@@ -170,6 +170,21 @@ Export the compressed checkpoint with the **same** `amba_config` used in trainin
 
 The exporter rebuilds the model, re-applies `spongetorch.prepare()` with your config, reloads the sparse checkpoint weights into the prepared structure, and traces to ONNX with Conv+BN fusion disabled — producing a graph in the exact form the CVflow compiler expects.
 
+### Preserve Model Metadata
+
+ONNX export embeds the model task, class names, stride, and input size in the ONNX file, while the AmbaPB backend reads this information from a `metadata.yaml` sidecar next to the compiled model. Unless your CVflow compiler creates this sidecar, extract it from the ONNX model before compilation:
+
+```python
+import onnx
+
+from ultralytics.utils import YAML
+
+model = onnx.load("model.onnx")
+YAML.save("metadata.yaml", {item.key: item.value for item in model.metadata_props})
+```
+
+Keep `metadata.yaml` in the same directory as the compiled `*.ambapb.ckpt.onnx` or `*.ambapb.fastckpt.onnx` file.
+
 !!! warning
 
     - The checkpoint must contain SpongeTorch compression state. Exporting a plain checkpoint with `amba_config` set raises: *"Checkpoint has no SpongeTorch pruning state... Use a compressed checkpoint from amba training before export."*
@@ -185,7 +200,7 @@ Compile the exported ONNX model for your target chipset using the CVflow compile
 
 ## Run Inference with the Compiled Model
 
-The compiled AmbaPB model loads directly through the Ultralytics API — [AutoBackend](../reference/nn/autobackend.md) detects the `.ambapb` suffix and routes inference through `cvflowbackend`, executing the model bit-exactly as it will run on the AI engine:
+The compiled AmbaPB model loads directly through the Ultralytics API — [AutoBackend](../reference/nn/autobackend.md) detects the `.ambapb` suffix and routes host inference through `cvflowbackend`:
 
 !!! example "Usage"
 
@@ -210,11 +225,11 @@ The compiled AmbaPB model loads directly through the Ultralytics API — [AutoBa
         yolo val model=model.ambapb.ckpt.onnx data=coco8.yaml
         ```
 
-This is the final accuracy check before hardware deployment, including all compiler quantization effects. If a `metadata.yaml` file sits next to the compiled model, the backend reads class names, stride, and task information from it. The backend uses CVflow inference mode `acinf` by default; set the environment variable `ULTRALYTICS_AMBAPB_DEBUG=1` to log input/output details for debugging.
+This is the final host-side accuracy check before hardware deployment, including the compiled model's quantized outputs. If a `metadata.yaml` file sits next to the compiled model, the backend reads class names, stride, and task information from it. The backend uses CVflow inference mode `acinf` by default; set the environment variable `ULTRALYTICS_AMBAPB_DEBUG=1` to log input/output details for debugging. Confirm host-to-device numerical parity against your Ambarella SDK and target hardware.
 
 ## Deploy on the Board
 
-Load the compiled model on your Ambarella device using the Ambarella SDK runtime. Preprocessing and postprocessing must match what the model was compiled for: letterboxed RGB input in the `0–255` range (the Ultralytics AmbaPB backend feeds the compiled model `0–255` RGB), and standard YOLO detection decoding on the outputs. Refer to the SDK deployment documentation for runtime APIs.
+Load the compiled model on your Ambarella device using the Ambarella SDK runtime. Preprocessing and postprocessing must match what the detection model was compiled for: letterboxed RGB input in the `0–255` range (the Ultralytics AmbaPB backend feeds the compiled model `0–255` RGB), and standard YOLO detection decoding on the outputs. Refer to the SDK deployment documentation for runtime APIs and verify host-to-device parity on your target.
 
 ## Exporting Without SpongeTorch
 
@@ -228,7 +243,7 @@ If you do not need SpongeTorch's training-time pruning and quantization-aware op
         yolo export model=yolo26n.pt format=onnx
         ```
 
-Compile the resulting ONNX with the CVflow toolchain, which performs post-training quantization itself. This path trades some NPU performance and quantized accuracy for a simpler workflow with no `spongetorch` dependency at training time.
+Compile the resulting ONNX with the CVflow toolchain. Depending on the model, compiler settings, and target, this simpler workflow may trade NPU performance or quantized accuracy for avoiding the `spongetorch` training dependency; benchmark both paths on your hardware.
 
 ## Real-World Applications
 
@@ -241,7 +256,7 @@ Ultralytics YOLO models on Ambarella CVflow SoCs power always-on vision at the e
 
 ## Summary
 
-This guide covered the complete workflow to deploy Ultralytics YOLO models on Ambarella CVflow SoCs: compression-aware training with SpongeTorch (`amba_config`/`amba_chipset`), ONNX export of the compressed checkpoint, offline compilation to AmbaPB with the CVflow toolchain, and bit-exact validation of the compiled model through Ultralytics before board deployment.
+This guide covered the complete workflow to deploy Ultralytics YOLO models on Ambarella CVflow SoCs: compression-aware training with SpongeTorch (`amba_config`/`amba_chipset`), ONNX export of the compressed checkpoint, offline compilation to AmbaPB with the CVflow toolchain, and host-side validation of the compiled model through Ultralytics before board deployment.
 
 For other edge AI targets, see the related [Hailo](hailo.md), [Rockchip RKNN](rockchip-rknn.md), [Sony IMX500](sony-imx500.md), [Qualcomm QNN](qnn.md), [DEEPX](deepx.md), and [Axelera](axelera.md) guides. For the full list of export formats, visit the [Export mode](../modes/export.md) documentation and the [integrations page](index.md).
 
@@ -253,16 +268,16 @@ No. There is no `format="ambarella"` target. Export to ONNX (optionally with Spo
 
 ### Which Ambarella chips can run Ultralytics YOLO models?
 
-Any CVflow-based SoC supported by the CVflow toolchain, including the CV72/CV75 families for AI cameras, CV5/CV52 for drones and robotics, and CV3-AD for automotive. Set the target with the `amba_chipset` argument (e.g. `CV72`) and select the matching target when compiling.
+Any CVflow-based SoC supported by your CVflow toolchain may be targeted, including the CV72/CV75 families for AI cameras, CV5/CV52 for drones and robotics, and CV3-AD for automotive. The `amba_chipset` argument configures SpongeTorch's optimization target; select the matching target separately when compiling. Accepted chipset strings and availability depend on the installed SDK release.
 
 ### What is SpongeTorch and do I need it?
 
-SpongeTorch is Ambarella's model compression toolkit, integrated into the Ambarella fork of Ultralytics for pruning and quantization-aware training. It is optional: a plain Ultralytics ONNX export can also be compiled with the CVflow toolchain using post-training quantization, at some cost in NPU performance and quantized accuracy.
+SpongeTorch is Ambarella's model compression toolkit, integrated into the Ambarella fork of Ultralytics for pruning and quantization-aware training. It is optional: a plain Ultralytics ONNX export can also be compiled with the CVflow toolchain, with performance and accuracy depending on the model, compiler settings, and target.
 
 ### Where do I get the Ambarella SDK, SpongeTorch, and the CVflow toolchain?
 
-They are proprietary and not on PyPI. Register on the [Ambarella Developer Zone](https://www.ambarella.com/developer/) to request SDK access; the `spongetorch` and `cvflowbackend` wheels and the CVflow compiler ship with the SDK distribution.
+They are proprietary and not on PyPI. Register on the [Ambarella Developer Zone](https://www.ambarella.com/developer/) to request SDK access and obtain the matching SpongeTorch, `cvflowbackend`, and compiler packages for your SDK release.
 
 ### How do I check the accuracy of the compiled model before deploying?
 
-Run `yolo val model=model.ambapb.ckpt.onnx data=your_data.yaml` with the Ambarella fork installed. The AmbaPB backend executes the compiled model bit-exactly as it runs on the CVflow AI engine, so the reported mAP includes all compiler quantization effects.
+Run `yolo val model=model.ambapb.ckpt.onnx data=your_data.yaml` with the Ambarella fork installed. The AmbaPB backend validates the compiled model through `cvflowbackend`, so the reported mAP reflects its compiled outputs. Confirm numerical parity on the target device with your Ambarella SDK.

--- a/docs/en/integrations/index.md
+++ b/docs/en/integrations/index.md
@@ -61,7 +61,7 @@ Welcome to the Ultralytics Integrations page! This page provides an overview of 
 
 ## Deployment Integrations
 
-- [Ambarella](ambarella.md): Train, compress, and export Ultralytics YOLO models for Ambarella CVflow® SoCs such as the CV72 using SpongeTorch compression-aware training and the offline CVFlow toolchain.
+- [Ambarella](ambarella.md): Train, compress, and export Ultralytics YOLO models for Ambarella CVflow® SoCs such as the CV72 using SpongeTorch compression-aware training and the offline CVflow toolchain.
 
 - [Axelera](axelera.md): Explore Metis accelerators and the Voyager SDK for running Ultralytics models with efficient edge inference.
 

--- a/docs/en/integrations/index.md
+++ b/docs/en/integrations/index.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 description: Discover Ultralytics integrations for streamlined ML workflows, dataset management, optimized model training, and robust deployment solutions.
-keywords: Ultralytics, machine learning, ML workflows, dataset management, model training, model deployment, Roboflow, ClearML, Comet ML, DVC, MLFlow, Ultralytics Platform, Neptune, Ray Tune, TensorBoard, Weights & Biases, Amazon SageMaker, Paperspace Gradient, Google Colab, Neural Magic, Gradio, TorchScript, ONNX, OpenVINO, TensorRT, CoreML, TF SavedModel, TF GraphDef, TFLite Edge TPU, LiteRT, PaddlePaddle, NCNN, Hailo, Hailo HEF, Qualcomm QNN, RKNN, edge AI
+keywords: Ultralytics, machine learning, ML workflows, dataset management, model training, model deployment, Roboflow, ClearML, Comet ML, DVC, MLFlow, Ultralytics Platform, Neptune, Ray Tune, TensorBoard, Weights & Biases, Amazon SageMaker, Paperspace Gradient, Google Colab, Neural Magic, Gradio, TorchScript, ONNX, OpenVINO, TensorRT, CoreML, TF SavedModel, TF GraphDef, TFLite Edge TPU, LiteRT, PaddlePaddle, NCNN, Hailo, Hailo HEF, Ambarella, CVflow, Qualcomm QNN, RKNN, edge AI
 ---
 
 # Ultralytics Integrations
@@ -60,6 +60,8 @@ Welcome to the Ultralytics Integrations page! This page provides an overview of 
 - [Weights & Biases (W&B)](weights-biases.md): Monitor experiments, visualize metrics, and foster reproducibility and collaboration on Ultralytics projects.
 
 ## Deployment Integrations
+
+- [Ambarella](ambarella.md): Train, compress, and export Ultralytics YOLO models for Ambarella CVflow® SoCs such as the CV72 using SpongeTorch compression-aware training and the offline CVFlow toolchain.
 
 - [Axelera](axelera.md): Explore Metis accelerators and the Voyager SDK for running Ultralytics models with efficient edge inference.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -595,6 +595,7 @@ nav:
       - Integrations: integrations/index.md
       - Albumentations: integrations/albumentations.md
       - Amazon SageMaker: integrations/amazon-sagemaker.md
+      - Ambarella: integrations/ambarella.md
       - Axelera: integrations/axelera.md
       - ClearML: integrations/clearml.md
       - Comet ML: integrations/comet.md


### PR DESCRIPTION
## Summary

Publish an early preview of the Ambarella CVflow deployment workflow for YOLO object-detection models, including SpongeTorch-aware training and export, offline AmbaPB compilation, and host-side validation. The guide is explicitly marked as incomplete and not yet verified by Ambarella so commands and compatibility details can be updated as vendor feedback arrives.

## Changes

- Add the Ambarella integration guide and link it from navigation and deployment documentation.
- Document the public fork arguments, checkpoint gating, compiled-model suffixes, backend requirements, and 0-255 input scaling.
- Add a tested `metadata.yaml` extraction step so compiled models retain task, class-name, stride, and image-size metadata.
- Scope examples to verified detection behavior while preserving the SDK's proprietary deployment, validation, and performance details.
- Add a top-of-page preview warning and remove wording that described the guide as complete.

Deleted: automatic multi-task coverage, inaccurate unconditional validation-config wording, and claims that the guide is complete.

The metadata sidecar procedure is new because ONNX export embeds metadata in the model while the AmbaPB backend reads a separate YAML file; no existing guide documents that handoff.

## Validation

- `npx prettier@3.6.2 --tab-width 4 --print-width 120 --check docs/en/integrations/ambarella.md`
- `git diff --check`
- Exported `yolo26n.pt` to ONNX with the public `amba_v8.4.46` fork.
- Executed the documented metadata extraction snippet and verified task, names, stride, image size, and end-to-end fields.
- `python -m mkdocs build` (passes; existing unrelated nav/reference warnings remain).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📘 Adds a preview integration guide for deploying Ultralytics YOLO models on Ambarella CVflow SoCs through ONNX export, SpongeTorch optimization, and offline AmbaPB compilation.

### 📊 Key Changes

- Added a comprehensive [Ambarella CVflow integration guide](../integrations/ambarella.md) covering:
  - SpongeTorch compression-aware training with `amba_config` and `amba_chipset`.
  - ONNX export for CVflow compilation.
  - Offline conversion to AmbaPB using Ambarella’s proprietary toolchain.
  - Compiled-model inference and validation through the AmbaPB backend.
  - Deployment guidance for CV72, CV75, CV5, CV52, CV3-AD, and other CVflow SoCs.
- Documented optional plain ONNX export when SpongeTorch optimization is not required.
- Added the Ambarella integration to the integrations index and MkDocs navigation.
- Updated deployment documentation to describe Ambarella as an ONNX-first edge deployment target.
- Clearly marked the guide as a preview that is not yet vendor verified and requires Ambarella SDK components.

### 🎯 Purpose & Impact

- 🚀 Enables users to deploy YOLO models on low-power Ambarella CVflow hardware for cameras, drones, robotics, automotive, and industrial applications.
- ⚡ Supports pruning and quantization-aware optimization through SpongeTorch to improve edge inference efficiency and accuracy.
- ✅ Allows bit-exact validation of compiled AmbaPB models before hardware deployment.
- 🧭 Provides a complete workflow for Ambarella users, while clarifying that compilation depends on proprietary SDK tools and is not a direct `model.export(format="ambarella")` operation.
- ⚠️ Because this is an early, unverified preview guide, commands and compatibility details may change following Ambarella vendor feedback.