### PR TITLE
Fix version comparisons for 4-segment pins like opencv-python!=4.13.0.90

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -831,6 +831,8 @@ def test_utils_checks():
     # parse_version must pad to at least 3 components and keep all segments so any version pair compares correctly
     assert checks.parse_version("2") == (2, 0, 0)
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
+    assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
+    assert checks.parse_version("1.0.0rc1") == (1, 0, 0)
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement
     assert checks.check_version("2.1", "==2.1.0")
     assert checks.check_version("4.13.0.92", "!=4.13.0.90")  # 4-segment pins must not be truncated

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -834,6 +834,7 @@ def test_utils_checks():
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
     assert checks.parse_version("1.0.0rc1") == (1, 0, 0)
     assert checks.parse_version("v2.1") == (2, 1, 0)
+    assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
     assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement
     assert checks.check_version("2.1", "==2.1.0")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -828,10 +828,14 @@ def test_utils_checks():
     checks.check_imshow(warn=True)
     checks.check_suffix("https://example.com/model.pt?token=abc", ".pt")
     checks.check_version("ultralytics", "8.0.0")
-    # parse_version must pad to a 3-tuple so shorter version strings compare correctly
+    # parse_version must pad to at least 3 components and keep all segments so any version pair compares correctly
     assert checks.parse_version("2") == (2, 0, 0)
+    assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement
     assert checks.check_version("2.1", "==2.1.0")
+    assert checks.check_version("4.13.0.92", "!=4.13.0.90")  # 4-segment pins must not be truncated
+    assert not checks.check_version("4.13.0.90", "!=4.13.0.90")
+    assert checks.check_version("2.0.1", "<2.0.1.5")
     checks.print_args()
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -833,6 +833,8 @@ def test_utils_checks():
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
     assert checks.parse_version("1.0.0rc1") == (1, 0, 0)
+    assert checks.parse_version("v2.1") == (2, 1, 0)
+    assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement
     assert checks.check_version("2.1", "==2.1.0")
     assert checks.check_version("4.13.0.92", "!=4.13.0.90")  # 4-segment pins must not be truncated

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -595,7 +595,11 @@ class Exporter:
                             "Please upgrade TensorRT to 8.5.0 or later to enable end2end export."
                         )
 
-                    if self.args.quantize == 8 and check_version(trt.__version__, "==10.3.0") and is_jetson(jetpack=6):
+                    if (
+                        self.args.quantize == 8
+                        and check_version(trt.__version__, ">=10.3.0,<10.4.0")  # JetPack 6 builds report 10.3.0.x
+                        and is_jetson(jetpack=6)
+                    ):
                         # https://github.com/ultralytics/ultralytics/issues/23841
                         model.end2end = False
                         LOGGER.warning(

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -113,13 +113,16 @@ def get_distribution_name(import_name: str) -> str:
 
 @functools.lru_cache
 def parse_version(version="0.0.0") -> tuple:
-    """Convert a version string to a tuple of integers, ignoring any extra non-numeric string attached to the version.
+    """Convert a version string to a tuple of integers from its release segments, ignoring prefixes and suffixes.
+
+    Not PEP 440: pre-release/dev/post/local suffixes are dropped, so '1.0rc1', '1.0.post1', and '1.0+cu118' all
+    compare equal to '1.0'. Use the `packaging` library where exact pre-release ordering matters.
 
     Args:
-        version (str): Version string, i.e. '2.0.1+cpu' or '4.13.0.92'
+        version (str): Version string, i.e. '2.0.1+cpu', '4.13.0.92', or 'v2.1'
 
     Returns:
-        (tuple): Tuple of integers representing the numeric part of the version, at least 3 long, i.e. (2, 0, 1)
+        (tuple): Tuple of integers representing the release segments, at least 3 long, i.e. (2, 0, 1)
     """
     try:
         nums = [int(x) for x in re.search(r"\d+(?:\.\d+)*", version).group(0).split(".")]

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -116,14 +116,14 @@ def parse_version(version="0.0.0") -> tuple:
     """Convert a version string to a tuple of integers, ignoring any extra non-numeric string attached to the version.
 
     Args:
-        version (str): Version string, i.e. '2.0.1+cpu'
+        version (str): Version string, i.e. '2.0.1+cpu' or '4.13.0.92'
 
     Returns:
-        (tuple): Tuple of integers representing the numeric part of the version, i.e. (2, 0, 1)
+        (tuple): Tuple of integers representing the numeric part of the version, at least 3 long, i.e. (2, 0, 1)
     """
     try:
-        nums = [int(x) for x in re.findall(r"\d+", version)[:3]]
-        return tuple(nums + [0] * (3 - len(nums)))  # pad to 3, i.e. '2.0.1+cpu' -> (2, 0, 1), '2' -> (2, 0, 0)
+        nums = [int(x) for x in re.findall(r"\d+", version)]
+        return tuple(nums + [0] * (3 - len(nums)))  # '2.0.1+cpu' -> (2, 0, 1), '2' -> (2, 0, 0), keep all segments
     except Exception as e:
         LOGGER.warning(f"failure for parse_version({version}), returning (0, 0, 0): {e}")
         return 0, 0, 0
@@ -276,17 +276,19 @@ def check_version(
         if not op:
             op = ">="  # assume >= if no op passed
         v = parse_version(version)  # '1.2.3' -> (1, 2, 3)
-        if op == "==" and c != v:
+        n = max(len(c), len(v))  # pad to equal length so 4-segment pins like '!=4.13.0.90' compare exactly
+        cn, vn = c + (0,) * (n - len(c)), v + (0,) * (n - len(v))
+        if op == "==" and cn != vn:
             result = False
-        elif op == "!=" and c == v:
+        elif op == "!=" and cn == vn:
             result = False
-        elif op == ">=" and not (c >= v):
+        elif op == ">=" and not (cn >= vn):
             result = False
-        elif op == "<=" and not (c <= v):
+        elif op == "<=" and not (cn <= vn):
             result = False
-        elif op == ">" and not (c > v):
+        elif op == ">" and not (cn > vn):
             result = False
-        elif op == "<" and not (c < v):
+        elif op == "<" and not (cn < vn):
             result = False
     if not result:
         warning = f"{name}{required} is required, but {name}=={current} is currently installed {msg}"
@@ -842,7 +844,7 @@ def collect_system_info():
     for r in parse_requirements(package=get_distribution_name("ultralytics")):
         try:
             current = metadata.version(r.name)
-            is_met = "✅ " if check_version(current, str(r.specifier), name=r.name, hard=True) else "❌ "
+            is_met = "✅ " if check_version(current, str(r.specifier), name=r.name) else "❌ "
         except metadata.PackageNotFoundError:
             current = "(not installed)"
             is_met = "❌ "

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -122,8 +122,8 @@ def parse_version(version="0.0.0") -> tuple:
         (tuple): Tuple of integers representing the numeric part of the version, at least 3 long, i.e. (2, 0, 1)
     """
     try:
-        nums = [int(x) for x in re.match(r"\d+(?:\.\d+)*", version).group(0).split(".")]
-        return tuple(nums + [0] * (3 - len(nums)))  # keep all release segments, ignore suffixes like '+cu118'/'rc1'
+        nums = [int(x) for x in re.search(r"\d+(?:\.\d+)*", version).group(0).split(".")]
+        return tuple(nums + [0] * (3 - len(nums)))  # keep all release segments, ignore 'v' prefix and '+cu118'/'rc1'
     except Exception as e:
         LOGGER.warning(f"failure for parse_version({version}), returning (0, 0, 0): {e}")
         return 0, 0, 0

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -115,8 +115,8 @@ def get_distribution_name(import_name: str) -> str:
 def parse_version(version="0.0.0") -> tuple:
     """Convert a version string to a tuple of integers from its release segments, ignoring prefixes and suffixes.
 
-    Not PEP 440: pre-release/dev/post/local suffixes are dropped, so '1.0rc1', '1.0.post1', and '1.0+cu118' all
-    compare equal to '1.0'. Use the `packaging` library where exact pre-release ordering matters.
+    Not PEP 440: pre-release/dev/post/local suffixes are dropped, so '1.0rc1', '1.0.post1', and '1.0+cu118' all compare
+    equal to '1.0'. Use the `packaging` library where exact pre-release ordering matters.
 
     Args:
         version (str): Version string, i.e. '2.0.1+cpu', '4.13.0.92', or 'v2.1'

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -122,8 +122,8 @@ def parse_version(version="0.0.0") -> tuple:
         (tuple): Tuple of integers representing the numeric part of the version, at least 3 long, i.e. (2, 0, 1)
     """
     try:
-        nums = [int(x) for x in re.findall(r"\d+", version)]
-        return tuple(nums + [0] * (3 - len(nums)))  # '2.0.1+cpu' -> (2, 0, 1), '2' -> (2, 0, 0), keep all segments
+        nums = [int(x) for x in re.match(r"\d+(?:\.\d+)*", version).group(0).split(".")]
+        return tuple(nums + [0] * (3 - len(nums)))  # keep all release segments, ignore suffixes like '+cu118'/'rc1'
     except Exception as e:
         LOGGER.warning(f"failure for parse_version({version}), returning (0, 0, 0): {e}")
         return 0, 0, 0


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves version parsing and comparison reliability, especially for 4-part dependency versions and Jetson TensorRT exports 🚀

### 📊 Key Changes
- Updated `parse_version()` to preserve all numeric release segments, such as `4.13.0.92`, instead of truncating to 3 parts 🔢
- Improved `check_version()` to compare versions of different lengths accurately by padding them before comparison ✅
- Expanded test coverage for versions with prefixes, suffixes, pre-release tags, local build tags, and 4-segment pins 🧪
- Adjusted TensorRT export logic for JetPack 6 to match the full TensorRT `10.3.x` family instead of only `10.3.0` ⚙️
- Updated system info collection to avoid raising hard errors during dependency checks, making diagnostics more robust 🛠️

### 🎯 Purpose & Impact
- Prevents incorrect dependency checks when packages use 4-part version numbers, improving compatibility and reliability 📦
- Fixes Jetson TensorRT quantized export handling for JetPack 6 builds that report versions like `10.3.0.x` 🤖
- Reduces false positives or false negatives in version constraints such as exact matches, exclusions, and range checks 🎯
- Makes system diagnostics more user-friendly by reporting unmet requirements without interrupting execution 🧩