### PR TITLE
Pin ARM export torch below 2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ export = [
     "ultralytics[export-tensorflow]",
     "ultralytics[export-coreml]",
     "ultralytics[export-litert]",
-    "torch>=2.12.0,<2.13.0; platform_system == 'Linux' and platform_machine == 'aarch64'",
+    "torch>=2.12.0,<2.13.0; platform_system == 'Linux' and platform_machine == 'aarch64' and python_version == '3.11'",
 ]
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ export = [
     "ultralytics[export-tensorflow]",
     "ultralytics[export-coreml]",
     "ultralytics[export-litert]",
+    # Raspberry Pi Python 3.11 ExecuTorch inference requires the last known-good Linux ARM64 Torch 2.12 stack.
     "torch>=2.12.0,<2.13.0; platform_system == 'Linux' and platform_machine == 'aarch64' and python_version == '3.11'",
 ]
 solutions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ export = [
     "ultralytics[export-tensorflow]",
     "ultralytics[export-coreml]",
     "ultralytics[export-litert]",
+    "torch>=2.12.0,<2.13.0; platform_system == 'Linux' and platform_machine == 'aarch64'",
 ]
 solutions = [
     "shapely>=2.0.0",    # shapely for point and polygon data matching


### PR DESCRIPTION
## Summary
- pin the Linux aarch64 Python 3.11 `export` extra to `torch<2.13` so Raspberry Pi benchmark installs resolve to the last known-good Torch 2.12 stack
- keep the full Raspberry Pi benchmark path intact, including ExecuTorch export and inference
- leave Jetson/NVIDIA ARM64 Docker Python 3.8, 3.10, and 3.12 paths outside this pin

## Root Cause
The failing scheduled Raspberry Pi job resolved `.[export]` on Python 3.11 to `torch==2.13.0+cpu`; ExecuTorch then auto-installed into that process and failed importing `_portable_lib` with an undefined C++ symbol. The previous successful scheduled Raspberry Pi job used `torch==2.12.1+cpu` and completed ExecuTorch export/inference.

Deleted: nothing; this is a dependency metadata fix because the failing behavior is caused by upstream ARM wheel resolver drift, not removable repo code.

## Validation
- `uv pip compile pyproject.toml --extra export --torch-backend cpu --python-platform aarch64-unknown-linux-gnu --python-version 3.11` resolves `torch==2.12.1+cpu`, `torchvision==0.27.1+cpu`, `numpy==1.26.4`, `tensorflow==2.19.0`
- `uv pip compile pyproject.toml --extra export --torch-backend cpu --python-platform aarch64-manylinux_2_35 --python-version 3.10` resolves `torch==2.13.0+cpu`, confirming Jetson Python 3.10 is not affected
- `uv pip compile pyproject.toml --extra export --torch-backend cpu --python-platform aarch64-manylinux_2_35 --python-version 3.12` resolves `torch==2.13.0+cpu`, confirming NVIDIA ARM64 Python 3.12 is not affected
- `python -m pytest tests/test_python.py::test_utils_checks -q`
- RaspberryPi-only dispatch https://github.com/ultralytics/ultralytics/actions/runs/29033152858 succeeded end-to-end; its benchmark env installed `torch==2.12.1+cpu`, `torchvision==0.27.1+cpu`, and `numpy==1.26.4`, then ExecuTorch 1.3.1 export/inference passed for the detection benchmark
- PR CI rerun https://github.com/ultralytics/ultralytics/actions/runs/29033129620 passed after rerunning unrelated asset-download 504 failures

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a Raspberry Pi–specific PyTorch dependency pin for Python 3.11 export/inference support on Linux ARM64 🥧🚀

### 📊 Key Changes
- Added a conditional `torch` dependency for Linux `aarch64` systems running Python 3.11.
- Pins PyTorch to the compatible `>=2.12.0,<2.13.0` range for this platform.
- Documents the reason directly in `pyproject.toml`: Raspberry Pi Python 3.11 ExecuTorch inference requires the last known-good Linux ARM64 Torch 2.12 stack.

### 🎯 Purpose & Impact
- Improves reliability for Raspberry Pi users by installing a known-compatible PyTorch version automatically ✅
- Helps prevent dependency conflicts or unsupported Torch versions during export and ExecuTorch inference workflows.
- Makes edge deployment on ARM64 devices smoother, especially for users running YOLO models on Raspberry Pi with Python 3.11.