### PR TITLE
Validate string-only CLI args (e.g. split) at cfg layer (#25056)

### DIFF
--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -1,0 +1,29 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+import pytest
+
+from ultralytics.cfg import check_cfg
+
+
+def test_check_cfg_str_keys_reject_non_str():
+    """A string-only arg like `split` passed a non-str (e.g. the fuzzed `split={}`) must raise a clean TypeError.
+
+    This guards issue ultralytics/ultralytics#25056: an invalid CLI value such as `split={}` previously crashed deep
+    inside the validator with a raw `TypeError`, instead of failing fast at the cfg layer.
+    """
+    with pytest.raises(TypeError, match="'split='"):
+        check_cfg({"split": {}}, hard=True)
+    with pytest.raises(TypeError, match="'split='"):
+        check_cfg({"split": ["val"]}, hard=True)
+    # None is allowed (optional arg) and a valid str passes through untouched.
+    cfg = {"split": None}
+    check_cfg(cfg, hard=True)
+    assert cfg["split"] is None
+    check_cfg({"split": "val"}, hard=True)
+
+
+def test_check_cfg_str_keys_soft_convert():
+    """With hard=False a non-str `split` is coerced to str rather than raising."""
+    cfg = {"split": 123}
+    check_cfg(cfg, hard=False)
+    assert cfg["split"] == "123"

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -286,6 +286,11 @@ CFG_BOOL_KEYS = frozenset(
         "cls_remap",
     }
 )
+CFG_STR_KEYS = frozenset(
+    {  # string-only arguments that are consumed by name (e.g. dataset split selection)
+        "split",
+    }
+)
 
 
 def cfg2dict(cfg: str | Path | dict | SimpleNamespace) -> dict:
@@ -450,6 +455,13 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                         f"'{k}' must be a bool (i.e. '{k}=True' or '{k}=False')"
                     )
                 cfg[k] = bool(v)
+            elif k in CFG_STR_KEYS and not isinstance(v, str):
+                if hard:
+                    raise TypeError(
+                        f"'{k}={v}' is of invalid type {type(v).__name__}. '{k}' must be a str "
+                        f"(i.e. '{k}=val', '{k}=test' or '{k}=train')"
+                    )
+                cfg[k] = str(v)
             elif k == "quantize":  # canonicalize 8/16/32 or w-notation to a scheme (unset stays None for FP32)
                 scheme = QUANTIZE_ALIASES.get(str(v).lower())
                 if scheme is None:


### PR DESCRIPTION
## Summary

A string-only CLI arg such as `split` passed a non-`str` value (e.g. the fuzzed
`split={}`) previously crashed deep inside the validator with a raw `TypeError`
instead of failing fast at the configuration layer. This PR rejects such values
in `check_cfg` with a clear, actionable message, matching the existing
`CFG_FLOAT_KEYS` / `CFG_INT_KEYS` / `CFG_BOOL_KEYS` validation pattern.

- Adds `CFG_STR_KEYS` (currently `{split}`), validated in `check_cfg`:
  - `hard=True` raises a `TypeError` listing valid `str` values.
  - `hard=False` coerces the value to `str` (consistent with how float/int keys
    are soft-converted).
  - `None` stays allowed (optional arg); a valid `str` passes through untouched.
- Invalid input such as `yolo val classify model=... split={}` now fails with:

  ```
  'split={}' is of invalid type dict. 'split' must be a str (i.e. 'split=val', 'split=test' or 'split=train')
  ```

## Fixes

- Closes the `split={}` fuzz signature in ultralytics/ultralytics#25056
  (rolling "CLI validation gaps" meta-issue; this is one contained sub-bug of many).

## Test

- `tests/test_cfg.py` (new): asserts non-`str` `split` raises on `hard=True`,
  `None` is allowed, a valid `str` is accepted, and soft-conversion to `str`
  occurs on `hard=False`.

## Notes for reviewers

- **Deleted:** nothing — net-additive `cfg` guard. Relocation to a deeper layer
  wasn't possible because `split` is consumed by name in multiple validators
  (`check_cls_dataset`, `self.data.get(self.args.split)`), and the cfg layer is
  the single choke point that runs on every CLI invocation.
- This PR addresses only the `split={}` signature of the rolling #25056 issue;
  the other fuzz signatures remain tracked in that meta-issue for separate PRs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds cfg-layer validation for string-only CLI arguments like `split` to fail fast with clear errors and improve robustness. 🛡️

### 📊 Key Changes
- Introduces `CFG_STR_KEYS` with `split` as a string-only configuration key.
- Updates `check_cfg()` to raise a clean `TypeError` for non-string `split` values when `hard=True`.
- Supports soft conversion to string when `hard=False`.
- Adds new tests in `tests/test_cfg.py` covering invalid, optional, valid, and soft-conversion cases.

### 🎯 Purpose & Impact
- Prevents invalid CLI inputs such as `split={}` from crashing deeper in validation logic. ✅
- Improves error clarity for users by catching type issues at the configuration layer. 🔍
- Adds regression coverage for issue `#25056`, improving long-term stability. 🧪