### PR TITLE
Handle v-prefixed versions in check_version

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -833,7 +833,7 @@ def test_utils_checks():
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
     assert not checks.check_version("v2.1-not-a-version", ">=2.0")  # dotted v+digit package names use metadata
-    assert checks.check_version("v2.1", ">=2.0")  # v-prefixed versions must not be mistaken for package names
+    assert all(checks.check_version(v, ">=2.0") for v in ("v2", "v2.1rc1", "v2.1.post1", "v2.1+cu118"))
     assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
     assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -832,7 +832,7 @@ def test_utils_checks():
     assert checks.parse_version("2") == (2, 0, 0)
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
-    assert not checks.check_version("v2-not-a-version", ">=2.0")  # v+digit package names stay on metadata path
+    assert not checks.check_version("v2.1-not-a-version", ">=2.0")  # dotted v+digit package names use metadata
     assert checks.check_version("v2.1", ">=2.0")  # v-prefixed versions must not be mistaken for package names
     assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
     assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -818,7 +818,7 @@ def test_utils_init():
     is_github_action_running()
 
 
-def test_utils_checks():
+def test_utils_checks(monkeypatch):
     """Test various utility checks for filenames, requirements, image sizes, display capabilities, and versions."""
     checks.check_yolov5u_filename("yolov5n.pt")
     checks.check_requirements("numpy")  # check requirements.txt
@@ -827,13 +827,13 @@ def test_utils_checks():
         checks.check_imgsz("640x480")  # malformed imgsz string raises a helpful ValueError, not a raw SyntaxError
     checks.check_imshow(warn=True)
     checks.check_suffix("https://example.com/model.pt?token=abc", ".pt")
-    checks.check_version("ultralytics", "8.0.0")
     # parse_version must pad to at least 3 components and keep all segments so any version pair compares correctly
     assert checks.parse_version("2") == (2, 0, 0)
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
-    assert not checks.check_version("v2.1-not-a-version", ">=2.0")  # dotted v+digit package names use metadata
-    assert all(checks.check_version(v, ">=2.0") for v in ("v2", "v2.1rc1", "v2.1.post1", "v2.1+cu118"))
+    assert all(checks.check_version(v, ">=2.0") for v in ("v2", "v2.1-rc1", "v2.1RC1", "v2.1.post1", "v2.1+cu118"))
+    monkeypatch.setattr(checks.metadata, "version", lambda _: "1.0")
+    assert not checks.check_version("v2-package", ">=2.0")  # installed v+digit package names keep metadata precedence
     assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
     assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -832,7 +832,7 @@ def test_utils_checks():
     assert checks.parse_version("2") == (2, 0, 0)
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
-    assert checks.parse_version("1.0.0rc1") == (1, 0, 0)
+    assert not checks.check_version("v2-not-a-version", ">=2.0")  # v+digit package names stay on metadata path
     assert checks.check_version("v2.1", ">=2.0")  # v-prefixed versions must not be mistaken for package names
     assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
     assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -9,7 +9,6 @@ import urllib
 import zipfile
 from copy import copy
 from pathlib import Path
-from unittest.mock import Mock
 
 import cv2
 import numpy as np
@@ -821,6 +820,12 @@ def test_utils_init():
 
 def test_utils_checks(monkeypatch):
     """Test various utility checks for filenames, requirements, image sizes, display capabilities, and versions."""
+
+    def package_version(name):
+        if name == "v2":
+            return "1.0"
+        raise checks.metadata.PackageNotFoundError
+
     checks.check_yolov5u_filename("yolov5n.pt")
     checks.check_requirements("numpy")  # check requirements.txt
     checks.check_imgsz([600, 600], max_dim=1)
@@ -828,13 +833,20 @@ def test_utils_checks(monkeypatch):
         checks.check_imgsz("640x480")  # malformed imgsz string raises a helpful ValueError, not a raw SyntaxError
     checks.check_imshow(warn=True)
     checks.check_suffix("https://example.com/model.pt?token=abc", ".pt")
+    checks.check_version("ultralytics", "8.0.0")
     # parse_version must pad to at least 3 components and keep all segments so any version pair compares correctly
+    assert checks.parse_version("2") == (2, 0, 0)
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
-    assert all(checks.check_version(v, ">=2.0") for v in ("v2", "v2.1-rc1", "v2.1RC1", "v2.1.post1", "v2.1+cu118"))
-    monkeypatch.setattr(checks.metadata, "version", Mock(side_effect=["1.0", checks.metadata.PackageNotFoundError()]))
-    assert not checks.check_version("v2-package", ">=2.0")  # installed v+digit package names keep metadata precedence
-    assert not checks.check_version("v2-missing", ">=2.0")
+    assert checks.parse_version("1.0.0rc1") == (1, 0, 0)
+    assert checks.parse_version("v2.1") == (2, 1, 0)
+    assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
+    monkeypatch.setattr(checks.metadata, "version", package_version)
+    assert not checks.check_version("v2", ">=2.0")  # installed version-shaped package keeps metadata precedence
+    versions = ("v2.1-rc.1", "v2.1-beta1", "v2.1rev1", "v2.1-dev1", "v2.1+cu118")
+    assert all(checks.check_version(v, ">=2.0") for v in versions)
+    with pytest.raises(ModuleNotFoundError):
+        checks.check_version("v2-missing", ">=2.0", hard=True)
     assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement
     assert checks.check_version("2.1", "==2.1.0")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -9,6 +9,7 @@ import urllib
 import zipfile
 from copy import copy
 from pathlib import Path
+from unittest.mock import Mock
 
 import cv2
 import numpy as np
@@ -828,13 +829,12 @@ def test_utils_checks(monkeypatch):
     checks.check_imshow(warn=True)
     checks.check_suffix("https://example.com/model.pt?token=abc", ".pt")
     # parse_version must pad to at least 3 components and keep all segments so any version pair compares correctly
-    assert checks.parse_version("2") == (2, 0, 0)
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
     assert all(checks.check_version(v, ">=2.0") for v in ("v2", "v2.1-rc1", "v2.1RC1", "v2.1.post1", "v2.1+cu118"))
-    monkeypatch.setattr(checks.metadata, "version", lambda _: "1.0")
+    monkeypatch.setattr(checks.metadata, "version", Mock(side_effect=["1.0", checks.metadata.PackageNotFoundError()]))
     assert not checks.check_version("v2-package", ">=2.0")  # installed v+digit package names keep metadata precedence
-    assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
+    assert not checks.check_version("v2-missing", ">=2.0")
     assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement
     assert checks.check_version("2.1", "==2.1.0")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -833,7 +833,7 @@ def test_utils_checks():
     assert checks.parse_version("4.13.0.92") == (4, 13, 0, 92)
     assert checks.parse_version("2.0.1+cu118") == (2, 0, 1)  # numeric local/build suffixes are not release segments
     assert checks.parse_version("1.0.0rc1") == (1, 0, 0)
-    assert checks.parse_version("v2.1") == (2, 1, 0)
+    assert checks.check_version("v2.1", ">=2.0")  # v-prefixed versions must not be mistaken for package names
     assert checks.parse_version("1.0rc1") == (1, 0, 0)  # documented non-PEP-440 tradeoff: pre-releases equal the final
     assert checks.check_version("10.3.0.30", ">=10.3.0,<10.4.0")  # Jetson TensorRT family pin
     assert checks.check_version("6.0", ">=6.0.0")  # 2-component current must satisfy 3-component requirement

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -250,7 +250,7 @@ def check_version(
     if not current:  # if current is '' or None
         LOGGER.warning(f"invalid check_version({current}, {required}) requested, please check values.")
         return True
-    elif not current[0].isdigit():  # current is package name rather than version string, i.e. current='ultralytics'
+    elif not re.match(r"v?\d", current):  # current is package name rather than version string, i.e. 'ultralytics'
         try:
             name = current  # assigned package name to 'name' arg
             current = metadata.version(current)  # get version string from package name

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -250,7 +250,9 @@ def check_version(
     if not current:  # if current is '' or None
         LOGGER.warning(f"invalid check_version({current}, {required}) requested, please check values.")
         return True
-    elif not current[0].isdigit() and not re.fullmatch(r"v\d+(?:\.\d+)+", current):  # package name, e.g. 'ultralytics'
+    elif not current[0].isdigit() and not re.fullmatch(
+        r"v\d+(?:\.\d+)*(?:\.?(?:a|b|rc|post|dev)\d*)?(?:\+[\w.-]+)?", current
+    ):
         try:
             name = current  # assigned package name to 'name' arg
             current = metadata.version(current)  # get version string from package name
@@ -270,8 +272,6 @@ def check_version(
     ):
         return True
 
-    op = ""
-    version = ""
     result = True
     c = parse_version(current)  # '1.2.3' -> (1, 2, 3)
     for r in required.strip(",").split(","):

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -250,7 +250,7 @@ def check_version(
     if not current:  # if current is '' or None
         LOGGER.warning(f"invalid check_version({current}, {required}) requested, please check values.")
         return True
-    elif not re.match(r"(?:v\d+(?:\.\d+)+|\d)", current):  # package name rather than version, i.e. 'ultralytics'
+    elif not current[0].isdigit() and not re.fullmatch(r"v\d+(?:\.\d+)+", current):  # package name, e.g. 'ultralytics'
         try:
             name = current  # assigned package name to 'name' arg
             current = metadata.version(current)  # get version string from package name

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -255,7 +255,7 @@ def check_version(
             name = current  # assigned package name to 'name' arg
             current = metadata.version(current)  # get version string from package name
         except metadata.PackageNotFoundError as e:
-            if re.match(r"v\d", current):  # not an installed package: compare the v-prefixed version directly
+            if re.fullmatch(r"v\d+(\.\d+)*([-_.]?(a|b|rc|post|dev)\d*)?(\+[\w.-]+)?", current, re.I):
                 pass
             elif hard:
                 raise ModuleNotFoundError(f"{current} package is required but not installed") from e

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -250,7 +250,7 @@ def check_version(
     if not current:  # if current is '' or None
         LOGGER.warning(f"invalid check_version({current}, {required}) requested, please check values.")
         return True
-    elif not re.match(r"v?\d", current):  # current is package name rather than version string, i.e. 'ultralytics'
+    elif not re.match(r"(?:v\d+(?:\.\d+)+|\d)", current):  # package name rather than version, i.e. 'ultralytics'
         try:
             name = current  # assigned package name to 'name' arg
             current = metadata.version(current)  # get version string from package name

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -250,14 +250,14 @@ def check_version(
     if not current:  # if current is '' or None
         LOGGER.warning(f"invalid check_version({current}, {required}) requested, please check values.")
         return True
-    elif not current[0].isdigit() and not re.fullmatch(
-        r"v\d+(?:\.\d+)*(?:\.?(?:a|b|rc|post|dev)\d*)?(?:\+[\w.-]+)?", current
-    ):
+    elif not current[0].isdigit():  # current is package name rather than version string, i.e. current='ultralytics'
         try:
             name = current  # assigned package name to 'name' arg
             current = metadata.version(current)  # get version string from package name
         except metadata.PackageNotFoundError as e:
-            if hard:
+            if re.match(r"v\d", current):  # not an installed package: compare the v-prefixed version directly
+                pass
+            elif hard:
                 raise ModuleNotFoundError(f"{current} package is required but not installed") from e
             else:
                 return False

--- a/ultralytics/utils/checks.py
+++ b/ultralytics/utils/checks.py
@@ -255,7 +255,12 @@ def check_version(
             name = current  # assigned package name to 'name' arg
             current = metadata.version(current)  # get version string from package name
         except metadata.PackageNotFoundError as e:
-            if re.fullmatch(r"v\d+(\.\d+)*([-_.]?(a|b|rc|post|dev)\d*)?(\+[\w.-]+)?", current, re.I):
+            if re.fullmatch(
+                r"v\d+(\.\d+)*([-_.]?(a|b|c|rc|alpha|beta|pre|preview)[-_.]?\d*)?"
+                r"([-_.]?(post|rev|r)[-_.]?\d*)?([-_.]?dev[-_.]?\d*)?(\+[\w.-]+)?",
+                current,
+                re.I,
+            ):
                 pass
             elif hard:
                 raise ModuleNotFoundError(f"{current} package is required but not installed") from e


### PR DESCRIPTION
## Summary

`parse_version()` accepts release strings such as `v2.1`, but `check_version()` previously returned `False` after treating every non-digit-leading value as a package name. Preserve installed-package lookup as the first authority, then fall back to the existing `parse_version()` comparison only when an uninstalled input has a complete supported `v`-prefixed release shape.

Regression coverage explicitly drives all three metadata outcomes: an installed version-shaped package, missing valid version literals across separator/case/prerelease/post/dev/local forms, and a missing invalid package with `hard=True`.

Refs #25079.

Deleted: two dead pre-loop assignments. The bugfix is net-positive because the overloaded public API requires distinct metadata-success, valid-fallback, and missing-package regression coverage; deleting or relocating the package-name mode would break existing callers.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves version checking so version strings that start with `v` are handled correctly without being mistaken for missing package names ✅

### 📊 Key Changes
- Updated `check_version()` in `ultralytics/utils/checks.py` to better distinguish between package names and valid version-like strings such as `v2.1`, `v2.1-rc.1`, `v2.1-beta1`, and `v2.1+cu118`.
- Added support for common pre-release, post-release, development, and build metadata suffixes in `v`-prefixed versions.
- Preserved package metadata precedence: if a package named like `v2` is installed, its installed package version is still used.
- Added tests covering:
  - Installed package-like names such as `v2`
  - Missing package behavior with `hard=True`
  - Multiple `v`-prefixed version formats

### 🎯 Purpose & Impact
- Prevents valid version strings like `v2.1-rc.1` from incorrectly raising “package not installed” errors 🚀
- Makes Ultralytics version checks more robust across real-world version formats, including release candidates, beta builds, dev builds, and CUDA-style build tags.
- Improves reliability for users and developers working with dependencies, model/version labels, or platform-specific package builds.
- Maintains backward-compatible behavior for actual Python package checks, reducing risk of unintended changes.