### PR TITLE
Fix `segment2box` shrinking boxes when augmented polygons cross image bounds

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -909,6 +909,13 @@ def test_utils_ops():
     # segment2box must not drop a polygon lying on the left image edge (all x == 0) to a zero box
     assert segment2box(np.array([[0, 100], [0, 150], [0, 200]]), 640, 640).tolist() == [0, 100, 0, 200]
 
+    # segment2box must keep the visible extent when edge points shift out of frame after augmentation (issue #24935)
+    seg = np.array([[550.0, 100.0], [690.0, 100.0], [690.0, 200.0], [550.0, 200.0]])
+    assert segment2box(seg, 640, 640).tolist() == [550, 100, 640, 200]
+    assert segment2box(np.array([[700.0, 100.0], [750.0, 150.0]]), 640, 640).tolist() == [0, 0, 0, 0]
+    seg = np.array([[-100.0, -100.0], [740.0, -100.0], [740.0, 740.0], [-100.0, 740.0]])  # surrounds the image
+    assert segment2box(seg, 640, 640).tolist() == [0, 0, 640, 640]
+
 
 def test_nms_end2end_classes_before_max_det():
     """The end-to-end NMS branch must filter classes before truncating to max_det, like the NMS-based branch."""

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -912,6 +912,14 @@ def test_utils_ops():
     # segment2box must keep the visible extent when edge points shift out of frame after augmentation (issue #24935)
     seg = np.array([[550.0, 100.0], [690.0, 100.0], [690.0, 200.0], [550.0, 200.0]])
     assert segment2box(seg, 640, 640).tolist() == [550, 100, 640, 200]
+    seg = np.array([[-10.0, 100.0], [650.0, 100.0], [650.0, 200.0], [-10.0, 200.0]])
+    assert segment2box(seg, 640, 640).tolist() == [0, 100, 640, 200]
+    assert segment2box(np.array([[100.0, 100.0], [200.0, 100.0], [700.0, -100.0]]), 640, 640).tolist() == [
+        100,
+        0,
+        450,
+        100,
+    ]
     assert segment2box(np.array([[700.0, 100.0], [750.0, 150.0]]), 640, 640).tolist() == [0, 0, 0, 0]
     seg = np.array([[-100.0, -100.0], [740.0, -100.0], [740.0, 740.0], [-100.0, 740.0]])  # surrounds the image
     assert segment2box(seg, 640, 640).tolist() == [0, 0, 640, 640]

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -74,8 +74,8 @@ class Profile(contextlib.ContextDecorator):
 def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.ndarray:
     """Convert segment coordinates to bounding box coordinates.
 
-    Converts a single segment label to a box label by finding the minimum and maximum x and y coordinates of the
-    polygon clipped to the image, so segments crossing the image boundary keep their visible extent.
+    Converts a single segment label to a box label by finding the minimum and maximum x and y coordinates of the polygon
+    clipped to the image, so segments crossing the image boundary keep their visible extent.
 
     Args:
         segment (np.ndarray): Segment coordinates in format (N, 2) where N is number of points.

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -74,8 +74,8 @@ class Profile(contextlib.ContextDecorator):
 def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.ndarray:
     """Convert segment coordinates to bounding box coordinates.
 
-    Converts a single segment label to a box label by finding the minimum and maximum x and y coordinates. Applies
-    inside-image constraint and clips coordinates when necessary.
+    Converts a single segment label to a box label by finding the minimum and maximum x and y coordinates of the
+    polygon clipped to the image, so segments crossing the image boundary keep their visible extent.
 
     Args:
         segment (np.ndarray): Segment coordinates in format (N, 2) where N is number of points.
@@ -86,18 +86,14 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
         (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
     """
     x, y = segment.T  # segment xy
-    # Clip coordinates if 3 out of 4 sides are outside the image
-    if np.array([x.min() < 0, y.min() < 0, x.max() > width, y.max() > height]).sum() >= 3:
-        x = x.clip(0, width)
-        y = y.clip(0, height)
     inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
-    x = x[inside]
-    y = y[inside]
-    return (
-        np.array([x.min(), y.min(), x.max(), y.max()], dtype=segment.dtype)
-        if len(x)  # avoid any(x) as drops x=0 segments
-        else np.zeros(4, dtype=segment.dtype)
-    )  # xyxy
+    # Fully out-of-frame polygon: keep a box only if it surrounds the image (3+ sides outside)
+    if not inside.any() and np.array([x.min() < 0, y.min() < 0, x.max() > width, y.max() > height]).sum() < 3:
+        return np.zeros(4, dtype=segment.dtype)
+    # Clip instead of dropping outside points so boundary-crossing polygons keep their true extent
+    x = x.clip(0, width)
+    y = y.clip(0, height)
+    return np.array([x.min(), y.min(), x.max(), y.max()], dtype=segment.dtype)  # xyxy
 
 
 def scale_boxes(

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -85,15 +85,26 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
     Returns:
         (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
     """
-    x, y = segment.T  # segment xy
-    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
-    # Fully out-of-frame polygon: keep a box only if it surrounds the image (3+ sides outside)
-    if not inside.any() and np.array([x.min() < 0, y.min() < 0, x.max() > width, y.max() > height]).sum() < 3:
-        return np.zeros(4, dtype=segment.dtype)
-    # Clip instead of dropping outside points so boundary-crossing polygons keep their true extent
-    x = x.clip(0, width)
-    y = y.clip(0, height)
-    return np.array([x.min(), y.min(), x.max(), y.max()], dtype=segment.dtype)  # xyxy
+    points = [segment[((segment >= 0) & (segment <= (width, height))).all(1)]]
+    start, delta = segment, np.roll(segment, -1, axis=0) - segment
+    for axis, boundary in ((0, 0), (0, width), (1, 0), (1, height)):
+        with np.errstate(divide="ignore", invalid="ignore"):
+            t = (boundary - start[:, axis]) / delta[:, axis]
+        edge = (t >= 0) & (t <= 1)
+        intersections = start[edge] + t[edge, None] * delta[edge]
+        other = 1 - axis
+        points.append(
+            intersections[(intersections[:, other] >= 0) & (intersections[:, other] <= (height, width)[axis])]
+        )
+    corners = np.array(((0, 0), (width, 0), (0, height), (width, height)), dtype=segment.dtype)
+    contour = segment.astype(np.float32)
+    points.append(corners[[cv2.pointPolygonTest(contour, tuple(map(float, p)), False) >= 0 for p in corners]])
+    points = np.concatenate(points)
+    return (
+        np.array([*points.min(0), *points.max(0)], dtype=segment.dtype)
+        if len(points)
+        else np.zeros(4, dtype=segment.dtype)
+    )
 
 
 def scale_boxes(


### PR DESCRIPTION
Fixes #24935

## Problem

`RandomPerspective.apply_segments()` rebuilds augmented boxes with `segment2box()`. The old implementation discarded
out-of-frame polygon vertices, which could shrink a box away from the image boundary or collapse it entirely. Simply
clipping every vertex is also insufficient: it returns zero when all vertices are outside but polygon edges cross the
image, and it can fabricate extrema for oblique crossings.

## Changes

`segment2box()` now derives the box from the exact polygon-image intersection candidates:

- polygon vertices inside the image,
- polygon-edge intersections with the four image boundaries, and
- image corners enclosed by the polygon.

This preserves visible extents for sparse boundary annotations while keeping fully outside polygons at zero and
handling polygons that surround the image.

Deleted: the 3-of-4-sides heuristic, inside-only point filtering, and coordinate-wise clipping fallback.

This bugfix is net-positive because exact polygon-rectangle intersection requires edge-intersection and enclosed-corner
candidates; deletion or relocation alone cannot distinguish a truly out-of-frame polygon from one whose edges cross the
image.

## Validation

- `ruff format ultralytics/utils/ops.py tests/test_python.py`
- `ruff check ultralytics/utils/ops.py tests/test_python.py`
- `pytest -q tests/test_python.py::test_utils_ops`
- `pytest -q tests/test_python.py` (`100 passed, 2 skipped`)
- 10,000 randomized convex polygon cases matched Shapely intersection bounds
- Fresh independent Codex adversarial review: LGTM

Regression coverage includes one-sided border crossing, all-vertices-outside crossing, oblique crossing, fully outside,
surrounding-image, and the existing `x == 0` edge case.
