### PR TITLE
Fix compiled model predictor reuse

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -295,7 +295,7 @@ class BasePredictor:
             LOGGER.info("")
 
         # Setup model
-        if not self.model:
+        if self.model is None:
             self.setup_model(model)
 
         with self._lock:  # for thread-safe inference


### PR DESCRIPTION
## Summary

Replace the predictor model truthiness check with the initialization sentinel it owns. `torch.compile` wrappers implement truthiness through `__len__`, so reusing a compiled predictor raised before inference.

## Validation

- Confirmed the exact issue command fails on `main` with `TypeError: AutoBackend does not support len()`
- Confirmed the exact issue command completes after this replacement
- `ruff check ultralytics/engine/predictor.py`
- `git diff --check`

Deleted: the model truthiness check that invoked `__len__` on compiled wrappers.

Fixes #25089

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Refines predictor model initialization by checking explicitly for `None`. 🛠️

### 📊 Key Changes

- Updated the model setup condition in `stream_inference()` from a truth-value check to an explicit `self.model is None` check.
- Ensures `setup_model()` runs only when no model has been assigned.

### 🎯 Purpose & Impact

- ✅ Improves reliability for model objects with custom or ambiguous truth-value behavior.
- 🔒 Prevents valid, already-initialized models from being reloaded unnecessarily.
- 🚀 Makes inference initialization more precise without changing normal prediction behavior.