### PR TITLE
Validate requested detection dataset split

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -667,6 +667,8 @@ def test_data_utils(tmp_path):
     autosplit(tmp_path / "coco8/images")
     assert any((tmp_path / "coco8").glob("autosplit_*.txt"))
     assert zip_directory(images_dir).is_file()
+    with pytest.raises(FileNotFoundError, match="'test:' images not found"):
+        check_det_dataset("coco8.yaml", split="test")
 
 
 def test_safe_download_unzips_local_path_archive(tmp_path):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -671,7 +671,7 @@ def test_data_utils(tmp_path):
         check_det_dataset("coco8.yaml", split="test")
     data_yaml = tmp_path / "coco8.yaml"
     data_yaml.write_text("train: images/train\nval: images/val\ntest: images/test\nnames: [item]\n")
-    with pytest.raises(FileNotFoundError, match="images/test"):
+    with pytest.raises(FileNotFoundError, match="images not found"):
         check_det_dataset(data_yaml, split="test")
 
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -669,6 +669,10 @@ def test_data_utils(tmp_path):
     assert zip_directory(images_dir).is_file()
     with pytest.raises(FileNotFoundError, match="'test:' images not found"):
         check_det_dataset("coco8.yaml", split="test")
+    data_yaml = tmp_path / "coco8.yaml"
+    data_yaml.write_text("train: images/train\nval: images/val\ntest: images/test\nnames: [item]\n")
+    with pytest.raises(FileNotFoundError, match="images/test"):
+        check_det_dataset(data_yaml, split="test")
 
 
 def test_safe_download_unzips_local_path_archive(tmp_path):

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -532,7 +532,7 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
                 data[k] = [str((path / x).resolve()) for x in data[k]]
 
     # Parse YAML
-    val, s = (data.get(x) for x in ("val", "download"))
+    val, s = (data.get(x) for x in (split or "val", "download"))
     if val:
         val = [Path(x).resolve() for x in (val if isinstance(val, list) else [val])]  # val path
         if not all(x.exists() for x in val):

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -450,7 +450,7 @@ def convert_ndjson_to_yolo_if_needed(data: str | Path) -> str | Path:
     return data
 
 
-def check_det_dataset(dataset: str, autodownload: bool = True) -> dict[str, Any]:
+def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") -> dict[str, Any]:
     """Download, verify, and/or unzip a dataset if not found locally.
 
     This function checks the availability of a specified dataset, and if not found, it has the option to download and
@@ -460,6 +460,7 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> dict[str, Any]
     Args:
         dataset (str): Path to the dataset or dataset descriptor (like a YAML file).
         autodownload (bool, optional): Whether to automatically download the dataset if not found.
+        split (str, optional): Dataset split required by the caller.
 
     Returns:
         (dict[str, Any]): Parsed dataset information and paths.
@@ -491,6 +492,8 @@ def check_det_dataset(dataset: str, autodownload: bool = True) -> dict[str, Any]
                 )
             LOGGER.warning("renaming data YAML 'validation' key to 'val' to match YOLO format.")
             data["val"] = data.pop("validation")  # replace 'validation' key with 'val' key
+    if split and not data.get(split):
+        raise FileNotFoundError(f"{dataset} '{split}:' images not found ❌")
     if "names" not in data and "nc" not in data:
         raise SyntaxError(emojis(f"{dataset} key missing ❌.\n either 'names' or 'nc' are required in all data YAMLs."))
     if "nc" in data and not isinstance(data["nc"], int):

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -204,7 +204,7 @@ class BaseValidator:
                 "obb",
                 "semantic",
             }:
-                self.data = check_det_dataset(self.args.data)
+                self.data = check_det_dataset(self.args.data, split=self.args.split)
             else:
                 raise FileNotFoundError(emojis(f"Dataset '{self.args.data}' for task={self.args.task} not found ❌"))
 


### PR DESCRIPTION
## Summary

Pass the requested validation split into the existing detection dataset validator and reject missing split data there. This relocates the error from dataset construction to the YAML validation boundary without silently substituting another split. The existing path/autodownload check now validates the selected split instead of always validating `val`.

This source diff is net-positive because `check_det_dataset()` previously had no access to the caller's requested split, so relocating the rejection requires passing that context into the existing validator.

## Validation

- Exact fuzz reproducer is now classified as an expected input error
- Missing and configured-but-unavailable `test` splits are covered
- `pytest tests/test_python.py::test_data_utils -q -p no:rerunfailures`
- `ruff check ultralytics/data/utils.py ultralytics/engine/validator.py tests/test_python.py`
- `git diff --check`

Deleted: unconditional `val`-only path validation; missing requested splits no longer reach `BaseDataset` construction.

Fixes #25090

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✅ Dataset validation now checks the user-selected split, including custom `test` datasets, and reports clearer errors when it is missing.

### 📊 Key Changes
- Added a `split` parameter to `check_det_dataset()` in `ultralytics/data/utils.py`.
- Validates that the requested split exists in the dataset YAML and that its image paths are available.
- Uses the selected split instead of always defaulting to `val` when resolving dataset paths.
- Updated the validator to pass the configured split to `check_det_dataset()`.
- Added tests covering missing `test` keys and missing `test` directories.

### 🎯 Purpose & Impact
- 🧪 Prevents validation from silently using the wrong dataset split.
- 🚨 Provides earlier, clearer `FileNotFoundError` messages for incomplete or misconfigured datasets.
- 📈 Improves support for evaluating on `train`, `val`, or `test` splits through the standard validation workflow.
- 🔒 Existing behavior remains unchanged when no split is explicitly provided, preserving the default `val` workflow.