### PR TITLE
Fix RKNN INT8 multi-batch export

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -21,7 +21,7 @@ from tests import SOURCE
 from tests.conftest import isolated_model_path
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS, _handle_deprecation, get_cfg
-from ultralytics.engine.exporter import EXPORT_ENVS, export_formats, validate_args
+from ultralytics.engine.exporter import EXPORT_ENVS, Exporter, export_formats, validate_args
 from ultralytics.utils import (
     ARM64,
     IS_RASPBERRYPI,
@@ -163,6 +163,38 @@ def test_modelopt_quantize_onnx_requires_int8_dataset():
     """Check INT8 ModelOpt quantization fails early without calibration data."""
     with pytest.raises(ValueError, match="requires a calibration dataset"):
         modelopt_quantize_onnx("model.onnx", quantize=8)
+
+
+def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
+    """Check RKNN calibrates batch 1 before Toolkit expands to the requested batch."""
+    calls = {}
+    rknn = SimpleNamespace(
+        config=lambda **kwargs: 0,
+        load_onnx=lambda **kwargs: 0,
+        build=lambda **kwargs: calls.update(build=kwargs),
+        export_rknn=lambda file: Path(file).write_bytes(b"0" * 1024**2) and 0,
+    )
+    api = SimpleNamespace(RKNN=lambda **kwargs: rknn)
+    monkeypatch.setitem(sys.modules, "rknn", SimpleNamespace(api=api))
+    monkeypatch.setitem(sys.modules, "rknn.api", api)
+    monkeypatch.setattr(checks, "check_requirements", lambda *args, **kwargs: None)
+
+    image = tmp_path / "image.jpg"
+    exporter = SimpleNamespace(
+        args=SimpleNamespace(opset=None, quantize=8, name="rk3588", batch=8),
+        im=torch.zeros(8, 3, 32, 32),
+        file=tmp_path / "model.pt",
+        metadata={},
+        get_int8_calibration_dataloader=lambda prefix: SimpleNamespace(dataset=SimpleNamespace(im_files=[image])),
+    )
+    exporter.export_onnx = lambda: calls.update(onnx_batch=len(exporter.im)) or tmp_path / "model.onnx"
+    Exporter.export_rknn(exporter)
+    assert calls["onnx_batch"] == 1
+    assert calls["build"] == {
+        "do_quantization": True,
+        "dataset": str(tmp_path / "model_rknn_model" / "dataset.txt"),
+        "rknn_batch_size": 8,
+    }
 
 
 def test_modelopt_quantize_onnx_excludes_sigmoid(monkeypatch):
@@ -466,10 +498,10 @@ def test_export_imx():
 
 @pytest.mark.slow
 @pytest.mark.skipif(not LINUX or ARM64, reason="RKNN export only supported on non-aarch64 Linux")
-@pytest.mark.parametrize("quantize", [8, 16])
-def test_export_rknn(isolated_model, quantize):
+@pytest.mark.parametrize("quantize,batch", [(8, 8), (16, 1)])
+def test_export_rknn(isolated_model, quantize, batch):
     """Test YOLO export to RKNN format."""
-    file = YOLO(isolated_model).export(format="rknn", imgsz=32, quantize=quantize, data="coco8.yaml")
+    file = YOLO(isolated_model).export(format="rknn", imgsz=32, quantize=quantize, batch=batch, data="coco8.yaml")
     assert next(Path(file).rglob("*.rknn"), None), f"RKNN export failed, no RKNN model found in: {file}"
     shutil.rmtree(file, ignore_errors=True)
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -168,16 +168,10 @@ def test_modelopt_quantize_onnx_requires_int8_dataset():
 def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
     """Check RKNN calibrates batch 1 before Toolkit expands to the requested batch."""
     calls = {}
-    rknn = SimpleNamespace(
-        config=lambda **kwargs: 0,
-        load_onnx=lambda **kwargs: 0,
-        build=lambda **kwargs: calls.update(build=kwargs),
-        export_rknn=lambda file: Path(file).write_bytes(b"0" * 1024**2) and 0,
+    monkeypatch.setattr(
+        "ultralytics.utils.export.rknn.onnx2rknn", lambda **kwargs: calls.update(kwargs) or kwargs["output_dir"]
     )
-    api = SimpleNamespace(RKNN=lambda **kwargs: rknn)
-    monkeypatch.setitem(sys.modules, "rknn", SimpleNamespace(api=api))
-    monkeypatch.setitem(sys.modules, "rknn.api", api)
-    monkeypatch.setattr(checks, "check_requirements", lambda *args, **kwargs: None)
+    monkeypatch.setattr("ultralytics.engine.exporter.file_size", lambda _: 1)
 
     image = tmp_path / "image.jpg"
     exporter = SimpleNamespace(
@@ -190,11 +184,7 @@ def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
     exporter.export_onnx = lambda: calls.update(onnx_batch=len(exporter.im)) or tmp_path / "model.onnx"
     Exporter.export_rknn(exporter)
     assert calls["onnx_batch"] == 1
-    assert calls["build"] == {
-        "do_quantization": True,
-        "dataset": str(tmp_path / "model_rknn_model" / "dataset.txt"),
-        "rknn_batch_size": 8,
-    }
+    assert calls["batch"] == 8
 
 
 def test_modelopt_quantize_onnx_excludes_sigmoid(monkeypatch):

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.91"
+__version__ = "8.4.92"
 
 import importlib
 import os

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -1324,6 +1324,7 @@ class Exporter:
         from ultralytics.utils.export.rknn import onnx2rknn
 
         self.args.opset = min(self.args.opset or 19, 19)  # rknn-toolkit expects opset<=19
+        self.im = self.im[:1]  # RKNN Toolkit expands the batch after calibrating the batch-1 ONNX model
         f_onnx = self.export_onnx()
         output_dir = Path(str(self.file).replace(self.file.suffix, f"_rknn_model{os.sep}"))
         rknn_dataset = None
@@ -1342,6 +1343,7 @@ class Exporter:
             output_dir=output_dir,
             name=self.args.name,
             quantize=self.args.quantize,
+            batch=self.args.batch,
             dataset=rknn_dataset,
             metadata=self.metadata,
             prefix=prefix,

--- a/ultralytics/utils/export/rknn.py
+++ b/ultralytics/utils/export/rknn.py
@@ -21,6 +21,7 @@ def onnx2rknn(
     dataset: Path | str | None = None,
     metadata: dict | None = None,
     prefix: str = "",
+    batch: int = 1,
 ) -> str:
     """Export an ONNX model to RKNN format for Rockchip NPUs with optional INT8 quantization.
 
@@ -34,6 +35,7 @@ def onnx2rknn(
             them to this internal image-path list.
         metadata (dict | None): Metadata saved as ``metadata.yaml``.
         prefix (str): Prefix for log messages.
+        batch (int): Inference batch size applied by RKNN Toolkit after loading the batch-1 ONNX model.
 
     Returns:
         (str): Path to the exported ``_rknn_model`` directory.
@@ -75,7 +77,7 @@ def onnx2rknn(
     build_kwargs = {"do_quantization": use_int8}
     if use_int8:
         build_kwargs["dataset"] = str(dataset)
-    _check_rknn_return(rknn.build(**build_kwargs), "build")
+    _check_rknn_return(rknn.build(**build_kwargs, rknn_batch_size=batch), "build")
     _check_rknn_return(rknn.export_rknn(str(output_dir / f"{Path(onnx_file).stem}-{name}.rknn")), "export_rknn")
     if metadata:
         YAML.save(output_dir / "metadata.yaml", metadata)


### PR DESCRIPTION
## Summary

Fixes [alpha/ALPHA-RE](https://ultralytics.sentry.io/issues/7287166152/), a Platform worker failure owned by the `ultralytics` package.

A valid RKNN INT8 export with `batch=8` produced an ONNX graph with a static batch of 8, but RKNN calibration inputs are one image per dataset line. Toolkit therefore received shape `(1, H, W, C)` while the graph required `(8, H, W, C)`.

The exporter now creates the calibration ONNX graph at batch 1 and passes the requested inference batch to RKNN Toolkit through its existing `rknn_batch_size` build parameter. This moves batch expansion to the component that owns it. The package patch version is bumped to `8.4.92`.

Replaced: batch-N ONNX calibration ownership with batch-1 ONNX calibration plus RKNN Toolkit batch expansion.

Deleted: nothing — deletion or relocation alone cannot pass the requested runtime batch across the exporter-to-Toolkit boundary; the added parameter and fast regression test are required to preserve multi-batch exports.

## Verification

- `ruff format tests/test_exports.py ultralytics/utils/export/rknn.py ultralytics/engine/exporter.py ultralytics/__init__.py`
- `ruff check tests/test_exports.py ultralytics/utils/export/rknn.py ultralytics/engine/exporter.py ultralytics/__init__.py`
- `pytest -q tests/test_exports.py::test_export_rknn_batch_expansion` — 1 passed
- Real RKNN integration coverage updated to exercise INT8 `batch=8`; locally skipped because RKNN Toolkit export is Linux-only
- `git diff --check`

Sentry: `ALPHA-RE` marked resolved in the next `alpha` release.

Reviews: independent reviewer agent — LGTM; independent Codex CLI review — LGTM. Both confirmed no symptom guard and no further deletion opportunity.

Coordinated PR: [portal#2743](https://github.com/ultralytics/portal/pull/2743) updates all six Portal package/version surfaces to `8.4.92` and must merge only after this release is published.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Improved RKNN export handling so calibration uses batch 1 while the final model supports the requested batch size.

### 📊 Key Changes

- Updated RKNN export to generate the intermediate ONNX model with a batch size of 1.
- Passed the user-requested batch size to the RKNN Toolkit through `rknn_batch_size`.
- Extended `onnx2rknn()` with a new `batch` argument.
- Added unit and integration tests covering RKNN batch expansion for INT8 and FP16 exports.
- Incremented the Ultralytics version from `8.4.91` to `8.4.92`.

### 🎯 Purpose & Impact

- ✅ Fixes RKNN export behavior where the toolkit expects calibration from a batch-1 ONNX model.
- 📦 Allows exported RKNN models to correctly support larger inference batches, such as batch 8.
- 🎯 Improves INT8 calibration reliability without changing the requested runtime batch size.
- 🧪 Adds regression coverage to help prevent future RKNN export issues.