### PR TITLE
Speed up segment2box

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -927,6 +927,7 @@ def test_utils_ops():
         100,
     ]
     assert segment2box(np.array([[700.0, 100.0], [750.0, 150.0]]), 640, 640).tolist() == [0, 0, 0, 0]
+    assert segment2box(np.empty((0, 2)), 640, 640).tolist() == [0, 0, 0, 0]
     seg = np.array([[-100.0, -100.0], [740.0, -100.0], [740.0, 740.0], [-100.0, 740.0]])  # surrounds the image
     assert segment2box(seg, 640, 640).tolist() == [0, 0, 640, 640]
 

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -87,9 +87,10 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
         (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
     """
     x, y = segment[:, 0], segment[:, 1]
-    xmin, ymin, xmax, ymax = x.min(), y.min(), x.max(), y.max()
-    if xmin >= 0 and ymin >= 0 and xmax <= width and ymax <= height:  # fully inside image, no clipping needed
-        return np.array([xmin, ymin, xmax, ymax], dtype=segment.dtype)
+    if len(segment):
+        xmin, ymin, xmax, ymax = x.min(), y.min(), x.max(), y.max()
+        if xmin >= 0 and ymin >= 0 and xmax <= width and ymax <= height:  # fully inside image
+            return np.array([xmin, ymin, xmax, ymax], dtype=segment.dtype)
     axes = np.array((0, 0, 1, 1))
     bounds = np.array((0, width, 0, height), dtype=segment.dtype)
     lims = np.array((height, height, width, width), dtype=segment.dtype)  # (height, width)[axis] per boundary

--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -75,7 +75,8 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
     """Convert segment coordinates to bounding box coordinates.
 
     Converts a single segment label to a box label by finding the minimum and maximum x and y coordinates of the polygon
-    clipped to the image, so segments crossing the image boundary keep their visible extent.
+    clipped to the image, so segments crossing the image boundary keep their visible extent. Segments already inside the
+    image return immediately without clipping.
 
     Args:
         segment (np.ndarray): Segment coordinates in format (N, 2) where N is number of points.
@@ -85,21 +86,27 @@ def segment2box(segment: np.ndarray, width: int = 640, height: int = 640) -> np.
     Returns:
         (np.ndarray): Bounding box coordinates in xyxy format [x1, y1, x2, y2].
     """
-    points = [segment[((segment >= 0) & (segment <= (width, height))).all(1)]]
+    x, y = segment[:, 0], segment[:, 1]
+    xmin, ymin, xmax, ymax = x.min(), y.min(), x.max(), y.max()
+    if xmin >= 0 and ymin >= 0 and xmax <= width and ymax <= height:  # fully inside image, no clipping needed
+        return np.array([xmin, ymin, xmax, ymax], dtype=segment.dtype)
+    axes = np.array((0, 0, 1, 1))
+    bounds = np.array((0, width, 0, height), dtype=segment.dtype)
+    lims = np.array((height, height, width, width), dtype=segment.dtype)  # (height, width)[axis] per boundary
     start, delta = segment, np.roll(segment, -1, axis=0) - segment
-    for axis, boundary in ((0, 0), (0, width), (1, 0), (1, height)):
-        with np.errstate(divide="ignore", invalid="ignore"):
-            t = (boundary - start[:, axis]) / delta[:, axis]
-        edge = (t >= 0) & (t <= 1)
-        intersections = start[edge] + t[edge, None] * delta[edge]
-        other = 1 - axis
-        points.append(
-            intersections[(intersections[:, other] >= 0) & (intersections[:, other] <= (height, width)[axis])]
-        )
+    with np.errstate(divide="ignore", invalid="ignore"):
+        t = (bounds - start[:, axes]) / delta[:, axes]
+        inter = start[:, None, :] + t[:, :, None] * delta[:, None, :]
+    other = inter[:, np.arange(4), 1 - axes]
     corners = np.array(((0, 0), (width, 0), (0, height), (width, height)), dtype=segment.dtype)
     contour = segment.astype(np.float32)
-    points.append(corners[[cv2.pointPolygonTest(contour, tuple(map(float, p)), False) >= 0 for p in corners]])
-    points = np.concatenate(points)
+    points = np.concatenate(
+        (
+            segment[(x >= 0) & (y >= 0) & (x <= width) & (y <= height)],
+            inter[(t >= 0) & (t <= 1) & (other >= 0) & (other <= lims)],
+            corners[[cv2.pointPolygonTest(contour, tuple(map(float, p)), False) >= 0 for p in corners]],
+        )
+    )
     return (
         np.array([*points.min(0), *points.max(0)], dtype=segment.dtype)
         if len(points)


### PR DESCRIPTION
This makes `segment2box` faster without changing its output.

Two changes:

1. Most polygons are fully inside the image and do not need any clipping. The function now checks this first and returns the box right away when it is true.

2. When a polygon does cross the image border, the four boundary checks used to run in a Python loop. They now run as one vectorized NumPy step.

The result is the same as the current code in every case. It passes all test cases from #25086 and matches the current function on 100,000 random polygons with zero differences.

Speed per call (20,000 runs each):

| case            | before #25086 | after #25086 | this fix |
| --------------- | ------------: | -----------: | -------: |
| fully inside    |       13.0 µs |      50.5 µs |   3.5 µs |
| crosses border  |       10.7 µs |      51.6 µs |  32.5 µs |
| surrounds image |       12.6 µs |      53.8 µs |  32.3 µs |

Note: #25086 fixed the box being wrong at image borders, but it also made the function much slower. The old code before #25086 was faster but gave wrong boxes. This fix keeps the correct result from #25086 and brings the speed back down — the common "fully inside" case is now even faster than before #25086.

Deleted: the 4-iteration Python boundary loop and the `points` list appends, replaced by a fully-inside fast path and a single batched intersection.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves `segment2box` to handle empty and in-image segments more efficiently and reliably. 🚀

### 📊 Key Changes
- Added an early return for segments fully contained within the image, avoiding unnecessary clipping calculations.
- Reworked boundary-intersection logic using vectorized NumPy operations.
- Added explicit handling and regression coverage for empty segment arrays, returning `[0, 0, 0, 0]`.
- Preserved support for segments crossing image boundaries, including polygon-corner checks and visible extents.

### 🎯 Purpose & Impact
- ✅ Prevents failures when processing empty segmentation data.
- ⚡ Improves performance for the common case of segments already inside image boundaries.
- 🎯 Maintains accurate bounding boxes for clipped or out-of-bounds polygons.
- 🧪 Strengthens test coverage and reduces the risk of regressions in segmentation-to-detection workflows.