### PR TITLE
Pin numpy<=2.3.5 for CoreML export on all Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ export-tensorflow = [
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
 ]
 export-coreml = [
-    "numpy<=2.3.5; python_version >= '3.13'",  # pin until CoreML>9.0 new release
+    "numpy<=2.3.5",  # pin until CoreML>9.0 fixes numpy>=2.4 int() cast crash; all Python versions, not just 3.13
     "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
 ]


### PR DESCRIPTION
The `export-coreml` extra pinned `numpy<=2.3.5` only for `python_version >= '3.13'`, so `pip install "ultralytics[export-coreml]"` on Python<3.13 resolved numpy 2.4.x and crashed exporting any C2PSA attention model (YOLO26/11/10 detect, pose, segment, obb) with `TypeError: only 0-dimensional arrays can be converted to Python scalars`. coremltools 9.0 converts the attention's `aten::Int` node via `int(x.val)`, and numpy>=2.4 made `int()` on a 1-element array a hard error. Extending the cap to all Python versions closes the gap with no model or graph change.

Verified on macOS 26 (Apple M4), coremltools 9.0, same unmodified attention code:

- numpy 2.4.6: `export(format="coreml")` crashes with the TypeError above
- numpy 2.3.5: exports `yolo11n.mlpackage` cleanly

A model-level fix (`view(..., -1)` to drop the `aten::Int`) was rejected: it deletes an FX `mul` node, which renumbers the IMX `MCT_CONFIG` node names (`mul_2` -> `mul_1`) and breaks `export(format="imx")` (`No nodes found in the graph for filter {'node_name': 'mul_2'}`). The dependency pin is the correct altitude, the defect is upstream in coremltools 9.0 and is contained until CoreML>9.0 ships a fix.

Fixes #25098

Deleted: the `python_version >= '3.13'` condition on the CoreML numpy pin, which left Python<3.13 uncapped.

```bash
pip install "ultralytics[export-coreml]" # now resolves numpy<=2.3.5 on all Python versions
```
