### PR TITLE
Pin numpy<=2.3.5 for CoreML export to avoid numpy>=2.4 crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ export-tensorflow = [
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
 ]
 export-coreml = [
-    "numpy<=2.3.5; python_version >= '3.13'",  # pin until CoreML>9.0 new release
+    "numpy<=2.3.5",  # pin until CoreML>9.0 fixes numpy>=2.4 int() cast crash; all Python versions, not just 3.13
     "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ export-tensorflow = [
     "h5py!=3.11.0; platform_machine == 'aarch64'", # fix h5py build issues due to missing aarch64 wheels in 3.11 release
 ]
 export-coreml = [
-    "numpy<=2.3.5",  # pin until CoreML>9.0 fixes numpy>=2.4 int() cast crash; all Python versions, not just 3.13
+    "numpy<=2.3.5; platform_system != 'Windows' and python_version <= '3.13'",  # pin until CoreML>9.0 fixes numpy>=2.4 int() cast crash
     "coremltools>=9.0; platform_system != 'Windows' and python_version <= '3.13'", # CoreML supported on macOS and Linux
     "scikit-learn>=1.3.2; platform_system != 'Windows' and python_version <= '3.13'", # CoreML k-means quantization
 ]


### PR DESCRIPTION
`export-coreml` pinned `numpy<=2.3.5` only for Python 3.13, so Python<3.13 installs resolved numpy 2.4.x and crashed CoreML export of attention models with `TypeError: only 0-dimensional arrays can be converted to Python scalars` (coremltools 9.0 hits numpy>=2.4's stricter `int()`). Scope the cap to match the CoreML tooling marker (non-Windows, Python<=3.13).

Workaround for #25098

Deleted: the `python_version >= '3.13'` condition on the CoreML numpy pin.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated CoreML dependency constraints to prevent NumPy compatibility crashes on supported non-Windows platforms. 🛠️

### 📊 Key Changes
- Adjusted the `numpy<=2.3.5` pin for the `export-coreml` extra.
- Applied the pin on non-Windows systems running Python 3.13 or earlier.
- Documented that the restriction prevents an `int()` cast crash with NumPy 2.4 and CoreML.

### 🎯 Purpose & Impact
- Improves reliability when exporting models to CoreML on macOS and Linux. ✅
- Prevents known CoreML failures caused by NumPy 2.4 incompatibility.
- Leaves Windows behavior unchanged, where the CoreML dependencies are not enabled.