### PR TITLE
Fix `BOTSORT` native-ReID crash with user-supplied detections

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -412,6 +412,22 @@ def test_track_second_association_low_conf_keeps_id(tracker_type):
     assert int(frame2[0, 4]) == tid, f"id switched on low-confidence frame: {tid} -> {int(frame2[0, 4])}\n{frame2}"
 
 
+@pytest.mark.parametrize("tracker_type", ["botsort", "deepocsort", "tracktrack"])
+def test_track_reid_auto_user_detections(tracker_type):
+    """Native ReID (model='auto') must degrade to motion-only with user-supplied detections, not encode the raw frame."""
+    from ultralytics.engine.results import Boxes
+    from ultralytics.trackers.track import TRACKER_MAP
+    from ultralytics.utils import ROOT, YAML, IterableSimpleNamespace
+
+    cfg = {**YAML.load(ROOT / f"cfg/trackers/{tracker_type}.yaml"), "with_reid": True, "model": "auto"}
+    tracker = TRACKER_MAP[tracker_type](IterableSimpleNamespace(**cfg))
+    img = np.full((640, 640, 3), 128, dtype=np.uint8)  # nonzero so bogus frame-derived features would not be dropped
+    data = torch.tensor([[10, 10, 50, 50, 0.9, 0], [200, 200, 260, 260, 0.9, 0]], dtype=torch.float32)
+    for _ in range(3):  # frame 2 used to crash in embedding_distance after storing image rows as track features
+        tracks = tracker.update(Boxes(data, (640, 640)), img)
+    assert len(tracks) == 2, f"native-ReID tracker must keep tracking without feats:\n{tracks}"
+
+
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 @pytest.mark.parametrize("model", MODELS)
 def test_track_stream(model, tmp_path):

--- a/ultralytics/trackers/bot_sort.py
+++ b/ultralytics/trackers/bot_sort.py
@@ -181,7 +181,7 @@ class BOTSORT(BYTETracker):
         if len(results) == 0:
             return []
         bboxes = parse_bboxes(results)
-        if self.args.with_reid and self.encoder is not None:
+        if self.args.with_reid and self.encoder is not None and img is not None:
             features_keep = self.encoder(img, bboxes)
             return [BOTrack(xywh, s, c, f) for (xywh, s, c, f) in zip(bboxes, results.conf, results.cls, features_keep)]
         return [BOTrack(xywh, s, c) for (xywh, s, c) in zip(bboxes, results.conf, results.cls)]

--- a/ultralytics/trackers/byte_tracker.py
+++ b/ultralytics/trackers/byte_tracker.py
@@ -317,8 +317,10 @@ class BYTETracker:
     def _input_for(self, img: np.ndarray | None, feats: np.ndarray | None, mask: np.ndarray) -> Any:
         """Return the per-detection auxiliary input for ``init_track``.
 
-        Default behavior preserves the legacy flow: when ``feats`` is provided it is sliced by the
-        detection mask, otherwise the raw frame ``img`` is passed through.
+        When ``feats`` is provided it is sliced by the detection mask. Trackers with a native
+        (``model="auto"``) ReID encoder get None when feats are missing (e.g. user-supplied
+        detections), so ``init_track`` falls back to the no-encoding path instead of feeding the
+        BGR frame into the auto encoder. External ReID models always take the frame.
 
         Args:
             img (np.ndarray | None): Current BGR frame.
@@ -326,10 +328,12 @@ class BYTETracker:
             mask (np.ndarray): Boolean mask used to slice ``feats``.
 
         Returns:
-            (Any): The auxiliary payload (features or image) to hand to ``init_track``.
+            (Any): The auxiliary payload (features, image or None) to hand to ``init_track``.
         """
         if feats is not None and len(feats):
             return feats[mask]
+        if getattr(self, "encoder", None) is not None and getattr(self.args, "model", "auto") == "auto":
+            return None
         return img
 
     def _split_tracked(self) -> tuple[list[STrack], list[STrack]]:

--- a/ultralytics/trackers/deep_oc_sort.py
+++ b/ultralytics/trackers/deep_oc_sort.py
@@ -224,20 +224,6 @@ class DeepOCSORT(OCSORT):
             for (xywh, s, c) in zip(bboxes, results.conf, results.cls)
         ]
 
-    def _input_for(self, img: np.ndarray | None, feats: np.ndarray | None, mask: np.ndarray) -> np.ndarray | None:
-        """Return what `init_track` should receive.
-
-        For `model="auto"` (native-features mode) the encoder iterates a per-detection feature
-        tensor, so we must hand it `feats[mask]`. If the upstream pipeline didn't populate
-        `feats` (e.g. user-supplied detections), return None so `init_track` falls back
-        to the no-encoding path instead of feeding a BGR frame into the auto encoder. For
-        external ReID models, `init_track` always wants the BGR frame.
-        """
-        use_native = self.encoder is not None and getattr(self.args, "model", "auto") == "auto"
-        if use_native:
-            return feats[mask] if (feats is not None and len(feats)) else None
-        return img
-
     def _pre_first_associate(
         self,
         strack_pool: list[DeepOCSortTrack],


### PR DESCRIPTION
Fixes #25101

## Problem

`BOTSORT` with `with_reid: True` and `model: auto` crashes on the second frame when it is driven through the direct tracker API (user-supplied detections, no native feats). The base `_input_for` falls back to the raw BGR frame, the auto encoder iterates the image rows as if they were per-detection features, and `(W, 3)` rows get stored as track embeddings. The next call fails in `matching.embedding_distance` with `ValueError: matmul ... size 640 is different from 3`. It also reproduces with mixed state: one frame through `model.track` with real feats, then the direct API on the same instance.

The guard for this exact case already exists twice in the codebase: `DeepOCSORT._input_for` (its comment describes this precise failure) and inline in `TRACKTRACK.update`. Only `BOTSORT` inherits the unguarded base.

## Changes

The guard is now in the shared base, `BYTETracker._input_for`: with a native (`model="auto"`) ReID encoder and no feats it returns `None`, so `init_track` falls back to the no-encoding path and the tracker degrades to motion-only, same as its siblings. `BOTSORT.init_track` also gets the `img is not None` fallback that `DeepOCSORT.init_track` already had.

The whole `DeepOCSORT._input_for` override (14 lines) is deleted, it is redundant now that the base has the guard. Net −12 lines of production code.

I audited the six `TRACKER_MAP` trackers: `bytetrack`/`ocsort`/`fasttrack` have no `encoder`, the new guard short-circuits on the `getattr` and their behaviour is untouched (verified bit-identical). `botsort` and `deepocsort` inherit the consolidated `_input_for`. `tracktrack` does not inherit from `BYTETracker` and keeps its equivalent inline guard: its `update` has a different structure (high/low/recovered buckets, feats via kwargs), and a shared helper for two structurally different callers seemed premature abstraction to me. All three `self.encoder(...)` call sites in the codebase are now guarded against a `None` payload.

## Validation

- New regression test `tests/test_python.py::test_track_reid_auto_user_detections`, parametrized over the three native-ReID trackers (`botsort`, `deepocsort`, `tracktrack`). It fails on main (`botsort` raises the matmul ValueError) and passes with the fix. The test uses a nonzero image so bogus frame-derived features would not be silently dropped by the zero-norm check.
- In order to discard a silent regression in the other trackers, I ran a mode matrix before and after the fix: {reid off, reid auto} × 6 trackers via the direct API, external ReID model (`.pt`) via the direct API, and `model.track` with native feats. Every cell is bit-identical except the crashing one, which now tracks. The mixed-state sequence (real feats then no feats) also passes: `embedding_distance` pads the missing features and the appearance gate falls back to IoU.
- Full tracker suite `pytest -k track`: 13 passed.
- Perf: `_input_for` runs twice per frame, and the guard only adds one `getattr` plus a string compare on the no-feats path. A full `update()` call takes ~328 µs (3 detections) and the guard is below 1 µs, so the impact is negligible.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a native-ReID `BOTSORT` crash when tracking user-supplied detections without per-detection features.

### 📊 Key Changes
- Updates auxiliary-input handling so native `model="auto"` ReID receives `None` when features are unavailable instead of the raw image.
- Prevents `BOTSORT` from attempting native encoding when no image is provided, falling back to motion-only tracking.
- Removes duplicated `DeepOCSort` input-selection logic in favor of the shared tracker behavior.
- Adds regression coverage for `BOTSORT`, `DeepOCSort`, and `TrackTrack` with user-supplied detections.

### 🎯 Purpose & Impact
- Prevents frame 2 tracking crashes caused by treating raw image rows as track features.
- Preserves tracking continuity by degrading gracefully to motion-only association when native ReID features are unavailable.
- External ReID models continue to receive the image as before, minimizing compatibility impact.

Deleted: the duplicated DeepOCSORT._input_for override; native-ReID input selection now reuses BYTETracker._input_for.