### PR TITLE
Fix silent FP32 fallback for legacy precision flags in `benchmark`

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -17,7 +17,7 @@ if sys.platform == "win32":
 import pytest
 import torch
 
-from tests import SOURCE
+from tests import MODEL, SOURCE
 from tests.conftest import isolated_model_path
 from ultralytics import YOLO
 from ultralytics.cfg import TASK2DATA, TASK2MODEL, TASKS, _handle_deprecation, get_cfg
@@ -149,6 +149,20 @@ def test_quantize_deprecation():
     assert _handle_deprecation({"half": True})["quantize"] == 16
     assert _handle_deprecation({"half": True, "int8": True})["quantize"] == 8  # int8 wins
     assert "half" not in _handle_deprecation({"half": True})  # legacy flag is removed after forwarding
+    assert _handle_deprecation({"half": True, "quantize": None})["quantize"] == 16  # forwarded None must not block
+    assert _handle_deprecation({"int8": True, "quantize": None})["quantize"] == 8
+    assert _handle_deprecation({"half": True, "quantize": 8})["quantize"] == 8  # explicit quantize still wins
+    assert _handle_deprecation({"int8": False, "quantize": None})["quantize"] is None  # explicit off stays FP32
+
+
+def test_benchmark_forwards_legacy_precision(monkeypatch):
+    """model.benchmark(half=True) must reach the benchmark call as quantize=16, not silently run FP32."""
+    import ultralytics.utils.benchmarks as bm
+
+    captured = {}
+    monkeypatch.setattr(bm, "benchmark", lambda **kw: captured.update(kw) or {})
+    YOLO(MODEL).benchmark(half=True, format="onnx", data="coco8.yaml")
+    assert captured["quantize"] == 16, f"legacy half was dropped: quantize={captured.get('quantize')}"
 
 
 def test_qnn_quantize_requires_w8a16():

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -149,10 +149,8 @@ def test_quantize_deprecation():
     assert _handle_deprecation({"half": True})["quantize"] == 16
     assert _handle_deprecation({"half": True, "int8": True})["quantize"] == 8  # int8 wins
     assert "half" not in _handle_deprecation({"half": True})  # legacy flag is removed after forwarding
-    assert _handle_deprecation({"half": True, "quantize": None})["quantize"] == 16  # forwarded None must not block
-    assert _handle_deprecation({"int8": True, "quantize": None})["quantize"] == 8
+    assert _handle_deprecation({"half": True, "quantize": None})["quantize"] is None  # explicit quantize wins
     assert _handle_deprecation({"half": True, "quantize": 8})["quantize"] == 8  # explicit quantize still wins
-    assert _handle_deprecation({"int8": False, "quantize": None})["quantize"] is None  # explicit off stays FP32
 
 
 def test_benchmark_forwards_legacy_precision(monkeypatch):

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -531,7 +531,7 @@ def _handle_deprecation(custom: dict) -> dict:
     # flag maps to None to clear any inherited quantize. An explicit `quantize=` always wins over the legacy flags.
     int8 = custom.pop("int8", None)
     half = custom.pop("half", None)
-    if (int8 is not None or half is not None) and custom.get("quantize") is None:
+    if (int8 is not None or half is not None) and "quantize" not in custom:
         int8_on = int8 is not None and str(int8).strip().lower() not in {"none", "false", "0"}
         half_on = half is not None and str(half).strip().lower() not in {"none", "false", "0"}
         custom["quantize"] = 8 if int8_on else 16 if half_on else None  # False/0 clears precision back to FP32

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -531,7 +531,7 @@ def _handle_deprecation(custom: dict) -> dict:
     # flag maps to None to clear any inherited quantize. An explicit `quantize=` always wins over the legacy flags.
     int8 = custom.pop("int8", None)
     half = custom.pop("half", None)
-    if (int8 is not None or half is not None) and "quantize" not in custom:
+    if (int8 is not None or half is not None) and custom.get("quantize") is None:
         int8_on = int8 is not None and str(int8).strip().lower() not in {"none", "false", "0"}
         half_on = half is not None and str(half).strip().lower() not in {"none", "false", "0"}
         custom["quantize"] = 8 if int8_on else 16 if half_on else None  # False/0 clears precision back to FP32

--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 from PIL import Image
 
-from ultralytics.cfg import TASK2DATA, get_cfg, get_save_dir
+from ultralytics.cfg import TASK2DATA, _handle_deprecation, get_cfg, get_save_dir
 from ultralytics.engine.results import Results
 from ultralytics.nn.tasks import guess_model_task, load_checkpoint, yaml_model_load
 from ultralytics.utils import (
@@ -655,6 +655,7 @@ class Model(torch.nn.Module):
         from .exporter import export_formats
 
         custom = {"verbose": False}  # method defaults
+        kwargs = _handle_deprecation(kwargs)  # forward legacy flags (e.g. half/int8 -> quantize) before merging
         args = {**DEFAULT_CFG_DICT, **self.model.args, **custom, **kwargs, "mode": "benchmark"}
         fmts = export_formats()
         export_args = set(dict(zip(fmts["Argument"], fmts["Arguments"])).get(format.lower(), [])) - {


### PR DESCRIPTION
Fixes #25105

## Problem

`model.benchmark(half=True)` and `model.benchmark(int8=True)` silently benchmark in FP32 because `Model.benchmark()` filters legacy flags before the existing deprecation handler can translate them to `quantize`.

## Change

`Model.benchmark()` now passes its raw user kwargs through the existing `_handle_deprecation()` owner before merging defaults and model arguments. Explicit canonical `quantize=` values still win, including `quantize=None`.

Deleted: nothing. The bug is an omitted call to the existing normalization owner, so the smallest fix is one production line; deleting or relocating existing behavior would break the other entry points that already use `_handle_deprecation()`.

The direct `ultralytics.utils.benchmarks.benchmark(half=True)` helper remains outside this fix because its explicit `quantize=None` parameter is indistinguishable from a caller explicitly selecting FP32; changing global cfg precedence would make deprecated flags override canonical arguments.

## Validation

- `tests/test_exports.py::test_benchmark_forwards_legacy_precision` verifies `model.benchmark(half=True)` reaches the benchmark utility as `quantize=16`.
- `tests/test_exports.py::test_quantize_deprecation` verifies explicit canonical precision still wins.
- Local exact-head validation: 2 targeted tests passed; Ruff and `git diff --check` passed.
- Fresh cold-context Codex review: LGTM after removing the initial global cfg precedence change.