### PR TITLE
Fix custom callbacks silently dropped during DDP training

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1368,8 +1368,8 @@ def test_ddp_callback_injection_custom():
 
 def test_ddp_callback_injection_lambda():
     """Test that lambda callbacks are skipped with warning."""
-    from ultralytics.utils.dist import _get_custom_callback_injection_code
     from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
     trainer = BaseTrainer(overrides=overrides)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1421,3 +1421,63 @@ def test_ddp_callback_injection_multiple():
     assert "__custom_cb_1" in result
     assert 'trainer.add_callback("on_train_start", __custom_cb_0)' in result
     assert 'trainer.add_callback("on_fit_epoch_end", __custom_cb_1)' in result
+
+
+def test_ddp_callback_injection_oserror():
+    """Test that OSError from inspect.getsource is caught and the callback is skipped."""
+    from unittest.mock import patch
+
+    from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
+
+    def my_callback(trainer):
+        pass
+
+    overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
+    trainer = BaseTrainer(overrides=overrides)
+    trainer.callbacks.clear()
+    trainer.add_callback("on_train_start", my_callback)
+
+    with patch("ultralytics.utils.dist.inspect.getsource", side_effect=OSError("source not available")):
+        result = _get_custom_callback_injection_code(trainer)
+    assert result == "", "OSError should cause callback to be skipped, returning empty"
+
+
+def test_ddp_callback_injection_non_function_source():
+    """Test that source not starting with def/async def/@ is skipped."""
+    from unittest.mock import patch
+
+    from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
+
+    def my_callback(trainer):
+        pass
+
+    overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
+    trainer = BaseTrainer(overrides=overrides)
+    trainer.callbacks.clear()
+    trainer.add_callback("on_train_start", my_callback)
+
+    with patch("ultralytics.utils.dist.inspect.getsource", return_value="x = 1  # not a function definition"):
+        result = _get_custom_callback_injection_code(trainer)
+    assert result == "", "Non-function source should be skipped, returning empty"
+
+
+def test_ddp_callback_injection_import_warning():
+    """Test that callbacks referencing external callable names produce a warning but still inject."""
+    from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
+
+    # YOLO is a class (type) imported at module level, so it appears in __globals__
+    # and is a type — this triggers the unresolved-imports warning path.
+    def my_callback(trainer):
+        _ = YOLO("yolo26n.pt")
+
+    overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
+    trainer = BaseTrainer(overrides=overrides)
+    trainer.callbacks.clear()
+    trainer.add_callback("on_train_start", my_callback)
+    result = _get_custom_callback_injection_code(trainer)
+    # Warning is logged but the callback should still be injected
+    assert "def __custom_cb_0" in result
+    assert 'trainer.add_callback("on_train_start", __custom_cb_0)' in result

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1339,8 +1339,8 @@ def test_semantic_polygon_data():
 
 def test_ddp_callback_injection_empty():
     """Test callback injection returns empty string when no custom callbacks exist."""
-    from ultralytics.utils.dist import _get_custom_callback_injection_code
     from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
     trainer = BaseTrainer(overrides=overrides)
@@ -1350,8 +1350,8 @@ def test_ddp_callback_injection_empty():
 
 def test_ddp_callback_injection_custom():
     """Test that a simple named callback is properly injected."""
-    from ultralytics.utils.dist import _get_custom_callback_injection_code
     from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
 
     def my_callback(trainer):
         pass
@@ -1367,8 +1367,9 @@ def test_ddp_callback_injection_custom():
 def test_ddp_callback_injection_lambda():
     """Test that lambda callbacks are skipped with warning."""
     import logging
-    from ultralytics.utils.dist import _get_custom_callback_injection_code
+
     from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
     trainer = BaseTrainer(overrides=overrides)
@@ -1382,13 +1383,14 @@ def test_ddp_callback_injection_lambda():
 
 def test_ddp_callback_injection_closure():
     """Test that closures are skipped."""
-    from ultralytics.utils.dist import _get_custom_callback_injection_code
     from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
 
     def make_cb(threshold):
         def inner(trainer):
             if trainer.epoch > threshold:
                 pass
+
         return inner
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
@@ -1400,8 +1402,8 @@ def test_ddp_callback_injection_closure():
 
 def test_ddp_callback_injection_multiple():
     """Test that multiple custom callbacks get unique variable names."""
-    from ultralytics.utils.dist import _get_custom_callback_injection_code
     from ultralytics.engine.trainer import BaseTrainer
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
 
     def cb_a(trainer):
         pass

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1344,6 +1344,7 @@ def test_ddp_callback_injection_empty():
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
     trainer = BaseTrainer(overrides=overrides)
+    trainer.callbacks.clear()  # Remove built-in integration callbacks (hub, platform, etc.)
     result = _get_custom_callback_injection_code(trainer)
     assert result == "", f"Expected empty string, got: {result!r}"
 
@@ -1358,6 +1359,7 @@ def test_ddp_callback_injection_custom():
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
     trainer = BaseTrainer(overrides=overrides)
+    trainer.callbacks.clear()  # Remove built-in integration callbacks (hub, platform, etc.)
     trainer.add_callback("on_train_start", my_callback)
     result = _get_custom_callback_injection_code(trainer)
     assert "def __custom_cb_0" in result
@@ -1366,17 +1368,14 @@ def test_ddp_callback_injection_custom():
 
 def test_ddp_callback_injection_lambda():
     """Test that lambda callbacks are skipped with warning."""
-    import logging
-
-    from ultralytics.engine.trainer import BaseTrainer
     from ultralytics.utils.dist import _get_custom_callback_injection_code
+    from ultralytics.engine.trainer import BaseTrainer
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
     trainer = BaseTrainer(overrides=overrides)
+    trainer.callbacks.clear()  # Remove built-in integration callbacks (hub, platform, etc.)
     trainer.add_callback("on_train_start", lambda t: None)
 
-    with logging.getLogger("ultralytics")._log_state.get(None):
-        pass
     result = _get_custom_callback_injection_code(trainer)
     assert result == "", "Lambda should be skipped, returning empty string"
 
@@ -1395,6 +1394,7 @@ def test_ddp_callback_injection_closure():
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
     trainer = BaseTrainer(overrides=overrides)
+    trainer.callbacks.clear()  # Remove built-in integration callbacks (hub, platform, etc.)
     trainer.add_callback("on_train_epoch_end", make_cb(10))
     result = _get_custom_callback_injection_code(trainer)
     assert result == "", "Closure should be skipped, returning empty string"
@@ -1413,6 +1413,7 @@ def test_ddp_callback_injection_multiple():
 
     overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
     trainer = BaseTrainer(overrides=overrides)
+    trainer.callbacks.clear()  # Remove built-in integration callbacks (hub, platform, etc.)
     trainer.add_callback("on_train_start", cb_a)
     trainer.add_callback("on_fit_epoch_end", cb_b)
     result = _get_custom_callback_injection_code(trainer)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1335,3 +1335,86 @@ def test_semantic_polygon_data():
     model = YOLO("yolo26n-sem.pt")
     model.train(data="coco8-seg.yaml", epochs=1, imgsz=32, close_mosaic=1)
     model.val(data="coco8-seg.yaml")
+
+
+def test_ddp_callback_injection_empty():
+    """Test callback injection returns empty string when no custom callbacks exist."""
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
+    from ultralytics.engine.trainer import BaseTrainer
+
+    overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
+    trainer = BaseTrainer(overrides=overrides)
+    result = _get_custom_callback_injection_code(trainer)
+    assert result == "", f"Expected empty string, got: {result!r}"
+
+
+def test_ddp_callback_injection_custom():
+    """Test that a simple named callback is properly injected."""
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
+    from ultralytics.engine.trainer import BaseTrainer
+
+    def my_callback(trainer):
+        pass
+
+    overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
+    trainer = BaseTrainer(overrides=overrides)
+    trainer.add_callback("on_train_start", my_callback)
+    result = _get_custom_callback_injection_code(trainer)
+    assert "def __custom_cb_0" in result
+    assert 'trainer.add_callback("on_train_start", __custom_cb_0)' in result
+
+
+def test_ddp_callback_injection_lambda():
+    """Test that lambda callbacks are skipped with warning."""
+    import logging
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
+    from ultralytics.engine.trainer import BaseTrainer
+
+    overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
+    trainer = BaseTrainer(overrides=overrides)
+    trainer.add_callback("on_train_start", lambda t: None)
+
+    with logging.getLogger("ultralytics")._log_state.get(None):
+        pass
+    result = _get_custom_callback_injection_code(trainer)
+    assert result == "", "Lambda should be skipped, returning empty string"
+
+
+def test_ddp_callback_injection_closure():
+    """Test that closures are skipped."""
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
+    from ultralytics.engine.trainer import BaseTrainer
+
+    def make_cb(threshold):
+        def inner(trainer):
+            if trainer.epoch > threshold:
+                pass
+        return inner
+
+    overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
+    trainer = BaseTrainer(overrides=overrides)
+    trainer.add_callback("on_train_epoch_end", make_cb(10))
+    result = _get_custom_callback_injection_code(trainer)
+    assert result == "", "Closure should be skipped, returning empty string"
+
+
+def test_ddp_callback_injection_multiple():
+    """Test that multiple custom callbacks get unique variable names."""
+    from ultralytics.utils.dist import _get_custom_callback_injection_code
+    from ultralytics.engine.trainer import BaseTrainer
+
+    def cb_a(trainer):
+        pass
+
+    def cb_b(trainer):
+        pass
+
+    overrides = {"model": "yolo26n.pt", "data": "coco8.yaml", "imgsz": 32, "epochs": 1}
+    trainer = BaseTrainer(overrides=overrides)
+    trainer.add_callback("on_train_start", cb_a)
+    trainer.add_callback("on_fit_epoch_end", cb_b)
+    result = _get_custom_callback_injection_code(trainer)
+    assert "__custom_cb_0" in result
+    assert "__custom_cb_1" in result
+    assert 'trainer.add_callback("on_train_start", __custom_cb_0)' in result
+    assert 'trainer.add_callback("on_fit_epoch_end", __custom_cb_1)' in result

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -83,6 +83,33 @@ def _get_custom_callback_injection_code(trainer: BaseTrainer) -> str:
                     "Lambda and dynamically generated callbacks are not supported."
                 )
                 continue
+            # Closures capture variables from enclosing scope that don't exist in DDP child
+            if getattr(cb, "__closure__", None) is not None:
+                LOGGER.warning(
+                    "WARNING ⚠️ Cannot serialize closure callback "
+                    f"'{name}' for DDP training — captured variables would be undefined - skipping"
+                )
+                continue
+            # Detect callbacks that reference external imports that won't exist in DDP child.
+            # __globals__ contains the module's global namespace; filter to non-builtin names.
+            import builtins as _builtins_module
+            _cb_globals = getattr(cb, "__globals__", {})
+            _builtin_names = set(dir(_builtins_module))
+            _unresolved = set()
+            for _gname, _gval in _cb_globals.items():
+                if _gname.startswith("_") or _gname in _builtin_names:
+                    continue
+                if _gname not in source:
+                    continue
+                if callable(_gval) or isinstance(_gval, type):
+                    _unresolved.add(_gname)
+            if _unresolved:
+                LOGGER.warning(
+                    "WARNING ⚠️ Callback '{}' references external names {} from module '{}' — "
+                    "these must be importable in the DDP child process. The injection will "
+                    "proceed, but the callback will raise NameError if the imports are missing.".format(
+                        name, sorted(_unresolved), getattr(cb, "__module__", "unknown"))
+                )
             # Normalize indentation so the source fits inside the ``if __name__ == "__main__":`` block
             source = textwrap.dedent(source)
             # Skip if the dedented source does not look like a function/async-function definition

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import inspect
 import os
+import re
 import shutil
 import sys
 import tempfile
+import textwrap
 from typing import TYPE_CHECKING
 
-from . import USER_CONFIG_DIR
+from . import LOGGER, USER_CONFIG_DIR
 from .torch_utils import TORCH_1_9
 
 if TYPE_CHECKING:
@@ -29,6 +32,84 @@ def find_free_network_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]  # port
+
+
+def _get_custom_callback_injection_code(trainer: BaseTrainer) -> str:
+    """Generate Python source code to re-register custom callbacks in DDP child processes.
+
+    When DDP training uses a temporary Python file, user-registered callbacks added via
+    ``model.add_callback()`` are not included because the temp file creates a fresh trainer.
+    This function extracts the source code of user-defined callbacks and generates code to
+    re-define and re-register them in each DDP child process.
+
+    Only callbacks whose function objects are NOT in the built-in ``default_callbacks`` are
+    serialized. Callbacks that fail ``inspect.getsource`` (lambdas, dynamic functions) are
+    skipped with a warning.
+
+    Args:
+        trainer (BaseTrainer): The trainer instance whose callbacks should be serialized.
+
+    Returns:
+        (str): Indented Python source code to inject after the trainer is created in the DDP
+        temp file, or an empty string if there are no custom callbacks to serialize.
+    """
+    from ultralytics.utils.callbacks.base import default_callbacks as _base_defaults
+
+    # Collect built-in callback function objects so we can exclude them
+    builtins: set = set()
+    for cb_list in _base_defaults.values():
+        for cb in cb_list:
+            builtins.add(cb)
+
+    # Walk trainer.callbacks and collect user-registered callbacks not in builtins
+    custom_entries: list[tuple[str, str, str]] = []  # (event, func_name, dedented_source)
+    for event, cb_list in trainer.callbacks.items():
+        for cb in cb_list:
+            if cb in builtins:
+                continue
+            try:
+                source = inspect.getsource(cb)
+                name: str | None = getattr(cb, "__name__", None)
+                if not name or name == "<lambda>":
+                    LOGGER.warning(
+                        "WARNING ⚠️ Cannot serialize anonymous or lambda callback "
+                        f"'{getattr(cb, '__name__', repr(cb))}' for DDP training - skipping"
+                    )
+                    continue
+            except (OSError, TypeError):
+                LOGGER.warning(
+                    "WARNING ⚠️ Cannot serialize callback "
+                    f"'{getattr(cb, '__name__', repr(cb))}' for DDP training - skipping. "
+                    "Lambda and dynamically generated callbacks are not supported."
+                )
+                continue
+            # Normalize indentation so the source fits inside the ``if __name__ == "__main__":`` block
+            source = textwrap.dedent(source)
+            # Skip if the dedented source does not look like a function/async-function definition
+            source_stripped = source.lstrip()
+            if not (source_stripped.startswith(("def ", "async def ", "@"))):
+                LOGGER.warning(
+                    "WARNING ⚠️ Cannot serialize callback "
+                    f"'{name}' for DDP training — source is not a valid function definition - skipping"
+                )
+                continue
+            custom_entries.append((event, name, source))
+
+    if not custom_entries:
+        return ""
+
+    lines: list[str] = ["", "    # === Injected custom callbacks (auto-generated for DDP) ==="]
+    for i, (event, name, source) in enumerate(custom_entries):
+        # Give each callback a unique local variable name to prevent collisions
+        cb_var = f"__custom_cb_{i}"
+        # Rename the function definition in-place so the unique name is used
+        source = re.sub(rf"\bdef\s+{re.escape(name)}\b", f"def {cb_var}", source, count=1)
+        indented = textwrap.indent(source, "    ")
+        lines.append(indented)
+        lines.append(f'    trainer.add_callback("{event}", {cb_var})')
+    lines.append("    # === End injected custom callbacks ===\n")
+
+    return "\n".join(lines)
 
 
 def generate_ddp_file(trainer: BaseTrainer) -> str:
@@ -60,6 +141,9 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
 
         overrides["augmentations"] = [A.to_dict(t) for t in overrides["augmentations"]]
 
+    # Collect user-registered custom callbacks so they survive the DDP subprocess launch
+    custom_cb_code = _get_custom_callback_injection_code(trainer)
+
     content = f"""
 # Ultralytics Multi-GPU training temp file (should be automatically deleted after use)
 from pathlib import Path, PosixPath  # For model arguments stored as Path instead of str
@@ -78,6 +162,7 @@ if __name__ == "__main__":
     cfg.update(save_dir='')   # handle the extra key 'save_dir'
     trainer = {name}(cfg=cfg, overrides=overrides)
     trainer.args.model = "{getattr(trainer.hub_session, "model_url", trainer.args.model)}"
+{custom_cb_code}
     results = trainer.train()
 """
     (USER_CONFIG_DIR / "DDP").mkdir(exist_ok=True)

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -37,10 +37,9 @@ def find_free_network_port() -> int:
 def _get_custom_callback_injection_code(trainer: BaseTrainer) -> str:
     """Generate Python source code to re-register custom callbacks in DDP child processes.
 
-    When DDP training uses a temporary Python file, user-registered callbacks added via
-    ``model.add_callback()`` are not included because the temp file creates a fresh trainer.
-    This function extracts the source code of user-defined callbacks and generates code to
-    re-define and re-register them in each DDP child process.
+    When DDP training uses a temporary Python file, user-registered callbacks added via ``model.add_callback()`` are not
+    included because the temp file creates a fresh trainer. This function extracts the source code of user-defined
+    callbacks and generates code to re-define and re-register them in each DDP child process.
 
     Only callbacks whose function objects are NOT in the built-in ``default_callbacks`` are
     serialized. Callbacks that fail ``inspect.getsource`` (lambdas, dynamic functions) are
@@ -50,8 +49,8 @@ def _get_custom_callback_injection_code(trainer: BaseTrainer) -> str:
         trainer (BaseTrainer): The trainer instance whose callbacks should be serialized.
 
     Returns:
-        (str): Indented Python source code to inject after the trainer is created in the DDP
-        temp file, or an empty string if there are no custom callbacks to serialize.
+        (str): Indented Python source code to inject after the trainer is created in the DDP temp file, or an empty
+            string if there are no custom callbacks to serialize.
     """
     from ultralytics.utils.callbacks.base import default_callbacks as _base_defaults
 
@@ -93,6 +92,7 @@ def _get_custom_callback_injection_code(trainer: BaseTrainer) -> str:
             # Detect callbacks that reference external imports that won't exist in DDP child.
             # __globals__ contains the module's global namespace; filter to non-builtin names.
             import builtins as _builtins_module
+
             _cb_globals = getattr(cb, "__globals__", {})
             _builtin_names = set(dir(_builtins_module))
             _unresolved = set()
@@ -108,7 +108,8 @@ def _get_custom_callback_injection_code(trainer: BaseTrainer) -> str:
                     "WARNING ⚠️ Callback '{}' references external names {} from module '{}' — "
                     "these must be importable in the DDP child process. The injection will "
                     "proceed, but the callback will raise NameError if the imports are missing.".format(
-                        name, sorted(_unresolved), getattr(cb, "__module__", "unknown"))
+                        name, sorted(_unresolved), getattr(cb, "__module__", "unknown")
+                    )
                 )
             # Normalize indentation so the source fits inside the ``if __name__ == "__main__":`` block
             source = textwrap.dedent(source)


### PR DESCRIPTION
Fixes #6168.

Custom callbacks registered via model.add_callback() are silently dropped
during multi-GPU DDP training because PR #6009 switched to a temporary
Python file that creates a fresh trainer with only built-in callbacks.

This injects callback source code into the generated DDP temp file using
inspect.getsource (stdlib, zero new dependencies). Each DDP child process
re-defines and re-registers user callbacks before training starts.

Known limitations (non-silent -- warn or crash visibly):
- Callbacks using external imports need those modules importable in DDP context
- Closures and dynamically generated callbacks are skipped with a warning
- Bound methods should be registered as standalone functions

save_dir cleanup is untouched.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Preserves user-defined callbacks when training with distributed data parallel (DDP) by injecting them into the generated child-process script.

### 📊 Key Changes
- Adds callback source inspection and code generation in `ultralytics/utils/dist.py`.
- Excludes built-in callbacks and re-registers custom callbacks on the recreated trainer.
- Warns and skips unsupported anonymous, lambda, dynamic, or invalid callback definitions.
- Injects serialized callback definitions into the temporary DDP training file before training starts.

### 🎯 Purpose & Impact
- Prevents custom callbacks added with `model.add_callback()` from being silently lost during multi-GPU DDP training.
- Keeps callback behavior consistent between the parent process and DDP child processes.
- Improves transparency by warning users when a callback cannot be serialized.
- Introduces source-based callback serialization, so callbacks with unavailable or unsupported source code will continue to be skipped.