### PR TITLE
Add Platform cloud storage integration docs (GCS, S3, Azure)

### DIFF
--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -15,7 +15,7 @@ Ultralytics Platform accepts multiple upload formats for flexibility.
 
 !!! tip "Already have data elsewhere?"
 
-    If you already have datasets in [Ultralytics HUB](../integrations/ultralytics-hub.md) or [Roboflow](../integrations/roboflow.md), use [Integrations](../integrations/index.md) to import them directly — no manual export or re-upload needed.
+    If you already have datasets in [Ultralytics HUB](../integrations/ultralytics-hub.md) or [Roboflow](../integrations/roboflow.md), use [Integrations](../integrations/index.md) to import them directly — no manual export or re-upload needed. Data in Google Cloud Storage, Amazon S3, or Azure Blob Storage can be used in place through the [cloud storage integration](../integrations/cloud-storage.md): the **Cloud storage** tab in **New Dataset** indexes your images and YOLO labels without copying them into Platform.
 
 ### Supported Formats
 

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -24,6 +24,7 @@ Data preparation is the foundation of successful [computer vision](https://www.u
 The Data section of Ultralytics Platform helps you:
 
 - **Upload** images, videos, and dataset files (ZIP, TAR including `.tar.gz`/`.tgz`, NDJSON)
+- **Connect** [cloud storage](../integrations/cloud-storage.md) and use data in Google Cloud Storage, Amazon S3, or Azure Blob Storage without uploading a copy
 - **Annotate** with manual drawing tools and SAM-powered smart labeling — choose from [SAM 2.1](../../models/sam-2.md) or the new [SAM 3](../../models/sam-3.md)
 - **Analyze** your data with statistics and visualizations
 - **Export** in [NDJSON format](../../datasets/detect/index.md#ultralytics-ndjson-format) for local training

--- a/docs/en/platform/integrations/cloud-storage.md
+++ b/docs/en/platform/integrations/cloud-storage.md
@@ -1,0 +1,69 @@
+---
+comments: true
+description: Connect Google Cloud Storage, Amazon S3, or Azure Blob Storage and train YOLO models on your data without uploading a copy to Ultralytics Platform.
+keywords: Ultralytics Platform, cloud storage, Google Cloud Storage, GCS, Amazon S3, Azure Blob Storage, dataset import, YOLO, computer vision, integrations
+title: Cloud Storage Datasets - Ultralytics Platform
+---
+
+# Cloud Storage Integration
+
+The cloud storage integration connects [Google Cloud Storage](https://cloud.google.com/storage), [Amazon S3](https://aws.amazon.com/s3/), and [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your own buckets and containers — Platform indexes them in place, so you can browse, annotate, and train without uploading a copy.
+
+All three providers share one integration model: connect a credential once, then browse every connected location through the same interface and create datasets from any folder.
+
+## Connect a Provider
+
+1. Go to **Settings > [Integrations](index.md)** and find the **Google Cloud**, **Amazon S3**, or **Microsoft Azure** card.
+2. Click **Connect** and paste the provider credential:
+    - **Google Cloud Storage** — a service account JSON key with read access to your buckets.
+    - **Amazon S3** — an access key ID, secret access key, and bucket region for a dedicated IAM user with only list and read access. Never use root credentials.
+    - **Azure Blob Storage** — a storage account connection string from **Security + networking > Access keys**.
+3. Platform lists the buckets or containers the credential can read. Select the ones you want to connect, or enter a name manually if the credential doesn't permit discovery.
+4. Click **Connect**. Platform verifies it can list and read each selected location before saving anything.
+
+Reconnecting the same credential later adds new locations to the existing integration. A saved credential is only replaced once its replacement can still read every location you've already connected.
+
+!!! tip "Use least-privilege, read-only credentials"
+
+    Platform only ever reads from your storage — it never writes, modifies, or deletes your objects. Grant the credential list and read permissions only (for example `Storage Object Viewer` on GCS, `s3:ListBucket` + `s3:GetObject` on AWS).
+
+!!! note "Credential security"
+
+    Credentials are encrypted at rest with AES-256-GCM, are never returned to the browser, and never enter training job payloads. To revoke access, rotate or delete the key with your cloud provider.
+
+## Create a Dataset from Cloud Storage
+
+1. Click **New Dataset** and open the **Cloud storage** tab.
+2. Pick a connected location and browse to the folder containing your data.
+3. Confirm the folder, adjust the dataset name, and create the dataset.
+
+Platform lists the folder once and indexes what it finds:
+
+- **Images** — `.jpg`, `.jpeg`, `.png`, `.webp`, and `.avif` files are indexed with their dimensions read from bounded header requests. Source pixels are never copied.
+- **Labels** — YOLO `.txt` sidecars are parsed into Platform annotations, matched by the standard `images/` → `labels/` layout or as same-folder siblings.
+- **Metadata** — a `data.yaml`/`data.yml` provides class names, task type, and pose keypoint shape, exactly like an [archive upload](../data/datasets.md#supported-formats).
+- **Splits** — `train`, `val`, and `test` folder names in the object path assign splits automatically.
+
+The dataset then behaves like any other: browse and [annotate](../data/annotation.md) it, set it public or private, share it with your [team](../account/teams.md), and [train](../train/index.md) on it through managed training. Original images are streamed on demand through Platform; indexed images do not consume your Platform [storage quota](../account/billing.md).
+
+!!! note "Limits"
+
+    A single import indexes up to 50,000 objects, and label or YAML files up to 1 MB each. Larger folders should be split across multiple datasets.
+
+!!! warning "Keep indexed objects immutable"
+
+    Every indexed image is pinned to the exact object revision that was read, and Platform fails closed if an object changes underneath it. Add new files instead of overwriting existing ones.
+
+## Failed Imports
+
+If an import fails — an empty folder, a typo in the path, or revoked permissions — the dataset shows the error on its page. Editors can click **Retry import** to restart it with the stored location, or create a new dataset pointing at the corrected folder.
+
+## Training
+
+Managed training works through the normal training flow. Workers download the pinned originals into temporary job storage for the run and remove them with job cleanup — your provider credentials never reach compute.
+
+## Current Limitations
+
+Cloud-backed datasets currently exclude features that require Platform-owned copies of your images: auto-annotation, [clustering analysis](../data/datasets.md#clustering), dataset cloning, and immutable [version snapshots](../data/datasets.md#versions-tab). These are planned to arrive as the shared boundaries learn to resolve external originals.
+
+Deleting a cloud-backed dataset, or individual images from it, removes Platform's references only — your objects are never touched.

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -23,8 +23,8 @@ Imports start with a preview so you can review exactly what will be transferred 
 
 ## Available Integrations
 
-| Integration                               | What it brings in                                                    |
-| ----------------------------------------- | -------------------------------------------------------------------- |
+| Integration                               | What it brings in                                                     |
+| ----------------------------------------- | --------------------------------------------------------------------- |
 | [**Ultralytics HUB**](ultralytics-hub.md) | Your datasets, projects, models, and account balance                  |
 | [**Roboflow**](roboflow.md)               | Your datasets                                                         |
 | [**Cloud Storage**](cloud-storage.md)     | Datasets indexed in place from GCS, Amazon S3, and Azure Blob Storage |

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -1,13 +1,13 @@
 ---
 title: Platform Integrations
 comments: true
-description: Connect Ultralytics Platform to the tools you already use and bring your data across with a single API key. Import from Ultralytics HUB and Roboflow — no manual export or re-upload.
-keywords: Ultralytics Platform, integrations, data import, Roboflow, Ultralytics HUB, dataset migration, YOLO, computer vision
+description: Connect Ultralytics Platform to the tools you already use. Import from Ultralytics HUB and Roboflow, or train directly on data in Google Cloud Storage, Amazon S3, and Azure Blob Storage.
+keywords: Ultralytics Platform, integrations, data import, Roboflow, Ultralytics HUB, cloud storage, GCS, Amazon S3, Azure Blob Storage, dataset migration, YOLO, computer vision
 ---
 
 # Integrations
 
-[Ultralytics Platform](https://platform.ultralytics.com) integrations connect your workspace to other tools and services you already use. Today, integrations let you bring your data without manually exporting archives and re-uploading them — connect an account with an API key.
+[Ultralytics Platform](https://platform.ultralytics.com) integrations connect your workspace to other tools and services you already use. Import existing datasets with a single API key, or connect your cloud storage and use the data where it lives — no manual export or re-upload either way.
 
 ![Ultralytics Platform Settings Integrations Tab](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-integrations-tab.avif)
 
@@ -17,17 +17,18 @@ All integrations are managed from your account settings:
 
 1. Go to **Settings > Integrations**
 2. Find the card for the service you want to connect
-3. Paste your API key and click **Import**
+3. Paste your API key or storage credential and follow the prompts
 
-Each import starts with a preview so you can review exactly what will be transferred — and confirm you have enough [storage](../account/billing.md) — before anything is imported.
+Imports start with a preview so you can review exactly what will be transferred — and confirm you have enough [storage](../account/billing.md) — before anything is imported. Cloud storage connections verify list and read access before anything is saved.
 
 ## Available Integrations
 
-| Integration                               | What it brings in                                    |
-| ----------------------------------------- | ---------------------------------------------------- |
-| [**Ultralytics HUB**](ultralytics-hub.md) | Your datasets, projects, models, and account balance |
-| [**Roboflow**](roboflow.md)               | Your datasets                                        |
+| Integration                               | What it brings in                                                    |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| [**Ultralytics HUB**](ultralytics-hub.md) | Your datasets, projects, models, and account balance                  |
+| [**Roboflow**](roboflow.md)               | Your datasets                                                         |
+| [**Cloud Storage**](cloud-storage.md)     | Datasets indexed in place from GCS, Amazon S3, and Azure Blob Storage |
 
-Connect once with an API key and the matching content lands in your workspace.
+Connect once and the matching content lands in your workspace.
 
 A **Weights & Biases** integration is coming soon to sync training runs, metrics, and artifacts with your W&B workspace.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -655,6 +655,7 @@ nav:
           - platform/integrations/index.md
           - Ultralytics HUB: platform/integrations/ultralytics-hub.md
           - Roboflow: platform/integrations/roboflow.md
+          - Cloud Storage: platform/integrations/cloud-storage.md
       - Account:
           - platform/account/index.md
           - API Keys: platform/account/api-keys.md


### PR DESCRIPTION
## Summary

Documents the new Ultralytics Platform cloud storage integration (ultralytics/portal#2749): connect Google Cloud Storage, Amazon S3, or Azure Blob Storage once, then browse, annotate, and train on data indexed in place — no upload, no copies.

## Changes

- **New page** `docs/en/platform/integrations/cloud-storage.md`: connecting each provider (least-privilege credential guidance per vendor), creating datasets from the **Cloud storage** tab, what gets indexed (images, YOLO labels, `data.yaml`, splits), limits (50k objects/import, 1 MB sidecars), revision pinning and object immutability, failed-import retry, training behavior, credential security, and current limitations (no auto-annotation, clustering, cloning, or version snapshots yet).
- `platform/integrations/index.md`: adds Cloud Storage to the available integrations table and generalizes the intro beyond API-key imports.
- `platform/data/datasets.md` + `platform/data/index.md`: cross-link cloud storage as a dataset source.
- `mkdocs.yml`: nav entry under Platform → Integrations.

No screenshots yet — can add `settings-integrations-cloud-*` assets to the CDN in a follow-up once captured.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds documentation for connecting cloud storage to Ultralytics Platform and creating datasets directly from Google Cloud Storage, Amazon S3, and Azure Blob Storage. ☁️

### 📊 Key Changes
- Added a dedicated Cloud Storage Integration guide covering:
  - Provider setup and credential requirements
  - Dataset creation from cloud folders
  - Image, YOLO label, metadata, and split detection
  - Import limits, failed imports, training behavior, and current limitations
- Updated Platform data documentation to explain that cloud-hosted datasets can be indexed without copying images into Platform.
- Added Cloud Storage to the integrations overview and documentation navigation.
- Documented security practices, including encrypted credentials, read-only access, and provider-side credential revocation.
- Clarified that cloud-backed datasets stream original images on demand and use pinned object revisions for consistency.

### 🎯 Purpose & Impact
- 🚀 Enables users to browse, annotate, and train on datasets stored in Google Cloud Storage, Amazon S3, or Azure Blob Storage without manual exports or duplicate uploads.
- 💾 Reduces Platform storage usage because indexed source images remain in the user’s cloud storage.
- 🔐 Improves security by using least-privilege credentials and keeping provider credentials away from browsers and training workers.
- 🧩 Makes cloud-backed datasets behave similarly to standard Platform datasets while clearly documenting unsupported features such as cloning, clustering, auto-annotation, and version snapshots.
- 📚 Provides users with clear setup and troubleshooting guidance for integrating existing cloud-hosted YOLO datasets.