### PR TITLE
Fall back to eager when torch.compile fails at first forward

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -96,6 +96,20 @@ def skip_rpi_semantic():
         pytest.skip("Semantic segmentation tests are skipped on Raspberry Pi due to memory constraints.")
 
 
+def test_attempt_compile_falls_back_to_eager(monkeypatch):
+    """A backend failure at the first forward pass of a compiled model must fall back to eager, not raise."""
+    compile_fx = pytest.importorskip("torch._inductor.compile_fx")
+    from ultralytics.utils.torch_utils import attempt_compile
+
+    def broken_backend(*args, **kwargs):
+        raise RuntimeError("simulated missing C++ compiler")  # e.g. InvalidCxxCompiler on Windows CPU
+
+    monkeypatch.setattr(compile_fx, "compile_fx", broken_backend)
+    model = attempt_compile(torch.nn.Sequential(torch.nn.Conv2d(3, 8, 3)), device=torch.device("cpu"), mode=True)
+    assert model(torch.zeros(1, 3, 16, 16)).shape == (1, 8, 14, 14)
+    torch._dynamo.reset()  # clear the poisoned compile cache for other tests
+
+
 def test_select_device(monkeypatch):
     """The same device string must resolve to the same GPU on every call, and the environment is never mutated."""
     from ultralytics.utils import torch_utils

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -96,19 +96,6 @@ def skip_rpi_semantic():
         pytest.skip("Semantic segmentation tests are skipped on Raspberry Pi due to memory constraints.")
 
 
-def test_attempt_compile_without_cpp_compiler(monkeypatch):
-    """CPU compile requests must return the eager model unchanged when inductor has no host C++ compiler."""
-    cpp_builder = pytest.importorskip("torch._inductor.cpp_builder")
-    from ultralytics.utils.torch_utils import attempt_compile
-
-    def missing_compiler():
-        raise RuntimeError("Compiler: cl is not found.")  # e.g. InvalidCxxCompiler on Windows CPU
-
-    monkeypatch.setattr(cpp_builder, "get_cpp_compiler", missing_compiler)
-    model = torch.nn.Sequential(torch.nn.Conv2d(3, 8, 3))
-    assert attempt_compile(model, device=torch.device("cpu"), mode=True) is model
-
-
 def test_select_device(monkeypatch):
     """The same device string must resolve to the same GPU on every call, and the environment is never mutated."""
     from ultralytics.utils import torch_utils
@@ -912,6 +899,24 @@ def test_utils_torchutils():
     time_sync()
 
 
+@pytest.mark.parametrize("nc", [1, 3])
+def test_semantic_loss_all_ignore(nc):
+    """SemanticSegmentationLoss must stay finite when the whole batch is ignore (255), e.g. unlabeled/void frames."""
+    from ultralytics.cfg import get_cfg
+    from ultralytics.nn.tasks import SemanticSegmentationModel
+    from ultralytics.utils.loss import SemanticSegmentationLoss
+
+    model = SemanticSegmentationModel(cfg="yolo26-sem.yaml", nc=nc, verbose=False)
+    model.args = get_cfg()
+    loss_fn = SemanticSegmentationLoss(model)
+    preds = torch.randn(1, nc, 64, 64, requires_grad=True)
+    aux = torch.randn(1, nc, 32, 32, requires_grad=True)
+    loss, items = loss_fn((preds, aux), {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
+    assert torch.isfinite(loss).all() and torch.isfinite(items).all()
+    loss.backward()
+    assert preds.grad is not None and aux.grad is not None
+
+
 def test_utils_ops():
     """Test utility operations for coordinate transformations and normalizations."""
     from ultralytics.utils.ops import (
@@ -956,6 +961,7 @@ def test_utils_ops():
         100,
     ]
     assert segment2box(np.array([[700.0, 100.0], [750.0, 150.0]]), 640, 640).tolist() == [0, 0, 0, 0]
+    assert segment2box(np.empty((0, 2)), 640, 640).tolist() == [0, 0, 0, 0]
     seg = np.array([[-100.0, -100.0], [740.0, -100.0], [740.0, 740.0], [-100.0, 740.0]])  # surrounds the image
     assert segment2box(seg, 640, 640).tolist() == [0, 0, 640, 640]
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -899,24 +899,6 @@ def test_utils_torchutils():
     time_sync()
 
 
-@pytest.mark.parametrize("nc", [1, 3])
-def test_semantic_loss_all_ignore(nc):
-    """SemanticSegmentationLoss must stay finite when the whole batch is ignore (255), e.g. unlabeled/void frames."""
-    from ultralytics.cfg import get_cfg
-    from ultralytics.nn.tasks import SemanticSegmentationModel
-    from ultralytics.utils.loss import SemanticSegmentationLoss
-
-    model = SemanticSegmentationModel(cfg="yolo26-sem.yaml", nc=nc, verbose=False)
-    model.args = get_cfg()
-    loss_fn = SemanticSegmentationLoss(model)
-    preds = torch.randn(1, nc, 64, 64, requires_grad=True)
-    aux = torch.randn(1, nc, 32, 32, requires_grad=True)
-    loss, items = loss_fn((preds, aux), {"semantic_mask": torch.full((1, 64, 64), 255, dtype=torch.long)})
-    assert torch.isfinite(loss).all() and torch.isfinite(items).all()
-    loss.backward()
-    assert preds.grad is not None and aux.grad is not None
-
-
 def test_utils_ops():
     """Test utility operations for coordinate transformations and normalizations."""
     from ultralytics.utils.ops import (
@@ -961,7 +943,6 @@ def test_utils_ops():
         100,
     ]
     assert segment2box(np.array([[700.0, 100.0], [750.0, 150.0]]), 640, 640).tolist() == [0, 0, 0, 0]
-    assert segment2box(np.empty((0, 2)), 640, 640).tolist() == [0, 0, 0, 0]
     seg = np.array([[-100.0, -100.0], [740.0, -100.0], [740.0, 740.0], [-100.0, 740.0]])  # surrounds the image
     assert segment2box(seg, 640, 640).tolist() == [0, 0, 640, 640]
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -96,18 +96,17 @@ def skip_rpi_semantic():
         pytest.skip("Semantic segmentation tests are skipped on Raspberry Pi due to memory constraints.")
 
 
-def test_attempt_compile_falls_back_to_eager(monkeypatch):
-    """A backend failure at the first forward pass of a compiled model must fall back to eager, not raise."""
-    compile_fx = pytest.importorskip("torch._inductor.compile_fx")
+def test_attempt_compile_without_cpp_compiler(monkeypatch):
+    """CPU compile requests must return the eager model unchanged when inductor has no host C++ compiler."""
+    cpp_builder = pytest.importorskip("torch._inductor.cpp_builder")
     from ultralytics.utils.torch_utils import attempt_compile
 
-    def broken_backend(*args, **kwargs):
-        raise RuntimeError("simulated missing C++ compiler")  # e.g. InvalidCxxCompiler on Windows CPU
+    def missing_compiler():
+        raise RuntimeError("Compiler: cl is not found.")  # e.g. InvalidCxxCompiler on Windows CPU
 
-    monkeypatch.setattr(compile_fx, "compile_fx", broken_backend)
-    model = attempt_compile(torch.nn.Sequential(torch.nn.Conv2d(3, 8, 3)), device=torch.device("cpu"), mode=True)
-    assert model(torch.zeros(1, 3, 16, 16)).shape == (1, 8, 14, 14)
-    torch._dynamo.reset()  # clear the poisoned compile cache for other tests
+    monkeypatch.setattr(cpp_builder, "get_cpp_compiler", missing_compiler)
+    model = torch.nn.Sequential(torch.nn.Conv2d(3, 8, 3))
+    assert attempt_compile(model, device=torch.device("cpu"), mode=True) is model
 
 
 def test_select_device(monkeypatch):

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1042,6 +1042,8 @@ def attempt_compile(
 
     Notes:
         - If the current PyTorch build does not provide torch.compile, the function returns the input model immediately.
+        - Compilation is lazy and runs at the first forward pass, so dynamo error suppression is enabled to fall back
+          to eager execution if the backend fails there (e.g. no C++ compiler for inductor on CPU).
         - Warmup runs under torch.inference_mode and may use torch.autocast for CUDA/MPS to align compute precision.
         - CUDA devices are synchronized after warmup to account for asynchronous kernel execution.
     """
@@ -1057,6 +1059,7 @@ def attempt_compile(
         mode = "max-autotune-no-cudagraphs"
     t0 = time.perf_counter()
     try:
+        torch._dynamo.config.suppress_errors = True  # compilation is lazy, so fall back to eager if it fails later
         model = torch.compile(model, mode=mode, backend="inductor")
     except Exception as e:
         LOGGER.warning(f"{prefix} torch.compile failed, continuing uncompiled: {e}")

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -1042,8 +1042,8 @@ def attempt_compile(
 
     Notes:
         - If the current PyTorch build does not provide torch.compile, the function returns the input model immediately.
-        - Compilation is lazy and runs at the first forward pass, so dynamo error suppression is enabled to fall back
-          to eager execution if the backend fails there (e.g. no C++ compiler for inductor on CPU).
+        - Compilation is lazy and runs at the first forward pass, so the inductor CPU prerequisite of a host C++
+          compiler is verified up front and the original model is returned if none is available.
         - Warmup runs under torch.inference_mode and may use torch.autocast for CUDA/MPS to align compute precision.
         - CUDA devices are synchronized after warmup to account for asynchronous kernel execution.
     """
@@ -1053,13 +1053,22 @@ def attempt_compile(
     if mode is True:
         mode = "default"
     prefix = colorstr("compile:")
+    if device.type == "cpu":
+        try:  # compilation is lazy, so verify the inductor CPU requirement of a host C++ compiler before compiling
+            from torch._inductor.cpp_builder import get_cpp_compiler
+
+            get_cpp_compiler()
+        except ImportError:
+            pass  # older torch without cpp_builder, defer to torch.compile
+        except Exception as e:
+            LOGGER.warning(f"{prefix} no C++ compiler found for the inductor backend, continuing uncompiled: {e}")
+            return model
     LOGGER.info(f"{prefix} starting torch.compile with '{mode}' mode...")
     if mode == "max-autotune":
         LOGGER.warning(f"{prefix} mode='{mode}' not recommended, using mode='max-autotune-no-cudagraphs' instead")
         mode = "max-autotune-no-cudagraphs"
     t0 = time.perf_counter()
     try:
-        torch._dynamo.config.suppress_errors = True  # compilation is lazy, so fall back to eager if it fails later
         model = torch.compile(model, mode=mode, backend="inductor")
     except Exception as e:
         LOGGER.warning(f"{prefix} torch.compile failed, continuing uncompiled: {e}")


### PR DESCRIPTION
`attempt_compile` documents that "if compilation is unavailable or fails, the original model is returned unchanged", but `torch.compile` is lazy: the inductor backend actually builds at the first forward pass, outside the existing `try`. On Windows CPU without MSVC on PATH (the common case for end users), `yolo predict compile=True` crashes with `InductorError: InvalidCxxCompiler: Compiler: cl is not found` instead of falling back.

Since inductor CPU codegen always requires a host C++ compiler, this verifies that prerequisite up front using torch's own probe (`torch._inductor.cpp_builder.get_cpp_compiler`, the exact function that raised in the issue) and returns the eager model with a one-line warning when it is missing. The check is scoped to `attempt_compile` and CPU devices — no global dynamo state is touched, and older torch versions without `cpp_builder` defer to `torch.compile` as before.

Fixes https://github.com/ultralytics/ultralytics/issues/25109 and https://github.com/ultralytics/ultralytics/issues/25119.

Verified empirically: with the compiler probe patched to raise, `attempt_compile` returns the original model object and inference proceeds eagerly; happy path confirmed with a real `compile=True` predict (compiles and runs normally on a machine with clang++).

Deleted: nothing — the fix is a precondition check in the function that owns compilation, reusing torch's own compiler detection rather than duplicating it; the crash previously happened inside torch itself, so there is no downstream code to remove.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Improved CPU `torch.compile` handling by detecting missing C++ compiler requirements before compilation starts.

### 📊 Key Changes
- Added an upfront check for a host C++ compiler when compiling models on CPU with the Inductor backend.
- Returns the original, uncompiled model with a warning if no suitable compiler is available.
- Preserves compatibility with older PyTorch versions that do not include the compiler-check utility.
- Updated documentation to explain that compilation is lazy and begins during the first forward pass.

### 🎯 Purpose & Impact
- 🚫 Prevents delayed compilation failures caused by missing CPU C++ compiler dependencies.
- ✅ Allows inference or training to continue normally without compilation when prerequisites are unavailable.
- 📣 Provides clearer warnings so users can understand why CPU compilation was skipped.
- ⚡ Improves reliability for CPU deployments and environments with limited build tooling.