### PR TITLE
Fix segment mask conversion output directory

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -756,24 +756,6 @@ def test_data_converter(tmp_path):
     coco80_to_coco91_class()
 
 
-def test_convert_segment_masks_to_yolo_seg_creates_output_dir(tmp_path):
-    """Test segmentation mask conversion creates missing output directories."""
-    from ultralytics.data.converter import convert_segment_masks_to_yolo_seg
-
-    masks_dir = tmp_path / "masks"
-    output_dir = tmp_path / "labels"
-    masks_dir.mkdir()
-    mask = np.zeros((8, 8), dtype=np.uint8)
-    mask[2:6, 2:6] = 1
-    cv2.imwrite(str(masks_dir / "sample.png"), mask)
-
-    convert_segment_masks_to_yolo_seg(masks_dir, output_dir, classes=1)
-
-    label_file = output_dir / "sample.txt"
-    assert label_file.is_file()
-    assert label_file.read_text().startswith("0 ")
-
-
 def test_data_annotator(tmp_path):
     """Test automatic annotation of data using detection and segmentation models."""
     from ultralytics.data.annotator import auto_annotate

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -756,6 +756,24 @@ def test_data_converter(tmp_path):
     coco80_to_coco91_class()
 
 
+def test_convert_segment_masks_to_yolo_seg_creates_output_dir(tmp_path):
+    """Test segmentation mask conversion creates missing output directories."""
+    from ultralytics.data.converter import convert_segment_masks_to_yolo_seg
+
+    masks_dir = tmp_path / "masks"
+    output_dir = tmp_path / "labels"
+    masks_dir.mkdir()
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[2:6, 2:6] = 1
+    cv2.imwrite(str(masks_dir / "sample.png"), mask)
+
+    convert_segment_masks_to_yolo_seg(masks_dir, output_dir, classes=1)
+
+    label_file = output_dir / "sample.txt"
+    assert label_file.is_file()
+    assert label_file.read_text().startswith("0 ")
+
+
 def test_data_annotator(tmp_path):
     """Test automatic annotation of data using detection and segmentation models."""
     from ultralytics.data.annotator import auto_annotate

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -382,9 +382,13 @@ def convert_segment_masks_to_yolo_seg(masks_dir: str, output_dir: str, classes: 
                 └─ mask_yolo_04.txt
     """
     pixel_to_class_mapping = {i + 1: i for i in range(classes)}
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
     for mask_path in Path(masks_dir).iterdir():
         if mask_path.suffix in {".png", ".jpg"}:
             mask = cv2.imread(str(mask_path), cv2.IMREAD_GRAYSCALE)  # Read the mask image in grayscale
+            if mask.ndim == 3:
+                mask = mask[..., 0] if mask.shape[-1] == 1 else cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY)
             img_height, img_width = mask.shape  # Get image dimensions
             LOGGER.info(f"Processing {mask_path} imgsz = {img_height} x {img_width}")
 
@@ -414,7 +418,7 @@ def convert_segment_masks_to_yolo_seg(masks_dir: str, output_dir: str, classes: 
                             yolo_format.append(round(point[1] / img_height, 6))
                         yolo_format_data.append(yolo_format)
             # Save Ultralytics YOLO format data to file
-            output_path = Path(output_dir) / f"{mask_path.stem}.txt"
+            output_path = output_dir / f"{mask_path.stem}.txt"
             with open(output_path, "w", encoding="utf-8") as file:
                 for item in yolo_format_data:
                     line = " ".join(map(str, item))

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -387,9 +387,7 @@ def convert_segment_masks_to_yolo_seg(masks_dir: str, output_dir: str, classes: 
     for mask_path in Path(masks_dir).iterdir():
         if mask_path.suffix in {".png", ".jpg"}:
             mask = cv2.imread(str(mask_path), cv2.IMREAD_GRAYSCALE)  # Read the mask image in grayscale
-            if mask.ndim == 3:
-                mask = mask[..., 0] if mask.shape[-1] == 1 else cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY)
-            img_height, img_width = mask.shape  # Get image dimensions
+            img_height, img_width = mask.shape[:2]  # patched Windows imread returns (H, W, 1) for grayscale
             LOGGER.info(f"Processing {mask_path} imgsz = {img_height} x {img_width}")
 
             unique_values = np.unique(mask)  # Get unique pixel values representing different classes


### PR DESCRIPTION
`convert_segment_masks_to_yolo_seg()` had two real failures, both verified empirically:

1. The documented usage passes an output directory directly, but a missing directory raised `FileNotFoundError` on the first label write. Now created up front (`parents=True, exist_ok=True`), matching sibling converters that create their own output tree.
2. Ultralytics' patched `cv2.imread` (Windows) always returns 3-dim arrays, so grayscale masks arrive as `(H, W, 1)` and `img_height, img_width = mask.shape` failed to unpack. Fixed by reading `mask.shape[:2]` — OpenCV treats `(H, W, 1)` as single-channel throughout the rest of the pipeline (`np.unique`, `findContours`), so no channel manipulation is needed.

Verified: conversion from a missing output dir produces correct labels, and a simulated Windows read (`patches.imread`, shape `(8, 8, 1)`) produces byte-identical labels to the 2-D path.

Deleted: the speculative channel-normalization branch (`mask[..., 0]` / `cv2.cvtColor(BGR2GRAY)` — the cvtColor arm was unreachable under `IMREAD_GRAYSCALE` and would corrupt class ids if ever hit) and the 18-line regression test, per repo test-minimalism. The shape unpack was replaced, not guarded. Net +4/−2 on the converter; the two added lines are the missing directory creation, which has no existing code path to relocate.