### PR TITLE
fix(ddp): serialize custom callbacks across DDP subprocess boundary

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -457,7 +457,6 @@ def test_ddp_callback_serialization(tmp_path):
 
 def test_ddp_no_callbacks_no_pickle(tmp_path):
     """Verify no callbacks pickle file is created when only default callbacks are registered."""
-
     from ultralytics.utils import callbacks as callback_utils
     from ultralytics.utils.dist import ddp_cleanup, generate_ddp_file
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -414,3 +414,64 @@ def test_setup_model_respects_pretrained_arg_for_pt_models(monkeypatch, pretrain
 
     assert captured["cfg"] == checkpoint_model.yaml, "Checkpoint config was not used"
     assert captured["weights"] is (checkpoint_model if uses_weights else None), "Unexpected weights loaded"
+
+
+def test_ddp_callback_serialization(tmp_path):
+    """Verify custom callbacks are pickled into the DDP temp file (issue #6168)."""
+    import os
+    import pickle
+
+    from ultralytics.utils import callbacks as callback_utils
+    from ultralytics.utils.dist import ddp_cleanup, generate_ddp_file
+
+    # Build a minimal trainer-like object with the attributes generate_ddp_file reads
+    trainer = SimpleNamespace(
+        __class__=BaseTrainer,
+        args=SimpleNamespace(augmentations=None, model="yolo26n.pt"),
+        callbacks=callback_utils.get_default_callbacks(),
+        hub_session=None,
+    )
+    # Use module-level test_func (defined at top of file) since pickle can't serialize local closures
+    trainer.callbacks["on_train_end"].append(test_func)
+
+    file = generate_ddp_file(trainer)
+    try:
+        with open(file) as f:
+            content = f.read()
+        # The generated file must reference a callbacks pickle file
+        assert "callbacks_file" in content
+        assert "_callbacks" in content
+        # Extract the pickle path and verify it contains our callback
+        import re
+
+        match = re.search(r"callbacks_file = '([^']+)'", content)
+        assert match, "callbacks_file path not found in generated content"
+        pkl_path = match.group(1)
+        assert os.path.exists(pkl_path), f"Callbacks pickle file not created at {pkl_path}"
+        with open(pkl_path, "rb") as f:
+            loaded = pickle.load(f)
+        assert test_func in loaded["on_train_end"], "Custom callback not in pickled callbacks"
+    finally:
+        ddp_cleanup(trainer, file)
+
+
+def test_ddp_no_callbacks_no_pickle(tmp_path):
+    """Verify no callbacks pickle file is created when only default callbacks are registered."""
+
+    from ultralytics.utils import callbacks as callback_utils
+    from ultralytics.utils.dist import ddp_cleanup, generate_ddp_file
+
+    trainer = SimpleNamespace(
+        __class__=BaseTrainer,
+        args=SimpleNamespace(augmentations=None, model="yolo26n.pt"),
+        callbacks=callback_utils.get_default_callbacks(),
+        hub_session=None,
+    )
+
+    file = generate_ddp_file(trainer)
+    try:
+        with open(file) as f:
+            content = f.read()
+        assert "callbacks_file = None" in content, "Should not create pickle file for default callbacks"
+    finally:
+        ddp_cleanup(trainer, file)

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -35,7 +35,8 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
     """Generate a DDP (Distributed Data Parallel) file for multi-GPU training.
 
     This function creates a temporary Python file that enables distributed training across multiple GPUs. The file
-    contains the necessary configuration to initialize the trainer in a distributed environment.
+    contains the necessary configuration to initialize the trainer in a distributed environment, including custom
+    callbacks serialized via pickle so they survive the subprocess boundary (issue #6168).
 
     Args:
         trainer (ultralytics.engine.trainer.BaseTrainer): The trainer containing training configuration and arguments.
@@ -49,8 +50,13 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
         - Trainer class import
         - Configuration overrides from the trainer arguments
         - Model path configuration
+        - Custom callbacks (pickled alongside the temp file)
         - Training initialization code
     """
+    import pickle
+
+    from . import callbacks as callback_utils
+
     module, name = f"{trainer.__class__.__module__}.{trainer.__class__.__name__}".rsplit(".", 1)
 
     # Serialize augmentations to JSON-safe dicts to avoid NameError in DDP subprocess
@@ -60,23 +66,46 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
 
         overrides["augmentations"] = [A.to_dict(t) for t in overrides["augmentations"]]
 
+    # Serialize custom callbacks to a pickle file so they survive the DDP subprocess boundary (#6168)
+    callbacks_file = None
+    if trainer.callbacks != callback_utils.get_default_callbacks():
+        (USER_CONFIG_DIR / "DDP").mkdir(exist_ok=True)
+        callbacks_file = tempfile.NamedTemporaryFile(
+            prefix="_callbacks_",
+            suffix=f"{id(trainer)}.pkl",
+            mode="wb",
+            dir=USER_CONFIG_DIR / "DDP",
+            delete=False,
+        )
+        pickle.dump(trainer.callbacks, callbacks_file)
+        callbacks_file.close()
+        callbacks_file = callbacks_file.name
+
     content = f"""
 # Ultralytics Multi-GPU training temp file (should be automatically deleted after use)
 from pathlib import Path, PosixPath  # For model arguments stored as Path instead of str
 overrides = {overrides}
+callbacks_file = {repr(callbacks_file)}
 
 if __name__ == "__main__":
     from {module} import {name}
     from ultralytics.utils import DEFAULT_CFG_DICT
+    import pickle
 
     # Deserialize augmentations from dicts back to Albumentations transform objects
     if overrides.get("augmentations") is not None:
         import albumentations as A
         overrides["augmentations"] = [A.from_dict(t) for t in overrides["augmentations"]]
 
+    # Load custom callbacks pickled by the parent process (#6168)
+    _callbacks = None
+    if callbacks_file:
+        with open(callbacks_file, "rb") as f:
+            _callbacks = pickle.load(f)
+
     cfg = DEFAULT_CFG_DICT.copy()
     cfg.update(save_dir='')   # handle the extra key 'save_dir'
-    trainer = {name}(cfg=cfg, overrides=overrides)
+    trainer = {name}(cfg=cfg, overrides=overrides, _callbacks=_callbacks)
     trainer.args.model = "{getattr(trainer.hub_session, "model_url", trainer.args.model)}"
     results = trainer.train()
 """
@@ -127,7 +156,7 @@ def ddp_cleanup(trainer: BaseTrainer, file: str) -> None:
     """Delete temporary file if created during distributed data parallel (DDP) training.
 
     This function checks if the provided file contains the trainer's ID in its name, indicating it was created as a
-    temporary file for DDP training, and deletes it if so.
+    temporary file for DDP training, and deletes it if so. Also removes the associated callbacks pickle file.
 
     Args:
         trainer (ultralytics.engine.trainer.BaseTrainer): The trainer used for distributed training.
@@ -140,3 +169,6 @@ def ddp_cleanup(trainer: BaseTrainer, file: str) -> None:
     """
     if f"{id(trainer)}.py" in file:  # if temp_file suffix in file
         os.remove(file)
+        callbacks_file = file.replace("_temp_", "_callbacks_").replace(".py", ".pkl")
+        if os.path.exists(callbacks_file):
+            os.remove(callbacks_file)

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -85,7 +85,7 @@ def generate_ddp_file(trainer: BaseTrainer) -> str:
 # Ultralytics Multi-GPU training temp file (should be automatically deleted after use)
 from pathlib import Path, PosixPath  # For model arguments stored as Path instead of str
 overrides = {overrides}
-callbacks_file = {repr(callbacks_file)}
+callbacks_file = {callbacks_file!r}
 
 if __name__ == "__main__":
     from {module} import {name}


### PR DESCRIPTION
## Summary

- Custom callbacks registered via `model.add_callback()` were silently dropped during DDP (multi-GPU) training because `generate_ddp_file()` only serialized `trainer.args`, not `trainer.callbacks`. The subprocess trainer initialized with default callbacks only (issue #6168).
- Pickles `trainer.callbacks` to a temp `.pkl` file alongside the existing temp `.py` file when they differ from defaults, and loads them in the subprocess via the `_callbacks=` parameter.
- Extends `ddp_cleanup` to remove the `.pkl` file. No new dependencies (uses stdlib `pickle`).

**Deleted:** nothing — DDP subprocess is a separate process with no shared memory; serialization is the only bridge to transfer in-memory callback functions across the process boundary.

#### Test plan

- [x] `test_ddp_callback_serialization` — verifies custom callbacks are pickled and referenced in the generated DDP file
- [x] `test_ddp_no_callbacks_no_pickle` — verifies no pickle file is created when only default callbacks are registered (backward compatible)
- [x] Full `tests/test_engine.py` suite passes (33/33)

Generated with [Devin](https://devin.ai)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes custom callback loss when launching distributed training subprocesses by serializing callbacks to a temporary pickle file.

### 📊 Key Changes
- Serializes non-default trainer callbacks alongside the DDP temporary script.
- Loads serialized callbacks in the subprocess and passes them to the trainer.
- Removes callback pickle files during DDP cleanup.
- Adds tests covering custom callback serialization and the default-callback-only path.

### 🎯 Purpose & Impact
- 🐛 Preserves user-defined training callbacks across the DDP process boundary, addressing issue #6168.
- 🚀 Improves multi-GPU training reliability without creating unnecessary pickle files for unchanged default callbacks.
- 🧹 Ensures temporary callback artifacts are cleaned up after distributed training.