### PR TITLE
Fix `ValueError` when `predict` is called with an empty `embed` list

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -183,7 +183,7 @@ class BaseModel(torch.nn.Module):
             (torch.Tensor): The last output of the model.
         """
         y, dt, embeddings = [], [], []  # outputs
-        embed = frozenset(embed) if embed is not None else {-1}
+        embed = frozenset(embed) if embed else {-1}
         max_idx = max(embed)
         for m in self.model:
             if m.f != -1:  # if not from previous layer
@@ -981,7 +981,7 @@ class RTDETRDetectionModel(DetectionModel):
             (torch.Tensor): Model's output tensor.
         """
         y, dt, embeddings = [], [], []  # outputs
-        embed = frozenset(embed) if embed is not None else {-1}
+        embed = frozenset(embed) if embed else {-1}
         max_idx = max(embed)
         for m in self.model[:-1]:  # except the head part
             if m.f != -1:  # if not from previous layer
@@ -1091,7 +1091,7 @@ class WorldModel(DetectionModel):
             txt_feats = txt_feats.expand(x.shape[0], -1, -1)
         ori_txt_feats = txt_feats.clone()
         y, dt, embeddings = [], [], []  # outputs
-        embed = frozenset(embed) if embed is not None else {-1}
+        embed = frozenset(embed) if embed else {-1}
         max_idx = max(embed)
         for m in self.model:  # except the head part
             if m.f != -1:  # if not from previous layer
@@ -1331,7 +1331,7 @@ class YOLOEModel(DetectionModel):
         """
         y, dt, embeddings = [], [], []  # outputs
         b = x.shape[0]
-        embed = frozenset(embed) if embed is not None else {-1}
+        embed = frozenset(embed) if embed else {-1}
         max_idx = max(embed)
         for m in self.model:  # except the head part
             if m.f != -1:  # if not from previous layer


### PR DESCRIPTION
## Description

Calling `model.predict(source, embed=[])` crashes with `ValueError: max() arg is an empty sequence`:

```python
embed = frozenset(embed) if embed is not None else {-1}
max_idx = max(embed)  # embed=[] -> empty frozenset -> ValueError
```

The same pattern appears at four sites in `ultralytics/nn/tasks.py` (`BaseModel._predict_once`, its YOLOE/RTDETR counterparts). An empty list passes the `is not None` check, producing an empty frozenset that `max()` rejects.

This PR switches the four checks to truthiness (`if embed`), so an empty list falls back to `{-1}` and runs a normal forward pass — the same convention the public API already uses: `Model.embed()` treats an empty `embed` as "no indices" via `if not kwargs.get("embed")` and substitutes the default layer. The model layer now agrees with the facade instead of crashing.

Verified empirically on this branch: `predict(img, embed=[])` returns normal `Results` (previously `ValueError`), plain `predict(img)` unchanged, and `model.embed(img)` still returns the `(256,)` embedding tensor.

Deleted: the `is not None` checks at all four embedding-normalization sites, replaced with truthiness — a pure replacement, net-zero diff with no added conditions.