### PR TITLE
Upgrade Python Docker image to Debian Trixie

### DIFF
--- a/docker/Dockerfile-python
+++ b/docker/Dockerfile-python
@@ -3,8 +3,7 @@
 # Builds ultralytics/ultralytics:latest-python image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Lightweight CPU image optimized for YOLO inference
 
-# Use official Python 3.11.10 base image for reproducibility
-FROM python:3.11.10-slim-bookworm
+FROM python:3.11-slim-trixie
 
 # Set environment variables (suppress PyTorch NNPACK warnings)
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Summary
- retain Python 3.11 while moving `latest-python` and its derivative images from Debian Bookworm to Trixie
- use the minor-floating `python:3.11-slim-trixie` tag for Python patch and Debian security updates on rebuild
- conservative alternative to the Python 3.13/Trixie PR; merge one, not both

## Validation
- `git diff --check`
- `docker buildx imagetools inspect python:3.11-slim-trixie`
- full image and derivative builds run in the Docker CI workflow

Deleted: the patch-pinned Python 3.11.10/Bookworm base reference and its stale reproducibility comment; replaced them with the Python 3.11/Trixie tag.

This is a replacement-only dependency update; relocation is not applicable because the base image is owned by this Dockerfile.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Upgrades the Python Docker image from Debian Bookworm to Debian Trixie while retaining Python 3.11.

### 📊 Key Changes
- Replaces the pinned `python:3.11.10-slim-bookworm` base image with `python:3.11-slim-trixie`.
- Keeps the existing lightweight CPU-focused Docker image configuration unchanged.

### 🎯 Purpose & Impact
- 🐳 Moves the image to the newer Debian Trixie slim base for updated system packages and support.
- 🔄 Uses the rolling Python 3.11 slim tag, which may receive newer patch releases automatically.
- ⚠️ May introduce compatibility or dependency changes from the Debian distribution upgrade, so Docker build and runtime CI validation are important.