### PR TITLE
Upgrade Python Docker image to 3.13 Trixie

### DIFF
--- a/docker/Dockerfile-python
+++ b/docker/Dockerfile-python
@@ -3,8 +3,7 @@
 # Builds ultralytics/ultralytics:latest-python image on DockerHub https://hub.docker.com/r/ultralytics/ultralytics
 # Lightweight CPU image optimized for YOLO inference
 
-# Use official Python 3.11.10 base image for reproducibility
-FROM python:3.11.10-slim-bookworm
+FROM python:3.13-slim-trixie
 
 # Set environment variables (suppress PyTorch NNPACK warnings)
 ENV PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Summary
- move `latest-python` and its derivative images from Python 3.11/Bookworm to the Python 3.13 version exercised by primary CI
- use the minor-floating `python:3.13-slim-trixie` tag for Python patch and Debian security updates on rebuild
- alternative to the conservative Python 3.11/Trixie-only PR; merge one, not both

## Validation
- `git diff --check`
- `docker buildx imagetools inspect python:3.13-slim-trixie`
- full image and derivative builds run in the Docker CI workflow

Deleted: the patch-pinned Python 3.11.10/Bookworm base reference and its stale reproducibility comment; replaced them with the CI-aligned Python 3.13/Trixie tag.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🐍 Updates the lightweight Python Docker image to Python 3.13 on Debian Trixie.

### 📊 Key Changes

- Replaces the pinned `python:3.11.10-slim-bookworm` base image with `python:3.13-slim-trixie`.
- Removes the previous comment describing Python 3.11 reproducibility.
- Keeps the image focused on lightweight, CPU-based YOLO inference.

### 🎯 Purpose & Impact

- 🚀 Provides access to newer Python features and improvements.
- 📦 Moves the container to the newer Debian Trixie distribution.
- ⚠️ May improve long-term platform support, but could introduce compatibility issues for dependencies that do not yet fully support Python 3.13 or Debian Trixie.