### PR TITLE
Update `ultralytics-inference` version to 0.0.27 in documentation

### DIFF
--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -55,7 +55,7 @@ Rust 1.89 or newer is required. The [video](#cargo-features) feature additionall
     ```toml
     # Or add it manually to Cargo.toml
     [dependencies]
-    ultralytics-inference = "0.0.22"
+    ultralytics-inference = "0.0.27"
     ```
 
 ## CLI quickstart
@@ -409,7 +409,7 @@ cargo install ultralytics-inference --features cuda,tensorrt
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.22", features = ["video"] }
+ultralytics-inference = { version = "0.0.27", features = ["video"] }
 ```
 
 ## Output and saving


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📦 Updated the Rust inference dependency documentation from `0.0.22` to `0.0.27`.

### 📊 Key Changes

- Updated the `ultralytics-inference` version in the Rust installation example.
- Updated the Rust video feature example to use version `0.0.27`.

### 🎯 Purpose & Impact

- ✅ Keeps the inference documentation aligned with the latest published Rust package.
- 🚀 Helps Rust users install the intended dependency version and access the latest updates and fixes.
- 🛠️ No functional code changes; this PR only affects documentation examples.