### PR TITLE
Reject undersized Axelera exports

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -171,12 +171,6 @@ def test_qnn_quantize_requires_w8a16():
         validate_args("qnn", SimpleNamespace(quantize=8), valid_args)
 
 
-def test_axelera_rejects_small_imgsz():
-    """Axelera exports should reject inputs smaller than the compiler's 64-pixel minimum before compilation."""
-    with pytest.raises(ValueError, match="Axelera export requires imgsz>=64"):
-        YOLO(MODEL).export(format="axelera", imgsz=32)
-
-
 def test_modelopt_quantize_onnx_requires_int8_dataset():
     """Check INT8 ModelOpt quantization fails early without calibration data."""
     with pytest.raises(ValueError, match="requires a calibration dataset"):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -171,6 +171,12 @@ def test_qnn_quantize_requires_w8a16():
         validate_args("qnn", SimpleNamespace(quantize=8), valid_args)
 
 
+def test_axelera_rejects_small_imgsz():
+    """Axelera exports should reject inputs smaller than the compiler's 64-pixel minimum before compilation."""
+    with pytest.raises(ValueError, match="Axelera export requires imgsz>=64"):
+        YOLO(MODEL).export(format="axelera", imgsz=32)
+
+
 def test_modelopt_quantize_onnx_requires_int8_dataset():
     """Check INT8 ModelOpt quantization fails early without calibration data."""
     with pytest.raises(ValueError, match="requires a calibration dataset"):

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -612,6 +612,8 @@ class Exporter:
         if self.args.quantize == 16 and fmt == "torchscript" and self.device.type == "cpu":
             raise ValueError("FP16 TorchScript export is only supported on GPU, i.e. use device=0.")
         self.imgsz = check_imgsz(self.args.imgsz, stride=model.stride, min_dim=2)  # check image size
+        if fmt == "axelera" and min(self.imgsz) < 64:
+            raise ValueError(f"Axelera export requires imgsz>=64, but got imgsz={self.imgsz}.")
         if self.args.optimize:
             assert fmt != "ncnn", "optimize=True not compatible with format='ncnn', i.e. use optimize=False"
             assert self.device.type == "cpu", "optimize=True not compatible with cuda devices, i.e. use device='cpu'"


### PR DESCRIPTION
## Summary
- reject Axelera exports when either image dimension is below the compiler minimum of 64 pixels
- fail before calibration and compiler startup with an actionable error

## Validation
- reproduced the Axelera compiler crash at `imgsz=32` with YOLO26n and YOLO11n
- confirmed the same backend succeeds at `imgsz=64`
- `ruff check ultralytics/engine/exporter.py`
- `git diff --check`

Deleted: nothing. The exporter-boundary validation is required because the third-party compiler fails deep in TVM for undersized inputs and no existing package validation owns this backend constraint.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛡️ Added input-size validation for Axelera exports to prevent unsupported image dimensions.

### 📊 Key Changes

- Added a check in `ultralytics/engine/exporter.py` for `format="axelera"`.
- Raises a clear `ValueError` when the smallest image dimension is below 64 pixels.
- Reports both the required minimum size and the provided `imgsz` value.

### 🎯 Purpose & Impact

- ✅ Prevents Axelera export failures caused by unsupported small input sizes.
- 💬 Provides an immediate, actionable error message during export.
- 🚀 Improves export reliability without affecting other model formats.