### PR TITLE
Refactor semantic dataset docs

### DIFF
--- a/docs/en/datasets/semantic/ade20k.md
+++ b/docs/en/datasets/semantic/ade20k.md
@@ -31,7 +31,7 @@ ADEChallengeData2016/
 
 !!! warning "Manual Download Required"
 
-    ADE20K has no automatic download script. Download the ~1 GB [`ADEChallengeData2016.zip`](http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip) archive and extract it into the `datasets/ADEChallengeData2016` root — no reorganization is needed, since the archive already matches the layout above.
+    ADE20K has no automatic download script. Download the ~1 GB [`ADEChallengeData2016.zip`](http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip) archive and extract it directly into your `datasets/` folder. The archive's own top-level folder is already named `ADEChallengeData2016/`, so this produces `datasets/ADEChallengeData2016/` matching the layout above — do not create an `ADEChallengeData2016` folder yourself and extract into it, or you'll end up with a nested `datasets/ADEChallengeData2016/ADEChallengeData2016/` directory that the YAML won't find.
 
 The `masks_dir` field is set to `annotations`, so each image under `images/` is paired with its corresponding mask under `annotations/`. The original ADE20K masks use source label IDs where `0` is ignored, and the `label_mapping` section converts valid labels `1` through `150` to contiguous train IDs `0` through `149`, mapping ignored pixels to `255`.
 

--- a/docs/en/datasets/semantic/ade20k.md
+++ b/docs/en/datasets/semantic/ade20k.md
@@ -134,7 +134,7 @@ The ADE20K dataset follows the official ADEChallengeData2016 layout, with images
 
 ### Do I need to download ADE20K manually?
 
-Yes. Download the [`ADEChallengeData2016.zip`](http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip) archive (~1 GB) and extract it into the `ADEChallengeData2016` dataset root before training. Unlike Cityscapes, no additional reorganization step is needed — the archive already matches the `images/` and `annotations/` layout that `ade20k.yaml` expects.
+Yes. Download the [`ADEChallengeData2016.zip`](http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip) archive (~1 GB) and extract it directly into your `datasets/` folder before training — the archive's own top-level folder is already named `ADEChallengeData2016/`, so extracting it there (not into a separate `ADEChallengeData2016` folder you create yourself) produces the `images/` and `annotations/` layout that `ade20k.yaml` expects.
 
 ### Why does ADE20K use `label_mapping`?
 

--- a/docs/en/datasets/semantic/ade20k.md
+++ b/docs/en/datasets/semantic/ade20k.md
@@ -76,7 +76,9 @@ To train a YOLO26n-sem model on the ADE20K dataset for 100 [epochs](https://www.
         yolo semantic train data=ade20k.yaml model=yolo26n-sem.pt epochs=100 imgsz=512
         ```
 
-## Citations and Acknowledgments
+## Citations, License and Acknowledgments
+
+ADE20K images are released for [non-commercial research and educational use only](https://ade20k.csail.mit.edu/terms); the dataset's annotation software is separately licensed under BSD-3. Commercial use requires permission from MIT CSAIL.
 
 If you use the ADE20K dataset in your research or development work, please cite the following paper:
 
@@ -137,3 +139,7 @@ Yes. Download the [`ADEChallengeData2016.zip`](http://data.csail.mit.edu/places/
 ### Why does ADE20K use `label_mapping`?
 
 ADE20K annotation masks store source label IDs where `0` denotes the ignore or background class. The `label_mapping` section maps valid labels `1` through `150` to contiguous train IDs `0` through `149`, and assigns `255` to ignored pixels so they are excluded from the loss and metrics during training and validation.
+
+### Is the ADE20K dataset free for commercial use?
+
+No. ADE20K images are released under [terms restricting use to non-commercial research and education](https://ade20k.csail.mit.edu/terms); the accompanying annotation software is separately licensed under BSD-3. Contact MIT CSAIL for commercial licensing options.

--- a/docs/en/datasets/semantic/ade20k.md
+++ b/docs/en/datasets/semantic/ade20k.md
@@ -1,19 +1,19 @@
 ---
 title: ADE20K Segmentation Dataset
 comments: true
-description: Explore the ADE20K semantic segmentation dataset with Ultralytics YOLO. Learn about its structure, 150 scene-parsing classes, YAML configuration, and training examples.
+description: Train Ultralytics YOLO on the ADE20K dataset — 20,210 training and 2,000 validation images across 150 scene-parsing classes for semantic segmentation.
 keywords: ADE20K dataset, semantic segmentation, scene parsing, Ultralytics YOLO, YOLO26, ADEChallengeData2016, computer vision, deep learning
 ---
 
 # ADE20K Dataset
 
-The [ADE20K](http://sceneparsing.csail.mit.edu/) dataset is a large-scale [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation) and scene parsing benchmark released by MIT CSAIL. It provides densely annotated images covering a wide variety of indoor, outdoor, object, and stuff categories, making it an essential resource for researchers and developers working on dense scene understanding tasks with [Ultralytics YOLO](../../models/index.md) models.
+The [ADE20K](http://sceneparsing.csail.mit.edu/) dataset is a large-scale [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation) benchmark from MIT CSAIL with 20,210 training and 2,000 validation images densely annotated across 150 indoor, outdoor, object, and stuff categories. It is a standard resource for training and evaluating dense scene-understanding models with [Ultralytics YOLO](../../models/index.md).
 
 ## Key Features
 
-- ADE20K contains 20,210 training images, 2,000 validation images, and 3,352 test images.
+- ADE20K's full SceneParsing benchmark totals 25,562 images: 20,210 for training, 2,000 for validation, and 3,352 for testing. Test-image annotations are not publicly released, so the downloadable `ADEChallengeData2016` archive and the Ultralytics `ade20k.yaml` config use only the training and validation splits.
 - The dataset covers 150 semantic classes spanning indoor, outdoor, object, and stuff categories.
-- Annotations are pixel-level segmentation masks suitable for dense scene parsing.
+- Annotations are dense pixel-level segmentation masks suitable for scene parsing.
 
 ## Dataset Structure
 
@@ -29,13 +29,17 @@ ADEChallengeData2016/
     └── validation/
 ```
 
+!!! warning "Manual Download Required"
+
+    ADE20K has no automatic download script. Download the ~1 GB [`ADEChallengeData2016.zip`](http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip) archive and extract it into the `datasets/ADEChallengeData2016` root — no reorganization is needed, since the archive already matches the layout above.
+
 The `masks_dir` field is set to `annotations`, so each image under `images/` is paired with its corresponding mask under `annotations/`. The original ADE20K masks use source label IDs where `0` is ignored, and the `label_mapping` section converts valid labels `1` through `150` to contiguous train IDs `0` through `149`, mapping ignored pixels to `255`.
 
 ## Applications
 
 ADE20K is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in semantic segmentation and scene parsing. Its diverse set of categories and complex scenes make it valuable for applications such as autonomous navigation, robotics, augmented reality, and image editing.
 
-The breadth of indoor and outdoor scenes also makes ADE20K a strong benchmark for evaluating model generalization across domains.
+The breadth of indoor and outdoor scenes also makes ADE20K a strong benchmark for evaluating model generalization across domains. Pretrained YOLO26 semantic segmentation models reach up to 51.5 mIoU on the ADE20K validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. ADE20K-format datasets are also fully compatible with [Ultralytics Platform](https://platform.ultralytics.com/) for dataset management and training.
 
 ## Dataset YAML
 
@@ -95,7 +99,7 @@ We would like to acknowledge the MIT CSAIL Computer Vision Group for creating an
 
 ### What is the ADE20K dataset and why is it important for computer vision?
 
-The [ADE20K](http://sceneparsing.csail.mit.edu/) dataset is a large-scale scene parsing benchmark used for [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation). It contains 25,562 densely annotated images across 150 categories covering indoor, outdoor, object, and stuff classes. Researchers use ADE20K because of its diverse scenes, fine-grained category set, and standardized evaluation metrics like mean Intersection over Union (mIoU), which make it ideal for benchmarking dense prediction models.
+The [ADE20K](http://sceneparsing.csail.mit.edu/) dataset is a large-scale scene parsing benchmark used for [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation), with 20,210 training and 2,000 validation images publicly released across 150 categories covering indoor, outdoor, object, and stuff classes. Researchers use ADE20K because of its diverse scenes, fine-grained category set, and standardized evaluation metrics like mean Intersection over Union (mIoU), which make it ideal for benchmarking dense prediction models.
 
 ### How can I train a YOLO model using the ADE20K dataset?
 
@@ -125,6 +129,10 @@ To train a YOLO26n-sem model on the ADE20K dataset for 100 epochs with an image 
 ### How is the ADE20K dataset structured?
 
 The ADE20K dataset follows the official ADEChallengeData2016 layout, with images organized under `images/training/` and `images/validation/`, and corresponding masks under `annotations/training/` and `annotations/validation/`. The Ultralytics YAML file pairs each image with its mask via the `masks_dir: annotations` field, and uses `label_mapping` to convert source label IDs `1`–`150` into contiguous train IDs `0`–`149`, mapping the ignore label to `255`.
+
+### Do I need to download ADE20K manually?
+
+Yes. Download the [`ADEChallengeData2016.zip`](http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip) archive (~1 GB) and extract it into the `ADEChallengeData2016` dataset root before training. Unlike Cityscapes, no additional reorganization step is needed — the archive already matches the `images/` and `annotations/` layout that `ade20k.yaml` expects.
 
 ### Why does ADE20K use `label_mapping`?
 

--- a/docs/en/datasets/semantic/cityscapes.md
+++ b/docs/en/datasets/semantic/cityscapes.md
@@ -1,18 +1,20 @@
 ---
+title: Cityscapes Semantic Segmentation Dataset
 comments: true
-description: Explore the Cityscapes semantic segmentation dataset with Ultralytics YOLO. Learn about its 19 urban classes, dataset structure, YAML configuration, and training examples.
+description: Train Ultralytics YOLO on Cityscapes — 2,975 training and 500 validation images across 19 urban classes for semantic segmentation of street scenes.
 keywords: Cityscapes dataset, semantic segmentation, Ultralytics YOLO, YOLO26, autonomous driving, urban scene understanding, computer vision, deep learning
 ---
 
 # Cityscapes Dataset
 
-The [Cityscapes](https://www.cityscapes-dataset.com/) dataset is a large-scale [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation) benchmark focused on urban street scenes captured across 50 European cities. It provides high-quality pixel-level annotations and is one of the most widely used datasets for autonomous driving research and urban scene understanding with [Ultralytics YOLO](../../models/index.md) models.
+The [Cityscapes](https://www.cityscapes-dataset.com/) dataset is a large-scale [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation) benchmark of urban street scenes captured across 50 European cities, with 2,975 finely annotated training images and 500 validation images across 19 classes. It is one of the most widely used datasets for autonomous driving research and urban scene understanding with [Ultralytics YOLO](../../models/index.md) models.
 
 ## Key Features
 
-- Cityscapes fine annotations include 2,975 training images, 500 validation images, and 1,525 test images.
-- The dataset covers 19 evaluation classes spanning road, vehicle, human, construction, object, nature, and sky categories.
+- Cityscapes fine annotations include 2,975 training images and 500 validation images across 19 classes; the archive also ships 1,525 test images, but their released masks only label the ego-vehicle and image border — real class annotations are withheld, and official test-set scores require submitting predictions to the [Cityscapes evaluation server](https://www.cityscapes-dataset.com/benchmarks/).
+- The dataset covers 19 evaluation classes spanning flat, human, vehicle, construction, object, nature, and sky categories.
 - Cityscapes provides standardized evaluation metrics like [mean Intersection over Union](https://www.ultralytics.com/glossary/intersection-over-union-iou) (mIoU) for semantic segmentation, enabling effective comparison of model performance.
+- Before committing to the ~11 GB manual download, sanity-check your training pipeline against the 8-image [Cityscapes8](cityscapes8.md) subset.
 
 ## Dataset Structure
 
@@ -30,13 +32,21 @@ cityscapes/
     └── test/
 ```
 
-The semantic masks are single-channel PNG files. The original Cityscapes label IDs are mapped to the standard 19 train IDs via the `label_mapping` section, and ignored or void labels are mapped to `255` so they are excluded from training and evaluation. Download the official `leftImg8bit` and `gtFine` archives from the Cityscapes website and extract them into the dataset root; the preparation block in `cityscapes.yaml` then organizes images and masks into this layout.
+!!! warning "Manual Download Required"
+
+    Cityscapes has no automatic archive download. Create an account on the [Cityscapes website](https://www.cityscapes-dataset.com/), then download the `leftImg8bit_trainvaltest.zip` and `gtFine_trainvaltest.zip` archives (~11 GB combined) and extract both into the `cityscapes` dataset root. Ultralytics automatically reorganizes them into the `images/` and `masks/` layout above the first time you train.
+
+The semantic masks are single-channel PNG files. The original Cityscapes label IDs are mapped to the standard 19 train IDs via the `label_mapping` section, and ignored or void labels are mapped to `255` so they are excluded from training and evaluation.
+
+!!! note
+
+    The publicly released `gtFine/test` masks only label the ego-vehicle and image border regions — all other classes are void. Compute mIoU on the `val` split for local evaluation; official test-set scores require submitting predictions to the [Cityscapes evaluation server](https://www.cityscapes-dataset.com/benchmarks/).
 
 ## Applications
 
 Cityscapes is widely used for training and evaluating [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) models in semantic segmentation, particularly for [autonomous driving](https://www.ultralytics.com/glossary/autonomous-vehicles), advanced driver-assistance systems (ADAS), and urban robotics.
 
-Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments.
+Its high-resolution images and detailed annotations also make it valuable for research on real-time scene parsing, lane and obstacle understanding, and any task that requires dense pixel-level understanding of complex urban environments. Pretrained YOLO26 semantic segmentation models reach up to 83.6 mIoU on the Cityscapes validation set — see the [semantic segmentation models](../../tasks/semantic.md) page for the full benchmark table. Cityscapes annotations are also available on [Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cityscapes) for browsing and dataset management.
 
 ## Dataset YAML
 
@@ -73,7 +83,9 @@ To train a YOLO26n-sem model on the Cityscapes dataset for 100 [epochs](https://
         yolo semantic train data=cityscapes.yaml model=yolo26n-sem.pt epochs=100 imgsz=1024
         ```
 
-## Citations and Acknowledgments
+## Citations, License and Acknowledgments
+
+Cityscapes is released under a [custom non-commercial license](https://www.cityscapes-dataset.com/license/) — free for academic research and evaluation, but commercial use, licensing, or redistribution of the data requires separate permission from the Cityscapes team.
 
 If you use the Cityscapes dataset in your research or development work, please cite the following paper:
 
@@ -96,7 +108,7 @@ We would like to acknowledge the Cityscapes team for creating and maintaining th
 
 ### What is the Cityscapes dataset and why is it important for computer vision?
 
-The [Cityscapes](https://www.cityscapes-dataset.com/) dataset is a large-scale [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation) benchmark focused on urban street scenes captured across 50 European cities. It contains 5,000 finely annotated images across 19 evaluation classes, making it a foundational resource for autonomous driving and urban scene understanding research. Its high-resolution images, dense annotations, and standardized mean Intersection over Union (mIoU) metric make it ideal for benchmarking dense prediction models.
+The [Cityscapes](https://www.cityscapes-dataset.com/) dataset is a large-scale [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation) benchmark of urban street scenes across 50 European cities, widely used as a standard reference for autonomous driving and ADAS research. Its 19 finely annotated evaluation classes, high-resolution imagery, and standardized mean Intersection over Union (mIoU) metric make it one of the most cited benchmarks for dense scene-understanding models.
 
 ### How can I train a YOLO model using the Cityscapes dataset?
 
@@ -125,12 +137,16 @@ To train a YOLO26n-sem model on the Cityscapes dataset for 100 epochs with an im
 
 ### How is the Cityscapes dataset structured?
 
-After preparation, the dataset is organized into `images/{train,val,test}/` and `masks/{train,val,test}/` directories, with each image paired with a single-channel PNG mask. The Ultralytics YAML file pairs each image with its mask via the `masks_dir: masks` field, and uses `label_mapping` to convert original Cityscapes label IDs into the standard 19 contiguous train IDs, mapping ignored and void labels to `255`.
+After preparation, the dataset is organized into `images/{train,val,test}/` and `masks/{train,val,test}/` directories, with each image paired with a single-channel PNG mask. The Ultralytics YAML file pairs each image with its mask via the `masks_dir: masks` field, and uses `label_mapping` to convert original Cityscapes label IDs into the standard 19 contiguous train IDs, mapping ignored and void labels to `255`. The `test` split's masks only label ego-vehicle and border regions, so use `val` for local mIoU checks.
 
 ### Do I need to download Cityscapes manually?
 
-Yes. Cityscapes requires accepting the dataset terms on the official website. Download and extract `leftImg8bit` and `gtFine` into the `cityscapes` dataset root before using the preparation block in `cityscapes.yaml` to create the expected `images/` and `masks/` layout.
+Yes. Create an account on the [Cityscapes website](https://www.cityscapes-dataset.com/) and download the `leftImg8bit_trainvaltest.zip` and `gtFine_trainvaltest.zip` archives (~11 GB combined). Extract both into the `cityscapes` dataset root — Ultralytics automatically reorganizes them into the expected `images/` and `masks/` layout the first time you train.
 
 ### Why does Cityscapes use `label_mapping`?
 
 Cityscapes source masks store original label IDs that differ from the 19 train IDs used for evaluation. The `label_mapping` section converts valid labels to contiguous class IDs `0`–`18`, and assigns `255` to ignored and void labels so they are excluded from the loss and metrics during training and validation.
+
+### Is the Cityscapes dataset free for commercial use?
+
+No. Cityscapes is released under a [non-commercial license](https://www.cityscapes-dataset.com/license/) that permits academic research, teaching, and evaluation, but prohibits commercial use, licensing, or selling the dataset or derivative works. Contact the Cityscapes team directly for commercial licensing options.

--- a/docs/en/datasets/semantic/cityscapes8.md
+++ b/docs/en/datasets/semantic/cityscapes8.md
@@ -1,4 +1,5 @@
 ---
+title: Cityscapes8 Semantic Segmentation Dataset
 comments: true
 description: Explore the Ultralytics Cityscapes8 dataset, a compact set of 8 urban-scene images for testing semantic segmentation models and training pipelines.
 keywords: Cityscapes8, Ultralytics, dataset, semantic segmentation, YOLO26, semantic, training, validation, urban scenes, computer vision
@@ -11,6 +12,28 @@ keywords: Cityscapes8, Ultralytics, dataset, semantic segmentation, YOLO26, sema
 The [Ultralytics](https://www.ultralytics.com/) Cityscapes8 dataset is a compact [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation) dataset with 8 images sampled from the [Cityscapes](cityscapes.md) dataset: 4 for training and 4 for validation. It is designed for rapid testing, debugging, and experimentation with [YOLO](../../models/yolo26.md) semantic segmentation models and training pipelines. Its urban-scene content provides a useful pipeline check before scaling to the full Cityscapes dataset.
 
 Cityscapes8 uses the same 19 evaluation classes and the same `label_mapping` behavior as the full Cityscapes dataset, and is fully compatible with [YOLO26](../../models/yolo26.md) semantic segmentation workflows.
+
+!!! note
+
+    Cityscapes8 is for pipeline testing only, not benchmarking — its 8 images are too few for a meaningful mIoU comparison. Use the full [Cityscapes](cityscapes.md) validation set for representative results.
+
+## Dataset Structure
+
+Cityscapes8 mirrors the full dataset's layout, without a `test` split:
+
+```text
+cityscapes8/
+├── images/
+│   ├── train/  # 4 images
+│   └── val/    # 4 images
+└── masks/
+    ├── train/  # 4 single-channel PNG masks
+    └── val/    # 4 single-channel PNG masks
+```
+
+Masks are paired with images via the `masks_dir: masks` field, and `label_mapping` converts source Cityscapes label IDs into the 19 contiguous train IDs described in the [full Cityscapes dataset structure](cityscapes.md#dataset-structure).
+
+Explore [Cityscapes8 on Ultralytics Platform](https://platform.ultralytics.com/ultralytics/datasets/cityscapes8) to browse every image with its segmentation masks and clone it to train in the cloud.
 
 ## Dataset YAML
 
@@ -47,7 +70,9 @@ To train a YOLO26n-sem model on the Cityscapes8 dataset for 100 [epochs](https:/
         yolo semantic train data=cityscapes8.yaml model=yolo26n-sem.pt epochs=100 imgsz=1024
         ```
 
-## Citations and Acknowledgments
+## Citations, License and Acknowledgments
+
+Cityscapes8 is sampled from Cityscapes, which is released under a [custom non-commercial license](https://www.cityscapes-dataset.com/license/) — see the full [Cityscapes dataset page](cityscapes.md#citations-license-and-acknowledgments) for details.
 
 If you use the Cityscapes dataset in your research or development, please cite the following paper:
 
@@ -68,11 +93,15 @@ Special thanks to the [Cityscapes team](https://www.cityscapes-dataset.com/) for
 
 ## FAQ
 
-### What Is the Ultralytics Cityscapes8 Dataset Used For?
+### What is the Ultralytics Cityscapes8 dataset used for?
 
 The Ultralytics Cityscapes8 dataset is designed for rapid testing and debugging of [semantic segmentation](https://www.ultralytics.com/glossary/semantic-segmentation) models. With only 8 images (4 for training, 4 for validation), it is ideal for verifying [YOLO](../../models/yolo26.md) semantic segmentation pipelines, including mask loading, augmentations, validation, and export paths, before scaling to the full [Cityscapes](cityscapes.md) dataset. Explore the [Cityscapes8 YAML configuration](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/cityscapes8.yaml) for more details.
 
-### How Do I Train a YOLO26 Model Using the Cityscapes8 Dataset?
+### How does Cityscapes8 differ from the full Cityscapes dataset?
+
+Cityscapes8 samples 8 images (4 train, 4 val) from Cityscapes' 2,975-training/500-validation split, using the same 19 classes and `label_mapping`, so a pipeline that runs on Cityscapes8 runs unmodified on the full dataset — just point `data=` at `cityscapes.yaml` instead of `cityscapes8.yaml`. Unlike the full dataset, Cityscapes8 has no manual-download step and no `test` split.
+
+### How do I train a YOLO26 model using the Cityscapes8 dataset?
 
 You can train a YOLO26 semantic segmentation model on Cityscapes8 using either Python or the CLI:
 
@@ -93,11 +122,12 @@ You can train a YOLO26 semantic segmentation model on Cityscapes8 using either P
     === "CLI"
 
         ```bash
+        # Train YOLO26n-sem on Cityscapes8 using the command line
         yolo semantic train data=cityscapes8.yaml model=yolo26n-sem.pt epochs=100 imgsz=1024
         ```
 
 For additional training options, refer to the [YOLO Training documentation](../../modes/train.md).
 
-### Should I Use Cityscapes8 for Benchmarking?
+### Should I use Cityscapes8 for benchmarking?
 
 No. Cityscapes8 is too small for meaningful model comparison and is intended for training and evaluation pipeline checks. Use the full [Cityscapes](cityscapes.md) validation set when you need representative benchmark results for semantic segmentation.

--- a/docs/en/datasets/semantic/index.md
+++ b/docs/en/datasets/semantic/index.md
@@ -1,7 +1,7 @@
 ---
 comments: true
 description: Learn how to prepare semantic segmentation datasets for Ultralytics YOLO, including PNG mask labels, dataset YAML fields, ignore labels, and supported datasets.
-keywords: Ultralytics, YOLO, semantic segmentation, semantic, dataset format, pixel masks, Cityscapes, ADE20K, Pascal VOC
+keywords: Ultralytics, YOLO, semantic segmentation, semantic, dataset format, pixel masks, Cityscapes, ADE20K
 title: Semantic Segmentation Datasets
 ---
 
@@ -13,7 +13,7 @@ This guide explains the dataset format used by Ultralytics YOLO semantic segment
 
 ## Supported Dataset Formats
 
-Two label formats are supported. The dataset loader picks the path based on whether the dataset YAML defines a `masks_dir` key.
+Two label formats are supported. The dataset loader picks PNG masks when the dataset YAML defines a `masks_dir` key, or when a `masks/` folder already exists next to your images at the dataset root; otherwise it falls back to YOLO polygon labels.
 
 ### PNG mask format
 
@@ -42,7 +42,7 @@ For example, an image at `images/train/aachen_000000_000019.png` is paired with 
 
 If your dataset already has Ultralytics YOLO polygon labels (one `.txt` per image with `<class-index> <x1> <y1> <x2> <y2> ...` rows), you can train semantic segmentation directly from them — no PNG mask conversion needed. See the [instance segmentation dataset format](../segment/index.md#ultralytics-yolo-format) for the row-level layout.
 
-This path is selected automatically when the dataset YAML **omits** `masks_dir`. Behavior:
+This path is selected automatically when the dataset YAML **omits** `masks_dir` **and** no `masks/` folder exists next to your images at the dataset root — remove or rename any leftover `masks/` folder, or the loader falls back to PNG-mask mode and looks for masks there instead. Behavior:
 
 - Polygons are converted to a per-image semantic mask at load time, sorted by area so smaller objects override larger ones in overlap regions.
 - **Multi-class** (`N > 1` in `names`): an extra `background` class is appended after your declared classes for pixels not covered by any polygon. The model is built with `N + 1` output channels and the last channel is background.
@@ -55,15 +55,15 @@ Use this path when your data is already labeled as instance polygons and you wan
 
 Semantic segmentation datasets are configured with YAML files. The main fields are:
 
-| Key             | Description                                                                                       |
-| --------------- | ------------------------------------------------------------------------------------------------- |
-| `path`          | Dataset root directory.                                                                           |
-| `train`         | Training image path relative to `path`, or an absolute path.                                      |
-| `val`           | Validation image path relative to `path`, or an absolute path.                                    |
-| `test`          | Optional test image path.                                                                         |
-| `masks_dir`     | Directory name used for semantic masks. Omit this key to switch to the YOLO polygon label format. |
-| `names`         | Class ID to class name mapping.                                                                   |
-| `label_mapping` | Optional mapping from source dataset IDs to training IDs or `ignore_label`.                       |
+| Key             | Description                                                                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`          | Dataset root directory.                                                                                                                         |
+| `train`         | Training image path relative to `path`, or an absolute path.                                                                                    |
+| `val`           | Validation image path relative to `path`, or an absolute path.                                                                                  |
+| `test`          | Optional test image path.                                                                                                                       |
+| `masks_dir`     | Directory name used for semantic masks. Omit this key (with no `masks/` folder at the dataset root) to switch to the YOLO polygon label format. |
+| `names`         | Class ID to class name mapping.                                                                                                                 |
+| `label_mapping` | Optional mapping from source dataset IDs to training IDs or `ignore_label`.                                                                     |
 
 !!! example "ultralytics/cfg/datasets/cityscapes8.yaml"
 
@@ -99,7 +99,7 @@ Train a YOLO26 semantic segmentation model with Python or CLI:
 
 ## Supported Datasets
 
-Ultralytics provides semantic segmentation dataset YAML files for these datasets:
+Ultralytics provides semantic segmentation dataset YAML files for these datasets. See the [semantic segmentation task page](../../tasks/semantic.md) for the full pretrained-model benchmark table.
 
 - [Cityscapes](cityscapes.md): Urban street-scene semantic segmentation dataset with 19 train classes.
 - [Cityscapes8](cityscapes8.md): An 8-image Cityscapes subset for quick tests and CI checks.
@@ -131,7 +131,8 @@ names:
 
 1. Lay out images and `.txt` polygon files exactly as for [instance segmentation](../segment/index.md).
 2. Create a dataset YAML with `path`, `train`, `val`, and `names` — **omit** `masks_dir`.
-3. Do not add a "background" entry to `names`. For multi-class datasets the loader appends one automatically; for single-class datasets training stays at 1 class — your declared class becomes `1` in the mask and uncovered pixels become `0`.
+3. Make sure no `masks/` folder exists next to your images at the dataset root — its presence alone switches the loader to PNG-mask mode even without `masks_dir` in the YAML.
+4. Do not add a "background" entry to `names`. For multi-class datasets the loader appends one automatically; for single-class datasets training stays at 1 class — your declared class becomes `1` in the mask and uncovered pixels become `0`.
 
 ```yaml
 path: path/to/my-polygon-dataset
@@ -142,6 +143,8 @@ names:
     0: person
     1: car
 ```
+
+[Ultralytics Platform](https://platform.ultralytics.com/) provides a polygon annotation tool for the semantic task, plus SAM-assisted Smart annotation — annotate directly in the browser and export or train on the resulting polygon-labeled dataset without setting up this layout by hand.
 
 ## FAQ
 
@@ -155,7 +158,7 @@ Pixel value `255` is used as the ignore label. These pixels are skipped during l
 
 ### Do mask file names need to match image file names?
 
-Yes. Each semantic mask should have the same file stem as the corresponding image. The dataset loader replaces the `images` directory component with `masks_dir` and searches for matching mask files.
+Yes. Each semantic mask should have the same file stem as the corresponding image. The dataset loader replaces the `images` directory component with `masks_dir` and searches for matching mask files, falling back to other supported image extensions (`.jpg`, `.tiff`, etc.) if a `.png` mask isn't found — though only lossless formats are recommended, since the fallback doesn't enforce this.
 
 ### Can I use original dataset label IDs directly?
 
@@ -163,4 +166,8 @@ Yes, if they already match your `names` class IDs. If the source dataset uses no
 
 ### Can I use my instance segmentation dataset to train semantic segmentation?
 
-Yes. Instance segmentation datasets use Ultralytics YOLO polygon labels (one `.txt` per image with `<class-index> <x1> <y1> <x2> <y2> ...` rows), and the same files can be reused for semantic segmentation — just **omit** `masks_dir` from the dataset YAML. The loader converts polygons to per-image masks on the fly. For multi-class datasets (`N > 1`) an extra `background` class is appended and the model is built with `N + 1` output channels. For single-class datasets (`N == 1`) training stays at 1 class — the mask shows your declared class as `1` and uncovered pixels as `0`.
+Yes. Instance segmentation datasets use Ultralytics YOLO polygon labels (one `.txt` per image with `<class-index> <x1> <y1> <x2> <y2> ...` rows), and the same files can be reused for semantic segmentation — just **omit** `masks_dir` from the dataset YAML, and make sure no `masks/` folder exists next to your images at the dataset root (its presence alone triggers PNG-mask mode even without `masks_dir` set). The loader then converts polygons to per-image masks on the fly. For multi-class datasets (`N > 1`) an extra `background` class is appended, and the model is built with `N + 1` output channels. For single-class datasets (`N == 1`) training stays at 1 class — the mask shows your declared class as `1` and uncovered pixels as `0`.
+
+### Which datasets ship with Ultralytics for semantic segmentation?
+
+Ultralytics includes ready-to-use dataset YAML files for [Cityscapes](cityscapes.md) (19 urban-scene classes), the lightweight [Cityscapes8](cityscapes8.md) subset for pipeline testing, and [ADE20K](ade20k.md) (150 scene-parsing classes). Each page documents the exact class list, download steps, and a verified training example.


### PR DESCRIPTION
## Summary

Refactor of the semantic segmentation dataset pages under `docs/en/datasets/semantic/`, done one page (or closely related pair) per commit. Numbers are verified against each dataset YAML, real downloads and counts, and live training runs.

- **ADE20K**: notes that the public archive and `ade20k.yaml` only ship and use the training/validation splits (not the 3,352-image test split), adds a manual-download note and a pretrained-model mIoU reference, and documents the non-commercial license terms.
- **Cityscapes / Cityscapes8**: corrects the seven Cityscapes category names (`flat` was previously listed as `road`), documents that the publicly released `test`-split masks only label the ego-vehicle and image border (not real class annotations), surfaces the ~11 GB manual-download size and the non-commercial license terms, and adds a missing Dataset Structure section to Cityscapes8.
- **index** (format overview): documents that `build_yolo_dataset()` also falls back to PNG-mask mode when a `masks/` folder exists on disk, even if the YAML omits `masks_dir` — the doc previously implied omitting `masks_dir` alone was sufficient to select polygon-label mode. Removes "Pascal VOC" from keywords (no semantic segmentation YAML exists for VOC), adds a Platform annotation-tool mention and a link to the task benchmark page.

### Pages

- [x] ade20k
- [x] cityscapes
- [x] cityscapes8
- [x] index

Deleted: nothing (net-additive doc corrections — license terms, a test-split caveat, corrected category names, a download-size note, a missing structure section, and a missing PNG-mask-fallback caveat; see the Summary above for what each fixes).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 Expanded semantic segmentation dataset documentation with clearer setup guidance, licensing details, benchmark context, and improved mask-format behavior.

### 📊 Key Changes
- Updated **ADE20K** documentation with:
  - Accurate public train/validation split details and test-set annotation limitations.
  - Manual download and extraction instructions.
  - YOLO26 validation performance references and Ultralytics Platform compatibility.
  - Non-commercial licensing information and an expanded FAQ.
- Updated **Cityscapes** documentation with:
  - Precise split, annotation, and test-set evaluation details.
  - Manual download requirements, account setup, and archive sizes.
  - Guidance to use the validation split for local metrics.
  - Licensing information and YOLO26 benchmark references.
- Expanded **Cityscapes8** documentation with:
  - Dataset structure and mask details.
  - Clear guidance that the 8-image subset is for pipeline testing, not benchmarking.
  - Ultralytics Platform links and improved FAQs.
- Clarified semantic segmentation dataset loading:
  - PNG masks are selected when `masks_dir` is configured **or** a root-level `masks/` directory exists.
  - Polygon-based datasets require omitting `masks_dir` and removing conflicting `masks/` folders.
  - Documented mask extension fallback behavior and label-mapping requirements.
- Added links to the semantic segmentation benchmark page and [Ultralytics Platform](https://platform.ultralytics.com/) annotation and dataset-management tools.

### 🎯 Purpose & Impact
- ✅ Helps users download and organize ADE20K and Cityscapes correctly, reducing common path and dataset-preparation errors.
- 📈 Sets clearer expectations for benchmark results by distinguishing validation metrics from unavailable or submission-only test metrics.
- 🧪 Makes Cityscapes8 more useful for quickly verifying training, validation, augmentation, and export pipelines before using the full dataset.
- 🛠️ Prevents unexpected loader behavior when polygon datasets contain an unintended `masks/` directory.
- ⚖️ Improves awareness of ADE20K and Cityscapes non-commercial licensing restrictions before research or commercial use.
- 🚀 Provides clearer guidance for training YOLO26 semantic segmentation models and managing datasets through Ultralytics Platform.