### PR TITLE
Stop coco.yaml and coco-pose.yaml from downloading test2017.zip by default

### DIFF
--- a/docs/en/datasets/detect/coco.md
+++ b/docs/en/datasets/detect/coco.md
@@ -55,7 +55,7 @@ A YAML (Yet Another Markup Language) file is used to define the dataset configur
 
 ## Usage
 
-The full COCO2017 dataset (20.3 GB) downloads automatically the first time you start training. To train a YOLO26n model on COCO for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page. You can also run COCO training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/).
+The COCO2017 training and validation data (20.3 GB) downloads automatically the first time you start training. To train a YOLO26n model on COCO for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page. You can also run COCO training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/).
 
 !!! example "Train Example"
 

--- a/docs/en/datasets/detect/coco.md
+++ b/docs/en/datasets/detect/coco.md
@@ -55,7 +55,7 @@ A YAML (Yet Another Markup Language) file is used to define the dataset configur
 
 ## Usage
 
-The full COCO2017 dataset (20.1 GB) downloads automatically the first time you start training. To train a YOLO26n model on COCO for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page. You can also run COCO training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/).
+The full COCO2017 dataset (20.3 GB) downloads automatically the first time you start training. To train a YOLO26n model on COCO for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page. You can also run COCO training in the cloud with [Ultralytics Platform](https://platform.ultralytics.com/).
 
 !!! example "Train Example"
 

--- a/docs/en/datasets/pose/coco.md
+++ b/docs/en/datasets/pose/coco.md
@@ -20,7 +20,7 @@ The [COCO-Pose](https://cocodataset.org/#keypoints-2017) dataset adapts COCO (Co
 - COCO-Pose builds upon the [COCO Keypoints 2017](http://presentations.cocodataset.org/COCO17-Keypoints-Overview.pdf) challenge, which labels 1,710,498 individual keypoints across 156,165 annotated people.
 - Each person annotation uses 17 keypoint types — nose, eyes, ears, shoulders, elbows, wrists, hips, knees, and ankles — stored as `(x, y, visibility)` triplets.
 - Like COCO, it provides standardized evaluation metrics, including Object Keypoint Similarity (OKS) for pose estimation tasks, making it suitable for comparing model performance.
-- **Download size**: ~27 GB on first use. The `coco-pose.yaml` header lists 20.1 GB (`train2017.zip` + `val2017.zip` only), but the download script also fetches the 7 GB `test2017.zip` unconditionally, even though that archive is needed only for the optional test-dev2017 submission split.
+- **Download size**: ~20.2 GB on first use (`train2017.zip` + `val2017.zip` + labels). The 7 GB `test2017.zip` is not fetched automatically, since those images have withheld ground truth and are only needed for a [test-dev2017 submission](https://codalab.lisn.upsaclay.fr/competitions/7403).
 
 ## Dataset Structure
 

--- a/docs/en/datasets/segment/coco.md
+++ b/docs/en/datasets/segment/coco.md
@@ -19,7 +19,7 @@ The [COCO-Seg](https://cocodataset.org/#home) dataset provides [COCO](https://co
 - The dataset consists of the same 80 object categories found in the original COCO dataset.
 - Annotations provide instance segmentation masks in the YOLO polygon label format.
 - COCO-Seg provides standardized mAP and mAR metrics for evaluating instance segmentation performance, enabling effective comparison of model performance.
-- **Download size**: ~27 GB on first use. The `coco.yaml` header lists 20.1 GB (`train2017.zip` + `val2017.zip` only), but the download script also fetches the 7 GB `test2017.zip` unconditionally, even though that archive is needed only for the optional test-dev2017 submission split.
+- **Download size**: ~20.3 GB on first use (`train2017.zip` + `val2017.zip` + labels). The 7 GB `test2017.zip` is not fetched automatically, since those images have withheld ground truth and are only needed for a [test-dev2017 submission](https://cocodataset.org/#detection-eval).
 
 ## Dataset Structure
 

--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -45,6 +45,7 @@ kpt_names:
 
 # Download script/URL (optional)
 download: |
+  import os
   from pathlib import Path
 
   from ultralytics.utils import ASSETS_URL
@@ -57,8 +58,8 @@ download: |
   download(urls, dir=dir.parent)
 
   if split == "test":
-      line = next(iter((dir / "test-dev2017.txt").read_text().strip().splitlines()), "")
-      img = dir / (line[2:] if line.startswith("./") else line)
+      line = next(iter((dir / "test-dev2017.txt").read_text(encoding="utf-8").strip().splitlines()), "")
+      img = Path(line.replace("./", f"{dir}{os.sep}", 1) if line.startswith("./") else line)
       if not img.exists():
           raise FileNotFoundError(
               "coco-pose.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld "

--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -6,7 +6,7 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── coco-pose ← downloads here (20.1 GB)
+#     └── coco-pose ← downloads here (20.2 GB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: coco-pose # dataset root dir
@@ -55,10 +55,10 @@ download: |
 
   urls = [f"{ASSETS_URL}/coco2017labels-pose.zip"]
   download(urls, dir=dir.parent)
-  # Download data
+  # Download data (test2017.zip excluded: ground truth is withheld, only used for the CodaLab test-dev split;
+  # fetch it manually before running split=test on a directory that has never downloaded train/val images)
   urls = [
       "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
       "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
-      "http://images.cocodataset.org/zips/test2017.zip",  # 7G, 41k images (optional)
   ]
   download(urls, dir=dir / "images", threads=3)

--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -56,7 +56,7 @@ download: |
   urls = [f"{ASSETS_URL}/coco2017labels-pose.zip"]
   download(urls, dir=dir.parent)
 
-  if split == "test":
+  if split == "test" and not (dir / "images" / "test2017").exists():
       raise FileNotFoundError(
           "coco-pose.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and "
           "only used for the CodaLab test-dev split. Download manually: "

--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -45,7 +45,6 @@ kpt_names:
 
 # Download script/URL (optional)
 download: |
-  import os
   from pathlib import Path
 
   from ultralytics.utils import ASSETS_URL
@@ -57,19 +56,9 @@ download: |
   urls = [f"{ASSETS_URL}/coco2017labels-pose.zip"]
   download(urls, dir=dir.parent)
 
-  if split == "test":
-      line = next(iter((dir / "test-dev2017.txt").read_text(encoding="utf-8").strip().splitlines()), "")
-      img = Path(line.replace("./", f"{dir}{os.sep}", 1) if line.startswith("./") else line)
-      if not img.exists():
-          raise FileNotFoundError(
-              "coco-pose.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld "
-              "and only used for the CodaLab test-dev split. Download manually: "
-              "http://images.cocodataset.org/zips/test2017.zip"
-          )
-  else:
-      # Download data (test2017.zip excluded: ground truth is withheld, only used for the CodaLab test-dev split)
-      urls = [
-          "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
-          "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
-      ]
-      download(urls, dir=dir / "images", threads=3)
+  # Download data (test2017.zip excluded: ground truth is withheld, only used for the CodaLab test-dev split)
+  urls = [
+      "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
+      "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
+  ]
+  download(urls, dir=dir / "images", threads=3)

--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -50,13 +50,19 @@ download: |
   from ultralytics.utils import ASSETS_URL
   from ultralytics.utils.downloads import download
 
+  if split == "test":
+      raise FileNotFoundError(
+          "coco-pose.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and "
+          "only used for the CodaLab test-dev split. Download manually: "
+          "http://images.cocodataset.org/zips/test2017.zip"
+      )
+
   # Download labels
   dir = Path(yaml["path"])  # dataset root dir
 
   urls = [f"{ASSETS_URL}/coco2017labels-pose.zip"]
   download(urls, dir=dir.parent)
-  # Download data (test2017.zip excluded: ground truth is withheld, only used for the CodaLab test-dev split;
-  # fetch it manually before running split=test on a directory that has never downloaded train/val images)
+  # Download data (test2017.zip excluded: ground truth is withheld, only used for the CodaLab test-dev split)
   urls = [
       "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
       "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images

--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -56,16 +56,17 @@ download: |
   urls = [f"{ASSETS_URL}/coco2017labels-pose.zip"]
   download(urls, dir=dir.parent)
 
-  if split == "test" and not (dir / "images" / "test2017").exists():
-      raise FileNotFoundError(
-          "coco-pose.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and "
-          "only used for the CodaLab test-dev split. Download manually: "
-          "http://images.cocodataset.org/zips/test2017.zip"
-      )
-
-  # Download data (test2017.zip excluded: ground truth is withheld, only used for the CodaLab test-dev split)
-  urls = [
-      "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
-      "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
-  ]
-  download(urls, dir=dir / "images", threads=3)
+  if split == "test":
+      if not (dir / "images" / "test2017").exists():
+          raise FileNotFoundError(
+              "coco-pose.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld "
+              "and only used for the CodaLab test-dev split. Download manually: "
+              "http://images.cocodataset.org/zips/test2017.zip"
+          )
+  else:
+      # Download data (test2017.zip excluded: ground truth is withheld, only used for the CodaLab test-dev split)
+      urls = [
+          "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
+          "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
+      ]
+      download(urls, dir=dir / "images", threads=3)

--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -50,6 +50,12 @@ download: |
   from ultralytics.utils import ASSETS_URL
   from ultralytics.utils.downloads import download
 
+  # Download labels
+  dir = Path(yaml["path"])  # dataset root dir
+
+  urls = [f"{ASSETS_URL}/coco2017labels-pose.zip"]
+  download(urls, dir=dir.parent)
+
   if split == "test":
       raise FileNotFoundError(
           "coco-pose.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and "
@@ -57,11 +63,6 @@ download: |
           "http://images.cocodataset.org/zips/test2017.zip"
       )
 
-  # Download labels
-  dir = Path(yaml["path"])  # dataset root dir
-
-  urls = [f"{ASSETS_URL}/coco2017labels-pose.zip"]
-  download(urls, dir=dir.parent)
   # Download data (test2017.zip excluded: ground truth is withheld, only used for the CodaLab test-dev split)
   urls = [
       "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images

--- a/ultralytics/cfg/datasets/coco-pose.yaml
+++ b/ultralytics/cfg/datasets/coco-pose.yaml
@@ -57,7 +57,9 @@ download: |
   download(urls, dir=dir.parent)
 
   if split == "test":
-      if not (dir / "images" / "test2017").exists():
+      line = next(iter((dir / "test-dev2017.txt").read_text().strip().splitlines()), "")
+      img = dir / (line[2:] if line.startswith("./") else line)
+      if not img.exists():
           raise FileNotFoundError(
               "coco-pose.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld "
               "and only used for the CodaLab test-dev split. Download manually: "

--- a/ultralytics/cfg/datasets/coco.yaml
+++ b/ultralytics/cfg/datasets/coco.yaml
@@ -6,7 +6,7 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── coco ← downloads here (20.1 GB)
+#     └── coco ← downloads here (20.3 GB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: coco # dataset root dir
@@ -109,10 +109,10 @@ download: |
   dir = Path(yaml["path"])  # dataset root dir
   urls = [ASSETS_URL + ("/coco2017labels-segments.zip" if segments else "/coco2017labels.zip")]  # labels
   download(urls, dir=dir.parent)
-  # Download data
+  # Download data (test2017.zip excluded: ground truth is withheld, only used for the eval-server test-dev split;
+  # fetch it manually before running split=test on a directory that has never downloaded train/val images)
   urls = [
       "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
       "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
-      "http://images.cocodataset.org/zips/test2017.zip",  # 7G, 41k images (optional)
   ]
   download(urls, dir=dir / "images", threads=3)

--- a/ultralytics/cfg/datasets/coco.yaml
+++ b/ultralytics/cfg/datasets/coco.yaml
@@ -99,6 +99,7 @@ names:
 
 # Download script/URL (optional)
 download: |
+  import os
   from pathlib import Path
 
   from ultralytics.utils import ASSETS_URL
@@ -111,8 +112,8 @@ download: |
   download(urls, dir=dir.parent)
 
   if split == "test":
-      line = next(iter((dir / "test-dev2017.txt").read_text().strip().splitlines()), "")
-      img = dir / (line[2:] if line.startswith("./") else line)
+      line = next(iter((dir / "test-dev2017.txt").read_text(encoding="utf-8").strip().splitlines()), "")
+      img = Path(line.replace("./", f"{dir}{os.sep}", 1) if line.startswith("./") else line)
       if not img.exists():
           raise FileNotFoundError(
               "coco.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and "

--- a/ultralytics/cfg/datasets/coco.yaml
+++ b/ultralytics/cfg/datasets/coco.yaml
@@ -111,7 +111,9 @@ download: |
   download(urls, dir=dir.parent)
 
   if split == "test":
-      if not (dir / "images" / "test2017").exists():
+      line = next(iter((dir / "test-dev2017.txt").read_text().strip().splitlines()), "")
+      img = dir / (line[2:] if line.startswith("./") else line)
+      if not img.exists():
           raise FileNotFoundError(
               "coco.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and "
               "only used for the eval-server test-dev split. Download manually: "

--- a/ultralytics/cfg/datasets/coco.yaml
+++ b/ultralytics/cfg/datasets/coco.yaml
@@ -110,7 +110,7 @@ download: |
   urls = [ASSETS_URL + ("/coco2017labels-segments.zip" if segments else "/coco2017labels.zip")]  # labels
   download(urls, dir=dir.parent)
 
-  if split == "test":
+  if split == "test" and not (dir / "images" / "test2017").exists():
       raise FileNotFoundError(
           "coco.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and only "
           "used for the eval-server test-dev split. Download manually: "

--- a/ultralytics/cfg/datasets/coco.yaml
+++ b/ultralytics/cfg/datasets/coco.yaml
@@ -110,16 +110,17 @@ download: |
   urls = [ASSETS_URL + ("/coco2017labels-segments.zip" if segments else "/coco2017labels.zip")]  # labels
   download(urls, dir=dir.parent)
 
-  if split == "test" and not (dir / "images" / "test2017").exists():
-      raise FileNotFoundError(
-          "coco.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and only "
-          "used for the eval-server test-dev split. Download manually: "
-          "http://images.cocodataset.org/zips/test2017.zip"
-      )
-
-  # Download data (test2017.zip excluded: ground truth is withheld, only used for the eval-server test-dev split)
-  urls = [
-      "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
-      "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
-  ]
-  download(urls, dir=dir / "images", threads=3)
+  if split == "test":
+      if not (dir / "images" / "test2017").exists():
+          raise FileNotFoundError(
+              "coco.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and "
+              "only used for the eval-server test-dev split. Download manually: "
+              "http://images.cocodataset.org/zips/test2017.zip"
+          )
+  else:
+      # Download data (test2017.zip excluded: ground truth is withheld, only used for the eval-server test-dev split)
+      urls = [
+          "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
+          "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
+      ]
+      download(urls, dir=dir / "images", threads=3)

--- a/ultralytics/cfg/datasets/coco.yaml
+++ b/ultralytics/cfg/datasets/coco.yaml
@@ -99,7 +99,6 @@ names:
 
 # Download script/URL (optional)
 download: |
-  import os
   from pathlib import Path
 
   from ultralytics.utils import ASSETS_URL
@@ -111,19 +110,9 @@ download: |
   urls = [ASSETS_URL + ("/coco2017labels-segments.zip" if segments else "/coco2017labels.zip")]  # labels
   download(urls, dir=dir.parent)
 
-  if split == "test":
-      line = next(iter((dir / "test-dev2017.txt").read_text(encoding="utf-8").strip().splitlines()), "")
-      img = Path(line.replace("./", f"{dir}{os.sep}", 1) if line.startswith("./") else line)
-      if not img.exists():
-          raise FileNotFoundError(
-              "coco.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and "
-              "only used for the eval-server test-dev split. Download manually: "
-              "http://images.cocodataset.org/zips/test2017.zip"
-          )
-  else:
-      # Download data (test2017.zip excluded: ground truth is withheld, only used for the eval-server test-dev split)
-      urls = [
-          "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
-          "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
-      ]
-      download(urls, dir=dir / "images", threads=3)
+  # Download data (test2017.zip excluded: ground truth is withheld, only used for the eval-server test-dev split)
+  urls = [
+      "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
+      "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
+  ]
+  download(urls, dir=dir / "images", threads=3)

--- a/ultralytics/cfg/datasets/coco.yaml
+++ b/ultralytics/cfg/datasets/coco.yaml
@@ -104,6 +104,12 @@ download: |
   from ultralytics.utils import ASSETS_URL
   from ultralytics.utils.downloads import download
 
+  # Download labels
+  segments = True  # segment or box labels
+  dir = Path(yaml["path"])  # dataset root dir
+  urls = [ASSETS_URL + ("/coco2017labels-segments.zip" if segments else "/coco2017labels.zip")]  # labels
+  download(urls, dir=dir.parent)
+
   if split == "test":
       raise FileNotFoundError(
           "coco.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and only "
@@ -111,11 +117,6 @@ download: |
           "http://images.cocodataset.org/zips/test2017.zip"
       )
 
-  # Download labels
-  segments = True  # segment or box labels
-  dir = Path(yaml["path"])  # dataset root dir
-  urls = [ASSETS_URL + ("/coco2017labels-segments.zip" if segments else "/coco2017labels.zip")]  # labels
-  download(urls, dir=dir.parent)
   # Download data (test2017.zip excluded: ground truth is withheld, only used for the eval-server test-dev split)
   urls = [
       "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images

--- a/ultralytics/cfg/datasets/coco.yaml
+++ b/ultralytics/cfg/datasets/coco.yaml
@@ -104,13 +104,19 @@ download: |
   from ultralytics.utils import ASSETS_URL
   from ultralytics.utils.downloads import download
 
+  if split == "test":
+      raise FileNotFoundError(
+          "coco.yaml 'test:' images are not downloaded automatically: test2017 ground truth is withheld and only "
+          "used for the eval-server test-dev split. Download manually: "
+          "http://images.cocodataset.org/zips/test2017.zip"
+      )
+
   # Download labels
   segments = True  # segment or box labels
   dir = Path(yaml["path"])  # dataset root dir
   urls = [ASSETS_URL + ("/coco2017labels-segments.zip" if segments else "/coco2017labels.zip")]  # labels
   download(urls, dir=dir.parent)
-  # Download data (test2017.zip excluded: ground truth is withheld, only used for the eval-server test-dev split;
-  # fetch it manually before running split=test on a directory that has never downloaded train/val images)
+  # Download data (test2017.zip excluded: ground truth is withheld, only used for the eval-server test-dev split)
   urls = [
       "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
       "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -552,7 +552,7 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
                 LOGGER.info(f"Running {s} ...")
                 subprocess.run(s.split(), check=True)
             else:  # python script
-                exec(s, {"yaml": data})
+                exec(s, {"yaml": data, "split": split or "val"})
             dt = f"({round(time.time() - t, 1)}s)"
             s = f"success ✅ {dt}, saved to {colorstr('bold', DATASETS_DIR)}" if r in {0, None} else f"failure {dt} ❌"
             LOGGER.info(f"Dataset download {s}\n")

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -535,20 +535,10 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
     val, s = (data.get(x) for x in (split or "val", "download"))
     if val:
         val = [Path(x).resolve() for x in (val if isinstance(val, list) else [val])]  # val path
-        missing = next((x for x in val if not x.exists()), None)
-        if missing is None and split:
-            # an existing manifest file is not proof the images it lists were ever downloaded
-            for x in val:
-                if x.suffix == ".txt":
-                    line = next(iter(x.read_text(encoding="utf-8").strip().splitlines()), "")
-                    img = Path(line.replace("./", f"{x.parent}{os.sep}", 1) if line.startswith("./") else line)
-                    if line and not img.exists():
-                        missing = img
-                        break
-        if missing is not None:
+        if not all(x.exists() for x in val):
             name = clean_url(dataset)  # dataset name with URL auth stripped
             LOGGER.info("")
-            m = f"Dataset '{name}' images not found, missing path '{missing}'"
+            m = f"Dataset '{name}' images not found, missing path '{next(x for x in val if not x.exists())}'"
             if s and autodownload:
                 LOGGER.warning(m)
             else:
@@ -562,7 +552,7 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
                 LOGGER.info(f"Running {s} ...")
                 subprocess.run(s.split(), check=True)
             else:  # python script
-                exec(s, {"yaml": data, "split": split or "val"})
+                exec(s, {"yaml": data})
             dt = f"({round(time.time() - t, 1)}s)"
             s = f"success ✅ {dt}, saved to {colorstr('bold', DATASETS_DIR)}" if r in {0, None} else f"failure {dt} ❌"
             LOGGER.info(f"Dataset download {s}\n")

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -535,10 +535,20 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
     val, s = (data.get(x) for x in (split or "val", "download"))
     if val:
         val = [Path(x).resolve() for x in (val if isinstance(val, list) else [val])]  # val path
-        if not all(x.exists() for x in val):
+        missing = next((x for x in val if not x.exists()), None)
+        if missing is None and split:
+            # an existing manifest file is not proof the images it lists were ever downloaded
+            for x in val:
+                if x.suffix == ".txt":
+                    line = next(iter(x.read_text().strip().splitlines()), "")
+                    img = x.parent / (line[2:] if line.startswith("./") else line)
+                    if line and not img.exists():
+                        missing = img
+                        break
+        if missing is not None:
             name = clean_url(dataset)  # dataset name with URL auth stripped
             LOGGER.info("")
-            m = f"Dataset '{name}' images not found, missing path '{next(x for x in val if not x.exists())}'"
+            m = f"Dataset '{name}' images not found, missing path '{missing}'"
             if s and autodownload:
                 LOGGER.warning(m)
             else:

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -540,8 +540,8 @@ def check_det_dataset(dataset: str, autodownload: bool = True, split: str = "") 
             # an existing manifest file is not proof the images it lists were ever downloaded
             for x in val:
                 if x.suffix == ".txt":
-                    line = next(iter(x.read_text().strip().splitlines()), "")
-                    img = x.parent / (line[2:] if line.startswith("./") else line)
+                    line = next(iter(x.read_text(encoding="utf-8").strip().splitlines()), "")
+                    img = Path(line.replace("./", f"{x.parent}{os.sep}", 1) if line.startswith("./") else line)
                     if line and not img.exists():
                         missing = img
                         break


### PR DESCRIPTION
## Summary

Stops `coco.yaml` and `coco-pose.yaml` from downloading the optional 7 GB `test2017.zip` archive by default. The download lists now own the behavior directly: they fetch only training, validation, and label data, while the docs and YAML headers report the resulting 20.3 GB and 20.2 GB totals.

Deleted: the unconditional `test2017.zip` URLs, shared manifest probing, split plumbing, and duplicated YAML guards.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

COCO dataset downloads are now smaller and more accurate by excluding the optional `test2017.zip` archive. 📦

### 📊 Key Changes

- Removed automatic downloading of the 7 GB `test2017.zip` archive from:
  - COCO detection and segmentation datasets.
  - COCO pose datasets.
- Updated documented download sizes:
  - Detection: approximately 20.3 GB.
  - Segmentation: approximately 20.3 GB.
  - Pose: approximately 20.2 GB.
- Clarified that `test2017.zip` is only required for optional `test-dev2017` submissions, where ground-truth labels are withheld.
- Updated dataset configuration comments and documentation to reflect the new download behavior.

### 🎯 Purpose & Impact

- 🚀 Reduces initial COCO download requirements by about 7 GB, saving time, bandwidth, and storage.
- ✅ Aligns documentation with the actual training and validation data automatically used by Ultralytics.
- 🧪 Standard training, validation, detection, segmentation, and pose workflows are unaffected.
- 📤 Users submitting results to the COCO `test-dev2017` evaluation server must download `test2017.zip` separately when needed.