### PR TITLE
Reject zero dataset fractions

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -270,7 +270,7 @@ def sample_mutation(rng, uni, chaos=False):
         key = rng.choice(uni[f"{family}_keys"])
         pool = PROBES[family]
     value = rng.choice(pool["valid"] + pool["invalid"] + (CHAOS_PROBES if chaos else []))
-    return key, value, value in pool["valid"]
+    return key, value, value in pool["valid"] and not (key == "fraction" and value == "0.0")
 
 
 def run_trial(trial, timeout=None):

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -442,7 +442,7 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                             f"Valid '{k}' types are int (i.e. '{k}=0') or float (i.e. '{k}=0.5')"
                         )
                     cfg[k] = v = float(v)
-                if not (0.0 <= v <= 1.0):
+                if not (0.0 <= v <= 1.0) or (k == "fraction" and v == 0.0):
                     raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
             elif k in CFG_INT_KEYS:
                 if not isinstance(v, int):

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -208,7 +208,7 @@ CFG_FLOAT_KEYS = frozenset(
     }
 )
 CFG_FRACTION_KEYS = frozenset(
-    {  # fractional float arguments with 0.0<=values<=1.0
+    {  # fractional floats use [0.0, 1.0], except dataset fraction uses (0.0, 1.0]
         "dropout",
         "lr0",
         "lrf",
@@ -443,7 +443,7 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                         )
                     cfg[k] = v = float(v)
                 if not (0.0 <= v <= 1.0) or (k == "fraction" and v == 0.0):
-                    raise ValueError(f"'{k}={v}' is invalid. Use >0.0 for fraction; [0.0, 1.0] otherwise.")
+                    raise ValueError(f"'{k}={v}' is invalid. Use (0.0, 1.0] for fraction; [0.0, 1.0] otherwise.")
             elif k in CFG_INT_KEYS:
                 if not isinstance(v, int):
                     if hard:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -443,9 +443,7 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                         )
                     cfg[k] = v = float(v)
                 if not (0.0 <= v <= 1.0) or (k == "fraction" and v == 0.0):
-                    raise ValueError(
-                        f"'{k}={v}' is invalid. Use [0.0, 1.0]; dataset fraction must be greater than 0.0."
-                    )
+                    raise ValueError(f"'{k}={v}' is invalid. Use >0.0 for fraction; [0.0, 1.0] otherwise.")
             elif k in CFG_INT_KEYS:
                 if not isinstance(v, int):
                     if hard:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -443,8 +443,9 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                         )
                     cfg[k] = v = float(v)
                 if not (0.0 <= v <= 1.0) or (k == "fraction" and v == 0.0):
-                    bounds = "(0.0, 1.0]" if k == "fraction" else "[0.0, 1.0]"
-                    raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are in {bounds}.")
+                    raise ValueError(
+                        f"'{k}={v}' is invalid. Use [0.0, 1.0]; dataset fraction must be greater than 0.0."
+                    )
             elif k in CFG_INT_KEYS:
                 if not isinstance(v, int):
                     if hard:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -401,7 +401,7 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
     Notes:
         - The function modifies the input dictionary in-place.
         - None values are ignored as they may be from optional arguments.
-        - Fraction keys are checked to be within the range [0.0, 1.0].
+        - Fraction keys use [0.0, 1.0], except dataset fraction, which uses (0.0, 1.0].
     """
     typed_keys = CFG_FLOAT_KEYS | CFG_FRACTION_KEYS | CFG_INT_KEYS | CFG_BOOL_KEYS | {"scale", "compile"}
     for k, v in cfg.items():
@@ -443,7 +443,8 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                         )
                     cfg[k] = v = float(v)
                 if not (0.0 <= v <= 1.0) or (k == "fraction" and v == 0.0):
-                    raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are between 0.0 and 1.0.")
+                    bounds = "(0.0, 1.0]" if k == "fraction" else "[0.0, 1.0]"
+                    raise ValueError(f"'{k}={v}' is an invalid value. Valid '{k}' values are in {bounds}.")
             elif k in CFG_INT_KEYS:
                 if not isinstance(v, int):
                     if hard:

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -34,7 +34,7 @@ cos_lr: False # (bool) cosine learning rate scheduler
 close_mosaic: 10 # (int) disable mosaic augmentation for final N epochs (0 to keep enabled)
 resume: False # (bool) resume training from last checkpoint in the run dir
 amp: True # (bool) Automatic Mixed Precision (AMP) training; True runs AMP capability check
-fraction: 1.0 # (float) fraction of training dataset to use (1.0 = all)
+fraction: 1.0 # (float) fraction of training dataset to use (>0.0, 1.0 = all)
 profile: False # (bool) profile ONNX/TensorRT speeds during training for loggers
 freeze: # (int | list, optional) freeze first N layers (int) or specific layer indices (list)
 multi_scale: 0.0 # (float) multi-scale range as a fraction of imgsz; sizes are rounded to stride multiples


### PR DESCRIPTION
## Summary

Reject `fraction=0` at configuration validation before dataset construction can receive an empty image list. Preserve zero as a valid value for the other fractional arguments and classify the dataset-specific zero probe as invalid in the fuzz workflow.

Fixes #25138.

## Validation

- `ruff format ultralytics/cfg/__init__.py .github/scripts/fuzz.py`
- `ruff check ultralytics/cfg/__init__.py .github/scripts/fuzz.py`
- direct config probes for rejected `fraction=0`, accepted `fraction=0.1`, and accepted zero-valued `dropout`/`scale`
- direct fuzz probe confirming `fraction=0.0` is classified as invalid
- `git diff --check`

Deleted: zero-valued dataset fractions from the accepted config and fuzz-valid input sets.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚦 Enforces that the dataset `fraction` parameter must be greater than zero while preserving inclusive ranges for other fractional settings.

### 📊 Key Changes

- Updated configuration validation so `fraction` accepts values in `(0.0, 1.0]`, while other fractional parameters continue to accept `[0.0, 1.0]`.
- Added clearer error messages explaining the valid range for `fraction` and other fractional options.
- Updated the default configuration documentation to clarify that `fraction=0.0` is invalid.
- Adjusted fuzz testing so `fraction=0.0` is treated as an invalid input.

### 🎯 Purpose & Impact

- 🛡️ Prevents invalid dataset configurations that would attempt to train on zero data.
- ✅ Maintains existing behavior for parameters such as learning rates, dropout, and multi-scale settings.
- 🧪 Improves automated validation and fuzz testing coverage for this edge case.
- 📚 Provides clearer guidance to users when an invalid dataset fraction is supplied.