### PR TITLE
Stop lvis.yaml from downloading the unused test2017.zip archive

### DIFF
--- a/docs/en/datasets/detect/lvis.md
+++ b/docs/en/datasets/detect/lvis.md
@@ -62,7 +62,7 @@ The `lvis.yaml` file defines the dataset configuration — the dataset paths, cl
 
 ## Usage
 
-To train a YOLO26n model on the LVIS dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. The dataset (20.1 GB) downloads automatically on first use. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page.
+To train a YOLO26n model on the LVIS dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) with an image size of 640, you can use the following code snippets. The dataset (20.7 GB) downloads automatically on first use. For a comprehensive list of available arguments, refer to the model [Training](../../modes/train.md) page.
 
 !!! example "Train Example"
 

--- a/ultralytics/cfg/datasets/lvis.yaml
+++ b/ultralytics/cfg/datasets/lvis.yaml
@@ -6,7 +6,7 @@
 # parent
 # ├── ultralytics
 # └── datasets
-#     └── lvis ← downloads here (20.1 GB)
+#     └── lvis ← downloads here (20.7 GB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: lvis # dataset root dir
@@ -1231,10 +1231,9 @@ download: |
   urls = [f"{ASSETS_URL}/lvis-labels-segments.zip"]
   download(urls, dir=dir.parent)
 
-  # Download data
+  # Download data (test2017.zip excluded: LVIS has no 'test:' split and never reads it)
   urls = [
       "http://images.cocodataset.org/zips/train2017.zip",  # 19G, 118k images
       "http://images.cocodataset.org/zips/val2017.zip",  # 1G, 5k images
-      "http://images.cocodataset.org/zips/test2017.zip",  # 7G, 41k images (optional)
   ]
   download(urls, dir=dir / "images", threads=3)


### PR DESCRIPTION
## Summary

Stops `lvis.yaml` from downloading the unused 7 GB `test2017.zip` archive. LVIS declares no `test:` split, so only the train, validation, and label archives are needed. The YAML header and dataset guide now report their verified 20.7 GB total.

Deleted: the unused `test2017.zip` URL from `lvis.yaml`'s default download list.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🗂️ Updates the LVIS dataset configuration to avoid downloading unused COCO test images and accurately reflect the reduced download requirements.

### 📊 Key Changes

- Removed the optional `test2017.zip` download from the LVIS dataset setup.
- Clarified that LVIS does not define or use a `test` split.
- Updated the documented dataset size from **20.1 GB to 20.7 GB**.
- Updated directory comments to match the revised download contents.

### 🎯 Purpose & Impact

- ⚡ Reduces unnecessary downloads by excluding approximately 7 GB of unused test images.
- 💾 Saves storage space and download time for users preparing the LVIS dataset.
- ✅ Keeps documentation and dataset configuration consistent with the files actually required for training and validation.
- 🔄 No changes to model behavior or training workflows.