### PR TITLE
Add additional notes to dog-pose, hand keypoints, and tiger-pose entries in pose dataset index

### DIFF
--- a/docs/en/datasets/pose/index.md
+++ b/docs/en/datasets/pose/index.md
@@ -129,6 +129,7 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 - **Number of Classes**: 1 (dog).
 - **Keypoints**: 24 keypoints, each with a visibility dimension, tailored to dog poses such as limbs, joints, and head positions.
 - **Usage**: Ideal for training models to estimate dog poses in various scenarios, from research to [real-world applications](https://www.ultralytics.com/blog/custom-training-ultralytics-yolo11-for-dog-pose-estimation).
+- **Additional Notes**: Images and annotations are sourced from the [Stanford Dogs Dataset](http://vision.stanford.edu/aditya86/ImageNetDogs/).
 - [Read more about Dog-Pose](dog-pose.md)
 
 ### Hand Keypoints
@@ -138,6 +139,7 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 - **Number of Classes**: 1 (hand).
 - **Keypoints**: 21 keypoints.
 - **Usage**: Great for human hand pose estimation and [gesture recognition](https://www.ultralytics.com/blog/enhancing-hand-keypoints-estimation-with-ultralytics-yolo11).
+- **Additional Notes**: Keypoint annotations are generated using [Google MediaPipe](https://developers.google.com/mediapipe/solutions/vision/hand_landmarker) for consistent labeling.
 - [Read more about Hand Keypoints](hand-keypoints.md)
 
 ### Tiger-Pose
@@ -147,6 +149,7 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 - **Number of Classes**: 1 (tiger).
 - **Keypoints**: 12 keypoints.
 - **Usage**: Great for animal pose or any other pose that is not human-based.
+- **Additional Notes**: Released under the [AGPL-3.0 License](https://github.com/ultralytics/ultralytics/blob/main/LICENSE).
 - [Read more about Tiger-Pose](tiger-pose.md)
 
 ### Adding your own dataset

--- a/docs/en/datasets/pose/index.md
+++ b/docs/en/datasets/pose/index.md
@@ -129,7 +129,7 @@ This section outlines the datasets that are compatible with Ultralytics YOLO for
 - **Number of Classes**: 1 (dog).
 - **Keypoints**: 24 keypoints, each with a visibility dimension, tailored to dog poses such as limbs, joints, and head positions.
 - **Usage**: Ideal for training models to estimate dog poses in various scenarios, from research to [real-world applications](https://www.ultralytics.com/blog/custom-training-ultralytics-yolo11-for-dog-pose-estimation).
-- **Additional Notes**: Images and annotations are sourced from the [Stanford Dogs Dataset](http://vision.stanford.edu/aditya86/ImageNetDogs/).
+- **Additional Notes**: Source images are drawn from the [Stanford Dogs Dataset](http://vision.stanford.edu/aditya86/ImageNetDogs/).
 - [Read more about Dog-Pose](dog-pose.md)
 
 ### Hand Keypoints


### PR DESCRIPTION
## Summary

Adds an Additional Notes bullet to the Dog-Pose, Hand Keypoints, and Tiger-Pose entries in `docs/en/datasets/pose/index.md`, matching the field already present for COCO-Pose and COCO8-Pose. The notes reuse facts documented on the corresponding dataset pages: Stanford Dogs image provenance, MediaPipe annotation generation, and the Tiger-Pose license.

Deleted: nothing — these missing index-summary notes reuse existing dataset-page facts, so there was no obsolete index text to delete or relocate.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Clarifies the sources, annotation methods, and licensing for Ultralytics pose estimation datasets. 📚

### 📊 Key Changes

- Added the Stanford Dogs Dataset as the source for Dog-Pose images.
- Documented that Hand Keypoints annotations are generated with Google MediaPipe.
- Added the AGPL-3.0 license information for the Tiger-Pose dataset.

### 🎯 Purpose & Impact

- Improves dataset transparency by helping users understand image origins and annotation workflows.
- Makes licensing details easier to find before using Tiger-Pose in projects.
- Provides clearer documentation for researchers and developers selecting pose datasets. ✅