### PR TITLE
Fix `PoseMetrics.curves` returning duplicated box labels

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -42,14 +42,6 @@ from ultralytics.utils import (
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download, safe_download
-from ultralytics.utils.metrics import (
-    ClassifyMetrics,
-    DetMetrics,
-    OBBMetrics,
-    PoseMetrics,
-    SegmentMetrics,
-    SemanticMetrics,
-)
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
 
 
@@ -527,38 +519,12 @@ def test_val_save_txt_pose(tmp_path):
                 assert abs(cx - x) < w / 2 + 0.05 and abs(cy - y) < h / 2 + 0.05, "keypoints misaligned with box"
 
 
-@pytest.mark.parametrize(
-    "metrics_class", [DetMetrics, SegmentMetrics, PoseMetrics, OBBMetrics, ClassifyMetrics, SemanticMetrics]
-)
-def test_metrics_curves_labels_match_results(metrics_class):
-    """Check that curve labels and curve data series stay 1:1 for every metrics class.
+def test_pose_metrics_curves():
+    """Test that pose curve labels contain four unique box and pose series."""
+    from ultralytics.utils.metrics import PoseMetrics
 
-    utils/callbacks/wb.py::on_train_end logs W&B panels via zip(curves, curves_results), so each label is the panel id
-    for the data series it is paired with. A length mismatch silently drops or mislabels curves (PoseMetrics returned 12
-    labels for 8 series, so pose curve data was logged under box ids and the (P) panels were never created) and a
-    duplicate label collides two series into one panel. Run the real process() pipeline so curves_results is actually
-    populated.
-    """
-    names = {0: "a", 1: "b"}
-    m = metrics_class() if metrics_class is ClassifyMetrics else metrics_class(names=names)
-    if isinstance(m, DetMetrics):  # populate px/p_curve/... through the real ap_per_class + Metric.update
-        rng = np.random.default_rng(0)
-        n = 12
-        stat = {
-            "conf": rng.random(n),
-            "pred_cls": rng.integers(0, len(names), n),
-            "target_cls": rng.integers(0, len(names), n),
-            "target_img": np.zeros(n),
-            "im_name": "im0",
-        }
-        for k in m.stats:  # tp, plus tp_m (segment) or tp_p (pose)
-            if k.startswith("tp"):
-                stat[k] = rng.random((n, 10)) > 0.5
-        m.update_stats(stat)
-        m.process()
-    labels, results = m.curves, m.curves_results
-    assert len(labels) == len(results), f"{metrics_class.__name__}: {len(labels)} labels but {len(results)} series"
-    assert len(labels) == len(set(labels)), f"{metrics_class.__name__}: duplicate curve ids {labels}"
+    curves = PoseMetrics().curves
+    assert len(curves) == len(set(curves)) == 8
 
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -42,6 +42,14 @@ from ultralytics.utils import (
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download, safe_download
+from ultralytics.utils.metrics import (
+    ClassifyMetrics,
+    DetMetrics,
+    OBBMetrics,
+    PoseMetrics,
+    SegmentMetrics,
+    SemanticMetrics,
+)
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
 
 
@@ -517,6 +525,40 @@ def test_val_save_txt_pose(tmp_path):
             if len(visible):
                 cx, cy = visible.mean(0)
                 assert abs(cx - x) < w / 2 + 0.05 and abs(cy - y) < h / 2 + 0.05, "keypoints misaligned with box"
+
+
+@pytest.mark.parametrize(
+    "metrics_class", [DetMetrics, SegmentMetrics, PoseMetrics, OBBMetrics, ClassifyMetrics, SemanticMetrics]
+)
+def test_metrics_curves_labels_match_results(metrics_class):
+    """Check that curve labels and curve data series stay 1:1 for every metrics class.
+
+    utils/callbacks/wb.py::on_train_end logs W&B panels via zip(curves, curves_results), so each
+    label is the panel id for the data series it is paired with. A length mismatch silently drops or
+    mislabels curves (PoseMetrics returned 12 labels for 8 series, so pose curve data was logged
+    under box ids and the (P) panels were never created) and a duplicate label collides two series
+    into one panel. Run the real process() pipeline so curves_results is actually populated.
+    """
+    names = {0: "a", 1: "b"}
+    m = metrics_class() if metrics_class is ClassifyMetrics else metrics_class(names=names)
+    if isinstance(m, DetMetrics):  # populate px/p_curve/... through the real ap_per_class + Metric.update
+        rng = np.random.default_rng(0)
+        n = 12
+        stat = {
+            "conf": rng.random(n),
+            "pred_cls": rng.integers(0, len(names), n),
+            "target_cls": rng.integers(0, len(names), n),
+            "target_img": np.zeros(n),
+            "im_name": "im0",
+        }
+        for k in m.stats:  # tp, plus tp_m (segment) or tp_p (pose)
+            if k.startswith("tp"):
+                stat[k] = rng.random((n, 10)) > 0.5
+        m.update_stats(stat)
+        m.process()
+    labels, results = m.curves, m.curves_results
+    assert len(labels) == len(results), f"{metrics_class.__name__}: {len(labels)} labels but {len(results)} series"
+    assert len(labels) == len(set(labels)), f"{metrics_class.__name__}: duplicate curve ids {labels}"
 
 
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -533,11 +533,11 @@ def test_val_save_txt_pose(tmp_path):
 def test_metrics_curves_labels_match_results(metrics_class):
     """Check that curve labels and curve data series stay 1:1 for every metrics class.
 
-    utils/callbacks/wb.py::on_train_end logs W&B panels via zip(curves, curves_results), so each
-    label is the panel id for the data series it is paired with. A length mismatch silently drops or
-    mislabels curves (PoseMetrics returned 12 labels for 8 series, so pose curve data was logged
-    under box ids and the (P) panels were never created) and a duplicate label collides two series
-    into one panel. Run the real process() pipeline so curves_results is actually populated.
+    utils/callbacks/wb.py::on_train_end logs W&B panels via zip(curves, curves_results), so each label is the panel id
+    for the data series it is paired with. A length mismatch silently drops or mislabels curves (PoseMetrics returned 12
+    labels for 8 series, so pose curve data was logged under box ids and the (P) panels were never created) and a
+    duplicate label collides two series into one panel. Run the real process() pipeline so curves_results is actually
+    populated.
     """
     names = {0: "a", 1: "b"}
     m = metrics_class() if metrics_class is ClassifyMetrics else metrics_class(names=names)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -1528,10 +1528,6 @@ class PoseMetrics(DetMetrics):
         """Return a list of curves for accessing specific metrics curves."""
         return [
             *DetMetrics.curves.fget(self),
-            "Precision-Recall(B)",
-            "F1-Confidence(B)",
-            "Precision-Confidence(B)",
-            "Recall-Confidence(B)",
             "Precision-Recall(P)",
             "F1-Confidence(P)",
             "Precision-Confidence(P)",


### PR DESCRIPTION
Fixes #25147

## Problem

PoseMetrics.curves returned the four inherited box labels twice, producing 12 labels for 8 result series. W&B pairs labels and series positionally, so pose panels were mislabeled or lost.

## Change

Remove the duplicated box labels. PoseMetrics now returns the four inherited box labels followed by four pose labels, matching its eight result series and the existing SegmentMetrics pattern.

Deleted: the four duplicated box curve labels in PoseMetrics.curves.

The production fix is pure deletion. The only added code is a direct eight-line regression test asserting eight unique pose/box labels.

## Validation

- Focused pose metrics regression passes.
- Ruff format and lint pass.
- Full GitHub CI passed on the functional fix and is rerunning on the reduced test diff.