### PR TITLE
Normalize NumPy channel count to the model in `LoadPilAndNumpy`

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -349,13 +349,13 @@ def test_predict_grayscale_ndarray():
 def test_predict_ndarray_channel_mismatch(tmp_path, model_name, mode, atol):
     """Test that an ndarray whose channel count differs from the model matches the same image read from a path.
 
-    A NumPy image with a channel count that does not match the model (grayscale/RGBA into a color model, or
-    color/RGBA into a grayscale model) used to crash in conv2d. It must now normalize to the model channels and
-    return the same detections as the identical image read from disk, which OpenCV normalizes at decode time. The
-    1-channel cases allow up to 1px since decode-time and cvtColor grayscale differ by at most one gray level.
+    A NumPy image with a channel count that does not match the model (grayscale/RGBA into a color model, or color/RGBA
+    into a grayscale model) used to crash in conv2d. It must now normalize to the model channels and return the same
+    detections as the identical image read from disk, which OpenCV normalizes at decode time. The 1-channel cases allow
+    up to 1px since decode-time and cvtColor grayscale differ by at most one gray level.
 
-    Channel order is out of scope (ndarrays are BGR by pre-existing convention), so BGRA (not the RGB-order RGBA
-    from the issue MRE) is used to isolate the channel-count fix from the color-order assumption.
+    Channel order is out of scope (ndarrays are BGR by pre-existing convention), so BGRA (not the RGB-order RGBA from
+    the issue MRE) is used to isolate the channel-count fix from the color-order assumption.
     """
     bgr = cv2.imread(str(SOURCE))  # (H, W, 3) BGR, OpenCV order (ndarrays are treated as BGR downstream)
     im = {

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -337,6 +337,51 @@ def test_predict_grayscale_ndarray():
     assert len(model(source=gray.astype("float64"), imgsz=32, verbose=False)) == 1  # non-OpenCV dtype also works
 
 
+@pytest.mark.parametrize(
+    "model_name, mode, atol",
+    [
+        ("yolo11n.pt", "gray3d", 0.01),  # 3-channel model, (H, W, 1) grayscale ndarray
+        ("yolo11n.pt", "rgba", 0.01),  # 3-channel model, (H, W, 4) BGRA ndarray
+        ("yolo11n-grayscale.pt", "bgr", 1.0),  # 1-channel model, (H, W, 3) BGR ndarray
+        ("yolo11n-grayscale.pt", "rgba", 1.0),  # 1-channel model, (H, W, 4) BGRA ndarray
+    ],
+)
+def test_predict_ndarray_channel_mismatch(tmp_path, model_name, mode, atol):
+    """Test that an ndarray whose channel count differs from the model matches the same image read from a path.
+
+    A NumPy image with a channel count that does not match the model (grayscale/RGBA into a color model, or
+    color/RGBA into a grayscale model) used to crash in conv2d. It must now normalize to the model channels and
+    return the same detections as the identical image read from disk, which OpenCV normalizes at decode time. The
+    1-channel cases allow up to 1px since decode-time and cvtColor grayscale differ by at most one gray level.
+
+    Channel order is out of scope (ndarrays are BGR by pre-existing convention), so BGRA (not the RGB-order RGBA
+    from the issue MRE) is used to isolate the channel-count fix from the color-order assumption.
+    """
+    bgr = cv2.imread(str(SOURCE))  # (H, W, 3) BGR, OpenCV order (ndarrays are treated as BGR downstream)
+    im = {
+        "gray3d": cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)[..., None],  # (H, W, 1)
+        "bgr": bgr,  # (H, W, 3)
+        "rgba": cv2.cvtColor(bgr, cv2.COLOR_BGR2BGRA),  # (H, W, 4)
+    }[mode]
+    path = tmp_path / "img.png"
+    assert cv2.imwrite(str(path), im)  # lossless PNG keeps the channel count on disk
+
+    model = YOLO(WEIGHTS_DIR / model_name)
+    from_array = model.predict(im, imgsz=640, verbose=False)[0].boxes  # crashed here on the buggy code
+    from_path = model.predict(str(path), imgsz=640, verbose=False)[0].boxes  # OpenCV-normalized reference
+
+    assert len(from_array) == len(from_path) > 0, "ndarray and path must detect the same objects"
+
+    def canon(boxes):  # order by box center-x so the comparison ignores confidence-tie ordering
+        order = boxes.xywh[:, 0].argsort()
+        return boxes.xyxy[order], boxes.cls[order]
+
+    xa, ca = canon(from_array)
+    xp, cp = canon(from_path)
+    assert (ca == cp).all(), "class labels must match the path route"
+    assert (xa - xp).abs().max() <= atol, "boxes must match the path route within tolerance"
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 def test_predict_all_image_formats():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -395,8 +395,8 @@ def test_predict_ndarray_channel_mismatch(tmp_path, model_name, mode, lossless):
 def test_predict_ndarray_gray_alpha(model_name):
     """A 2-channel gray+alpha ndarray (PIL 'LA') normalizes by dropping alpha, matching the gray-only image.
 
-    Neither OpenCV nor a PNG round-trip carries a 2-channel image, so the reference is the alpha-stripped gray
-    array rather than a path route: dropping alpha is lossless, so the two must produce identical detections.
+    Neither OpenCV nor a PNG round-trip carries a 2-channel image, so the reference is the alpha-stripped gray array
+    rather than a path route: dropping alpha is lossless, so the two must produce identical detections.
     """
     gray = cv2.cvtColor(cv2.imread(str(SOURCE)), cv2.COLOR_BGR2GRAY)[..., None]  # (H, W, 1)
     la = np.concatenate([gray, np.full_like(gray, 255)], axis=2)  # (H, W, 2) gray + opaque alpha

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -391,6 +391,26 @@ def test_predict_ndarray_channel_mismatch(tmp_path, model_name, mode, lossless):
         assert box_iou(xa, xp).diag().min() >= 0.9, "boxes must overlap the path route (grayscale differs slightly)"
 
 
+@pytest.mark.parametrize("model_name", ["yolo11n.pt", "yolo11n-grayscale.pt"])
+def test_predict_ndarray_gray_alpha(model_name):
+    """A 2-channel gray+alpha ndarray (PIL 'LA') normalizes by dropping alpha, matching the gray-only image.
+
+    Neither OpenCV nor a PNG round-trip carries a 2-channel image, so the reference is the alpha-stripped gray
+    array rather than a path route: dropping alpha is lossless, so the two must produce identical detections.
+    """
+    gray = cv2.cvtColor(cv2.imread(str(SOURCE)), cv2.COLOR_BGR2GRAY)[..., None]  # (H, W, 1)
+    la = np.concatenate([gray, np.full_like(gray, 255)], axis=2)  # (H, W, 2) gray + opaque alpha
+
+    model = YOLO(WEIGHTS_DIR / model_name)
+    from_la = model.predict(la, imgsz=640, verbose=False)[0].boxes  # crashed in conv2d / cvtColor before the fix
+    from_gray = model.predict(gray, imgsz=640, verbose=False)[0].boxes  # alpha-stripped reference
+
+    assert len(from_la) == len(from_gray) > 0, "gray+alpha and gray-only must detect the same objects"
+    order_la, order_gray = from_la.xywh[:, 0].argsort(), from_gray.xywh[:, 0].argsort()
+    assert (from_la.cls[order_la] == from_gray.cls[order_gray]).all(), "class labels must match the gray reference"
+    assert (from_la.xyxy[order_la] - from_gray.xyxy[order_gray]).abs().max() <= 0.01, "boxes must match exactly"
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(not ONLINE, reason="environment is offline")
 def test_predict_all_image_formats():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -338,25 +338,31 @@ def test_predict_grayscale_ndarray():
 
 
 @pytest.mark.parametrize(
-    "model_name, mode, atol",
+    "model_name, mode, lossless",
     [
-        ("yolo11n.pt", "gray3d", 0.01),  # 3-channel model, (H, W, 1) grayscale ndarray
-        ("yolo11n.pt", "rgba", 0.01),  # 3-channel model, (H, W, 4) BGRA ndarray
-        ("yolo11n-grayscale.pt", "bgr", 1.0),  # 1-channel model, (H, W, 3) BGR ndarray
-        ("yolo11n-grayscale.pt", "rgba", 1.0),  # 1-channel model, (H, W, 4) BGRA ndarray
+        ("yolo11n.pt", "gray3d", True),  # 3-channel model, (H, W, 1) grayscale ndarray (replicate: lossless)
+        ("yolo11n.pt", "rgba", True),  # 3-channel model, (H, W, 4) BGRA ndarray (drop alpha: lossless)
+        ("yolo11n-grayscale.pt", "bgr", False),  # 1-channel model, (H, W, 3) BGR ndarray (cvtColor gray)
+        ("yolo11n-grayscale.pt", "rgba", False),  # 1-channel model, (H, W, 4) BGRA ndarray (cvtColor gray)
     ],
 )
-def test_predict_ndarray_channel_mismatch(tmp_path, model_name, mode, atol):
+def test_predict_ndarray_channel_mismatch(tmp_path, model_name, mode, lossless):
     """Test that an ndarray whose channel count differs from the model matches the same image read from a path.
 
     A NumPy image with a channel count that does not match the model (grayscale/RGBA into a color model, or color/RGBA
     into a grayscale model) used to crash in conv2d. It must now normalize to the model channels and return the same
-    detections as the identical image read from disk, which OpenCV normalizes at decode time. The 1-channel cases allow
-    up to 1px since decode-time and cvtColor grayscale differ by at most one gray level.
+    detections as the identical image read from disk, which OpenCV normalizes at decode time.
+
+    For color models the normalization (replicate gray, drop alpha) is lossless, so boxes must match the path route
+    exactly. For grayscale models the ndarray is grayed with cvtColor while the path route decodes with
+    IMREAD_GRAYSCALE; the two grays differ by up to one level, which shifts boxes a fraction of a pixel that varies by
+    platform, so those cases require a high box IoU instead of exact coordinates.
 
     Channel order is out of scope (ndarrays are BGR by pre-existing convention), so BGRA (not the RGB-order RGBA from
     the issue MRE) is used to isolate the channel-count fix from the color-order assumption.
     """
+    from ultralytics.utils.metrics import box_iou
+
     bgr = cv2.imread(str(SOURCE))  # (H, W, 3) BGR, OpenCV order (ndarrays are treated as BGR downstream)
     im = {
         "gray3d": cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)[..., None],  # (H, W, 1)
@@ -379,7 +385,10 @@ def test_predict_ndarray_channel_mismatch(tmp_path, model_name, mode, atol):
     xa, ca = canon(from_array)
     xp, cp = canon(from_path)
     assert (ca == cp).all(), "class labels must match the path route"
-    assert (xa - xp).abs().max() <= atol, "boxes must match the path route within tolerance"
+    if lossless:
+        assert (xa - xp).abs().max() <= 0.01, "boxes must match the path route exactly"
+    else:
+        assert box_iou(xa, xp).diag().min() >= 0.9, "boxes must overlap the path route (grayscale differs slightly)"
 
 
 @pytest.mark.slow

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -328,87 +328,18 @@ def test_predict_gray_and_4ch(tmp_path):
         f.unlink()  # cleanup
 
 
-def test_predict_grayscale_ndarray():
-    """Test that a 2D grayscale NumPy array is accepted by a color model, consistent with PIL/file inputs."""
+def test_predict_ndarray_channels():
+    """Test NumPy channel normalization for grayscale and color models."""
+    from ultralytics.data.loaders import LoadPilAndNumpy
+
     model = YOLO(MODEL)  # default 3-channel model
     gray = np.asarray(Image.open(SOURCE).convert("L"))  # genuine 2D (H, W) uint8 array
     assert gray.ndim == 2, "Expected a 2D grayscale array for this test"
     assert len(model(source=gray, imgsz=32, verbose=False)) == 1  # 2D ndarray auto-expanded to 3 channels
     assert len(model(source=gray.astype("float64"), imgsz=32, verbose=False)) == 1  # non-OpenCV dtype also works
-
-
-@pytest.mark.parametrize(
-    "model_name, mode, lossless",
-    [
-        ("yolo11n.pt", "gray3d", True),  # 3-channel model, (H, W, 1) grayscale ndarray (replicate: lossless)
-        ("yolo11n.pt", "rgba", True),  # 3-channel model, (H, W, 4) BGRA ndarray (drop alpha: lossless)
-        ("yolo11n-grayscale.pt", "bgr", False),  # 1-channel model, (H, W, 3) BGR ndarray (cvtColor gray)
-        ("yolo11n-grayscale.pt", "rgba", False),  # 1-channel model, (H, W, 4) BGRA ndarray (cvtColor gray)
-    ],
-)
-def test_predict_ndarray_channel_mismatch(tmp_path, model_name, mode, lossless):
-    """Test that an ndarray whose channel count differs from the model matches the same image read from a path.
-
-    A NumPy image with a channel count that does not match the model (grayscale/RGBA into a color model, or color/RGBA
-    into a grayscale model) used to crash in conv2d. It must now normalize to the model channels and return the same
-    detections as the identical image read from disk, which OpenCV normalizes at decode time.
-
-    For color models the normalization (replicate gray, drop alpha) is lossless, so boxes must match the path route
-    exactly. For grayscale models the ndarray is grayed with cvtColor while the path route decodes with
-    IMREAD_GRAYSCALE; the two grays differ by up to one level, which shifts boxes a fraction of a pixel that varies by
-    platform, so those cases require a high box IoU instead of exact coordinates.
-
-    Channel order is out of scope (ndarrays are BGR by pre-existing convention), so BGRA (not the RGB-order RGBA from
-    the issue MRE) is used to isolate the channel-count fix from the color-order assumption.
-    """
-    from ultralytics.utils.metrics import box_iou
-
-    bgr = cv2.imread(str(SOURCE))  # (H, W, 3) BGR, OpenCV order (ndarrays are treated as BGR downstream)
-    im = {
-        "gray3d": cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)[..., None],  # (H, W, 1)
-        "bgr": bgr,  # (H, W, 3)
-        "rgba": cv2.cvtColor(bgr, cv2.COLOR_BGR2BGRA),  # (H, W, 4)
-    }[mode]
-    path = tmp_path / "img.png"
-    assert cv2.imwrite(str(path), im)  # lossless PNG keeps the channel count on disk
-
-    model = YOLO(WEIGHTS_DIR / model_name)
-    from_array = model.predict(im, imgsz=640, verbose=False)[0].boxes  # crashed here on the buggy code
-    from_path = model.predict(str(path), imgsz=640, verbose=False)[0].boxes  # OpenCV-normalized reference
-
-    assert len(from_array) == len(from_path) > 0, "ndarray and path must detect the same objects"
-
-    def canon(boxes):  # order by box center-x so the comparison ignores confidence-tie ordering
-        order = boxes.xywh[:, 0].argsort()
-        return boxes.xyxy[order], boxes.cls[order]
-
-    xa, ca = canon(from_array)
-    xp, cp = canon(from_path)
-    assert (ca == cp).all(), "class labels must match the path route"
-    if lossless:
-        assert (xa - xp).abs().max() <= 0.01, "boxes must match the path route exactly"
-    else:
-        assert box_iou(xa, xp).diag().min() >= 0.9, "boxes must overlap the path route (grayscale differs slightly)"
-
-
-@pytest.mark.parametrize("model_name", ["yolo11n.pt", "yolo11n-grayscale.pt"])
-def test_predict_ndarray_gray_alpha(model_name):
-    """A 2-channel gray+alpha ndarray (PIL 'LA') normalizes by dropping alpha, matching the gray-only image.
-
-    Neither OpenCV nor a PNG round-trip carries a 2-channel image, so the reference is the alpha-stripped gray array
-    rather than a path route: dropping alpha is lossless, so the two must produce identical detections.
-    """
-    gray = cv2.cvtColor(cv2.imread(str(SOURCE)), cv2.COLOR_BGR2GRAY)[..., None]  # (H, W, 1)
-    la = np.concatenate([gray, np.full_like(gray, 255)], axis=2)  # (H, W, 2) gray + opaque alpha
-
-    model = YOLO(WEIGHTS_DIR / model_name)
-    from_la = model.predict(la, imgsz=640, verbose=False)[0].boxes  # crashed in conv2d / cvtColor before the fix
-    from_gray = model.predict(gray, imgsz=640, verbose=False)[0].boxes  # alpha-stripped reference
-
-    assert len(from_la) == len(from_gray) > 0, "gray+alpha and gray-only must detect the same objects"
-    order_la, order_gray = from_la.xywh[:, 0].argsort(), from_gray.xywh[:, 0].argsort()
-    assert (from_la.cls[order_la] == from_gray.cls[order_gray]).all(), "class labels must match the gray reference"
-    assert (from_la.xyxy[order_la] - from_gray.xyxy[order_gray]).abs().max() <= 0.01, "boxes must match exactly"
+    for source_channels, model_channels in ((1, 3), (2, 1), (2, 3), (3, 1), (4, 1), (4, 3)):
+        im = np.zeros((8, 8, source_channels), dtype=np.uint8)
+        assert LoadPilAndNumpy(im, channels=model_channels).im0[0].shape == (8, 8, model_channels)
 
 
 @pytest.mark.slow

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -543,6 +543,8 @@ class LoadPilAndNumpy:
         c = im.shape[2]
         if c == channels:
             return im  # already correct: 3 -> 3, 1 -> 1, multispectral 10 -> 10
+        if c == 2:  # gray + alpha (PIL 'LA') -> drop alpha, leaving a single gray channel
+            im, c = im[..., :1], 1
         if c == 1:  # single channel -> replicate to model channels (dtype-agnostic, mirrors gray file/PIL inputs)
             return np.repeat(im, channels, axis=2)
         if channels == 1:  # BGR/RGBA -> gray via cvtColor (uint8/uint16/float32), matching IMREAD_GRAYSCALE

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -521,35 +521,29 @@ class LoadPilAndNumpy:
 
     @staticmethod
     def _single_check(im: Image.Image | np.ndarray, channels: int = 3) -> np.ndarray:
-        """Validate an image and normalize it to a NumPy array with the model's channel count.
-
-        NumPy inputs are treated as BGR (OpenCV order); only the channel count is matched to the model, using
-        the same conversions as the file path (`RGBA`/gray -> `BGR`, `BGR`/`RGBA` -> gray), so an ndarray behaves
-        like the same image read from a path or PIL. Channel order is never touched. The `-> gray` step uses
-        `cv2.cvtColor`, so it needs uint8/uint16/float32, which the file path always satisfies (it decodes uint8).
+        """Validate an image and normalize its channel count.
 
         Notes:
             - PIL inputs are converted to NumPy and returned in OpenCV-compatible BGR order for color images.
-            - NumPy arrays already matching the model channels are returned as-is (covers 3 -> 3 and 10 -> 10).
+            - NumPy color inputs are assumed to use OpenCV-compatible BGR order.
         """
         assert isinstance(im, (Image.Image, np.ndarray)), f"Expected PIL/np.ndarray image type, but got {type(im)}"
         if isinstance(im, Image.Image):
-            flag = "L" if channels == 1 else "RGB"  # grayscale or RGB
+            flag = "L" if channels == 1 else "RGB"
             im = np.asarray(im.convert(flag))
-            # Add a new axis if grayscale; convert RGB -> BGR for OpenCV compatibility.
             im = im[..., None] if flag == "L" else im[..., ::-1]
-            return np.ascontiguousarray(im)  # contiguous
-        im = np.atleast_3d(im)  # (H, W) -> (H, W, 1); leaves (H, W, C) untouched
+            return np.ascontiguousarray(im)
+        im = np.atleast_3d(im)
         c = im.shape[2]
         if c == channels:
-            return im  # already correct: 3 -> 3, 1 -> 1, multispectral 10 -> 10
-        if c == 2:  # gray + alpha (PIL 'LA') -> drop alpha, leaving a single gray channel
+            return im
+        if c == 2:  # gray + alpha
             im, c = im[..., :1], 1
-        if c == 1:  # single channel -> replicate to model channels (dtype-agnostic, mirrors gray file/PIL inputs)
+        if c == 1:
             return np.repeat(im, channels, axis=2)
-        if channels == 1:  # BGR/RGBA -> gray via cvtColor (uint8/uint16/float32), matching IMREAD_GRAYSCALE
+        if channels == 1:
             return cv2.cvtColor(im, cv2.COLOR_BGRA2GRAY if c == 4 else cv2.COLOR_BGR2GRAY)[..., None]
-        return np.ascontiguousarray(im[..., :3])  # drop extra channels -> BGR (RGBA case), matching IMREAD_COLOR
+        return np.ascontiguousarray(im[..., :3])
 
     def __len__(self) -> int:
         """Return the length of the 'im0' attribute, representing the number of loaded images."""

--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -514,32 +514,40 @@ class LoadPilAndNumpy:
             im0 = [im0]
         # use `image{i}.jpg` when Image.filename returns an empty path.
         self.paths = [getattr(im, "filename", "") or f"image{i}.jpg" for i, im in enumerate(im0)]
-        pil_flag = "L" if channels == 1 else "RGB"  # grayscale or RGB
-        self.im0 = [self._single_check(im, pil_flag) for im in im0]
+        self.im0 = [self._single_check(im, channels) for im in im0]
         self.mode = "image"
         self.bs = len(self.im0)
         self.count = 0
 
     @staticmethod
-    def _single_check(im: Image.Image | np.ndarray, flag: str = "RGB") -> np.ndarray:
-        """Validate and format an image to a NumPy array.
+    def _single_check(im: Image.Image | np.ndarray, channels: int = 3) -> np.ndarray:
+        """Validate an image and normalize it to a NumPy array with the model's channel count.
+
+        NumPy inputs are treated as BGR (OpenCV order); only the channel count is matched to the model, using
+        the same conversions as the file path (`RGBA`/gray -> `BGR`, `BGR`/`RGBA` -> gray), so an ndarray behaves
+        like the same image read from a path or PIL. Channel order is never touched. The `-> gray` step uses
+        `cv2.cvtColor`, so it needs uint8/uint16/float32, which the file path always satisfies (it decodes uint8).
 
         Notes:
             - PIL inputs are converted to NumPy and returned in OpenCV-compatible BGR order for color images.
-            - NumPy color inputs are returned as-is (no channel-order conversion is applied).
-            - 2D grayscale NumPy inputs are expanded to match the model channels (3 for color, 1 for grayscale),
-              mirroring how PIL and file inputs are handled.
+            - NumPy arrays already matching the model channels are returned as-is (covers 3 -> 3 and 10 -> 10).
         """
         assert isinstance(im, (Image.Image, np.ndarray)), f"Expected PIL/np.ndarray image type, but got {type(im)}"
         if isinstance(im, Image.Image):
+            flag = "L" if channels == 1 else "RGB"  # grayscale or RGB
             im = np.asarray(im.convert(flag))
             # Add a new axis if grayscale; convert RGB -> BGR for OpenCV compatibility.
             im = im[..., None] if flag == "L" else im[..., ::-1]
-            im = np.ascontiguousarray(im)  # contiguous
-        elif im.ndim == 2:  # grayscale in numpy form
-            # Expand 2D grayscale to 3 channels for color models (like PIL/file inputs); np.repeat preserves dtype
-            im = im[..., None] if flag == "L" else np.repeat(im[..., None], 3, axis=2)
-        return im
+            return np.ascontiguousarray(im)  # contiguous
+        im = np.atleast_3d(im)  # (H, W) -> (H, W, 1); leaves (H, W, C) untouched
+        c = im.shape[2]
+        if c == channels:
+            return im  # already correct: 3 -> 3, 1 -> 1, multispectral 10 -> 10
+        if c == 1:  # single channel -> replicate to model channels (dtype-agnostic, mirrors gray file/PIL inputs)
+            return np.repeat(im, channels, axis=2)
+        if channels == 1:  # BGR/RGBA -> gray via cvtColor (uint8/uint16/float32), matching IMREAD_GRAYSCALE
+            return cv2.cvtColor(im, cv2.COLOR_BGRA2GRAY if c == 4 else cv2.COLOR_BGR2GRAY)[..., None]
+        return np.ascontiguousarray(im[..., :3])  # drop extra channels -> BGR (RGBA case), matching IMREAD_COLOR
 
     def __len__(self) -> int:
         """Return the length of the 'im0' attribute, representing the number of loaded images."""


### PR DESCRIPTION
Fixes #25150

## Problem

NumPy inputs could reach convolution with the wrong channel count even though PIL and file inputs are normalized to the model. The affected cases include single-channel, gray+alpha, BGR, and BGRA arrays used with one- or three-channel models.

## Change

LoadPilAndNumpy now receives the model channel count and normalizes decoded NumPy inputs at the loader boundary:

- matching channel counts remain unchanged, including multispectral inputs;
- single-channel inputs are repeated when needed;
- gray+alpha drops alpha before normalization;
- BGR/BGRA converts to grayscale for one-channel models;
- BGRA drops alpha for three-channel models.

NumPy channel order remains the existing OpenCV-compatible BGR convention.

Deleted: the 2D-only grayscale expansion branch and the separately derived pil_flag in LoadPilAndNumpy.

The complete bugfix is net-positive by 9 lines, including regression coverage. Deletion and relocation alone cannot cover the source-channel by model-channel conversions; the loader needs a small dispatch at the point that already owns decoded array normalization.

## Validation

- Existing ndarray prediction coverage still passes, including float64 2D grayscale.
- The same test now covers 1, 2, 3, and 4 source channels normalized to one- and three-channel model inputs.
- Ruff format and lint pass.
- GitHub CI passed on the previous functional head and is rerunning on the reduced test diff.