### PR TITLE
fix(rtdetr): honor max_det in decoder exports and validation

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -416,6 +416,10 @@ def test_export_coreml_rtdetr():
     stdout, stderr = io.StringIO(), io.StringIO()
     with redirect_stdout(stdout), redirect_stderr(stderr):
         file = YOLO(WEIGHTS_DIR / "rtdetr-l.pt").export(format="coreml", imgsz=160)
+        import coremltools as ct
+
+        shape = ct.models.MLModel(file).get_spec().description.output[0].type.multiArrayType.shape
+        assert shape[-2] == 300
         if MACOS:
             YOLO(file)(SOURCE, imgsz=160)
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -418,7 +418,7 @@ def test_export_coreml_rtdetr():
         file = YOLO(WEIGHTS_DIR / "rtdetr-l.pt").export(format="coreml", imgsz=160)
         import coremltools as ct
 
-        shape = ct.models.MLModel(file).get_spec().description.output[0].type.multiArrayType.shape
+        shape = ct.models.MLModel(str(file)).get_spec().description.output[0].type.multiArrayType.shape
         assert shape[-2] == 300
         if MACOS:
             YOLO(file)(SOURCE, imgsz=160)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -740,9 +740,13 @@ class Exporter:
                 m.dynamic = self.args.dynamic
                 m.export = True
                 m.format = self.args.format
-                # Clamp max_det to anchor count for small image sizes (required for TensorRT compatibility)
-                anchors = sum(int(self.imgsz[0] / s) * int(self.imgsz[1] / s) for s in model.stride.tolist())
-                m.max_det = min(self.args.max_det, anchors)
+                # Clamp max_det to available queries/anchors (required for TensorRT compatibility)
+                available = (
+                    m.num_queries
+                    if isinstance(m, RTDETRDecoder)
+                    else sum(int(self.imgsz[0] / s) * int(self.imgsz[1] / s) for s in model.stride.tolist())
+                )
+                m.max_det = min(self.args.max_det, available)
                 m.agnostic_nms = self.args.agnostic_nms
                 m.xyxy = self.args.nms and fmt != "coreml"
                 m.shape = None  # reset cached shape for new export input size

--- a/ultralytics/models/rtdetr/val.py
+++ b/ultralytics/models/rtdetr/val.py
@@ -148,7 +148,7 @@ class RTDETRValidator(DetectionValidator):
         bboxes, scores, labels = preds.split((4, 1, 1), dim=-1)
         bboxes = ops.xywh2xyxy(bboxes) * self.args.imgsz
         scores, labels = scores.squeeze(-1), labels.squeeze(-1)
-        masks = scores > self.args.conf
+        masks = [(score > self.args.conf).nonzero().squeeze(1)[: self.args.max_det] for score in scores]
 
         return [
             {"bboxes": bbox[m], "conf": score[m], "cls": label[m]}

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1458,8 +1458,6 @@ class RTDETRDecoder(nn.Module):
 
     export = False  # export mode
     max_det = 300  # max detections per image
-    agnostic_nms = False
-    end2end = True
     shapes = []
     anchors = torch.empty(0)
     valid_mask = torch.empty(0)

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1457,6 +1457,9 @@ class RTDETRDecoder(nn.Module):
     """
 
     export = False  # export mode
+    max_det = 300  # max detections per image
+    agnostic_nms = False
+    end2end = True
     shapes = []
     anchors = torch.empty(0)
     valid_mask = torch.empty(0)
@@ -1600,10 +1603,11 @@ class RTDETRDecoder(nn.Module):
             scores (torch.Tensor): Class scores with shape (batch_size, num_queries, nc).
 
         Returns:
-            (torch.Tensor): Processed predictions with shape (batch_size, num_queries, 6) and last dimension format [cx,
-                cy, w, h, max_class_prob, class_index].
+            (torch.Tensor): Processed predictions with shape (batch_size, min(max_det, num_queries), 6) and last
+                dimension format [cx, cy, w, h, max_class_prob, class_index].
         """
-        scores, index = scores.flatten(1).topk(self.num_queries)
+        k = min(self.num_queries, self.max_det)
+        scores, index = scores.flatten(1).topk(k)
         # CoreML MIL lacks integer floor-div and mod lowering: use torch.div(rounding_mode="floor") and (index - q*nc).
         query_idx = torch.div(index, self.nc, rounding_mode="floor")
         boxes = boxes.gather(dim=1, index=query_idx.unsqueeze(-1).expand(-1, -1, 4).long())

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -1601,10 +1601,10 @@ class RTDETRDecoder(nn.Module):
             scores (torch.Tensor): Class scores with shape (batch_size, num_queries, nc).
 
         Returns:
-            (torch.Tensor): Processed predictions with shape (batch_size, min(max_det, num_queries), 6) and last
-                dimension format [cx, cy, w, h, max_class_prob, class_index].
+            (torch.Tensor): Processed predictions with shape (batch_size, num_queries, 6), limited to max_det during
+                export, and last dimension format [cx, cy, w, h, max_class_prob, class_index].
         """
-        k = min(self.num_queries, self.max_det)
+        k = min(self.num_queries, self.max_det) if self.export else self.num_queries
         scores, index = scores.flatten(1).topk(k)
         # CoreML MIL lacks integer floor-div and mod lowering: use torch.div(rounding_mode="floor") and (index - q*nc).
         query_idx = torch.div(index, self.nc, rounding_mode="floor")


### PR DESCRIPTION
Fixes #3286

## Summary

RT-DETR now honors `max_det` at the layers that own it:

- Native prediction keeps all decoder queries, then applies confidence/class filtering and `max_det` in `RTDETRPredictor`.
- Validation applies confidence filtering and `max_det` in `RTDETRValidator`.
- Export limits decoder top-k to `max_det`, clamped by RT-DETR query capacity rather than YOLO anchor count.

The earlier proposal marked RT-DETR as a standard YOLO end-to-end head. That was too broad: training resume uses that flag to enter the one-to-one criterion update lifecycle, which RT-DETR does not implement.

Deleted: the proposed `agnostic_nms` and `end2end` `RTDETRDecoder` flags and their incorrect standard-lifecycle integration.

The source change is net-positive by 6 lines, plus 4 lines in an existing export test. Deletion alone cannot make exported decoder top-k configurable or apply validation post-filter limits; the remaining additions live at those two ownership boundaries.

## Validation

- Ruff format and lint pass on all changed files.
- Decoder probes verify native custom-query models retain every candidate while export honors `max_det`.
- Validator probes verify confidence filtering precedes `max_det` truncation.
- The existing RT-DETR CoreML export test now asserts its 300-detection output dimension.
- Fresh adversarial review rounds found and resolved the training-lifecycle, anchor-clamp, and native pre-filter truncation regressions; the final round returned LGTM.