### PR TITLE
Fix restricted loading of training checkpoints

### DIFF
--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -187,6 +187,9 @@
 79740115+0xSynapse@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/79740115?v=4
   username: ankanpy
+81671190+vedantparnaik@users.noreply.github.com:
+  avatar: https://avatars.githubusercontent.com/u/81671190?v=4
+  username: vedantparnaik
 82823259+fbertil@users.noreply.github.com:
   avatar: https://avatars.githubusercontent.com/u/82823259?v=4
   username: fbertil

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -17,8 +17,8 @@ from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models.yolo import classify, detect, obb, pose, segment, semantic
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.tasks import DetectionModel, load_checkpoint, torch_safe_load
-from ultralytics.utils.loss import E2ELoss
 from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR
+from ultralytics.utils.loss import E2ELoss
 from ultralytics.utils.torch_utils import unwrap_model
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -16,7 +16,8 @@ from ultralytics.engine.exporter import Exporter
 from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models.yolo import classify, detect, obb, pose, segment, semantic
 from ultralytics.nn.distill_model import DistillationModel
-from ultralytics.nn.tasks import DetectionModel, load_checkpoint
+from ultralytics.nn.tasks import DetectionModel, load_checkpoint, torch_safe_load
+from ultralytics.utils.loss import E2ELoss
 from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR
 from ultralytics.utils.torch_utils import unwrap_model
 
@@ -229,6 +230,28 @@ def test_load_checkpoint_state_dict_rejected(ckpt, tmp_path):
     torch.save(ckpt, weight)
     with pytest.raises(TypeError, match="supported Ultralytics checkpoint format"):
         load_checkpoint(weight)
+
+
+def test_checkpoint_drops_ema_criterion(tmp_path):
+    """Test raw training checkpoints omit the EMA criterion without mutating the live EMA."""
+    trainer = detect.DetectionTrainer(
+        overrides={
+            "data": "coco8.yaml",
+            "model": "yolo26n.yaml",
+            "imgsz": 32,
+            "epochs": 1,
+            "workers": 0,
+            "plots": False,
+            "project": tmp_path,
+        }
+    )
+    trainer.final_eval = lambda: None
+    trainer.train()
+
+    checkpoint, _ = torch_safe_load(trainer.last, safe_only=True)
+
+    assert isinstance(trainer.ema.ema.criterion, E2ELoss)
+    assert checkpoint["ema"].criterion is None
 
 
 def test_nan_recovery():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -240,6 +240,7 @@ def test_checkpoint_drops_ema_criterion(tmp_path):
             "model": "yolo26n.yaml",
             "imgsz": 32,
             "epochs": 1,
+            "optimizer": "SGD",
             "workers": 0,
             "plots": False,
             "project": tmp_path,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -16,9 +16,8 @@ from ultralytics.engine.exporter import Exporter
 from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models.yolo import classify, detect, obb, pose, segment, semantic
 from ultralytics.nn.distill_model import DistillationModel
-from ultralytics.nn.tasks import DetectionModel, load_checkpoint, torch_safe_load
+from ultralytics.nn.tasks import DetectionModel, load_checkpoint
 from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_RASPBERRYPI, WEIGHTS_DIR
-from ultralytics.utils.loss import E2ELoss
 from ultralytics.utils.torch_utils import unwrap_model
 
 
@@ -230,29 +229,6 @@ def test_load_checkpoint_state_dict_rejected(ckpt, tmp_path):
     torch.save(ckpt, weight)
     with pytest.raises(TypeError, match="supported Ultralytics checkpoint format"):
         load_checkpoint(weight)
-
-
-def test_checkpoint_drops_ema_criterion(tmp_path):
-    """Test raw training checkpoints omit the EMA criterion without mutating the live EMA."""
-    trainer = detect.DetectionTrainer(
-        overrides={
-            "data": "coco8.yaml",
-            "model": "yolo26n.yaml",
-            "imgsz": 32,
-            "epochs": 1,
-            "optimizer": "SGD",
-            "workers": 0,
-            "plots": False,
-            "project": tmp_path,
-        }
-    )
-    trainer.final_eval = lambda: None
-    trainer.train()
-
-    checkpoint, _ = torch_safe_load(trainer.last, safe_only=True)
-
-    assert isinstance(trainer.ema.ema.criterion, E2ELoss)
-    assert checkpoint["ema"].criterion is None
 
 
 def test_nan_recovery():

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.4.94"
+__version__ = "8.4.95"
 
 import importlib
 import os

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -437,16 +437,18 @@ class BaseTrainer:
                     self.accumulate = max(1, int(np.interp(ni, xi, [1, self.args.nbs / self.batch_size]).round()))
                     for x in self.optimizer.param_groups:
                         # Bias lr falls from 0.1 to lr0, all other lrs rise from 0.0 to lr0
-                        x["lr"] = np.interp(
-                            ni,
-                            xi,
-                            [
-                                self.args.warmup_bias_lr if x.get("param_group") == "bias" else 0.0,
-                                x["initial_lr"] * self.lf(epoch),
-                            ],
+                        x["lr"] = float(
+                            np.interp(
+                                ni,
+                                xi,
+                                [
+                                    self.args.warmup_bias_lr if x.get("param_group") == "bias" else 0.0,
+                                    x["initial_lr"] * self.lf(epoch),
+                                ],
+                            )
                         )
                         if "momentum" in x:
-                            x["momentum"] = np.interp(ni, xi, [self.args.warmup_momentum, self.args.momentum])
+                            x["momentum"] = float(np.interp(ni, xi, [self.args.warmup_momentum, self.args.momentum]))
 
                 # Forward
                 try:
@@ -672,6 +674,8 @@ class BaseTrainer:
                 if isinstance(v, torch.Tensor) and not torch.isfinite(v).all() and torch.isfinite(model_sd[k]).all():
                     v.copy_(model_sd[k])
         ema = deepcopy(ema).half()
+        if hasattr(ema, "criterion"):
+            ema.criterion = None  # strip training-only state from the serialization snapshot
         # Clamp fp16 serialization overflow without mutating the live EMA.
         for v in ema.state_dict().values():
             if isinstance(v, torch.Tensor) and v.is_floating_point():


### PR DESCRIPTION
## Summary

Fixes restricted loading of raw training checkpoints produced by Platform GPU workers.

| Evidence | Root cause | Fix |
|---|---|---|
| `alpha` [ALPHA-1DM](https://ultralytics.sentry.io/issues/7432157731/), event `29a350cfa5df407da5cc7031`; GPU job `6a541db4a9b04852794774e4` | Validation attaches the training-only `E2ELoss` criterion to the EMA, then `save_model()` serialized it into raw checkpoints. Warmup also stored NumPy scalars in optimizer metadata. Both are rejected by `weights_only=True`. | Strip `criterion` only from the deep-copied EMA serialization snapshot and store warmup LR/momentum as Python floats. |

Evidence export: `/Users/glennjocher/PycharmProjects/portal/worker-log-export-2026-07-13`

- `ultra1` / `workers-gpu-worker-11`: Ultralytics 8.4.86, 107 successful jobs, 0 failures.
- `ultra5` / `workers-gpu-worker-34`: Ultralytics 8.4.93, 199 successful jobs, 2 failures. The actionable checkpoint failure above is fixed here; the other failure was an oversized user configuration (`yolo26x`, `batch=128`, `imgsz=1280`) that exhausted automatic OOM retries.
- `ultra5` / `Platform-API`: Ultralytics 8.4.89. Its WebSocket send-after-close error is already fixed on Portal main by PR #2719; the running image predates that fix.

The Sentry group was not marked resolved because `ALPHA-1DM` combines this fixed checkpoint failure with unrelated, still-occurring expected training failures such as user-configured OOM. Resolving the mixed group would hide unfixed event classes.

## Core principles

Primarily replacement/deletion: training-only criterion state is deleted at checkpoint serialization ownership; NumPy scalar assignments are replaced with Python scalar assignments. No Sentry suppression, unsafe-load fallback, allow-list expansion, new helper, new test, or new file.

Deleted: training-only `criterion` state from raw checkpoint EMA snapshots.

Net-add justification: the existing final `strip_optimizer()` runs too late to protect resumable/intermediate Platform checkpoints, so the serialization boundary must remove training-only state before writing them.

## Verification

- `pytest -q tests/test_engine.py` — 31 passed
- Focused sticky-NaN/FP16/resume/distillation checkpoint tests — passed
- Safe-load resume passed for classify, detect, segment, pose, OBB, and semantic tasks
- `ruff check ultralytics/engine/trainer.py tests/test_engine.py ultralytics/__init__.py` — passed
- `ruff format --check ultralytics/engine/trainer.py tests/test_engine.py ultralytics/__init__.py` — passed
- `git diff --check` — passed

## Independent review

- Cold reviewer agent: LGTM; live EMA, sticky-NaN resync, FP16 sanitation, resume, and distillation remain intact.
- Codex CLI reviewer: LGTM; no further deletions available and no added condition suppresses a symptom.

## Release

Bumps Ultralytics from `8.4.94` to `8.4.95`. The downstream Portal version PR is ultralytics/portal#2813 and will merge only after both `ultralytics==8.4.95` distributions are published on PyPI.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Improves training-value compatibility and produces cleaner EMA model checkpoints in Ultralytics 8.4.95.

### 📊 Key Changes

- 📈 Explicitly converts interpolated learning rates and momentum values to standard Python floats during warmup.
- 🧹 Removes the training-only `criterion` state from EMA models before serialization.
- 🔢 Updates the package version from `8.4.94` to `8.4.95`.
- 👤 Adds the new contributor @vedantparnaik to the documentation authors list.

### 🎯 Purpose & Impact

- ✅ Reduces potential type-related issues in optimizer parameter handling during training.
- 💾 Makes saved EMA checkpoints cleaner and more focused on inference and model reuse by excluding unnecessary training state.
- 🚀 Helps improve checkpoint portability and serialization reliability without changing the live training model.
- 📦 Provides a minor release update with contributor attribution.