### PR TITLE
Fix classify `ConfusionMatrix` gaining a phantom `background` class

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -508,7 +508,7 @@ def test_val(task: str, weight: str, data: str) -> None:
         metrics.confusion_matrix.to_csv()
         metrics.confusion_matrix.to_json()
         cm = metrics.confusion_matrix
-        expected = cm.nc if task in {"classify", "semantic"} else cm.nc + 1  # background row/col only for detect/obb
+        expected = cm.nc if task in {"classify", "semantic"} else cm.nc + 1  # detection-style tasks include background
         assert cm.matrix.shape == (expected, expected), f"{task} confusion matrix is {cm.matrix.shape}"
         assert len(cm.tp_fp()[0]) == cm.nc  # per-class TP/FP never include background
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -507,6 +507,10 @@ def test_val(task: str, weight: str, data: str) -> None:
         metrics.confusion_matrix.to_df()
         metrics.confusion_matrix.to_csv()
         metrics.confusion_matrix.to_json()
+        cm = metrics.confusion_matrix
+        expected = cm.nc if task in {"classify", "semantic"} else cm.nc + 1  # background row/col only for detect/obb
+        assert cm.matrix.shape == (expected, expected), f"{task} confusion matrix is {cm.matrix.shape}"
+        assert len(cm.tp_fp()[0]) == cm.nc  # per-class TP/FP never include background
 
 
 def test_val_save_txt_pose(tmp_path):

--- a/ultralytics/models/yolo/classify/val.py
+++ b/ultralytics/models/yolo/classify/val.py
@@ -78,7 +78,7 @@ class ClassificationValidator(BaseValidator):
         self.nc = len(model.names)
         self.pred = []
         self.targets = []
-        self.confusion_matrix = ConfusionMatrix(names=model.names)
+        self.confusion_matrix = ConfusionMatrix(names=model.names, task="classify")
 
     def preprocess(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Preprocess input batch by moving data to device and converting to appropriate dtype."""

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -492,7 +492,7 @@ class ConfusionMatrix(DataExportMixin):
         tp = self.matrix.diagonal()  # true positives
         fp = self.matrix.sum(1) - tp  # false positives
         # fn = self.matrix.sum(0) - tp  # false negatives (missed detections)
-        return (tp, fp) if self.task == "classify" else (tp[:-1], fp[:-1])  # remove background class if task=detect
+        return (tp, fp) if self.task in {"classify", "semantic"} else (tp[:-1], fp[:-1])  # remove background row/col
 
     def plot_matches(
         self, img: torch.Tensor, im_file: str, save_dir: Path, show_labels: bool = True, show_conf: bool = True
@@ -560,7 +560,7 @@ class ConfusionMatrix(DataExportMixin):
             names = names[keep_idx]  # slice class names
             array = array[keep_idx, :][:, keep_idx]  # slice matrix rows and cols
             n = (self.nc + k - 1) // k  # number of retained classes
-        nc = n if self.task == "classify" else n + 1  # adjust for background if needed
+        nc = n if self.task in {"classify", "semantic"} else n + 1  # adjust for background if needed
         ticklabels = "auto"
         if 0 < nc < 99:
             ticklabels = names if self.task in {"classify", "semantic"} else [*names, "background"]


### PR DESCRIPTION
In classification `val`, `results.confusion_matrix` comes out with an extra `background` class that does not exist in the dataset. The matrix is `(nc+1, nc+1)` instead of `(nc, nc)`, the `confusion_matrix.png` plots an all-zero `background` row and column, and `summary()`/`to_df()`/`to_csv()`/`to_json()` all carry the extra `background` entry. The top1/top5 numbers are fine, only the confusion matrix and everything exported from it are affected.

The reason is simple: `ClassificationValidator.init_metrics` builds `ConfusionMatrix(names=model.names)` without a task, so it falls back to the default `task="detect"` and allocates the `(nc+1, nc+1)` detection matrix, where the extra row/col is the background used for FP/FN in detection. Classification has no background, so that row and column stay empty and leak into every export.

It is the only validator that does not set its task: `obb/val.py` fixes it after the fact (`self.confusion_matrix.task = "obb"`), `semantic/val.py` passes it in (`task="semantic"`), and `detect` keeps the default on purpose.

**Changes**

The fix mirrors semantic:

```python
self.confusion_matrix = ConfusionMatrix(names=model.names, task="classify")
```

#19169 already touched this area, but it only patched `ConfusionMatrix.print()` (`range(nc + 1)` → `range(matrix.shape[0])`) so the console print would not iterate over the empty background row. The matrix itself, the plot and the exports still get the extra class. Setting the task at the source makes `ConfusionMatrix` build the `(nc, nc)` matrix from the start.

While checking for siblings I found the same background assumption in two more spots of `ConfusionMatrix` itself, both checking `task == "classify"` where `__init__`/`summary()` already check `task in {"classify", "semantic"}`. `tp_fp()` trims the last row/col for semantic too, so it drops a real class: with 3 classes and `task="semantic"` it returns vectors of length 2 (verified on `main`). And `plot()` computes its tick count as `n + 1` for semantic, off by one against its own `(nc, nc)` matrix (only cosmetic: font sizes and the `nc < 30` annotation cutoff). Both lines now use the same set check. Detect/obb keep the extra background row/col everywhere, and pose/segment inherit the detect matrix, so they are not affected.

**Validation**

To confirm it, a classify validator with 3 classes gives `confusion_matrix.matrix.shape == (3, 3)` and `summary()` columns `['Predicted', 'cat', 'dog', 'fox']` with the fix, before it was `(4, 4)` with a `background` column. I added two assertions to the existing `test_val` so they hold across all tasks: the matrix shape is `(nc, nc)` for classify/semantic and `(nc+1, nc+1)` otherwise, and `len(tp_fp()[0]) == nc` for every task since detect/obb strip the background. On `main` they fail for classify (shape) and semantic (`tp_fp`), and with the fix `test_val` passes for all six tasks.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes classification confusion matrices incorrectly gaining a phantom `background` class.

### 📊 Key Changes
- Explicitly initializes classification validation confusion matrices with `task="classify"`.
- Treats classification and semantic segmentation confusion matrices consistently when calculating per-class metrics and plotting.
- Adds validation tests to confirm matrix dimensions and TP/FP lengths across supported tasks.

### 🎯 Purpose & Impact
- Prevents incorrect extra background rows and columns in classification confusion matrices.
- Ensures per-class TP/FP metrics contain only actual classes.
- Improves regression coverage for classification, semantic segmentation, detection, and OBB validation workflows.

Deleted: the implicit detection-task default from classification confusion-matrix construction and two classify-only branches that incorrectly excluded semantic matrices.