### PR TITLE
Fix `Results.update(probs=...)` to wrap probs in `Probs` like the other attributes

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -680,6 +680,17 @@ def test_results_plot_without_boxes():
         assert r.plot(color_mode=color_mode).shape == orig_img.shape
 
 
+def test_results_update_probs():
+    """Test that Results.update(probs=...) wraps the tensor in Probs like the sibling attributes."""
+    from ultralytics.engine.results import Probs, Results
+
+    orig_img = np.zeros((32, 32, 3), dtype=np.uint8)
+    r = Results(orig_img, path="image.jpg", names={i: f"c{i}" for i in range(5)}, probs=torch.rand(5))
+    r.update(probs=torch.rand(5))
+    assert isinstance(r.probs, Probs), "update(probs=) should wrap the tensor in Probs, not store a raw Tensor"
+    assert r.verbose() and r.summary(), "verbose()/summary() raise AttributeError on a raw Tensor probs"
+
+
 def test_labels_and_crops():
     """Test output from prediction args for saving YOLO detection labels and crops."""
     imgs = [SOURCE, ASSETS / "zidane.jpg"]

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -345,7 +345,7 @@ class Results(SimpleClass, DataExportMixin):
         if masks is not None:
             self.masks = Masks(masks, self.orig_shape)
         if probs is not None:
-            self.probs = probs
+            self.probs = Probs(probs)
         if obb is not None:
             self.obb = OBB(obb, self.orig_shape)
         if keypoints is not None:


### PR DESCRIPTION
When you call `results.update(probs=...)` on a classification result, `results.probs` stays as a raw `torch.Tensor` instead of a `Probs` object. Every method that reads it then breaks: `verbose()`, `summary()`, `plot()`, `to_json()`, `to_df()` and `to_csv()` all raise `AttributeError: 'Tensor' object has no attribute 'top5'`.

`update()` wraps every other attribute in its result class — `boxes` in `Boxes`, `masks` in `Masks`, `obb` in `OBB`, `keypoints` in `Keypoints`, `semantic_mask` in `SemanticMask` — and `__init__` does the same for probs (`self.probs = Probs(probs)`). The probs branch of `update()` was the only one keeping the raw tensor. The internal classify predictor builds the result through `__init__`, so this branch never runs inside the repo, the broken state only appears through the public `update()` API.

The fix is the same as the sibling branches and `__init__`:

```python
if probs is not None:
    self.probs = Probs(probs)
```

Repro on `main` (no model needed):

```python
import torch, numpy as np
from ultralytics.engine.results import Results
r = Results(np.zeros((32, 32, 3), np.uint8), path="x.jpg", names={i: f"c{i}" for i in range(5)}, probs=torch.rand(5))
r.update(probs=torch.rand(5))
r.verbose()   # AttributeError: 'Tensor' object has no attribute 'top5'
```

With the fix `type(r.probs)` is `Probs` and `verbose()/summary()/to_df()` all work.

I added a small regression test next to `test_results_plot_without_boxes`: it builds a synthetic classification `Results`, calls `update(probs=...)`, and checks that the type stays `Probs` and that `verbose()/summary()` run. It fails on `main` and passes with the fix.

Deleted: nothing — the fix itself is a 1-line replace (`self.probs = probs` → `self.probs = Probs(probs)`); the net +11 is the regression test.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🐛 Fixes `Results.update(probs=...)` so probability tensors are consistently wrapped in `Probs`.

### 📊 Key Changes
- Updates `Results.update()` to assign `Probs(probs)` instead of storing a raw tensor.
- Adds a regression test confirming the wrapped type and compatibility with `verbose()` and `summary()`.

### 🎯 Purpose & Impact
- Prevents `AttributeError` failures when calling result reporting methods after updating probabilities.
- Keeps `probs` behavior consistent with other `Results` attributes such as boxes, masks, and keypoints.
- Improves reliability for classification result updates without changing the public API.