### PR TITLE
Document masks/-folder fallback in semantic task faq

### DIFF
--- a/docs/en/tasks/semantic.md
+++ b/docs/en/tasks/semantic.md
@@ -260,7 +260,7 @@ Semantic segmentation is best suited for scene understanding tasks like autonomo
 
 ### Can I use instance segmentation data to train semantic segmentation?
 
-Yes. If your dataset uses Ultralytics YOLO polygon labels (one `.txt` per image), **omit** `masks_dir` from the dataset YAML and the loader will convert polygons to per-image semantic masks on the fly. For multi-class datasets (`N > 1`) an extra `background` class is appended to `names` automatically. For single-class datasets (`N == 1`) training stays at 1 class — your declared class becomes `1` in the mask and uncovered pixels become `0`. See the [Semantic Segmentation Dataset Guide](../datasets/semantic/index.md#yolo-polygon-label-format) for details.
+Yes. If your dataset uses Ultralytics YOLO polygon labels (one `.txt` per image), **omit** `masks_dir` from the dataset YAML, and make sure no `masks/` folder exists next to your images at the dataset root (its presence alone triggers PNG-mask mode even without `masks_dir` set). The loader then converts polygons to per-image semantic masks on the fly. For multi-class datasets (`N > 1`) an extra `background` class is appended to `names` automatically. For single-class datasets (`N == 1`) training stays at 1 class — your declared class becomes `1` in the mask and uncovered pixels become `0`. See the [Semantic Segmentation Dataset Guide](../datasets/semantic/index.md#yolo-polygon-label-format) for details.
 
 ### What datasets are supported for semantic segmentation?
 


### PR DESCRIPTION
## summary

the semantic task faq answer on training from polygon labels said omitting `masks_dir` is enough to select polygon mode, but a `masks/` folder present at the dataset root still routes to png-mask mode. this adds the same caveat already shipped on the semantic dataset guide so both pages describe the loader's actual 3-way selection.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Clarifies dataset setup requirements for training semantic segmentation from YOLO polygon labels. 🧩

### 📊 Key Changes

- Updated the semantic segmentation documentation to state that `masks_dir` must be omitted.
- Added a warning that a `masks/` folder next to the images automatically enables PNG-mask mode, even without `masks_dir`.
- Retained details about automatic polygon-to-mask conversion and background-class handling.

### 🎯 Purpose & Impact

- Helps users avoid unexpected dataset-loading behavior caused by an existing `masks/` directory. ⚠️
- Makes polygon-based semantic segmentation setup clearer and reduces configuration errors.
- Ensures users understand how class labels and background pixels are handled during training. ✅