### PR TITLE
Add depth8 debug dataset with auto-download

### DIFF
--- a/docs/en/datasets/depth/depth8.md
+++ b/docs/en/datasets/depth/depth8.md
@@ -1,0 +1,99 @@
+---
+comments: true
+description: Explore the Ultralytics Depth8 dataset, a compact set of 8 indoor RGB-D images for testing monocular depth estimation models and training pipelines.
+keywords: Depth8, Ultralytics, dataset, depth estimation, monocular depth, YOLO26, training, validation, debugging, SUN RGB-D
+---
+
+# Depth8 Dataset
+
+## Introduction
+
+The [Ultralytics](https://www.ultralytics.com/) Depth8 dataset is a compact [monocular depth estimation](index.md) dataset with 8 images sampled from the [SUN RGB-D](sunrgbd.md) dataset: 4 for training and 4 for validation, one per RGB-D sensor (Kinect v1, Kinect v2, Intel RealSense, Asus Xtion) in each split. It is designed for rapid testing, debugging, and experimentation with [YOLO26](../../models/yolo26.md) depth estimation models and training pipelines — the 1.5 MB archive auto-downloads on first use, so `yolo depth train data=depth8.yaml` starts training within seconds.
+
+!!! note
+
+    Depth8 is for pipeline testing only, not benchmarking — its 8 images are far too few for meaningful depth metrics. Use the full [NYU Depth V2](nyu-depth-v2.md) or [SUN RGB-D](sunrgbd.md) validation sets for representative results.
+
+## Dataset Structure
+
+Depth8 follows the standard [Ultralytics depth dataset layout](index.md#supported-dataset-format): RGB images with paired `.npy` float32 depth maps in meters, matched by file stem.
+
+```text
+depth8/
+├── images/
+│   ├── train/  # 4 images
+│   └── val/    # 4 images
+└── depth/
+    ├── train/  # 4 float32 .npy depth maps
+    └── val/    # 4 float32 .npy depth maps
+```
+
+Depth values are real indoor sensor captures ranging from roughly 0.6 m to 9 m, matching the ≤10 m range of the full SUN RGB-D dataset.
+
+## Dataset YAML
+
+The Depth8 dataset configuration is defined in a dataset YAML file, which specifies dataset paths, class names, and the download URL for the small packaged subset.
+
+!!! example "ultralytics/cfg/datasets/depth8.yaml"
+
+    ```yaml
+    --8<-- "ultralytics/cfg/datasets/depth8.yaml"
+    ```
+
+## Usage
+
+To train a YOLO26n-depth model on the Depth8 dataset with an image size of 640, use the following examples. For a full list of training options, see the [YOLO Training documentation](../../modes/train.md).
+
+!!! example "Train Example"
+
+    === "Python"
+
+        ```python
+        from ultralytics import YOLO
+
+        # Load a pretrained YOLO26n-depth model
+        model = YOLO("yolo26n-depth.pt")
+
+        # Train the model on Depth8
+        results = model.train(data="depth8.yaml", epochs=100, imgsz=640)
+        ```
+
+    === "CLI"
+
+        ```bash
+        # Train YOLO26n-depth on Depth8 using the command line
+        yolo depth train data=depth8.yaml model=yolo26n-depth.pt epochs=100 imgsz=640
+        ```
+
+## Citations and Acknowledgments
+
+Depth8 is sampled from SUN RGB-D — see the full [SUN RGB-D dataset page](sunrgbd.md#citations-and-acknowledgments) for license details.
+
+If you use the SUN RGB-D dataset in your research or development work, please cite the following paper:
+
+!!! quote ""
+
+    === "BibTeX"
+
+        ```bibtex
+        @inproceedings{song2015sunrgbd,
+              title={SUN RGB-D: A RGB-D Scene Understanding Benchmark Suite},
+              author={Song, Shuran and Lichtenberg, Samuel P. and Xiao, Jianxiong},
+              booktitle={Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR)},
+              year={2015}
+        }
+        ```
+
+## FAQ
+
+### What is the Ultralytics Depth8 dataset used for?
+
+The Ultralytics Depth8 dataset is designed for rapid testing and debugging of [monocular depth estimation](../../tasks/depth.md) pipelines. With only 8 images (4 train, 4 val) in a 1.5 MB auto-downloading archive, it verifies the full train / val / predict cycle — paired depth-map loading, augmentation, loss computation, and metrics — in seconds, before scaling to a full dataset such as [SUN RGB-D](sunrgbd.md) or [NYU Depth V2](nyu-depth-v2.md).
+
+### How does Depth8 differ from the full SUN RGB-D dataset?
+
+Depth8 samples 8 images from SUN RGB-D's 9,245-train/1,090-val split, keeping one image per RGB-D sensor per split. It uses the identical directory layout and `.npy` depth format, so a pipeline that runs on Depth8 runs unmodified on the full dataset — just point `data=` at `depth-sunrgbd.yaml` instead of `depth8.yaml`. Unlike the full dataset, Depth8 downloads in seconds and needs no conversion step.
+
+### Should I use Depth8 for benchmarking?
+
+No. Depth8 is too small for meaningful model comparison and is intended for training and evaluation pipeline checks. Use the full [NYU Depth V2](nyu-depth-v2.md) or [SUN RGB-D](sunrgbd.md) validation sets when you need representative depth estimation metrics.

--- a/docs/en/datasets/depth/index.md
+++ b/docs/en/datasets/depth/index.md
@@ -82,6 +82,10 @@ Train a YOLO26 depth estimation model with Python or CLI:
 
 The YOLO26 depth models are pretrained on a broad multi-dataset mix (~2.19M images) spanning indoor (≤10 m) to outdoor (~80 m) ranges, then evaluated zero-shot across five benchmarks. Each dataset has a dedicated page:
 
+**Debugging**
+
+- [Depth8](depth8.md) — 8 SUN RGB-D images in a 1.5 MB auto-downloading archive, for rapid pipeline testing
+
 **Pretraining sources**
 
 - [ARKitScenes](arkitscenes.md) — real indoor, Apple ARKit LiDAR (largest real source)

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -84,7 +84,7 @@ The largest gains are on the longer-range outdoor benchmarks (KITTI, ETH3D) — 
 
 ## Train
 
-Train YOLO26n-depth on the NYU Depth V2 dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
+Train YOLO26n-depth on the [Depth8](../datasets/depth/depth8.md) dataset for 100 [epochs](https://www.ultralytics.com/glossary/epoch) at image size 640. For a full list of available arguments see the [Configuration](../usage/cfg.md) page.
 
 !!! example
 
@@ -99,20 +99,20 @@ Train YOLO26n-depth on the NYU Depth V2 dataset for 100 [epochs](https://www.ult
         model = YOLO("yolo26n-depth.yaml").load("yolo26n-depth.pt")  # build from YAML and transfer weights
 
         # Train the model
-        results = model.train(data="nyu-depth.yaml", epochs=100, imgsz=640)
+        results = model.train(data="depth8.yaml", epochs=100, imgsz=640)
         ```
 
     === "CLI"
 
         ```bash
         # Build a new model from YAML and start training from scratch
-        yolo depth train data=nyu-depth.yaml model=yolo26n-depth.yaml epochs=100 imgsz=640
+        yolo depth train data=depth8.yaml model=yolo26n-depth.yaml epochs=100 imgsz=640
 
         # Start training from a pretrained *.pt model
-        yolo depth train data=nyu-depth.yaml model=yolo26n-depth.pt epochs=100 imgsz=640
+        yolo depth train data=depth8.yaml model=yolo26n-depth.pt epochs=100 imgsz=640
 
         # Build a new model from YAML, transfer pretrained weights to it and start training
-        yolo depth train data=nyu-depth.yaml model=yolo26n-depth.yaml pretrained=yolo26n-depth.pt epochs=100 imgsz=640
+        yolo depth train data=depth8.yaml model=yolo26n-depth.yaml pretrained=yolo26n-depth.pt epochs=100 imgsz=640
         ```
 
 See full `train` mode details in the [Train](../modes/train.md) page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -477,6 +477,7 @@ nav:
       - Depth Estimation:
           - datasets/depth/index.md
           - ARKitScenes: datasets/depth/arkitscenes.md
+          - Depth8: datasets/depth/depth8.md
           - DIODE: datasets/depth/diode.md
           - ETH3D: datasets/depth/eth3d.md
           - Hypersim: datasets/depth/hypersim.md

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -125,11 +125,12 @@ def test_task(trainer_cls, validator_cls, predictor_cls, data, model, weights):
 
 
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
-def test_depth_engine_cycle():
+def test_depth_engine_cycle(tmp_path):
     """Test depth estimation train / val / predict cycle on the auto-downloading depth8 dataset."""
+    args = {"data": "depth8.yaml", "imgsz": 32, "batch": 2, "device": "cpu", "plots": False, "project": str(tmp_path)}
     m = YOLO("ultralytics/cfg/models/26/yolo26-depth.yaml")
-    m.train(data="depth8.yaml", epochs=1, imgsz=32, batch=2, device="cpu", cache=False, plots=False, workers=0)
-    m.val(data="depth8.yaml", imgsz=32, batch=2, device="cpu", plots=False)
+    m.train(epochs=1, cache=False, workers=0, **args)
+    m.val(**args)
     r = m.predict(SOURCE, imgsz=32, device="cpu")
     assert r[0].depth is not None, "predict() should return a result with a depth map"
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-import cv2
-import numpy as np
 import pytest
 import torch
 
@@ -19,7 +17,7 @@ from ultralytics.engine.trainer import BaseTrainer
 from ultralytics.models.yolo import classify, detect, obb, pose, segment, semantic
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.tasks import DetectionModel, load_checkpoint
-from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_JETSON, IS_RASPBERRYPI, WEIGHTS_DIR, YAML
+from ultralytics.utils import ASSETS, DEFAULT_CFG, IS_JETSON, IS_RASPBERRYPI, WEIGHTS_DIR
 from ultralytics.utils.torch_utils import unwrap_model
 
 
@@ -126,40 +124,13 @@ def test_task(trainer_cls, validator_cls, predictor_cls, data, model, weights):
         trainer_cls(overrides={**overrides, "resume": trainer.last}).train()
 
 
-def _make_depth_dataset(root):
-    """Build a tiny hermetic depth dataset under *root* and return the YAML path.
-
-    Layout mirrors what DepthDataset expects:
-        <root>/images/<split>/*.jpg   — RGB images
-        <root>/depth/<split>/*.npy    — float32 (H, W) depth maps
-
-    DepthDataset._depth_path_for() maps image → depth paths by renaming the last 'images' path component to 'depth' and
-    swapping the suffix to .npy, so basenames must match exactly.
-    """
-    root = Path(root)
-    for split in ("train", "val"):
-        (root / "images" / split).mkdir(parents=True, exist_ok=True)
-        (root / "depth" / split).mkdir(parents=True, exist_ok=True)
-        for i in range(4):
-            img = (np.random.rand(64, 64, 3) * 255).astype("uint8")
-            cv2.imwrite(str(root / "images" / split / f"{i}.jpg"), img)
-            np.save(root / "depth" / split / f"{i}.npy", (np.random.rand(64, 64) * 10).astype("float32"))
-
-    yaml_path = root / "depth8.yaml"
-    YAML.save(
-        yaml_path, {"path": str(root), "train": "images/train", "val": "images/val", "nc": 1, "names": {0: "depth"}}
-    )
-    return str(yaml_path)
-
-
 @pytest.mark.skipif(IS_JETSON or IS_RASPBERRYPI, reason="Edge devices not intended for training")
-def test_depth_engine_cycle(tmp_path):
-    """Test depth estimation train / val / predict cycle using a hermetic synthetic dataset."""
-    data = _make_depth_dataset(tmp_path)
+def test_depth_engine_cycle():
+    """Test depth estimation train / val / predict cycle on the auto-downloading depth8 dataset."""
     m = YOLO("ultralytics/cfg/models/26/yolo26-depth.yaml")
-    m.train(data=data, epochs=1, imgsz=32, batch=2, device="cpu", cache=False, plots=False, workers=0)
-    m.val(data=data, imgsz=32, batch=2, device="cpu", plots=False)
-    r = m.predict(str(tmp_path / "images" / "val" / "0.jpg"), imgsz=32, device="cpu")
+    m.train(data="depth8.yaml", epochs=1, imgsz=32, batch=2, device="cpu", cache=False, plots=False, workers=0)
+    m.val(data="depth8.yaml", imgsz=32, batch=2, device="cpu", plots=False)
+    r = m.predict(SOURCE, imgsz=32, device="cpu")
     assert r[0].depth is not None, "predict() should return a result with a depth map"
 
 

--- a/ultralytics/cfg/datasets/depth8.yaml
+++ b/ultralytics/cfg/datasets/depth8.yaml
@@ -1,0 +1,24 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Depth8 dataset (8 images from SUN RGB-D, one per RGB-D sensor per split) by Ultralytics
+# Documentation: https://docs.ultralytics.com/datasets/depth/depth8
+# Example usage: yolo depth train data=depth8.yaml model=yolo26n-depth.pt
+# parent
+# ├── ultralytics
+# └── datasets
+#     └── depth8 ← downloads here (1.5 MB)
+#         ├── images/{train,val}  # RGB images
+#         └── depth/{train,val}   # paired *.npy, float32 meters (images/ -> depth/)
+
+path: depth8 # dataset root dir (relative to Ultralytics settings 'datasets_dir')
+train: images/train # train images (relative to 'path') 4 images
+val: images/val # val images (relative to 'path') 4 images
+
+nc: 1
+names:
+  0: depth
+
+channels: 3
+
+# Download script/URL (optional)
+download: https://github.com/ultralytics/assets/releases/download/v0.0.0/depth8.zip


### PR DESCRIPTION
## Summary

Adds `depth8`, the depth-task counterpart of [coco8](https://docs.ultralytics.com/datasets/detect/coco8/)/`cityscapes8`: an 8-image SUN RGB-D subset (4 train / 4 val, one image per RGB-D sensor — Kinect v1/v2, RealSense, Xtion — per split) packaged as a 1.5 MB zip and uploaded to the `ultralytics/assets` `v0.0.0` release, so

```bash
yolo depth train data=depth8.yaml model=yolo26n-depth.pt
```

auto-downloads everything and starts training in seconds.

## Changes

- `ultralytics/cfg/datasets/depth8.yaml` — coco8-style dataset config with assets download URL
- `docs/en/datasets/depth/depth8.md` — dataset page (modeled on `cityscapes8.md`), linked from the depth datasets index and mkdocs nav
- `docs/en/tasks/depth.md` — Train quickstart examples now use `depth8.yaml` (mirrors detect's `coco8.yaml`); Val examples keep `nyu-depth.yaml` since that is the benchmark
- `tests/test_engine.py` — `test_depth_engine_cycle` now trains/vals on the real `depth8.yaml`, giving the shipped YAML and archive CI coverage

Deleted: `tests/test_engine.py::_make_depth_dataset()` synthetic-fixture (24 lines) and its now-unused `cv2`/`numpy`/`YAML` imports — replaced by the real auto-downloading dataset, consistent with how other tasks test against coco8.

## Verification

- Local: `pytest tests/test_engine.py::test_depth_engine_cycle` passes in 3.7 s with a cold datasets dir (verified the zip downloads fresh)
- ultra7 end-to-end with fresh `YOLO_CONFIG_DIR` + empty datasets dir: `yolo depth train data=depth8.yaml model=yolo26n-depth.pt epochs=1` completed download → train → val in 8.8 s total (both the GitHub release URL and the ultralytics.com CDN mirror serve the zip)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📘 Adds the compact **Depth8** dataset and integrates it into YOLO26 depth-estimation documentation and automated testing.

### 📊 Key Changes

- Added documentation for Depth8, an 8-image subset of SUN RGB-D with:
  - 4 training and 4 validation images.
  - Paired RGB images and float32 `.npy` depth maps.
  - A small 1.5 MB archive that downloads automatically.
- Added `depth8.yaml` dataset configuration with the download URL, directory structure, and dataset metadata.
- Updated depth-estimation documentation and navigation to feature Depth8 as a rapid debugging dataset.
- Changed the depth training examples from NYU Depth V2 to Depth8 for faster initial experimentation.
- Updated `test_depth_engine_cycle` to use the auto-downloading Depth8 dataset instead of generating a synthetic dataset locally.
- Removed now-unneeded OpenCV, NumPy, and YAML imports from the engine tests.

### 🎯 Purpose & Impact

- ⚡ Enables developers to verify YOLO26 depth training, validation, prediction, data loading, and metrics in seconds.
- 🧪 Makes depth pipeline testing more realistic by using sampled SUN RGB-D data and genuine sensor depth maps.
- 📦 Simplifies setup through automatic dataset downloading and a standard dataset layout compatible with larger depth datasets.
- ✅ Improves test coverage by exercising the full depth workflow with a packaged dataset.
- ⚠️ Depth8 is intended for debugging and pipeline checks—not meaningful benchmarking; users should use full SUN RGB-D or NYU Depth V2 datasets for representative metrics.