### PR TITLE
Document Enterprise On Premise workers

### DIFF
--- a/docs/en/platform/account/activity.md
+++ b/docs/en/platform/account/activity.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Account Activity Feed
 comments: true
 description: Track all account activity and events on Ultralytics Platform with the activity feed, including training, uploads, and system events.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, activity feed, audit log, notifications, event t
 ---
 
 # Activity Feed
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides a comprehensive activity feed that tracks all events and actions across your account. Monitor training progress and system events in one centralized location.
 

--- a/docs/en/platform/account/activity.md
+++ b/docs/en/platform/account/activity.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, activity feed, audit log, notifications, event t
 
 # Activity Feed
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) provides a comprehensive activity feed that tracks all events and actions across your account. Monitor training progress and system events in one centralized location.
 
 ![Ultralytics Platform Activity Page Inbox Tab With Event List](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/activity-page-inbox-tab-with-event-list.avif)

--- a/docs/en/platform/account/api-keys.md
+++ b/docs/en/platform/account/api-keys.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: API Key Management
 comments: true
 description: Create and manage API keys for Ultralytics Platform with secure AES-256-GCM encryption for remote training and programmatic access.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, API keys, authentication, remote training, secur
 ---
 
 # API Keys
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) API keys enable secure programmatic access for remote training, inference, and automation. Create named keys with AES-256-GCM encryption for different use cases.
 

--- a/docs/en/platform/account/api-keys.md
+++ b/docs/en/platform/account/api-keys.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, API keys, authentication, remote training, secur
 
 # API Keys
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) API keys enable secure programmatic access for remote training, inference, and automation. Create named keys with AES-256-GCM encryption for different use cases.
 
 ![Ultralytics Platform Settings Profile Tab Api Keys Section With Key List](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-profile-tab-api-keys-section-with-key-list.avif)

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Billing & Credits
 comments: true
 description: Manage credits, payments, and subscriptions on Ultralytics Platform with transparent pricing for cloud training and deployments.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, billing, credits, pricing, subscription, payment
 ---
 
 # Billing
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) uses a credit-based billing system for cloud training and dedicated endpoints. Add credits, track usage, and manage your subscription from `Settings > Billing`.
 

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, billing, credits, pricing, subscription, payment
 
 # Billing
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) uses a credit-based billing system for cloud training and dedicated endpoints. Add credits, track usage, and manage your subscription from `Settings > Billing`.
 
 ![Ultralytics Platform Settings Billing Tab Credit Balance And Plan Card](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-billing-tab-credit-balance-and-plan-card.avif)
@@ -79,7 +81,7 @@ For organizations with advanced needs:
 - Unlimited models, storage, trainings, and deployments · 50 GB dataset upload limit
 - Enterprise License (commercial use, non-AGPL)
 - SSO / SAML authentication
-- On-premise deployment (coming soon)
+- [On Premise](../integrations/on-premise.md) data and compute
 - ISO/SOC compliance (coming soon)
 - SLA guarantees (coming soon)
 - Enterprise support

--- a/docs/en/platform/account/billing.md
+++ b/docs/en/platform/account/billing.md
@@ -82,8 +82,8 @@ For organizations with advanced needs:
 - Enterprise License (commercial use, non-AGPL)
 - SSO / SAML authentication
 - [On Premise](../integrations/on-premise.md) data and compute
-- ISO/SOC compliance (coming soon)
-- SLA guarantees (coming soon)
+- [ISO/IEC 27001:2022 and SOC 2 Type I compliance](https://www.ultralytics.com/security)
+- Enterprise SLA guarantees
 - Enterprise support
 
 See [Ultralytics Licensing](https://www.ultralytics.com/license) for Enterprise plan details.

--- a/docs/en/platform/account/index.md
+++ b/docs/en/platform/account/index.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Manage your Ultralytics Platform account including API keys, billing, and user settings with security and GDPR compliance.
 keywords: Ultralytics Platform, account, settings, API keys, billing, security, GDPR
 ---
 
 # Account Management
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive account management for API keys, billing, teams, and user settings. Manage your account securely with GDPR-compliant data handling.
 

--- a/docs/en/platform/account/index.md
+++ b/docs/en/platform/account/index.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, account, settings, API keys, billing, security, 
 
 # Account Management
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive account management for API keys, billing, teams, and user settings. Manage your account securely with GDPR-compliant data handling.
 
 <p align="center">

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -7,6 +7,8 @@ title: Account Settings
 
 # Settings
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) settings allow you to configure your profile, social links, workspace preferences, and manage your data with GDPR-compliant export and deletion options.
 
 Settings is organized into seven tabs (in order): `Profile`, `API Keys`, `Plans`, `Billing`, `Teams`, `Integrations`, and `Trash`.
@@ -304,6 +306,7 @@ The `Integrations` tab lets you import datasets and projects from external servi
 
 - **Ultralytics HUB** — import your existing datasets and projects from [Ultralytics HUB](../integrations/ultralytics-hub.md).
 - **Roboflow** — import annotated datasets from a [Roboflow](../integrations/roboflow.md) workspace using a Roboflow API key.
+- **On Premise** — connect Enterprise CPU/GPU workers and keep dataset pixels on your own host. See [On Premise](../integrations/on-premise.md).
 - **Weights & Biases** — experiment-tracking sync (coming soon).
 
 See [Integrations](../integrations/index.md) for the full list of supported services.

--- a/docs/en/platform/account/settings.md
+++ b/docs/en/platform/account/settings.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Configure your Ultralytics Platform profile, preferences, and data settings with GDPR-compliant data export and deletion options.
 keywords: Ultralytics Platform, settings, profile, preferences, GDPR, data export, privacy
@@ -6,8 +7,6 @@ title: Account Settings
 ---
 
 # Settings
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) settings allow you to configure your profile, social links, workspace preferences, and manage your data with GDPR-compliant export and deletion options.
 

--- a/docs/en/platform/account/teams.md
+++ b/docs/en/platform/account/teams.md
@@ -1,4 +1,5 @@
 ---
+plans: [pro, enterprise]
 title: Team Management & Roles
 comments: true
 description: Create and manage teams on Ultralytics Platform with role-based access control, shared resources, and enterprise features for collaborative computer vision workflows.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, teams, collaboration, enterprise, roles, permiss
 ---
 
 # Teams
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) team features enable collaborative computer vision workflows. Create a team workspace to share datasets, projects, models, and deployments with your colleagues using role-based access control.
 

--- a/docs/en/platform/account/teams.md
+++ b/docs/en/platform/account/teams.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, teams, collaboration, enterprise, roles, permiss
 
 # Teams
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) team features enable collaborative computer vision workflows. Create a team workspace to share datasets, projects, models, and deployments with your colleagues using role-based access control.
 
 ![Ultralytics Platform Teams Member List With Roles](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-teams-tab-member-list-with-roles.avif)

--- a/docs/en/platform/account/trash.md
+++ b/docs/en/platform/account/trash.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, trash, restore, soft delete, recover, deleted it
 
 # Trash and Restore
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) implements a 30-day soft delete policy, allowing you to recover accidentally deleted projects, datasets, and models. Deleted items are moved to Trash where they can be restored before permanent deletion.
 
 ![Ultralytics Platform Settings Trash Tab With Items And Storage Treemap](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/settings-trash-tab-with-items-and-storage-treemap.avif)

--- a/docs/en/platform/account/trash.md
+++ b/docs/en/platform/account/trash.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Learn how to recover deleted projects, datasets, and models from Trash on Ultralytics Platform with the 30-day soft delete policy.
 keywords: Ultralytics Platform, trash, restore, soft delete, recover, deleted items, data recovery
 ---
 
 # Trash and Restore
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) implements a 30-day soft delete policy, allowing you to recover accidentally deleted projects, datasets, and models. Deleted items are moved to Trash where they can be restored before permanent deletion.
 

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Complete REST API reference for Ultralytics Platform including authentication, endpoints, and examples for datasets, models, and deployments.
 keywords: Ultralytics Platform, REST API, API reference, authentication, endpoints, YOLO, programmatic access
 ---
 
 # REST API Reference
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides a comprehensive REST API for programmatic access to datasets, models, training, and deployments.
 

--- a/docs/en/platform/api/index.md
+++ b/docs/en/platform/api/index.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, REST API, API reference, authentication, endpoin
 
 # REST API Reference
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) provides a comprehensive REST API for programmatic access to datasets, models, training, and deployments.
 
 ![Ultralytics Platform Api Overview](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-api-overview.avif)

--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Learn to annotate images in Ultralytics Platform with manual tools, skeleton templates for pose estimation, and Smart annotation with SAM and YOLO models for detect, segment, semantic, and OBB tasks.
 keywords: Ultralytics Platform, annotation, labeling, SAM, auto-annotation, bounding box, polygon, keypoints, skeleton templates, pose estimation, segmentation, YOLO
 ---
 
 # Annotation Editor
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) includes a powerful annotation editor for labeling images with bounding boxes, polygons, keypoints, oriented boxes, and classifications. The editor supports manual drawing and [SAM-powered smart annotation](https://www.ultralytics.com/annotate).
 

--- a/docs/en/platform/data/annotation.md
+++ b/docs/en/platform/data/annotation.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, annotation, labeling, SAM, auto-annotation, boun
 
 # Annotation Editor
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) includes a powerful annotation editor for labeling images with bounding boxes, polygons, keypoints, oriented boxes, and classifications. The editor supports manual drawing and [SAM-powered smart annotation](https://www.ultralytics.com/annotate).
 
 ![Ultralytics Platform Annotate Editor Toolbar With Canvas](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-annotate-editor-toolbar-with-canvas.avif)

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, datasets, dataset management, dataset versioning
 
 # Datasets
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) datasets provide a streamlined solution for managing your training data. After upload, the platform processes images, labels, and statistics automatically. A dataset is ready to train once processing has completed and it has at least one image in the `train` split, at least one image in either the `val` or `test` split, at least one labeled image, and a total of at least two images.
 
 ## Upload Dataset
@@ -15,7 +17,7 @@ Ultralytics Platform accepts multiple upload formats for flexibility.
 
 !!! tip "Already have data elsewhere?"
 
-    If you already have datasets in [Ultralytics HUB](../integrations/ultralytics-hub.md) or [Roboflow](../integrations/roboflow.md), use [Integrations](../integrations/index.md) to import them directly — no manual export or re-upload needed. Data in [Google Cloud Storage](../integrations/google-cloud-storage.md), [Amazon S3](../integrations/amazon-s3.md), or [Azure Blob Storage](../integrations/azure-blob-storage.md) can be used in place: the **Cloud storage** tab in **New Dataset** indexes your images and YOLO labels without copying them into Platform.
+    If you already have datasets in [Ultralytics HUB](../integrations/ultralytics-hub.md) or [Roboflow](../integrations/roboflow.md), use [Integrations](../integrations/index.md) to import them directly — no manual export or re-upload needed. Data in [Google Cloud Storage](../integrations/google-cloud-storage.md), [Amazon S3](../integrations/amazon-s3.md), or [Azure Blob Storage](../integrations/azure-blob-storage.md) can be used in place through **Cloud storage**. Enterprise workspaces can use [On Premise](../integrations/on-premise.md) to index and train on local data without sending pixels to Platform.
 
 ### Supported Formats
 

--- a/docs/en/platform/data/datasets.md
+++ b/docs/en/platform/data/datasets.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Dataset Management
 comments: true
 description: Learn how to upload, manage, and organize datasets in Ultralytics Platform for YOLO model training with automatic processing and statistics.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, datasets, dataset management, dataset versioning
 ---
 
 # Datasets
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) datasets provide a streamlined solution for managing your training data. After upload, the platform processes images, labels, and statistics automatically. A dataset is ready to train once processing has completed and it has at least one image in the `train` split, at least one image in either the `val` or `test` split, at least one labeled image, and a total of at least two images.
 

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Learn about data management in Ultralytics Platform including dataset upload, annotation tools, and statistics visualization for YOLO model training.
 keywords: Ultralytics Platform, data management, datasets, annotation, YOLO, computer vision, data preparation, labeling
 ---
 
 # Data Preparation
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 Data preparation is the foundation of successful [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models. [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive tools for managing your training data, from upload through annotation to analysis.
 

--- a/docs/en/platform/data/index.md
+++ b/docs/en/platform/data/index.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, data management, datasets, annotation, YOLO, com
 
 # Data Preparation
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 Data preparation is the foundation of successful [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) models. [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive tools for managing your training data, from upload through annotation to analysis.
 
 <p align="center">
@@ -25,6 +27,7 @@ The Data section of Ultralytics Platform helps you:
 
 - **Upload** images, videos, and dataset files (ZIP, TAR including `.tar.gz`/`.tgz`, NDJSON)
 - **Connect** [Google Cloud Storage](../integrations/google-cloud-storage.md), [Amazon S3](../integrations/amazon-s3.md), or [Azure Blob Storage](../integrations/azure-blob-storage.md) and use your data in place without uploading a copy
+- **Keep pixels on premise** with Enterprise [On Premise](../integrations/on-premise.md) CPU/GPU workers
 - **Annotate** with manual drawing tools and SAM-powered smart labeling — choose from [SAM 2.1](../../models/sam-2.md) or the new [SAM 3](../../models/sam-3.md)
 - **Analyze** your data with statistics and visualizations
 - **Export** in [NDJSON format](../../datasets/detect/index.md#ultralytics-ndjson-format) for local training

--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, deployment, endpoints, YOLO, production, scaling
 
 # Dedicated Endpoints
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) enables deployment of YOLO models to dedicated endpoints in 43 global regions. Each endpoint is a single-tenant service with scale-to-zero behavior, a unique endpoint URL, and independent monitoring.
 
 ![Ultralytics Platform Model Deploy Tab With Region Map And Table](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/model-deploy-tab-with-region-map-and-table.avif)

--- a/docs/en/platform/deploy/endpoints.md
+++ b/docs/en/platform/deploy/endpoints.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Deploy YOLO models to dedicated endpoints in 43 global regions with scale-to-zero behavior and monitoring on Ultralytics Platform.
 keywords: Ultralytics Platform, deployment, endpoints, YOLO, production, scaling, global regions
 ---
 
 # Dedicated Endpoints
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) enables deployment of YOLO models to dedicated endpoints in 43 global regions. Each endpoint is a single-tenant service with scale-to-zero behavior, a unique endpoint URL, and independent monitoring.
 

--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, deployment, inference, endpoints, monitoring, YO
 
 # Deployment
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive deployment options for putting your YOLO models into production. Test models with browser-based inference, deploy to dedicated endpoints across 43 global regions, and monitor performance in real-time.
 
 <p align="center">

--- a/docs/en/platform/deploy/index.md
+++ b/docs/en/platform/deploy/index.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Model Deployment Options
 comments: true
 description: Learn about model deployment options in Ultralytics Platform including inference testing, dedicated endpoints, and monitoring dashboards.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, deployment, inference, endpoints, monitoring, YO
 ---
 
 # Deployment
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive deployment options for putting your YOLO models into production. Test models with browser-based inference, deploy to dedicated endpoints across 43 global regions, and monitor performance in real-time.
 

--- a/docs/en/platform/deploy/inference.md
+++ b/docs/en/platform/deploy/inference.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, inference, API, YOLO, object detection, predicti
 
 # Inference
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) provides an inference API for testing trained models. Use the browser-based `Predict` tab for quick validation or the [REST API](../api/index.md#models-api) for programmatic access.
 
 ![Ultralytics Platform Model Predict Tab With Detections Overlay](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/model-predict-tab-with-detections-overlay.avif)

--- a/docs/en/platform/deploy/inference.md
+++ b/docs/en/platform/deploy/inference.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Inference API Testing
 comments: true
 description: Learn how to test YOLO models with the Ultralytics Platform inference API including browser testing and programmatic access.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, inference, API, YOLO, object detection, predicti
 ---
 
 # Inference
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides an inference API for testing trained models. Use the browser-based `Predict` tab for quick validation or the [REST API](../api/index.md#models-api) for programmatic access.
 

--- a/docs/en/platform/deploy/monitoring.md
+++ b/docs/en/platform/deploy/monitoring.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Deployment Monitoring
 comments: true
 description: Monitor deployed YOLO models on Ultralytics Platform with real-time metrics, request logs, and performance dashboards.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, monitoring, metrics, logs, deployment, performan
 ---
 
 # Monitoring
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides monitoring for deployed endpoints. Track request metrics, view logs, and check health status with automatic polling.
 

--- a/docs/en/platform/deploy/monitoring.md
+++ b/docs/en/platform/deploy/monitoring.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, monitoring, metrics, logs, deployment, performan
 
 # Monitoring
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) provides monitoring for deployed endpoints. Track request metrics, view logs, and check health status with automatic polling.
 
 ![Ultralytics Platform Deploy Page Overview Cards And World Map](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/deploy-page-overview-cards-and-world-map.avif)

--- a/docs/en/platform/explore.md
+++ b/docs/en/platform/explore.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Explore Datasets & Projects
 comments: true
 description: Discover public datasets and projects on the Ultralytics Platform Explore page. Browse, search, and clone community content for computer vision and YOLO.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, explore, public datasets, public projects, compu
 ---
 
 # Explore
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) Explore page showcases public content from the community. Discover [datasets](data/datasets.md) and [projects](train/projects.md) for inspiration and learning. The Explore page is accessible to everyone — even without signing in.
 

--- a/docs/en/platform/explore.md
+++ b/docs/en/platform/explore.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, explore, public datasets, public projects, compu
 
 # Explore
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) Explore page showcases public content from the community. Discover [datasets](data/datasets.md) and [projects](train/projects.md) for inspiration and learning. The Explore page is accessible to everyone — even without signing in.
 
 ![Ultralytics Platform Explore Datasets Tab Cards View](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-explore-datasets-tab-cards-view.avif)

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Ultralytics Platform is an end-to-end computer vision platform for data preparation, model training, and deployment with multi-region infrastructure.
 keywords: Ultralytics Platform, YOLO, computer vision, model training, cloud deployment, annotation, inference, YOLO11, YOLO26, machine learning
 ---
 
 # Ultralytics Platform
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) is a comprehensive end-to-end computer vision platform that streamlines the entire ML workflow from data preparation to model deployment. Built for teams and individuals who need production-ready [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) solutions without the infrastructure complexity.
 

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, YOLO, computer vision, model training, cloud dep
 
 # Ultralytics Platform
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) is a comprehensive end-to-end computer vision platform that streamlines the entire ML workflow from data preparation to model deployment. Built for teams and individuals who need production-ready [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) solutions without the infrastructure complexity.
 
 ![Ultralytics Platform Dataset Screenshot](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif)

--- a/docs/en/platform/integrations/amazon-s3.md
+++ b/docs/en/platform/integrations/amazon-s3.md
@@ -11,9 +11,7 @@ title: Amazon S3 Datasets - Ultralytics Platform
 
 The [Amazon S3](https://aws.amazon.com/s3/) integration connects your S3 buckets to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your buckets — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
-!!! note "Pro feature"
-
-    Amazon S3 datasets require a [Pro or Enterprise plan](../account/billing.md#plans). Free workspaces see the integration and are prompted to upgrade when connecting. Existing Amazon S3 datasets stay fully accessible if a subscription ends — only new connections and imports require Pro.
+Existing Amazon S3 datasets stay fully accessible if a subscription ends; only new connections and imports require Pro.
 
 ## Create a Read-Only IAM User
 

--- a/docs/en/platform/integrations/amazon-s3.md
+++ b/docs/en/platform/integrations/amazon-s3.md
@@ -1,4 +1,5 @@
 ---
+plans: [pro, enterprise]
 comments: true
 description: Connect Amazon S3 to Ultralytics Platform and train YOLO models on images in your S3 buckets without uploading a copy.
 keywords: Ultralytics Platform, Amazon S3, AWS S3, S3 bucket, IAM access key, dataset import, YOLO, computer vision, cloud storage
@@ -7,11 +8,11 @@ title: Amazon S3 Datasets - Ultralytics Platform
 
 # Amazon S3 Integration
 
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Pro", "Enterprise"]) }}
-
 The [Amazon S3](https://aws.amazon.com/s3/) integration connects your S3 buckets to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your buckets — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
-Existing Amazon S3 datasets stay fully accessible if a subscription ends; only new connections and imports require Pro.
+!!! note "Pro feature"
+
+    Amazon S3 datasets require a [Pro or Enterprise plan](../account/billing.md#plans). Free workspaces see the integration and are prompted to upgrade when connecting. Existing Amazon S3 datasets stay fully accessible if a subscription ends — only new connections and imports require Pro.
 
 ## Create a Read-Only IAM User
 

--- a/docs/en/platform/integrations/amazon-s3.md
+++ b/docs/en/platform/integrations/amazon-s3.md
@@ -7,6 +7,8 @@ title: Amazon S3 Datasets - Ultralytics Platform
 
 # Amazon S3 Integration
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Pro", "Enterprise"]) }}
+
 The [Amazon S3](https://aws.amazon.com/s3/) integration connects your S3 buckets to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your buckets — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
 !!! note "Pro feature"

--- a/docs/en/platform/integrations/azure-blob-storage.md
+++ b/docs/en/platform/integrations/azure-blob-storage.md
@@ -1,4 +1,5 @@
 ---
+plans: [pro, enterprise]
 comments: true
 description: Connect Azure Blob Storage to Ultralytics Platform and train YOLO models on images in your Azure containers without uploading a copy.
 keywords: Ultralytics Platform, Azure Blob Storage, Azure storage account, blob container, connection string, dataset import, YOLO, computer vision, cloud storage
@@ -7,11 +8,11 @@ title: Azure Blob Storage Datasets - Ultralytics Platform
 
 # Azure Blob Storage Integration
 
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Pro", "Enterprise"]) }}
-
 The [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) integration connects your storage account containers to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your containers — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
-Existing Azure Blob Storage datasets stay fully accessible if a subscription ends; only new connections and imports require Pro.
+!!! note "Pro feature"
+
+    Azure Blob Storage datasets require a [Pro or Enterprise plan](../account/billing.md#plans). Free workspaces see the integration and are prompted to upgrade when connecting. Existing Azure Blob Storage datasets stay fully accessible if a subscription ends — only new connections and imports require Pro.
 
 ## Get a Connection String
 

--- a/docs/en/platform/integrations/azure-blob-storage.md
+++ b/docs/en/platform/integrations/azure-blob-storage.md
@@ -11,9 +11,7 @@ title: Azure Blob Storage Datasets - Ultralytics Platform
 
 The [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) integration connects your storage account containers to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your containers — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
-!!! note "Pro feature"
-
-    Azure Blob Storage datasets require a [Pro or Enterprise plan](../account/billing.md#plans). Free workspaces see the integration and are prompted to upgrade when connecting. Existing Azure Blob Storage datasets stay fully accessible if a subscription ends — only new connections and imports require Pro.
+Existing Azure Blob Storage datasets stay fully accessible if a subscription ends; only new connections and imports require Pro.
 
 ## Get a Connection String
 

--- a/docs/en/platform/integrations/azure-blob-storage.md
+++ b/docs/en/platform/integrations/azure-blob-storage.md
@@ -7,6 +7,8 @@ title: Azure Blob Storage Datasets - Ultralytics Platform
 
 # Azure Blob Storage Integration
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Pro", "Enterprise"]) }}
+
 The [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) integration connects your storage account containers to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your containers — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
 !!! note "Pro feature"

--- a/docs/en/platform/integrations/google-cloud-storage.md
+++ b/docs/en/platform/integrations/google-cloud-storage.md
@@ -1,4 +1,5 @@
 ---
+plans: [pro, enterprise]
 comments: true
 description: Connect Google Cloud Storage to Ultralytics Platform and train YOLO models on images in your GCS buckets without uploading a copy.
 keywords: Ultralytics Platform, Google Cloud Storage, GCS, GCS bucket, service account, dataset import, YOLO, computer vision, cloud storage
@@ -7,11 +8,11 @@ title: Google Cloud Storage Datasets - Ultralytics Platform
 
 # Google Cloud Storage Integration
 
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Pro", "Enterprise"]) }}
-
 The [Google Cloud Storage](https://cloud.google.com/storage) integration connects your GCS buckets to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your buckets — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
-Existing Google Cloud Storage datasets stay fully accessible if a subscription ends; only new connections and imports require Pro.
+!!! note "Pro feature"
+
+    Google Cloud Storage datasets require a [Pro or Enterprise plan](../account/billing.md#plans). Free workspaces see the integration and are prompted to upgrade when connecting. Existing Google Cloud Storage datasets stay fully accessible if a subscription ends — only new connections and imports require Pro.
 
 ## Create a Read-Only Service Account
 

--- a/docs/en/platform/integrations/google-cloud-storage.md
+++ b/docs/en/platform/integrations/google-cloud-storage.md
@@ -11,9 +11,7 @@ title: Google Cloud Storage Datasets - Ultralytics Platform
 
 The [Google Cloud Storage](https://cloud.google.com/storage) integration connects your GCS buckets to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your buckets — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
-!!! note "Pro feature"
-
-    Google Cloud Storage datasets require a [Pro or Enterprise plan](../account/billing.md#plans). Free workspaces see the integration and are prompted to upgrade when connecting. Existing Google Cloud Storage datasets stay fully accessible if a subscription ends — only new connections and imports require Pro.
+Existing Google Cloud Storage datasets stay fully accessible if a subscription ends; only new connections and imports require Pro.
 
 ## Create a Read-Only Service Account
 

--- a/docs/en/platform/integrations/google-cloud-storage.md
+++ b/docs/en/platform/integrations/google-cloud-storage.md
@@ -7,6 +7,8 @@ title: Google Cloud Storage Datasets - Ultralytics Platform
 
 # Google Cloud Storage Integration
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Pro", "Enterprise"]) }}
+
 The [Google Cloud Storage](https://cloud.google.com/storage) integration connects your GCS buckets to [Ultralytics Platform](https://platform.ultralytics.com). Your images stay in your buckets — Platform indexes them in place, so you can browse, annotate, and train YOLO models without uploading a copy.
 
 !!! note "Pro feature"

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Platform Integrations
 comments: true
 description: Connect Ultralytics Platform to existing tools, cloud storage, and Enterprise On Premise compute and datasets.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, integrations, data import, Roboflow, Ultralytics
 ---
 
 # Integrations
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) integrations connect your workspace to other tools and services you already use. Import existing datasets with a single API key, or connect your cloud storage and use the data where it lives — no manual export or re-upload either way.
 

--- a/docs/en/platform/integrations/index.md
+++ b/docs/en/platform/integrations/index.md
@@ -1,11 +1,13 @@
 ---
 title: Platform Integrations
 comments: true
-description: Connect Ultralytics Platform to the tools you already use. Import from Ultralytics HUB and Roboflow, or train directly on data in Google Cloud Storage, Amazon S3, and Azure Blob Storage.
-keywords: Ultralytics Platform, integrations, data import, Roboflow, Ultralytics HUB, cloud storage, GCS, Amazon S3, Azure Blob Storage, dataset migration, YOLO, computer vision
+description: Connect Ultralytics Platform to existing tools, cloud storage, and Enterprise On Premise compute and datasets.
+keywords: Ultralytics Platform, integrations, data import, Roboflow, Ultralytics HUB, cloud storage, GCS, Amazon S3, Azure Blob Storage, On Premise, dataset migration, YOLO, computer vision
 ---
 
 # Integrations
+
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) integrations connect your workspace to other tools and services you already use. Import existing datasets with a single API key, or connect your cloud storage and use the data where it lives — no manual export or re-upload either way.
 
@@ -30,6 +32,7 @@ Imports start with a preview so you can review exactly what will be transferred 
 | [**Google Cloud Storage**](google-cloud-storage.md) | Datasets indexed in place from your GCS buckets      |
 | [**Amazon S3**](amazon-s3.md)                       | Datasets indexed in place from your S3 buckets       |
 | [**Azure Blob Storage**](azure-blob-storage.md)     | Datasets indexed in place from your blob containers  |
+| [**On Premise**](on-premise.md)                     | Local CPU/GPU workers with pixels kept on your host  |
 
 Connect once and the matching content lands in your workspace. Google Cloud Storage, Amazon S3, and Azure Blob Storage connections require a [Pro or Enterprise plan](../account/billing.md#plans).
 

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -1,0 +1,88 @@
+---
+title: On Premise - Ultralytics Platform
+description: Connect an Enterprise host to Ultralytics Platform for local dataset ingest, previews, and NVIDIA GPU training without sending pixels to the cloud.
+keywords: Ultralytics Platform, On Premise, on-premise computer vision, private datasets, local GPU training, data residency, YOLO
+---
+
+# On Premise
+
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Enterprise"]) }}
+
+[On Premise](https://platform.ultralytics.com) connects CPU and optional NVIDIA GPU workers on your own Linux host to Ultralytics Platform. Platform remains the hosted control plane for the UI, authentication, metadata, annotations, and job orchestration, while every pixel and trained model artifact stays on your premises.
+
+Your host needs Docker and outbound HTTPS access to Platform. The installer adds Docker automatically when it is missing, so the normal setup is one command.
+
+## Data Boundary
+
+| Stays on your premises                                     | Stored in Platform                                  |
+| ---------------------------------------------------------- | --------------------------------------------------- |
+| Source images and videos                                   | Dataset names, paths, dimensions, and revisions     |
+| Extracted archives, downloaded NDJSON images, video frames | Classes, labels, annotations, and split assignments |
+| Training data, checkpoints, weights, and run artifacts     | Job state, scalar metrics, and worker health        |
+
+Dataset folders are mounted read-only. Platform and its hosted workers never receive the source or derived pixels, and On Premise jobs never fall back to Ultralytics or RunPod compute.
+
+!!! note "Connected On Premise"
+
+    Platform, authentication, and metadata remain hosted. Workers initiate outbound HTTPS connections to claim jobs and report metadata. On Premise is not an air-gapped or fully self-hosted Platform installation, and it does not require a local MongoDB instance.
+
+## Connect a Host
+
+1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux host that can access your datasets.
+2. Go to `Settings > Integrations` and select **Connect** on the **On premise** card.
+3. Keep the prefilled values or change them:
+    - **Machine name:** `On Premise host`
+    - **Dataset folder:** `/datasets`
+    - **Models folder:** `/models`
+4. Select **Create install command**.
+5. Copy and run the generated command on the host. It installs Docker Compose when needed, creates the selected folders, starts the CPU worker, and starts the GPU worker automatically when `nvidia-smi` is available.
+6. Close the dialog when the host shows as connected.
+
+The command contains a one-time enrollment token that expires after 10 minutes. The installed worker exchanges it for a revocable worker key stored in a mode-`0600` environment file. It never receives Platform MongoDB or cloud-storage credentials.
+
+!!! info "NVIDIA training"
+
+    CPU ingest only needs Docker. On-premise GPU training also requires a supported NVIDIA driver and NVIDIA Container Toolkit on the host.
+
+## Create an On-Premise Dataset
+
+1. Put the dataset beneath the connected dataset folder. For example, `/datasets/warehouse` is `warehouse` inside the default root.
+2. In Platform, select **New Dataset > On premise**.
+3. Select the connected host, enter the relative dataset path, choose the task and visibility, and create the dataset.
+4. The host indexes the dataset and reports metadata. Platform never uploads the images.
+
+On Premise uses the same CPU ingest code as hosted uploads. It supports:
+
+- loose images and videos;
+- ZIP, TAR, TAR.GZ, and TGZ archives;
+- Ultralytics NDJSON and COCO JSON;
+- YOLO datasets and classification folder layouts; and
+- detect, segment, pose, OBB, and classify tasks, including the same class mapping, task inference, validation, and split handling.
+
+The storage output is the only difference. Hosted ingestion may resize or normalize images and create thumbnails in Platform storage. On Premise never resizes, re-encodes, edits, or deletes mounted originals. Archive contents, remote NDJSON assets, and 1 FPS video frames are written only to a Docker volume on the host.
+
+## Preview and Annotate
+
+Platform authorizes each preview, then your browser loads the revision-bound file directly from `http://localhost:8765` on the same computer. No hostname, certificate, VPN, proxy, or preview setting is required.
+
+Annotations are stored as Platform metadata. Editing or deleting an image in Platform changes the Platform reference and annotations only; it never changes a source file or label sidecar.
+
+## Train on a Local GPU
+
+Start training from the normal project training dialog. A dataset bound to an On Premise host is claimable only by that host's GPU worker. Training reads the mounted files, writes checkpoints and weights beneath the configured models folder, and returns job state and scalar metrics to Platform.
+
+On-premise training does not consume Platform compute credits. Ultralytics hosted workers and RunPod cannot claim the job or read its pixels or artifacts.
+
+## Manage the Worker
+
+Use the **On premise** card in `Settings > Integrations` to view CPU/GPU availability, reconnect a host, or disconnect it. Reconnecting rotates the worker secret without changing existing dataset identity. Disconnecting revokes future claims and preview access; it does not delete datasets, source files, cached pixels, or model artifacts from the host.
+
+To inspect or stop the installation on the host:
+
+```bash
+cd /opt/ultralytics-worker
+docker compose logs -f
+docker compose down
+```
+
+Also see [Datasets](../data/datasets.md), [Annotation](../data/annotation.md), and [Cloud Training](../train/cloud-training.md).

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -1,12 +1,11 @@
 ---
+plans: [enterprise]
 title: On Premise - Ultralytics Platform
 description: Connect an Enterprise host to Ultralytics Platform for local dataset ingest, previews, and NVIDIA GPU training without sending pixels to the cloud.
 keywords: Ultralytics Platform, On Premise, on-premise computer vision, private datasets, local GPU training, data residency, YOLO
 ---
 
 # On Premise
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Enterprise"]) }}
 
 [On Premise](https://platform.ultralytics.com) connects CPU and optional NVIDIA GPU workers on your own Linux host to Ultralytics Platform. Platform remains the hosted control plane for the UI, authentication, metadata, annotations, and job orchestration, while every pixel and trained model artifact stays on your premises.
 

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -35,10 +35,11 @@ Dataset folders are mounted read-only. Platform and its hosted workers never rec
     - **Dataset folder:** `/datasets`
     - **Models folder:** `/models`
 4. Select **Create install command**.
-5. Copy and run the generated command on the host. It installs Docker Compose when needed, creates the selected folders, starts the CPU worker, and starts the GPU worker automatically when Docker's NVIDIA runtime is available.
-6. Close the dialog when the host shows as connected.
+5. Copy and run the generated command on the host. It installs Docker Compose when needed and creates the selected folders.
+6. Paste the one-time enrollment token when prompted. The installer starts the CPU worker and starts the GPU worker automatically when Docker's NVIDIA runtime is available.
+7. Close the dialog when the host shows as connected.
 
-The command contains a one-time enrollment token that expires after 10 minutes. The installed worker exchanges it for a revocable worker key stored in a mode-`0600` environment file. It never receives Platform MongoDB or cloud-storage credentials.
+The enrollment token expires after 10 minutes and is not stored in shell history. The installed worker exchanges it for a revocable worker key stored in a mode-`0600` environment file. It never receives Platform MongoDB or cloud-storage credentials.
 
 !!! info "NVIDIA training"
 
@@ -48,7 +49,7 @@ The command contains a one-time enrollment token that expires after 10 minutes. 
 
 1. Put the dataset beneath the connected dataset folder. For example, `/datasets/warehouse` is `warehouse` inside the default root.
 2. In Platform, select **New Dataset > On Premise**.
-3. Select the connected host, enter the relative dataset path, choose the task and visibility, and create the dataset.
+3. Select the connected host, enter the relative dataset path, choose the task, and create the private dataset.
 4. The host indexes the dataset and reports metadata. Platform never uploads the images.
 
 On Premise uses the same CPU ingest code as hosted uploads. It supports:

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -7,7 +7,7 @@ keywords: Ultralytics Platform, On Premise, on-premise computer vision, private 
 
 # On Premise
 
-[On Premise](https://platform.ultralytics.com) connects CPU and optional NVIDIA GPU workers on your own Linux, macOS, or Windows host to Ultralytics Platform. Platform remains the hosted control plane for the UI, authentication, metadata, annotations, and job orchestration, while every pixel and trained model artifact stays on your premises.
+[On Premise](https://platform.ultralytics.com) connects CPU and optional NVIDIA GPU workers on your own Linux, Apple Silicon macOS, or Windows host to Ultralytics Platform. Platform remains the hosted control plane for the UI, authentication, metadata, annotations, and job orchestration, while every pixel and trained model artifact stays on your premises.
 
 Your host needs Docker and outbound HTTPS access to Platform. The installer adds Docker automatically when it is missing, so the normal setup is one command.
 
@@ -39,9 +39,9 @@ Dataset folders are mounted read-only. Platform and its hosted workers never rec
 
 ## Connect a Host
 
-1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux, macOS, or Windows host that can access your datasets.
+1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux, Apple Silicon macOS, or Windows host that can access your datasets.
 2. Go to `Settings > Integrations` and select **Connect** on the **On Premise** card.
-3. Platform selects the detected Linux, macOS, or Windows command. Keep the prefilled values or change them:
+3. Platform selects the detected Linux, Apple Silicon macOS, or Windows command. Keep the prefilled values or change them:
     - **Machine name:** `On Premise host`
     - **Dataset folder:** `/datasets` on Linux or `~/Ultralytics/datasets` on macOS and Windows
     - **Models folder:** `/models` on Linux or `~/Ultralytics/models` on macOS and Windows

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -35,7 +35,7 @@ Dataset folders are mounted read-only. Platform and its hosted workers never rec
     - **Dataset folder:** `/datasets`
     - **Models folder:** `/models`
 4. Select **Create install command**.
-5. Copy and run the generated command on the host. It installs Docker Compose when needed, creates the selected folders, starts the CPU worker, and starts the GPU worker automatically when `nvidia-smi` is available.
+5. Copy and run the generated command on the host. It installs Docker Compose when needed, creates the selected folders, starts the CPU worker, and starts the GPU worker automatically when Docker's NVIDIA runtime is available.
 6. Close the dialog when the host shows as connected.
 
 The command contains a one-time enrollment token that expires after 10 minutes. The installed worker exchanges it for a revocable worker key stored in a mode-`0600` environment file. It never receives Platform MongoDB or cloud-storage credentials.

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -31,9 +31,9 @@ Dataset folders are mounted read-only. Platform and its hosted workers never rec
 1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux host that can access your datasets.
 2. Go to `Settings > Integrations` and select **Connect** on the **On Premise** card.
 3. Keep the prefilled values or change them:
-   - **Machine name:** `On Premise host`
-   - **Dataset folder:** `/datasets`
-   - **Models folder:** `/models`
+    - **Machine name:** `On Premise host`
+    - **Dataset folder:** `/datasets`
+    - **Models folder:** `/models`
 4. Select **Create install command**.
 5. Copy and run the generated command on the host. It installs Docker Compose when needed and creates the selected folders.
 6. Paste the one-time enrollment token when prompted. The installer starts the CPU worker and starts the GPU worker automatically when Docker's NVIDIA runtime is available.

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -60,7 +60,7 @@ On Premise uses the same CPU ingest code as hosted uploads. It supports:
 - YOLO datasets and classification folder layouts; and
 - detect, segment, pose, OBB, and classify tasks, including the same class mapping, task inference, validation, and split handling.
 
-The storage output is the only difference. Hosted ingestion may resize or normalize images and create thumbnails in Platform storage. On Premise never resizes, re-encodes, edits, or deletes mounted originals. Archive contents, remote NDJSON assets, and 1 FPS video frames are written only to a Docker volume on the host.
+The storage output is the only difference. Hosted ingestion may resize or normalize images and create thumbnails in Platform storage. On Premise never resizes, re-encodes, edits, or deletes mounted originals. Archive contents, remote NDJSON assets, and video frames sampled at 1 FPS up to 100 frames, then evenly across longer videos, are written only to a Docker volume on the host.
 
 ## Preview and Annotate
 

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -41,7 +41,7 @@ Dataset folders are mounted read-only. Platform and its hosted workers never rec
 
 1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux, Apple Silicon macOS, or Windows host that can access your datasets.
 2. Go to `Settings > Integrations` and select **Connect** on the **On Premise** card.
-3. Platform selects the detected Linux, Apple Silicon macOS, or Windows command. Keep the prefilled values or change them:
+3. Platform selects the detected Linux, macOS, or Windows command. Apple Silicon is required on macOS. Keep the prefilled values or change them:
     - **Machine name:** `On Premise host`
     - **Dataset folder:** `/datasets` on Linux or `~/Ultralytics/datasets` on macOS and Windows
     - **Models folder:** `/models` on Linux or `~/Ultralytics/models` on macOS and Windows

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -31,9 +31,9 @@ Dataset folders are mounted read-only. Platform and its hosted workers never rec
 1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux host that can access your datasets.
 2. Go to `Settings > Integrations` and select **Connect** on the **On Premise** card.
 3. Keep the prefilled values or change them:
-    - **Machine name:** `On Premise host`
-    - **Dataset folder:** `/datasets`
-    - **Models folder:** `/models`
+   - **Machine name:** `On Premise host`
+   - **Dataset folder:** `/datasets`
+   - **Models folder:** `/models`
 4. Select **Create install command**.
 5. Copy and run the generated command on the host. It installs Docker Compose when needed and creates the selected folders.
 6. Paste the one-time enrollment token when prompted. The installer starts the CPU worker and starts the GPU worker automatically when Docker's NVIDIA runtime is available.
@@ -49,7 +49,7 @@ The enrollment token expires after 10 minutes and is not stored in shell history
 
 1. Put the dataset beneath the connected dataset folder. For example, `/datasets/warehouse` is `warehouse` inside the default root.
 2. In Platform, select **New Dataset > On Premise**.
-3. Select the connected host, enter the relative dataset path, choose the task, and create the private dataset.
+3. Select the connected host, optionally narrow it to a relative dataset path, choose the task, and create the private dataset.
 4. The host indexes the dataset and reports metadata. Platform never uploads the images.
 
 On Premise uses the same CPU ingest code as hosted uploads. It supports:

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -7,9 +7,21 @@ keywords: Ultralytics Platform, On Premise, on-premise computer vision, private 
 
 # On Premise
 
-[On Premise](https://platform.ultralytics.com) connects CPU and optional NVIDIA GPU workers on your own Linux host to Ultralytics Platform. Platform remains the hosted control plane for the UI, authentication, metadata, annotations, and job orchestration, while every pixel and trained model artifact stays on your premises.
+[On Premise](https://platform.ultralytics.com) connects CPU and optional NVIDIA GPU workers on your own Linux, macOS, or Windows host to Ultralytics Platform. Platform remains the hosted control plane for the UI, authentication, metadata, annotations, and job orchestration, while every pixel and trained model artifact stays on your premises.
 
 Your host needs Docker and outbound HTTPS access to Platform. The installer adds Docker automatically when it is missing, so the normal setup is one command.
+
+## System Requirements
+
+|                  | Minimum                                                         | Recommended                                                                      |
+| ---------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Operating system | 64-bit Linux, Apple Silicon macOS, or x86-64 Windows with WSL 2 | Current OS and Docker releases                                                   |
+| CPU              | 4 cores                                                         | 8 or more cores for CPU training                                                 |
+| Memory           | 8 GB RAM                                                        | 16 GB or more                                                                    |
+| Storage          | 20 GB free plus space for datasets and models                   | SSD with free space at least twice the working dataset size plus model artifacts |
+| Network          | Outbound HTTPS to Platform and container registries             | Stable broadband for initial image pulls                                         |
+
+CPU ingest and training work on all three operating systems. The installer selects the official native arm64 image on Apple Silicon and ARM Linux, so small jobs such as YOLO26n on COCO8 run without x86 emulation. NVIDIA acceleration is optional; when it is unavailable, training runs on CPU.
 
 ## Data Boundary
 
@@ -27,28 +39,27 @@ Dataset folders are mounted read-only. Platform and its hosted workers never rec
 
 ## Connect a Host
 
-1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux host that can access your datasets.
+1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux, macOS, or Windows host that can access your datasets.
 2. Go to `Settings > Integrations` and select **Connect** on the **On Premise** card.
-3. Keep the prefilled values or change them:
+3. Platform selects the detected Linux, macOS, or Windows command. Keep the prefilled values or change them:
     - **Machine name:** `On Premise host`
-    - **Dataset folder:** `/datasets`
-    - **Models folder:** `/models`
-4. Select **Create install command**.
-5. Copy and run the generated command on the host. It installs Docker Compose when needed and creates the selected folders.
-6. Paste the one-time enrollment token when prompted. The installer starts the CPU worker and starts the GPU worker automatically when Docker's NVIDIA runtime is available.
-7. Close the dialog when the host shows as connected.
+    - **Dataset folder:** `/datasets` on Linux or `~/Ultralytics/datasets` on macOS and Windows
+    - **Models folder:** `/models` on Linux or `~/Ultralytics/models` on macOS and Windows
+4. Select **Create install command**. The dialog tells you which terminal to open for the selected operating system.
+5. Copy the complete command, paste it into that terminal, and run it. The command includes the one-time enrollment token, installs and starts Docker when needed, and creates the selected folders.
+6. Leave the dialog open. Platform checks every 500 milliseconds and shows the host as connected when the CPU worker starts. A GPU worker starts automatically when Docker exposes a supported NVIDIA runtime.
 
-The enrollment token expires after 10 minutes and is not stored in shell history. The installed worker exchanges it for a revocable worker key stored in a mode-`0600` environment file. It never receives Platform MongoDB or cloud-storage credentials.
+The enrollment token expires after 10 minutes and can be exchanged only once. The installed worker stores the resulting revocable worker key in a mode-`0600` environment file. It never receives Platform MongoDB or cloud-storage credentials. Compose restarts the workers automatically, and setup configures Docker to start at boot on Linux or sign-in on macOS and Windows.
 
-!!! info "NVIDIA training"
+!!! info "Training hardware"
 
-    CPU ingest only needs Docker. On Premise GPU training also requires a supported NVIDIA driver and NVIDIA Container Toolkit on the host.
+    CPU ingest and training only need Docker. Optional GPU acceleration also requires a supported NVIDIA driver and container runtime on the host.
 
 ## Create an On Premise Dataset
 
 1. Put the dataset beneath the connected dataset folder. For example, `/datasets/warehouse` is `warehouse` inside the default root.
 2. In Platform, select **New Dataset > On Premise**.
-3. Select the connected host, optionally narrow it to a relative dataset path, choose the task, and create the private dataset.
+3. Browse the connected host with the same folder browser used for Google Cloud Storage, Amazon S3, and Azure Blob Storage, select a folder, choose the task, and create the private dataset.
 4. The host indexes the dataset and reports metadata. Platform never uploads the images.
 
 On Premise uses the same CPU ingest code as hosted uploads. It supports:
@@ -67,9 +78,9 @@ Platform authorizes each preview, then your browser loads the revision-bound fil
 
 Annotations are stored as Platform metadata. Editing or deleting an image in Platform changes the Platform reference and annotations only; it never changes a source file or label sidecar.
 
-## Train on a Local GPU
+## Train Locally
 
-Start training from the normal project training dialog. A dataset bound to an On Premise host is claimable only by that host's GPU worker. Training reads the mounted files, writes checkpoints and weights beneath the configured models folder, and returns job state, scalar metrics, and the immutable checkpoint reference to Platform. Model downloads use the same signed `localhost` connection as previews, so the weights move directly from your host to your browser.
+Start training from the normal project training dialog. A dataset bound to an On Premise host is claimable only by that host. Platform uses its GPU worker when available and otherwise runs the same training code on its CPU worker. Training reads the mounted files, writes checkpoints and weights beneath the configured models folder, and returns job state, scalar metrics, and the immutable checkpoint reference to Platform. Model downloads use the same signed `localhost` connection as previews, so the weights move directly from your host to your browser.
 
 On Premise training does not consume Platform compute credits. Ultralytics hosted workers and RunPod cannot claim the job or read its pixels or artifacts.
 
@@ -77,12 +88,14 @@ On Premise training does not consume Platform compute credits. Ultralytics hoste
 
 Use the **On Premise** card in `Settings > Integrations` to view CPU/GPU availability, reconnect a host, or disconnect it. Reconnecting rotates the worker secret without changing existing dataset identity. Disconnecting revokes future claims and preview access; it does not delete datasets, source files, cached pixels, or model artifacts from the host.
 
-To inspect or stop the installation on the host:
+To inspect or stop the installation on Linux:
 
 ```bash
 cd /opt/ultralytics-worker
 docker compose logs -f
 docker compose down
 ```
+
+On macOS and Windows, the installer prints the equivalent command using `~/.ultralytics/worker`.
 
 Also see [Datasets](../data/datasets.md), [Annotation](../data/annotation.md), and [Cloud Training](../train/cloud-training.md).

--- a/docs/en/platform/integrations/on-premise.md
+++ b/docs/en/platform/integrations/on-premise.md
@@ -29,7 +29,7 @@ Dataset folders are mounted read-only. Platform and its hosted workers never rec
 ## Connect a Host
 
 1. Open [Ultralytics Platform](https://platform.ultralytics.com) on the Linux host that can access your datasets.
-2. Go to `Settings > Integrations` and select **Connect** on the **On premise** card.
+2. Go to `Settings > Integrations` and select **Connect** on the **On Premise** card.
 3. Keep the prefilled values or change them:
     - **Machine name:** `On Premise host`
     - **Dataset folder:** `/datasets`
@@ -42,12 +42,12 @@ The command contains a one-time enrollment token that expires after 10 minutes. 
 
 !!! info "NVIDIA training"
 
-    CPU ingest only needs Docker. On-premise GPU training also requires a supported NVIDIA driver and NVIDIA Container Toolkit on the host.
+    CPU ingest only needs Docker. On Premise GPU training also requires a supported NVIDIA driver and NVIDIA Container Toolkit on the host.
 
-## Create an On-Premise Dataset
+## Create an On Premise Dataset
 
 1. Put the dataset beneath the connected dataset folder. For example, `/datasets/warehouse` is `warehouse` inside the default root.
-2. In Platform, select **New Dataset > On premise**.
+2. In Platform, select **New Dataset > On Premise**.
 3. Select the connected host, enter the relative dataset path, choose the task and visibility, and create the dataset.
 4. The host indexes the dataset and reports metadata. Platform never uploads the images.
 
@@ -69,13 +69,13 @@ Annotations are stored as Platform metadata. Editing or deleting an image in Pla
 
 ## Train on a Local GPU
 
-Start training from the normal project training dialog. A dataset bound to an On Premise host is claimable only by that host's GPU worker. Training reads the mounted files, writes checkpoints and weights beneath the configured models folder, and returns job state and scalar metrics to Platform.
+Start training from the normal project training dialog. A dataset bound to an On Premise host is claimable only by that host's GPU worker. Training reads the mounted files, writes checkpoints and weights beneath the configured models folder, and returns job state, scalar metrics, and the immutable checkpoint reference to Platform. Model downloads use the same signed `localhost` connection as previews, so the weights move directly from your host to your browser.
 
-On-premise training does not consume Platform compute credits. Ultralytics hosted workers and RunPod cannot claim the job or read its pixels or artifacts.
+On Premise training does not consume Platform compute credits. Ultralytics hosted workers and RunPod cannot claim the job or read its pixels or artifacts.
 
 ## Manage the Worker
 
-Use the **On premise** card in `Settings > Integrations` to view CPU/GPU availability, reconnect a host, or disconnect it. Reconnecting rotates the worker secret without changing existing dataset identity. Disconnecting revokes future claims and preview access; it does not delete datasets, source files, cached pixels, or model artifacts from the host.
+Use the **On Premise** card in `Settings > Integrations` to view CPU/GPU availability, reconnect a host, or disconnect it. Reconnecting rotates the worker secret without changing existing dataset identity. Disconnecting revokes future claims and preview access; it does not delete datasets, source files, cached pixels, or model artifacts from the host.
 
 To inspect or stop the installation on the host:
 

--- a/docs/en/platform/integrations/roboflow.md
+++ b/docs/en/platform/integrations/roboflow.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Import every dataset from your Roboflow workspace into Ultralytics Platform with a single API key.
 keywords: Ultralytics Platform, Roboflow, Roboflow import, dataset import, integrations, YOLO, computer vision
@@ -6,8 +7,6 @@ title: Roboflow Dataset Import - Ultralytics Platform
 ---
 
 # Roboflow Integration
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 The Roboflow integration imports every supported dataset in your Roboflow workspace into [Ultralytics Platform](https://platform.ultralytics.com) at its latest version. Re-run it any time to pull in datasets you've added since your last import.
 

--- a/docs/en/platform/integrations/roboflow.md
+++ b/docs/en/platform/integrations/roboflow.md
@@ -7,6 +7,8 @@ title: Roboflow Dataset Import - Ultralytics Platform
 
 # Roboflow Integration
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 The Roboflow integration imports every supported dataset in your Roboflow workspace into [Ultralytics Platform](https://platform.ultralytics.com) at its latest version. Re-run it any time to pull in datasets you've added since your last import.
 
 ## Import from Roboflow

--- a/docs/en/platform/integrations/ultralytics-hub.md
+++ b/docs/en/platform/integrations/ultralytics-hub.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Import your datasets, projects, models, and account balance from Ultralytics HUB into Ultralytics Platform with a single API key.
 keywords: Ultralytics Platform, Ultralytics HUB, HUB import, dataset migration, integrations, YOLO, computer vision
 ---
 
 # Ultralytics HUB Integration
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 The Ultralytics HUB integration transfers everything from your [Ultralytics HUB](https://hub.ultralytics.com) account into [Ultralytics Platform](https://platform.ultralytics.com) in one step — your datasets, projects, models, and account balance.
 

--- a/docs/en/platform/integrations/ultralytics-hub.md
+++ b/docs/en/platform/integrations/ultralytics-hub.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, Ultralytics HUB, HUB import, dataset migration, 
 
 # Ultralytics HUB Integration
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 The Ultralytics HUB integration transfers everything from your [Ultralytics HUB](https://hub.ultralytics.com) account into [Ultralytics Platform](https://platform.ultralytics.com) in one step — your datasets, projects, models, and account balance.
 
 ## Import from Ultralytics HUB

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -1,12 +1,11 @@
 ---
+plans: [free, pro, enterprise]
 comments: true
 description: Get started with Ultralytics Platform in minutes. Learn to create an account, upload datasets, train YOLO models, and deploy to production.
 keywords: Ultralytics Platform, Quickstart, YOLO models, dataset upload, model training, cloud deployment, machine learning
 ---
 
 # Ultralytics Platform Quickstart
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) is designed to be user-friendly and intuitive, allowing users to quickly upload their datasets and train new YOLO models. It offers a range of pretrained models to choose from, making it easy for users to get started. Once a model is trained, it can be tested directly in the browser and deployed to production with a single click.
 

--- a/docs/en/platform/quickstart.md
+++ b/docs/en/platform/quickstart.md
@@ -6,6 +6,8 @@ keywords: Ultralytics Platform, Quickstart, YOLO models, dataset upload, model t
 
 # Ultralytics Platform Quickstart
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) is designed to be user-friendly and intuitive, allowing users to quickly upload their datasets and train new YOLO models. It offers a range of pretrained models to choose from, making it easy for users to get started. Once a model is trained, it can be tested directly in the browser and deployed to production with a single click.
 
 <p align="center">

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, cloud training, GPU training, remote training, Y
 
 # Cloud Training
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) Cloud Training offers single-click training on cloud GPUs, making model training accessible without complex setup. Train YOLO models with real-time metrics streaming and automatic checkpoint saving.
 
 ```mermaid

--- a/docs/en/platform/train/cloud-training.md
+++ b/docs/en/platform/train/cloud-training.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Cloud GPU Training
 comments: true
 description: Learn how to train YOLO models on cloud GPUs with Ultralytics Platform, including remote training and real-time metrics streaming.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, cloud training, GPU training, remote training, Y
 ---
 
 # Cloud Training
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) Cloud Training offers single-click training on cloud GPUs, making model training accessible without complex setup. Train YOLO models with real-time metrics streaming and automatic checkpoint saving.
 

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, model training, cloud training, YOLO, GPU traini
 
 # Model Training
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive tools for training YOLO models, from organizing experiments to running cloud training jobs with real-time metrics streaming.
 
 <p align="center">

--- a/docs/en/platform/train/index.md
+++ b/docs/en/platform/train/index.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Cloud Model Training
 comments: true
 description: Learn about model training in Ultralytics Platform including project organization, cloud training, and real-time metrics streaming.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, model training, cloud training, YOLO, GPU traini
 ---
 
 # Model Training
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive tools for training YOLO models, from organizing experiments to running cloud training jobs with real-time metrics streaming.
 

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, models, model management, export, ONNX, TensorRT
 
 # Models
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive model management for training, analyzing, and deploying YOLO models. Upload pretrained models or train new ones directly on the platform.
 
 ![Ultralytics Platform Model Page Overview Tab](https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-model-page-overview-tab.avif)

--- a/docs/en/platform/train/models.md
+++ b/docs/en/platform/train/models.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Trained Model Management
 comments: true
 description: Learn how to manage, analyze, and export trained models in Ultralytics Platform with support for 19+ deployment formats.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, models, model management, export, ONNX, TensorRT
 ---
 
 # Models
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) provides comprehensive model management for training, analyzing, and deploying YOLO models. Upload pretrained models or train new ones directly on the platform.
 

--- a/docs/en/platform/train/projects.md
+++ b/docs/en/platform/train/projects.md
@@ -1,4 +1,5 @@
 ---
+plans: [free, pro, enterprise]
 title: Project Management
 comments: true
 description: Learn how to organize and manage projects in Ultralytics Platform for efficient model development.
@@ -6,8 +7,6 @@ keywords: Ultralytics Platform, projects, model management, experiment tracking,
 ---
 
 # Projects
-
-{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
 
 [Ultralytics Platform](https://platform.ultralytics.com) projects provide an effective solution for organizing and managing your models. Group related models together to facilitate easier management, comparison, and development.
 

--- a/docs/en/platform/train/projects.md
+++ b/docs/en/platform/train/projects.md
@@ -7,6 +7,8 @@ keywords: Ultralytics Platform, projects, model management, experiment tracking,
 
 # Projects
 
+{% from "macros/platform-plans.md" import plan_badges %} {{ plan_badges(["Free", "Pro", "Enterprise"]) }}
+
 [Ultralytics Platform](https://platform.ultralytics.com) projects provide an effective solution for organizing and managing your models. Group related models together to facilitate easier management, comparison, and development.
 
 ```mermaid

--- a/docs/macros/platform-plans.md
+++ b/docs/macros/platform-plans.md
@@ -1,7 +1,0 @@
-{% macro plan_badges(plans) -%}
-
-<p class="platform-plan-badges" aria-label="Available plans">
-  <span>Available on</span>
-  {% for plan in plans %}<strong class="platform-plan-badge platform-plan-badge--{{ plan | lower }}">{{ plan }}</strong>{% endfor %}
-</p>
-{%- endmacro %}

--- a/docs/macros/platform-plans.md
+++ b/docs/macros/platform-plans.md
@@ -1,0 +1,7 @@
+{% macro plan_badges(plans) -%}
+
+<p class="platform-plan-badges" aria-label="Available plans">
+  <span>Available on</span>
+  {% for plan in plans %}<strong class="platform-plan-badge platform-plan-badge--{{ plan | lower }}">{{ plan }}</strong>{% endfor %}
+</p>
+{%- endmacro %}

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -1,5 +1,32 @@
 /* Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license */
 
+/* Platform plan badges -------------------------------------------------------------------------------------------- */
+.platform-plan-badges {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: -0.5rem 0 1rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.7rem;
+}
+.platform-plan-badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  color: var(--md-primary-bg-color);
+  line-height: 1;
+}
+.platform-plan-badge--free {
+  background: var(--md-default-fg-color--lightest);
+  color: var(--md-default-fg-color--light);
+}
+.platform-plan-badge--pro {
+  background: var(--md-primary-fg-color);
+}
+.platform-plan-badge--enterprise {
+  background: var(--md-accent-fg-color);
+}
+/* Platform plan badges -------------------------------------------------------------------------------------------- */
+
 /* Table format like GitHub ----------------------------------------------------------------------------------------- */
 th,
 td {
@@ -217,7 +244,13 @@ div.highlight {
   font-weight: 600;
   text-align: center;
   color: #fff;
-  background-image: linear-gradient(93deg, #b8fff2, #e3fffa 24%, #eef1fe 70%, #a1b0f3);
+  background-image: linear-gradient(
+    93deg,
+    #b8fff2,
+    #e3fffa 24%,
+    #eef1fe 70%,
+    #a1b0f3
+  );
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -17,13 +17,14 @@
 }
 .platform-plan-badge--free {
   background: var(--md-default-fg-color--lightest);
-  color: var(--md-default-fg-color--light);
+  color: var(--md-default-fg-color);
 }
 .platform-plan-badge--pro {
   background: var(--md-primary-fg-color);
 }
 .platform-plan-badge--enterprise {
-  background: var(--md-accent-fg-color);
+  background: var(--md-default-fg-color);
+  color: var(--md-default-bg-color);
 }
 /* Platform plan badges -------------------------------------------------------------------------------------------- */
 

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -244,13 +244,7 @@ div.highlight {
   font-weight: 600;
   text-align: center;
   color: #fff;
-  background-image: linear-gradient(
-    93deg,
-    #b8fff2,
-    #e3fffa 24%,
-    #eef1fe 70%,
-    #a1b0f3
-  );
+  background-image: linear-gradient(93deg, #b8fff2, #e3fffa 24%, #eef1fe 70%, #a1b0f3);
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/docs/overrides/stylesheets/style.css
+++ b/docs/overrides/stylesheets/style.css
@@ -1,33 +1,5 @@
 /* Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license */
 
-/* Platform plan badges -------------------------------------------------------------------------------------------- */
-.platform-plan-badges {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  margin: -0.5rem 0 1rem;
-  color: var(--md-default-fg-color--light);
-  font-size: 0.7rem;
-}
-.platform-plan-badge {
-  padding: 0.25rem 0.5rem;
-  border-radius: 999px;
-  color: var(--md-primary-bg-color);
-  line-height: 1;
-}
-.platform-plan-badge--free {
-  background: var(--md-default-fg-color--lightest);
-  color: var(--md-default-fg-color);
-}
-.platform-plan-badge--pro {
-  background: var(--md-primary-fg-color);
-}
-.platform-plan-badge--enterprise {
-  background: var(--md-default-fg-color);
-  color: var(--md-default-bg-color);
-}
-/* Platform plan badges -------------------------------------------------------------------------------------------- */
-
 /* Table format like GitHub ----------------------------------------------------------------------------------------- */
 th,
 td {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -660,6 +660,7 @@ nav:
           - Google Cloud Storage: platform/integrations/google-cloud-storage.md
           - Amazon S3: platform/integrations/amazon-s3.md
           - Azure Blob Storage: platform/integrations/azure-blob-storage.md
+          - On Premise: platform/integrations/on-premise.md
       - Account:
           - platform/account/index.md
           - API Keys: platform/account/api-keys.md


### PR DESCRIPTION
## Summary

- Document Enterprise On Premise setup on 64-bit Linux, Apple Silicon macOS, and x86-64 Windows with WSL 2, including minimum/recommended specifications.
- Document the detected OS command, prefilled dataset/model folders, automatic Docker setup, 500 ms live connection status, restart behavior, and optional NVIDIA acceleration.
- Document CPU and GPU training through the normal Platform training journey, including YOLO26n/COCO8-class CPU workloads on Apple Silicon.
- Document that On Premise reuses the same folder browser and CPU ingest pipeline as GCS, S3, Azure, and hosted ingestion while leaving mounted originals untouched.
- Add `plans` frontmatter to all 29 Platform pages: free features list all tiers, cloud storage and Teams list Pro + Enterprise, and On Premise lists Enterprise.
- Keep plan ownership in source frontmatter while Portal renders the existing `@ultralytics/ui` `PlanBadge`; traditional MkDocs contains no parallel badge component, CSS, macro, or route map.
- List On Premise alongside existing Platform integrations and remove stale coming-soon copy.

## Core Principles

Deleted: the custom MiniJinja plan-badge macro; 28 lines of copied badge CSS; all 29 macro calls; three redundant Pro callouts; stale compliance/SLA and On Premise coming-soon copy; Linux-only setup wording; the separate enrollment-token prompt; GPU-only training wording; free-text On Premise path instructions; and generic Intel-capable macOS requirements.

Reused: ordinary Markdown frontmatter as the single plan owner, Portal's shared MkDocs parser/renderer, the existing shared `PlanBadge`, existing integration navigation, existing connected-storage browser terminology, and the shipped worker/install behavior. The On Premise page is necessarily net-positive because the shipped feature had no public documentation; plan metadata adds one declarative field per page and no docs-side renderer or duplicated UI.

## Validation

- Prettier 3.6.2
- MkDocs build completed successfully; reported warnings are existing generated compare/reference warnings
- all 29 Platform pages contain valid `plans` frontmatter
- no plan-badge macro, copied CSS, or badge markup remains in this repository
- Portal production docs build and rendered Free/Pro/Enterprise route smoke from the paired PR
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds Enterprise On Premise support to Ultralytics Platform documentation and introduces plan-based visibility across Platform guides. 🏢🔒

### 📊 Key Changes

- Added comprehensive On Premise integration documentation covering:
  - Local CPU/GPU workers on Linux, Apple Silicon macOS, and Windows with WSL 2.
  - Local dataset indexing, annotation previews, and YOLO model training.
  - Data boundaries ensuring source pixels, checkpoints, and artifacts remain on the customer’s host.
  - Docker-based installation, worker management, GPU requirements, and troubleshooting commands.
- Added On Premise to the Platform integrations navigation and related account, data, and billing documentation.
- Updated Enterprise plan details to list:
  - On-premise data and compute.
  - ISO/IEC 27001:2022 and SOC 2 Type I compliance.
  - Enterprise SLA guarantees.
- Added `plans` metadata to Platform documentation pages to identify content available to Free, Pro, and Enterprise users.
- Marked cloud storage integrations as available for Pro and Enterprise plans, and team management as available for Pro and Enterprise plans.
- Updated dataset and integration descriptions to explain local data processing and Enterprise data residency options. 📚

### 🎯 Purpose & Impact

- Enables Enterprise customers to train models and process datasets locally while retaining control of sensitive image and video data. 🔐
- Provides a hosted control plane for authentication, metadata, annotations, orchestration, and metrics without transferring source pixels to Platform.
- Supports optional NVIDIA GPU acceleration while preserving CPU-based fallback across supported operating systems.
- Improves documentation discoverability through plan-specific metadata and clearer navigation.
- Clarifies Enterprise security, compliance, SLA, and deployment capabilities, helping organizations evaluate Platform for private or regulated workloads.