### PR TITLE
Fix stale tracker default and dropped row in object-blurring solutions table

### DIFF
--- a/docs/en/guides/object-blurring.md
+++ b/docs/en/guides/object-blurring.md
@@ -96,7 +96,7 @@ Pass your video to the `ObjectBlurrer` solution and it detects objects each fram
 Here's a table with the `ObjectBlurrer` arguments:
 
 {% from "macros/solutions-args.md" import param_table %}
-{{ param_table(["model", "line_width", "blur_ratio"]) }}
+{{ param_table(["model", "blur_ratio"]) }}
 
 The `ObjectBlurrer` solution also supports a range of `track` arguments:
 

--- a/docs/macros/track-args.md
+++ b/docs/macros/track-args.md
@@ -5,7 +5,7 @@
     "source": ["str", "None", "Specifies the source directory for images or videos. Supports file paths, URLs, and video streams."],
     "persist": ["bool", "False", "Enables persistent tracking of objects between frames, maintaining IDs across video sequences."],
     "stream": ["bool", "False", "Treats the input source as a continuous video stream for real-time processing."],
-    "tracker": ["str", "'botsort.yaml'", "Specifies the tracking algorithm to use. Built-in options: `botsort.yaml`, `bytetrack.yaml`, `ocsort.yaml`, `deepocsort.yaml`, `fasttrack.yaml`, `tracktrack.yaml`."],
+    "tracker": ["str", "'tracktrack.yaml'", "Specifies the tracking algorithm to use. Built-in options: `botsort.yaml`, `bytetrack.yaml`, `ocsort.yaml`, `deepocsort.yaml`, `fasttrack.yaml`, `tracktrack.yaml`."],
     "conf": ["float", "0.1", "Sets the confidence threshold for detections; lower values allow more objects to be tracked but may include false positives."],
     "iou": ["float", "0.7", "Sets the [Intersection over Union](https://www.ultralytics.com/glossary/intersection-over-union-iou) (IoU) threshold for filtering overlapping detections."],
     "classes": ["list", "None", "Filters results by class index. For example, `classes=[0, 2, 3]` only tracks the specified classes."],


### PR DESCRIPTION
## Summary

Update the `track-args` macro tracker default to `tracktrack.yaml` to match `cfg/default.yaml`, which switched the default tracker; the macro still showed the old `botsort.yaml`.

Remove `line_width` from the `object-blurring` guide's `solutions-args` `param_table` call: `line_width` is not a key in that macro's dict, so the row was silently dropped. It is already documented on the same page via the `visualization-args` table.

Deleted: line_width key from the object-blurring solutions-args param_table call

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Ultralytics documentation to reflect current object-blurring and tracking defaults. 📝

### 📊 Key Changes

- Removed the obsolete `line_width` argument from the `ObjectBlurrer` documentation.
- Updated the documented default tracker from `botsort.yaml` to `tracktrack.yaml`.
- Kept the list of supported tracking algorithms unchanged.

### 🎯 Purpose & Impact

- 📚 Makes the documentation more consistent with the current implementation.
- ✅ Helps users avoid relying on an unsupported or outdated `line_width` option for object blurring.
- 🚀 Ensures users are aware that `tracktrack.yaml` is now the default tracking configuration.