### PR TITLE
Fix `save_one_box` to return the crop in the requested BGR format regardless of `save`

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -722,6 +722,15 @@ def test_labels_and_crops():
         # Same number of crops as detections
         crop_count = len([f for f in crop_files if im_name in f.name])
         assert crop_count == len(r.boxes.data), f"Crop count {crop_count} != detection count {len(r.boxes.data)}"
+    # save_one_box must return the crop in the requested BGR format regardless of the save flag
+    from ultralytics.utils.plotting import save_one_box
+
+    im = np.zeros((50, 50, 3), dtype=np.uint8)
+    im[..., 0], im[..., 1], im[..., 2] = 10, 20, 30  # distinct B, G, R channel values
+    xyxy = torch.tensor([10.0, 10.0, 40.0, 40.0])
+    for save in (True, False):
+        crop = save_one_box(xyxy, im.copy(), file=save_path / "b.jpg", save=save, BGR=True)
+        assert tuple(crop[0, 0]) == (10, 20, 30), f"BGR crop return has swapped channels with save={save}"
 
 
 def test_data_utils(tmp_path):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -722,15 +722,6 @@ def test_labels_and_crops():
         # Same number of crops as detections
         crop_count = len([f for f in crop_files if im_name in f.name])
         assert crop_count == len(r.boxes.data), f"Crop count {crop_count} != detection count {len(r.boxes.data)}"
-    # save_one_box must return the crop in the requested BGR format regardless of the save flag
-    from ultralytics.utils.plotting import save_one_box
-
-    im = np.zeros((50, 50, 3), dtype=np.uint8)
-    im[..., 0], im[..., 1], im[..., 2] = 10, 20, 30  # distinct B, G, R channel values
-    xyxy = torch.tensor([10.0, 10.0, 40.0, 40.0])
-    for save in (True, False):
-        crop = save_one_box(xyxy, im.copy(), file=save_path / "b.jpg", save=save, BGR=True)
-        assert tuple(crop[0, 0]) == (10, 20, 30), f"BGR crop return has swapped channels with save={save}"
 
 
 def test_data_utils(tmp_path):

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -708,8 +708,8 @@ def save_one_box(
         file.parent.mkdir(parents=True, exist_ok=True)  # make directory
         f = str(increment_path(file).with_suffix(".jpg"))
         # cv2.imwrite(f, crop)  # save BGR, https://github.com/ultralytics/yolov5/issues/7007 chroma subsampling issue
-        crop = crop.squeeze(-1) if grayscale else crop[..., ::-1] if BGR else crop
-        Image.fromarray(crop).save(f, quality=95, subsampling=0)  # save RGB
+        im_save = crop.squeeze(-1) if grayscale else crop[..., ::-1] if BGR else crop
+        Image.fromarray(im_save).save(f, quality=95, subsampling=0)  # save RGB
     return crop
 
 


### PR DESCRIPTION
## Summary

`save_one_box()` converted the crop to PIL's save representation by reassigning `crop`. Because the same variable is returned, `save=True` changed BGR channel order and collapsed grayscale output from `(H, W, 1)` to `(H, W)`.

This keeps the save-only representation in `im_save` and returns the requested crop unchanged. Existing callers that discard saved returns and the `save=False` ReID path retain their behavior.

## Validation

- BGR and RGB returns with `save=True` and `save=False`
- RGB JPEG output
- Grayscale return shape
- Ruff format and lint
- Full CI on the original implementation head

Deleted: inline `save_one_box` regression assertions from `test_labels_and_crops`; behavior was validated directly without retaining synthetic coverage.
