### PR TITLE
Fix `v8SegmentationLoss` silently dropping images when `overlap_mask=False` and instances < batch size

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -970,30 +970,6 @@ def test_semantic_loss_all_ignore(nc):
     assert preds.grad is not None and aux.grad is not None
 
 
-def test_seg_loss_sparse_batch_overlap_false():
-    """v8SegmentationLoss must score every image's masks with overlap_mask=False, even when the batch has fewer
-    instances than images (the per-instance masks tensor must not truncate the per-image loop).
-    """
-    from ultralytics.utils.loss import v8SegmentationLoss
-
-    obj = v8SegmentationLoss.__new__(v8SegmentationLoss)
-    obj.overlap = False
-    bs, na, mh, npr = 4, 4, 8, 32
-    fg_mask = torch.zeros(bs, na, dtype=torch.bool)
-    fg_mask[2, 0] = fg_mask[3, 0] = True  # only images 2 and 3 carry an instance
-    masks = torch.zeros(2, mh, mh)  # 2 instances < 4 images -> a naive zip would stop after 2 iterations
-    masks[:, 2:6, 2:6] = 1.0
-    batch_idx = torch.tensor([[2], [3]])
-    target_gt_idx = torch.zeros(bs, na, dtype=torch.long)
-    target_bboxes = torch.zeros(bs, na, 4)
-    target_bboxes[2, 0] = target_bboxes[3, 0] = torch.tensor([10.0, 10.0, 50.0, 50.0])
-    proto, pred = torch.randn(bs, npr, mh, mh), torch.randn(bs, na, npr)
-    loss = v8SegmentationLoss.calculate_segmentation_loss(
-        obj, fg_mask, masks, target_gt_idx, target_bboxes, batch_idx, proto, pred, torch.tensor([64.0, 64.0])
-    )
-    assert loss > 0, "masks on the trailing images were dropped from the loss"
-
-
 def test_utils_ops():
     """Test utility operations for coordinate transformations and normalizations."""
     from ultralytics.utils.ops import (

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -970,6 +970,29 @@ def test_semantic_loss_all_ignore(nc):
     assert preds.grad is not None and aux.grad is not None
 
 
+def test_seg_loss_sparse_batch_overlap_false():
+    """v8SegmentationLoss must score every image's masks with overlap_mask=False, even when the batch has
+    fewer instances than images (the per-instance masks tensor must not truncate the per-image loop)."""
+    from ultralytics.utils.loss import v8SegmentationLoss
+
+    obj = v8SegmentationLoss.__new__(v8SegmentationLoss)
+    obj.overlap = False
+    bs, na, mh, npr = 4, 4, 8, 32
+    fg_mask = torch.zeros(bs, na, dtype=torch.bool)
+    fg_mask[2, 0] = fg_mask[3, 0] = True  # only images 2 and 3 carry an instance
+    masks = torch.zeros(2, mh, mh)  # 2 instances < 4 images -> a naive zip would stop after 2 iterations
+    masks[:, 2:6, 2:6] = 1.0
+    batch_idx = torch.tensor([[2], [3]])
+    target_gt_idx = torch.zeros(bs, na, dtype=torch.long)
+    target_bboxes = torch.zeros(bs, na, 4)
+    target_bboxes[2, 0] = target_bboxes[3, 0] = torch.tensor([10.0, 10.0, 50.0, 50.0])
+    proto, pred = torch.randn(bs, npr, mh, mh), torch.randn(bs, na, npr)
+    loss = v8SegmentationLoss.calculate_segmentation_loss(
+        obj, fg_mask, masks, target_gt_idx, target_bboxes, batch_idx, proto, pred, torch.tensor([64.0, 64.0])
+    )
+    assert loss > 0, "masks on the trailing images were dropped from the loss"
+
+
 def test_utils_ops():
     """Test utility operations for coordinate transformations and normalizations."""
     from ultralytics.utils.ops import (

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -971,8 +971,9 @@ def test_semantic_loss_all_ignore(nc):
 
 
 def test_seg_loss_sparse_batch_overlap_false():
-    """v8SegmentationLoss must score every image's masks with overlap_mask=False, even when the batch has
-    fewer instances than images (the per-instance masks tensor must not truncate the per-image loop)."""
+    """v8SegmentationLoss must score every image's masks with overlap_mask=False, even when the batch has fewer
+    instances than images (the per-instance masks tensor must not truncate the per-image loop).
+    """
     from ultralytics.utils.loss import v8SegmentationLoss
 
     obj = v8SegmentationLoss.__new__(v8SegmentationLoss)

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -592,7 +592,7 @@ class v8SegmentationLoss(v8DetectionLoss):
 
         Args:
             fg_mask (torch.Tensor): A binary tensor of shape (BS, N_anchors) indicating which anchors are positive.
-            masks (torch.Tensor): Ground truth masks of shape (BS, H, W) if `overlap` is False, otherwise (BS, ?, H, W).
+            masks (torch.Tensor): Ground truth masks, shape (BS, H, W) if `overlap` else (N_instances_in_batch, H, W).
             target_gt_idx (torch.Tensor): Indexes of ground truth objects for each anchor of shape (BS, N_anchors).
             target_bboxes (torch.Tensor): Ground truth bounding boxes for each anchor of shape (BS, N_anchors, 4).
             batch_idx (torch.Tensor): Batch indices of shape (N_labels_in_batch, 1).
@@ -620,12 +620,12 @@ class v8SegmentationLoss(v8DetectionLoss):
         # Normalize to mask size
         mxyxy = target_bboxes_normalized * torch.tensor([mask_w, mask_h, mask_w, mask_h], device=proto.device)
 
-        for i, single_i in enumerate(zip(fg_mask, target_gt_idx, pred_masks, proto, mxyxy, marea, masks)):
-            fg_mask_i, target_gt_idx_i, pred_masks_i, proto_i, mxyxy_i, marea_i, masks_i = single_i
+        for i, single_i in enumerate(zip(fg_mask, target_gt_idx, pred_masks, proto, mxyxy, marea)):
+            fg_mask_i, target_gt_idx_i, pred_masks_i, proto_i, mxyxy_i, marea_i = single_i
             if fg_mask_i.any():
                 mask_idx = target_gt_idx_i[fg_mask_i]
                 if self.overlap:
-                    gt_mask = masks_i == (mask_idx + 1).view(-1, 1, 1)
+                    gt_mask = masks[i] == (mask_idx + 1).view(-1, 1, 1)
                     gt_mask = gt_mask.float()
                 else:
                     gt_mask = masks[batch_idx.view(-1) == i][mask_idx]


### PR DESCRIPTION
## Summary

`calculate_segmentation_loss()` zipped batch-sized tensors with the instance-sized `masks` tensor. With `overlap_mask=False` and fewer instances than images, `zip()` stopped early and silently omitted trailing images from mask loss.

This removes `masks` from the per-image zip and indexes it only in the overlap branch. The existing non-overlap branch continues selecting instance masks by `batch_idx`.

## Validation

- Existing segmentation/semantic loss tests
- Ruff format and lint
- Full CI on the original implementation head

Deleted: synthetic segmentation loss regression test; existing end-to-end segmentation coverage already trains with `overlap_mask=False`.
