### PR TITLE
Fix FastSAM `postprocess` overwriting the first box

### DIFF
--- a/ultralytics/models/fastsam/predict.py
+++ b/ultralytics/models/fastsam/predict.py
@@ -68,7 +68,7 @@ class FastSAMPredictor(SegmentationPredictor):
                 [0, 0, result.orig_shape[1], result.orig_shape[0]], device=result.boxes.data.device, dtype=torch.float32
             )
             boxes = adjust_bboxes_to_image_border(result.boxes.xyxy, result.orig_shape)
-            idx = torch.nonzero(box_iou(full_box[None], boxes) > 0.9).flatten()
+            idx = torch.nonzero(box_iou(full_box[None], boxes)[0] > 0.9).flatten()
             if idx.numel() != 0:
                 result.boxes.xyxy[idx] = full_box
 


### PR DESCRIPTION
FastSAM overwrites the first (highest-confidence) box with the full-image box `[0, 0, W, H]` whenever some *other* detection covers almost the whole frame. So anything that reads `results[0].boxes` from FastSAM gets a wrong box 0: `save_one_box` crops, counting, tracking, and also the text-prompt path in `prompt()` that crops the image by `result.boxes.xyxy`.

The cause is in `FastSAMPredictor.postprocess`. `box_iou(full_box[None], boxes)` returns a `(1, N)` matrix, and `torch.nonzero()` on a 2D tensor returns `[row, col]` pairs. The row is always 0, so it comes out as `[[0, j1], [0, j2], ...]` and `.flatten()` mixes it into `[0, j1, 0, j2, ...]`. That row index `0` gets treated as a box index, and since `result.boxes.xyxy` is a view of `.data`, the assignment `result.boxes.xyxy[idx] = full_box` overwrites box 0 in place even when box 0 does not cover the image.

The fix indexes the single row before the threshold, so `nonzero` runs on a 1D vector and returns clean column indices:

```python
# before
idx = torch.nonzero(box_iou(full_box[None], boxes) > 0.9).flatten()
# after
idx = torch.nonzero(box_iou(full_box[None], boxes)[0] > 0.9).flatten()
```

With 3 boxes where box 1 (not the first) is the full image, `idx` goes from `[0, 1]` (it overwrites box 0) to `[1]` (only the box that is really full). To reproduce it end-to-end with the real model, I cropped `bus.jpg` so the bus fills the frame within the 20 px border threshold of `adjust_bboxes_to_image_border`:

```python
import cv2
from ultralytics import FastSAM

im = cv2.imread("ultralytics/assets/bus.jpg")
cv2.imwrite("bus_crop.jpg", im[222:752, 12:810])  # bus fills the frame, people in front
r = FastSAM("FastSAM-s.pt")("bus_crop.jpg")[0]
print(r.boxes.xyxy[0])
```

On `main`, box 0 (a person, conf 0.926) comes out as `[0, 0, 798, 530]`; with the fix it stays at `[59.7, 432.8, 175.1, 530.0]`, and box 7 (the bus, which really covers the full frame) keeps the full-image box as expected. I also checked for regressions, FastSAM-s on the uncropped `bus.jpg` gives identical results with and without the fix (94 detections, same box 0), since no detection there reaches IoU > 0.9 with the full image.

I checked the rest of the file too: this `full_box`/`box_iou` block only lives here, and the other `nonzero` in `prompt()` uses `as_tuple=True`, so it is not affected.

Deleted: nothing (one-character in-place fix, no net line change).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes FastSAM postprocessing so the correct bounding boxes are identified and updated without overwriting the first box.

### 📊 Key Changes
- Corrects the IoU tensor indexing in `ultralytics/models/fastsam/predict.py`.
- Selects matching boxes from the first row of the IoU results before applying the full-image box.

### 🎯 Purpose & Impact
- Prevents incorrect box selection caused by flattening the extra IoU dimension.
- Improves FastSAM prediction reliability when adjusting boxes to image borders.
- Limits the change to a focused bug fix with minimal impact on existing behavior.