### PR TITLE
Update CoreML and LiteRT mobile depth benchmarks

### DIFF
--- a/docs/en/integrations/coreml.md
+++ b/docs/en/integrations/coreml.md
@@ -6,7 +6,7 @@ keywords: CoreML export, Core ML, YOLO26 CoreML, Apple Neural Engine, ANE, mlpac
 
 # CoreML Export for YOLO26 Models
 
-Apple ships dedicated AI silicon — the Neural Engine — in every modern iPhone, iPad, and Mac, and [CoreML](https://developer.apple.com/documentation/coreml) is Ultralytics' supported path for deploying models to it today. Exporting [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics) models to CoreML turns a trained `.pt` checkpoint into a native `.mlpackage` that runs all seven YOLO tasks on-device at single-digit milliseconds, with no network connection and no data leaving the device.
+Apple ships dedicated AI silicon — the Neural Engine — in every modern iPhone, iPad, and Mac, and [CoreML](https://developer.apple.com/documentation/coreml) is Ultralytics' supported path for deploying models to it today. Exporting [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics) models to CoreML turns a trained `.pt` checkpoint into a native `.mlpackage` that runs all seven YOLO tasks on-device at low latency, with no network connection and no data leaving the device.
 
 !!! tip "Run YOLO on the Apple Neural Engine today with the official mobile apps"
 

--- a/docs/en/integrations/coreml.md
+++ b/docs/en/integrations/coreml.md
@@ -6,11 +6,11 @@ keywords: CoreML export, Core ML, YOLO26 CoreML, Apple Neural Engine, ANE, mlpac
 
 # CoreML Export for YOLO26 Models
 
-Apple ships dedicated AI silicon — the Neural Engine — in every modern iPhone, iPad, and Mac, and [CoreML](https://developer.apple.com/documentation/coreml) is Ultralytics' supported path for deploying models to it today. Exporting [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics) models to CoreML turns a trained `.pt` checkpoint into a native `.mlpackage` that runs all six YOLO tasks on-device at single-digit milliseconds, with no network connection and no data leaving the device.
+Apple ships dedicated AI silicon — the Neural Engine — in every modern iPhone, iPad, and Mac, and [CoreML](https://developer.apple.com/documentation/coreml) is Ultralytics' supported path for deploying models to it today. Exporting [Ultralytics YOLO26](https://github.com/ultralytics/ultralytics) models to CoreML turns a trained `.pt` checkpoint into a native `.mlpackage` that runs all seven YOLO tasks on-device at single-digit milliseconds, with no network connection and no data leaving the device.
 
 !!! tip "Run YOLO on the Apple Neural Engine today with the official mobile apps"
 
-    The official [Ultralytics YOLO iOS SDK](https://github.com/ultralytics/yolo-ios-app) and [Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) run CoreML exports on the Apple Neural Engine out of the box — real-time camera inference, single-image prediction, and automatic model download for all six YOLO26 tasks. For Android NPU deployment, see the [Qualcomm QNN integration](qnn.md).
+    The official [Ultralytics YOLO iOS SDK](https://github.com/ultralytics/yolo-ios-app) and [Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) run CoreML exports on the Apple Neural Engine out of the box — real-time camera inference, single-image prediction, and automatic model download for all seven YOLO26 tasks, including Depth. For Android NPU deployment, see the [Qualcomm QNN integration](qnn.md).
 
 !!! note "Apple's future Core AI format"
 
@@ -39,26 +39,27 @@ CoreML integrates directly with Apple's [Vision framework](https://developer.app
 
 ## Why Export YOLO26 to CoreML?
 
-- **Neural Engine speed**: YOLO26n detection runs end-to-end in **3.8 ms** on an iPhone 17 Pro for single images, and ~16 ms/frame in sustained real-time camera use (see the table and notes below) — comfortably real-time with headroom for the rest of your app.
+- **Neural Engine speed**: YOLO26n detection runs end-to-end in **3.8 ms** on an iPhone 17 Pro for single images and 11.3 ms/frame in sustained real-time camera use; YOLO26n Depth takes **5.5 ms** for a single image and 16.5 ms/frame in the live camera (see the table and notes below).
 - **NMS-free by design**: YOLO26 is [end-to-end](https://www.ultralytics.com/glossary/non-maximum-suppression-nms), so the exported graph needs no NMS pipeline and decode is sub-millisecond. Older models like YOLO11 can embed a CoreML NMS pipeline with `nms=True`.
 - **Private and offline**: All computation stays on the device — no cloud round-trips, no API keys, full [data privacy](https://www.ultralytics.com/glossary/data-privacy).
 - **One export, the whole ecosystem**: The same `.mlpackage` runs on iOS, iPadOS, macOS, watchOS, tvOS, and visionOS, and powers the official Ultralytics [iOS SDK](https://github.com/ultralytics/yolo-ios-app) and [Flutter plugin](https://github.com/ultralytics/yolo-flutter-app).
 
 ## Measured Performance
 
-End-to-end single-image inference for the official YOLO26n INT8 CoreML models on an iPhone 17 Pro (Apple A19, iOS 26.5). Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. On iOS, Vision performs input scaling inside the inference request, so preprocessing is reported as 0 and its cost is included in inference.
+End-to-end single-image inference for the official YOLO26n INT8 CoreML models on an iPhone 17 Pro (Apple A19, iOS 26.5.2). Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. On iOS, Vision performs input scaling inside the inference request, so preprocessing is reported as 0 and its cost is included in inference.
 
-| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>`.cpuOnly`<br>(ms)</sup> | Neural Engine<br><sup>`.cpuAndNeuralEngine`<br>(ms)</sup> |
-| ------------ | -------- | --------------------------- | ------------------------------------ | --------------------------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 9.1<br><sup>0.0 / 9.1 / 0.0</sup>    | **3.8**<br><sup>0.0 / 3.8 / 0.0</sup>                     |
-| YOLO26n-seg  | Segment  | 640                         | 12.3<br><sup>0.0 / 12.1 / 0.2</sup>  | **4.8**<br><sup>0.0 / 4.5 / 0.3</sup>                     |
-| YOLO26n-sem  | Semantic | 1024<sup>1</sup>            | 21.8<br><sup>0.0 / 21.0 / 0.8</sup>  | **12.1**<br><sup>0.0 / 11.3 / 0.8</sup>                   |
-| YOLO26n-cls  | Classify | 224                         | 2.2<br><sup>0.0 / 2.2 / 0.0</sup>    | **2.0**<br><sup>0.0 / 2.0 / 0.0</sup>                     |
-| YOLO26n-pose | Pose     | 640                         | 12.0<br><sup>0.0 / 11.9 / 0.0</sup>  | **3.8**<br><sup>0.0 / 3.8 / 0.0</sup>                     |
-| YOLO26n-obb  | OBB      | 1024                        | 21.7<br><sup>0.0 / 21.7 / 0.0</sup>  | **7.2**<br><sup>0.0 / 7.2 / 0.0</sup>                     |
+| Model         | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>`.cpuOnly`<br>(ms)</sup> | Neural Engine<br><sup>`.cpuAndNeuralEngine`<br>(ms)</sup> |
+| ------------- | -------- | --------------------------- | ------------------------------------ | --------------------------------------------------------- |
+| YOLO26n       | Detect   | 640                         | 9.1<br><sup>0.0 / 9.1 / 0.0</sup>    | **3.8**<br><sup>0.0 / 3.8 / 0.0</sup>                     |
+| YOLO26n-seg   | Segment  | 640                         | 12.3<br><sup>0.0 / 12.1 / 0.2</sup>  | **4.8**<br><sup>0.0 / 4.5 / 0.3</sup>                     |
+| YOLO26n-sem   | Semantic | 1024<sup>1</sup>            | 21.8<br><sup>0.0 / 21.0 / 0.8</sup>  | **12.1**<br><sup>0.0 / 11.3 / 0.8</sup>                   |
+| YOLO26n-depth | Depth    | 640                         | 24.8<br><sup>0.0 / 23.9 / 0.9</sup>  | **5.5**<br><sup>0.0 / 4.7 / 0.9</sup>                     |
+| YOLO26n-cls   | Classify | 224                         | 2.2<br><sup>0.0 / 2.2 / 0.0</sup>    | **2.0**<br><sup>0.0 / 2.0 / 0.0</sup>                     |
+| YOLO26n-pose  | Pose     | 640                         | 12.0<br><sup>0.0 / 11.9 / 0.0</sup>  | **3.8**<br><sup>0.0 / 3.8 / 0.0</sup>                     |
+| YOLO26n-obb   | OBB      | 1024                        | 21.7<br><sup>0.0 / 21.7 / 0.0</sup>  | **7.2**<br><sup>0.0 / 7.2 / 0.0</sup>                     |
 
 - <sup>1</sup> Semantic CoreML exports embed the ArgMax in the graph and return a compact full-resolution class map (`[1, 1024, 1024]`) instead of float logits, so the postprocess is a sub-millisecond color sweep and masks render pixel-sharp.
-- **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured through the [iOS SDK's](https://github.com/ultralytics/yolo-ios-app) per-stage timing via the [Flutter plugin's](https://github.com/ultralytics/yolo-flutter-app) benchmark harness in profile mode (optimized native code). Sustained real-time camera operation runs higher (full-sensor letterboxing every frame plus thermal settling): YOLO26n detect measures ~16 ms/frame in the live camera app on the same device — see the [iOS SDK performance doc](https://github.com/ultralytics/yolo-ios-app/blob/main/docs/performance.md) for steady-state profiling.
+- **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured through the [iOS SDK's](https://github.com/ultralytics/yolo-ios-app) per-stage timing via the [Flutter plugin's](https://github.com/ultralytics/yolo-flutter-app) benchmark harness in profile mode (optimized native code). Sustained real-time camera operation runs higher because it includes the capture and scaling pipeline plus thermal settling: YOLO26n detect measures 11.3 ms/frame and YOLO26n Depth 16.5 ms/frame in the live camera app on the same device — see the [iOS SDK performance doc](https://github.com/ultralytics/yolo-ios-app/blob/main/docs/performance.md) for steady-state profiling.
 - The matching Snapdragon CPU/GPU/NPU table is in the [Qualcomm QNN integration](qnn.md).
 
 ## Exporting YOLO26 Models to CoreML

--- a/docs/en/integrations/litert.md
+++ b/docs/en/integrations/litert.md
@@ -17,7 +17,7 @@ The LiteRT export format optimizes your models for tasks like [object detection]
 
 !!! tip "Run YOLO on Android with LiteRT today via the official Flutter plugin"
 
-    The official [Ultralytics YOLO Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) runs LiteRT `.tflite` exports on Android out of the box — real-time camera inference, single-image prediction, GPU acceleration, and automatic model download for all six YOLO26 tasks. For Apple devices use the [CoreML export](coreml.md); for Qualcomm Snapdragon NPUs see the [Qualcomm QNN integration](qnn.md).
+    The official [Ultralytics YOLO Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) runs LiteRT `.tflite` exports on Android out of the box — real-time camera inference, single-image prediction, GPU acceleration, and automatic model download for all seven YOLO26 tasks, including Depth. For Apple devices use the [CoreML export](coreml.md); for Qualcomm Snapdragon NPUs see the [Qualcomm QNN integration](qnn.md).
 
 !!! tip "Run YOLO on Web with LiteRT.js today via the official @ultralytics/yolo npm package"
 
@@ -47,19 +47,20 @@ One model format, every target:
 
 ## Measured Performance
 
-End-to-end single-image inference for the official YOLO26n Android LiteRT assets (`w8a32`: int8 weights, FP32 activations) on a [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) `0.6.8`. Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU runs the LiteRT XNNPACK delegate; GPU runs the LiteRT OpenCL/GL delegate (FP16).
+End-to-end single-image inference for the official YOLO26n Android LiteRT assets (`w8a32`: int8 weights, FP32 activations) on a [Xiaomi 17](https://www.mi.com/global/product/xiaomi-17/) phone powered by the Qualcomm Snapdragon 8 Elite Gen 5 (SM8850), measured through the [Ultralytics Flutter plugin](https://github.com/ultralytics/yolo-flutter-app) `0.6.10`. Each cell shows the **total time** (preprocessing + inference + postprocessing, excluding annotation) with the per-stage split beneath it. CPU runs the LiteRT XNNPACK delegate; GPU runs the LiteRT OpenCL/GL delegate (FP16).
 
-| Model        | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>w8a32 LiteRT<br>(ms)</sup> | GPU Adreno<br><sup>w8a32 LiteRT<br>(ms)</sup> |
-| ------------ | -------- | --------------------------- | -------------------------------------- | --------------------------------------------- |
-| YOLO26n      | Detect   | 640                         | 52.4<br><sup>1.8 / 48.2 / 2.4</sup>    | **13.5**<br><sup>1.9 / 8.1 / 3.5</sup>        |
-| YOLO26n-seg  | Segment  | 640                         | 72.8<br><sup>1.8 / 65.3 / 5.7</sup>    | **28.6**<br><sup>1.8 / 20.1 / 6.7</sup>       |
-| YOLO26n-sem  | Semantic | 640                         | 60.3<br><sup>1.8 / 50.4 / 8.1</sup>    | **32.9**<br><sup>1.8 / 23.0 / 8.2</sup>       |
-| YOLO26n-cls  | Classify | 224                         | 10.5<br><sup>0.9 / 9.6 / 0.1</sup>     | **3.2**<br><sup>1.0 / 2.2 / 0.1</sup>         |
-| YOLO26n-pose | Pose     | 640                         | 56.9<br><sup>1.8 / 53.9 / 1.2</sup>    | **14.0**<br><sup>1.9 / 9.3 / 2.8</sup>        |
-| YOLO26n-obb  | OBB      | 640                         | 50.5<br><sup>1.8 / 47.3 / 1.4</sup>    | **13.0**<br><sup>2.9 / 7.9 / 2.3</sup>        |
+| Model         | Task     | size<br><sup>(pixels)</sup> | CPU<br><sup>w8a32 LiteRT<br>(ms)</sup> | GPU Adreno<br><sup>w8a32 LiteRT<br>(ms)</sup> |
+| ------------- | -------- | --------------------------- | -------------------------------------- | --------------------------------------------- |
+| YOLO26n       | Detect   | 640                         | 52.4<br><sup>1.8 / 48.2 / 2.4</sup>    | **13.5**<br><sup>1.9 / 8.1 / 3.5</sup>        |
+| YOLO26n-seg   | Segment  | 640                         | 72.8<br><sup>1.8 / 65.3 / 5.7</sup>    | **28.6**<br><sup>1.8 / 20.1 / 6.7</sup>       |
+| YOLO26n-sem   | Semantic | 640                         | 60.3<br><sup>1.8 / 50.4 / 8.1</sup>    | **32.9**<br><sup>1.8 / 23.0 / 8.2</sup>       |
+| YOLO26n-depth | Depth    | 640                         | 325.1<br><sup>5.1 / 300.9 / 19.2</sup> | **23.0**<br><sup>2.0 / 12.9 / 8.2</sup>       |
+| YOLO26n-cls   | Classify | 224                         | 10.5<br><sup>0.9 / 9.6 / 0.1</sup>     | **3.2**<br><sup>1.0 / 2.2 / 0.1</sup>         |
+| YOLO26n-pose  | Pose     | 640                         | 56.9<br><sup>1.8 / 53.9 / 1.2</sup>    | **14.0**<br><sup>1.9 / 9.3 / 2.8</sup>        |
+| YOLO26n-obb   | OBB      | 640                         | 50.5<br><sup>1.8 / 47.3 / 1.4</sup>    | **13.0**<br><sup>2.9 / 7.9 / 2.3</sup>        |
 
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured with the Flutter plugin's on-device benchmark harness in profile mode. The full task suite runs back-to-back, so the CPU-bound preprocessing stage reflects sustained operation (a thermally rested single-task measurement is lower); the GPU/CPU inference stage is the steady-state compute cost.
-- The LiteRT export traces the PyTorch model directly, producing an **NCHW** `.tflite` with a float input — the GPU delegate compiles the whole graph (all six tasks run on the Adreno GPU here), and `w8a32` needs no calibration data. The official Android assets are hosted on the [yolo-flutter-app `v0.6.6` release](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.6.6), with the detailed benchmark record in [the Flutter performance doc](https://github.com/ultralytics/yolo-flutter-app/blob/main/doc/performance.md).
+- The LiteRT export traces the PyTorch model directly, producing an **NCHW** `.tflite` with a float input — the GPU delegate compiles the whole graph (all seven tasks run on the Adreno GPU here), and `w8a32` needs no calibration data. The official Android assets are hosted on the [yolo-flutter-app `v0.6.6` release](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.6.6), with the detailed benchmark record in [the Flutter performance doc](https://github.com/ultralytics/yolo-flutter-app/blob/main/doc/performance.md).
 - The matching Snapdragon **Hexagon NPU** numbers (and the INT8 TFLite CPU/GPU baseline) are in the [Qualcomm QNN integration](qnn.md).
 
 ## Export to LiteRT: Converting Your YOLO Model

--- a/docs/en/integrations/qnn.md
+++ b/docs/en/integrations/qnn.md
@@ -64,7 +64,7 @@ End-to-end single-image inference for the official YOLO26n models on a [Xiaomi 1
 | YOLO26n-obb  | OBB      | 1024                        | 50.3<br><sup>3.6 / 45.4 / 1.3</sup>   | **13.9**<br><sup>3.8 / 8.2 / 1.8</sup>       | 21.0<br><sup>8.8 / 10.9 / 1.3</sup>              |
 
 - **Speed** values are **single-image burst latencies** — the mean of 15 runs after 3 warmup runs on `bus.jpg`, measured with the [Flutter plugin's](https://github.com/ultralytics/yolo-flutter-app) on-device benchmark harness on a thermally rested device. Sustained real-time camera frame times run higher (per-frame capture letterboxing plus thermal settling); use the app's on-screen pre/inference/post breakdown for steady-state numbers on your device.
-- This table is kept as the QNN comparison snapshot. Current Android LiteRT CPU/GPU numbers measured with `ultralytics_yolo` `0.6.8` are in the [LiteRT integration](litert.md#measured-performance), and the detailed benchmark record is in the [Flutter performance doc](https://github.com/ultralytics/yolo-flutter-app/blob/main/doc/performance.md).
+- This table is kept as the QNN comparison snapshot. Current Android LiteRT CPU/GPU numbers measured with `ultralytics_yolo` `0.6.10` are in the [LiteRT integration](litert.md#measured-performance), and the detailed benchmark record is in the [Flutter performance doc](https://github.com/ultralytics/yolo-flutter-app/blob/main/doc/performance.md).
 - <sup>1</sup> Semantic QNN uses the in-graph ArgMax class-map output from this release, which replaced erratic 123-1065 ms logits decoding with a stable ~49 ms; the GPU remains slightly faster for semantic at 1024px.
 
 ### Windows on Snapdragon Laptop

--- a/docs/mkdocs_github_authors.yaml
+++ b/docs/mkdocs_github_authors.yaml
@@ -403,6 +403,9 @@ thunderbirdtr@gmail.com:
 tigran@ultralytics.com:
   avatar: https://avatars.githubusercontent.com/u/197762997?v=4
   username: t-hakobyan
+tomasz.bujewski@intel.com:
+  avatar: https://avatars.githubusercontent.com/u/29205246?v=4
+  username: tbujewsk
 vitali.lobanov@pm.me:
   avatar: https://avatars.githubusercontent.com/u/3666356?v=4
   username: lussebullar


### PR DESCRIPTION
## Summary

- document all seven mobile YOLO26 tasks on the CoreML and LiteRT integration pages
- add measured YOLO26n Depth CPU and accelerated latency from physical iPhone 17 Pro and Xiaomi 17 runs
- update the Flutter plugin version and sustained iOS camera figures to the shipped paths
- synchronize the QNN page's Flutter version cross-reference

Deleted: stale six-task mobile claims, the Depth benchmark omissions, the old Flutter 0.6.8 attribution, the retired 16 ms iOS camera figure, and the inaccurate blanket single-digit CoreML claim.

These documentation additions are required because the benchmark tables previously had no Depth row; there was no existing row to replace.

Merge order: this PR documents yolo-flutter-app #562 / plugin 0.6.10 and must merge after that plugin PR is published.

## Validation

- physical iPhone 17 Pro, iOS 26.5.2: Core ML CPU and Neural Engine Depth benchmarks
- physical Xiaomi 17: LiteRT XNNPACK CPU and Adreno GPU Depth benchmarks
- pinned Prettier 3.6.2 check with docs tab-width 4 and print-width 120
- git diff --check
- full docs build attempted but could not start locally because Beautiful Soup is not installed; GitHub Docs CI is authoritative
- single cold Codex review across Flutter f983d4e, iOS 6774c72, and Ultralytics b305153: LGTM

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 Updated YOLO26 mobile deployment documentation to add Depth support and refresh CoreML, LiteRT, and QNN performance details.

### 📊 Key Changes
- Added **Depth** as the seventh supported YOLO26 task in the CoreML and LiteRT integration guides.
- Added YOLO26n Depth benchmark results:
  - **CoreML Neural Engine:** 5.5 ms single-image latency and 16.5 ms/frame in sustained camera use.
  - **LiteRT Adreno GPU:** 23.0 ms single-image latency.
  - **LiteRT CPU:** 325.1 ms single-image latency.
- Updated CoreML performance measurements for sustained camera inference, including revised YOLO26n detection timing.
- Refreshed LiteRT benchmark references from Flutter plugin `0.6.8` to `0.6.10`.
- Updated QNN documentation to reference the latest LiteRT benchmark version.
- Added GitHub author metadata for @tbujewsk.

### 🎯 Purpose & Impact
- 📱 Gives developers current guidance for deploying all seven YOLO26 tasks—including Depth—on Apple and Android devices.
- ⚡ Helps users select suitable hardware: Depth is substantially faster on Apple Neural Engine and Android GPU than on Android CPU.
- 📊 Provides more accurate, real-world performance expectations for single-image and sustained camera workloads.
- 🔗 Keeps integration documentation aligned with the latest official Flutter plugin benchmarks and mobile deployment assets.