### PR TITLE
Fix `YOLOESegModel.loss` mixing text prompts into visual-prompt training

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1429,13 +1429,7 @@ class YOLOESegModel(YOLOEModel, SegmentationModel):
                 else self.init_criterion()
             )
 
-        if preds is None:
-            preds = self.forward(
-                batch["img"],
-                tpe=None if "visuals" in batch else batch.get("txt_feats", None),
-                vpe=batch.get("visuals", None),
-            )
-        return self.criterion(preds, batch)
+        return super().loss(batch, preds)
 
 
 class Ensemble(torch.nn.ModuleList):

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1430,7 +1430,11 @@ class YOLOESegModel(YOLOEModel, SegmentationModel):
             )
 
         if preds is None:
-            preds = self.forward(batch["img"], tpe=batch.get("txt_feats", None), vpe=batch.get("visuals", None))
+            preds = self.forward(
+                batch["img"],
+                tpe=None if "visuals" in batch else batch.get("txt_feats", None),
+                vpe=batch.get("visuals", None),
+            )
         return self.criterion(preds, batch)
 
 


### PR DESCRIPTION
## Summary

YOLOE segmentation visual-prompt training inherited the same prompt-selection requirement as YOLOE detection, but duplicated its own forward/loss tail and therefore missed the detection-path fix. After initializing the segmentation criterion, delegate to `YOLOEModel.loss`, which already excludes text embeddings when visual prompts are present.

This relocates ownership to the existing shared YOLOE loss path instead of copying another condition.

Deleted: the duplicated `YOLOESegModel.loss` forward call and direct criterion invocation; reused `YOLOEModel.loss`.

## Validation

- Net-negative source-only diff; no tests added.
- `ruff check ultralytics/nn/tasks.py`
- `git diff --check`
- Verified `YOLOESegModel` resolves `super().loss` to `YOLOEModel.loss`.