### PR TITLE
Remove obsolete docs workflow badge

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,6 @@ Welcome to Ultralytics Docs, your comprehensive resource for understanding and u
 
 [![pages-build-deployment](https://github.com/ultralytics/docs/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/ultralytics/docs/actions/workflows/pages/pages-build-deployment)
 [![Check Broken links](https://github.com/ultralytics/docs/actions/workflows/links.yml/badge.svg)](https://github.com/ultralytics/docs/actions/workflows/links.yml)
-[![Check Domains](https://github.com/ultralytics/docs/actions/workflows/check_domains.yml/badge.svg)](https://github.com/ultralytics/docs/actions/workflows/check_domains.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/docs/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/docs/actions/workflows/format.yml)
 
 <a href="https://discord.com/invite/ultralytics"><img alt="Discord" src="https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue"></a> <a href="https://community.ultralytics.com/"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a> <a href="https://www.reddit.com/r/ultralytics/"><img alt="Ultralytics Reddit" src="https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue"></a>


### PR DESCRIPTION
## Summary

Remove the Check Domains badge from docs/README.md because ultralytics/docs no longer has the referenced check_domains.yml workflow. The dead badge URL caused the scheduled broken-link check to fail.

## Validation

- confirmed the remaining three workflow badge URLs return HTTP 200
- confirmed docs/README.md no longer references check_domains.yml
- npx prettier@3.6.2 --check docs/README.md
- git diff --check

Deleted: the obsolete Check Domains badge and link.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Removes the obsolete domain-check workflow badge from the Ultralytics documentation README. 🧹

### 📊 Key Changes

- Deleted the **“Check Domains”** GitHub Actions badge from `docs/README.md`.
- Kept the documentation build, broken-link, and formatting status badges unchanged.

### 🎯 Purpose & Impact

- Keeps the README aligned with currently relevant documentation workflows. ✅
- Reduces outdated or misleading CI information for contributors and users.
- No functional changes to the Ultralytics package or documentation build process. 🚀