### PR TITLE
Fix ECC camera-motion translation not rescaled after downscale in `GMC`

### DIFF
--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -143,6 +143,10 @@ class GMC:
         # Run the ECC algorithm to find transformation matrix
         try:
             (_, H) = cv2.findTransformECC(self.prevFrame, frame, H, self.warp_mode, self.criteria, None, 1)
+            # Scale translation components back to original resolution
+            if self.downscale > 1.0:
+                H[0, 2] *= self.downscale
+                H[1, 2] *= self.downscale
         except Exception as e:
             LOGGER.warning(f"findTransformECC failed; using identity warp. {e}")
 

--- a/ultralytics/trackers/utils/gmc.py
+++ b/ultralytics/trackers/utils/gmc.py
@@ -143,10 +143,7 @@ class GMC:
         # Run the ECC algorithm to find transformation matrix
         try:
             (_, H) = cv2.findTransformECC(self.prevFrame, frame, H, self.warp_mode, self.criteria, None, 1)
-            # Scale translation components back to original resolution
-            if self.downscale > 1.0:
-                H[0, 2] *= self.downscale
-                H[1, 2] *= self.downscale
+            H[:, 2] *= (width / frame.shape[1], height / frame.shape[0])
         except Exception as e:
             LOGGER.warning(f"findTransformECC failed; using identity warp. {e}")
 


### PR DESCRIPTION
## Summary

ECC estimates translation in resized-frame pixels, but GMC applies the returned warp to full-resolution tracks. Rescale the translation column by the actual horizontal and vertical resize ratios so odd frame dimensions are handled exactly.

This stays at the ECC estimation boundary, where the resized-coordinate transform is produced. It adds no compatibility guard or shared helper.

Deleted: the downscale condition, explanatory comment, and separate per-axis assignments; replaced them with one vectorized exact-axis rescale.

## Validation

- Source-only diff; no tests added.
- `ruff check ultralytics/trackers/utils/gmc.py`
- `git diff --check`
- Verified the translation column uses `width / frame.shape[1]` and `height / frame.shape[0]`.