### PR TITLE
Validate CLI choice arguments in config

### DIFF
--- a/.github/scripts/fuzz.py
+++ b/.github/scripts/fuzz.py
@@ -146,6 +146,7 @@ EXPECTED_MODULES = (
     "ultralytics/cfg/__init__.py",
     "ultralytics/utils/checks.py",
     "ultralytics/data/utils.py",
+    "ultralytics/data/augment.py:classify_augmentations",
     "ultralytics/engine/exporter.py:validate_args",  # exporter's intentional per-format argument validation
     "ultralytics/engine/exporter.py:__call__",  # intentional compat asserts; per-format bugs raise in deeper frames
 )

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -82,12 +82,22 @@ def test_dataloader_empty_dataset_uses_dataloader_validation():
         build_dataloader([], batch=4, workers=2)
 
 
-def test_cfg_rejects_fuzzed_scalars():
-    """Test invalid scalar overrides fail in config validation."""
+def test_cfg_rejects_fuzzed_values():
+    """Test invalid overrides fail in config validation."""
     with pytest.raises(TypeError, match="degrees"):
         get_cfg(overrides={"degrees": None})
     with pytest.raises(ValueError, match="cls_pw"):
         get_cfg(overrides={"cls_pw": 10})
+    for key, value in (
+        ("split", []),
+        ("split", -0.0),
+        ("split", "🚀"),
+        ("optimizer", []),
+        ("auto_augment", "randaug"),
+        ("copy_paste_mode", {}),
+    ):
+        with pytest.raises(ValueError, match=key):
+            get_cfg(overrides={key: value})
 
 
 def skip_rpi_semantic():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -21,7 +21,7 @@ from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
 from ultralytics import RTDETR, YOLO
 from ultralytics.cfg import get_cfg
 from ultralytics.data.build import build_dataloader, load_inference_source
-from ultralytics.data.utils import check_det_dataset
+from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.utils import (
     ARM64,
     ASSETS,
@@ -91,13 +91,15 @@ def test_cfg_rejects_fuzzed_values():
     for key, value in (
         ("split", []),
         ("split", -0.0),
-        ("split", "🚀"),
         ("optimizer", []),
-        ("auto_augment", "randaug"),
         ("copy_paste_mode", {}),
+        ("optimizer", None),
+        ("split", None),
+        ("copy_paste_mode", None),
     ):
-        with pytest.raises(ValueError, match=key):
+        with pytest.raises((TypeError, ValueError), match=key):
             get_cfg(overrides={key: value})
+    assert get_cfg(overrides={"auto_augment": None}).auto_augment is None
 
 
 def skip_rpi_semantic():
@@ -746,6 +748,8 @@ def test_data_utils(tmp_path):
     autosplit(tmp_path / "coco8/images")
     assert any((tmp_path / "coco8").glob("autosplit_*.txt"))
     assert zip_directory(images_dir).is_file()
+    with pytest.raises(ValueError, match="split"):
+        check_cls_dataset("imagenet10", split="invalid")
     with pytest.raises(FileNotFoundError, match="'test:' images not found"):
         check_det_dataset("coco8.yaml", split="test")
     data_yaml = tmp_path / "coco8.yaml"

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -293,6 +293,12 @@ CFG_BOOL_KEYS = frozenset(
         "cls_remap",
     }
 )
+CFG_CHOICES = {
+    "optimizer": frozenset({"Adam", "Adamax", "AdamW", "MuSGD", "NAdam", "RAdam", "RMSProp", "SGD", "auto"}),
+    "split": frozenset({"train", "val", "test", "minival"}),
+    "copy_paste_mode": frozenset({"flip", "mixup"}),
+    "auto_augment": frozenset({"randaugment", "autoaugment", "augmix"}),
+}
 
 
 def cfg2dict(cfg: str | Path | dict | SimpleNamespace) -> dict:
@@ -460,6 +466,13 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                         f"'{k}' must be a bool (i.e. '{k}=True' or '{k}=False')"
                     )
                 cfg[k] = bool(v)
+            elif k in CFG_CHOICES:
+                choices = CFG_CHOICES[k]
+                valid = isinstance(v, str) and (
+                    v in choices or (k == "optimizer" and v.lower() in {x.lower() for x in choices})
+                )
+                if not valid:
+                    raise ValueError(f"'{k}={v}' is invalid. Valid '{k}' values are {sorted(choices)}.")
             elif k == "compile" and not isinstance(v, (bool, str)):  # False=off, True="default", or a mode string
                 if hard:
                     raise TypeError(

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -293,12 +293,7 @@ CFG_BOOL_KEYS = frozenset(
         "cls_remap",
     }
 )
-CFG_CHOICES = {
-    "optimizer": frozenset({"Adam", "Adamax", "AdamW", "MuSGD", "NAdam", "RAdam", "RMSProp", "SGD", "auto"}),
-    "split": frozenset({"train", "val", "test", "minival"}),
-    "copy_paste_mode": frozenset({"flip", "mixup"}),
-    "auto_augment": frozenset({"randaugment", "autoaugment", "augmix"}),
-}
+CFG_STR_KEYS = frozenset({"optimizer", "split", "copy_paste_mode", "auto_augment"})
 
 
 def cfg2dict(cfg: str | Path | dict | SimpleNamespace) -> dict:
@@ -409,9 +404,9 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
         - None values are ignored as they may be from optional arguments.
         - Fraction keys use [0.0, 1.0], except dataset fraction, which uses (0.0, 1.0].
     """
-    typed_keys = CFG_FLOAT_KEYS | CFG_FRACTION_KEYS | CFG_INT_KEYS | CFG_BOOL_KEYS | {"scale", "compile"}
+    typed_keys = CFG_FLOAT_KEYS | CFG_FRACTION_KEYS | CFG_INT_KEYS | CFG_BOOL_KEYS | CFG_STR_KEYS | {"scale", "compile"}
     for k, v in cfg.items():
-        if v is None and DEFAULT_CFG_DICT.get(k) is not None and k in typed_keys:
+        if v is None and DEFAULT_CFG_DICT.get(k) is not None and k in typed_keys and k != "auto_augment":
             raise TypeError(f"'{k}=None' is invalid. '{k}' must not be None.")
         if v is not None:  # None values may be from optional args
             if k in CFG_FLOAT_KEYS and not isinstance(v, FLOAT_OR_INT):
@@ -466,13 +461,10 @@ def check_cfg(cfg: dict, hard: bool = True) -> None:
                         f"'{k}' must be a bool (i.e. '{k}=True' or '{k}=False')"
                     )
                 cfg[k] = bool(v)
-            elif k in CFG_CHOICES:
-                choices = CFG_CHOICES[k]
-                valid = isinstance(v, str) and (
-                    v in choices or (k == "optimizer" and v.lower() in {x.lower() for x in choices})
-                )
-                if not valid:
-                    raise ValueError(f"'{k}={v}' is invalid. Valid '{k}' values are {sorted(choices)}.")
+            elif k in CFG_STR_KEYS and not isinstance(v, str):
+                if hard:
+                    raise TypeError(f"'{k}={v}' is of invalid type {type(v).__name__}. '{k}' must be a str.")
+                cfg[k] = str(v)
             elif k == "compile" and not isinstance(v, (bool, str)):  # False=off, True="default", or a mode string
                 if hard:
                     raise TypeError(

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -580,6 +580,9 @@ def check_cls_dataset(dataset: str | Path, split: str = "") -> dict[str, Any]:
             - 'nc' (int): The number of classes in the dataset.
             - 'names' (dict[int, str]): A dictionary of class names in the dataset.
     """
+    if split and split not in {"train", "val", "test"}:
+        raise ValueError(f"Invalid classification dataset split '{split}'. Use 'train', 'val', or 'test'.")
+
     # Download (optional if dataset=https://file.zip is passed directly)
     if str(dataset).startswith(("http:/", "https:/")):
         dataset = safe_download(dataset, dir=DATASETS_DIR, unzip=True, delete=False)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -25,7 +25,7 @@ from torch import distributed as dist
 from torch import nn, optim
 
 from ultralytics import __version__
-from ultralytics.cfg import _YOLO_CLI_COMMAND, get_cfg, get_save_dir
+from ultralytics.cfg import CFG_CHOICES, _YOLO_CLI_COMMAND, get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.tasks import load_checkpoint
@@ -1088,7 +1088,7 @@ class BaseTrainer:
         if not use_muon:
             g = [x.values() for x in g[:3]]  # convert to list of params
 
-        optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "SGD", "MuSGD", "auto"}
+        optimizers = CFG_CHOICES["optimizer"]
         name = {x.lower(): x for x in optimizers}.get(str(name).lower(), str(name))
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optim_args = dict(lr=lr, betas=(momentum, 0.999), weight_decay=0.0)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -25,7 +25,7 @@ from torch import distributed as dist
 from torch import nn, optim
 
 from ultralytics import __version__
-from ultralytics.cfg import CFG_CHOICES, _YOLO_CLI_COMMAND, get_cfg, get_save_dir
+from ultralytics.cfg import _YOLO_CLI_COMMAND, CFG_CHOICES, get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.tasks import load_checkpoint

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -25,7 +25,7 @@ from torch import distributed as dist
 from torch import nn, optim
 
 from ultralytics import __version__
-from ultralytics.cfg import _YOLO_CLI_COMMAND, CFG_CHOICES, get_cfg, get_save_dir
+from ultralytics.cfg import _YOLO_CLI_COMMAND, get_cfg, get_save_dir
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.tasks import load_checkpoint
@@ -1088,7 +1088,7 @@ class BaseTrainer:
         if not use_muon:
             g = [x.values() for x in g[:3]]  # convert to list of params
 
-        optimizers = CFG_CHOICES["optimizer"]
+        optimizers = {"Adam", "Adamax", "AdamW", "NAdam", "RAdam", "RMSProp", "SGD", "MuSGD", "auto"}
         name = {x.lower(): x for x in optimizers}.get(str(name).lower(), str(name))
         if name in {"Adam", "Adamax", "AdamW", "NAdam", "RAdam"}:
             optim_args = dict(lr=lr, betas=(momentum, 0.999), weight_decay=0.0)


### PR DESCRIPTION
## Summary

- validate string-typed CLI arguments at the shared config boundary
- validate classification split names in `check_cls_dataset()` while leaving detection dataset-defined splits untouched
- recognize the existing `classify_augmentations()` policy rejection as intentional in the fuzz oracle

## Validation

- `ruff format .github/scripts/fuzz.py ultralytics/cfg/__init__.py ultralytics/data/utils.py tests/test_python.py`
- `ruff check .github/scripts/fuzz.py ultralytics/cfg/__init__.py ultralytics/data/utils.py tests/test_python.py`
- `pytest tests/test_python.py::test_cfg_rejects_fuzzed_values tests/test_python.py::test_data_utils -q`
- replayed all six commands from fuzz run 29302528940 through `.github/scripts/fuzz.py repro`; all now classify as expected

Deleted: nothing. The bugfix is net-positive because config had no string-type validation family and classification datasets had no split-name validation to relocate; each added check stays at its existing owner, with no global choice registry or downstream guard.

Refs #25056

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛡️ Strengthens configuration validation and classification dataset checks to catch invalid inputs earlier.

### 📊 Key Changes
- Added strict string validation for configuration options including `optimizer`, `split`, `copy_paste_mode`, and `auto_augment`.
- Rejected invalid non-string values and `None` values for most newly validated options, while preserving `auto_augment=None` as valid.
- Added validation for classification dataset splits, allowing only `train`, `val`, or `test`.
- Expanded tests to cover invalid configuration values and dataset split handling.
- Included `classify_augmentations` in fuzz testing to improve robustness coverage.

### 🎯 Purpose & Impact
- 🚨 Detects malformed training and augmentation settings before they cause confusing runtime errors.
- ✅ Prevents invalid classification dataset splits from reaching dataset-loading logic.
- 🧪 Improves regression protection through broader automated and fuzz testing.
- 🔧 Makes configuration behavior more predictable for users and integrations.