### PR TITLE
Fix uint8 overflow in `polygons2masks_overlap` dropping instances past 128 overlaps

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -794,6 +794,17 @@ def test_data_utils(tmp_path):
     with pytest.raises(FileNotFoundError, match="images not found"):
         check_det_dataset(data_yaml, split="test")
 
+    # polygons2masks_overlap must not overflow uint8 on the transient `masks + mask` sum (reaches 2 * i + 1):
+    # with more than 128 overlapping instances every instance must keep a distinct index in the overlap mask
+    from ultralytics.data.utils import polygons2masks_overlap
+
+    segments = [
+        np.array([[150 - s, 150 - s], [150 + s, 150 - s], [150 + s, 150 + s], [150 - s, 150 + s]], dtype=np.float32)
+        for s in range(140, 10, -1)  # 130 concentric squares, all overlapping the center
+    ]
+    overlap, _ = polygons2masks_overlap((300, 300), segments)
+    assert len(np.unique(overlap)) == len(segments) + 1  # background + 130 instances, no uint8 wraparound
+
 
 def test_safe_download_unzips_local_path_archive(tmp_path):
     """Test safe_download() unzips local archive paths without treating them like remote URLs."""

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -410,10 +410,9 @@ def polygons2masks_overlap(
     areas = np.asarray(areas)
     index = np.argsort(-areas)
     ms = np.array(ms)[index]
+    # Running max: the old `masks + mask` sum hit 2 * i + 1 and overflowed uint8 past 128 overlapping instances
     for i in range(len(segments)):
-        mask = ms[i] * (i + 1)
-        masks = masks + mask
-        masks = np.clip(masks, a_min=0, a_max=i + 1)
+        np.maximum(masks, ms[i] * (i + 1), out=masks)
     return masks, index
 
 


### PR DESCRIPTION
## Summary

Prevent `uint8` overflow in `polygons2masks_overlap` when more than 128 instances overlap.

## Changes

- Replace accumulation plus clipping with an in-place running maximum.
- Preserve the existing area ordering, dtype, instance priority, and returned index mapping.
- Cover 130 concentric instances so every visible ring retains its label.

## Verification

- `pytest tests/test_python.py -k test_data_utils -q` — 1 passed.
- `ruff format ultralytics/data/utils.py tests/test_python.py`
- `ruff check --fix ultralytics/data/utils.py tests/test_python.py`
- Fresh adversarial Core Principles review: LGTM.

Deleted: the overflow-prone mask temporary, addition, and `np.clip` operation.

Net-positive justification: the production fix is net-negative; the added lines are focused regression coverage because no existing test exercised the greater-than-128 overlap boundary.