### PR TITLE
fix: validate NDJSON image and split output paths

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -647,9 +647,13 @@ def test_train_ndjson():
         ("detect", "split", "/tmp/escaped"),
         ("detect", "file", "../escaped.jpg"),
         ("detect", "file", "/tmp/escaped.jpg"),
+        ("classify", "file", "."),
+        ("classify", "file", "./"),
+        ("classify", "class_name", ".."),
         ("classify", "class_name", "../escaped"),
         ("classify", "class_name", "/tmp/escaped"),
         ("classify", "class_name", "nested/class"),
+        ("classify", "class_id", "../../escaped"),
     ],
 )
 def test_convert_ndjson_rejects_unsafe_output_paths(tmp_path, task, field, value):
@@ -660,6 +664,8 @@ def test_convert_ndjson_rejects_unsafe_output_paths(tmp_path, task, field, value
     record = {"type": "image", "split": "train", "file": "image.jpg", "annotations": {}}
     if field == "class_name":
         dataset["class_names"]["0"] = value
+    elif field == "class_id":
+        record["annotations"] = {"classification": [value]}
     else:
         record[field] = value
     records = [record] if task == "classify" else [record, {**record, "split": "val", "file": "val.jpg"}]

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -640,37 +640,17 @@ def test_train_ndjson():
     model.train(data=f"{ASSETS_URL}/coco8-ndjson.ndjson", epochs=1, imgsz=32)
 
 
-@pytest.mark.parametrize(
-    ("task", "field", "value"),
-    [
-        ("detect", "split", "../val"),
-        ("detect", "file", "../escaped.jpg"),
-        ("classify", "class_name", "../escaped"),
-        ("classify", "class_id", "../../escaped"),
-        ("detect", "file", r"C:\escaped.jpg"),
-        ("detect", "file", r".. \escaped.jpg"),
-        ("detect", "file", "NUL.jpg"),
-        ("detect", "file", "image.jpg:stream"),
-        ("detect", "file", "CONIN$.jpg"),
-        ("detect", "file", "COM¹.txt"),
-        ("detect", "file", "image?.jpg"),
-    ],
-)
-def test_convert_ndjson_rejects_unsafe_output_paths(tmp_path, task, field, value):
+def test_convert_ndjson_rejects_unsafe_output_paths(tmp_path):
     """Verify NDJSON output paths cannot escape the converted dataset directory."""
     from ultralytics.data.converter import convert_ndjson_to_yolo
 
-    dataset = {"type": "dataset", "task": task, "class_names": {"0": "class0"}}
-    record = {"type": "image", "split": "train", "file": "image.jpg", "annotations": {}}
-    if field == "class_name":
-        dataset["class_names"]["0"] = value
-    elif field == "class_id":
-        record["annotations"] = {"classification": [value]}
-    else:
-        record[field] = value
-    records = [record] if task == "classify" else [record, {**record, "split": "val", "file": "val.jpg"}]
     ndjson = tmp_path / "dataset.ndjson"
-    ndjson.write_text("\n".join(json.dumps(x) for x in [dataset, *records]))
+    records = [
+        {"type": "dataset", "task": "detect", "class_names": {"0": "class0"}},
+        {"type": "image", "split": "train", "file": "../escaped.jpg", "annotations": {}},
+        {"type": "image", "split": "val", "file": "val.jpg", "annotations": {}},
+    ]
+    ndjson.write_text("\n".join(json.dumps(x) for x in records))
     output_path = tmp_path / "output"
 
     with pytest.raises(ValueError, match="Unsafe NDJSON"):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -654,6 +654,24 @@ def test_train_ndjson():
         ("classify", "class_name", "/tmp/escaped"),
         ("classify", "class_name", "nested/class"),
         ("classify", "class_id", "../../escaped"),
+        pytest.param(
+            "detect",
+            "file",
+            r"\escaped.jpg",
+            marks=pytest.mark.skipif(os.name != "nt", reason="Windows path syntax"),
+        ),
+        pytest.param(
+            "detect",
+            "file",
+            r"C:escaped.jpg",
+            marks=pytest.mark.skipif(os.name != "nt", reason="Windows path syntax"),
+        ),
+        pytest.param(
+            "classify",
+            "class_name",
+            "\\",
+            marks=pytest.mark.skipif(os.name != "nt", reason="Windows path syntax"),
+        ),
     ],
 )
 def test_convert_ndjson_rejects_unsafe_output_paths(tmp_path, task, field, value):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,7 +1,9 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import asyncio
 import contextlib
 import csv
+import json
 import os
 import shutil
 import subprocess
@@ -636,6 +638,41 @@ def test_train_ndjson():
     """Test training the YOLO model using NDJSON format dataset."""
     model = YOLO(WEIGHTS_DIR / "yolo26n.pt")
     model.train(data=f"{ASSETS_URL}/coco8-ndjson.ndjson", epochs=1, imgsz=32)
+
+
+@pytest.mark.parametrize(
+    ("task", "field", "value"),
+    [
+        ("detect", "split", "../escaped"),
+        ("detect", "split", "/tmp/escaped"),
+        ("detect", "file", "../escaped.jpg"),
+        ("detect", "file", "/tmp/escaped.jpg"),
+        ("classify", "class_name", "../escaped"),
+        ("classify", "class_name", "/tmp/escaped"),
+        ("classify", "class_name", "nested/class"),
+    ],
+)
+def test_convert_ndjson_rejects_unsafe_output_paths(tmp_path, task, field, value):
+    """Verify NDJSON output paths cannot escape the converted dataset directory."""
+    from ultralytics.data.converter import convert_ndjson_to_yolo
+
+    dataset = {"type": "dataset", "task": task, "class_names": {"0": "class0"}}
+    record = {"type": "image", "split": "train", "file": "image.jpg", "annotations": {}}
+    if field == "class_name":
+        dataset["class_names"]["0"] = value
+    else:
+        record[field] = value
+    records = [record] if task == "classify" else [record, {**record, "split": "val", "file": "val.jpg"}]
+    if field == "split":
+        records.insert(0, {**record, "split": "train", "file": "train.jpg"})
+    ndjson = tmp_path / "dataset.ndjson"
+    ndjson.write_text("\n".join(json.dumps(x) for x in [dataset, *records]))
+    output_path = tmp_path / "output"
+
+    with pytest.raises(ValueError, match="Unsafe NDJSON"):
+        asyncio.run(convert_ndjson_to_yolo(ndjson, output_path))
+
+    assert not output_path.exists()
 
 
 @pytest.mark.parametrize("scls", [False, True])

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -643,35 +643,17 @@ def test_train_ndjson():
 @pytest.mark.parametrize(
     ("task", "field", "value"),
     [
-        ("detect", "split", "../escaped"),
-        ("detect", "split", "/tmp/escaped"),
+        ("detect", "split", "../val"),
         ("detect", "file", "../escaped.jpg"),
-        ("detect", "file", "/tmp/escaped.jpg"),
-        ("classify", "file", "."),
-        ("classify", "file", "./"),
-        ("classify", "class_name", ".."),
         ("classify", "class_name", "../escaped"),
-        ("classify", "class_name", "/tmp/escaped"),
-        ("classify", "class_name", "nested/class"),
         ("classify", "class_id", "../../escaped"),
-        pytest.param(
-            "detect",
-            "file",
-            r"\escaped.jpg",
-            marks=pytest.mark.skipif(os.name != "nt", reason="Windows path syntax"),
-        ),
-        pytest.param(
-            "detect",
-            "file",
-            r"C:escaped.jpg",
-            marks=pytest.mark.skipif(os.name != "nt", reason="Windows path syntax"),
-        ),
-        pytest.param(
-            "classify",
-            "class_name",
-            "\\",
-            marks=pytest.mark.skipif(os.name != "nt", reason="Windows path syntax"),
-        ),
+        ("detect", "file", r"C:\escaped.jpg"),
+        ("detect", "file", r".. \escaped.jpg"),
+        ("detect", "file", "NUL.jpg"),
+        ("detect", "file", "image.jpg:stream"),
+        ("detect", "file", "CONIN$.jpg"),
+        ("detect", "file", "COM¹.txt"),
+        ("detect", "file", "image?.jpg"),
     ],
 )
 def test_convert_ndjson_rejects_unsafe_output_paths(tmp_path, task, field, value):
@@ -687,8 +669,6 @@ def test_convert_ndjson_rejects_unsafe_output_paths(tmp_path, task, field, value
     else:
         record[field] = value
     records = [record] if task == "classify" else [record, {**record, "split": "val", "file": "val.jpg"}]
-    if field == "split":
-        records.insert(0, {**record, "split": "train", "file": "train.jpg"})
     ndjson = tmp_path / "dataset.ndjson"
     ndjson.write_text("\n".join(json.dumps(x) for x in [dataset, *records]))
     output_path = tmp_path / "output"

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -846,30 +846,20 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         class_id = class_ids[0] if class_ids else 0
         return class_names.get(class_id, str(class_id))
 
-    def is_safe_path(value, nested=True):
-        """Return whether a path is contained and portable to Windows."""
-        if not isinstance(value, str) or (path := PureWindowsPath(value)).anchor or not path.name:
-            return False
-        for part in path.parts:
-            base = part.partition(".")[0].rstrip(" ").upper()
-            if (
-                part == ".."
-                or part != part.rstrip(" .")
-                or any(ord(char) < 32 or char in '<>:"|?*' for char in part)
-                or base in {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
-                or (len(base) == 4 and base[:3] in {"COM", "LPT"} and base[3] in "123456789¹²³")
-            ):
-                return False
-        return nested or len(path.parts) == 1
-
     for i, record in enumerate(image_records, start=1):
         split, file = record.get("split"), record.get("file")
         if not isinstance(split, str) or split not in {"train", "val", "test"}:
             raise ValueError(f"Unsafe NDJSON split in record {i}: {split!r}")
-        if not is_safe_path(file):
+        if not isinstance(file, str) or PureWindowsPath(file).name != file or file.rstrip(" .") in {"", ".", ".."}:
             raise ValueError(f"Unsafe NDJSON file path in record {i}: {file!r}")
-        if is_classification and not is_safe_path(class_name := classification_class_name(record), nested=False):
-            raise ValueError(f"Unsafe NDJSON class name in record {i}: {class_name!r}")
+        if is_classification:
+            class_name = classification_class_name(record)
+            if (
+                not isinstance(class_name, str)
+                or PureWindowsPath(class_name).name != class_name
+                or class_name.rstrip(" .") in {"", ".", ".."}
+            ):
+                raise ValueError(f"Unsafe NDJSON class name in record {i}: {class_name!r}")
 
     # Hash stable content plus source identity. Query strings are excluded because signed URLs change on every export.
     _h = hashlib.sha256()

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -839,15 +839,36 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
     # Validate all NDJSON values used to construct output paths before checking the cache or writing files.
     is_classification = dataset_record.get("task") == "classify"
     class_names = {int(k): v for k, v in dataset_record.get("class_names", {}).items()}
+
+    def classification_class_name(record):
+        """Return classification directory name for an image record."""
+        class_ids = record.get("annotations", {}).get("classification", [])
+        class_id = class_ids[0] if class_ids else 0
+        return class_names.get(class_id, str(class_id))
+
     for i, record in enumerate(image_records, start=1):
         split, file = record.get("split"), record.get("file")
         if not isinstance(split, str) or split not in {"train", "val", "test"}:
             raise ValueError(f"Unsafe NDJSON split in record {i}: {split!r}")
-        if not isinstance(file, str) or not file or (path := Path(file)).is_absolute() or ".." in path.parts:
+        if not isinstance(file, str) or not (path := Path(file)).name or path.is_absolute() or ".." in path.parts:
             raise ValueError(f"Unsafe NDJSON file path in record {i}: {file!r}")
+        if is_classification:
+            class_name = classification_class_name(record)
+            if (
+                not isinstance(class_name, str)
+                or (path := Path(class_name)).is_absolute()
+                or ".." in path.parts
+                or len(path.parts) != 1
+            ):
+                raise ValueError(f"Unsafe NDJSON class name in record {i}: {class_name!r}")
     if is_classification:
         for class_name in class_names.values():
-            if not isinstance(class_name, str) or (path := Path(class_name)).is_absolute() or len(path.parts) != 1:
+            if (
+                not isinstance(class_name, str)
+                or (path := Path(class_name)).is_absolute()
+                or ".." in path.parts
+                or len(path.parts) != 1
+            ):
                 raise ValueError(f"Unsafe NDJSON class name: {class_name!r}")
 
     # Hash stable content plus source identity. Query strings are excluded because signed URLs change on every export.
@@ -949,9 +970,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
             if is_classification:
                 # Classification: place image in {split}/{class_name}/ folder
-                class_ids = annotations.get("classification", [])
-                class_id = class_ids[0] if class_ids else 0
-                class_name = class_names.get(class_id, str(class_id))
+                class_name = classification_class_name(record)
                 image_path = dataset_dir / split / class_name / original_name
             else:
                 # Detection: write label file and place image in images/{split}/
@@ -1034,10 +1053,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         for r in image_records:
             s, name = r["split"], r["file"]
             if is_classification:
-                ann = r.get("annotations", {})
-                cids = ann.get("classification", [])
-                cid = cids[0] if cids else 0
-                expected_paths.add(dataset_dir / s / class_names.get(cid, str(cid)) / name)
+                expected_paths.add(dataset_dir / s / classification_class_name(r) / name)
             else:
                 expected_paths.add(dataset_dir / "images" / s / name)
         img_root = dataset_dir if is_classification else (dataset_dir / "images")

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -9,7 +9,7 @@ import random
 import shutil
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import cv2
 import numpy as np
@@ -846,24 +846,30 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         class_id = class_ids[0] if class_ids else 0
         return class_names.get(class_id, str(class_id))
 
-    def is_unsafe_path(path):
-        """Check path for anchors or parent traversal."""
-        return bool(path.anchor) or ".." in path.parts
+    def is_safe_path(value, nested=True):
+        """Return whether a path is contained and portable to Windows."""
+        if not isinstance(value, str) or (path := PureWindowsPath(value)).anchor or not path.name:
+            return False
+        for part in path.parts:
+            base = part.partition(".")[0].rstrip(" ").upper()
+            if (
+                part == ".."
+                or part != part.rstrip(" .")
+                or any(ord(char) < 32 or char in '<>:"|?*' for char in part)
+                or base in {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
+                or (len(base) == 4 and base[:3] in {"COM", "LPT"} and base[3] in "123456789¹²³")
+            ):
+                return False
+        return nested or len(path.parts) == 1
 
     for i, record in enumerate(image_records, start=1):
         split, file = record.get("split"), record.get("file")
         if not isinstance(split, str) or split not in {"train", "val", "test"}:
             raise ValueError(f"Unsafe NDJSON split in record {i}: {split!r}")
-        if not isinstance(file, str) or not (path := Path(file)).name or is_unsafe_path(path):
+        if not is_safe_path(file):
             raise ValueError(f"Unsafe NDJSON file path in record {i}: {file!r}")
-        if is_classification:
-            class_name = classification_class_name(record)
-            if not isinstance(class_name, str) or is_unsafe_path(path := Path(class_name)) or len(path.parts) != 1:
-                raise ValueError(f"Unsafe NDJSON class name in record {i}: {class_name!r}")
-    if is_classification:
-        for class_name in class_names.values():
-            if not isinstance(class_name, str) or is_unsafe_path(path := Path(class_name)) or len(path.parts) != 1:
-                raise ValueError(f"Unsafe NDJSON class name: {class_name!r}")
+        if is_classification and not is_safe_path(class_name := classification_class_name(record), nested=False):
+            raise ValueError(f"Unsafe NDJSON class name in record {i}: {class_name!r}")
 
     # Hash stable content plus source identity. Query strings are excluded because signed URLs change on every export.
     _h = hashlib.sha256()

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -836,6 +836,20 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         lines = [json.loads(line.strip()) for line in f if line.strip()]
     dataset_record, image_records = lines[0], lines[1:]
 
+    # Validate all NDJSON values used to construct output paths before checking the cache or writing files.
+    is_classification = dataset_record.get("task") == "classify"
+    class_names = {int(k): v for k, v in dataset_record.get("class_names", {}).items()}
+    for i, record in enumerate(image_records, start=1):
+        split, file = record.get("split"), record.get("file")
+        if not isinstance(split, str) or split not in {"train", "val", "test"}:
+            raise ValueError(f"Unsafe NDJSON split in record {i}: {split!r}")
+        if not isinstance(file, str) or not file or (path := Path(file)).is_absolute() or ".." in path.parts:
+            raise ValueError(f"Unsafe NDJSON file path in record {i}: {file!r}")
+    if is_classification:
+        for class_name in class_names.values():
+            if not isinstance(class_name, str) or (path := Path(class_name)).is_absolute() or len(path.parts) != 1:
+                raise ValueError(f"Unsafe NDJSON class name: {class_name!r}")
+
     # Hash stable content plus source identity. Query strings are excluded because signed URLs change on every export.
     _h = hashlib.sha256()
     for r in lines:
@@ -862,9 +876,6 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
             pass
     splits = {record["split"] for record in image_records}
 
-    # Check if this is a classification dataset
-    is_classification = dataset_record.get("task") == "classify"
-    class_names = {int(k): v for k, v in dataset_record.get("class_names", {}).items()}
     inferred_nc = None
 
     # Validate required fields before downloading images

--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -846,29 +846,23 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
         class_id = class_ids[0] if class_ids else 0
         return class_names.get(class_id, str(class_id))
 
+    def is_unsafe_path(path):
+        """Check path for anchors or parent traversal."""
+        return bool(path.anchor) or ".." in path.parts
+
     for i, record in enumerate(image_records, start=1):
         split, file = record.get("split"), record.get("file")
         if not isinstance(split, str) or split not in {"train", "val", "test"}:
             raise ValueError(f"Unsafe NDJSON split in record {i}: {split!r}")
-        if not isinstance(file, str) or not (path := Path(file)).name or path.is_absolute() or ".." in path.parts:
+        if not isinstance(file, str) or not (path := Path(file)).name or is_unsafe_path(path):
             raise ValueError(f"Unsafe NDJSON file path in record {i}: {file!r}")
         if is_classification:
             class_name = classification_class_name(record)
-            if (
-                not isinstance(class_name, str)
-                or (path := Path(class_name)).is_absolute()
-                or ".." in path.parts
-                or len(path.parts) != 1
-            ):
+            if not isinstance(class_name, str) or is_unsafe_path(path := Path(class_name)) or len(path.parts) != 1:
                 raise ValueError(f"Unsafe NDJSON class name in record {i}: {class_name!r}")
     if is_classification:
         for class_name in class_names.values():
-            if (
-                not isinstance(class_name, str)
-                or (path := Path(class_name)).is_absolute()
-                or ".." in path.parts
-                or len(path.parts) != 1
-            ):
+            if not isinstance(class_name, str) or is_unsafe_path(path := Path(class_name)) or len(path.parts) != 1:
                 raise ValueError(f"Unsafe NDJSON class name: {class_name!r}")
 
     # Hash stable content plus source identity. Query strings are excluded because signed URLs change on every export.


### PR DESCRIPTION
## Summary

Reject NDJSON names that can escape the generated dataset directory before cache reuse or filesystem writes.

## Changes

- Allow only `train`, `val`, and `test` split names.
- Require image filenames and classification directory names to be single unanchored names under both POSIX and Windows syntax.
- Reuse one classification class-name resolution path for validation, conversion, and cleanup.
- Add one end-to-end parent-traversal regression.

## Verification

- `pytest tests/test_python.py -k convert_ndjson_rejects_unsafe_output_paths -q` — 1 passed.
- `ruff format ultralytics/data/converter.py tests/test_python.py`
- `ruff check --fix ultralytics/data/converter.py tests/test_python.py`
- Fresh adversarial Core Principles review: LGTM.

Deleted: generalized path-helper logic, nested filename support, Windows portability policy, duplicate classification class resolution, and the later duplicate `is_classification` / `class_names` initialization.

Net-positive justification: the NDJSON ingestion boundary previously accepted untrusted names directly into filesystem paths, so explicit source validation and one regression are required because no existing converter owner can be deleted or relocated to enforce containment.