### PR TITLE
Revert overbuilt subprocess import fix

### DIFF
--- a/docs/en/reference/utils/__init__.md
+++ b/docs/en/reference/utils/__init__.md
@@ -64,14 +64,6 @@ keywords: Ultralytics, utils, TQDM, Python, ML, Machine Learning utilities, YOLO
 
 <br><br><hr><br>
 
-## ::: ultralytics.utils.__init__.get_pythonpath_env
-
-<br><br><hr><br>
-
-## ::: ultralytics.utils.__init__.get_python_command
-
-<br><br><hr><br>
-
 ## ::: ultralytics.utils.__init__.read_device_model
 
 <br><br><hr><br>

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -4,8 +4,6 @@ import contextlib
 import csv
 import os
 import shutil
-import subprocess
-import sys
 import tarfile
 import urllib
 import zipfile
@@ -20,8 +18,8 @@ from PIL import Image
 
 import ultralytics.data.build as data_build
 from tests import CFG, MODEL, MODELS, SOURCE, SOURCES_LIST, TASK_MODEL_DATA
-from ultralytics import RTDETR, YOLO, __version__
-from ultralytics.cfg import _YOLO_CLI_COMMAND, get_cfg
+from ultralytics import RTDETR, YOLO
+from ultralytics.cfg import get_cfg
 from ultralytics.data.build import build_dataloader, load_inference_source
 from ultralytics.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.utils import (
@@ -41,45 +39,10 @@ from ultralytics.utils import (
     WINDOWS,
     YAML,
     checks,
-    get_pythonpath_env,
     is_github_action_running,
 )
 from ultralytics.utils.downloads import download, safe_download
 from ultralytics.utils.torch_utils import TORCH_1_11, TORCH_1_13
-
-
-def test_pythonpath_env(tmp_path, monkeypatch):
-    """Verify Python subprocesses import modules available only on the parent runtime path."""
-    (tmp_path / "parent_only.py").write_text("VALUE = 'ok'")
-    child_path = tmp_path / "child"
-    child_path.mkdir()
-    (child_path / "child_only.py").write_text("VALUE = 'ok'")
-    monkeypatch.syspath_prepend(tmp_path)
-    monkeypatch.setenv("PYTHONPATH", str(child_path))
-    result = subprocess.run(
-        [sys.executable, "-c", "import child_only, parent_only; print(child_only.VALUE, parent_only.VALUE)"],
-        check=True,
-        capture_output=True,
-        text=True,
-        env=get_pythonpath_env(),
-    )
-    assert result.stdout.strip() == "ok ok"
-
-
-def test_python_command_prefers_parent_path(tmp_path):
-    """Verify the real CLI subprocess imports the parent package ahead of a conflicting child working directory."""
-    stale_package = tmp_path / "ultralytics"
-    stale_package.mkdir()
-    (stale_package / "__init__.py").write_text("__version__ = 'stale'")
-    result = subprocess.run(
-        [*_YOLO_CLI_COMMAND, "version"],
-        check=True,
-        capture_output=True,
-        cwd=tmp_path,
-        text=True,
-        env=get_pythonpath_env(),
-    )
-    assert __version__ in result.stdout
 
 
 def test_dataloader_caps_workers_to_batches():

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -32,8 +32,6 @@ from ultralytics.utils import (
     checks,
     colorstr,
     deprecation_warn,
-    get_python_command,
-    get_pythonpath_env,
     vscode_msg,
 )
 
@@ -94,7 +92,7 @@ TASK2METRIC = {
 }
 
 ARGV = sys.argv or ["", ""]  # sometimes sys.argv = []
-_YOLO_CLI_COMMAND = get_python_command("ultralytics.cfg.__init__")
+_YOLO_CLI_COMMAND = [sys.executable, "-m", "ultralytics.cfg.__init__"]
 SOLUTIONS_HELP_MSG = f"""
     Arguments received: {["yolo", *ARGV[1:]]!s}. Ultralytics 'yolo solutions' usage overview:
 
@@ -817,15 +815,14 @@ def handle_yolo_solutions(args: list[str]) -> None:
         checks.check_requirements("streamlit>=1.29.0")
         LOGGER.info("💡 Loading Ultralytics live inference app...")
         subprocess.run(
-            [
-                *get_python_command("streamlit"),
+            [  # Run subprocess with Streamlit custom argument
+                "streamlit",
                 "run",
                 str(ROOT / "solutions/streamlit_inference.py"),
                 "--server.headless",
                 "true",
                 overrides.pop("model", "yolo26n.pt"),
-            ],
-            env=get_pythonpath_env(),
+            ]
         )
     else:
         import cv2  # Only needed for cap and vw functionality

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -42,7 +42,6 @@ from ultralytics.utils import (
     clean_url,
     colorstr,
     emojis,
-    get_pythonpath_env,
 )
 from ultralytics.utils.autobatch import check_train_batch_size
 from ultralytics.utils.checks import check_amp, check_file, check_imgsz, check_model_file_from_stem, print_args
@@ -231,7 +230,7 @@ class BaseTrainer:
             try:
                 cmd, file = generate_ddp_command(self)
                 LOGGER.info(f"{colorstr('DDP:')} debug command {' '.join(cmd)}")
-                subprocess.run(cmd, check=True, env=get_pythonpath_env())
+                subprocess.run(cmd, check=True)
             except Exception as e:
                 raise e
             finally:
@@ -1235,7 +1234,6 @@ class MultiTrainer:
                                 *(f"{k}={v}" for k, v in overrides.items() if k != "session"),
                             ],
                             check=True,
-                            env=get_pythonpath_env(),
                         )
                     else:
                         trainer = self.trainer(overrides=overrides, _callbacks=self.callbacks)

--- a/ultralytics/engine/tuner.py
+++ b/ultralytics/engine/tuner.py
@@ -30,7 +30,7 @@ import numpy as np
 import torch
 
 from ultralytics.cfg import _YOLO_CLI_COMMAND, CFG_INT_KEYS, get_cfg, get_save_dir
-from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, get_pythonpath_env, remove_colorstr
+from ultralytics.utils import DEFAULT_CFG, LOGGER, YAML, callbacks, colorstr, remove_colorstr
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.patches import torch_load
 from ultralytics.utils.plotting import plot_tune_results
@@ -505,7 +505,7 @@ class Tuner:
                     train_args["save_dir"] = str(save_dir[j])  # pass save_dir to subprocess to ensure same path is used
                     # Train YOLO model with mutated hyperparameters (run in subprocess to avoid dataloader hang)
                     cmd = [*_YOLO_CLI_COMMAND, "train", *(f"{k}={v}" for k, v in train_args.items())]
-                    subprocess.run(cmd, check=True, env=get_pythonpath_env())
+                    subprocess.run(cmd, check=True)
                     ckpt_file = weights_dir[j] / ("best.pt" if (weights_dir[j] / "best.pt").exists() else "last.pt")
                     metrics_i = torch_load(ckpt_file)["train_metrics"]
                     metrics = metrics_i

--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -523,24 +523,6 @@ def emojis(string=""):
     return string.encode().decode("ascii", "ignore") if WINDOWS else string
 
 
-def get_pythonpath_env():
-    """Return an environment that preserves the current Python import path in subprocesses."""
-    pythonpath = os.pathsep.join(os.getcwd() if path == "" else path for path in sys.path)
-    if inherited := os.getenv("PYTHONPATH"):
-        pythonpath = f"{pythonpath}{os.pathsep}{inherited}"
-    return {**os.environ, "PYTHONPATH": pythonpath}
-
-
-def get_python_command(module: str) -> list[str]:
-    """Return a command that runs a module with the parent import path ahead of the child working directory."""
-    code = (
-        "import os, runpy, sys; "
-        "sys.path[:0] = filter(None, os.environ.get('PYTHONPATH', '').split(os.pathsep)); "
-        "runpy.run_module(sys.argv.pop(1), run_name='__main__', alter_sys=True)"
-    )
-    return [sys.executable, "-c", code, module]
-
-
 class ThreadingLocked:
     """A decorator class for ensuring thread-safe execution of a function or method.
 

--- a/ultralytics/utils/dist.py
+++ b/ultralytics/utils/dist.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 from typing import TYPE_CHECKING
 
-from . import USER_CONFIG_DIR, get_python_command
+from . import USER_CONFIG_DIR
 from .torch_utils import TORCH_1_9
 
 if TYPE_CHECKING:
@@ -110,7 +111,9 @@ def generate_ddp_command(trainer: BaseTrainer) -> tuple[list[str], str]:
     dist_cmd = "torch.distributed.run" if TORCH_1_9 else "torch.distributed.launch"
     port = find_free_network_port()
     cmd = [
-        *get_python_command(dist_cmd),
+        sys.executable,
+        "-m",
+        dist_cmd,
         "--nproc_per_node",
         f"{trainer.world_size}",
         "--master_port",


### PR DESCRIPTION
## Summary

Reverts #24447 in full because the bugfix expanded to +79 / -14 across seven files and violated the repository deletion-first bar.

Deleted: get_pythonpath_env, get_python_command, two subprocess regression tests, generated helper references, and the expanded tuner/DDP/HUB/Streamlit launch plumbing.

## Validation

- Corrective diff is +14 / -79
- ruff check on all affected Python files
- python -m ultralytics.cfg.__init__ version

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 Simplifies Python subprocess execution by removing custom import-path handling and using standard interpreter/module commands.

### 📊 Key Changes
- Removed the `get_pythonpath_env()` and `get_python_command()` utilities and their API documentation.
- Updated CLI execution to use the current Python interpreter directly with `python -m ultralytics.cfg.__init__`.
- Simplified distributed training commands to use `sys.executable -m torch.distributed...`.
- Removed custom `PYTHONPATH` environment injection from:
  - Distributed training
  - Hyperparameter tuning
  - Training subprocesses
- Updated Streamlit solution launching to invoke the `streamlit` command directly.
- Removed tests covering the deleted Python path and command helpers.

### 🎯 Purpose & Impact
- 🧹 Reduces subprocess-related complexity and maintenance overhead.
- 🐍 Aligns command execution with standard Python and PyTorch practices, improving readability and portability.
- ⚡ Keeps training, tuning, and distributed execution behavior consistent while relying on the active runtime environment.
- ⚠️ Subprocesses no longer explicitly preserve or prioritize the parent process’s custom `sys.path` or `PYTHONPATH`, which may affect nonstandard development setups or locally shadowed packages.