### PR TITLE
Update ultralytics-inference version to 0.0.28 in rust docs

### DIFF
--- a/docs/en/inference/index.md
+++ b/docs/en/inference/index.md
@@ -55,7 +55,7 @@ Rust 1.89 or newer is required. The [video](#cargo-features) feature additionall
     ```toml
     # Or add it manually to Cargo.toml
     [dependencies]
-    ultralytics-inference = "0.0.27"
+    ultralytics-inference = "0.0.28"
     ```
 
 ## CLI quickstart
@@ -409,7 +409,7 @@ cargo install ultralytics-inference --features cuda,tensorrt
 
 ```toml
 [dependencies]
-ultralytics-inference = { version = "0.0.27", features = ["video"] }
+ultralytics-inference = { version = "0.0.28", features = ["video"] }
 ```
 
 ## Output and saving


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the Rust inference documentation to reference `ultralytics-inference` version `0.0.28`. 📦

### 📊 Key Changes

- Updated the dependency version from `0.0.27` to `0.0.28` in two Rust setup examples.
- Applied the update to both the standard dependency configuration and the video-feature configuration.

### 🎯 Purpose & Impact

- Keeps the documentation aligned with the latest published Rust inference package. ✅
- Helps users install the correct version when following the Rust inference and video setup guides.
- Prevents confusion caused by outdated dependency examples. 🚀