### PR TITLE
Fix device mismatch for TorchScript segment inference on GPU

### DIFF
--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -252,7 +252,7 @@ class AutoBackend(nn.Module):
         visualize: bool = False,
         embed: list | None = None,
         **kwargs: Any,
-    ) -> torch.Tensor | list[torch.Tensor]:
+    ) -> Any:
         """Run inference on an AutoBackend model.
 
         Args:
@@ -263,7 +263,7 @@ class AutoBackend(nn.Module):
             **kwargs (Any): Additional keyword arguments for model configuration.
 
         Returns:
-            (torch.Tensor | list[torch.Tensor]): The raw output tensor(s) from the model.
+            (Any): The raw model output, with NumPy arrays converted to tensors on `self.device`.
         """
         if self.nhwc:
             im = im.permute(0, 2, 3, 1)  # torch BCHW to numpy BHWC shape(1,320,192,3)
@@ -285,14 +285,14 @@ class AutoBackend(nn.Module):
         else:
             return self.from_numpy(y)
 
-    def from_numpy(self, x: np.ndarray | torch.Tensor) -> torch.Tensor:
-        """Convert a NumPy array to a torch tensor on the model device.
+    def from_numpy(self, x: Any) -> Any:
+        """Normalize a backend output to the model device when possible.
 
         Args:
-            x (np.ndarray | torch.Tensor): Input array or tensor.
+            x (Any): Backend output to normalize.
 
         Returns:
-            (torch.Tensor): Tensor on `self.device`.
+            (Any): Tensor on `self.device`, or the unchanged non-tensor output.
         """
         x = torch.tensor(x) if isinstance(x, np.ndarray) else x
         return x.to(self.device) if isinstance(x, torch.Tensor) else x

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -294,7 +294,8 @@ class AutoBackend(nn.Module):
         Returns:
             (torch.Tensor): Tensor on `self.device`.
         """
-        return (torch.tensor(x) if isinstance(x, np.ndarray) else x).to(self.device)
+        x = torch.tensor(x) if isinstance(x, np.ndarray) else x
+        return x.to(self.device) if isinstance(x, torch.Tensor) else x
 
     def warmup(self, imgsz: tuple[int, int, int, int] = (1, 3, 640, 640)) -> None:
         """Warm up the model by running forward pass(es) with a dummy input.

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -294,7 +294,7 @@ class AutoBackend(nn.Module):
         Returns:
             (torch.Tensor): Tensor on `self.device`.
         """
-        return torch.tensor(x).to(self.device) if isinstance(x, np.ndarray) else x
+        return (torch.tensor(x) if isinstance(x, np.ndarray) else x).to(self.device)
 
     def warmup(self, imgsz: tuple[int, int, int, int] = (1, 3, 640, 640)) -> None:
         """Warm up the model by running forward pass(es) with a dummy input.


### PR DESCRIPTION
## Problem

Running segment prediction with a TorchScript model on GPU crashes in `process_mask`:

```
yolo predict task=segment model=yolo11n-seg.torchscript imgsz=640
```

```
  File "/ultralytics/ultralytics/models/yolo/segment/predict.py", line 105, in construct_result
    masks = ops.process_mask(proto, pred[:, 6:], pred[:, :4], img.shape[2:], upsample=True)  # NHW
  File "/ultralytics/ultralytics/utils/ops.py", line 517, in process_mask
    masks = (masks_in @ protos.float().view(c, -1)).view(-1, mh, mw)  # NHW
RuntimeError: Expected all tensors to be on the same device, but got mat2 is on cuda:0, different from other tensors on cpu (when checking argument in method wrapper_CUDA_mm)
```

## Cause

`AutoBackend.from_numpy` is documented to return a tensor "on `self.device`", but it only moves numpy inputs and passes existing torch tensors through unmoved. A TorchScript model can return its detection head on CPU (decode ops frozen to CPU at trace time) while the proto tensor follows the CUDA input. AutoBackend forwarded both unchanged, so NMS output stayed on CPU and protos on CUDA, and `process_mask` mixed the two.

## Fix

Move both branches to `self.device` so `from_numpy` honors its contract. `.to()` is a no-op when the tensor is already on the target device, so the normal single-device path is unaffected.

Deleted: nothing. Small shared-owner change that corrects tensor device normalization and documents the existing non-tensor pass-through contract; no incorrect branch can be deleted because both behaviors are required.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Improved AutoBackend output handling to support non-tensor results while still converting NumPy arrays and moving tensors to the target device.

### 📊 Key Changes

- Updated `AutoBackend.forward()` to return any backend output type instead of only tensors or tensor lists.
- Enhanced `from_numpy()` to:
  - Convert NumPy arrays to PyTorch tensors.
  - Move tensors to `self.device`.
  - Preserve other output types unchanged.
- Updated type annotations and documentation to reflect the more flexible behavior.

### 🎯 Purpose & Impact

- ✅ Improves compatibility with backends that return scalars, dictionaries, tuples, or other non-tensor outputs.
- ⚡ Ensures tensor outputs continue to work consistently across devices.
- 🛠️ Reduces assumptions about backend output formats, making inference more robust and extensible.
- 📦 Existing tensor and NumPy-based workflows should continue working without changes.