### PR TITLE
Fix `save_crop=True` silently writing no crops without `save`/`save_txt`/`show`

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -710,7 +710,8 @@ def test_results_update_probs():
 def test_labels_and_crops(tmp_path):
     """Test output from prediction args for saving YOLO detection labels and crops."""
     imgs = [SOURCE, ASSETS / "zidane.jpg"]
-    results = YOLO(WEIGHTS_DIR / "yolo26n.pt")(imgs, imgsz=160, save_txt=True, save_crop=True)
+    model = YOLO(WEIGHTS_DIR / "yolo26n.pt")
+    results = model(imgs, imgsz=160, save_txt=True, save_crop=True)
     save_path = Path(results[0].save_dir)
     for r in results:
         im_name = Path(r.path).stem
@@ -735,15 +736,8 @@ def test_labels_and_crops(tmp_path):
         crop_count = len([f for f in crop_files if im_name in f.name])
         assert crop_count == len(r.boxes.data), f"Crop count {crop_count} != detection count {len(r.boxes.data)}"
 
-    # save_crop=True on its own (no save/save_txt/show) must still write crops, e.g. verbose=False batch harvesting
-    crop_dir = tmp_path / "crop_only"
-    YOLO(WEIGHTS_DIR / "yolo26n.pt")(
-        imgs, imgsz=160, save_crop=True, verbose=False, project=crop_dir, name="p", exist_ok=True
-    )
-    crops = crop_dir / "p" / "crops"
-    assert crops.is_dir() and any(crops.iterdir()), (
-        "save_crop=True alone must write crops even without save/save_txt/show"
-    )
+    model(SOURCE, imgsz=160, save_crop=True, verbose=False, project=tmp_path, name="crop", exist_ok=True)
+    assert any((tmp_path / "crop/crops").rglob("*.jpg")), "save_crop=True alone must write crop files"
 
 
 def test_data_utils(tmp_path):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -707,7 +707,7 @@ def test_results_update_probs():
     assert r.verbose() and r.summary(), "verbose()/summary() raise AttributeError on a raw Tensor probs"
 
 
-def test_labels_and_crops():
+def test_labels_and_crops(tmp_path):
     """Test output from prediction args for saving YOLO detection labels and crops."""
     imgs = [SOURCE, ASSETS / "zidane.jpg"]
     results = YOLO(WEIGHTS_DIR / "yolo26n.pt")(imgs, imgsz=160, save_txt=True, save_crop=True)
@@ -734,6 +734,16 @@ def test_labels_and_crops():
         # Same number of crops as detections
         crop_count = len([f for f in crop_files if im_name in f.name])
         assert crop_count == len(r.boxes.data), f"Crop count {crop_count} != detection count {len(r.boxes.data)}"
+
+    # save_crop=True on its own (no save/save_txt/show) must still write crops, e.g. verbose=False batch harvesting
+    crop_dir = tmp_path / "crop_only"
+    YOLO(WEIGHTS_DIR / "yolo26n.pt")(
+        imgs, imgsz=160, save_crop=True, verbose=False, project=crop_dir, name="p", exist_ok=True
+    )
+    crops = crop_dir / "p" / "crops"
+    assert crops.is_dir() and any(crops.iterdir()), (
+        "save_crop=True alone must write crops even without save/save_txt/show"
+    )
 
 
 def test_data_utils(tmp_path):

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -355,7 +355,13 @@ class BasePredictor:
                             "inference": profilers[1].dt * 1e3 / n,
                             "postprocess": profilers[2].dt * 1e3 / n,
                         }
-                        if self.args.verbose or self.args.save or self.args.save_txt or self.args.show:
+                        if (
+                            self.args.verbose
+                            or self.args.save
+                            or self.args.save_txt
+                            or self.args.save_crop
+                            or self.args.show
+                        ):
                             s[i] += self.write_results(i, Path(paths[i]), im, s)
                 except StopIteration:
                     break


### PR DESCRIPTION
When you call `model.predict(..., save_crop=True)` without also setting `save`, `save_txt` or `show`, no crops are written and there is no error. And worse, the run still prints `Results saved to ...`, so it looks like the crops are there when the folder is empty.

The reason is simple. The actual crop saving lives inside `write_results()` (`result.save_crop(...)` at `predictor.py:462`), and `write_results()` only runs when this gate is true:

```python
if self.args.verbose or self.args.save or self.args.save_txt or self.args.show:
```

`save_crop` is missing from that gate, while `save` and `save_txt` are both there, so the write never happens. Also, the final log line at L385 does include `save_crop`, which is why the misleading "Results saved" message still prints.

`verbose` defaults to `True` in the Python API, so a plain `model.predict(save_crop=True)` works, but only because of that default. The bug shows up on the legitimate pattern of collecting crops in a batch with `verbose=False` to avoid the per-image logs.

**Changes**

- Add `save_crop` to the gate at `predictor.py:358`, next to `save` and `save_txt`. This aligns the write gate (L358) with the print gate (L385), which already treats `save_crop` as a save operation. Nothing else changes, inside `write_results` every branch still runs behind its own flag, so with only `save_crop` set the single new effect is that the crops get written. Tasks without boxes (classify/OBB/semantic) are not affected: `Results.save_crop` already warns and returns for them, same as it does today when `verbose=True`.
- I did not touch the `mkdir` at L306. `save_crop` goes through `save_one_box`, which does its own `parent.mkdir(...)`, so the `crops/` folder is created on its own.

**Validation**

- Extended the existing `test_labels_and_crops` with a `save_crop=True` only case (`verbose=False`). The current tests always combine `save_crop` with `save_txt`, and that hides the bug because `save_txt` is already in the gate. Reverting only the predictor change makes the new assertion fail; with the fix `pytest tests/test_python.py::test_labels_and_crops` passes.
- Verified on v8.4.96: before the fix, `predict(save_crop=True, verbose=False)` writes 0 crops on `bus.jpg` while still printing "Results saved"; after the fix the crops are written regardless of `verbose`.

Deleted: nothing — the code fix is a one-token addition to an existing condition, and the test lines extend the existing `test_labels_and_crops` instead of adding a new test function.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `save_crop=True` so prediction crops are written even when `save`, `save_txt`, and `show` are disabled.

### 📊 Key Changes
- Updates predictor output handling to call result-writing logic when `save_crop` is enabled.
- Adds a regression test covering crop-only saving with `verbose=False` and a custom output directory.
- Verifies that crops are created in the expected `crops` directory for batch predictions.

### 🎯 Purpose & Impact
- Prevents `save_crop=True` from silently producing no files unless another output option is enabled.
- Enables reliable crop harvesting workflows without saving annotated images, labels, or displaying results.
- Improves detection prediction behavior while preserving existing output options.


Deletion or relocation cannot implement this fix: `write_results()` is already the owning path, so its invocation gate must include the existing `save_crop` output flag; the regression reuses the existing test and model.