### PR TITLE
Fix #25205: trust environment in aiohttp.ClientSession and allow it …

### DIFF
--- a/ultralytics/data/converter.py
+++ b/ultralytics/data/converter.py
@@ -1015,7 +1015,7 @@ async def convert_ndjson_to_yolo(ndjson_path: str | Path, output_path: str | Pat
 
     # Process all images with async downloads (limit connections for small datasets)
     semaphore = asyncio.Semaphore(min(128, len(image_records)))
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         pbar = TQDM(
             total=len(image_records),
             desc=f"Converting {ndjson_path.name} → {dataset_dir} ({len(image_records)} images)",


### PR DESCRIPTION
… to import and use HTTP_PROXY / HTTPS_PROXY env variables

Fixes #25205

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enables dataset image downloads to respect proxy and other network settings from the environment. 🌐

### 📊 Key Changes
- Updated the asynchronous `aiohttp.ClientSession` in `ultralytics/data/converter.py` to use `trust_env=True`.
- Allows downloads during dataset conversion to honor environment-based proxy and connection configuration.

### 🎯 Purpose & Impact
- Fixes download failures in environments that require HTTP or HTTPS proxies.
- Improves compatibility for users running dataset conversion behind enterprise networks or configured environments.
- Introduces a focused, low-risk change with no expected impact on environments without relevant network variables.


Deleted: the environment-isolated aiohttp ClientSession default; replaced it with aiohttp-owned trust_env proxy handling.