### PR TITLE
Fix `TVPSegmentLoss` crashing end-to-end YOLOE-Seg visual-prompt training on `tal_topk2`

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1250,10 +1250,10 @@ class TVPDetectLoss:
 class TVPSegmentLoss(TVPDetectLoss):
     """Criterion class for computing training losses for text-visual prompt segmentation."""
 
-    def __init__(self, model: torch.nn.Module, tal_topk=10):
+    def __init__(self, model: torch.nn.Module, tal_topk=10, tal_topk2: int | None = None):
         """Initialize TVPSegmentLoss with task-prompt and visual-prompt criteria using the provided model."""
         super().__init__(model)
-        self.vp_criterion = v8SegmentationLoss(model, tal_topk)
+        self.vp_criterion = v8SegmentationLoss(model, tal_topk, tal_topk2)
         self.hyp = self.vp_criterion.hyp
 
     def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
Training an end-to-end YOLOE-Seg model with visual prompts crashes while the loss is being built, before the first training step, with `TypeError: TVPSegmentLoss.__init__() got an unexpected keyword argument 'tal_topk2'`. The config `yoloe-26-seg.yaml` sets `end2end: True`, so the detection variant already works and only the segmentation one was missed.

The reason is simple: in `YOLOESegModel.loss`, when the batch has visual prompts and the model is end-to-end, the criterion is built as `E2ELoss(self, TVPSegmentLoss)`, and `E2ELoss.__init__` builds its one-to-one branch with `self.one2one = loss_fn(model, tal_topk=7, tal_topk2=1)`. But `TVPSegmentLoss.__init__` only accepts `(model, tal_topk=10)`, so the `tal_topk2=1` keyword raises the `TypeError`.

The sibling `TVPDetectLoss` already accepts and forwards `tal_topk2` (added in #23401), and `v8SegmentationLoss` (the loss that `TVPSegmentLoss` wraps) accepts it too, so the fix is to mirror the detect sibling:

```python
# before
def __init__(self, model, tal_topk=10):
    super().__init__(model)
    self.vp_criterion = v8SegmentationLoss(model, tal_topk)
# after
def __init__(self, model, tal_topk=10, tal_topk2: int | None = None):
    super().__init__(model)
    self.vp_criterion = v8SegmentationLoss(model, tal_topk, tal_topk2)
```

I checked every loss that `E2ELoss` builds with `tal_topk2=1` — `v8DetectionLoss`, `v8OBBLoss`, `v8SegmentationLoss`, `v8PoseLoss`/`PoseLoss26` and `TVPDetectLoss` — and all of them accept it already. `TVPSegmentLoss` was the only one left out, so no other loss needs the same change.

I verified it on `yoloe-26-seg.yaml`: on `main`, `E2ELoss(model, TVPSegmentLoss)` raises the `TypeError` while the detect sibling `E2ELoss(model, TVPDetectLoss)` builds fine. With the fix both build, the one-to-one criterion ends up with `topk2=1, topk=7` (same as detect) and the one-to-many branch stays at `topk=10`. No regression: `tal_topk2` defaults to `None`, so the non-end2end path `TVPSegmentLoss(self)` stays identical to before.

Deleted: nothing — 2 lines changed in place, no net additions, mirroring `TVPDetectLoss`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes `TVPSegmentLoss` so YOLOE-Seg visual-prompt training no longer crashes when using `tal_topk2`.

### 📊 Key Changes
- Adds an optional `tal_topk2` parameter to `TVPSegmentLoss`.
- Passes `tal_topk2` through to `v8SegmentationLoss` for consistent task-aligned assignment configuration.
- Preserves existing behavior when `tal_topk2` is not provided.

### 🎯 Purpose & Impact
- Resolves end-to-end YOLOE-Seg visual-prompt training failures related to `tal_topk2`.
- Enables users to configure the secondary top-k assignment setting for segmentation losses.
- Limits the fix to the loss initialization path, reducing the risk of unintended behavioral changes.