### PR TITLE
Fix depth model table size to native 768 training resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,16 +187,16 @@ See the [Depth Estimation Docs](https://docs.ultralytics.com/tasks/depth) for us
 
 | Model                                                                                            | size<br><sup>(pixels)</sup> | delta1<sup>NYU</sup> | abs_rel<sup>NYU</sup> | rmse<sup>NYU</sup> | params<br><sup>(M)</sup> | FLOPs<br><sup>(B)</sup> |
 | ------------------------------------------------------------------------------------------------ | --------------------------- | -------------------- | --------------------- | ------------------ | ------------------------ | ----------------------- |
-| [YOLO26n-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n-depth.pt) | 640                         | 0.882                | 0.109                 | 0.414              | 6.4                      | 32.6                    |
-| [YOLO26s-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26s-depth.pt) | 640                         | 0.896                | 0.104                 | 0.399              | 13.2                     | 47.1                    |
-| [YOLO26m-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26m-depth.pt) | 640                         | 0.921                | 0.089                 | 0.364              | 23.3                     | 90.8                    |
-| [YOLO26l-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26l-depth.pt) | 640                         | 0.930                | 0.083                 | 0.351              | 27.7                     | 109.2                   |
-| [YOLO26x-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-depth.pt) | 640                         | 0.933                | 0.080                 | 0.344              | 57.0                     | 209.7                   |
+| [YOLO26n-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n-depth.pt) | 768                         | 0.882                | 0.109                 | 0.414              | 6.4                      | 46.9                    |
+| [YOLO26s-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26s-depth.pt) | 768                         | 0.896                | 0.104                 | 0.399              | 13.2                     | 67.9                    |
+| [YOLO26m-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26m-depth.pt) | 768                         | 0.921                | 0.089                 | 0.364              | 23.3                     | 130.7                   |
+| [YOLO26l-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26l-depth.pt) | 768                         | 0.930                | 0.083                 | 0.351              | 27.7                     | 157.2                   |
+| [YOLO26x-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-depth.pt) | 768                         | 0.933                | 0.080                 | 0.344              | 57.0                     | 302.0                   |
 
 - **delta1<sup>NYU</sup>** is the percentage of pixels where the predicted depth is within a factor of 1.25 of the ground truth, on the NYU Depth V2 Eigen test split (654 images) with multi-scale + horizontal-flip TTA and log-least-squares alignment.
 - **abs_rel** is the mean absolute relative error between predicted and ground-truth depth values.
 - **rmse** is the root mean squared error in meters.
-- **params** and **FLOPs** are measured at 640×640. <br>Reproduce with `yolo depth val data=nyu-depth.yaml device=0 imgsz=640`
+- **params** and **FLOPs** are measured at 768×768, the training resolution of the released weights.
 
 </details>
 

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -25,16 +25,16 @@ YOLO26 depth models pretrained on a broad multi-dataset mix (indoor + outdoor, ~
 
 | Model                                                                                            | size<br><sup>(pixels)</sup> | delta1<sup>NYU</sup> | abs_rel<sup>NYU</sup> | rmse<sup>NYU</sup> | params<br><sup>(M)</sup> | FLOPs<br><sup>(B)</sup> |
 | ------------------------------------------------------------------------------------------------ | --------------------------- | -------------------- | --------------------- | ------------------ | ------------------------ | ----------------------- |
-| [YOLO26n-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n-depth.pt) | 640                         | 0.882                | 0.109                 | 0.414              | 6.4                      | 32.6                    |
-| [YOLO26s-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26s-depth.pt) | 640                         | 0.896                | 0.104                 | 0.399              | 13.2                     | 47.1                    |
-| [YOLO26m-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26m-depth.pt) | 640                         | 0.921                | 0.089                 | 0.364              | 23.3                     | 90.8                    |
-| [YOLO26l-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26l-depth.pt) | 640                         | 0.930                | 0.083                 | 0.351              | 27.7                     | 109.2                   |
-| [YOLO26x-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-depth.pt) | 640                         | 0.933                | 0.080                 | 0.344              | 57.0                     | 209.7                   |
+| [YOLO26n-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26n-depth.pt) | 768                         | 0.882                | 0.109                 | 0.414              | 6.4                      | 46.9                    |
+| [YOLO26s-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26s-depth.pt) | 768                         | 0.896                | 0.104                 | 0.399              | 13.2                     | 67.9                    |
+| [YOLO26m-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26m-depth.pt) | 768                         | 0.921                | 0.089                 | 0.364              | 23.3                     | 130.7                   |
+| [YOLO26l-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26l-depth.pt) | 768                         | 0.930                | 0.083                 | 0.351              | 27.7                     | 157.2                   |
+| [YOLO26x-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-depth.pt) | 768                         | 0.933                | 0.080                 | 0.344              | 57.0                     | 302.0                   |
 
 - **delta1<sup>NYU</sup>** is the percentage of pixels where the predicted depth is within a factor of 1.25 of the ground truth, on the NYU Depth V2 Eigen test split (654 images) with multi-scale + horizontal-flip TTA and log-least-squares alignment.
 - **abs_rel** is the mean absolute relative error between predicted and ground-truth depth values.
 - **rmse** is the root mean squared error in meters.
-- **params** and **FLOPs** are measured at 640×640.
+- **params** and **FLOPs** are measured at 768×768, the training resolution of the released weights.
 
 ## Depth range and the log-depth head
 
@@ -196,7 +196,7 @@ For example, an image at `images/train/scene_001.jpg` is paired with a depth map
 
 ## Val
 
-Validate a trained YOLO26n-depth model [accuracy](https://www.ultralytics.com/glossary/accuracy) on a depth estimation dataset. Pass `data` explicitly so validation uses the intended dataset YAML.
+Validate a trained YOLO26n-depth model [accuracy](https://www.ultralytics.com/glossary/accuracy) on a depth estimation dataset. Pass `data` explicitly so validation uses the intended dataset YAML. The released weights are trained at `imgsz=768`, so validate and predict at that size for best accuracy.
 
 !!! example
 


### PR DESCRIPTION
## Summary

The released `yolo26{n,s,m,l,x}-depth.pt` weights (assets v8.4.0, re-released 2026-07-09) are trained at `imgsz=768` — verified from `train_args` in every shipped checkpoint — but the README and docs model tables stated **640**, and FLOPs were measured at 640×640. A user loading the weights sees `imgsz: 768` and gets conflicting numbers from the docs.

## Changes

- **size column**: 640 → **768** in both `README.md` and `docs/en/tasks/depth.md` tables (5 rows each).
- **FLOPs**: re-measured at 768×768 via `model.info(imgsz=768)` on the current model YAMLs: n 46.9, s 67.9, m 130.7, l 157.2, x 302.0 B (verified 640 values reproduce the old column exactly, so the same method was used). Params are resolution-independent and unchanged.
- **Footnote**: `params and FLOPs are measured at 768×768, the training resolution of the released weights.`
- **Val section**: one sentence recommending `imgsz=768` for the released weights.

Deleted: the README's `Reproduce with yolo depth val data=nyu-depth.yaml device=0 imgsz=640` command — it was misleading on two counts: wrong size, and `depth val` (single-scale, median alignment) cannot reproduce the table's delta1/abs_rel/rmse, which come from the multi-scale + hflip TTA, log-least-squares protocol already described in the delta1 footnote.

## Verification

- Released checkpoint `train_args`: `imgsz=768, epochs=25` for all 5 sizes (staging dir `release_stage_20260708`, md5-matched to assets v8.4.0).
- FLOPs computed with `model.info(imgsz=640/768)` on `yolo26{n,s,m,l,x}-depth.yaml`; the 640 results (32.6/47.1/90.8/109.2/209.7) match the previous table values exactly.
- Markdown formatted with pinned prettier 3.6.2 per repo convention.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📏 Updated YOLO26 depth model FLOPs reporting and clarified the recommended 768-pixel evaluation workflow.

### 📊 Key Changes

- Corrected the reported FLOPs for all YOLO26 depth models in the README and depth estimation documentation.
- Added clarification that parameter and FLOPs measurements are based on the 768×768 training resolution.
- Updated validation guidance to recommend using `imgsz=768` with the released weights for best accuracy.
- Depth accuracy metrics and model parameter counts remain unchanged.

### 🎯 Purpose & Impact

- ✅ Improves documentation accuracy by aligning computational cost figures with the actual model configuration.
- 🎯 Helps users select an appropriate model based on more reliable FLOPs estimates.
- 🚀 Encourages validation and prediction at the released weights’ training resolution, supporting optimal depth estimation accuracy.
- 💡 No code or model behavior changes are introduced; the update is documentation-only.