### PR TITLE
Add reproducible single-scale val@768 delta1 footnote to depth tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ See the [Depth Estimation Docs](https://docs.ultralytics.com/tasks/depth) for us
 | [YOLO26x-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-depth.pt) | 768                         | 0.933                | 0.080                 | 0.344              | 57.0                     | 302.0                   |
 
 - **delta1<sup>NYU</sup>** is the percentage of pixels where the predicted depth is within a factor of 1.25 of the ground truth, on the NYU Depth V2 Eigen test split (654 images) with multi-scale + horizontal-flip TTA and log-least-squares alignment.
-- Single-scale accuracy without TTA is reproducible with `yolo depth val data=nyu-depth.yaml imgsz=768 device=0`, which uses median (scale-only) alignment and scores lower: delta1 0.785 (n), 0.786 (s), 0.827 (m), 0.839 (l), 0.843 (x).
+- Single-scale accuracy without TTA is reproducible with `yolo depth val model=yolo26n-depth.pt data=nyu-depth.yaml imgsz=768 device=0` (substitute `model=` for each size), which uses median (scale-only) alignment and scores lower: delta1 0.785 (n), 0.786 (s), 0.827 (m), 0.839 (l), 0.843 (x).
 - **abs_rel** is the mean absolute relative error between predicted and ground-truth depth values.
 - **rmse** is the root mean squared error in meters.
 - **params** and **FLOPs** are measured at 768×768. <br>Reproduce with `yolo depth val data=nyu-depth.yaml device=0 imgsz=768`

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ See the [Depth Estimation Docs](https://docs.ultralytics.com/tasks/depth) for us
 - Single-scale accuracy without TTA is reproducible with `yolo depth val model=yolo26n-depth.pt data=nyu-depth.yaml imgsz=768 device=0` (substitute `model=` for each size), which uses median (scale-only) alignment and scores lower: delta1 0.785 (n), 0.786 (s), 0.827 (m), 0.839 (l), 0.843 (x).
 - **abs_rel** is the mean absolute relative error between predicted and ground-truth depth values.
 - **rmse** is the root mean squared error in meters.
-- **params** and **FLOPs** are measured at 768×768. <br>Reproduce with `yolo depth val data=nyu-depth.yaml device=0 imgsz=768`
+- **params** and **FLOPs** are measured at 768×768, the training resolution of the released weights.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ See the [Depth Estimation Docs](https://docs.ultralytics.com/tasks/depth) for us
 | [YOLO26x-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-depth.pt) | 768                         | 0.933                | 0.080                 | 0.344              | 57.0                     | 302.0                   |
 
 - **delta1<sup>NYU</sup>** is the percentage of pixels where the predicted depth is within a factor of 1.25 of the ground truth, on the NYU Depth V2 Eigen test split (654 images) with multi-scale + horizontal-flip TTA and log-least-squares alignment.
+- Single-scale accuracy without TTA is reproducible with `yolo depth val data=nyu-depth.yaml imgsz=768 device=0`, which uses median (scale-only) alignment and scores lower: delta1 0.785 (n), 0.786 (s), 0.827 (m), 0.839 (l), 0.843 (x).
 - **abs_rel** is the mean absolute relative error between predicted and ground-truth depth values.
 - **rmse** is the root mean squared error in meters.
 - **params** and **FLOPs** are measured at 768×768. <br>Reproduce with `yolo depth val data=nyu-depth.yaml device=0 imgsz=768`

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -32,6 +32,7 @@ YOLO26 depth models pretrained on a broad multi-dataset mix (indoor + outdoor, ~
 | [YOLO26x-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-depth.pt) | 768                         | 0.933                | 0.080                 | 0.344              | 57.0                     | 302.0                   |
 
 - **delta1<sup>NYU</sup>** is the percentage of pixels where the predicted depth is within a factor of 1.25 of the ground truth, on the NYU Depth V2 Eigen test split (654 images) with multi-scale + horizontal-flip TTA and log-least-squares alignment.
+- Single-scale accuracy without TTA is reproducible with `yolo depth val data=nyu-depth.yaml imgsz=768 device=0`, which uses median (scale-only) alignment and scores lower: delta1 0.785 (n), 0.786 (s), 0.827 (m), 0.839 (l), 0.843 (x).
 - **abs_rel** is the mean absolute relative error between predicted and ground-truth depth values.
 - **rmse** is the root mean squared error in meters.
 - **params** and **FLOPs** are measured at 768×768, the training resolution of the released weights.

--- a/docs/en/tasks/depth.md
+++ b/docs/en/tasks/depth.md
@@ -32,7 +32,7 @@ YOLO26 depth models pretrained on a broad multi-dataset mix (indoor + outdoor, ~
 | [YOLO26x-depth](https://github.com/ultralytics/assets/releases/download/v8.4.0/yolo26x-depth.pt) | 768                         | 0.933                | 0.080                 | 0.344              | 57.0                     | 302.0                   |
 
 - **delta1<sup>NYU</sup>** is the percentage of pixels where the predicted depth is within a factor of 1.25 of the ground truth, on the NYU Depth V2 Eigen test split (654 images) with multi-scale + horizontal-flip TTA and log-least-squares alignment.
-- Single-scale accuracy without TTA is reproducible with `yolo depth val data=nyu-depth.yaml imgsz=768 device=0`, which uses median (scale-only) alignment and scores lower: delta1 0.785 (n), 0.786 (s), 0.827 (m), 0.839 (l), 0.843 (x).
+- Single-scale accuracy without TTA is reproducible with `yolo depth val model=yolo26n-depth.pt data=nyu-depth.yaml imgsz=768 device=0` (substitute `model=` for each size), which uses median (scale-only) alignment and scores lower: delta1 0.785 (n), 0.786 (s), 0.827 (m), 0.839 (l), 0.843 (x).
 - **abs_rel** is the mean absolute relative error between predicted and ground-truth depth values.
 - **rmse** is the root mean squared error in meters.
 - **params** and **FLOPs** are measured at 768×768, the training resolution of the released weights.


### PR DESCRIPTION
## Summary

The published depth-table metrics use multi-scale + hflip TTA with log-least-squares alignment, so no `yolo depth val` invocation can reproduce them. This PR gives users a verifiable reference the honest way: a footnote stating what each released checkpoint actually scores under the in-package protocol, and it deletes the README's contradictory claim that a plain val command reproduces the table.

## Changes

- One footnote added under the depth model table in both `README.md` and `docs/en/tasks/depth.md`:

  > Single-scale accuracy without TTA is reproducible with `yolo depth val model=yolo26n-depth.pt data=nyu-depth.yaml imgsz=768 device=0` (substitute `model=` for each size), which uses median (scale-only) alignment and scores lower: delta1 0.785 (n), 0.786 (s), 0.827 (m), 0.839 (l), 0.843 (x).

- `model=` is explicit in the command because without it the CLI falls back to `TASK2MODEL["depth"]` and only ever validates the task default (Ultralytics Actions review finding).

Deleted: the README params/FLOPs bullet's `<br>Reproduce with yolo depth val data=nyu-depth.yaml device=0 imgsz=768` fragment — that command scores delta1 0.785–0.843, not the table's 0.882–0.933, so presenting it as reproducing the table was misleading and directly contradicted the new footnote; the bullet now matches the docs wording ("measured at 768×768, the training resolution of the released weights").

## Verification

- Numbers measured by running `model.val(data="nyu-depth.yaml", imgsz=768)` on the md5-verified release staging checkpoints (identical to assets v8.4.0) with a clean checkout of current `depth_anything`; a parallel sweep at 640 confirmed 768 scores higher for every size, consistent with the weights' native 768 training resolution.
- "Median (scale-only) alignment" matches the `DepthMetrics` default (`align="median"`).
- Both files pass the pinned prettier 3.6.2 checks.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📏 Clarifies YOLO26 depth-model evaluation settings and adds reproducible single-scale validation results.

### 📊 Key Changes
- Added a validation command for reproducing single-scale YOLO26 depth accuracy on the NYU Depth V2 dataset.
- Documented that these results use median scale-only alignment without test-time augmentation (TTA).
- Listed single-scale delta1 scores for YOLO26n, s, m, l, and x depth models.
- Clarified that parameter and FLOPs measurements use the 768×768 training resolution.
- Applied the same updates to both the repository README and depth-estimation documentation.

### 🎯 Purpose & Impact
- ✅ Makes reported depth metrics easier to reproduce and compare.
- 🔍 Clearly distinguishes headline results using TTA and alignment from simpler single-scale validation.
- 📚 Improves transparency for users evaluating YOLO26 depth models.
- 🛠️ Provides a ready-to-run command for validating released weights on supported hardware.