### PR TITLE
rebuild docs landing page as a goal-based router

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -42,9 +42,17 @@ keywords: Ultralytics, YOLO, YOLO26, YOLO11, object detection, image segmentatio
 
 # Ultralytics YOLO Docs
 
-Ultralytics YOLO is one Python package and CLI for building [computer vision](https://www.ultralytics.com/blog/everything-you-need-to-know-about-computer-vision-in-2025) applications: train, validate, and deploy models for [object detection](https://www.ultralytics.com/glossary/object-detection), [instance segmentation](https://www.ultralytics.com/glossary/image-segmentation), pose estimation, classification, and object tracking. The latest model, [YOLO26](models/yolo26.md), features end-to-end NMS-free inference and optimized edge deployment; for stable production workloads, both YOLO26 and [YOLO11](models/yolo11.md) are recommended.
+[Ultralytics](https://www.ultralytics.com) YOLO is a family of real-time computer vision models for object detection, instance segmentation, semantic segmentation, classification, pose estimation, oriented bounding boxes, and tracking, available through one Python package and CLI. YOLO26 is built on deep learning and computer vision advancements, featuring end-to-end NMS-free inference and optimized edge deployment. Its streamlined design makes it suitable for various applications and easily adaptable to different hardware platforms, from edge devices to cloud APIs. For stable production workloads, both [YOLO26](models/yolo26.md) and [YOLO11](models/yolo11.md) are recommended.
+
+Explore the Ultralytics Docs, a comprehensive resource covering the YOLO package and CLI as well as the [Ultralytics Platform](platform/index.md), which adds data annotation, cloud training, and deployment on top of the same models. Whether you are a seasoned machine learning practitioner or new to the field, this hub aims to help you get the most out of YOLO in your projects.
 
 Request an Enterprise License for commercial use at [Ultralytics Licensing](https://www.ultralytics.com/license?utm_source=docs.ultralytics.com&utm_medium=referral&utm_content=license_inline_link).
+
+!!! tip "🚀 New: Knowledge Distillation"
+
+    Train smaller YOLO models with guidance from a larger teacher model — no extra inference cost, just better accuracy.
+
+    [:octicons-arrow-right-24: Learn more](guides/knowledge-distillation.md)
 
 ## Get Started in Two Commands
 
@@ -56,11 +64,23 @@ pip install ultralytics
 yolo predict model=yolo26n.pt source='https://github.com/ultralytics/assets/releases/download/v0.0.0/bus.jpg'
 ```
 
-The model weights and the example image download automatically, and the annotated result is saved to `runs/detect/predict`. For conda, Docker, GPU setup, or installation from source, see the [Quickstart](quickstart.md).
+The model weights and the example image download automatically, and the annotated result is saved to `runs/detect/predict`.
+
+See the [Quickstart](quickstart.md) guide for the full installation and usage reference.
 
 ## What Do You Want to Do?
 
 <div class="grid cards" markdown>
+
+- :fontawesome-solid-brain:{ .lg .middle } &nbsp; **Train a model on your own dataset**
+
+    ***
+
+    Fine-tune a pretrained YOLO26 model on your own dataset, tuning augmentation and hyperparameters for multi-GPU training
+
+    ***
+
+    [:octicons-arrow-right-24: Train a custom model](modes/train.md)
 
 - :material-image:{ .lg .middle } &nbsp; **Run a model on your images or video**
 
@@ -72,21 +92,21 @@ The model weights and the example image download automatically, and the annotate
 
     [:octicons-arrow-right-24: Predict on new data](modes/predict.md)
 
-- :fontawesome-solid-brain:{ .lg .middle } &nbsp; **Train a model on your own dataset**
+- :material-play-circle:{ .lg .middle } &nbsp; **Track objects across video frames**
 
     ***
 
-    Prepare your images and labels, fine-tune a pretrained model, and evaluate the results <br /> &nbsp;
+    Track objects across video frames with a persistent ID using BoT-SORT or ByteTrack, built into YOLO26's predict pipeline
 
     ***
 
-    [:octicons-arrow-right-24: Train a custom model](modes/train.md)
+    [:octicons-arrow-right-24: Multi-object tracking](modes/track.md)
 
-- :material-play-circle:{ .lg .middle } &nbsp; **Track or count objects in video**
+- :material-apps:{ .lg .middle } &nbsp; **Run a ready-made vision application**
 
     ***
 
-    Ready-made applications for object counting, tracking, heatmaps, queue management, and more
+    Ready-made vision apps for object counting, heatmaps, queue management, security alarms, and workouts, no training required
 
     ***
 
@@ -96,7 +116,7 @@ The model weights and the example image download automatically, and the annotate
 
     ***
 
-    Export trained models to ONNX, TensorRT, CoreML, and other formats for edge devices or cloud servers
+    Export trained models to ONNX, TensorRT, or OpenVINO for fast inference on edge devices, mobile hardware, and cloud servers
 
     ***
 
@@ -106,7 +126,7 @@ The model weights and the example image download automatically, and the annotate
 
     ***
 
-    Compare YOLO26, YOLO11, SAM 3, RT-DETR, and every other supported model family <br /> &nbsp;
+    Compare YOLO26, YOLO11, SAM 3, RT-DETR, and every other supported architecture by speed, accuracy, and use case
 
     ***
 
@@ -116,7 +136,7 @@ The model weights and the example image download automatically, and the annotate
 
     ***
 
-    Find classes, functions, and method signatures, auto-generated from the package source <br /> &nbsp;
+    Look up classes, functions, and method signatures for the Python API, auto-generated from source on every new release
 
     ***
 
@@ -126,7 +146,7 @@ The model weights and the example image download automatically, and the annotate
 
     ***
 
-    Discover Ultralytics' latest YOLO26 models with NMS-free inference and edge optimization <br /> &nbsp;
+    Ultralytics' newest model family delivers NMS-free, end-to-end inference with higher accuracy and lower latency than YOLO11
 
     ***
 
@@ -136,14 +156,16 @@ The model weights and the example image download automatically, and the annotate
 
 ## How These Docs Are Organized
 
-Four words appear everywhere in these docs, and each one is a top-level section:
+Every `yolo` command follows one grammar, `yolo TASK MODE ARGS`, and these docs are organized around the same three parts, plus one shortcut:
 
-- **[Tasks](tasks/index.md)** are what you want from an image: [detection](tasks/detect.md), [segmentation](tasks/segment.md), [semantic segmentation](tasks/semantic.md), [classification](tasks/classify.md), [pose estimation](tasks/pose.md), or [oriented boxes](tasks/obb.md).
-- **[Modes](modes/index.md)** are what you do with a model: [train](modes/train.md), [validate](modes/val.md), [predict](modes/predict.md), [export](modes/export.md), [track](modes/track.md), or [benchmark](modes/benchmark.md).
-- **[Models](models/index.md)** are the networks themselves: YOLO26, YOLO11, SAM 3, RT-DETR, and more.
-- **[Solutions](solutions/index.md)** are packaged applications built on top, like object counting and security alarms.
+- **[Task](tasks/index.md)** answers _what_ you want from an image: [detection](tasks/detect.md), [instance segmentation](tasks/segment.md), [semantic segmentation](tasks/semantic.md), [classification](tasks/classify.md), [pose estimation](tasks/pose.md), or [oriented boxes](tasks/obb.md).
+- **[Mode](modes/index.md)** answers _how_ you use a model: [train](modes/train.md), [validate](modes/val.md), [predict](modes/predict.md), [export](modes/export.md), [track](modes/track.md), or [benchmark](modes/benchmark.md).
+- **[Models](models/index.md)** answers _which_ network runs it: YOLO26, YOLO11, SAM 3, RT-DETR, and every other supported architecture.
+- **[Solutions](solutions/index.md)** is the shortcut: a finished application, like object counting or a security alarm, that skips Task and Mode entirely.
 
-[Datasets](datasets/index.md) lists ready-to-train datasets for every task, [Guides](guides/index.md) collects how-to articles from hyperparameter tuning to Raspberry Pi deployment, and [Integrations](integrations/index.md) covers third-party tools for training, tracking experiments, and deployment.
+Everything else supports that grammar: [Datasets](datasets/index.md) supplies what each Task trains on, [Guides](guides/index.md) is a broad collection of in-depth how-tos spanning hardware deployment, hyperparameter tuning, dataset conversion, and full project walkthroughs, [Integrations](integrations/index.md) connects the pipeline to the training and deployment tools you already use, and the [Reference](reference/index.md) section documents every class and function in the Python API.
+
+Beyond the Python package, two more surfaces run on the same models: the [Ultralytics Platform](platform/index.md) for cloud annotation, training, and deployment, and [Ultralytics Inference](inference/index.md), a standalone Rust library and CLI for running exported models without a Python runtime.
 
 <p align="center">
   <br>
@@ -167,23 +189,6 @@ Ultralytics offers two licensing options to accommodate diverse use cases:
 - **Enterprise License**: For development and production use, this license enables seamless integration of Ultralytics software and AI models into business products and services, including internal tools, automated workflows, and production deployments, bypassing the open-source requirements of AGPL-3.0. To get started, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
 
 Our licensing strategy is designed to ensure that any improvements to our open-source projects are returned to the community. We believe in open source, and our mission is to ensure that our contributions can be used and expanded in ways that benefit everyone.
-
-<div align="center">
-  <br>
-  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
-  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
-  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
-  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
-  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
-  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
-  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
-  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
-  <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
-  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
-  <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
-  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
-  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
-</div>
 
 ## FAQ
 
@@ -217,3 +222,20 @@ For more details, visit our [Licensing](https://www.ultralytics.com/license) pag
 ### How can Ultralytics YOLO be used for real-time object tracking?
 
 Ultralytics YOLO supports efficient and customizable multi-object tracking. Call `model.track(source="path/to/video.mp4")` in Python, or run `yolo track source=path/to/video.mp4` from the command line — both work with video files, live streams, and webcam input. For a detailed guide on setting up and running object tracking, check our [Track Mode](modes/track.md) documentation, which explains the configuration and practical applications in real-time scenarios.
+
+<div align="center">
+  <br>
+  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
+  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
+  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
+  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
+  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
+  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
+  <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
+  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
+  <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
+  <img width="3%" src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" alt="">
+  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
+</div>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -40,13 +40,133 @@ keywords: Ultralytics, YOLO, YOLO26, YOLO11, object detection, image segmentatio
 <br><br>
 </div>
 
-# Home
+# Ultralytics YOLO Docs
 
-Introducing Ultralytics [YOLO26](models/yolo26.md), the latest version of the acclaimed real-time object detection and image segmentation model. YOLO26 is built on [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) and [computer vision](https://www.ultralytics.com/blog/everything-you-need-to-know-about-computer-vision-in-2025) advancements, featuring end-to-end NMS-free inference and optimized edge deployment. Its streamlined design makes it suitable for various applications and easily adaptable to different hardware platforms, from edge devices to cloud APIs. For stable production workloads, both YOLO26 and [YOLO11](models/yolo11.md) are recommended.
-
-Explore the Ultralytics Docs, a comprehensive resource designed to help you understand and utilize its features and capabilities. Whether you are a seasoned [machine learning](https://www.ultralytics.com/glossary/machine-learning-ml) practitioner or new to the field, this hub aims to maximize YOLO's potential in your projects.
+Ultralytics YOLO is one Python package and CLI for building [computer vision](https://www.ultralytics.com/blog/everything-you-need-to-know-about-computer-vision-in-2025) applications: train, validate, and deploy models for [object detection](https://www.ultralytics.com/glossary/object-detection), [instance segmentation](https://www.ultralytics.com/glossary/image-segmentation), pose estimation, classification, and object tracking. The latest model, [YOLO26](models/yolo26.md), features end-to-end NMS-free inference and optimized edge deployment; for stable production workloads, both YOLO26 and [YOLO11](models/yolo11.md) are recommended.
 
 Request an Enterprise License for commercial use at [Ultralytics Licensing](https://www.ultralytics.com/license?utm_source=docs.ultralytics.com&utm_medium=referral&utm_content=license_inline_link).
+
+## Get Started in Two Commands
+
+```bash
+# Install the ultralytics package from PyPI
+pip install ultralytics
+
+# Detect objects in an image with a pretrained YOLO26 model
+yolo predict model=yolo26n.pt source='https://github.com/ultralytics/assets/releases/download/v0.0.0/bus.jpg'
+```
+
+The model weights and the example image download automatically, and the annotated result is saved to `runs/detect/predict`. For conda, Docker, GPU setup, or installation from source, see the [Quickstart](quickstart.md).
+
+## What Do You Want to Do?
+
+<div class="grid cards" markdown>
+
+- :material-image:{ .lg .middle } &nbsp; **Run a model on your images or video**
+
+    ***
+
+    Load a pretrained model and get bounding boxes, masks, or keypoints in a few lines of Python or a single CLI command
+
+    ***
+
+    [:octicons-arrow-right-24: Predict on new data](modes/predict.md)
+
+- :fontawesome-solid-brain:{ .lg .middle } &nbsp; **Train a model on your own dataset**
+
+    ***
+
+    Prepare your images and labels, fine-tune a pretrained model, and evaluate the results <br /> &nbsp;
+
+    ***
+
+    [:octicons-arrow-right-24: Train a custom model](modes/train.md)
+
+- :material-play-circle:{ .lg .middle } &nbsp; **Track or count objects in video**
+
+    ***
+
+    Ready-made applications for object counting, tracking, heatmaps, queue management, and more
+
+    ***
+
+    [:octicons-arrow-right-24: Explore Solutions](solutions/index.md)
+
+- :material-rocket-launch:{ .lg .middle } &nbsp; **Deploy your model**
+
+    ***
+
+    Export trained models to ONNX, TensorRT, CoreML, and other formats for edge devices or cloud servers
+
+    ***
+
+    [:octicons-arrow-right-24: Export and deploy](modes/export.md)
+
+- :material-magnify-expand:{ .lg .middle } &nbsp; **Pick the right model**
+
+    ***
+
+    Compare YOLO26, YOLO11, SAM 3, RT-DETR, and every other supported model family <br /> &nbsp;
+
+    ***
+
+    [:octicons-arrow-right-24: Browse all models](models/index.md)
+
+- :material-book-open-variant:{ .lg .middle } &nbsp; **Look up the Python API**
+
+    ***
+
+    Find classes, functions, and method signatures, auto-generated from the package source <br /> &nbsp;
+
+    ***
+
+    [:octicons-arrow-right-24: API Reference](reference/index.md)
+
+- :rocket:{ .lg .middle } &nbsp; **What's new: YOLO26**
+
+    ***
+
+    Discover Ultralytics' latest YOLO26 models with NMS-free inference and edge optimization <br /> &nbsp;
+
+    ***
+
+    [:octicons-arrow-right-24: Meet YOLO26](models/yolo26.md)
+
+</div>
+
+## How These Docs Are Organized
+
+Four words appear everywhere in these docs, and each one is a top-level section:
+
+- **[Tasks](tasks/index.md)** are what you want from an image: [detection](tasks/detect.md), [segmentation](tasks/segment.md), [semantic segmentation](tasks/semantic.md), [classification](tasks/classify.md), [pose estimation](tasks/pose.md), or [oriented boxes](tasks/obb.md).
+- **[Modes](modes/index.md)** are what you do with a model: [train](modes/train.md), [validate](modes/val.md), [predict](modes/predict.md), [export](modes/export.md), [track](modes/track.md), or [benchmark](modes/benchmark.md).
+- **[Models](models/index.md)** are the networks themselves: YOLO26, YOLO11, SAM 3, RT-DETR, and more.
+- **[Solutions](solutions/index.md)** are packaged applications built on top, like object counting and security alarms.
+
+[Datasets](datasets/index.md) lists ready-to-train datasets for every task, [Guides](guides/index.md) collects how-to articles from hyperparameter tuning to Raspberry Pi deployment, and [Integrations](integrations/index.md) covers third-party tools for training, tracking experiments, and deployment.
+
+<p align="center">
+  <br>
+  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/7lZa3Yi2kbo"
+    title="YouTube video player" frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+  <br>
+  <strong>Watch:</strong> How to Train a YOLO26 model on Your Custom Dataset in <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb" target="_blank">Google Colab</a>.
+</p>
+
+## YOLO Licenses: How is Ultralytics YOLO licensed?
+
+<a href="https://www.ultralytics.com/license?utm_source=docs.ultralytics.com&utm_medium=referral&utm_content=license_banner" target="_blank" rel="noopener noreferrer">
+<img width="100%" style="border-radius:.4rem" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-license.avif" alt="Ultralytics Enterprise License banner"></a>
+
+Ultralytics offers two licensing options to accommodate diverse use cases:
+
+- **AGPL-3.0 License**: This [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license is ideal for students and enthusiasts, promoting open collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) file for more details.
+- **Enterprise License**: For development and production use, this license enables seamless integration of Ultralytics software and AI models into business products and services, including internal tools, automated workflows, and production deployments, bypassing the open-source requirements of AGPL-3.0. To get started, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
+
+Our licensing strategy is designed to ensure that any improvements to our open-source projects are returned to the community. We believe in open source, and our mission is to ensure that our contributions can be used and expanded in ways that benefit everyone.
 
 <div align="center">
   <br>
@@ -65,135 +185,6 @@ Request an Enterprise License for commercial use at [Ultralytics Licensing](http
   <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
 </div>
 
-!!! tip "🚀 New: Knowledge Distillation"
-
-    Train smaller YOLO models with guidance from a larger teacher model — no extra inference cost, just better accuracy.
-
-    [:octicons-arrow-right-24: Learn more](guides/knowledge-distillation.md)
-
-## Where to Start
-
-<div class="grid cards" markdown>
-
-- :material-clock-fast:{ .lg .middle } &nbsp; **Getting Started**
-
-    ***
-
-    Install `ultralytics` with pip and get up and running in minutes to train a YOLO model
-
-    ***
-
-    [:octicons-arrow-right-24: Quickstart](quickstart.md)
-
-- :material-image:{ .lg .middle } &nbsp; **Predict**
-
-    ***
-
-    Predict on new images, videos and streams with YOLO <br /> &nbsp;
-
-    ***
-
-    [:octicons-arrow-right-24: Explore Predict mode](modes/predict.md)
-
-- :fontawesome-solid-brain:{ .lg .middle } &nbsp; **Train a Model**
-
-    ***
-
-    Train a new YOLO model on your own custom dataset from scratch or load and train on a pretrained model
-
-    ***
-
-    [:octicons-arrow-right-24: Explore Train mode](modes/train.md)
-
-- :material-magnify-expand:{ .lg .middle } &nbsp; **Explore Computer Vision Tasks**
-
-    ***
-
-    Discover YOLO tasks like detect, segment, semantic, classify, pose, OBB and track <br /> &nbsp;
-
-    ***
-
-    [:octicons-arrow-right-24: Explore Tasks](tasks/index.md)
-
-- :rocket:{ .lg .middle } &nbsp; **Explore YOLO26 🚀 NEW**
-
-    ***
-
-    Discover Ultralytics' latest YOLO26 models with NMS-free inference and edge optimization <br /> &nbsp;
-
-    ***
-
-    [:octicons-arrow-right-24: YOLO26 Models 🚀](models/yolo26.md)
-
-- :material-select-all:{ .lg .middle } &nbsp; **SAM 3: Segment Anything with Concepts 🚀 NEW**
-
-    ***
-
-    Meta's latest SAM 3 with Promptable Concept Segmentation - segment all instances using text or image exemplars
-
-    ***
-
-    [:octicons-arrow-right-24: SAM 3 Models](models/sam-3.md)
-
-- :material-scale-balance:{ .lg .middle } &nbsp; **Open Source, AGPL-3.0**
-
-    ***
-
-    Ultralytics offers two YOLO licenses: AGPL-3.0 and Enterprise. Explore YOLO on [GitHub](https://github.com/ultralytics/ultralytics).
-
-    ***
-
-    [:octicons-arrow-right-24: YOLO License](https://www.ultralytics.com/license)
-
-</div>
-
-<p align="center">
-  <br>
-  <iframe loading="lazy" width="720" height="405" src="https://www.youtube.com/embed/7lZa3Yi2kbo"
-    title="YouTube video player" frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    allowfullscreen>
-  </iframe>
-  <br>
-  <strong>Watch:</strong> How to Train a YOLO26 model on Your Custom Dataset in <a href="https://colab.research.google.com/github/ultralytics/ultralytics/blob/main/examples/tutorial.ipynb" target="_blank">Google Colab</a>.
-</p>
-
-## YOLO: A Brief History
-
-[YOLO](models/index.md) (You Only Look Once), a popular [object detection](https://www.ultralytics.com/glossary/object-detection) and [image segmentation](https://www.ultralytics.com/glossary/image-segmentation) model, was developed by Joseph Redmon and Ali Farhadi at the University of Washington. Launched in 2015, YOLO gained popularity for its high speed and accuracy.
-
-- [YOLOv2](models/index.md), released in 2016, improved the original model by incorporating batch normalization, anchor boxes, and dimension clusters.
-- [YOLOv3](models/yolov3.md), launched in 2018, further enhanced the model's performance using a more efficient backbone network, multiple anchors, and spatial pyramid pooling.
-- [YOLOv4](models/yolov4.md) was released in 2020, introducing innovations like Mosaic [data augmentation](https://www.ultralytics.com/glossary/data-augmentation), a new anchor-free detection head, and a new [loss function](https://www.ultralytics.com/glossary/loss-function).
-- [YOLOv5](models/yolov5.md) further improved the model's performance and added new features such as hyperparameter optimization, integrated experiment tracking, and automatic export to popular export formats.
-- [YOLOv6](models/yolov6.md) was open-sourced by [Meituan](https://www.meituan.com/) in 2022 and is used in many of the company's autonomous delivery robots.
-- [YOLOv7](models/yolov7.md) added additional tasks such as pose estimation on the COCO keypoints dataset.
-- [YOLOv8](models/yolov8.md) released in 2023 by Ultralytics, introduced new features and improvements for enhanced performance, flexibility, and efficiency, supporting a full range of vision AI tasks.
-- [YOLOv9](models/yolov9.md) introduces innovative methods like Programmable Gradient Information (PGI) and the Generalized Efficient Layer Aggregation Network (GELAN).
-- [YOLOv10](models/yolov10.md) created by researchers from [Tsinghua University](https://www.tsinghua.edu.cn/en/) using the [Ultralytics](https://www.ultralytics.com/) [Python package](https://pypi.org/project/ultralytics/), provides real-time [object detection](tasks/detect.md) advancements by introducing an End-to-End head that eliminates Non-Maximum Suppression (NMS) requirements.
-- **[YOLO11](models/yolo11.md)**: Released in September 2024, YOLO11 delivers excellent performance across multiple tasks, including [object detection](tasks/detect.md), [segmentation](tasks/segment.md), [pose estimation](tasks/pose.md), [tracking](modes/track.md), and [classification](tasks/classify.md), enabling deployment across diverse AI applications and domains.
-- **[YOLO26](models/yolo26.md) 🚀**: Ultralytics' next-generation YOLO model optimized for edge deployment with end-to-end NMS-free inference.
-
-## YOLO Licenses: How is Ultralytics YOLO licensed?
-
-<a href="https://www.ultralytics.com/license?utm_source=docs.ultralytics.com&utm_medium=referral&utm_content=license_banner" target="_blank" rel="noopener noreferrer">
-<img width="100%" style="border-radius:.4rem" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-license.avif" alt="Ultralytics Enterprise License banner"></a>
-
-Ultralytics offers two licensing options to accommodate diverse use cases:
-
-- **AGPL-3.0 License**: This [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license is ideal for students and enthusiasts, promoting open collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) file for more details.
-- **Enterprise License**: For development and production use, this license enables seamless integration of Ultralytics software and AI models into business products and services, including internal tools, automated workflows, and production deployments, bypassing the open-source requirements of AGPL-3.0. To get started, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
-
-Our licensing strategy is designed to ensure that any improvements to our open-source projects are returned to the community. We believe in open source, and our mission is to ensure that our contributions can be used and expanded in ways that benefit everyone.
-
-## The Evolution of Object Detection
-
-Object detection has evolved significantly over the years, from traditional computer vision techniques to advanced deep learning models. The [YOLO family of models](https://www.ultralytics.com/blog/the-evolution-of-object-detection-and-ultralytics-yolo-models) has been at the forefront of this evolution, consistently pushing the boundaries of what's possible in real-time object detection.
-
-YOLO's unique approach treats object detection as a single regression problem, predicting [bounding boxes](https://www.ultralytics.com/glossary/bounding-box) and class probabilities directly from full images in one evaluation. This revolutionary method has made YOLO models significantly faster than previous two-stage detectors while maintaining high accuracy.
-
-With each new version, YOLO has introduced architectural improvements and innovative techniques that have enhanced performance across various metrics. YOLO26 continues this tradition by incorporating the latest advancements in computer vision research, featuring end-to-end NMS-free inference and optimized edge deployment for real-world applications.
-
 ## FAQ
 
 ### What is Ultralytics YOLO and how does it improve object detection?
@@ -202,48 +193,15 @@ Ultralytics YOLO is the acclaimed YOLO (You Only Look Once) series for real-time
 
 ### How can I get started with YOLO installation and setup?
 
-Getting started with YOLO is quick and straightforward. You can install the Ultralytics package using [pip](https://pypi.org/project/ultralytics/) and get up and running in minutes. Here's a basic installation command:
-
-!!! example "Installation using pip"
-
-    === "CLI"
-
-        ```bash
-        pip install -U ultralytics
-        ```
-
-For a comprehensive step-by-step guide, visit our [Quickstart](quickstart.md) page. This resource will help you with installation instructions, initial setup, and running your first model.
+Getting started with YOLO is quick and straightforward. Install the Ultralytics package from [pip](https://pypi.org/project/ultralytics/) with `pip install ultralytics`, then run your first prediction with `yolo predict model=yolo26n.pt` — the model weights download automatically. For comprehensive instructions covering conda, Docker, and installation from source, visit the [Quickstart](quickstart.md) page.
 
 ### How can I train a custom YOLO model on my dataset?
 
 Training a custom YOLO model on your dataset involves a few detailed steps:
 
-1. Prepare your annotated dataset.
-2. Configure the training parameters in a YAML file.
-3. Use the `yolo TASK train` command to start training. (Each `TASK` has its own argument)
-
-Here's example code for the Object Detection Task:
-
-!!! example "Train Example for Object Detection Task"
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        # Load a pretrained YOLO model (you can choose n, s, m, l, or x versions)
-        model = YOLO("yolo26n.pt")
-
-        # Start training on your custom dataset
-        model.train(data="path/to/dataset.yaml", epochs=100, imgsz=640)
-        ```
-
-    === "CLI"
-
-        ```bash
-        # Train a YOLO model from the command line
-        yolo detect train data=path/to/dataset.yaml epochs=100 imgsz=640
-        ```
+1. Prepare your annotated dataset and describe it in a dataset YAML file.
+2. Load a pretrained model, for example `YOLO("yolo26n.pt")` in Python.
+3. Start training with `model.train(data="path/to/dataset.yaml", epochs=100, imgsz=640)`, or from the command line with `yolo detect train data=path/to/dataset.yaml epochs=100 imgsz=640`.
 
 For a detailed walkthrough, check out our [Train a Model](modes/train.md) guide, which includes examples and tips for optimizing your training process.
 
@@ -258,29 +216,4 @@ For more details, visit our [Licensing](https://www.ultralytics.com/license) pag
 
 ### How can Ultralytics YOLO be used for real-time object tracking?
 
-Ultralytics YOLO supports efficient and customizable multi-object tracking. To utilize tracking capabilities, you can use the `yolo track` command, as shown below:
-
-!!! example "Example for Object Tracking on a Video"
-
-    === "Python"
-
-        ```python
-        from ultralytics import YOLO
-
-        # Load a pretrained YOLO model
-        model = YOLO("yolo26n.pt")
-
-        # Start tracking objects in a video
-        # You can also use live video streams or webcam input
-        model.track(source="path/to/video.mp4")
-        ```
-
-    === "CLI"
-
-        ```bash
-        # Perform object tracking on a video from the command line
-        # You can specify different sources like webcam (0) or RTSP streams
-        yolo track source=path/to/video.mp4
-        ```
-
-For a detailed guide on setting up and running object tracking, check our [Track Mode](modes/track.md) documentation, which explains the configuration and practical applications in real-time scenarios.
+Ultralytics YOLO supports efficient and customizable multi-object tracking. Call `model.track(source="path/to/video.mp4")` in Python, or run `yolo track source=path/to/video.mp4` from the command line — both work with video files, live streams, and webcam input. For a detailed guide on setting up and running object tracking, check our [Track Mode](modes/track.md) documentation, which explains the configuration and practical applications in real-time scenarios.


### PR DESCRIPTION
## Summary
- Rewrite the docs landing page opening and hero copy to describe the full model family and cross-link the Ultralytics Platform.
- Replace the flat "How These Docs Are Organized" list with the `yolo TASK MODE ARGS` grammar, extending coverage to the Reference docs, the Ultralytics Platform, and the Ultralytics Inference Rust library/CLI.
- Add a "Train a model on your own dataset" tile and refresh the other goal-router card descriptions to be more specific.
- Move the social-links block below the FAQ section.

## Test plan
- [ ] Render `docs/en/index.md` locally and check the goal-router grid, grammar section, and social-links placement
- [ ] Verify all new/changed links (`platform/index.md`, `inference/index.md`, `reference/index.md`, `modes/train.md`) resolve

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Rebuilds the Ultralytics Docs landing page as a goal-based router that guides users to common workflows, models, modes, and API resources.

### 📊 Key Changes
- Renames the landing page to **Ultralytics YOLO Docs** and refreshes its introductory content.
- Adds a two-command installation and prediction quickstart using YOLO26.
- Replaces the former topic-oriented cards with goal-based paths for training, prediction, tracking, solutions, deployment, model selection, API lookup, and YOLO26 discovery.
- Adds an overview explaining how Tasks, Modes, Models, and Solutions organize the documentation.
- Expands navigation to the Ultralytics Platform and Ultralytics Inference documentation.
- Condenses FAQ examples and moves the social media links to the end of the page.
- Removes the longer YOLO history and object detection evolution sections to keep the landing page focused.

### 🎯 Purpose & Impact
- Helps new and experienced users reach the appropriate documentation faster based on what they want to accomplish.
- Makes the landing page more actionable with immediately runnable CLI commands and prominent workflow links.
- Improves discoverability of deployment, tracking, solutions, model comparisons, and the Python API.
- Reduces historical and explanatory content on the homepage, creating a more focused entry point while retaining links to detailed documentation.