### PR TITLE
Add DeepStream 8.0-9.1 and JetPack 7.x support to Jetson guide

### DIFF
--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -60,7 +60,7 @@ Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcosluc
 
 !!! note
 
-    The `DeepStream-Yolo` build and configuration steps below are validated by its maintainer through DeepStream 8.0. For DeepStream 9.0 and 9.1, NVIDIA also provides an official YOLO integration under [tools/yolo_deepstream](https://github.com/NVIDIA/DeepStream/tree/main/tools/yolo_deepstream) in the DeepStream monorepo. Check the target repository for the YOLO and DeepStream versions it supports before deploying.
+    The [DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo) build and configuration steps below are validated by its maintainer through DeepStream 8.0. For DeepStream 9.0 and 9.1, NVIDIA also provides an official YOLO integration under [tools/yolo_deepstream](https://github.com/NVIDIA/DeepStream/tree/main/tools/yolo_deepstream) in the DeepStream monorepo. Check the target repository for the YOLO and DeepStream versions it supports before deploying.
 
 1.  Install Ultralytics with necessary dependencies
 

--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -60,7 +60,7 @@ Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcosluc
 
 !!! warning "Supported DeepStream versions for this workflow"
 
-    The [DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo) clone, `export_yolo26.py`, and `make` steps below provide build configurations for DeepStream 8.0 and earlier (JetPack 7.0 and earlier), not for DeepStream 9.0 or 9.1. On DeepStream 9.0/9.1 (JetPack 7.1/7.2), use NVIDIA's official YOLO integration under [tools/yolo_deepstream](https://github.com/NVIDIA/DeepStream/tree/main/tools/yolo_deepstream) in the DeepStream monorepo, and check that repository for the YOLO versions it supports.
+    The [DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo) clone, `export_yolo26.py`, and `make` steps below provide build configurations for DeepStream 8.0 and earlier (JetPack 7.0 and earlier), not for DeepStream 9.0 or 9.1. A validated YOLO26 export and configuration workflow for DeepStream 9.0/9.1 is not yet available, so run YOLO26 with DeepStream 8.0 on JetPack 7.0 or earlier. NVIDIA's [tools/yolo_deepstream](https://github.com/NVIDIA/DeepStream/tree/main/tools/yolo_deepstream) integration in the DeepStream monorepo currently ships parsers and configs through YOLO11 only and does not yet cover YOLO26.
 
 1.  Install Ultralytics with necessary dependencies
 

--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -42,6 +42,7 @@ Before you start to follow this guide:
     - For JetPack 4.6.4, install [DeepStream 6.0.1](https://archive.docs.nvidia.com/metropolis/deepstream/6.0.1/dev-guide/text/DS_Quickstart.html)
     - For JetPack 5.1.3, install [DeepStream 6.3](https://archive.docs.nvidia.com/metropolis/deepstream/6.3/dev-guide/text/DS_Quickstart.html)
     - For JetPack 6.1, install [DeepStream 7.1](https://docs.nvidia.com/metropolis/deepstream/7.1/text/DS_Overview.html)
+    - For JetPack 7.0, install [DeepStream 8.0](https://docs.nvidia.com/metropolis/deepstream/8.0/text/DS_Overview.html)
     - For JetPack 7.1, install [DeepStream 9.0](https://docs.nvidia.com/metropolis/deepstream/9.0/text/DS_Overview.html)
     - For JetPack 7.2, install [DeepStream 9.1](https://docs.nvidia.com/metropolis/deepstream/9.1/text/DS_Overview.html)
 
@@ -49,13 +50,17 @@ Before you start to follow this guide:
 
     In this guide we have used the Debian package method of installing DeepStream SDK to the Jetson device. You can also visit the [DeepStream SDK on Jetson (Archived)](https://developer.nvidia.com/embedded/deepstream-on-jetson-downloads-archived) to access legacy versions of DeepStream.
 
-!!! note "DeepStream is now open source"
+!!! note "DeepStream source on GitHub"
 
-    Starting with DeepStream 9.1, the SDK is open-sourced on the [NVIDIA/DeepStream](https://github.com/NVIDIA/DeepStream) GitHub monorepo (Apache-2.0 source, CC-BY-4.0 docs). Release packages are published as GitHub Release assets (`.deb` and `.tar.gz` archives plus Python wheels) instead of NGC only, and you can alternatively build DeepStream from source with `bash build/build.sh`. The Debian package method described below remains the recommended path.
+    NVIDIA hosts the DeepStream SDK source on the [NVIDIA/DeepStream](https://github.com/NVIDIA/DeepStream) GitHub monorepo (the unified source home since DeepStream 9.0), and from DeepStream 9.1 the release packages (`.deb` and `.tar.gz` archives plus Python wheels) are published as GitHub Release assets rather than through NGC only. The SDK is not fully open source: the open-source components still require proprietary NVIDIA runtime libraries, which the source build (`bash build/build.sh`) downloads as release assets. The Debian package method described below remains the recommended path.
 
 ## DeepStream Configuration for YOLO26
 
 Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo) GitHub repository which includes NVIDIA DeepStream SDK support for YOLO models. We appreciate the efforts of marcoslucianops for his contributions!
+
+!!! note
+
+    The `DeepStream-Yolo` build and configuration steps below are validated by its maintainer through DeepStream 8.0. For DeepStream 9.0 and 9.1, NVIDIA also provides an official YOLO integration under [tools/yolo_deepstream](https://github.com/NVIDIA/DeepStream/tree/main/tools/yolo_deepstream) in the DeepStream monorepo. Check the target repository for the YOLO and DeepStream versions it supports before deploying.
 
 1.  Install Ultralytics with necessary dependencies
 
@@ -165,6 +170,12 @@ Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcosluc
 
     ```bash
     export CUDA_VER=12.6
+    ```
+
+    For JetPack 7.0:
+
+    ```bash
+    export CUDA_VER=13.0
     ```
 
     For JetPack 7.2:

--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -43,10 +43,15 @@ Before you start to follow this guide:
     - For JetPack 5.1.3, install [DeepStream 6.3](https://archive.docs.nvidia.com/metropolis/deepstream/6.3/dev-guide/text/DS_Quickstart.html)
     - For JetPack 6.1, install [DeepStream 7.1](https://docs.nvidia.com/metropolis/deepstream/7.1/text/DS_Overview.html)
     - For JetPack 7.1, install [DeepStream 9.0](https://docs.nvidia.com/metropolis/deepstream/9.0/text/DS_Overview.html)
+    - For JetPack 7.2, install [DeepStream 9.1](https://docs.nvidia.com/metropolis/deepstream/9.1/text/DS_Overview.html)
 
 !!! tip
 
     In this guide we have used the Debian package method of installing DeepStream SDK to the Jetson device. You can also visit the [DeepStream SDK on Jetson (Archived)](https://developer.nvidia.com/embedded/deepstream-on-jetson-downloads-archived) to access legacy versions of DeepStream.
+
+!!! note "DeepStream is now open source"
+
+    Starting with DeepStream 9.1, the SDK is open-sourced on the [NVIDIA/DeepStream](https://github.com/NVIDIA/DeepStream) GitHub monorepo (Apache-2.0 source, CC-BY-4.0 docs). Release packages are published as GitHub Release assets (`.deb` and `.tar.gz` archives plus Python wheels) instead of NGC only, and you can alternatively build DeepStream from source with `bash build/build.sh`. The Debian package method described below remains the recommended path.
 
 ## DeepStream Configuration for YOLO26
 
@@ -160,6 +165,12 @@ Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcosluc
 
     ```bash
     export CUDA_VER=12.6
+    ```
+
+    For JetPack 7.2:
+
+    ```bash
+    export CUDA_VER=13.2
     ```
 
 8.  Compile the library

--- a/docs/en/guides/deepstream-nvidia-jetson.md
+++ b/docs/en/guides/deepstream-nvidia-jetson.md
@@ -58,9 +58,9 @@ Before you start to follow this guide:
 
 Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo) GitHub repository which includes NVIDIA DeepStream SDK support for YOLO models. We appreciate the efforts of marcoslucianops for his contributions!
 
-!!! note
+!!! warning "Supported DeepStream versions for this workflow"
 
-    The [DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo) build and configuration steps below are validated by its maintainer through DeepStream 8.0. For DeepStream 9.0 and 9.1, NVIDIA also provides an official YOLO integration under [tools/yolo_deepstream](https://github.com/NVIDIA/DeepStream/tree/main/tools/yolo_deepstream) in the DeepStream monorepo. Check the target repository for the YOLO and DeepStream versions it supports before deploying.
+    The [DeepStream-Yolo](https://github.com/marcoslucianops/DeepStream-Yolo) clone, `export_yolo26.py`, and `make` steps below provide build configurations for DeepStream 8.0 and earlier (JetPack 7.0 and earlier), not for DeepStream 9.0 or 9.1. On DeepStream 9.0/9.1 (JetPack 7.1/7.2), use NVIDIA's official YOLO integration under [tools/yolo_deepstream](https://github.com/NVIDIA/DeepStream/tree/main/tools/yolo_deepstream) in the DeepStream monorepo, and check that repository for the YOLO versions it supports.
 
 1.  Install Ultralytics with necessary dependencies
 
@@ -172,7 +172,7 @@ Here we are using [marcoslucianops/DeepStream-Yolo](https://github.com/marcosluc
     export CUDA_VER=12.6
     ```
 
-    For JetPack 7.0:
+    For JetPack 7.0 and 7.1:
 
     ```bash
     export CUDA_VER=13.0


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Updates the NVIDIA Jetson DeepStream guide with JetPack 7.x compatibility details and clearer YOLO26 workflow limitations.

### 📊 Key Changes

- Adds installation guidance for:
  - JetPack 7.0 with DeepStream 8.0.
  - JetPack 7.1 with DeepStream 9.0.
  - JetPack 7.2 with DeepStream 9.1.
- Documents NVIDIA’s [DeepStream GitHub monorepo](https://github.com/NVIDIA/DeepStream) and explains how newer release packages are distributed.
- Clarifies that DeepStream is not fully open source and still depends on proprietary NVIDIA runtime libraries.
- Adds a warning that the documented [DeepStream-Yolo workflow](https://github.com/marcoslucianops/DeepStream-Yolo) supports DeepStream 8.0 and earlier, but is not yet validated for DeepStream 9.0 or 9.1.
- Adds the appropriate `CUDA_VER` values for JetPack 7.0–7.2:
  - JetPack 7.0 and 7.1: `13.0`
  - JetPack 7.2: `13.2`

### 🎯 Purpose & Impact

- 🧭 Helps users select the correct DeepStream version for their JetPack release.
- 🛠️ Reduces setup errors by providing the required CUDA environment variables for newer Jetson platforms.
- ⚠️ Sets clear expectations that the current YOLO26 DeepStream workflow is supported through DeepStream 8.0, while DeepStream 9.x support remains unavailable.
- 📦 Improves transparency around DeepStream source code, package distribution, and proprietary runtime requirements.