### PR TITLE
Validate INT8 calibration dataset split

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -182,6 +182,7 @@ def test_int8_calibration_validates_split():
     exporter = object.__new__(Exporter)
     exporter.model = SimpleNamespace(task="obb")
     exporter.args = SimpleNamespace(data="coco8.yaml", split="trainval")
+    exporter.imgsz = [32]
     with pytest.raises(FileNotFoundError, match="trainval"):
         exporter.get_int8_calibration_dataloader()
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -177,6 +177,15 @@ def test_modelopt_quantize_onnx_requires_int8_dataset():
         modelopt_quantize_onnx("model.onnx", quantize=8)
 
 
+def test_int8_calibration_validates_split():
+    """Check INT8 calibration rejects dataset splits that do not exist."""
+    exporter = object.__new__(Exporter)
+    exporter.model = SimpleNamespace(task="obb")
+    exporter.args = SimpleNamespace(data="coco8.yaml", split="trainval")
+    with pytest.raises(FileNotFoundError, match="trainval"):
+        exporter.get_int8_calibration_dataloader()
+
+
 def test_export_rknn_batch_expansion(monkeypatch, tmp_path):
     """Check RKNN calibrates batch 1 before Toolkit expands to the requested batch."""
     calls = {}

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -850,7 +850,9 @@ class Exporter:
     def get_int8_calibration_dataloader(self, prefix=""):
         """Build and return a dataloader for calibration of INT8 models."""
         LOGGER.info(f"{prefix} collecting INT8 calibration images from 'data={self.args.data}'")
-        data = (check_cls_dataset if self.model.task == "classify" else check_det_dataset)(self.args.data)
+        data = (check_cls_dataset if self.model.task == "classify" else check_det_dataset)(
+            self.args.data, split=self.args.split
+        )
         cfg = deepcopy(self.args)
         cfg.imgsz = max(self.imgsz)
         if self.model.task == "classify":

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -850,18 +850,17 @@ class Exporter:
     def get_int8_calibration_dataloader(self, prefix=""):
         """Build and return a dataloader for calibration of INT8 models."""
         LOGGER.info(f"{prefix} collecting INT8 calibration images from 'data={self.args.data}'")
-        data = (check_cls_dataset if self.model.task == "classify" else check_det_dataset)(
-            self.args.data, split=self.args.split
-        )
         cfg = deepcopy(self.args)
         cfg.imgsz = max(self.imgsz)
         if self.model.task == "classify":
             import torchvision.transforms as T  # scope for faster 'import ultralytics'
 
+            data = check_cls_dataset(self.args.data)
             dataset = ClassificationDataset(data[self.args.split or "val"], args=cfg, augment=False)
             # INT8 backends divide images by 255, so emit uint8 [0, 255] center-cropped like classify inference
             dataset.torch_transforms = T.Compose([T.Resize(cfg.imgsz), T.CenterCrop(cfg.imgsz), T.PILToTensor()])
         else:
+            data = check_det_dataset(self.args.data, split=self.args.split)
             dataset = build_yolo_dataset(
                 cfg,
                 data[self.args.split or "val"],


### PR DESCRIPTION
## Summary

- relocate each calibration dataset check into its existing task branch
- pass the requested split to detection/OBB dataset validation while preserving classification fallback behavior
- cover the fuzzed `split=trainval` failure without running an OpenVINO conversion

Deleted: the shared calibration dataset dispatch that prevented detection/OBB from validating the requested split.

The bugfix is net-positive only for the focused regression test; the production change replaces the shared dispatch and reuses `check_det_dataset()` split validation.

## Validation

- `ruff format ultralytics/engine/exporter.py tests/test_exports.py`
- `ruff check ultralytics/engine/exporter.py tests/test_exports.py`
- `pytest tests/test_exports.py::test_int8_calibration_validates_split -q`
- replayed the exact `split=trainval` OBB INT8 export through `.github/scripts/fuzz.py repro`; it now classifies as expected

Refs #25056

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ INT8 calibration now validates that the requested dataset split exists before building the calibration dataloader.

### 📊 Key Changes

- Updated `get_int8_calibration_dataloader()` to pass the selected split to `check_det_dataset()`.
- Added a regression test confirming invalid splits, such as `trainval`, raise a clear `FileNotFoundError`.
- Preserved separate dataset validation and loading behavior for classification tasks.

### 🎯 Purpose & Impact

- ✅ Prevents confusing calibration failures caused by nonexistent dataset splits.
- 🔍 Provides earlier, clearer feedback when exporting detection or OBB models to INT8.
- 📦 Improves export reliability without changing valid calibration workflows.